### PR TITLE
Don't generate same-named imports in fact modules

### DIFF
--- a/crates/environ/src/fact.rs
+++ b/crates/environ/src/fact.rs
@@ -262,7 +262,7 @@ impl<'a> Module<'a> {
         let memory = memory.as_ref().map(|memory| {
             self.import_memory(
                 "memory",
-                "",
+                &format!("m{}", self.imported_memories.len()),
                 MemoryType {
                     minimum: 0,
                     maximum: None,
@@ -279,7 +279,12 @@ impl<'a> Module<'a> {
                 ValType::I32
             };
             let ty = self.core_types.function(&[ptr, ptr, ptr, ptr], &[ptr]);
-            self.import_func("realloc", "", ty, func.clone())
+            self.import_func(
+                "realloc",
+                &format!("f{}", self.imported_funcs.len()),
+                ty,
+                func.clone(),
+            )
         });
 
         AdapterOptions {


### PR DESCRIPTION
Ensure that all imports have unique module/name combos to ensure that the module can be instantiable in JS where separate functions need to be provided for each import.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
