### PR TITLE
Make C-API usable from Rust

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [lib]
 name = "wasmtime"
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["staticlib", "cdylib", "rlib"]
 doc = false
 test = false
 doctest = false

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -11,6 +11,8 @@
 
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
+pub use wasmtime::*;
+
 mod config;
 mod engine;
 mod error;


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This PR gives the `c-api` library a distinct name and adds `rlib` to the `crate-type` list, so that it can also be used from Rust. This is useful in situations like https://github.com/tree-sitter/tree-sitter/pull/1864, where a project (here tree-sitter) is mainly written in C and uses the wasmtime C library, but also provides Rust bindings. The easiest way to vendor the wasmtime C library for the tree-sitter C library during compilation of the tree-sitter Rust crate is then to simply depend on the `wasmtime-c-api` crate in the Rust bindings.