### PR TITLE
Reference a missing filename when parsing modules

### DIFF
--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -235,9 +235,11 @@ impl Module {
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     #[cfg_attr(nightlydoc, doc(cfg(any(feature = "cranelift", feature = "winch"))))]
     pub fn from_file(engine: &Engine, file: impl AsRef<Path>) -> Result<Module> {
+        let file = file.as_ref();
         match Self::new(
             engine,
-            &fs::read(&file).with_context(|| "failed to read input file")?,
+            &fs::read(file)
+                .with_context(|| format!("failed to read input file: {}", file.display()))?,
         ) {
             Ok(m) => Ok(m),
             Err(e) => {


### PR DESCRIPTION
Currently wasmtime's error message for `wasmtime nonexistent.wasm` doesn't actually refer to `nonexistent.wasm` anywhere, so this commit fills that in as contextual information on the returned error.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
