### PR TITLE
aarch64: Fix `return_call`'s interaction with pointer authentication

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -902,7 +902,7 @@
        ;; Pointer authentication code for instruction address with modifier in SP;
        ;; equivalent to a no-op if Pointer authentication (FEAT_PAuth) is not
        ;; supported.
-       (Pacisp
+       (Paci
         (key APIKey))
 
        ;; Strip pointer authentication code from instruction address in LR;
@@ -1645,8 +1645,14 @@
 ;; Keys for instruction address PACs
 (type APIKey
   (enum
-    (A)
-    (B)
+    ;; API key A with the modifier of SP
+    (ASP)
+    ;; API key B with the modifier of SP
+    (BSP)
+    ;; API key A with the modifier of zero
+    (AZ)
+    ;; API key B with the modifier of zero
+    (BZ)
 ))
 
 ;; Branch target types

--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -739,3 +739,17 @@ impl VectorSize {
         }
     }
 }
+
+impl APIKey {
+    /// Returns the encoding of the `auti{key}` instruction used to decrypt the
+    /// `lr` register.
+    pub fn enc_auti_hint(&self) -> u32 {
+        let (crm, op2) = match self {
+            APIKey::AZ => (0b0011, 0b100),
+            APIKey::ASP => (0b0011, 0b101),
+            APIKey::BZ => (0b0011, 0b110),
+            APIKey::BSP => (0b0011, 0b111),
+        };
+        0xd503201f | (crm << 8) | (op2 << 5)
+    }
+}

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -71,7 +71,7 @@ fn test_aarch64_binemit() {
             stack_bytes_to_pop: 0,
         },
         "FF0F5FD6",
-        "retab",
+        "retabsp",
     ));
     insns.push((
         Inst::AuthenticatedRet {
@@ -81,7 +81,7 @@ fn test_aarch64_binemit() {
             stack_bytes_to_pop: 16,
         },
         "FF430091FF0B5FD6",
-        "add sp, sp, #16 ; retaa",
+        "add sp, sp, #16 ; retaasp",
     ));
     insns.push((Inst::Paci { key: APIKey::BSP }, "7F2303D5", "pacibsp"));
     insns.push((Inst::Xpaclri, "FF2003D5", "xpaclri"));

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -55,7 +55,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::AuthenticatedRet {
-            key: APIKey::A,
+            key: APIKey::ASP,
             is_hint: true,
             rets: vec![],
             stack_bytes_to_pop: 0,
@@ -65,7 +65,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::AuthenticatedRet {
-            key: APIKey::B,
+            key: APIKey::BSP,
             is_hint: false,
             rets: vec![],
             stack_bytes_to_pop: 0,
@@ -75,7 +75,7 @@ fn test_aarch64_binemit() {
     ));
     insns.push((
         Inst::AuthenticatedRet {
-            key: APIKey::A,
+            key: APIKey::ASP,
             is_hint: false,
             rets: vec![],
             stack_bytes_to_pop: 16,
@@ -83,7 +83,7 @@ fn test_aarch64_binemit() {
         "FF430091FF0B5FD6",
         "add sp, sp, #16 ; retaa",
     ));
-    insns.push((Inst::Pacisp { key: APIKey::B }, "7F2303D5", "pacibsp"));
+    insns.push((Inst::Paci { key: APIKey::BSP }, "7F2303D5", "pacibsp"));
     insns.push((Inst::Xpaclri, "FF2003D5", "xpaclri"));
     insns.push((
         Inst::Bti {

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -110,7 +110,7 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
             caller_conv,
             self.backend.flags().clone(),
         );
-        call_site.emit_return_call(self.lower_ctx, args);
+        call_site.emit_return_call(self.lower_ctx, args, &self.backend.isa_flags);
 
         InstOutput::new()
     }
@@ -138,7 +138,7 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
             caller_conv,
             self.backend.flags().clone(),
         );
-        call_site.emit_return_call(self.lower_ctx, args);
+        call_site.emit_return_call(self.lower_ctx, args, &self.backend.isa_flags);
 
         InstOutput::new()
     }

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -253,6 +253,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
     fn gen_ret(
         _setup_frame: bool,
         _isa_flags: &Self::F,
+        _call_conv: isa::CallConv,
         rets: Vec<RetPair>,
         stack_bytes_to_pop: u32,
     ) -> Inst {

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -443,6 +443,7 @@ impl ABIMachineSpec for S390xMachineDeps {
     fn gen_ret(
         _setup_frame: bool,
         _isa_flags: &s390x_settings::Flags,
+        _call_conv: isa::CallConv,
         rets: Vec<RetPair>,
         stack_bytes_to_pop: u32,
     ) -> Inst {

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -351,6 +351,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     fn gen_ret(
         _setup_frame: bool,
         _isa_flags: &x64_settings::Flags,
+        _call_conv: isa::CallConv,
         rets: Vec<RetPair>,
         stack_bytes_to_pop: u32,
     ) -> Self::I {

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -451,6 +451,7 @@ pub trait ABIMachineSpec {
     fn gen_ret(
         setup_frame: bool,
         isa_flags: &Self::F,
+        call_conv: isa::CallConv,
         rets: Vec<RetPair>,
         stack_bytes_to_pop: u32,
     ) -> Self::I;
@@ -1713,6 +1714,7 @@ impl<M: ABIMachineSpec> Callee<M> {
         M::gen_ret(
             self.setup_frame,
             &self.isa_flags,
+            self.call_conv,
             rets,
             self.stack_bytes_to_pop(sigs),
         )
@@ -1980,6 +1982,7 @@ impl<M: ABIMachineSpec> Callee<M> {
         insts.push(M::gen_ret(
             self.setup_frame,
             &self.isa_flags,
+            self.call_conv,
             vec![],
             self.stack_bytes_to_pop(sigs),
         ));

--- a/cranelift/filetests/filetests/isa/aarch64/call-pauth-bkey.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call-pauth-bkey.clif
@@ -1,6 +1,6 @@
 test compile precise-output
 set unwind_info=false
-target aarch64 sign_return_address
+target aarch64 sign_return_address sign_return_address_with_bkey has_pauth
 
 function %f1(i64) -> i64 {
     fn0 = %g(i64) -> i64
@@ -11,18 +11,18 @@ block0(v0: i64):
 }
 
 ; VCode:
-;   paciasp
+;   pacibsp
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
 ;   load_ext_name x3, TestCase(%g)+0
 ;   blr x3
 ;   ldp fp, lr, [sp], #16
-;   autiasp ; ret
+;   retabsp
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   paciasp
+;   pacibsp
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0xc
@@ -32,8 +32,7 @@ block0(v0: i64):
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   blr x3
 ;   ldp x29, x30, [sp], #0x10
-;   autiasp
-;   ret
+;   retab
 
 function %f2(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -60,7 +59,7 @@ block0(v0: i64):
 }
 
 ; VCode:
-;   paciaz
+;   pacibz
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
@@ -69,11 +68,11 @@ block0(v0: i64):
 ;   blr x3
 ;   mov x2, x0
 ;   ldp fp, lr, [sp], #16
-;   autiaz ; ret
+;   retabz
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   paciaz
+;   pacibz
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0xc
@@ -85,7 +84,7 @@ block0(v0: i64):
 ;   blr x3
 ;   mov x2, x0
 ;   ldp x29, x30, [sp], #0x10
-;   autiaz
+;   autibz
 ;   ret
 
 function %tail_call(i64) -> i64 tail {
@@ -96,7 +95,7 @@ block0(v0: i64):
 }
 
 ; VCode:
-;   paciaz
+;   pacibz
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
@@ -105,7 +104,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   paciaz
+;   pacibz
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0xc
@@ -116,6 +115,6 @@ block0(v0: i64):
 ;   ldp x16, x30, [x29]
 ;   add sp, x29, #0x10
 ;   mov x29, x16
-;   autiaz
+;   autibz
 ;   br x3
 


### PR DESCRIPTION
This commit fixes an issue where a `return_call` would not decrypt the return address when pointer authentication is enabled. The return address would be encrypted upon entry into the function but would never get restored later on.

This addresses the issue by changing the encryption keys in use from the A/B key plus SP to instead using A/B plus the zero key. The reason for this is that during a normal function call before returning the SP value is guaranteed to be the same as it was upon entry. For tail calls though SP may be different due to differing numbers of stack arguments. This means that the modifier of SP can't be used for the tail convention.

New `APIKey` definitions were added and that now additionally represents the A/B key plus the modifier. Non-`tail` calling conventions still use the same keys as before, it's just the `tail` convention that's different.

Closes #6799

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
