### PR TITLE
Dependency gardening for Wasmtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3603,7 +3603,7 @@ name = "wasi-common"
 version = "12.0.0"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags 2.2.1",
  "cap-rand",
  "cap-std",
  "io-extras",
@@ -4346,7 +4346,7 @@ version = "12.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 1.3.2",
+ "bitflags 2.2.1",
  "cap-fs-ext",
  "cap-rand",
  "cap-std",
@@ -4517,7 +4517,7 @@ version = "12.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 1.3.2",
+ "bitflags 2.2.1",
  "proptest",
  "thiserror",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -130,7 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -317,7 +317,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -333,7 +333,7 @@ dependencies = [
  "ipnet",
  "maybe-owned",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
  "winx",
 ]
 
@@ -812,7 +812,7 @@ dependencies = [
  "region",
  "target-lexicon",
  "wasmtime-jit-icache-coherence",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1304,7 +1304,7 @@ checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1352,7 +1352,7 @@ checksum = "39ae6b3d9530211fb3b12a95374b8b0823be812f53d09e18c5675c0146b09642"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1426,7 +1426,7 @@ checksum = "7833d0f115a013d51c55950a3b09d30e4b057be9961b709acb9b5b17a1108861"
 dependencies = [
  "io-lifetimes",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1824,7 +1824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde93d48f0d9277f977a333eca8313695ddd5301dc96f7e02aeddcb0dd99096f"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1835,7 +1835,7 @@ checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.0",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1853,7 +1853,7 @@ dependencies = [
  "hermit-abi 0.3.0",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2101,14 +2101,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2820,7 +2819,7 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "once_cell",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3024,9 +3023,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
@@ -3153,7 +3152,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys",
  "winx",
 ]
 
@@ -3165,15 +3164,16 @@ checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "tempfile"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg 1.1.0",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3290,31 +3290,31 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.26.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg 1.1.0",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "pin-project-lite",
  "socket2",
  "tokio-macros",
- "windows-sys 0.45.0",
+ "windows-sys",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "1.7.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b557f72f448c511a979e2564e55d74e6c4432fc96ff4f6241bc6bded342643b7"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3595,7 +3595,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "wasi-common",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3613,7 +3613,7 @@ dependencies = [
  "tracing",
  "wasmtime",
  "wiggle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -3940,7 +3940,7 @@ dependencies = [
  "wasmtime-wasi",
  "wasmtime-winch",
  "wat",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4010,7 +4010,7 @@ dependencies = [
  "sha2 0.10.2",
  "tempfile",
  "toml",
- "windows-sys 0.48.0",
+ "windows-sys",
  "zstd",
 ]
 
@@ -4061,7 +4061,7 @@ dependencies = [
  "wasmtime-wast",
  "wast 61.0.0",
  "wat",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4193,7 +4193,7 @@ dependencies = [
  "rustix",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4272,7 +4272,7 @@ dependencies = [
  "wasmtime-jit-debug",
  "wasmtime-jit-icache-coherence",
  "wasmtime-runtime",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4291,7 +4291,7 @@ version = "12.0.0"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4318,7 +4318,7 @@ dependencies = [
  "wasmtime-fiber",
  "wasmtime-jit-debug",
  "wasmtime-versioned-export-macros",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4363,7 +4363,7 @@ dependencies = [
  "wasi-tokio",
  "wasmtime",
  "wiggle",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -4660,35 +4660,11 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.1",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.0",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.1",
- "windows_aarch64_msvc 0.42.1",
- "windows_i686_gnu 0.42.1",
- "windows_i686_msvc 0.42.1",
- "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm 0.42.1",
- "windows_x86_64_msvc 0.42.1",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4697,20 +4673,14 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -4720,21 +4690,9 @@ checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4744,21 +4702,9 @@ checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4768,21 +4714,9 @@ checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4798,7 +4732,7 @@ checksum = "1c52a121f0fbf9320d5f2a9a5d82f6cb7557eda5e8b47fc3e7f359ec866ae960"
 dependencies = [
  "bitflags 1.3.2",
  "io-lifetimes",
- "windows-sys 0.48.0",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ dependencies = [
  "fxhash",
  "indicatif",
  "log",
- "pretty_env_logger",
+ "pretty_env_logger 0.5.0",
  "rayon",
  "regalloc2",
  "serde",
@@ -2209,7 +2209,7 @@ dependencies = [
  "libloading",
  "once_cell",
  "openvino-finder",
- "pretty_env_logger",
+ "pretty_env_logger 0.4.0",
 ]
 
 [[package]]
@@ -2416,6 +2416,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
 dependencies = [
  "env_logger 0.7.1",
+ "log",
+]
+
+[[package]]
+name = "pretty_env_logger"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
+dependencies = [
+ "env_logger 0.10.0",
  "log",
 ]
 
@@ -3976,7 +3986,7 @@ dependencies = [
  "filetime",
  "log",
  "once_cell",
- "pretty_env_logger",
+ "pretty_env_logger 0.5.0",
  "rustix",
  "serde",
  "sha2 0.10.2",
@@ -4043,7 +4053,7 @@ dependencies = [
  "anyhow",
  "clap",
  "file-per-thread-logger",
- "pretty_env_logger",
+ "pretty_env_logger 0.5.0",
  "rayon",
  "wasmtime",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
 dependencies = [
  "gimli",
 ]
@@ -187,9 +187,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.67"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
 dependencies = [
  "addr2line",
  "cc",
@@ -1544,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.0"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 dependencies = [
  "fallible-iterator",
  "indexmap 1.9.1",
@@ -1957,9 +1957,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.141"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3304a64d199bb964be99741b7a14d26972741915b3649639149b2479bb46f4b5"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2092,9 +2092,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.6.2"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -2179,9 +2179,9 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.30.3"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "crc32fast",
  "hashbrown 0.13.2",
@@ -3660,7 +3660,7 @@ dependencies = [
  "byte-array-literals",
  "object",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-encoder 0.25.0",
+ "wasm-encoder 0.30.0",
  "wit-bindgen",
 ]
 
@@ -3743,15 +3743,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
-
-[[package]]
-name = "wasm-encoder"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eff853c4f09eec94d76af527eddad4e9de13b11d6286a1ef7134bc30135a2b7"
-dependencies = [
- "leb128",
-]
 
 [[package]]
 name = "wasm-encoder"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,13 +150,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.53"
+version = "0.1.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6aa3524a2dfcf9fe180c51eae2b58738348d819517ceadf95789c51fff7600"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -591,7 +591,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -1107,13 +1107,13 @@ dependencies = [
 
 [[package]]
 name = "derive_arbitrary"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cdeb9ec472d588e539a818b2dee436825730da08ad0017c4b1a17676bdc8b7"
+checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3236,22 +3236,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3365,13 +3365,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.21"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
 ]
 
 [[package]]
@@ -3692,9 +3692,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3702,24 +3702,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3727,22 +3727,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.80"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"
@@ -4084,7 +4084,7 @@ dependencies = [
  "component-macro-test-helpers",
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
  "tracing",
  "wasmtime",
  "wasmtime-component-util",
@@ -4537,7 +4537,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "shellexpand",
- "syn 1.0.92",
+ "syn 2.0.25",
  "witx",
 ]
 
@@ -4547,7 +4547,7 @@ version = "12.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
  "wiggle",
  "wiggle-generate",
 ]
@@ -4634,7 +4634,7 @@ dependencies = [
  "glob",
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,42 +510,44 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.8"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+checksum = "3eab9e8ceb9afdade1ab3f0fd8dbce5b1b2f468ad653baf10e771781b2b67b73"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
  "clap_derive",
- "clap_lex",
- "indexmap 1.9.1",
  "once_cell",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2763db829349bf00cfc06251268865ed4363b93a943174f638daf3ecdba2cd"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
  "strsim",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.7"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
- "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 1.0.92",
+ "syn 2.0.25",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "codespan-reporting"
@@ -507,6 +558,12 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "command-tests"
@@ -879,19 +936,19 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
  "anes",
- "atty",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
@@ -2213,12 +2270,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-
-[[package]]
 name = "p256"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2427,30 +2478,6 @@ checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
 dependencies = [
  "env_logger 0.10.0",
  "log",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.92",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
 ]
 
 [[package]]
@@ -3208,12 +3235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "textwrap"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
-
-[[package]]
 name = "thiserror"
 version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3464,6 +3485,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2095,9 +2095,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg 1.1.0",
 ]
@@ -4332,7 +4332,7 @@ dependencies = [
  "log",
  "mach",
  "memfd",
- "memoffset 0.8.0",
+ "memoffset 0.9.0",
  "once_cell",
  "paste",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,9 +244,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.2.1"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "block-buffer"
@@ -310,38 +310,38 @@ dependencies = [
 
 [[package]]
 name = "cap-fs-ext"
-version = "1.0.14"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1742f5106155d46a41eac5f730ee189bf92fde6ae109fbf2cdb67176726ca5d"
+checksum = "b779b2d0a001c125b4584ad586268fb4b92d957bff8d26d7fe0dd78283faa814"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "io-lifetimes",
+ "io-lifetimes 2.0.2",
  "windows-sys",
 ]
 
 [[package]]
 name = "cap-primitives"
-version = "1.0.14"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42068f579028e856717d61423645c85d2d216dde8eff62c9b30140e725c79177"
+checksum = "2bf30c373a3bee22c292b1b6a7a26736a38376840f1af3d2d806455edf8c3899"
 dependencies = [
  "ambient-authority",
  "fs-set-times",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 2.0.2",
  "ipnet",
  "maybe-owned",
- "rustix",
+ "rustix 0.38.4",
  "windows-sys",
  "winx",
 ]
 
 [[package]]
 name = "cap-rand"
-version = "1.0.14"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3be2ededc13f42a5921c08e565b854cb5ff9b88753e2c6ec12c58a24e7e8d4e"
+checksum = "577de6cff7c2a47d6b13efe5dd28bf116bd7f8f7db164ea95b7cc2640711f522"
 dependencies = [
  "ambient-authority",
  "rand 0.8.5",
@@ -349,37 +349,37 @@ dependencies = [
 
 [[package]]
 name = "cap-std"
-version = "1.0.14"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "559ad6fab5fedcc9bd5877160e1433fcd481f8af615068d6ca49472b1201cc6c"
+checksum = "84bade423fa6403efeebeafe568fdb230e8c590a275fba2ba978dd112efcf6e9"
 dependencies = [
  "cap-primitives",
  "io-extras",
- "io-lifetimes",
- "rustix",
+ "io-lifetimes 2.0.2",
+ "rustix 0.38.4",
 ]
 
 [[package]]
 name = "cap-tempfile"
-version = "1.0.14"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92372a5de78a858f20c22a8dbe3ea55e1cc2daeb82016a3150dab8cf51ea3235"
+checksum = "7b9e3348a3510c4619b4c7a7bcdef09a71221da18f266bda3ed6b9aea2c509e2"
 dependencies = [
  "cap-std",
  "rand 0.8.5",
- "rustix",
+ "rustix 0.38.4",
  "uuid",
 ]
 
 [[package]]
 name = "cap-time-ext"
-version = "1.0.14"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a74e04cd32787bfa3a911af745b0fd5d99d4c3fc16c64449e1622c06fa27c8e"
+checksum = "f8f52b3c8f4abfe3252fd0a071f3004aaa3b18936ec97bdbd8763ce03aff6247"
 dependencies = [
  "cap-primitives",
  "once_cell",
- "rustix",
+ "rustix 0.38.4",
  "winx",
 ]
 
@@ -1346,12 +1346,12 @@ dependencies = [
 
 [[package]]
 name = "fd-lock"
-version = "3.0.12"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ae6b3d9530211fb3b12a95374b8b0823be812f53d09e18c5675c0146b09642"
+checksum = "0b0377f1edc77dbd1118507bc7a66e4ab64d2b90c66f90726dc801e73a8c68f9"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.38.4",
  "windows-sys",
 ]
 
@@ -1420,12 +1420,12 @@ dependencies = [
 
 [[package]]
 name = "fs-set-times"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7833d0f115a013d51c55950a3b09d30e4b057be9961b709acb9b5b17a1108861"
+checksum = "dd738b84894214045e8414eaded76359b4a5773f0a0a56b16575110739cdcf39"
 dependencies = [
- "io-lifetimes",
- "rustix",
+ "io-lifetimes 2.0.2",
+ "rustix 0.38.4",
  "windows-sys",
 ]
 
@@ -1493,7 +1493,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags 2.2.1",
+ "bitflags 2.3.3",
  "debugid",
  "fxhash",
  "serde",
@@ -1819,11 +1819,11 @@ dependencies = [
 
 [[package]]
 name = "io-extras"
-version = "0.17.4"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde93d48f0d9277f977a333eca8313695ddd5301dc96f7e02aeddcb0dd99096f"
+checksum = "9d3c230ee517ee76b1cc593b52939ff68deda3fae9e41eca426c6b4993df51c4"
 dependencies = [
- "io-lifetimes",
+ "io-lifetimes 2.0.2",
  "windows-sys",
 ]
 
@@ -1839,6 +1839,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffb4def18c48926ccac55c1223e02865ce1a821751a95920448662696e7472c"
+
+[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,8 +1857,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
  "hermit-abi 0.3.0",
- "io-lifetimes",
- "rustix",
+ "io-lifetimes 1.0.10",
+ "rustix 0.37.13",
  "windows-sys",
 ]
 
@@ -1995,6 +2001,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+
+[[package]]
 name = "listenfd"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,7 +2072,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
 dependencies = [
- "rustix",
+ "rustix 0.37.13",
 ]
 
 [[package]]
@@ -2814,10 +2826,23 @@ checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 1.0.10",
+ "libc",
+ "linux-raw-sys 0.3.3",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
  "itoa",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.3",
  "once_cell",
  "windows-sys",
 ]
@@ -3142,16 +3167,16 @@ dependencies = [
 
 [[package]]
 name = "system-interface"
-version = "0.25.7"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928ebd55ab758962e230f51ca63735c5b283f26292297c81404289cda5d78631"
+checksum = "27ce32341b2c0b70c144bbf35627fdc1ef18c76ced5e5e7b3ee8b5ba6b2ab6a0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.3.3",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
- "io-lifetimes",
- "rustix",
+ "io-lifetimes 2.0.2",
+ "rustix 0.38.4",
  "windows-sys",
  "winx",
 ]
@@ -3172,7 +3197,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix",
+ "rustix 0.37.13",
  "windows-sys",
 ]
 
@@ -3587,10 +3612,10 @@ dependencies = [
  "cap-time-ext",
  "fs-set-times",
  "io-extras",
- "io-lifetimes",
+ "io-lifetimes 2.0.2",
  "is-terminal",
  "once_cell",
- "rustix",
+ "rustix 0.38.4",
  "system-interface",
  "tempfile",
  "tracing",
@@ -3603,12 +3628,12 @@ name = "wasi-common"
 version = "12.0.0"
 dependencies = [
  "anyhow",
- "bitflags 2.2.1",
+ "bitflags 2.3.3",
  "cap-rand",
  "cap-std",
  "io-extras",
  "log",
- "rustix",
+ "rustix 0.38.4",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -3681,8 +3706,8 @@ dependencies = [
  "cap-std",
  "cap-tempfile",
  "io-extras",
- "io-lifetimes",
- "rustix",
+ "io-lifetimes 2.0.2",
+ "rustix 0.38.4",
  "tempfile",
  "tokio",
  "wasi-cap-std-sync",
@@ -4005,7 +4030,7 @@ dependencies = [
  "log",
  "once_cell",
  "pretty_env_logger 0.5.0",
- "rustix",
+ "rustix 0.38.4",
  "serde",
  "sha2 0.10.2",
  "tempfile",
@@ -4035,7 +4060,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rayon",
- "rustix",
+ "rustix 0.38.4",
  "serde",
  "serde_json",
  "target-lexicon",
@@ -4190,7 +4215,7 @@ dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
- "rustix",
+ "rustix 0.38.4",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
  "windows-sys",
@@ -4265,7 +4290,7 @@ dependencies = [
  "log",
  "object",
  "rustc-demangle",
- "rustix",
+ "rustix 0.38.4",
  "serde",
  "target-lexicon",
  "wasmtime-environ",
@@ -4281,7 +4306,7 @@ version = "12.0.0"
 dependencies = [
  "object",
  "once_cell",
- "rustix",
+ "rustix 0.38.4",
  "wasmtime-versioned-export-macros",
 ]
 
@@ -4311,7 +4336,7 @@ dependencies = [
  "once_cell",
  "paste",
  "rand 0.8.5",
- "rustix",
+ "rustix 0.38.4",
  "sptr",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -4346,7 +4371,7 @@ version = "12.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.2.1",
+ "bitflags 2.3.3",
  "cap-fs-ext",
  "cap-rand",
  "cap-std",
@@ -4354,7 +4379,7 @@ dependencies = [
  "fs-set-times",
  "io-extras",
  "libc",
- "rustix",
+ "rustix 0.38.4",
  "system-interface",
  "thiserror",
  "tracing",
@@ -4517,7 +4542,7 @@ version = "12.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.2.1",
+ "bitflags 2.3.3",
  "proptest",
  "thiserror",
  "tokio",
@@ -4726,12 +4751,11 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winx"
-version = "0.35.1"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c52a121f0fbf9320d5f2a9a5d82f6cb7557eda5e8b47fc3e7f359ec866ae960"
+checksum = "4857cedf8371f690bb6782a3e2b065c54d1b6661be068aaf3eac8b45e813fdf8"
 dependencies = [
- "bitflags 1.3.2",
- "io-lifetimes",
+ "bitflags 2.3.3",
  "windows-sys",
 ]
 
@@ -4741,7 +4765,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a628591b3905328e886462f75de3b2af1e546b19af5f4c359086b26bec29c4bd"
 dependencies = [
- "bitflags 2.2.1",
+ "bitflags 2.3.3",
  "wit-bindgen-rust-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,14 +187,16 @@ regalloc2 = "0.9.2"
 
 # cap-std family:
 target-lexicon = { version = "0.12.3", default-features = false, features = ["std"] }
-cap-std = "1.0.12"
-cap-rand = { version = "1.0.12", features = ["small_rng"] }
-cap-fs-ext = "1.0.12"
-cap-time-ext = "1.0.0"
-fs-set-times = "0.19.0"
-system-interface = { version = "0.25.1", features = ["cap_std_impls"] }
-io-lifetimes = { version = "1.0.0", default-features = false }
-rustix = "0.37.13"
+cap-std = "2.0.0"
+cap-rand = { version = "2.0.0", features = ["small_rng"] }
+cap-fs-ext = "2.0.0"
+cap-time-ext = "2.0.0"
+cap-tempfile = "2.0.0"
+fs-set-times = "0.20.0"
+system-interface = { version = "0.26.0", features = ["cap_std_impls"] }
+io-lifetimes = { version = "2.0.2", default-features = false }
+io-extras = "0.18.0"
+rustix = "0.38.4"
 
 # wit-bindgen:
 wit-bindgen = { version = "0.7.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,8 +225,8 @@ once_cell = "1.12.0"
 smallvec = { version = "1.6.1", features = ["union"] }
 tracing = "0.1.26"
 bitflags = "1.2"
-thiserror = "1.0.15"
-async-trait = "0.1.42"
+thiserror = "1.0.43"
+async-trait = "0.1.71"
 heck = "0.4"
 similar = "2.1.0"
 toml = "0.5.9"
@@ -242,6 +242,7 @@ libc = "0.2.60"
 file-per-thread-logger = "0.2.0"
 indexmap = "2.0.0"
 pretty_env_logger = "0.5.0"
+syn = "2.0.25"
 
 [features]
 default = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -224,7 +224,7 @@ capstone = "0.9.0"
 once_cell = "1.12.0"
 smallvec = { version = "1.6.1", features = ["union"] }
 tracing = "0.1.26"
-bitflags = "1.2"
+bitflags = "2.0"
 thiserror = "1.0.43"
 async-trait = "0.1.71"
 heck = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -241,6 +241,7 @@ filecheck = "0.5.0"
 libc = "0.2.60"
 file-per-thread-logger = "0.2.0"
 indexmap = "2.0.0"
+pretty_env_logger = "0.5.0"
 
 [features]
 default = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ wit-component = "0.12.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
-object = { version = "0.30.3", default-features = false, features = ['read_core', 'elf', 'std'] }
+object = { version = "0.31.1", default-features = false, features = ['read_core', 'elf', 'std'] }
 gimli = { version = "0.27.0", default-features = false, features = ['read', 'std'] }
 anyhow = "1.0.22"
 windows-sys = "0.48.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ test-programs = { path = "crates/test-programs" }
 wasmtime-runtime = { workspace = true }
 tokio = { version = "1.8.0", features = ["rt", "time", "macros", "rt-multi-thread"] }
 wast = { workspace = true }
-criterion = "0.4.0"
+criterion = "0.5.0"
 num_cpus = "1.13.0"
 memchr = "2.4"
 async-trait = { workspace = true }
@@ -218,7 +218,7 @@ anyhow = "1.0.22"
 windows-sys = "0.48.0"
 env_logger = "0.10"
 log = { version = "0.4.8", default-features = false }
-clap = { version = "3.2.0", features = ["color", "suggestions", "derive"] }
+clap = { version = "4.3.12", features = ["color", "suggestions", "derive"] }
 hashbrown = "0.13.2"
 capstone = "0.9.0"
 once_cell = "1.12.0"

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -38,7 +38,7 @@ termcolor = "1.1.2"
 capstone = { workspace = true, optional = true }
 wat = { workspace = true, optional = true }
 target-lexicon = { workspace = true, features = ["std"] }
-pretty_env_logger = "0.4.0"
+pretty_env_logger = { workspace = true }
 rayon = { version = "1", optional = true }
 indicatif = "0.13.0"
 thiserror = { workspace = true }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -36,7 +36,7 @@ sha2 = { version = "0.10.2", optional = true }
 # accomodated in `tests`.
 
 [dev-dependencies]
-criterion = { version = "0.4.0", features = ["html_reports"] }
+criterion = { version = "0.5.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]

--- a/cranelift/src/clif-util.rs
+++ b/cranelift/src/clif-util.rs
@@ -142,3 +142,9 @@ fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn verify_cli() {
+    use clap::CommandFactory;
+    Commands::command().debug_assert()
+}

--- a/cranelift/src/wasm.rs
+++ b/cranelift/src/wasm.rs
@@ -111,7 +111,7 @@ pub struct Options {
     color: ColorOpt,
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Clone)]
 enum ColorOpt {
     Auto,
     Never,

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -32,5 +32,5 @@ rustix = { workspace = true, features = ["process"] }
 [dev-dependencies]
 filetime = "0.2.7"
 once_cell = { workspace = true }
-pretty_env_logger = "0.4.0"
+pretty_env_logger = { workspace = true }
 tempfile = "3"

--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -12,7 +12,7 @@ edition.workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true }
 file-per-thread-logger = { workspace = true }
-pretty_env_logger = "0.4.0"
+pretty_env_logger = { workspace = true }
 rayon = "1.5.0"
 wasmtime = { workspace = true }
 

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -107,11 +107,11 @@ fn init_file_per_thread_logger(prefix: &'static str) {
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct CommonOptions {
     /// Use specified configuration file
-    #[clap(long, parse(from_os_str), value_name = "CONFIG_PATH")]
+    #[clap(long, value_name = "CONFIG_PATH")]
     pub config: Option<PathBuf>,
 
     /// Disable logging
-    #[clap(long, conflicts_with = "log-to-files")]
+    #[clap(long, conflicts_with = "log_to_files")]
     pub disable_logging: bool,
 
     /// Log to per-thread log files instead of stderr
@@ -131,11 +131,11 @@ pub struct CommonOptions {
     pub disable_parallel_compilation: bool,
 
     /// Enable or disable WebAssembly features
-    #[clap(long, value_name = "FEATURE,FEATURE,...", parse(try_from_str = parse_wasm_features))]
+    #[clap(long, value_name = "FEATURE,FEATURE,...", value_parser = parse_wasm_features)]
     pub wasm_features: Option<WasmFeatures>,
 
     /// Enable or disable WASI modules
-    #[clap(long, value_name = "MODULE,MODULE,...", parse(try_from_str = parse_wasi_modules))]
+    #[clap(long, value_name = "MODULE,MODULE,...", value_parser = parse_wasi_modules)]
     pub wasi_modules: Option<WasiModules>,
 
     /// Generate jitdump file (supported on --features=profiling build)
@@ -148,14 +148,20 @@ pub struct CommonOptions {
     #[clap(
         long,
         value_name = "LEVEL",
-        parse(try_from_str = parse_opt_level),
+        value_parser = parse_opt_level,
         verbatim_doc_comment,
     )]
     pub opt_level: Option<wasmtime::OptLevel>,
 
     /// Set a Cranelift setting to a given value.
     /// Use `wasmtime settings` to list Cranelift settings for a target.
-    #[clap(long = "cranelift-set", value_name = "NAME=VALUE", number_of_values = 1, verbatim_doc_comment, parse(try_from_str = parse_cranelift_flag))]
+    #[clap(
+        long = "cranelift-set",
+        value_name = "NAME=VALUE",
+        number_of_values = 1,
+        verbatim_doc_comment,
+        value_parser = parse_cranelift_flag,
+    )]
     pub cranelift_set: Vec<(String, String)>,
 
     /// Enable a Cranelift boolean setting or preset.

--- a/crates/component-macro/Cargo.toml
+++ b/crates/component-macro/Cargo.toml
@@ -19,7 +19,7 @@ doctest = false
 anyhow = "1.0"
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits"] }
+syn = { workspace = true, features = ["extra-traits"] }
 wasmtime-component-util = { workspace = true }
 wasmtime-wit-bindgen = { workspace = true }
 wit-parser = { workspace = true }

--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -252,7 +252,7 @@ impl Parse for Opt {
             let contents;
             let _lbrace = braced!(contents in input);
             let fields: Punctuated<(String, String, String), Token![,]> =
-                contents.parse_terminated(trappable_error_field_parse)?;
+                contents.parse_terminated(trappable_error_field_parse, Token![,])?;
             Ok(Opt::TrappableErrorType(
                 fields
                     .into_iter()
@@ -273,7 +273,7 @@ impl Parse for Opt {
             let contents;
             let _lbrace = braced!(contents in input);
             let fields: Punctuated<(String, String), Token![,]> =
-                contents.parse_terminated(with_field_parse)?;
+                contents.parse_terminated(with_field_parse, Token![,])?;
             Ok(Opt::With(HashMap::from_iter(fields.into_iter())))
         } else {
             Err(l.error())

--- a/crates/environ/examples/factc.rs
+++ b/crates/environ/examples/factc.rs
@@ -55,10 +55,10 @@ struct Factc {
     #[clap(short, long)]
     text: bool,
 
-    #[clap(long, parse(try_from_str = parse_string_encoding), default_value = "utf8")]
+    #[clap(long, value_parser = parse_string_encoding, default_value = "utf8")]
     lift_str: StringEncoding,
 
-    #[clap(long, parse(try_from_str = parse_string_encoding), default_value = "utf8")]
+    #[clap(long, value_parser = parse_string_encoding, default_value = "utf8")]
     lower_str: StringEncoding,
 
     /// TODO

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -27,4 +27,4 @@ cc = "1.0"
 wasmtime-versioned-export-macros = { workspace = true }
 
 [dev-dependencies]
-backtrace = "0.3.61"
+backtrace = "0.3.68"

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -20,7 +20,7 @@ cfg-if = { workspace = true }
 gimli = { workspace = true }
 object = { workspace = true }
 serde = { version = "1.0.94", features = ["derive"] }
-addr2line = { version = "0.19.0", default-features = false }
+addr2line = { version = "0.20.0", default-features = false }
 bincode = "1.2.1"
 rustc-demangle = "0.1.16"
 cpp_demangle = "0.3.2"

--- a/crates/misc/component-macro-test/Cargo.toml
+++ b/crates/misc/component-macro-test/Cargo.toml
@@ -14,4 +14,4 @@ doctest = false
 [dependencies]
 proc-macro2 = "1.0"
 quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { workspace = true, features = ["full"] }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -18,7 +18,7 @@ wasmtime-jit-debug = { workspace = true, features = ["gdb_jit_int"] }
 wasmtime-versioned-export-macros = { workspace = true }
 libc = { version = "0.2.112", default-features = false }
 log = { workspace = true }
-memoffset = "0.8.0"
+memoffset = "0.9.0"
 indexmap = { workspace = true }
 cfg-if = { workspace = true }
 rand = { version = "0.8.3", features = ['small_rng'] }

--- a/crates/runtime/src/mmap/unix.rs
+++ b/crates/runtime/src/mmap/unix.rs
@@ -108,7 +108,7 @@ impl Mmap {
         let flags = if enable_branch_protection {
             #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
             if std::arch::is_aarch64_feature_detected!("bti") {
-                MprotectFlags::from_bits_unchecked(flags.bits() | /* PROT_BTI */ 0x10)
+                MprotectFlags::from_bits_retain(flags.bits() | /* PROT_BTI */ 0x10)
             } else {
                 flags
             }

--- a/crates/versioned-export-macros/Cargo.toml
+++ b/crates/versioned-export-macros/Cargo.toml
@@ -10,7 +10,7 @@ version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = { version = "2.0", features = ["full"] }
+syn = { workspace = true, features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -32,7 +32,7 @@ log = { workspace = true }
 rustix = { workspace = true, features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies]
-io-extras = "0.17.0"
+io-extras = { workspace = true }
 
 [target.'cfg(windows)'.dependencies.windows-sys]
 workspace = true

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -16,21 +16,21 @@ wasi-common = { workspace = true }
 async-trait = { workspace = true }
 anyhow = { workspace = true }
 cap-std = { workspace = true }
-cap-fs-ext = "1.0.0"
-cap-time-ext = "1.0.0"
+cap-fs-ext = { workspace = true }
+cap-time-ext = { workspace = true }
 cap-rand = { workspace = true }
-fs-set-times = "0.19.0"
-system-interface = { version = "0.25.0", features = ["cap_std_impls"] }
+fs-set-times = { workspace = true }
+system-interface = { workspace = true, features = ["cap_std_impls"] }
 tracing = { workspace = true }
 io-lifetimes = { workspace = true }
 is-terminal = "0.4.0"
 
 [target.'cfg(unix)'.dependencies]
-rustix = { workspace = true, features = ["fs"] }
+rustix = { workspace = true, features = ["fs", "event"] }
 
 [target.'cfg(windows)'.dependencies]
 once_cell = { workspace = true }
-io-extras = "0.17.0"
+io-extras = { workspace = true }
 rustix = { workspace = true, features = ["net"] }
 
 [target.'cfg(windows)'.dependencies.windows-sys]

--- a/crates/wasi-common/cap-std-sync/src/sched/unix.rs
+++ b/crates/wasi-common/cap-std-sync/src/sched/unix.rs
@@ -1,5 +1,5 @@
 use cap_std::time::Duration;
-use rustix::io::{PollFd, PollFlags};
+use rustix::event::{PollFd, PollFlags};
 use std::convert::TryInto;
 use wasi_common::sched::subscription::{RwEventFlags, Subscription};
 use wasi_common::{sched::Poll, Error, ErrorExt};
@@ -44,7 +44,7 @@ pub async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
             poll_fds = tracing::field::debug(&pollfds),
             "poll"
         );
-        match rustix::io::poll(&mut pollfds, poll_timeout) {
+        match rustix::event::poll(&mut pollfds, poll_timeout) {
             Ok(ready) => break ready,
             Err(rustix::io::Errno::INTR) => continue,
             Err(err) => return Err(std::io::Error::from(err).into()),

--- a/crates/wasi-common/src/file.rs
+++ b/crates/wasi-common/src/file.rs
@@ -150,6 +150,7 @@ pub enum FileType {
 }
 
 bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct FdFlags: u32 {
         const APPEND   = 0b1;
         const DSYNC    = 0b10;
@@ -160,6 +161,7 @@ bitflags! {
 }
 
 bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct SdFlags: u32 {
         const RD = 0b1;
         const WR = 0b10;
@@ -167,11 +169,13 @@ bitflags! {
 }
 
 bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct SiFlags: u32 {
     }
 }
 
 bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct RiFlags: u32 {
         const RECV_PEEK    = 0b1;
         const RECV_WAITALL = 0b10;
@@ -179,12 +183,14 @@ bitflags! {
 }
 
 bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct RoFlags: u32 {
         const RECV_DATA_TRUNCATED = 0b1;
     }
 }
 
 bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct OFlags: u32 {
         const CREATE    = 0b1;
         const DIRECTORY = 0b10;
@@ -224,6 +230,7 @@ pub(crate) struct FileEntry {
 }
 
 bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct FileAccessMode : u32 {
         const READ = 0b1;
         const WRITE= 0b10;

--- a/crates/wasi-common/src/sched/subscription.rs
+++ b/crates/wasi-common/src/sched/subscription.rs
@@ -5,6 +5,7 @@ use bitflags::bitflags;
 use cap_std::time::{Duration, Instant};
 
 bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct RwEventFlags: u32 {
         const HANGUP = 0b1;
     }

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -23,9 +23,9 @@ io-lifetimes = { workspace = true }
 rustix = { workspace = true, features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies]
-io-extras = "0.17.0"
+io-extras = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.1.0"
 tokio = { version = "1.8.0", features = [ "macros" ] }
-cap-tempfile = "1.0.0"
+cap-tempfile = { workspace = true }

--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -10,7 +10,7 @@ description = "Experimental HTTP library for WebAssembly in Wasmtime"
 [dependencies]
 anyhow = { workspace = true }
 bytes = "1.1.0"
-hyper = { version = "1.0.0-rc.3", features = ["full"] }
+hyper = { version = "=1.0.0-rc.3", features = ["full"] }
 tokio = { version = "1", default-features = false, features = ["net", "rt-multi-thread", "time"] }
 http = { version = "0.2.9" }
 http-body = "1.0.0-rc.2"

--- a/crates/wasi-preview1-component-adapter/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/Cargo.toml
@@ -11,8 +11,8 @@ wit-bindgen = { workspace = true, default-features = false, features = ["macros"
 byte-array-literals = { workspace = true }
 
 [build-dependencies]
-wasm-encoder = "0.25"
-object = { version = "0.30.0", default-features = false, features = ["archive"] }
+wasm-encoder = { workspace = true }
+object = { workspace = true, default-features = false, features = ["archive"] }
 
 [lib]
 test = false

--- a/crates/wasi-preview1-component-adapter/build.rs
+++ b/crates/wasi-preview1-component-adapter/build.rs
@@ -220,8 +220,8 @@ fn build_raw_intrinsics() -> Vec<u8> {
 
         subsection.encode(&mut linking);
         module.section(&CustomSection {
-            name: "linking",
-            data: &linking,
+            name: "linking".into(),
+            data: linking.into(),
         });
     }
 
@@ -257,8 +257,8 @@ fn build_raw_intrinsics() -> Vec<u8> {
         8u32.encode(&mut reloc); // symbol index
 
         module.section(&CustomSection {
-            name: "reloc.CODE",
-            data: &reloc,
+            name: "reloc.CODE".into(),
+            data: reloc.into(),
         });
     }
 

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -34,10 +34,10 @@ system-interface = { workspace = true, optional = true}
 rustix = { workspace = true, features = ["net"], optional = true}
 
 [target.'cfg(unix)'.dependencies]
-rustix = { workspace = true, features = ["fs"] }
+rustix = { workspace = true, features = ["fs", "event"] }
 
 [target.'cfg(windows)'.dependencies]
-io-extras = "0.17.1"
+io-extras = { workspace = true }
 windows-sys = { workspace = true }
 
 [features]

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -31,10 +31,10 @@ fs-set-times = { workspace = true, optional = true }
 bitflags = { workspace = true, optional = true }
 async-trait = { workspace = true, optional = true }
 system-interface = { workspace = true, optional = true}
-rustix = { workspace = true, features = ["net"], optional = true}
+rustix = { workspace = true, features = ["net", "event"], optional = true}
 
 [target.'cfg(unix)'.dependencies]
-rustix = { workspace = true, features = ["fs", "event"] }
+rustix = { workspace = true, features = ["fs"] }
 
 [target.'cfg(windows)'.dependencies]
 io-extras = { workspace = true }

--- a/crates/wasi/src/preview2/filesystem.rs
+++ b/crates/wasi/src/preview2/filesystem.rs
@@ -3,6 +3,7 @@ use std::any::Any;
 use std::sync::Arc;
 
 bitflags::bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct FilePerms: usize {
         const READ = 0b1;
         const WRITE = 0b10;
@@ -63,6 +64,7 @@ impl TableFsExt for Table {
 }
 
 bitflags::bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct DirPerms: usize {
         const READ = 0b1;
         const MUTATE = 0b10;

--- a/crates/wasi/src/preview2/sched/subscription.rs
+++ b/crates/wasi/src/preview2/sched/subscription.rs
@@ -6,6 +6,7 @@ use anyhow::Error;
 use bitflags::bitflags;
 
 bitflags! {
+    #[derive(Copy, Clone, Debug, PartialEq, Eq)]
     pub struct RwEventFlags: u32 {
         const HANGUP = 0b1;
     }

--- a/crates/wasi/src/preview2/sched/sync.rs
+++ b/crates/wasi/src/preview2/sched/sync.rs
@@ -2,7 +2,7 @@ use crate::preview2::sched::{
     subscription::{RwEventFlags, RwStream},
     Poll, WasiSched,
 };
-use rustix::io::{PollFd, PollFlags};
+use rustix::event::{PollFd, PollFlags};
 use std::thread;
 use std::time::Duration;
 
@@ -96,7 +96,7 @@ pub(crate) async fn poll_oneoff<'a>(poll: &mut Poll<'a>) -> Result<(), Error> {
                 poll_fds = tracing::field::debug(&pollfds),
                 "poll"
             );
-            match rustix::io::poll(&mut pollfds, poll_timeout) {
+            match rustix::event::poll(&mut pollfds, poll_timeout) {
                 Ok(_num_ready) => {
                     ready = true;
                     break;

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -463,7 +463,7 @@ impl FrameInfo {
         if let Some(s) = &module.symbolize_context().ok().and_then(|c| c) {
             if let Some(offset) = instr.and_then(|i| i.file_offset()) {
                 let to_lookup = u64::from(offset) - s.code_section_offset();
-                if let Ok(mut frames) = s.addr2line().find_frames(to_lookup) {
+                if let Ok(mut frames) = s.addr2line().find_frames(to_lookup).skip_all_loads() {
                     while let Ok(Some(frame)) = frames.next() {
                         symbols.push(FrameSymbol {
                             name: frame

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -19,5 +19,5 @@ quote = "1.0"
 proc-macro2 = "1.0"
 heck = { workspace = true }
 anyhow = { workspace = true }
-syn = { version = "1.0", features = ["full"] }
+syn = { workspace = true, features = ["full"] }
 shellexpand = "2.0"

--- a/crates/wiggle/generate/src/config.rs
+++ b/crates/wiggle/generate/src/config.rs
@@ -164,7 +164,7 @@ impl Parse for Config {
         let contents;
         let _lbrace = braced!(contents in input);
         let fields: Punctuated<ConfigField, Token![,]> =
-            contents.parse_terminated(ConfigField::parse)?;
+            contents.parse_terminated(ConfigField::parse, Token![,])?;
         Ok(Config::build(fields.into_iter(), input.span())?)
     }
 }
@@ -239,7 +239,8 @@ impl Parse for Paths {
     fn parse(input: ParseStream) -> Result<Self> {
         let content;
         let _ = bracketed!(content in input);
-        let path_lits: Punctuated<LitStr, Token![,]> = content.parse_terminated(Parse::parse)?;
+        let path_lits: Punctuated<LitStr, Token![,]> =
+            content.parse_terminated(Parse::parse, Token![,])?;
 
         let expanded_paths = path_lits
             .iter()
@@ -287,7 +288,7 @@ impl Parse for ErrorConf {
         let content;
         let _ = braced!(content in input);
         let items: Punctuated<ErrorConfField, Token![,]> =
-            content.parse_terminated(Parse::parse)?;
+            content.parse_terminated(Parse::parse, Token![,])?;
         let mut m = HashMap::new();
         for i in items {
             match m.insert(i.abi_error().clone(), i.clone()) {
@@ -466,7 +467,7 @@ impl Parse for AsyncFunctions {
         if lookahead.peek(syn::token::Brace) {
             let _ = braced!(content in input);
             let items: Punctuated<FunctionField, Token![,]> =
-                content.parse_terminated(Parse::parse)?;
+                content.parse_terminated(Parse::parse, Token![,])?;
             let mut functions: HashMap<String, Vec<String>> = HashMap::new();
             use std::collections::hash_map::Entry;
             for i in items {
@@ -509,7 +510,7 @@ impl Parse for FunctionField {
             let content;
             let _ = braced!(content in input);
             let function_names: Punctuated<Ident, Token![,]> =
-                content.parse_terminated(Parse::parse)?;
+                content.parse_terminated(Parse::parse, Token![,])?;
             Ok(FunctionField {
                 module_name,
                 function_names: function_names.iter().cloned().collect(),
@@ -569,7 +570,7 @@ impl Parse for WasmtimeConfig {
         let contents;
         let _lbrace = braced!(contents in input);
         let fields: Punctuated<WasmtimeConfigField, Token![,]> =
-            contents.parse_terminated(WasmtimeConfigField::parse)?;
+            contents.parse_terminated(WasmtimeConfigField::parse, Token![,])?;
         Ok(WasmtimeConfig::build(fields.into_iter(), input.span())?)
     }
 }
@@ -665,7 +666,7 @@ impl Parse for TracingConf {
             let content;
             let _ = braced!(content in input);
             let items: Punctuated<FunctionField, Token![,]> =
-                content.parse_terminated(Parse::parse)?;
+                content.parse_terminated(Parse::parse, Token![,])?;
             let mut functions: HashMap<String, Vec<String>> = HashMap::new();
             use std::collections::hash_map::Entry;
             for i in items {

--- a/crates/wiggle/generate/src/types/flags.rs
+++ b/crates/wiggle/generate/src/types/flags.rs
@@ -23,6 +23,7 @@ pub(super) fn define_flags(
 
     quote! {
         wiggle::bitflags::bitflags! {
+            #[derive(Copy, Clone, Debug, PartialEq, Eq)]
             pub struct #ident: #repr {
                 #(const #names_ = #values_;)*
             }
@@ -34,7 +35,7 @@ pub(super) fn define_flags(
                 f.write_str("(")?;
                 ::std::fmt::Debug::fmt(self, f)?;
                 f.write_str(" (0x")?;
-                ::std::fmt::LowerHex::fmt(&self.bits, f)?;
+                ::std::fmt::LowerHex::fmt(&self.bits(), f)?;
                 f.write_str("))")?;
                 Ok(())
             }
@@ -47,7 +48,7 @@ pub(super) fn define_flags(
                 if #repr::from(!#ident::all()) & value != 0 {
                     Err(wiggle::GuestError::InvalidFlagValue(stringify!(#ident)))
                 } else {
-                    Ok(#ident { bits: value })
+                    Ok(#ident::from_bits_truncate(value))
                 }
             }
         }
@@ -63,7 +64,7 @@ pub(super) fn define_flags(
         impl From<#ident> for #repr {
             #[inline]
             fn from(e: #ident) -> #repr {
-                e.bits
+                e.bits()
             }
         }
 

--- a/crates/wiggle/generate/src/types/flags.rs
+++ b/crates/wiggle/generate/src/types/flags.rs
@@ -45,11 +45,8 @@ pub(super) fn define_flags(
             type Error = wiggle::GuestError;
             #[inline]
             fn try_from(value: #repr) -> Result<Self, wiggle::GuestError> {
-                if #repr::from(!#ident::all()) & value != 0 {
-                    Err(wiggle::GuestError::InvalidFlagValue(stringify!(#ident)))
-                } else {
-                    Ok(#ident::from_bits_truncate(value))
-                }
+                #ident::from_bits(value)
+                    .ok_or(wiggle::GuestError::InvalidFlagValue(stringify!(#ident)))
             }
         }
 

--- a/crates/wiggle/macro/Cargo.toml
+++ b/crates/wiggle/macro/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 [dependencies]
 wiggle-generate = { workspace = true }
 quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+syn = { workspace = true, features = ["full"] }
 proc-macro2 = "1.0"
 
 [dev-dependencies]

--- a/crates/wiggle/tests/flags.rs
+++ b/crates/wiggle/tests/flags.rs
@@ -103,11 +103,11 @@ proptest! {
 #[test]
 fn flags_fmt() {
     let empty = format!("{}", types::CarConfig::empty());
-    assert_eq!(empty, "CarConfig((empty) (0x0))");
+    assert_eq!(empty, "CarConfig(CarConfig(0x0) (0x0))");
     let one_flag = format!("{}", types::CarConfig::AWD);
-    assert_eq!(one_flag, "CarConfig(AWD (0x2))");
+    assert_eq!(one_flag, "CarConfig(CarConfig(AWD) (0x2))");
     let two_flags = format!("{}", types::CarConfig::AUTOMATIC | types::CarConfig::SUV);
-    assert_eq!(two_flags, "CarConfig(AUTOMATIC | SUV (0x5))");
+    assert_eq!(two_flags, "CarConfig(CarConfig(AUTOMATIC | SUV) (0x5))");
     let all = format!("{}", types::CarConfig::all());
-    assert_eq!(all, "CarConfig(AUTOMATIC | AWD | SUV (0x7))");
+    assert_eq!(all, "CarConfig(CarConfig(AUTOMATIC | AWD | SUV) (0x7))");
 }

--- a/deny.toml
+++ b/deny.toml
@@ -53,9 +53,9 @@ skip-tree = [
     # dependencies relative to Wasmtime's main dependency tree.
     { name = "witx", depth = 20 },
 
-    # This is somewhat unmaintained at this point and seems to pull in an old
-    # version of `env_logger`, so ignore it.
-    { name = "pretty_env_logger", depth = 20 },
+    # The openvino-sys crate uses an older version of `pretty_env_logger` so
+    # ignore its dependency tree for now until it updates.
+    { name = "openvino-sys", depth = 20 },
 
     # They want to publish version 2.0 to upgrade `hashbrown` so in the meantime
     # it is duplicated for us.

--- a/deny.toml
+++ b/deny.toml
@@ -44,10 +44,9 @@ skip-tree = [
     # the multiple-versions errors it will introduce.
     { name = "wit-bindgen", depth = 20 },
 
-    # Criterion 0.3 is pretty old at this point and has had an upcoming 0.4 for
-    # a long time. This is a dev-dependency so we don't really mind its
-    # dependency tree, so skip it entirely.
-    { name = "criterion", depth = 20 },
+    # proptest depends on bitflags 1.x.x while other crates depend on 2.x.x so
+    # ignore its dependency tree until it updates.
+    { name = "proptest", depth = 20 },
 
     # This is maintained externally and we allow it to have duplicate
     # dependencies relative to Wasmtime's main dependency tree.

--- a/deny.toml
+++ b/deny.toml
@@ -61,10 +61,6 @@ skip-tree = [
     # it is duplicated for us.
     { name = "indexmap", depth = 2 },
 
-    # This is on and older version of `wasm-encoder` and is one we can't
-    # necessarily easily update, so let `wasm-encoder` get duplicated for now.
-    { name = "wasm-coredump-builder", depth = 2 },
-
     # The native-tls crate hasn't kept up with updates to the underlying
     # windows-sys, while the rest of the ecosystem has. This duplicated
     # dependency appears to be benign.

--- a/deny.toml
+++ b/deny.toml
@@ -59,9 +59,4 @@ skip-tree = [
     # They want to publish version 2.0 to upgrade `hashbrown` so in the meantime
     # it is duplicated for us.
     { name = "indexmap", depth = 2 },
-
-    # The native-tls crate hasn't kept up with updates to the underlying
-    # windows-sys, while the rest of the ecosystem has. This duplicated
-    # dependency appears to be benign.
-    { name = "windows-sys", depth = 3 },
 ]

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -4,7 +4,7 @@
 //! See `wasmtime --help` for usage.
 
 use anyhow::Result;
-use clap::{ErrorKind, Parser};
+use clap::{error::ErrorKind, Parser};
 use wasmtime_cli::commands::{
     CompileCommand, ConfigCommand, ExploreCommand, RunCommand, SettingsCommand, WastCommand,
 };
@@ -62,10 +62,16 @@ impl Wasmtime {
 fn main() -> Result<()> {
     Wasmtime::try_parse()
         .unwrap_or_else(|e| match e.kind() {
-            ErrorKind::UnrecognizedSubcommand | ErrorKind::UnknownArgument => {
+            ErrorKind::InvalidSubcommand | ErrorKind::UnknownArgument => {
                 Wasmtime::Run(RunCommand::parse())
             }
             _ => e.exit(),
         })
         .execute()
+}
+
+#[test]
+fn verify_cli() {
+    use clap::CommandFactory;
+    Wasmtime::command().debug_assert()
 }

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -47,15 +47,15 @@ pub struct CompileCommand {
     target: Option<String>,
 
     /// The path of the output compiled module; defaults to <MODULE>.cwasm
-    #[clap(short = 'o', long, value_name = "OUTPUT", parse(from_os_str))]
+    #[clap(short = 'o', long, value_name = "OUTPUT")]
     output: Option<PathBuf>,
 
     /// The directory path to write clif files into, one clif file per wasm function.
-    #[clap(long = "emit-clif", value_name = "PATH", parse(from_os_str))]
+    #[clap(long = "emit-clif", value_name = "PATH")]
     emit_clif: Option<PathBuf>,
 
     /// The path of the WebAssembly to compile
-    #[clap(index = 1, value_name = "MODULE", parse(from_os_str))]
+    #[clap(index = 1, value_name = "MODULE")]
     module: PathBuf,
 }
 

--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -22,7 +22,7 @@ pub struct WastCommand {
     common: CommonOptions,
 
     /// The path of the WebAssembly test script to run
-    #[clap(required = true, value_name = "SCRIPT_FILE", parse(from_os_str))]
+    #[clap(required = true, value_name = "SCRIPT_FILE")]
     scripts: Vec<PathBuf>,
 }
 

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -670,6 +670,12 @@ This is a minor update for addr2line which looks to mainly update its
 dependencies and refactor existing code to expose more functionality and such.
 """
 
+[[audits.addr2line]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.19.0 -> 0.20.0"
+notes = "This version brings support for split-dwarf which while it uses the filesystem is always done at the behest of the caller, so everything is as expected for this update."
+
 [[audits.ahash]]
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
@@ -1233,6 +1239,12 @@ more features, etc. Some minor `unsafe` code was added that does not appear
 incorrect. Otherwise looks like someone probably ran clippy and/or rustfmt.
 """
 
+[[audits.gimli]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.27.0 -> 0.27.3"
+notes = "More support for more DWARF, nothing major in this update. Some small refactorings and updates to publication of the package but otherwise everything's in order."
+
 [[audits.glob]]
 who = "Jamey Sharp <jsharp@fastly.com>"
 criteria = "safe-to-deploy"
@@ -1402,6 +1414,12 @@ ensure that the ABI it describes matches the ABI described by the C header
 files in the correspond to match.
 """
 
+[[audits.libc]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.146 -> 0.2.147"
+notes = "Only new type definitions and updating others for some platforms, no major changes"
+
 [[audits.libfuzzer-sys]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-run"
@@ -1519,6 +1537,12 @@ notes = """
 No unsafe blocks or I/O in the diff. The only changes clearly implement what
 the changelog says is new in these versions.
 """
+
+[[audits.object]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.30.3 -> 0.31.1"
+notes = "A large-ish update to the crate but nothing out of the ordering. Support for new formats like xcoff, new constants, minor refactorings, etc. Nothing out of the ordinary."
 
 [[audits.once_cell]]
 who = "Chris Fallin <chris@cfallin.org>"
@@ -2710,6 +2734,12 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-07-23"
 end = "2024-07-06"
+
+[[trusted.backtrace]]
+criteria = "safe-to-deploy"
+user-id = 2915 # Amanieu d'Antras (Amanieu)
+start = "2023-06-29"
+end = "2024-07-14"
 
 [[trusted.clap]]
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -676,6 +676,12 @@ criteria = "safe-to-deploy"
 delta = "0.19.0 -> 0.20.0"
 notes = "This version brings support for split-dwarf which while it uses the filesystem is always done at the behest of the caller, so everything is as expected for this update."
 
+[[audits.adler]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "1.0.2"
+notes = "This is a small crate which forbids unsafe code and is a straightforward implementation of the adler hashing algorithm."
+
 [[audits.ahash]]
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
@@ -1510,6 +1516,20 @@ contains no significant changes.
 
 [[audits.miniz_oxide]]
 who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.7.1"
+notes = """
+This crate is a Rust implementation of zlib compression/decompression and has
+been used by default by the Rust standard library for quite some time. It's also
+a default dependency of the popular `backtrace` crate for decompressing debug
+information. This crate forbids unsafe code and does not otherwise access system
+resources. It's originally a port of the `miniz.c` library as well, and given
+its own longevity should be relatively hardened against some of the more common
+compression-related issues.
+"""
+
+[[audits.miniz_oxide]]
+who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-run"
 delta = "0.5.1 -> 0.5.3"
 notes = """
@@ -1517,6 +1537,12 @@ This looks to be a minor update to the crate to remove some `unsafe` code,
 update Rust stylistic conventions, and perhaps some clippy lints. No major
 changes.
 """
+
+[[audits.mio]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.6 -> 0.8.8"
+notes = "Mostly OS portability updates along with some minor bugfixes."
 
 [[audits.native-tls]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -1802,6 +1828,12 @@ few minor issues related to Stacked Borrows and running in MIRI. No fundamental
 change to any preexisting unsafe code is happening here.
 """
 
+[[audits.socket2]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.7 -> 0.4.9"
+notes = "Minor OS compat updates but otherwise nothing major here."
+
 [[audits.spin]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-run"
@@ -1864,6 +1896,12 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 delta = "3.3.0 -> 3.5.0"
 
+[[audits.tempfile]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "3.5.0 -> 3.6.0"
+notes = "Dependency updates and new optimized trait implementations, but otherwise everything looks normal."
+
 [[audits.test-log]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -1898,6 +1936,12 @@ This looks to be a minor release primarily to fix a security-related Windows
 issue plus some reorganization around lazy initialization. Altogether nothing
 amiss here.
 """
+
+[[audits.tokio-macros]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.7.0 -> 2.1.0"
+notes = "A number of updates to parsed syntax and such but nothing unexpected and entirely what one would expect a Rust procedural macro to do."
 
 [[audits.tokio-native-tls]]
 who = "Pat Hickey <phickey@fastly.com>"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1602,6 +1602,12 @@ criteria = "safe-to-deploy"
 version = "0.3.25"
 notes = "This crate shells out to the pkg-config executable, but it appears to sanitize inputs reasonably."
 
+[[audits.pretty_env_logger]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.5.0"
+notes = "This is a minor update which bumps the `env_logger` dependency and has other formatting, no major changes."
+
 [[audits.proc-macro2]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1520,6 +1520,12 @@ criteria = "safe-to-deploy"
 delta = "0.7.1 -> 0.8.0"
 notes = "This was a small update to the crate which has to do with Rust language features and compiler versions, no substantial changes."
 
+[[audits.memoffset]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.8.0 -> 0.9.0"
+notes = "No major changes in the crate, mostly updates to use new nightly Rust features."
+
 [[audits.memory_units]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-run"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -793,6 +793,15 @@ with that library enabled, but I believe the impls satisfy the documented
 safety requirements for bytemuck. The other changes are minor.
 """
 
+[[audits.bitflags]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.3.2 -> 2.3.3"
+notes = """
+Nothing outside the realm of what one would expect from a bitflags generator,
+all as expected.
+"""
+
 [[audits.block-buffer]]
 who = "Benjamin Bouvier <public@benj.me>"
 criteria = "safe-to-deploy"
@@ -2797,6 +2806,42 @@ user-id = 2915 # Amanieu d'Antras (Amanieu)
 start = "2023-06-29"
 end = "2024-07-14"
 
+[[trusted.cap-fs-ext]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2020-12-11"
+end = "2024-07-14"
+
+[[trusted.cap-primitives]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2020-08-07"
+end = "2024-07-14"
+
+[[trusted.cap-rand]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2020-09-24"
+end = "2024-07-14"
+
+[[trusted.cap-std]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2020-06-25"
+end = "2024-07-14"
+
+[[trusted.cap-tempfile]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2020-08-07"
+end = "2024-07-14"
+
+[[trusted.cap-time-ext]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2020-09-21"
+end = "2024-07-14"
+
 [[trusted.clap]]
 criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)
@@ -2827,6 +2872,24 @@ user-id = 539 # Josh Stone (cuviper)
 start = "2023-02-05"
 end = "2024-07-11"
 
+[[trusted.fd-lock]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2022-01-21"
+end = "2024-07-14"
+
+[[trusted.filecheck]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2020-03-17"
+end = "2024-07-14"
+
+[[trusted.fs-set-times]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2020-09-15"
+end = "2024-07-14"
+
 [[trusted.hashbrown]]
 criteria = "safe-to-deploy"
 user-id = 2915 # Amanieu d'Antras (Amanieu)
@@ -2838,6 +2901,24 @@ criteria = "safe-to-deploy"
 user-id = 539 # Josh Stone (cuviper)
 start = "2020-01-15"
 end = "2024-07-06"
+
+[[trusted.io-extras]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2021-11-09"
+end = "2024-07-14"
+
+[[trusted.io-lifetimes]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2021-06-12"
+end = "2024-07-14"
+
+[[trusted.is-terminal]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2022-01-22"
+end = "2024-07-14"
 
 [[trusted.itoa]]
 criteria = "safe-to-deploy"
@@ -2856,6 +2937,12 @@ criteria = "safe-to-deploy"
 user-id = 2915 # Amanieu d'Antras (Amanieu)
 start = "2022-02-06"
 end = "2024-07-06"
+
+[[trusted.linux-raw-sys]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2021-06-12"
+end = "2024-07-14"
 
 [[trusted.lock_api]]
 criteria = "safe-to-deploy"
@@ -2886,6 +2973,12 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-04-09"
 end = "2024-07-11"
+
+[[trusted.rustix]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2021-10-29"
+end = "2024-07-14"
 
 [[trusted.ryu]]
 criteria = "safe-to-deploy"
@@ -2922,6 +3015,18 @@ criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
 start = "2019-03-01"
 end = "2024-07-06"
+
+[[trusted.system-interface]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2020-10-27"
+end = "2024-07-14"
+
+[[trusted.target-lexicon]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2019-03-06"
+end = "2024-07-14"
 
 [[trusted.thiserror]]
 criteria = "safe-to-deploy"
@@ -3024,3 +3129,9 @@ criteria = "safe-to-deploy"
 user-id = 64539 # Kenny Kerr (kennykerr)
 start = "2021-10-27"
 end = "2024-06-17"
+
+[[trusted.winx]]
+criteria = "safe-to-deploy"
+user-id = 6825 # Dan Gohman (sunfishcode)
+start = "2019-08-20"
+end = "2024-07-14"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2675,6 +2675,36 @@ criteria = "safe-to-deploy"
 version = "0.6.4"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[trusted.anstream]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-16"
+end = "2024-07-14"
+
+[[trusted.anstyle]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2022-05-18"
+end = "2024-07-14"
+
+[[trusted.anstyle-parse]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-08"
+end = "2024-07-14"
+
+[[trusted.anstyle-query]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-04-13"
+end = "2024-07-14"
+
+[[trusted.anstyle-wincon]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-08"
+end = "2024-07-14"
+
 [[trusted.async-trait]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)
@@ -2686,6 +2716,12 @@ criteria = "safe-to-deploy"
 user-id = 6743 # Ed Page (epage)
 start = "2021-12-08"
 end = "2024-07-06"
+
+[[trusted.clap_builder]]
+criteria = "safe-to-deploy"
+user-id = 6743 # Ed Page (epage)
+start = "2023-03-28"
+end = "2024-07-14"
 
 [[trusted.clap_derive]]
 criteria = "safe-to-deploy"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1079,6 +1079,12 @@ criteria = "safe-to-deploy"
 version = "1.1.4"
 notes = "I am the author of this crate."
 
+[[audits.derive_arbitrary]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "1.3.0 -> 1.3.1"
+notes = "This updates `syn` to 2.x.x, nothing else in this diff."
+
 [[audits.digest]]
 who = "Benjamin Bouvier <public@benj.me>"
 criteria = "safe-to-deploy"
@@ -1960,6 +1966,12 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.7.4"
 notes = "Alex Crichton audited the safety of src/sync/reusable_box.rs, I audited the remainder of the crate."
+
+[[audits.tracing-attributes]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.1.21 -> 0.1.26"
+notes = "This range notably updated `syn` to 2.x.x and otherwise adds a few features here and there but nothing out of the ordering for a procedural macro."
 
 [[audits.try-lock]]
 who = "Pat Hickey <phickey@fastly.com>"
@@ -2928,6 +2940,36 @@ criteria = "safe-to-deploy"
 user-id = 1 # Alex Crichton (alexcrichton)
 start = "2019-05-16"
 end = "2024-07-06"
+
+[[trusted.wasm-bindgen]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2024-07-14"
+
+[[trusted.wasm-bindgen-backend]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2024-07-14"
+
+[[trusted.wasm-bindgen-macro]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2024-07-14"
+
+[[trusted.wasm-bindgen-macro-support]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2024-07-14"
+
+[[trusted.wasm-bindgen-shared]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2019-03-04"
+end = "2024-07-14"
 
 [[trusted.windows-sys]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -401,10 +401,6 @@ criteria = "safe-to-deploy"
 version = "0.10.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.filecheck]]
-version = "0.5.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.filetime]]
 version = "0.2.16"
 criteria = "safe-to-run"
@@ -821,10 +817,6 @@ criteria = "safe-to-deploy"
 [[exemptions.symbolic_expressions]]
 version = "5.0.3"
 criteria = "safe-to-run"
-
-[[exemptions.target-lexicon]]
-version = "0.12.3"
-criteria = "safe-to-deploy"
 
 [[exemptions.tempfile]]
 version = "3.3.0"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -197,10 +197,6 @@ audit-as-crates-io = false
 version = "0.17.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.adler]]
-version = "1.0.2"
-criteria = "safe-to-run"
-
 [[exemptions.aead]]
 version = "0.4.3"
 criteria = "safe-to-deploy"
@@ -855,7 +851,7 @@ version = "1.2.1"
 criteria = "safe-to-run"
 
 [[exemptions.tokio]]
-version = "1.26.0"
+version = "1.29.1"
 criteria = "safe-to-deploy"
 notes = "we are exempting tokio, hyper, and their tightly coupled dependencies by the same authors, expecting that the authors at aws will publish attestions we can import at some point soon"
 

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -903,26 +903,6 @@ criteria = "safe-to-deploy"
 version = "0.11.0+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
 
-[[exemptions.wasm-bindgen]]
-version = "0.2.80"
-criteria = "safe-to-deploy"
-notes = "dependency of ring for wasm32 browser platform, which our project does not target"
-
-[[exemptions.wasm-bindgen-backend]]
-version = "0.2.80"
-criteria = "safe-to-deploy"
-notes = "dependency of ring for wasm32 browser platform, which our project does not target"
-
-[[exemptions.wasm-bindgen-macro]]
-version = "0.2.80"
-criteria = "safe-to-deploy"
-notes = "dependency of ring for wasm32 browser platform, which our project does not target"
-
-[[exemptions.wasm-bindgen-macro-support]]
-version = "0.2.80"
-criteria = "safe-to-deploy"
-notes = "dependency of ring for wasm32 browser platform, which our project does not target"
-
 [[exemptions.web-sys]]
 version = "0.3.57"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -397,6 +397,41 @@ audited_as = "0.8.1"
 version = "0.10.0"
 audited_as = "0.8.1"
 
+[[publisher.anstream]]
+version = "0.3.2"
+when = "2023-05-01"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.anstyle]]
+version = "1.0.1"
+when = "2023-06-20"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.anstyle-parse]]
+version = "0.2.1"
+when = "2023-06-20"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.anstyle-query]]
+version = "1.0.0"
+when = "2023-04-13"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.anstyle-wincon]]
+version = "1.0.1"
+when = "2023-04-24"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
 [[publisher.arbitrary]]
 version = "1.3.0"
 when = "2023-03-13"
@@ -425,6 +460,20 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.clap]]
+version = "4.3.12"
+when = "2023-07-14"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.clap_builder]]
+version = "4.3.12"
+when = "2023-07-14"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
 [[publisher.clap_derive]]
 version = "3.2.7"
 when = "2022-06-28"
@@ -432,9 +481,23 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.clap_derive]]
+version = "4.3.12"
+when = "2023-07-14"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
 [[publisher.clap_lex]]
 version = "0.2.4"
 when = "2022-06-28"
+user-id = 6743
+user-login = "epage"
+user-name = "Ed Page"
+
+[[publisher.clap_lex]]
+version = "0.5.0"
+when = "2023-05-19"
 user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
@@ -1277,6 +1340,12 @@ who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
 version = "1.0.58"
 
+[[audits.embark-studios.audits.colorchoice]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "1.0.0"
+notes = "No unsafe usage or ambient capabilities"
+
 [[audits.embark-studios.audits.cty]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -1298,6 +1367,12 @@ Builds C/asm dependency which this review has not audited in detail, but is well
 Exposes FFI types & functions generated through bindgen. No other logic.
 No ambient capabilities
 """
+
+[[audits.embark-studios.audits.utf8parse]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.2.1"
+notes = "Single unsafe usage that looks sound, no ambient capabilities"
 
 [[audits.embark-studios.audits.valuable]]
 who = "Johan Andersson <opensource@embark-studios.com>"
@@ -1366,6 +1441,11 @@ aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 version = "0.9.0"
+
+[[audits.isrg.audits.criterion]]
+who = "Brandon Pitman <bran@bran.land>"
+criteria = "safe-to-run"
+delta = "0.4.0 -> 0.5.1"
 
 [[audits.isrg.audits.libc]]
 who = "Brandon Pitman <bran@bran.land>"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -446,6 +446,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.async-trait]]
+version = "0.1.71"
+when = "2023-07-05"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.backtrace]]
 version = "0.3.68"
 when = "2023-06-29"
@@ -806,9 +813,23 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.thiserror]]
+version = "1.0.43"
+when = "2023-07-07"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.thiserror-impl]]
 version = "1.0.31"
 when = "2022-04-30"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
+[[publisher.thiserror-impl]]
+version = "1.0.43"
+when = "2023-07-07"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
@@ -858,6 +879,41 @@ version = "10.0.1"
 when = "2023-06-21"
 user-id = 73222
 user-login = "wasmtime-publish"
+
+[[publisher.wasm-bindgen]]
+version = "0.2.87"
+when = "2023-06-12"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-backend]]
+version = "0.2.87"
+when = "2023-06-12"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-macro]]
+version = "0.2.87"
+when = "2023-06-12"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-macro-support]]
+version = "0.2.87"
+when = "2023-06-12"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-bindgen-shared]]
+version = "0.2.87"
+when = "2023-06-12"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
 
 [[publisher.wasm-encoder]]
 version = "0.29.0"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -446,6 +446,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.backtrace]]
+version = "0.3.68"
+when = "2023-06-29"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
 [[publisher.bumpalo]]
 version = "3.12.0"
 when = "2023-01-17"
@@ -649,6 +656,13 @@ user-name = "David Tolnay"
 [[publisher.libc]]
 version = "0.2.132"
 when = "2022-08-16"
+user-id = 2915
+user-login = "Amanieu"
+user-name = "Amanieu d'Antras"
+
+[[publisher.libc]]
+version = "0.2.146"
+when = "2023-06-06"
 user-id = 2915
 user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
@@ -1417,6 +1431,12 @@ aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-run"
 version = "0.6.2"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.miniz_oxide]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+delta = "0.6.2 -> 0.7.1"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.google.audits.proc-macro-error-attr]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -467,6 +467,48 @@ user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
+[[publisher.cap-fs-ext]]
+version = "2.0.0"
+when = "2023-06-30"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.cap-primitives]]
+version = "2.0.0"
+when = "2023-06-30"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.cap-rand]]
+version = "2.0.0"
+when = "2023-06-30"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.cap-std]]
+version = "2.0.0"
+when = "2023-06-30"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.cap-tempfile]]
+version = "2.0.0"
+when = "2023-06-30"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.cap-time-ext]]
+version = "2.0.0"
+when = "2023-06-30"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
 [[publisher.clap]]
 version = "3.2.8"
 when = "2022-06-30"
@@ -632,6 +674,27 @@ user-id = 539
 user-login = "cuviper"
 user-name = "Josh Stone"
 
+[[publisher.fd-lock]]
+version = "4.0.0"
+when = "2023-06-30"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.filecheck]]
+version = "0.5.0"
+when = "2020-03-17"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.fs-set-times]]
+version = "0.20.0"
+when = "2023-06-29"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
 [[publisher.hashbrown]]
 version = "0.14.0"
 when = "2023-06-05"
@@ -652,6 +715,27 @@ when = "2023-06-23"
 user-id = 539
 user-login = "cuviper"
 user-name = "Josh Stone"
+
+[[publisher.io-extras]]
+version = "0.18.0"
+when = "2023-06-11"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.io-lifetimes]]
+version = "2.0.2"
+when = "2023-06-30"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.is-terminal]]
+version = "0.4.9"
+when = "2023-07-06"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
 
 [[publisher.itoa]]
 version = "1.0.1"
@@ -680,6 +764,13 @@ when = "2023-05-15"
 user-id = 2915
 user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
+
+[[publisher.linux-raw-sys]]
+version = "0.4.3"
+when = "2023-06-14"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
 
 [[publisher.lock_api]]
 version = "0.4.7"
@@ -729,6 +820,13 @@ when = "2023-07-14"
 user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"
+
+[[publisher.rustix]]
+version = "0.38.4"
+when = "2023-07-11"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
 
 [[publisher.ryu]]
 version = "1.0.9"
@@ -805,6 +903,20 @@ when = "2023-07-09"
 user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
+
+[[publisher.system-interface]]
+version = "0.26.0"
+when = "2023-06-30"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
+[[publisher.target-lexicon]]
+version = "0.12.3"
+when = "2022-02-01"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
 
 [[publisher.thiserror]]
 version = "1.0.31"
@@ -1334,6 +1446,13 @@ user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
+[[publisher.winx]]
+version = "0.36.1"
+when = "2023-06-29"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
 [[publisher.wit-bindgen]]
 version = "0.7.0"
 when = "2023-05-26"
@@ -1648,6 +1767,12 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Nicolas Silva <nical@fastmail.com>"
 criteria = "safe-to-deploy"
 delta = "2.0.2 -> 2.1.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Teodor Tanasoaia <ttanasoaia@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.2.1 -> 2.3.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.crypto-common]]

--- a/winch/test-macros/Cargo.toml
+++ b/winch/test-macros/Cargo.toml
@@ -15,6 +15,6 @@ doctest = false
 
 [dependencies]
 quote = "1.0"
-syn = { version = "1.0", features = ["full"]}
+syn = { workspace = true, features = ["full"]}
 proc-macro2 = "1.0"
 glob = { workspace = true }


### PR DESCRIPTION
This PR is a series of commits to handle a number of updates to dependencies in Wasmtime. I've separated out each dependency by commit to see what's going on. The biggest upgrades were `syn 2.x.x`, `clap 4.x.x`, and `bitflags 2.x.x`. All the other updates were mostly minor.

In terms of vetting I've added a number of new trusted annotations crates that are authored by those we already trust (e.g. me, Dan, epage, etc). I've additionally performed a variety of audits for new versions that aren't covered by our preexisting policies.

At some point we need to revisit `cargo deny`'s configuration because we have quite a few duplicated dependencies which aren't being caught by `cargo deny` and I'm not entirely sure why. I think that our ignore list is too aggressive and/or not interacting well with how `cargo deny` works. I'll try to poke at this in the future.