### PR TITLE
Configure Mach ports vs signals via `Config`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -268,7 +268,6 @@ wasi-threads = ["dep:wasmtime-wasi-threads"]
 wasi-http = ["dep:wasmtime-wasi-http"]
 pooling-allocator = ["wasmtime/pooling-allocator", "wasmtime-cli-flags/pooling-allocator"]
 all-arch = ["wasmtime/all-arch"]
-posix-signals-on-macos = ["wasmtime/posix-signals-on-macos"]
 component-model = [
   "wasmtime/component-model",
   "wasmtime-wast/component-model",

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -60,11 +60,6 @@ async = ["wasmtime-fiber"]
 # Enables support for the pooling instance allocator
 pooling-allocator = []
 
-# Enables trap handling using POSIX signals instead of Mach exceptions on MacOS.
-# It is useful for applications that do not bind their own exception ports and
-# need portable signal handling.
-posix-signals-on-macos = []
-
 component-model = [
   "wasmtime-environ/component-model",
   "dep:encoding_rs",

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -136,12 +136,14 @@ pub fn init_traps(is_wasm_pc: fn(usize) -> bool, macos_use_mach_ports: bool) {
 }
 
 fn lazy_per_thread_init() {
+    #[cfg(target_os = "macos")]
     unsafe {
         if MACOS_USE_MACH_PORTS {
             return macos::lazy_per_thread_init();
         }
-        sys::lazy_per_thread_init();
     }
+
+    sys::lazy_per_thread_init();
 }
 
 /// Raises a trap immediately.

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -118,11 +118,6 @@ all-arch = [
   "wasmtime-winch?/all-arch",
 ]
 
-# Enables trap handling using POSIX signals instead of Mach exceptions on MacOS.
-# It is useful for applications that do not bind their own exception ports and
-# need portable signal handling.
-posix-signals-on-macos = ["wasmtime-runtime/posix-signals-on-macos"]
-
 # Enables in-progress support for the component model. Note that this feature is
 # in-progress, buggy, and incomplete. This is primarily here for internal
 # testing purposes.

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -77,7 +77,7 @@ impl Engine {
         // Ensure that wasmtime_runtime's signal handlers are configured. This
         // is the per-program initialization required for handling traps, such
         // as configuring signals, vectored exception handlers, etc.
-        wasmtime_runtime::init_traps(crate::module::is_wasm_trap_pc);
+        wasmtime_runtime::init_traps(crate::module::is_wasm_trap_pc, config.macos_use_mach_ports);
         debug_builtins::ensure_exported();
 
         let registry = SignatureRegistry::new();


### PR DESCRIPTION
This commit adds a `Config::macos_use_mach_ports` configuration option to replace the old `posix-signals-on-macos` compile-time Cargo feature. This'll make Wasmtime a tad larger on macOS but likely negligibly so. Otherwise this is intended to provide a resolution to #6785 where embedders will be able to use any build of Wasmtime and configure at runtime how trap handling should happen.

Functionally this commit additionally registers a `pthread_atfork` handler to cause any usage of Wasmtime in the child to panic. This should help head off a known-invalid state in case anyone runs into it in the future.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
