### PR TITLE
Fix broken link to WASI API documentation

### DIFF
--- a/docs/WASI-documents.md
+++ b/docs/WASI-documents.md
@@ -5,7 +5,7 @@ To get started using WASI, see [the intro document](WASI-intro.md) and
 
 For more detail on what WASI is, see [the overview](WASI-overview.md).
 
-For specifics on the API, see the [API documentation](https://github.com/WebAssembly/WASI/blob/master/phases/snapshot/docs.md).
+For specifics on the API, see the [API documentation](https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md).
 Additionally, a C header file describing the WASI API is
 [here](https://github.com/WebAssembly/wasi-libc/blob/master/libc-bottom-half/headers/public/wasi/api.h).
 


### PR DESCRIPTION
This file was moved in WebAssembly/WASI#510. Arguably its modern replacement is [`Proposals.md`](https://github.com/WebAssembly/WASI/blob/main/Proposals.md) but that’s a different document; for now, I’m just trying to keep the existing link working.