### PR TITLE
Wasmtime: Introduce `{Module,Component}::resources_required`

### DIFF
--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -404,6 +404,7 @@ mod memory;
 mod module;
 mod profiling;
 mod r#ref;
+mod resources;
 mod signatures;
 mod store;
 mod trampoline;
@@ -422,6 +423,7 @@ pub use crate::memory::*;
 pub use crate::module::Module;
 pub use crate::profiling::GuestProfiler;
 pub use crate::r#ref::ExternRef;
+pub use crate::resources::*;
 #[cfg(feature = "async")]
 pub use crate::store::CallHookHandler;
 pub use crate::store::{

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -1,5 +1,6 @@
-use crate::code::CodeObject;
 use crate::{
+    code::CodeObject,
+    resources::ResourcesRequired,
     signatures::SignatureCollection,
     types::{ExportType, ExternType, ImportType},
     Engine,
@@ -902,6 +903,75 @@ impl Module {
     /// Returns the [`Engine`] that this [`Module`] was compiled by.
     pub fn engine(&self) -> &Engine {
         &self.inner.engine
+    }
+
+    /// Returns a summary of the resources required to instantiate this
+    /// [`Module`].
+    ///
+    /// Potential uses of the returned information:
+    ///
+    /// * Determining whether your pooling allocator configuration supports
+    ///   instantiating this module.
+    ///
+    /// * Deciding how many of which `Module` you want to instantiate within a
+    ///   fixed amount of resources, e.g. determining whether to create 5
+    ///   instances of module X or 10 instances of module Y.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # fn main() -> wasmtime::Result<()> {
+    /// use wasmtime::{Config, Engine, Module};
+    ///
+    /// let mut config = Config::new();
+    /// config.wasm_multi_memory(true);
+    /// let engine = Engine::new(&config)?;
+    ///
+    /// let module = Module::new(&engine, r#"
+    ///     (module
+    ///         ;; Import a memory. Doesn't count towards required resources.
+    ///         (import "a" "b" (memory 10))
+    ///         ;; Define two local memories. These count towards the required
+    ///         ;; resources.
+    ///         (memory 1)
+    ///         (memory 6)
+    ///     )
+    /// "#)?;
+    ///
+    /// let resources = module.resources_required();
+    ///
+    /// // Instantiating the module will require allocating two memories, and
+    /// // the maximum initial memory size is six Wasm pages.
+    /// assert_eq!(resources.num_memories, 2);
+    /// assert_eq!(resources.max_initial_memory_size, Some(6));
+    ///
+    /// // The module doesn't need any tables.
+    /// assert_eq!(resources.num_tables, 0);
+    /// assert_eq!(resources.max_initial_table_size, None);
+    /// # Ok(()) }
+    /// ```
+    pub fn resources_required(&self) -> ResourcesRequired {
+        let em = self.env_module();
+        let num_memories = u32::try_from(em.memory_plans.len() - em.num_imported_memories).unwrap();
+        let max_initial_memory_size = em
+            .memory_plans
+            .values()
+            .skip(em.num_imported_memories)
+            .map(|plan| plan.memory.minimum)
+            .max();
+        let num_tables = u32::try_from(em.table_plans.len() - em.num_imported_tables).unwrap();
+        let max_initial_table_size = em
+            .table_plans
+            .values()
+            .skip(em.num_imported_tables)
+            .map(|plan| plan.table.minimum)
+            .max();
+        ResourcesRequired {
+            num_memories,
+            max_initial_memory_size,
+            num_tables,
+            max_initial_table_size,
+        }
     }
 
     /// Returns the `ModuleInner` cast as `ModuleRuntimeInfo` for use

--- a/crates/wasmtime/src/resources.rs
+++ b/crates/wasmtime/src/resources.rs
@@ -1,0 +1,33 @@
+/// A summary of the amount of resources required to instantiate a particular
+/// [`Module`][crate::Module] or [`Component`][crate::component::Component].
+///
+/// Example uses of this information:
+///
+/// * Determining whether your pooling allocator configuration supports
+///   instantiating this module.
+///
+/// * Deciding how many of which `Module` you want to instantiate within a
+///   fixed amount of resources, e.g. determining whether to create 5
+///   instances of module `X` or 10 instances of module `Y`.
+pub struct ResourcesRequired {
+    /// The number of memories that are required.
+    pub num_memories: u32,
+    /// The maximum initial size required by any memory, in units of Wasm pages.
+    pub max_initial_memory_size: Option<u64>,
+    /// The number of tables that are required.
+    pub num_tables: u32,
+    /// The maximum initial size required by any table.
+    pub max_initial_table_size: Option<u32>,
+}
+
+impl ResourcesRequired {
+    #[cfg(feature = "component-model")]
+    pub(crate) fn add(&mut self, other: &ResourcesRequired) {
+        self.num_memories += other.num_memories;
+        self.max_initial_memory_size =
+            std::cmp::max(self.max_initial_memory_size, other.max_initial_memory_size);
+        self.num_tables += other.num_tables;
+        self.max_initial_table_size =
+            std::cmp::max(self.max_initial_table_size, other.max_initial_table_size);
+    }
+}


### PR DESCRIPTION
Returns a summary of the resources required to instantiate this module or component.

Potential uses of the returned information:

* Determining whether your pooling allocator configuration supports instantiating this module.

* Deciding how many of which `Module` you want to instantiate within a fixed amount of resources, e.g. determining whether to create 5 instances of module X or 10 instances of module Y.

Part of #6627.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
