### PR TITLE
Fix flaky tests in preview2 streams

### DIFF
--- a/crates/wasi/src/preview2/pipe.rs
+++ b/crates/wasi/src/preview2/pipe.rs
@@ -666,10 +666,13 @@ mod test {
         assert_eq!(len, chunk.len());
         assert_eq!(state, StreamState::Open);
 
-        // But I expect this to block additional writes:
+        // It is possible for subsequent writes to be refused, but it is nondeterminstic because
+        // the worker task consuming them is in another thread:
         let (len, state) = writer.write(chunk.clone()).unwrap();
-        assert_eq!(len, 0);
         assert_eq!(state, StreamState::Open);
+        if !(len == 0 || len == chunk.len()) {
+            unreachable!()
+        }
 
         tokio::time::timeout(REASONABLE_DURATION, writer.ready())
             .await

--- a/crates/wasi/src/preview2/preview2/io.rs
+++ b/crates/wasi/src/preview2/preview2/io.rs
@@ -412,7 +412,7 @@ pub mod sync {
             stream: OutputStream,
             bytes: Vec<u8>,
         ) -> Result<(u64, streams::StreamStatus), streams::Error> {
-            in_tokio(async { AsyncHost::write(self, stream, bytes).await })
+            in_tokio(async { AsyncHost::blocking_write(self, stream, bytes).await })
                 .map(|(a, b)| (a, b.into()))
                 .map_err(streams::Error::from)
         }


### PR DESCRIPTION
#6556 introduced (at least) 2 flaky tests:
* I made a bug in the `sink_write_stream` test in pipes. This test has been fixed, and the comment describes the race.
* `poll_oneoff_stdio` is failed nondeterministically in the `wasi-preview2-components-sync` suite. We found a typo in the sync-to-async translation that caused this bug.

Thanks @silentbicycle, we used autoclave to reproduce this after a few hundred iterations:
```
RUST_LOG=wasmtime_wasi=trace autoclave cargo test -p test-programs --features test_programs --test wasi-preview2-components-sync -- poll_oneoff_stdio --nocapture
```