### PR TITLE
Ignore async_stack_size if async_support is disabled

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1498,7 +1498,7 @@ impl Config {
             bail!("feature 'threads' requires 'bulk_memory' to be enabled");
         }
         #[cfg(feature = "async")]
-        if self.max_wasm_stack > self.async_stack_size {
+        if self.async_support && self.max_wasm_stack > self.async_stack_size {
             bail!("max_wasm_stack size cannot exceed the async_stack_size");
         }
         if self.max_wasm_stack == 0 {

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -1643,3 +1643,13 @@ fn same_module_multiple_stores() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn async_stack_size_ignored_if_disabled() -> Result<()> {
+    let mut config = Config::new();
+    config.async_support(false);
+    config.max_wasm_stack(8 << 20);
+    Engine::new(&config)?;
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes an issue where max_wasm_stack was being validated against async_stack_size when async_support was disabled, discussed in #6762.

I added a really simple test. I wasn't sure where to put it, let me know if there's a better spot for it (or some way to avoid the magic number of 8MB).

Background: wasmtime-go is currently panicking when trying to set the stack size (see: https://github.com/bytecodealliance/wasmtime-go/issues/182).