### PR TITLE
Try adding a `minimal-versions` test to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -667,6 +667,44 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
+  # Use Cargo's `-Z minimal-versions` feature to ensure that the lower bound
+  # of our dependencies are ideally all valid.
+  check-minimal-versions:
+    needs: determine
+    if: needs.determine.outputs.run-full
+    name: Check Minimal Verisons
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: nightly-2023-07-02
+    - run: cargo generate-lockfile -Z minimal-versions
+
+    # Update some dependencies manually which cause issues in transitive
+    # dependencies.  Having to need to do this is a bummer and is why this is
+    # still a `-Z` flag and not a stable cargo feature.
+    #
+    # Here `futures-util` is a transitive dep of HTTP things that needed a
+    # higher lower bound. The `syn` dep for example is tricky since we don't
+    # explicitly depend on `syn` 1.x.x but it's transitively used through other
+    # crates like `tracing` and we're using syntax not supported by the lower
+    # bounds of those crates, so it's a bit odd there too.
+    - run: cargo update -p futures-util -p syn
+
+    # Make sure everything works. Note that this isn't super exhaustive, but
+    # it's meant to cover our bases braodly.
+    - run: cargo check
+
+    # common logic to cancel the entire run if this job fails
+    - run: gh run cancel ${{ github.run_id }}
+      if: failure() && github.event_name != 'pull_request'
+      env:
+        GH_TOKEN: ${{ github.token }}
+
+
   # Perform release builds of `wasmtime` and `libwasmtime.so`. Builds a variety
   # of platforms and architectures and then uploads the release artifacts to
   # this workflow run's list of artifacts.
@@ -775,6 +813,7 @@ jobs:
       - determine
       - miri
       - build-preview1-component-adapter
+      - check-minimal-versions
     if: always()
     steps:
     - name: Dump needs context

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -669,6 +669,29 @@ jobs:
 
   # Use Cargo's `-Z minimal-versions` feature to ensure that the lower bound
   # of our dependencies are ideally all valid.
+  #
+  # The goal of this CI check is to ensure that the version listed in Cargo.toml
+  # for wasmtime's dependencies is correct even if the minimal version is used
+  # to satisfy that version bound. This is meant to prevent situations such as:
+  #
+  # * A dependency is added at some minimal version bound.
+  # * Later the crate is updated, perhaps for some unrelated reason. The bound
+  #   written in `Cargo.toml` is not changed, however.
+  # * Afterwards a PR is updated to use a new function from the updated version.
+  #
+  # If this new function is not available in the original version used then that
+  # means that the version bound for the dependency is technically incorrect and
+  # needs to be raised to the first version that has the new functionality.
+  #
+  # Note though that `-Zminimal-versions` is an unstable feature for Cargo
+  # because it's possible for this check to fail with no way for Wasmtime itself
+  # to fix it.  For example if a transitive dependency's minimal version bounds
+  # are incorrect the build will fail due to that and there's not much we can do
+  # about that. To paper over that there's some `cargo update` commands below.
+  #
+  # In general this CI check is a test to see if it's reasonable to run this in
+  # CI. I nothing is ever caught or this ends up just causing a lot of issues
+  # then this is fine to remove.
   check-minimal-versions:
     needs: determine
     if: needs.determine.outputs.run-full
@@ -695,7 +718,7 @@ jobs:
     - run: cargo update -p futures-util -p syn@1.0.67
 
     # Make sure everything works. Note that this isn't super exhaustive, but
-    # it's meant to cover our bases braodly.
+    # it's meant to cover our bases broadly.
     - run: cargo check
 
     # common logic to cancel the entire run if this job fails

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -692,7 +692,7 @@ jobs:
     # explicitly depend on `syn` 1.x.x but it's transitively used through other
     # crates like `tracing` and we're using syntax not supported by the lower
     # bounds of those crates, so it's a bit odd there too.
-    - run: cargo update -p futures-util -p syn
+    - run: cargo update -p futures-util -p syn@1.0.67
 
     # Make sure everything works. Note that this isn't super exhaustive, but
     # it's meant to cover our bases braodly.


### PR DESCRIPTION
This commit is an attempt to add another CI check for Wasmtime to ensure that the minimum version bounds on all of our dependencies are accurate. This is not a stable feature of Cargo and thus requires usage of nightly. Additionally one of the reasons it's not stable is that the DX is not great as many minimal-versions errors come from transitive dependencies that we can't do anything about. Nevertheless I figure it might be good to try out having it on CI and see how it fares.

This is inspired by #6755 where we picked up a dependency on a newer version of `system-interface` but forgot to update the minimum version bound. Whether or not this prevents the issue or causes too many headaches is I think yet to be seen.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
