### PR TITLE
Fix incorrect sample code in documentation (#6796)

### DIFF
--- a/crates/wasmtime/README.md
+++ b/crates/wasmtime/README.md
@@ -94,7 +94,7 @@ fn main() -> Result<()> {
     // this case we're using `4` for.
     let mut store = Store::new(&engine, 4);
     let instance = linker.instantiate(&mut store, &module)?;
-    let hello = instance.get_typed_func::<(), (), _>(&mut store, "hello")?;
+    let hello = instance.get_typed_func::<(), ()>(&mut store, "hello")?;
 
     // And finally we can call the wasm!
     hello.call(&mut store, ())?;


### PR DESCRIPTION
Sample code provided in Readme of `wasmtime` crate specifies three generic arguments for `get_typed_func` API, while it needs only two. This fixes the sample code by removing the last generic argument.

Fixes #6796 