### PR TITLE
consistient WASI preview1 rights reporting

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/path_open_preopen.rs
+++ b/crates/test-programs/wasi-tests/src/bin/path_open_preopen.rs
@@ -20,6 +20,18 @@ unsafe fn path_open_preopen() {
         fdstat.fs_rights_base,
         fdstat.fs_rights_inheriting
     );
+    for (right, name) in directory_base_rights() {
+        assert!(
+            (fdstat.fs_rights_base & right) == right,
+            "fs_rights_base does not have required right `{name}`"
+        );
+    }
+    for (right, name) in directory_inheriting_rights() {
+        assert!(
+            (fdstat.fs_rights_inheriting & right) == right,
+            "fs_rights_inheriting does not have required right `{name}`"
+        );
+    }
 
     // Open with same rights it has now:
     let _ = wasi::path_open(
@@ -89,4 +101,53 @@ fn main() {
     unsafe {
         path_open_preopen();
     }
+}
+
+// Hard-code the set of rights expected for a preopened directory. This is
+// more brittle than we wanted to test for, but various userland
+// implementations expect (at least) this set of rights to be present on all
+// directories:
+
+fn directory_base_rights() -> Vec<(wasi::Rights, &'static str)> {
+    vec![
+        (wasi::RIGHTS_PATH_CREATE_DIRECTORY, "PATH_CREATE_DIRECTORY"),
+        (wasi::RIGHTS_PATH_CREATE_FILE, "PATH_CREATE_FILE"),
+        (wasi::RIGHTS_PATH_LINK_SOURCE, "PATH_LINK_SOURCE"),
+        (wasi::RIGHTS_PATH_LINK_TARGET, "PATH_LINK_TARGET"),
+        (wasi::RIGHTS_PATH_OPEN, "PATH_OPEN"),
+        (wasi::RIGHTS_FD_READDIR, "FD_READDIR"),
+        (wasi::RIGHTS_PATH_READLINK, "PATH_READLINK"),
+        (wasi::RIGHTS_PATH_RENAME_SOURCE, "PATH_RENAME_SOURCE"),
+        (wasi::RIGHTS_PATH_RENAME_TARGET, "PATH_RENAME_TARGET"),
+        (wasi::RIGHTS_PATH_SYMLINK, "PATH_SYMLINK"),
+        (wasi::RIGHTS_PATH_REMOVE_DIRECTORY, "PATH_REMOVE_DIRECTORY"),
+        (wasi::RIGHTS_PATH_UNLINK_FILE, "PATH_UNLINK_FILE"),
+        (wasi::RIGHTS_PATH_FILESTAT_GET, "PATH_FILESTAT_GET"),
+        (
+            wasi::RIGHTS_PATH_FILESTAT_SET_TIMES,
+            "PATH_FILESTAT_SET_TIMES",
+        ),
+        (wasi::RIGHTS_FD_FILESTAT_GET, "FD_FILESTAT_GET"),
+        (wasi::RIGHTS_FD_FILESTAT_SET_TIMES, "FD_FILESTAT_SET_TIMES"),
+    ]
+}
+
+pub(crate) fn directory_inheriting_rights() -> Vec<(wasi::Rights, &'static str)> {
+    let mut rights = directory_base_rights();
+    rights.extend_from_slice(&[
+        (wasi::RIGHTS_FD_DATASYNC, "FD_DATASYNC"),
+        (wasi::RIGHTS_FD_READ, "FD_READ"),
+        (wasi::RIGHTS_FD_SEEK, "FD_SEEK"),
+        (wasi::RIGHTS_FD_FDSTAT_SET_FLAGS, "FD_FDSTAT_SET_FLAGS"),
+        (wasi::RIGHTS_FD_SYNC, "FD_SYNC"),
+        (wasi::RIGHTS_FD_TELL, "FD_TELL"),
+        (wasi::RIGHTS_FD_WRITE, "FD_WRITE"),
+        (wasi::RIGHTS_FD_ADVISE, "FD_ADVISE"),
+        (wasi::RIGHTS_FD_ALLOCATE, "FD_ALLOCATE"),
+        (wasi::RIGHTS_FD_FILESTAT_GET, "FD_FILESTAT_GET"),
+        (wasi::RIGHTS_FD_FILESTAT_SET_SIZE, "FD_FILESTAT_SET_SIZE"),
+        (wasi::RIGHTS_FD_FILESTAT_SET_TIMES, "FD_FILESTAT_SET_TIMES"),
+        (wasi::RIGHTS_POLL_FD_READWRITE, "POLL_FD_READWRITE"),
+    ]);
+    rights
 }

--- a/crates/wasi/src/preview2/preview1/mod.rs
+++ b/crates/wasi/src/preview2/preview1/mod.rs
@@ -861,7 +861,47 @@ impl<
                     fs_rights_inheriting: fs_rights_base,
                 });
             }
-            Descriptor::PreopenDirectory((fd, _)) => (*fd, false, false),
+            Descriptor::PreopenDirectory((_, _)) => {
+                // Hard-coded set or rights expected by many userlands:
+                let fs_rights_base = types::Rights::PATH_CREATE_DIRECTORY
+                    | types::Rights::PATH_CREATE_FILE
+                    | types::Rights::PATH_LINK_SOURCE
+                    | types::Rights::PATH_LINK_TARGET
+                    | types::Rights::PATH_OPEN
+                    | types::Rights::FD_READDIR
+                    | types::Rights::PATH_READLINK
+                    | types::Rights::PATH_RENAME_SOURCE
+                    | types::Rights::PATH_RENAME_TARGET
+                    | types::Rights::PATH_SYMLINK
+                    | types::Rights::PATH_REMOVE_DIRECTORY
+                    | types::Rights::PATH_UNLINK_FILE
+                    | types::Rights::PATH_FILESTAT_GET
+                    | types::Rights::PATH_FILESTAT_SET_TIMES
+                    | types::Rights::FD_FILESTAT_GET
+                    | types::Rights::FD_FILESTAT_SET_TIMES;
+
+                let fs_rights_inheriting = fs_rights_base
+                    | types::Rights::FD_DATASYNC
+                    | types::Rights::FD_READ
+                    | types::Rights::FD_SEEK
+                    | types::Rights::FD_FDSTAT_SET_FLAGS
+                    | types::Rights::FD_SYNC
+                    | types::Rights::FD_TELL
+                    | types::Rights::FD_WRITE
+                    | types::Rights::FD_ADVISE
+                    | types::Rights::FD_ALLOCATE
+                    | types::Rights::FD_FILESTAT_GET
+                    | types::Rights::FD_FILESTAT_SET_SIZE
+                    | types::Rights::FD_FILESTAT_SET_TIMES
+                    | types::Rights::POLL_FD_READWRITE;
+
+                return Ok(types::Fdstat {
+                    fs_filetype: types::Filetype::Directory,
+                    fs_flags: types::Fdflags::empty(),
+                    fs_rights_base,
+                    fs_rights_inheriting,
+                });
+            }
             Descriptor::File(File {
                 fd,
                 blocking,


### PR DESCRIPTION

We have three preview1 implementations in tree:
* `wasi-common`
* `wasi-preview1-component-adapter`
* `wasmtime-wasi::preview2::preview1`

This PR makes all of them report the exact same set of rights for directories.

wasi-libc based userlands (e.g. wasi-sdk, tinygo, some parts of rust std, and others!) will sometimes check whether they have a preview1 Right to perform an import function call, and return early if they do not.

Last attempt at adjusting how we report Rights https://github.com/bytecodealliance/wasmtime/pull/6463
 hard-coded the set of rights in wasi-common. That PR also added a wasi-test `path_open_preopen` that was intended to check whether wasi-libc's expectations were met. This test focused on the bug report we had wasi-libc around opening directories, and short of testing for the full expected set or rights. 

We got a bug report on zulip that tinygo, which uses wasi-libc, failed in the go call `os.Create`: https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime/topic/Problem.20with.20WasiCtxBuilder.2Epush_preopened_dir.20for.20component . It appeared this was getting rejected in wasi-libc, using the rights reported from the wasi-preview1-component-adapter.

To avoid chasing these individual wasi-libc behaviors much further, I decided to add the expectation of the set of rights to `path_open_preopen`, and fix `wasi-preview1-component-adapter` and `wasmtime-wasi::preview2::preview1` to always report those rights. This does mean duplicating that list of rights in a few more places in the source code, but theres no good way to do code sharing among these crates because the constants are coming from different crates/binding generators across these projects.

I'd love for this to be the last time we have to kick the Rights can down the road. However, I'm now paranoid that, even with directories taken care of, we will run into the a similar problem with wasi-libc's expectation of file rights. I believe the behavior for file rights is consistent across all three implementations, so since we haven't gotten any file related bug reports since #6463 I am hopeful we have it right everywhere.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
