### PR TITLE
c-api: Expose async_stack_size configuration

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -33,8 +33,9 @@ cap-std = { workspace = true, optional = true }
 wasi-common = { workspace = true, optional = true }
 
 [features]
-default = ['jitdump', 'wat', 'wasi', 'cache', 'parallel-compilation']
+default = ['jitdump', 'wat', 'wasi', 'cache', 'parallel-compilation', 'async']
 jitdump = ["wasmtime/jitdump"]
 cache = ["wasmtime/cache"]
 parallel-compilation = ['wasmtime/parallel-compilation']
 wasi = ['wasi-cap-std-sync', 'wasmtime-wasi', 'cap-std', 'wasi-common']
+async = ['wasmtime/async']

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -67,6 +67,12 @@ pub extern "C" fn wasmtime_config_max_wasm_stack_set(c: &mut wasm_config_t, size
 }
 
 #[no_mangle]
+#[cfg(feature = "async")]
+pub extern "C" fn wasmtime_config_async_stack_size_set(c: &mut wasm_config_t, size: usize) {
+    c.config.async_stack_size(size);
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_config_wasm_threads_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_threads(enable);
 }


### PR DESCRIPTION
Adds wasm_config_async_stack_size_set to C API. Also updates the stack-related comments in config.h to match the latest Rust ones.

Motivation: I want to set the stack size in wasmtime-go, but max_wasm_stack is limited by async_stack_size, so we need to set this too.