### PR TITLE
[11.0.0] Lock dependency on hyper to a single version

### DIFF
--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -10,7 +10,7 @@ description = "Experimental HTTP library for WebAssembly in Wasmtime"
 [dependencies]
 anyhow = { workspace = true }
 bytes = "1.1.0"
-hyper = { version = "1.0.0-rc.3", features = ["full"] }
+hyper = { version = "=1.0.0-rc.3", features = ["full"] }
 tokio = { version = "1", default-features = false, features = ["net", "rt-multi-thread", "time"] }
 http = { version = "0.2.9" }
 http-body = "1.0.0-rc.2"


### PR DESCRIPTION
This is a backport of https://github.com/bytecodealliance/wasmtime/pull/6729 to the 11.0.0 release branch to fix `cargo install` for the upcoming release.