### PR TITLE
Cap the maximum basic block padding in Cranelift

### DIFF
--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1059,13 +1059,13 @@ impl<I: VCodeInst> VCode<I> {
             // Padding can get quite large during fuzzing though so place a
             // total cap on it where when a per-function threshold is exceeded
             // the padding is turned back down to zero. This avoids a small-ish
-            // test case generating a 2GB memory footprint in Cranelift for
+            // test case generating a GB+ memory footprint in Cranelift for
             // example.
             if !bb_padding.is_empty() {
                 buffer.put_data(&bb_padding);
                 buffer.align_to(I::LabelUse::ALIGN);
                 total_bb_padding += bb_padding.len();
-                if total_bb_padding > (1 << 20) {
+                if total_bb_padding > (64 << 20) {
                     bb_padding = Vec::new();
                 }
             }

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1065,7 +1065,7 @@ impl<I: VCodeInst> VCode<I> {
                 buffer.put_data(&bb_padding);
                 buffer.align_to(I::LabelUse::ALIGN);
                 total_bb_padding += bb_padding.len();
-                if total_bb_padding > (64 << 20) {
+                if total_bb_padding > (150 << 20) {
                     bb_padding = Vec::new();
                 }
             }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -214,7 +214,7 @@ impl Config {
         //
         // To keep this setting under control there are a few limits in place:
         //
-        // * Cranelift will generate at most 64M of padding per-function,
+        // * Cranelift will generate at most 150M of padding per-function,
         //   regardless of how many basic blocks there are.
         // * Here it's limited to enable this setting only when there's at most
         //   10 functions to ensure that the overhead for all functions is <1G
@@ -226,11 +226,11 @@ impl Config {
         // With all that combined this is intended to still be enabled,
         // although perhaps not all the time, and stress enough interesting test
         // cases in cranelift.
-        if self.module_config.config.max_funcs < 10 {
+        if self.module_config.config.max_funcs < 5 {
             unsafe {
                 cfg.cranelift_flag_set(
                     "bb_padding_log2_minus_one",
-                    &(self.wasmtime.bb_padding_log2 % 26).to_string(),
+                    &(self.wasmtime.bb_padding_log2 % 27).to_string(),
                 );
             }
         }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -218,7 +218,7 @@ impl Config {
         //   regardless of how many basic blocks there are.
         // * Here it's limited to enable this setting only when there's at most
         //   10 functions to ensure that the overhead for all functions is <1G
-        //   ish or otherwise dosn't run away.
+        //   ish or otherwise doesn't run away.
         // * The `bb_padding_log2_minus_one` setting isn't allowed to be
         //   larger than 26 as that allows for `1<<25` maximum padding size
         //   which is 32M.


### PR DESCRIPTION
This commit is a fix for a fuzz failure that came in the other day where a module took more than 2GB of memory to compile, triggering the fuzzer to fail. Investigating locally it looks like the problem lies in the basic-block padding added recently. Turning on that option increases the memory usage of Cranelift from ~70M to ~2.5G. The setting in the test was to add `1<<14` bytes of padding between all basic blocks, and with a lot of basic blocks that can add up quite quickly.

The solution implemented here is to implement a per-function limit of the amount of padding that can be injected. I've set it to 1MB for now which is hopefully enough to continue to stress the various bits of the `MachBuffer` while not blowing limits accidentally while fuzzing.

After this commit the fuzz test case in question jumps from 70M to 470M with basic block padding enabled, which while still large is a bit more modest and sticks within the limits of the fuzzer.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
