### PR TITLE
Wasmtime: Move `OnDemandInstanceAllocator` to its own module

### DIFF
--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -1,6 +1,6 @@
 use crate::imports::Imports;
-use crate::instance::{Instance, InstanceHandle, RuntimeMemoryCreator};
-use crate::memory::{DefaultMemoryCreator, Memory};
+use crate::instance::{Instance, InstanceHandle};
+use crate::memory::Memory;
 use crate::table::Table;
 use crate::{CompiledModuleId, ModuleRuntimeInfo, Store};
 use anyhow::{anyhow, bail, Result};
@@ -15,9 +15,11 @@ use wasmtime_environ::{
     WasmType, WASM_PAGE_SIZE,
 };
 
+mod on_demand;
+pub use self::on_demand::OnDemandInstanceAllocator;
+
 #[cfg(feature = "pooling-allocator")]
 mod pooling;
-
 #[cfg(feature = "pooling-allocator")]
 pub use self::pooling::{InstanceLimits, PoolingInstanceAllocator, PoolingInstanceAllocatorConfig};
 
@@ -409,123 +411,4 @@ pub(super) fn initialize_instance(
     initialize_memories(instance, &module)?;
 
     Ok(())
-}
-
-/// Represents the on-demand instance allocator.
-#[derive(Clone)]
-pub struct OnDemandInstanceAllocator {
-    mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>,
-    #[cfg(feature = "async")]
-    stack_size: usize,
-}
-
-impl OnDemandInstanceAllocator {
-    /// Creates a new on-demand instance allocator.
-    pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>, stack_size: usize) -> Self {
-        let _ = stack_size; // suppress unused warnings w/o async feature
-        Self {
-            mem_creator,
-            #[cfg(feature = "async")]
-            stack_size,
-        }
-    }
-}
-
-impl Default for OnDemandInstanceAllocator {
-    fn default() -> Self {
-        Self {
-            mem_creator: None,
-            #[cfg(feature = "async")]
-            stack_size: 0,
-        }
-    }
-}
-
-unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
-    fn allocate_index(&self, _req: &InstanceAllocationRequest) -> Result<usize> {
-        Ok(0)
-    }
-
-    fn deallocate_index(&self, index: usize) {
-        assert_eq!(index, 0);
-    }
-
-    fn allocate_memories(
-        &self,
-        _index: usize,
-        req: &mut InstanceAllocationRequest,
-        memories: &mut PrimaryMap<DefinedMemoryIndex, Memory>,
-    ) -> Result<()> {
-        let module = req.runtime_info.module();
-        let creator = self
-            .mem_creator
-            .as_deref()
-            .unwrap_or_else(|| &DefaultMemoryCreator);
-        let num_imports = module.num_imported_memories;
-        for (memory_idx, plan) in module.memory_plans.iter().skip(num_imports) {
-            let defined_memory_idx = module
-                .defined_memory_index(memory_idx)
-                .expect("Skipped imports, should never be None");
-            let image = req.runtime_info.memory_image(defined_memory_idx)?;
-
-            memories.push(Memory::new_dynamic(
-                plan,
-                creator,
-                unsafe {
-                    req.store
-                        .get()
-                        .expect("if module has memory plans, store is not empty")
-                },
-                image,
-            )?);
-        }
-        Ok(())
-    }
-
-    fn deallocate_memories(
-        &self,
-        _index: usize,
-        _mems: &mut PrimaryMap<DefinedMemoryIndex, Memory>,
-    ) {
-        // normal destructors do cleanup here
-    }
-
-    fn allocate_tables(
-        &self,
-        _index: usize,
-        req: &mut InstanceAllocationRequest,
-        tables: &mut PrimaryMap<DefinedTableIndex, Table>,
-    ) -> Result<()> {
-        let module = req.runtime_info.module();
-        let num_imports = module.num_imported_tables;
-        for (_, table) in module.table_plans.iter().skip(num_imports) {
-            tables.push(Table::new_dynamic(table, unsafe {
-                req.store
-                    .get()
-                    .expect("if module has table plans, store is not empty")
-            })?);
-        }
-        Ok(())
-    }
-
-    fn deallocate_tables(&self, _index: usize, _tables: &mut PrimaryMap<DefinedTableIndex, Table>) {
-        // normal destructors do cleanup here
-    }
-
-    #[cfg(feature = "async")]
-    fn allocate_fiber_stack(&self) -> Result<wasmtime_fiber::FiberStack> {
-        if self.stack_size == 0 {
-            bail!("fiber stacks are not supported by the allocator")
-        }
-
-        let stack = wasmtime_fiber::FiberStack::new(self.stack_size)?;
-        Ok(stack)
-    }
-
-    #[cfg(feature = "async")]
-    unsafe fn deallocate_fiber_stack(&self, _stack: &wasmtime_fiber::FiberStack) {
-        // The on-demand allocator has no further bookkeeping for fiber stacks
-    }
-
-    fn purge_module(&self, _: CompiledModuleId) {}
 }

--- a/crates/runtime/src/instance/allocator/on_demand.rs
+++ b/crates/runtime/src/instance/allocator/on_demand.rs
@@ -1,0 +1,127 @@
+use super::{InstanceAllocationRequest, InstanceAllocator};
+use crate::instance::RuntimeMemoryCreator;
+use crate::memory::{DefaultMemoryCreator, Memory};
+use crate::table::Table;
+use crate::CompiledModuleId;
+use anyhow::Result;
+use std::sync::Arc;
+use wasmtime_environ::{DefinedMemoryIndex, DefinedTableIndex, PrimaryMap};
+
+/// Represents the on-demand instance allocator.
+#[derive(Clone)]
+pub struct OnDemandInstanceAllocator {
+    mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>,
+    #[cfg(feature = "async")]
+    stack_size: usize,
+}
+
+impl OnDemandInstanceAllocator {
+    /// Creates a new on-demand instance allocator.
+    pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>, stack_size: usize) -> Self {
+        let _ = stack_size; // suppress unused warnings w/o async feature
+        Self {
+            mem_creator,
+            #[cfg(feature = "async")]
+            stack_size,
+        }
+    }
+}
+
+impl Default for OnDemandInstanceAllocator {
+    fn default() -> Self {
+        Self {
+            mem_creator: None,
+            #[cfg(feature = "async")]
+            stack_size: 0,
+        }
+    }
+}
+
+unsafe impl InstanceAllocator for OnDemandInstanceAllocator {
+    fn allocate_index(&self, _req: &InstanceAllocationRequest) -> Result<usize> {
+        Ok(0)
+    }
+
+    fn deallocate_index(&self, index: usize) {
+        assert_eq!(index, 0);
+    }
+
+    fn allocate_memories(
+        &self,
+        _index: usize,
+        req: &mut InstanceAllocationRequest,
+        memories: &mut PrimaryMap<DefinedMemoryIndex, Memory>,
+    ) -> Result<()> {
+        let module = req.runtime_info.module();
+        let creator = self
+            .mem_creator
+            .as_deref()
+            .unwrap_or_else(|| &DefaultMemoryCreator);
+        let num_imports = module.num_imported_memories;
+        for (memory_idx, plan) in module.memory_plans.iter().skip(num_imports) {
+            let defined_memory_idx = module
+                .defined_memory_index(memory_idx)
+                .expect("Skipped imports, should never be None");
+            let image = req.runtime_info.memory_image(defined_memory_idx)?;
+
+            memories.push(Memory::new_dynamic(
+                plan,
+                creator,
+                unsafe {
+                    req.store
+                        .get()
+                        .expect("if module has memory plans, store is not empty")
+                },
+                image,
+            )?);
+        }
+        Ok(())
+    }
+
+    fn deallocate_memories(
+        &self,
+        _index: usize,
+        _mems: &mut PrimaryMap<DefinedMemoryIndex, Memory>,
+    ) {
+        // normal destructors do cleanup here
+    }
+
+    fn allocate_tables(
+        &self,
+        _index: usize,
+        req: &mut InstanceAllocationRequest,
+        tables: &mut PrimaryMap<DefinedTableIndex, Table>,
+    ) -> Result<()> {
+        let module = req.runtime_info.module();
+        let num_imports = module.num_imported_tables;
+        for (_, table) in module.table_plans.iter().skip(num_imports) {
+            tables.push(Table::new_dynamic(table, unsafe {
+                req.store
+                    .get()
+                    .expect("if module has table plans, store is not empty")
+            })?);
+        }
+        Ok(())
+    }
+
+    fn deallocate_tables(&self, _index: usize, _tables: &mut PrimaryMap<DefinedTableIndex, Table>) {
+        // normal destructors do cleanup here
+    }
+
+    #[cfg(feature = "async")]
+    fn allocate_fiber_stack(&self) -> Result<wasmtime_fiber::FiberStack> {
+        if self.stack_size == 0 {
+            anyhow::bail!("fiber stacks are not supported by the allocator")
+        }
+
+        let stack = wasmtime_fiber::FiberStack::new(self.stack_size)?;
+        Ok(stack)
+    }
+
+    #[cfg(feature = "async")]
+    unsafe fn deallocate_fiber_stack(&self, _stack: &wasmtime_fiber::FiberStack) {
+        // The on-demand allocator has no further bookkeeping for fiber stacks
+    }
+
+    fn purge_module(&self, _: CompiledModuleId) {}
+}


### PR DESCRIPTION
Just code motion, no other changes.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
