### PR TITLE
[11.0.0] Update some minimum version requirements.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -674,6 +674,44 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
+  # Use Cargo's `-Z minimal-versions` feature to ensure that the lower bound
+  # of our dependencies are ideally all valid.
+  check-minimal-versions:
+    needs: determine
+    if: needs.determine.outputs.run-full
+    name: Check Minimal Verisons
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+      with:
+        toolchain: nightly-2023-03-20
+    - run: cargo generate-lockfile -Z minimal-versions
+
+    # Update some dependencies manually which cause issues in transitive
+    # dependencies.  Having to need to do this is a bummer and is why this is
+    # still a `-Z` flag and not a stable cargo feature.
+    #
+    # Here `futures-util` is a transitive dep of HTTP things that needed a
+    # higher lower bound. The `syn` dep for example is tricky since we don't
+    # explicitly depend on `syn` 1.x.x but it's transitively used through other
+    # crates like `tracing` and we're using syntax not supported by the lower
+    # bounds of those crates, so it's a bit odd there too.
+    - run: cargo update -p futures-util -p syn@1.0.74
+
+    # Make sure everything works. Note that this isn't super exhaustive, but
+    # it's meant to cover our bases braodly.
+    - run: cargo check
+
+    # common logic to cancel the entire run if this job fails
+    - run: gh run cancel ${{ github.run_id }}
+      if: failure() && github.event_name != 'pull_request'
+      env:
+        GH_TOKEN: ${{ github.token }}
+
+
   # Perform release builds of `wasmtime` and `libwasmtime.so`. Builds a variety
   # of platforms and architectures and then uploads the release artifacts to
   # this workflow run's list of artifacts.
@@ -782,6 +820,7 @@ jobs:
       - determine
       - miri
       - build-preview1-component-adapter
+      - check-minimal-versions
     if: always()
     steps:
     - name: Dump needs context

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ cap-rand = { version = "1.0.12", features = ["small_rng"] }
 cap-fs-ext = "1.0.12"
 cap-time-ext = "1.0.0"
 fs-set-times = "0.19.0"
-system-interface = { version = "0.25.1", features = ["cap_std_impls"] }
+system-interface = { version = "0.25.2", features = ["cap_std_impls"] }
 io-lifetimes = { version = "1.0.0", default-features = false }
 rustix = "0.37.13"
 
@@ -217,7 +217,7 @@ anyhow = "1.0.22"
 windows-sys = "0.48.0"
 env_logger = "0.10"
 log = { version = "0.4.8", default-features = false }
-clap = { version = "3.2.0", features = ["color", "suggestions", "derive"] }
+clap = { version = "3.2.8", features = ["color", "suggestions", "derive"] }
 hashbrown = "0.13.2"
 capstone = "0.9.0"
 once_cell = "1.12.0"


### PR DESCRIPTION
This PR seeks to fix #6755 by updating the 11.0.0 release branch's minimum version requirements for a few crates. This brings in the CI proposed by https://github.com/bytecodealliance/wasmtime/pull/6757 and then gets it passing locally by updating our `clap` and our `system-interface` dependencies. Note that `Cargo.lock` is not changing here which is intentional because the goal is to have the lower bound of the dependency be what's in `Cargo.lock` which is what we're testing against.

Also note that the actual modifications to dependency requirements is not needed on `main` due to other PRs that update dependencies. As such the dependency version requirements here are only required for the release branch.
 