### PR TITLE
Update preview1 to trap on misaligned pointers

### DIFF
--- a/crates/wasi-common/src/snapshots/preview_1/error.rs
+++ b/crates/wasi-common/src/snapshots/preview_1/error.rs
@@ -235,16 +235,19 @@ impl From<wiggle::GuestError> for Error {
         match err {
             InvalidFlagValue { .. } => Errno::Inval.into(),
             InvalidEnumValue { .. } => Errno::Inval.into(),
-            PtrOverflow { .. } => Errno::Fault.into(),
-            PtrOutOfBounds { .. } => Errno::Fault.into(),
             // As per
             // https://github.com/WebAssembly/wasi/blob/main/legacy/tools/witx-docs.md#pointers
             //
             // > If a misaligned pointer is passed to a function, the function
             // > shall trap.
+            // >
+            // > If an out-of-bounds pointer is passed to a function and the
+            // > function needs to dereference it, the function shall trap.
             //
-            // so this turns misalignment errors into traps.
-            PtrNotAligned { .. } => Error::trap(err.into()),
+            // so this turns OOB and misalignment errors into traps.
+            PtrOverflow { .. } | PtrOutOfBounds { .. } | PtrNotAligned { .. } => {
+                Error::trap(err.into())
+            }
             PtrBorrowed { .. } => Errno::Fault.into(),
             InvalidUtf8 { .. } => Errno::Ilseq.into(),
             TryFromIntError { .. } => Errno::Overflow.into(),

--- a/crates/wasi-common/src/snapshots/preview_1/error.rs
+++ b/crates/wasi-common/src/snapshots/preview_1/error.rs
@@ -237,7 +237,14 @@ impl From<wiggle::GuestError> for Error {
             InvalidEnumValue { .. } => Errno::Inval.into(),
             PtrOverflow { .. } => Errno::Fault.into(),
             PtrOutOfBounds { .. } => Errno::Fault.into(),
-            PtrNotAligned { .. } => Errno::Inval.into(),
+            // As per
+            // https://github.com/WebAssembly/wasi/blob/main/legacy/tools/witx-docs.md#pointers
+            //
+            // > If a misaligned pointer is passed to a function, the function
+            // > shall trap.
+            //
+            // so this turns misalignment errors into traps.
+            PtrNotAligned { .. } => Error::trap(err.into()),
             PtrBorrowed { .. } => Errno::Fault.into(),
             InvalidUtf8 { .. } => Errno::Ilseq.into(),
             TryFromIntError { .. } => Errno::Overflow.into(),

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -717,3 +717,17 @@ fn wasm_flags_without_subcommand() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn wasi_misaligned_pointer() -> Result<()> {
+    let output = get_wasmtime_command()?
+        .arg("./tests/all/cli_tests/wasi_misaligned_pointer.wat")
+        .output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Pointer not aligned"),
+        "bad stderr: {stderr}",
+    );
+    Ok(())
+}

--- a/tests/all/cli_tests/wasi_misaligned_pointer.wat
+++ b/tests/all/cli_tests/wasi_misaligned_pointer.wat
@@ -1,0 +1,16 @@
+(module
+  (import "wasi_snapshot_preview1" "fd_write" (func $write (param i32 i32 i32 i32) (result i32)))
+
+  (memory (export "memory") 1)
+
+  (func (export "_start")
+    (call $write
+      (i32.const 1) ;; fd=1
+      (i32.const 1) ;; ciovec_base=1 (misaligned)
+      (i32.const 1) ;; ciovec_len=1
+      (i32.const 0) ;; retptr=0
+    )
+    drop
+
+  )
+)


### PR DESCRIPTION
Previously Wasmtime would return `EINVAL` to a guest but the upstream documentation indicates that misaligned pointers should trap, so this commit updates the alignment error to get converted into a trap rather than than being returned to the guest.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
