### PR TITLE
Forward TypeChecker definiton error while reading wit component 

### DIFF
--- a/crates/wasmtime/src/component/linker.rs
+++ b/crates/wasmtime/src/component/linker.rs
@@ -5,7 +5,7 @@ use crate::component::{
     Component, ComponentNamedList, Instance, InstancePre, Lift, Lower, ResourceType, Val,
 };
 use crate::{AsContextMut, Engine, Module, StoreContextMut};
-use anyhow::{anyhow, bail, Context, Result};
+use anyhow::{anyhow, bail, Result};
 use indexmap::IndexMap;
 use std::collections::hash_map::{Entry, HashMap};
 use std::future::Future;

--- a/crates/wasmtime/src/component/linker.rs
+++ b/crates/wasmtime/src/component/linker.rs
@@ -148,8 +148,13 @@ impl<T> Linker<T> {
                 .strings
                 .lookup(name)
                 .and_then(|name| self.map.get(&name));
-            cx.definition(ty, import)
-                .with_context(|| format!("import `{name}` has the wrong type"))?;
+            match cx.definition(ty, import) {
+                Ok(_) => (),
+                Err(e) => bail!(
+                    "error while reading import `{name}` types: {}",
+                    e.to_string()
+                ),
+            }
         }
 
         // Now that all imports are known to be defined and satisfied by this


### PR DESCRIPTION
Make "error while reading import" more verbose

I had some issues moving from elder component / wit format recently, and have noticed that error message in linker is not very verbose -- it says what import has problems, but doesn't say what exactly happened.  

So I've decided that it would make sense to make it a little bit more verbose by appending the initial `TypeChecker` error message to the end. 

