### PR TITLE
Wasmtime: Add support for Wasm tail calls

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -31,6 +31,7 @@ fn main() -> anyhow::Result<()> {
             test_directory(out, "tests/misc_testsuite", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/multi-memory", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/simd", strategy)?;
+            test_directory_module(out, "tests/misc_testsuite/tail-call", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/threads", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/memory64", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/component-model", strategy)?;
@@ -61,6 +62,7 @@ fn main() -> anyhow::Result<()> {
                     "tests/spec_testsuite/proposals/relaxed-simd",
                     strategy,
                 )?;
+                test_directory_module(out, "tests/spec_testsuite/proposals/tail-call", strategy)?;
             } else {
                 println!(
                     "cargo:warning=The spec testsuite is disabled. To enable, run `git submodule \
@@ -210,11 +212,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
 
     // This is an empty file right now which the `wast` crate doesn't parse
     if testname.contains("memory_copy1") {
-        return true;
-    }
-
-    // Tail calls are not yet implemented.
-    if testname.contains("return_call") {
         return true;
     }
 

--- a/build.rs
+++ b/build.rs
@@ -238,6 +238,9 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
         "s390x" => {
             // FIXME: These tests fail under qemu due to a qemu bug.
             testname == "simd_f32x4_pmin_pmax" || testname == "simd_f64x2_pmin_pmax"
+                // TODO(#6530): These tests require tail calls, but s390x
+                // doesn't support them yet.
+                || testsuite == "function_references" || testsuite == "tail_call"
         }
 
         "riscv64" => {

--- a/cranelift/codegen/src/cursor.rs
+++ b/cranelift/codegen/src/cursor.rs
@@ -593,7 +593,7 @@ impl<'f> FuncCursor<'f> {
     }
 
     /// Create an instruction builder that inserts an instruction at the current position.
-    pub fn ins(&mut self) -> ir::InsertBuilder<&mut FuncCursor<'f>> {
+    pub fn ins(&mut self) -> ir::InsertBuilder<'_, &mut FuncCursor<'f>> {
         ir::InsertBuilder::new(self)
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -702,13 +702,13 @@ impl Riscv64ABICallSite {
         });
 
         match dest {
-            // TODO: Our riscv64 backend doesn't have relocs for direct calls,
-            // the callee is always put in a register and then the register is
-            // relocated, so we don't currently differentiate between
-            // `RelocDistance::Near` and `RelocDistance::Far`. We just always
-            // use indirect calls. We should eventually add a non-indirect
-            // `return_call` instruction and path.
-            CallDest::ExtName(name, _) => {
+            CallDest::ExtName(name, RelocDistance::Near) => {
+                ctx.emit(Inst::ReturnCall {
+                    callee: Box::new(name),
+                    info,
+                });
+            }
+            CallDest::ExtName(name, RelocDistance::Far) => {
                 let callee = ctx.alloc_tmp(ir::types::I64).only_reg().unwrap();
                 ctx.emit(Inst::LoadExtName {
                     rd: callee,

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -98,6 +98,11 @@
     (CallInd
       (info BoxCallIndInfo))
 
+    ;; A direct return-call macro instruction.
+    (ReturnCall
+      (callee BoxExternalName)
+      (info BoxReturnCallInfo))
+
     ;; An indirect return-call macro instruction.
     (ReturnCallInd
       (callee Reg)

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1781,6 +1781,9 @@ impl<I: VCodeInst> TextSectionBuilder for MachTextSectionBuilder<I> {
     }
 
     fn resolve_reloc(&mut self, offset: u64, reloc: Reloc, addend: Addend, target: usize) -> bool {
+        crate::trace!(
+            "Resolving relocation @ {offset:#x} + {addend:#x} to target {target} of kind {reloc:?}"
+        );
         let label = MachLabel::from_block(BlockIndex::new(target));
         let offset = u32::try_from(offset).unwrap();
         match I::LabelUse::from_reloc(reloc, addend) {

--- a/cranelift/filetests/filetests/isa/riscv64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/return-call.clif
@@ -69,8 +69,7 @@ block0(v0: i64):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   load_sym t2,%callee_i64+0
-;   return_call_ind t2 old_stack_arg_size:0 new_stack_arg_size:0 s1=s1
+;   return_call TestCase(%callee_i64) old_stack_arg_size:0 new_stack_arg_size:0 s1=s1
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -79,16 +78,12 @@ block0(v0: i64):
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
 ; block1: ; offset 0x10
-;   auipc t2, 0
-;   ld t2, 0xc(t2)
-;   j 0xc
-;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i64 0
-;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ld ra, 8(s0)
 ;   ld t6, 0(s0)
 ;   addi sp, s0, 0x10
 ;   ori s0, t6, 0
-;   jr t2
+;   auipc t6, 0 ; reloc_external RiscvCall %callee_i64 0
+;   jr t6
 
 ;;;; Test passing `f64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/src/test_wasm/env.rs
+++ b/cranelift/filetests/src/test_wasm/env.rs
@@ -417,6 +417,17 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
         )
     }
 
+    fn translate_return_call_ref(
+        &mut self,
+        builder: &mut cranelift_frontend::FunctionBuilder,
+        sig_ref: ir::SigRef,
+        callee: ir::Value,
+        call_args: &[ir::Value],
+    ) -> cranelift_wasm::WasmResult<()> {
+        self.inner
+            .translate_return_call_ref(builder, sig_ref, callee, call_args)
+    }
+
     fn translate_memory_grow(
         &mut self,
         pos: cranelift_codegen::cursor::FuncCursor,

--- a/cranelift/frontend/src/lib.rs
+++ b/cranelift/frontend/src/lib.rs
@@ -191,7 +191,7 @@ use hashbrown::HashMap;
 #[cfg(feature = "std")]
 use std::collections::HashMap;
 
-pub use crate::frontend::{FunctionBuilder, FunctionBuilderContext};
+pub use crate::frontend::{FuncInstBuilder, FunctionBuilder, FunctionBuilderContext};
 pub use crate::switch::Switch;
 pub use crate::variable::Variable;
 

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -39,6 +39,7 @@ pub const SUPPORTED_WASM_FEATURES: &[(&str, &str)] = &[
         "relaxed-simd",
         "enables support for the relaxed simd proposal",
     ),
+    ("tail-call", "enables support for WebAssembly tail calls"),
     ("threads", "enables support for WebAssembly threads"),
     ("memory64", "enables support for 64-bit memories"),
     #[cfg(feature = "component-model")]
@@ -371,6 +372,7 @@ impl CommonOptions {
             bulk_memory,
             reference_types,
             multi_value,
+            tail_call,
             threads,
             multi_memory,
             memory64,
@@ -396,6 +398,9 @@ impl CommonOptions {
         }
         if let Some(enable) = multi_value {
             config.wasm_multi_value(enable);
+        }
+        if let Some(enable) = tail_call {
+            config.wasm_tail_call(enable);
         }
         if let Some(enable) = threads {
             config.wasm_threads(enable);
@@ -441,6 +446,7 @@ pub struct WasmFeatures {
     pub bulk_memory: Option<bool>,
     pub simd: Option<bool>,
     pub relaxed_simd: Option<bool>,
+    pub tail_call: Option<bool>,
     pub threads: Option<bool>,
     pub multi_memory: Option<bool>,
     pub memory64: Option<bool>,
@@ -493,6 +499,7 @@ fn parse_wasm_features(features: &str) -> Result<WasmFeatures> {
         bulk_memory: all.or(values["bulk-memory"]),
         simd: all.or(values["simd"]),
         relaxed_simd: all.or(values["relaxed-simd"]),
+        tail_call: all.or(values["tail-call"]),
         threads: all.or(values["threads"]),
         multi_memory: all.or(values["multi-memory"]),
         memory64: all.or(values["memory64"]),
@@ -611,6 +618,7 @@ mod test {
             bulk_memory,
             simd,
             relaxed_simd,
+            tail_call,
             threads,
             multi_memory,
             memory64,
@@ -621,6 +629,7 @@ mod test {
         assert_eq!(multi_value, Some(true));
         assert_eq!(bulk_memory, Some(true));
         assert_eq!(simd, Some(true));
+        assert_eq!(tail_call, Some(true));
         assert_eq!(threads, Some(true));
         assert_eq!(multi_memory, Some(true));
         assert_eq!(memory64, Some(true));
@@ -640,6 +649,7 @@ mod test {
             bulk_memory,
             simd,
             relaxed_simd,
+            tail_call,
             threads,
             multi_memory,
             memory64,
@@ -650,6 +660,7 @@ mod test {
         assert_eq!(multi_value, Some(false));
         assert_eq!(bulk_memory, Some(false));
         assert_eq!(simd, Some(false));
+        assert_eq!(tail_call, Some(false));
         assert_eq!(threads, Some(false));
         assert_eq!(multi_memory, Some(false));
         assert_eq!(memory64, Some(false));
@@ -672,6 +683,7 @@ mod test {
             bulk_memory,
             simd,
             relaxed_simd,
+            tail_call,
             threads,
             multi_memory,
             memory64,
@@ -682,6 +694,7 @@ mod test {
         assert_eq!(multi_value, None);
         assert_eq!(bulk_memory, None);
         assert_eq!(simd, Some(true));
+        assert_eq!(tail_call, None);
         assert_eq!(threads, None);
         assert_eq!(multi_memory, Some(true));
         assert_eq!(memory64, Some(true));
@@ -725,6 +738,7 @@ mod test {
     feature_test!(test_bulk_memory_feature, bulk_memory, "bulk-memory");
     feature_test!(test_simd_feature, simd, "simd");
     feature_test!(test_relaxed_simd_feature, relaxed_simd, "relaxed-simd");
+    feature_test!(test_tail_call_feature, tail_call, "tail-call");
     feature_test!(test_threads_feature, threads, "threads");
     feature_test!(test_multi_memory_feature, multi_memory, "multi-memory");
     feature_test!(test_memory64_feature, memory64, "memory64");

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -8,10 +8,9 @@ use cranelift_frontend::FunctionBuilder;
 use std::any::Any;
 use wasmtime_cranelift_shared::{ALWAYS_TRAP_CODE, CANNOT_ENTER_CODE};
 use wasmtime_environ::component::*;
-use wasmtime_environ::{PtrSize, SignatureIndex, Tunables, WasmType};
+use wasmtime_environ::{PtrSize, SignatureIndex, WasmType};
 
 struct TrampolineCompiler<'a> {
-    tunables: &'a Tunables,
     compiler: &'a Compiler,
     isa: &'a (dyn TargetIsa + 'static),
     builder: FunctionBuilder<'a>,
@@ -32,7 +31,6 @@ enum Abi {
 
 impl<'a> TrampolineCompiler<'a> {
     fn new(
-        tunables: &'a Tunables,
         compiler: &'a Compiler,
         func_compiler: &'a mut super::FunctionCompiler<'_>,
         component: &'a Component,
@@ -46,14 +44,13 @@ impl<'a> TrampolineCompiler<'a> {
         let func = ir::Function::with_name_signature(
             ir::UserFuncName::user(0, 0),
             match abi {
-                Abi::Wasm => crate::wasm_call_signature(isa, ty, tunables),
+                Abi::Wasm => crate::wasm_call_signature(isa, ty, &compiler.tunables),
                 Abi::Native => crate::native_call_signature(isa, ty),
                 Abi::Array => crate::array_call_signature(isa),
             },
         );
         let (builder, block0) = func_compiler.builder(func);
         TrampolineCompiler {
-            tunables,
             compiler,
             isa,
             builder,
@@ -491,8 +488,11 @@ impl<'a> TrampolineCompiler<'a> {
                 i32::from(self.offsets.ptr.vm_func_ref_vmctx()),
             );
 
-            let sig =
-                crate::wasm_call_signature(self.isa, &self.types[self.signature], self.tunables);
+            let sig = crate::wasm_call_signature(
+                self.isa,
+                &self.types[self.signature],
+                &self.compiler.tunables,
+            );
             let sig_ref = self.builder.import_signature(sig);
 
             // NB: note that the "caller" vmctx here is the caller of this
@@ -624,7 +624,6 @@ impl<'a> TrampolineCompiler<'a> {
 impl ComponentCompiler for Compiler {
     fn compile_trampoline(
         &self,
-        tunables: &Tunables,
         component: &ComponentTranslation,
         types: &ComponentTypes,
         index: TrampolineIndex,
@@ -632,7 +631,6 @@ impl ComponentCompiler for Compiler {
         let compile = |abi: Abi| -> Result<_> {
             let mut compiler = self.function_compiler();
             let mut c = TrampolineCompiler::new(
-                tunables,
                 self,
                 &mut compiler,
                 &component.component,

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -186,6 +186,7 @@ pub trait Compiler: Send + Sync {
     fn compile_array_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
+        tunables: &Tunables,
         types: &ModuleTypes,
         index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError>;
@@ -198,6 +199,7 @@ pub trait Compiler: Send + Sync {
     fn compile_native_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
+        tunables: &Tunables,
         types: &ModuleTypes,
         index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError>;
@@ -209,6 +211,7 @@ pub trait Compiler: Send + Sync {
     /// Wasm-to-host transition (e.g. registers used for fast stack walking).
     fn compile_wasm_to_native_trampoline(
         &self,
+        tunables: &Tunables,
         wasm_func_ty: &WasmFuncType,
     ) -> Result<Box<dyn Any + Send>, CompileError>;
 
@@ -273,6 +276,7 @@ pub trait Compiler: Send + Sync {
     /// the function pointer to the host code.
     fn emit_trampolines_for_array_call_host_func(
         &self,
+        tunables: &Tunables,
         ty: &WasmFuncType,
         // Actually `host_fn: VMArrayCallFunction` but that type is not
         // available in `wasmtime-environ`.

--- a/crates/environ/src/component/compiler.rs
+++ b/crates/environ/src/component/compiler.rs
@@ -1,4 +1,5 @@
 use crate::component::{ComponentTranslation, ComponentTypes, TrampolineIndex};
+use crate::Tunables;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
@@ -40,6 +41,7 @@ pub trait ComponentCompiler: Send + Sync {
     /// this trait for Cranelift for more information.
     fn compile_trampoline(
         &self,
+        tunables: &Tunables,
         component: &ComponentTranslation,
         types: &ComponentTypes,
         trampoline: TrampolineIndex,

--- a/crates/environ/src/component/compiler.rs
+++ b/crates/environ/src/component/compiler.rs
@@ -1,5 +1,4 @@
 use crate::component::{ComponentTranslation, ComponentTypes, TrampolineIndex};
-use crate::Tunables;
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::any::Any;
@@ -41,7 +40,6 @@ pub trait ComponentCompiler: Send + Sync {
     /// this trait for Cranelift for more information.
     fn compile_trampoline(
         &self,
-        tunables: &Tunables,
         component: &ComponentTranslation,
         types: &ComponentTypes,
         trampoline: TrampolineIndex,

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -49,6 +49,9 @@ pub struct Tunables {
     /// Whether or not lowerings for relaxed simd instructions are forced to
     /// be deterministic.
     pub relaxed_simd_deterministic: bool,
+
+    /// Whether or not Wasm functions can be tail-called or not.
+    pub tail_callable: bool,
 }
 
 impl Default for Tunables {
@@ -106,6 +109,7 @@ impl Default for Tunables {
             generate_address_map: true,
             debug_adapter_modules: false,
             relaxed_simd_deterministic: false,
+            tail_callable: false,
         }
     }
 }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -152,6 +152,7 @@ impl Config {
             .wasm_multi_memory(self.module_config.config.max_memories > 1)
             .wasm_simd(self.module_config.config.simd_enabled)
             .wasm_memory64(self.module_config.config.memory64_enabled)
+            .wasm_tail_call(self.module_config.config.tail_call_enabled)
             .wasm_threads(self.module_config.config.threads_enabled)
             .native_unwind_info(self.wasmtime.native_unwind_info)
             .cranelift_nan_canonicalization(self.wasmtime.canonicalize_nans)

--- a/crates/wasmtime/src/compiler.rs
+++ b/crates/wasmtime/src/compiler.rs
@@ -32,8 +32,7 @@ use wasmtime_environ::{
 };
 use wasmtime_jit::{CompiledFunctionInfo, CompiledModuleInfo};
 
-type CompileInput<'a> =
-    Box<dyn FnOnce(&Tunables, &dyn Compiler) -> Result<CompileOutput> + Send + 'a>;
+type CompileInput<'a> = Box<dyn FnOnce(&dyn Compiler) -> Result<CompileOutput> + Send + 'a>;
 
 /// A sortable, comparable key for a compilation output.
 ///
@@ -168,10 +167,7 @@ pub struct CompileInputs<'a> {
 }
 
 impl<'a> CompileInputs<'a> {
-    fn push_input(
-        &mut self,
-        f: impl FnOnce(&Tunables, &dyn Compiler) -> Result<CompileOutput> + Send + 'a,
-    ) {
+    fn push_input(&mut self, f: impl FnOnce(&dyn Compiler) -> Result<CompileOutput> + Send + 'a) {
         self.inputs.push(Box::new(f));
     }
 
@@ -207,13 +203,13 @@ impl<'a> CompileInputs<'a> {
         ret.collect_inputs_in_translations(types.module_types(), module_translations);
 
         for (idx, trampoline) in component.trampolines.iter() {
-            ret.push_input(move |tunables, compiler| {
+            ret.push_input(move |compiler| {
                 Ok(CompileOutput {
                     key: CompileKey::trampoline(idx),
                     symbol: trampoline.symbol_name(),
                     function: compiler
                         .component_compiler()
-                        .compile_trampoline(tunables, component, types, idx)?
+                        .compile_trampoline(component, types, idx)?
                         .into(),
                     info: None,
                 })
@@ -228,9 +224,8 @@ impl<'a> CompileInputs<'a> {
         // requested through initializers above or such.
         if component.component.num_resources > 0 {
             if let Some(sig) = types.find_resource_drop_signature() {
-                ret.push_input(move |tunables, compiler| {
-                    let trampoline =
-                        compiler.compile_wasm_to_native_trampoline(tunables, &types[sig])?;
+                ret.push_input(move |compiler| {
+                    let trampoline = compiler.compile_wasm_to_native_trampoline(&types[sig])?;
                     Ok(CompileOutput {
                         key: CompileKey::resource_drop_wasm_to_native_trampoline(),
                         symbol: "resource_drop_trampoline".to_string(),
@@ -259,15 +254,10 @@ impl<'a> CompileInputs<'a> {
 
         for (module, translation, functions) in translations {
             for (def_func_index, func_body) in functions {
-                self.push_input(move |tunables, compiler| {
+                self.push_input(move |compiler| {
                     let func_index = translation.module.func_index(def_func_index);
-                    let (info, function) = compiler.compile_function(
-                        translation,
-                        def_func_index,
-                        func_body,
-                        tunables,
-                        types,
-                    )?;
+                    let (info, function) =
+                        compiler.compile_function(translation, def_func_index, func_body, types)?;
                     Ok(CompileOutput {
                         key: CompileKey::wasm_function(module, def_func_index),
                         symbol: format!(
@@ -282,11 +272,10 @@ impl<'a> CompileInputs<'a> {
 
                 let func_index = translation.module.func_index(def_func_index);
                 if translation.module.functions[func_index].is_escaping() {
-                    self.push_input(move |tunables, compiler| {
+                    self.push_input(move |compiler| {
                         let func_index = translation.module.func_index(def_func_index);
                         let trampoline = compiler.compile_array_to_wasm_trampoline(
                             translation,
-                            tunables,
                             types,
                             def_func_index,
                         )?;
@@ -302,11 +291,10 @@ impl<'a> CompileInputs<'a> {
                         })
                     });
 
-                    self.push_input(move |tunables, compiler| {
+                    self.push_input(move |compiler| {
                         let func_index = translation.module.func_index(def_func_index);
                         let trampoline = compiler.compile_native_to_wasm_trampoline(
                             translation,
-                            tunables,
                             types,
                             def_func_index,
                         )?;
@@ -330,10 +318,9 @@ impl<'a> CompileInputs<'a> {
         }
 
         for signature in sigs {
-            self.push_input(move |tunables, compiler| {
+            self.push_input(move |compiler| {
                 let wasm_func_ty = &types[signature];
-                let trampoline =
-                    compiler.compile_wasm_to_native_trampoline(tunables, wasm_func_ty)?;
+                let trampoline = compiler.compile_wasm_to_native_trampoline(wasm_func_ty)?;
                 Ok(CompileOutput {
                     key: CompileKey::wasm_to_native_trampoline(signature),
                     symbol: format!(
@@ -350,11 +337,10 @@ impl<'a> CompileInputs<'a> {
     /// Compile these `CompileInput`s (maybe in parallel) and return the
     /// resulting `UnlinkedCompileOutput`s.
     pub fn compile(self, engine: &Engine) -> Result<UnlinkedCompileOutputs> {
-        let tunables = &engine.config().tunables;
         let compiler = engine.compiler();
 
         // Compile each individual input in parallel.
-        let raw_outputs = engine.run_maybe_parallel(self.inputs, |f| f(tunables, compiler))?;
+        let raw_outputs = engine.run_maybe_parallel(self.inputs, |f| f(compiler))?;
 
         // Bucket the outputs by kind.
         let mut outputs: BTreeMap<u32, Vec<CompileOutput>> = BTreeMap::new();
@@ -474,7 +460,6 @@ impl FunctionIndices {
         let symbol_ids_and_locs = compiler.append_code(
             &mut obj,
             &compiled_funcs,
-            tunables,
             &|caller_index: usize, callee_index: FuncIndex| {
                 let module = self
                     .compiled_func_index_to_module

--- a/crates/wasmtime/src/component/component.rs
+++ b/crates/wasmtime/src/component/component.rs
@@ -205,7 +205,7 @@ impl Component {
 
         let (mut object, compilation_artifacts) = function_indices.link_and_append_code(
             object,
-            tunables,
+            &engine.config().tunables,
             compiler,
             compiled_funcs,
             module_translations,

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1662,6 +1662,8 @@ impl Config {
             compiler.enable_incremental_compilation(cache_store.clone())?;
         }
 
+        compiler.set_tunables(self.tunables.clone())?;
+
         Ok((self, compiler.build()?))
     }
 

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -162,6 +162,7 @@ struct WasmFeatures {
     bulk_memory: bool,
     component_model: bool,
     simd: bool,
+    tail_call: bool,
     threads: bool,
     multi_memory: bool,
     exceptions: bool,
@@ -200,7 +201,6 @@ impl Metadata {
         } = engine.config().features;
 
         assert!(!memory_control);
-        assert!(!tail_call);
         assert!(!gc);
         assert!(!component_model_values);
 
@@ -216,6 +216,7 @@ impl Metadata {
                 component_model,
                 simd,
                 threads,
+                tail_call,
                 multi_memory,
                 exceptions,
                 memory64,
@@ -315,6 +316,7 @@ impl Metadata {
             static_memory_bound_is_maximum,
             guard_before_linear_memory,
             relaxed_simd_deterministic,
+            tail_callable,
 
             // This doesn't affect compilation, it's just a runtime setting.
             dynamic_memory_growth_reserve: _,
@@ -375,6 +377,7 @@ impl Metadata {
             other.relaxed_simd_deterministic,
             "relaxed simd deterministic semantics",
         )?;
+        Self::check_bool(tail_callable, other.tail_callable, "WebAssembly tail calls")?;
 
         Ok(())
     }
@@ -386,6 +389,7 @@ impl Metadata {
             bulk_memory,
             component_model,
             simd,
+            tail_call,
             threads,
             multi_memory,
             exceptions,
@@ -416,6 +420,7 @@ impl Metadata {
             "WebAssembly component model support",
         )?;
         Self::check_bool(simd, other.simd, "WebAssembly SIMD support")?;
+        Self::check_bool(tail_call, other.tail_call, "WebAssembly tail calls support")?;
         Self::check_bool(threads, other.threads, "WebAssembly threads support")?;
         Self::check_bool(
             multi_memory,

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -89,7 +89,6 @@ where
     let (wasm_call_range, native_call_range) = engine
         .compiler()
         .emit_trampolines_for_array_call_host_func(
-            &engine.config().tunables,
             ft.as_wasm_func_type(),
             array_call_shim::<F> as usize,
             &mut obj,

--- a/crates/wasmtime/src/trampoline/func.rs
+++ b/crates/wasmtime/src/trampoline/func.rs
@@ -89,6 +89,7 @@ where
     let (wasm_call_range, native_call_range) = engine
         .compiler()
         .emit_trampolines_for_array_call_host_func(
+            &engine.config().tunables,
             ft.as_wasm_func_type(),
             array_call_shim::<F> as usize,
             &mut obj,

--- a/crates/winch/src/builder.rs
+++ b/crates/winch/src/builder.rs
@@ -38,6 +38,11 @@ impl CompilerBuilder for Builder {
         self.inner.settings()
     }
 
+    fn set_tunables(&mut self, tunables: wasmtime_environ::Tunables) -> Result<()> {
+        let _ = tunables;
+        Ok(())
+    }
+
     fn build(&self) -> Result<Box<dyn wasmtime_environ::Compiler>> {
         let isa = self.inner.build()?;
 

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -88,6 +88,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_array_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
+        _tunables: &Tunables,
         types: &ModuleTypes,
         index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError> {
@@ -107,6 +108,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_native_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
+        _tunables: &Tunables,
         types: &ModuleTypes,
         index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError> {
@@ -127,6 +129,7 @@ impl wasmtime_environ::Compiler for Compiler {
 
     fn compile_wasm_to_native_trampoline(
         &self,
+        _tunables: &Tunables,
         wasm_func_ty: &wasmtime_environ::WasmFuncType,
     ) -> Result<Box<dyn Any + Send>, CompileError> {
         let buffer = self
@@ -173,6 +176,7 @@ impl wasmtime_environ::Compiler for Compiler {
 
     fn emit_trampolines_for_array_call_host_func(
         &self,
+        _tunables: &Tunables,
         ty: &wasmtime_environ::WasmFuncType,
         // Actually `host_fn: VMArrayCallFunction` but that type is not
         // available in `wasmtime-environ`.

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -6,7 +6,7 @@ use wasmparser::FuncValidatorAllocations;
 use wasmtime_cranelift_shared::{CompiledFunction, ModuleTextBuilder};
 use wasmtime_environ::{
     CompileError, DefinedFuncIndex, FilePos, FuncIndex, FunctionBodyData, FunctionLoc,
-    ModuleTranslation, ModuleTypes, PrimaryMap, TrapEncodingBuilder, Tunables, WasmFunctionInfo,
+    ModuleTranslation, ModuleTypes, PrimaryMap, TrapEncodingBuilder, WasmFunctionInfo,
 };
 use winch_codegen::{TargetIsa, TrampolineKind};
 
@@ -53,7 +53,6 @@ impl wasmtime_environ::Compiler for Compiler {
         translation: &ModuleTranslation<'_>,
         index: DefinedFuncIndex,
         data: FunctionBodyData<'_>,
-        _tunables: &Tunables,
         types: &ModuleTypes,
     ) -> Result<(WasmFunctionInfo, Box<dyn Any + Send>), CompileError> {
         let index = translation.module.func_index(index);
@@ -88,7 +87,6 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_array_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
-        _tunables: &Tunables,
         types: &ModuleTypes,
         index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError> {
@@ -108,7 +106,6 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_native_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
-        _tunables: &Tunables,
         types: &ModuleTypes,
         index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError> {
@@ -129,7 +126,6 @@ impl wasmtime_environ::Compiler for Compiler {
 
     fn compile_wasm_to_native_trampoline(
         &self,
-        _tunables: &Tunables,
         wasm_func_ty: &wasmtime_environ::WasmFuncType,
     ) -> Result<Box<dyn Any + Send>, CompileError> {
         let buffer = self
@@ -147,7 +143,6 @@ impl wasmtime_environ::Compiler for Compiler {
         &self,
         obj: &mut Object<'static>,
         funcs: &[(String, Box<dyn Any + Send>)],
-        _tunables: &Tunables,
         resolve_reloc: &dyn Fn(usize, FuncIndex) -> usize,
     ) -> Result<Vec<(SymbolId, FunctionLoc)>> {
         let mut builder =
@@ -176,7 +171,6 @@ impl wasmtime_environ::Compiler for Compiler {
 
     fn emit_trampolines_for_array_call_host_func(
         &self,
-        _tunables: &Tunables,
         ty: &wasmtime_environ::WasmFuncType,
         // Actually `host_fn: VMArrayCallFunction` but that type is not
         // available in `wasmtime-environ`.

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -496,3 +496,154 @@ fn no_gc_middle_of_args() -> anyhow::Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn gc_and_tail_calls_and_stack_arguments() -> anyhow::Result<()> {
+    // Test that GC refs in tail-calls' stack arguments get properly accounted
+    // for in stack maps.
+    //
+    // What we do _not_ want to happen is for tail callers to be responsible for
+    // including stack arguments in their stack maps (and therefore whether or
+    // not they get marked at runtime). If that was the case, then we could have
+    // the following scenario:
+    //
+    // * `f` calls `g` without any stack arguments,
+    // * `g` tail calls `h` with GC ref stack arguments,
+    // * and then `h` triggers a GC.
+    //
+    // Because `g`, who is responsible for including the GC refs in its stack
+    // map in this hypothetical scenario, is no longer on the stack, we never
+    // see its stack map, and therefore never mark the GC refs, and then we
+    // collect them too early, and then we can get user-after-free bugs. Not
+    // good! Note also that `f`, which is the frame that `h` will return to,
+    // _cannot_ be responsible for including these stack arguments in its stack
+    // map, because it has no idea what frame will be returning to it, and it
+    // could be any number of different functions using that frame for long (and
+    // indirect!) tail-call chains.
+    //
+    // In Cranelift we avoid this scenario because stack arguments are eagerly
+    // loaded into virtual registers, and then when we insert a GC safe point,
+    // we spill these virtual registers to the callee stack frame, and the stack
+    // map includes entries for these stack slots.
+    //
+    // Nonetheless, this test exercises the above scenario just in case we do
+    // something in the future like lazily load stack arguments into virtual
+    // registers, to make sure that everything shows up in stack maps like they
+    // are supposed to.
+
+    let (mut store, module) = ref_types_module(
+        false,
+        r#"
+            (module
+                (import "" "make_some" (func $make (result externref externref externref)))
+                (import "" "take_some" (func $take (param externref externref externref)))
+                (import "" "gc" (func $gc))
+
+                (func $stack_args (param externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref externref)
+                  call $gc
+                  ;; Make sure all these GC refs are live, so that they need to
+                  ;; be put into the stack map.
+                  local.get 0
+                  local.get 1
+                  local.get 2
+                  call $take
+                  local.get 3
+                  local.get 4
+                  local.get 5
+                  call $take
+                  local.get 6
+                  local.get 7
+                  local.get 8
+                  call $take
+                  local.get 9
+                  local.get 10
+                  local.get 11
+                  call $take
+                  local.get 12
+                  local.get 13
+                  local.get 14
+                  call $take
+                  local.get 15
+                  local.get 16
+                  local.get 17
+                  call $take
+                  local.get 18
+                  local.get 19
+                  local.get 20
+                  call $take
+                  local.get 21
+                  local.get 22
+                  local.get 23
+                  call $take
+                  local.get 24
+                  local.get 25
+                  local.get 26
+                  call $take
+                  local.get 27
+                  local.get 28
+                  local.get 29
+                  call $take
+                )
+
+                (func $no_stack_args
+                  call $make
+                  call $make
+                  call $make
+                  call $make
+                  call $make
+                  call $make
+                  call $make
+                  call $make
+                  call $make
+                  call $make
+                  return_call $stack_args
+                )
+
+                (func (export "run")
+                    (local i32)
+                    i32.const 1000
+                    local.set 0
+                    loop
+                        call $no_stack_args
+                        local.get 0
+                        i32.const -1
+                        i32.add
+                        local.tee 0
+                        br_if 0
+                    end
+                )
+            )
+        "#,
+    )?;
+
+    let mut linker = Linker::new(store.engine());
+    linker.func_wrap("", "make_some", || {
+        (
+            Some(ExternRef::new("a".to_string())),
+            Some(ExternRef::new("b".to_string())),
+            Some(ExternRef::new("c".to_string())),
+        )
+    })?;
+    linker.func_wrap(
+        "",
+        "take_some",
+        |a: Option<ExternRef>, b: Option<ExternRef>, c: Option<ExternRef>| {
+            let a = a.unwrap();
+            let b = b.unwrap();
+            let c = c.unwrap();
+            assert_eq!(a.data().downcast_ref::<String>().unwrap(), "a");
+            assert_eq!(b.data().downcast_ref::<String>().unwrap(), "b");
+            assert_eq!(c.data().downcast_ref::<String>().unwrap(), "c");
+        },
+    )?;
+    linker.func_wrap("", "gc", |mut caller: Caller<()>| {
+        caller.gc();
+    })?;
+
+    let instance = linker.instantiate(&mut store, &module)?;
+    let func = instance.get_typed_func::<(), ()>(&mut store, "run")?;
+    func.call(&mut store, ())?;
+
+    Ok(())
+}

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -498,7 +498,11 @@ fn no_gc_middle_of_args() -> anyhow::Result<()> {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)]
+#[cfg_attr(any(
+    miri,
+    // TODO(6530): s390x doesn't support tail calls yet.
+    target_arch = "s390x"
+), ignore)]
 fn gc_and_tail_calls_and_stack_arguments() -> anyhow::Result<()> {
     // Test that GC refs in tail-calls' stack arguments get properly accounted
     // for in stack maps.

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -51,7 +51,12 @@ pub(crate) fn ref_types_module(
 
     let mut config = Config::new();
     config.wasm_reference_types(true);
-    config.wasm_tail_call(true);
+
+    if !cfg!(target_arch = "s390x") {
+        // TODO(6530): s390x doesn't support tail calls yet.
+        config.wasm_tail_call(true);
+    }
+
     if use_epochs {
         config.epoch_interruption(true);
     }

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -51,6 +51,7 @@ pub(crate) fn ref_types_module(
 
     let mut config = Config::new();
     config.wasm_reference_types(true);
+    config.wasm_tail_call(true);
     if use_epochs {
         config.epoch_interruption(true);
     }

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -27,6 +27,7 @@ fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()>
     let function_references = feature_found(wast, "function-references");
     let reference_types = !(threads && feature_found(wast, "proposals"));
     let relaxed_simd = feature_found(wast, "relaxed-simd");
+    let tail_call = feature_found(wast, "tail-call") || feature_found(wast, "function-references");
     let use_shared_memory = feature_found_src(&wast_bytes, "shared_memory")
         || feature_found_src(&wast_bytes, "shared)");
 
@@ -47,6 +48,7 @@ fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()>
         .wasm_function_references(function_references)
         .wasm_reference_types(reference_types)
         .wasm_relaxed_simd(relaxed_simd)
+        .wasm_tail_call(tail_call)
         .strategy(strategy);
 
     if is_cranelift {

--- a/tests/misc_testsuite/tail-call/loop-across-modules.wast
+++ b/tests/misc_testsuite/tail-call/loop-across-modules.wast
@@ -1,0 +1,43 @@
+;; Do the following loop: `A.f` indirect tail calls through the table, which is
+;; populated by `B.start` to contain `B.g`, which in turn tail calls `A.f` and
+;; the loop begins again.
+;;
+;; This is smoke testing that tail call chains across Wasm modules really do
+;; have O(1) stack usage.
+
+(module $A
+  (type (func (param i32) (result i32)))
+
+  (table (export "table") 1 1 funcref)
+
+  (func (export "f") (param i32) (result i32)
+    local.get 0
+    i32.eqz
+    if
+      (return (i32.const 42))
+    else
+      (i32.sub (local.get 0) (i32.const 1))
+      i32.const 0
+      return_call_indirect (type 0)
+    end
+    unreachable
+  )
+)
+
+(module $B
+  (import "A" "table" (table $table 1 1 funcref))
+  (import "A" "f" (func $f (param i32) (result i32)))
+
+  (func $g (export "g") (param i32) (result i32)
+    local.get 0
+    return_call $f
+  )
+
+  (func $start
+    (table.set $table (i32.const 0) (ref.func $g))
+  )
+  (start $start)
+)
+
+(assert_return (invoke $B "g" (i32.const 100000000))
+               (i32.const 42))


### PR DESCRIPTION
This adds the `Config::wasm_tail_call` method and `--wasm-features tail-call` CLI flag to enable the Wasm tail calls proposal in Wasmtime.

This PR is mostly just plumbing and enabling tests, since all the prerequisite work (Wasmtime trampoline overhauls and Cranelift tail calls) was completed in earlier pull requests.

When Wasm tail calls are enabled, Wasm code uses the `tail` calling convention. The `tail` calling convention is known to cause a 1-7% slow down for regular code that isn't using tail calls, which is why it isn't used unconditionally. This involved shepherding `Tunables` through to Wasm signature construction methods. The eventual plan is for the `tail` calling convention to be used unconditionally, but not until the performance regression is addressed. This work is tracked in
https://github.com/bytecodealliance/wasmtime/issues/6759

Additionally while our x86-64, aarch64, and riscv64 backends support tail calls, the s390x backend does not support them yet. Attempts to use tail calls on s390x will return errors. Support for s390x is tracked in https://github.com/bytecodealliance/wasmtime/issues/6530

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
