### PR TITLE
Implement component-to-component calls with resources

### DIFF
--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -100,6 +100,18 @@ impl<'a> TrampolineCompiler<'a> {
             Trampoline::ResourceNew(ty) => self.translate_resource_new(*ty),
             Trampoline::ResourceRep(ty) => self.translate_resource_rep(*ty),
             Trampoline::ResourceDrop(ty) => self.translate_resource_drop(*ty),
+            Trampoline::ResourceTransferOwn => {
+                self.translate_resource_simple(host::resource_transfer_own)
+            }
+            Trampoline::ResourceTransferBorrow => {
+                self.translate_resource_simple(host::resource_transfer_borrow)
+            }
+            Trampoline::ResourceEnterCall => {
+                self.translate_resource_simple(host::resource_enter_call)
+            }
+            Trampoline::ResourceExitCall => {
+                self.translate_resource_simple(host::resource_exit_call)
+            }
         }
     }
 
@@ -494,6 +506,41 @@ impl<'a> TrampolineCompiler<'a> {
         self.builder.switch_to_block(return_block);
         self.builder.ins().return_(&[]);
         self.builder.seal_block(return_block);
+    }
+
+    /// Invokes a host libcall and returns the result.
+    ///
+    /// Only intended for simple trampolines and effectively acts as a bridge
+    /// from the wasm abi to host.
+    fn translate_resource_simple(
+        &mut self,
+        get_libcall: fn(&dyn TargetIsa, &mut ir::Function) -> (ir::SigRef, u32),
+    ) {
+        match self.abi {
+            Abi::Wasm => {}
+
+            // These trampolines can only actually be called by Wasm, so
+            // let's assert that here.
+            Abi::Native | Abi::Array => {
+                self.builder
+                    .ins()
+                    .trap(ir::TrapCode::User(crate::DEBUG_ASSERT_TRAP_CODE));
+                return;
+            }
+        }
+
+        let args = self.builder.func.dfg.block_params(self.block0).to_vec();
+        let vmctx = args[0];
+        let mut host_args = vec![vmctx];
+        host_args.extend(args[2..].iter().copied());
+        let (host_sig, offset) = get_libcall(self.isa, &mut self.builder.func);
+        let host_fn = self.load_libcall(vmctx, offset);
+        let call = self
+            .builder
+            .ins()
+            .call_indirect(host_sig, host_fn, &host_args);
+        let results = self.builder.func.dfg.inst_results(call).to_vec();
+        self.builder.ins().return_(&results);
     }
 
     /// Loads a host function pointer for a libcall stored at the `offset`

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -101,16 +101,16 @@ impl<'a> TrampolineCompiler<'a> {
             Trampoline::ResourceRep(ty) => self.translate_resource_rep(*ty),
             Trampoline::ResourceDrop(ty) => self.translate_resource_drop(*ty),
             Trampoline::ResourceTransferOwn => {
-                self.translate_resource_simple(host::resource_transfer_own)
+                self.translate_resource_libcall(host::resource_transfer_own)
             }
             Trampoline::ResourceTransferBorrow => {
-                self.translate_resource_simple(host::resource_transfer_borrow)
+                self.translate_resource_libcall(host::resource_transfer_borrow)
             }
             Trampoline::ResourceEnterCall => {
-                self.translate_resource_simple(host::resource_enter_call)
+                self.translate_resource_libcall(host::resource_enter_call)
             }
             Trampoline::ResourceExitCall => {
-                self.translate_resource_simple(host::resource_exit_call)
+                self.translate_resource_libcall(host::resource_exit_call)
             }
         }
     }
@@ -512,7 +512,7 @@ impl<'a> TrampolineCompiler<'a> {
     ///
     /// Only intended for simple trampolines and effectively acts as a bridge
     /// from the wasm abi to host.
-    fn translate_resource_simple(
+    fn translate_resource_libcall(
         &mut self,
         get_libcall: fn(&dyn TargetIsa, &mut ir::Function) -> (ir::SigRef, u32),
     ) {

--- a/crates/environ/src/component.rs
+++ b/crates/environ/src/component.rs
@@ -85,6 +85,11 @@ macro_rules! foreach_builtin_component_function {
             // is encoded as a 64-bit integer where the low bit is Some/None
             // and bits 1-33 are the payload.
             resource_drop(vmctx: vmctx, resource: u32, idx: u32) -> u64;
+
+            resource_transfer_own(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u32;
+            resource_transfer_borrow(vmctx: vmctx, src_idx: u32, src_table: u32, dst_table: u32) -> u32;
+            resource_enter_call(vmctx: vmctx);
+            resource_exit_call(vmctx: vmctx);
         }
     };
 }

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -48,7 +48,7 @@ pub struct ComponentDfg {
 
     /// All trampolines and their type signature which will need to get
     /// compiled by Cranelift.
-    pub trampolines: PrimaryMap<TrampolineIndex, (SignatureIndex, Trampoline)>,
+    pub trampolines: Intern<TrampolineIndex, (SignatureIndex, Trampoline)>,
 
     /// Know reallocation functions which are used by `lowerings` (e.g. will be
     /// used by the host)
@@ -238,6 +238,7 @@ impl<T> CoreExport<T> {
 }
 
 /// Same as `info::Trampoline`
+#[derive(Clone, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
 pub enum Trampoline {
     LowerImport {
@@ -256,6 +257,10 @@ pub enum Trampoline {
     ResourceNew(TypeResourceTableIndex),
     ResourceRep(TypeResourceTableIndex),
     ResourceDrop(TypeResourceTableIndex),
+    ResourceTransferOwn,
+    ResourceTransferBorrow,
+    ResourceEnterCall,
+    ResourceExitCall,
 }
 
 /// Same as `info::CanonicalOptions`
@@ -581,6 +586,10 @@ impl LinearizeDfg<'_> {
             Trampoline::ResourceNew(ty) => info::Trampoline::ResourceNew(*ty),
             Trampoline::ResourceDrop(ty) => info::Trampoline::ResourceDrop(*ty),
             Trampoline::ResourceRep(ty) => info::Trampoline::ResourceRep(*ty),
+            Trampoline::ResourceTransferOwn => info::Trampoline::ResourceTransferOwn,
+            Trampoline::ResourceTransferBorrow => info::Trampoline::ResourceTransferBorrow,
+            Trampoline::ResourceEnterCall => info::Trampoline::ResourceEnterCall,
+            Trampoline::ResourceExitCall => info::Trampoline::ResourceExitCall,
         };
         let i1 = self.trampolines.push(*signature);
         let i2 = self.trampoline_defs.push(trampoline);

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -533,6 +533,24 @@ pub enum Trampoline {
 
     /// Same as `ResourceNew`, but for the `resource.drop` intrinsic.
     ResourceDrop(TypeResourceTableIndex),
+
+    /// An intrinsic used by FACT-generated modules which will transfer an owned
+    /// resource from one table to another. Used in component-to-component
+    /// adapter trampolines.
+    ResourceTransferOwn,
+
+    /// Same as `ResourceTransferOwn` but for borrows.
+    ResourceTransferBorrow,
+
+    /// An intrinsic used by FACT-generated modules which indicates that a call
+    /// is being entered and resource-related metadata needs to be configured.
+    ///
+    /// Note that this is currently only invoked when borrowed resources are
+    /// detected, otherwise this is "optimized out".
+    ResourceEnterCall,
+
+    /// Same as `ResourceEnterCall` except for when exiting a call.
+    ResourceExitCall,
 }
 
 impl Trampoline {
@@ -556,6 +574,10 @@ impl Trampoline {
             ResourceNew(i) => format!("component-resource-new[{}]", i.as_u32()),
             ResourceRep(i) => format!("component-resource-rep[{}]", i.as_u32()),
             ResourceDrop(i) => format!("component-resource-drop[{}]", i.as_u32()),
+            ResourceTransferOwn => format!("component-resource-transfer-own"),
+            ResourceTransferBorrow => format!("component-resource-transfer-borrow"),
+            ResourceEnterCall => format!("component-resource-enter-call"),
+            ResourceExitCall => format!("component-resource-exit-call"),
         }
     }
 }

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -257,6 +257,14 @@ fn fact_import_to_core_def(
     import: &fact::Import,
     ty: EntityType,
 ) -> dfg::CoreDef {
+    let mut simple_intrinsic = |trampoline: dfg::Trampoline| {
+        let signature = match ty {
+            EntityType::Function(signature) => signature,
+            _ => unreachable!(),
+        };
+        let index = dfg.trampolines.push((signature, trampoline));
+        dfg::CoreDef::Trampoline(index)
+    };
     match import {
         fact::Import::CoreDef(def) => def.clone(),
         fact::Import::Transcode {
@@ -294,6 +302,12 @@ fn fact_import_to_core_def(
             ));
             dfg::CoreDef::Trampoline(index)
         }
+        fact::Import::ResourceTransferOwn => simple_intrinsic(dfg::Trampoline::ResourceTransferOwn),
+        fact::Import::ResourceTransferBorrow => {
+            simple_intrinsic(dfg::Trampoline::ResourceTransferBorrow)
+        }
+        fact::Import::ResourceEnterCall => simple_intrinsic(dfg::Trampoline::ResourceEnterCall),
+        fact::Import::ResourceExitCall => simple_intrinsic(dfg::Trampoline::ResourceExitCall),
     }
 }
 

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -258,10 +258,7 @@ fn fact_import_to_core_def(
     ty: EntityType,
 ) -> dfg::CoreDef {
     let mut simple_intrinsic = |trampoline: dfg::Trampoline| {
-        let signature = match ty {
-            EntityType::Function(signature) => signature,
-            _ => unreachable!(),
-        };
+        let signature = ty.unwrap_func();
         let index = dfg.trampolines.push((signature, trampoline));
         dfg::CoreDef::Trampoline(index)
     };
@@ -286,10 +283,7 @@ fn fact_import_to_core_def(
 
             let from = dfg.memories.push(unwrap_memory(from));
             let to = dfg.memories.push(unwrap_memory(to));
-            let signature = match ty {
-                EntityType::Function(signature) => signature,
-                _ => unreachable!(),
-            };
+            let signature = ty.unwrap_func();
             let index = dfg.trampolines.push((
                 signature,
                 dfg::Trampoline::Transcoder {

--- a/crates/environ/src/fact/signature.rs
+++ b/crates/environ/src/fact/signature.rs
@@ -115,4 +115,21 @@ impl ComponentTypesBuilder {
             (abi.size32, abi.align32)
         }
     }
+
+    /// Tests whether the type signature for `options` contains a borrowed
+    /// resource anywhere.
+    pub(super) fn contains_borrow_resource(&self, options: &AdapterOptions) -> bool {
+        let ty = &self[options.ty];
+
+        // Only parameters need to be checked since results should never have
+        // borrowed resources.
+        debug_assert!(!self[ty.results]
+            .types
+            .iter()
+            .any(|t| self.ty_contains_borrow_resource(t)));
+        self[ty.params]
+            .types
+            .iter()
+            .any(|t| self.ty_contains_borrow_resource(t))
+    }
 }

--- a/crates/runtime/src/component.rs
+++ b/crates/runtime/src/component.rs
@@ -25,8 +25,8 @@ use wasmtime_environ::{HostPtr, PrimaryMap};
 
 const INVALID_PTR: usize = 0xdead_dead_beef_beef_u64 as usize;
 
+mod libcalls;
 mod resources;
-mod transcode;
 
 pub use self::resources::{CallContexts, ResourceTable, ResourceTables};
 
@@ -440,8 +440,7 @@ impl ComponentInstance {
 
     unsafe fn initialize_vmctx(&mut self, store: *mut dyn Store) {
         *self.vmctx_plus_offset_mut(self.offsets.magic()) = VMCOMPONENT_MAGIC;
-        *self.vmctx_plus_offset_mut(self.offsets.libcalls()) =
-            &transcode::VMComponentLibcalls::INIT;
+        *self.vmctx_plus_offset_mut(self.offsets.libcalls()) = &libcalls::VMComponentLibcalls::INIT;
         *self.vmctx_plus_offset_mut(self.offsets.store()) = store;
         *self.vmctx_plus_offset_mut(self.offsets.limits()) = (*store).vmruntime_limits();
 
@@ -606,7 +605,14 @@ impl ComponentInstance {
         let dst_owns_resource = self.resource_owned_by_own_instance(dst);
         let mut tables = self.resource_tables();
         let rep = tables.resource_lift_borrow(Some(src), idx)?;
-        // Implement `lower_borrow`'s special case here where if a borrow is
+        // Implement `lower_borrow`'s special case here where if a borrow's
+        // resource type is owned by `dst` then the destination receives the
+        // representation directly rather than a handle to the representation.
+        //
+        // This can perhaps become a different libcall in the future to avoid
+        // this check at runtime since we know at compile time whether the
+        // destination type owns the resource, but that's left as a future
+        // refactoring if truly necessary.
         if dst_owns_resource {
             return Ok(rep);
         }

--- a/crates/runtime/src/component/libcalls.rs
+++ b/crates/runtime/src/component/libcalls.rs
@@ -47,7 +47,7 @@ macro_rules! define_builtins {
         /// An array that stores addresses of builtin functions. We translate code
         /// to use indirect calls. This way, we don't have to patch the code.
         #[repr(C)]
-        pub struct VMComponentBuiltins {
+        struct VMComponentBuiltins {
             $(
                 $name: unsafe extern "C" fn(
                     $(signature!(@ty $param),)*
@@ -56,7 +56,7 @@ macro_rules! define_builtins {
         }
 
         impl VMComponentBuiltins {
-            pub const INIT: VMComponentBuiltins = VMComponentBuiltins {
+            const INIT: VMComponentBuiltins = VMComponentBuiltins {
                 $($name: trampolines::$name,)*
             };
         }
@@ -84,7 +84,7 @@ macro_rules! define_transcoders {
         /// An array that stores addresses of builtin functions. We translate code
         /// to use indirect calls. This way, we don't have to patch the code.
         #[repr(C)]
-        pub struct VMBuiltinTranscodeArray {
+        struct VMBuiltinTranscodeArray {
             $(
                 $name: unsafe extern "C" fn(
                     $(signature!(@ty $param),)*
@@ -93,7 +93,7 @@ macro_rules! define_transcoders {
         }
 
         impl VMBuiltinTranscodeArray {
-            pub const INIT: VMBuiltinTranscodeArray = VMBuiltinTranscodeArray {
+            const INIT: VMBuiltinTranscodeArray = VMBuiltinTranscodeArray {
                 $($name: trampolines::$name,)*
             };
         }

--- a/crates/runtime/src/component/transcode.rs
+++ b/crates/runtime/src/component/transcode.rs
@@ -538,3 +538,37 @@ unsafe fn resource_drop(vmctx: *mut VMComponentContext, resource: u32, idx: u32)
         })
     })
 }
+
+unsafe fn resource_transfer_own(
+    vmctx: *mut VMComponentContext,
+    src_idx: u32,
+    src_table: u32,
+    dst_table: u32,
+) -> Result<u32> {
+    let src_table = TypeResourceTableIndex::from_u32(src_table);
+    let dst_table = TypeResourceTableIndex::from_u32(dst_table);
+    ComponentInstance::from_vmctx(vmctx, |instance| {
+        instance.resource_transfer_own(src_idx, src_table, dst_table)
+    })
+}
+
+unsafe fn resource_transfer_borrow(
+    vmctx: *mut VMComponentContext,
+    src_idx: u32,
+    src_table: u32,
+    dst_table: u32,
+) -> Result<u32> {
+    let src_table = TypeResourceTableIndex::from_u32(src_table);
+    let dst_table = TypeResourceTableIndex::from_u32(dst_table);
+    ComponentInstance::from_vmctx(vmctx, |instance| {
+        instance.resource_transfer_borrow(src_idx, src_table, dst_table)
+    })
+}
+
+unsafe fn resource_enter_call(vmctx: *mut VMComponentContext) -> Result<()> {
+    ComponentInstance::from_vmctx(vmctx, |instance| Ok(instance.resource_enter_call()))
+}
+
+unsafe fn resource_exit_call(vmctx: *mut VMComponentContext) -> Result<()> {
+    ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_exit_call())
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -294,6 +294,48 @@ pub enum EntityType {
     Function(SignatureIndex),
 }
 
+impl EntityType {
+    /// Assert that this entity is a global
+    pub fn unwrap_global(&self) -> &Global {
+        match self {
+            EntityType::Global(g) => g,
+            _ => panic!("not a global"),
+        }
+    }
+
+    /// Assert that this entity is a memory
+    pub fn unwrap_memory(&self) -> &Memory {
+        match self {
+            EntityType::Memory(g) => g,
+            _ => panic!("not a memory"),
+        }
+    }
+
+    /// Assert that this entity is a tag
+    pub fn unwrap_tag(&self) -> &Tag {
+        match self {
+            EntityType::Tag(g) => g,
+            _ => panic!("not a tag"),
+        }
+    }
+
+    /// Assert that this entity is a table
+    pub fn unwrap_table(&self) -> &Table {
+        match self {
+            EntityType::Table(g) => g,
+            _ => panic!("not a table"),
+        }
+    }
+
+    /// Assert that this entity is a function
+    pub fn unwrap_func(&self) -> SignatureIndex {
+        match self {
+            EntityType::Function(g) => *g,
+            _ => panic!("not a func"),
+        }
+    }
+}
+
 /// A WebAssembly global.
 ///
 /// Note that we record both the original Wasm type and the Cranelift IR type

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -487,14 +487,10 @@ impl<'a> Instantiator<'a> {
         // there's no guarantee that there exists a trampoline for `f` so this
         // can't fall through to the case below
         if let wasmtime_runtime::Export::Function(f) = &export {
-            match expected {
-                EntityType::Function(expected) => {
-                    let actual = unsafe { f.func_ref.as_ref().type_index };
-                    assert_eq!(module.signatures().shared_signature(expected), Some(actual));
-                    return;
-                }
-                _ => panic!("function not expected"),
-            }
+            let expected = expected.unwrap_func();
+            let actual = unsafe { f.func_ref.as_ref().type_index };
+            assert_eq!(module.signatures().shared_signature(expected), Some(actual));
+            return;
         }
 
         let val = unsafe { crate::Extern::from_wasmtime_export(export, store) };


### PR DESCRIPTION
This fills out support in FACT in Wasmtime to support component-to-component calls that use resources. This ended up being relatively simple as it's "just" a matter of moving resources between tables which at this time bottoms out in calls to the host. These new trampolines are are relatively easy to add after #6751 which helps keep this change contained.

Closes #6696

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
