### PR TITLE
Cranelift: Fix `ABIMachineSpec::gen_add_imm` for riscv64

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -275,7 +275,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         let mut insts = SmallInstVec::new();
         if let Some(imm12) = Imm12::maybe_from_u64(imm as u64) {
             insts.push(Inst::AluRRImm12 {
-                alu_op: AluOPRRI::Andi,
+                alu_op: AluOPRRI::Addi,
                 rd: into_reg,
                 rs: from_reg,
                 imm12,

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1996,10 +1996,7 @@ impl MachInstEmit for Inst {
                 .emit(&[], sink, emit_info, state);
                 // trap
                 sink.bind_label(label_trap, &mut state.ctrl_plane);
-                Inst::Udf {
-                    trap_code: trap_code,
-                }
-                .emit(&[], sink, emit_info, state);
+                Inst::Udf { trap_code }.emit(&[], sink, emit_info, state);
                 sink.bind_label(label_jump_over, &mut state.ctrl_plane);
             }
             &Inst::TrapIf { test, trap_code } => {

--- a/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
@@ -147,7 +147,7 @@ block0(v0: i64):
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   andi t6,a0,176
+;   addi t6,a0,176
 ;   trap_ifc stk_ovf##(sp ult t6)
 ;   add sp,-176
 ; block0:
@@ -163,7 +163,7 @@ block0(v0: i64):
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   ori s0, sp, 0
-;   andi t6, a0, 0xb0
+;   addi t6, a0, 0xb0
 ;   bgeu sp, t6, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 ;   addi sp, sp, -0xb0
@@ -251,7 +251,7 @@ block0(v0: i64):
 ;   mv fp,sp
 ;   ld t6,0(a0)
 ;   ld t6,4(t6)
-;   andi t6,t6,32
+;   addi t6,t6,32
 ;   trap_ifc stk_ovf##(sp ult t6)
 ;   add sp,-32
 ; block0:
@@ -269,7 +269,7 @@ block0(v0: i64):
 ;   ori s0, sp, 0
 ;   ld t6, 0(a0)
 ;   ld t6, 4(t6)
-;   andi t6, t6, 0x20
+;   addi t6, t6, 0x20
 ;   bgeu sp, t6, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 ;   addi sp, sp, -0x20
@@ -363,7 +363,7 @@ block0(v0: i64):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ;   ld t6,400000(a0)
-;   andi t6,t6,32
+;   addi t6,t6,32
 ;   trap_ifc stk_ovf##(sp ult t6)
 ;   add sp,-32
 ; block0:
@@ -386,7 +386,7 @@ block0(v0: i64):
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   add t6, t6, a0
 ;   ld t6, 0(t6)
-;   andi t6, t6, 0x20
+;   addi t6, t6, 0x20
 ;   bgeu sp, t6, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 ;   addi sp, sp, -0x20


### PR DESCRIPTION
It was generating bit-wise and instructions instead of addition instructions.

While we are at it, use field literal short hand for a struct literal in riscv64 instruction emission.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
