### PR TITLE
riscv64: Add SIMD IFMA instruction support

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -334,6 +334,15 @@
       (probe_count u32)
       (tmp WritableReg))
 
+    (VecAluRRRR
+      (op VecAluOpRRRR)
+      (vd WritableReg)
+      (vd_src Reg)
+      (vs2 Reg)
+      (vs1 Reg)
+      (mask VecOpMasking)
+      (vstate VState))
+
     (VecAluRRRImm5
       (op VecAluOpRRRImm5)
       (vd WritableReg)

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -473,6 +473,7 @@ impl Inst {
 
             Inst::VecAluRR { vstate, .. } |
             Inst::VecAluRRR { vstate, .. } |
+            Inst::VecAluRRRR { vstate, .. } |
             Inst::VecAluRImm5 { vstate, .. } |
             Inst::VecAluRRImm5 { vstate, .. } |
             Inst::VecAluRRRImm5 { vstate, .. } |
@@ -2908,6 +2909,25 @@ impl MachInstEmit for Inst {
                 debug_assert_eq!(vd.to_reg(), vd_src);
 
                 sink.put4(encode_valu_rrr_imm(op, vd, imm, vs2, mask));
+            }
+            &Inst::VecAluRRRR {
+                op,
+                vd,
+                vd_src,
+                vs1,
+                vs2,
+                ref mask,
+                ..
+            } => {
+                let vs1 = allocs.next(vs1);
+                let vs2 = allocs.next(vs2);
+                let vd_src = allocs.next(vd_src);
+                let vd = allocs.next_writable(vd);
+                let mask = mask.with_allocs(&mut allocs);
+
+                debug_assert_eq!(vd.to_reg(), vd_src);
+
+                sink.put4(encode_valu_rrrr(op, vd, vs1, vs2, mask));
             }
             &Inst::VecAluRRR {
                 op,

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -9,8 +9,8 @@
 use super::{Imm12, Imm5, UImm5, VType};
 use crate::isa::riscv64::inst::reg_to_gpr_num;
 use crate::isa::riscv64::lower::isle::generated_code::{
-    VecAluOpRImm5, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecAluOpRRRImm5, VecElementWidth,
-    VecOpCategory, VecOpMasking,
+    VecAluOpRImm5, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecAluOpRRRImm5, VecAluOpRRRR,
+    VecElementWidth, VecOpCategory, VecOpMasking,
 };
 use crate::machinst::isle::WritableReg;
 use crate::Reg;
@@ -141,6 +141,24 @@ pub fn encode_valu_rr_imm(
         reg_to_gpr_num(vd.to_reg()),
         op.funct3(),
         imm,
+        reg_to_gpr_num(vs2),
+        funct7,
+    )
+}
+
+pub fn encode_valu_rrrr(
+    op: VecAluOpRRRR,
+    vd: WritableReg,
+    vs2: Reg,
+    vs1: Reg,
+    masking: VecOpMasking,
+) -> u32 {
+    let funct7 = (op.funct6() << 1) | masking.encode();
+    encode_r_type_bits(
+        op.opcode(),
+        reg_to_gpr_num(vd.to_reg()),
+        op.funct3(),
+        reg_to_gpr_num(vs1),
         reg_to_gpr_num(vs2),
         funct7,
     )

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -212,6 +212,17 @@
   (VslideupVI)
 ))
 
+;; Register-Register ALU Ops that modify the destination register
+(type VecAluOpRRRR (enum
+  ;; Vector-Vector Opcodes
+  (VmaccVV)
+  (VnmsacVV)
+
+  ;; Vector-Scalar Opcodes
+  (VmaccVX)
+  (VnmsacVX)
+))
+
 ;; Register-Imm ALU Ops
 (type VecAluOpRRImm5 (enum
   ;; Regular VI Opcodes
@@ -334,6 +345,14 @@
 ;; of the usual RISC-V register order.
 ;; See Section 10.1 of the RISC-V Vector Extension Specification.
 
+
+;; Helper for emitting `MInst.VecAluRRRR` instructions.
+;; These instructions modify the destination register.
+(decl vec_alu_rrrr (VecAluOpRRRR VReg VReg Reg VecOpMasking  VState) VReg)
+(rule (vec_alu_rrrr op vd_src vs2 vs1 mask vstate)
+      (let ((vd WritableVReg (temp_writable_vreg))
+            (_ Unit (emit (MInst.VecAluRRRR op vd vd_src vs2 vs1 mask vstate))))
+        vd))
 
 ;; Helper for emitting `MInst.VecAluRRRImm5` instructions.
 ;; These instructions modify the destination register.
@@ -644,6 +663,38 @@
 (decl rv_vsmul_vx (VReg XReg VecOpMasking VState) VReg)
 (rule (rv_vsmul_vx vs2 vs1 mask vstate)
   (vec_alu_rrr (VecAluOpRRR.VsmulVX) vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vmacc.vv` instruction.
+;;
+;; Integer multiply-add, overwrite addend
+;; # vd[i] = +(vs1[i] * vs2[i]) + vd[i]
+(decl rv_vmacc_vv (VReg VReg VReg VecOpMasking VState) VReg)
+(rule (rv_vmacc_vv vd vs2 vs1 mask vstate)
+  (vec_alu_rrrr (VecAluOpRRRR.VmaccVV) vd vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vmacc.vx` instruction.
+;;
+;; Integer multiply-add, overwrite addend
+;; # vd[i] = +(x[rs1] * vs2[i]) + vd[i]
+(decl rv_vmacc_vx (VReg VReg XReg VecOpMasking VState) VReg)
+(rule (rv_vmacc_vx vd vs2 vs1 mask vstate)
+  (vec_alu_rrrr (VecAluOpRRRR.VmaccVX) vd vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vnmsac.vv` instruction.
+;;
+;; Integer multiply-sub, overwrite minuend
+;; # vd[i] = -(vs1[i] * vs2[i]) + vd[i]
+(decl rv_vnmsac_vv (VReg VReg VReg VecOpMasking VState) VReg)
+(rule (rv_vnmsac_vv vd vs2 vs1 mask vstate)
+  (vec_alu_rrrr (VecAluOpRRRR.VnmsacVV) vd vs2 vs1 mask vstate))
+
+;; Helper for emitting the `vnmsac.vx` instruction.
+;;
+;; Integer multiply-sub, overwrite minuend
+;; # vd[i] = -(x[rs1] * vs2[i]) + vd[i]
+(decl rv_vnmsac_vx (VReg VReg XReg VecOpMasking VState) VReg)
+(rule (rv_vnmsac_vx vd vs2 vs1 mask vstate)
+  (vec_alu_rrrr (VecAluOpRRRR.VnmsacVX) vd vs2 vs1 mask vstate))
 
 ;; Helper for emitting the `sll.vv` instruction.
 (decl rv_vsll_vv (VReg VReg VecOpMasking VState) VReg)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -249,6 +249,49 @@
                                                             (uwiden_low y))))
   (rv_vwaddu_vv (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
+;; Fused Multiply Accumulate Rules `vmacc`
+;;
+;; I dont think we can use `vmadd`/`vmnsub` here since it just modifies the multiplication
+;; register instead of the addition one. The actual pattern matched seems to be
+;; exactly the same.
+
+(rule 9 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (imul y z))))
+  (rv_vmacc_vv x y z (unmasked) ty))
+
+(rule 10 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (imul y (splat z)))))
+  (rv_vmacc_vx x y z (unmasked) ty))
+
+(rule 11 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (imul (splat y) z))))
+  (rv_vmacc_vx x z y (unmasked) ty))
+
+(rule 12 (lower (has_type (ty_vec_fits_in_register ty) (iadd (imul x y) z)))
+  (rv_vmacc_vv z x y (unmasked) ty))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register ty) (iadd (imul x (splat y)) z)))
+  (rv_vmacc_vx z x y (unmasked) ty))
+
+(rule 14 (lower (has_type (ty_vec_fits_in_register ty) (iadd (imul (splat x) y) z)))
+  (rv_vmacc_vx z y x (unmasked) ty))
+
+;; Fused Multiply Subtract Rules `vnmsac`
+
+(rule 9 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (ineg (imul y z)))))
+  (rv_vnmsac_vv x y z (unmasked) ty))
+
+(rule 10 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (ineg (imul y (splat z))))))
+  (rv_vnmsac_vx x y z (unmasked) ty))
+
+(rule 11 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (ineg (imul (splat y) z)))))
+  (rv_vnmsac_vx x z y (unmasked) ty))
+
+(rule 12 (lower (has_type (ty_vec_fits_in_register ty) (iadd (ineg (imul x y)) z)))
+  (rv_vnmsac_vv z x y (unmasked) ty))
+
+(rule 13 (lower (has_type (ty_vec_fits_in_register ty) (iadd (ineg (imul x (splat y))) z)))
+  (rv_vnmsac_vx z x y (unmasked) ty))
+
+(rule 14 (lower (has_type (ty_vec_fits_in_register ty) (iadd (ineg (imul (splat x) y)) z)))
+  (rv_vnmsac_vx z y x (unmasked) ty))
 
 ;;; Rules for `uadd_overflow_trap` ;;;;;;;;;;;;;
 (rule

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ifma.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ifma.clif
@@ -1,0 +1,285 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_v
+
+
+function %iadd_imul_i64x2(i64x2, i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64x2):
+    v3 = imul v0, v1
+    v4 = iadd v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v7,48(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmacc.vv v7,v1,v3 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v7,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   addi t6, s0, 0x30
+;   .byte 0x87, 0x83, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0xd7, 0xa3, 0x30, 0xb6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_imul_splat_i64x2(i64x2, i64x2, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64):
+    v3 = splat.i64x2 v2
+    v4 = imul v0, v1
+    v5 = iadd v4, v3
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.v.x v7,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmacc.vv v7,v1,v3 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0xd7, 0x43, 0x05, 0x5e
+;   .byte 0xd7, 0xa3, 0x30, 0xb6
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_ineg_imul_i64x2(i64x2, i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64x2):
+    v3 = imul v0, v1
+    v4 = ineg v3
+    v5 = iadd v2, v4
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v7,48(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vnmsac.vv v7,v1,v3 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v7,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   addi t6, s0, 0x30
+;   .byte 0x87, 0x83, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0xd7, 0xa3, 0x30, 0xbe
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x03, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %iadd_ineg_imul_splat_i64x2(i64x2, i64x2, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64):
+    v3 = splat.i64x2 v2
+    v4 = imul v0, v1
+    v5 = ineg v4
+    v6 = iadd v5, v3
+    return v6
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmv.v.x v7,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vnmsac.vv v7,v1,v3 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v7,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0xd7, 0x43, 0x05, 0x5e
+;   .byte 0xd7, 0xa3, 0x30, 0xbe
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x83, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_imul_i64x2(i64x2, i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64x2):
+    v3 = imul v0, v1
+    v4 = isub v2, v3
+    return v4
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v5,48(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmul.vv v9,v1,v3 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vsub.vv v9,v5,v9 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v9,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   addi t6, s0, 0x30
+;   .byte 0x87, 0x82, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0xd7, 0xa4, 0x11, 0x96
+;   .byte 0xd7, 0x84, 0x54, 0x0a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0xa7, 0x04, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %isub_imul_splat_i64x2(i64x2, i64x2, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64):
+    v3 = splat.i64x2 v2
+    v4 = imul v0, v1
+    v5 = isub v4, v3
+    return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vle8.v v3,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vmul.vv v8,v1,v3 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vsub.vx v8,v8,a0 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v8,0(a1) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   ori s0, sp, 0
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x80, 0x0f, 0x02
+;   addi t6, s0, 0x20
+;   .byte 0x87, 0x81, 0x0f, 0x02
+;   .byte 0x57, 0x70, 0x81, 0xcd
+;   .byte 0x57, 0xa4, 0x11, 0x96
+;   .byte 0x57, 0x44, 0x85, 0x0a
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   .byte 0x27, 0x84, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/simd-ifma.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ifma.clif
@@ -1,0 +1,74 @@
+test run
+target aarch64
+target s390x
+target x86_64
+target x86_64 skylake
+target riscv64 has_v
+
+;; These tests test integer fused multiply add/subtract instructions.
+
+function %iadd_imul_i64x2(i64x2, i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64x2):
+    v3 = imul v0, v1
+    v4 = iadd v2, v3
+    return v4
+}
+; run: %iadd_imul_i64x2([0 1], [10 10], [20 20]) == [20 30]
+; run: %iadd_imul_i64x2([0 1], [0 0x80000000_00000000], [0 -1]) == [0 0x7FFFFFFF_FFFFFFFF]
+; run: %iadd_imul_i64x2([0 1], [0 0xFFFFFFFF_FFFFFFFF], [0 1]) == [0 0]
+
+function %iadd_imul_splat_i64x2(i64x2, i64x2, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64):
+    v3 = splat.i64x2 v2
+    v4 = imul v0, v1
+    v5 = iadd v4, v3
+    return v5
+}
+; run: %iadd_imul_splat_i64x2([0 1], [10 10], 20) == [20 30]
+; run: %iadd_imul_splat_i64x2([0 1], [0 0x80000000_00000000], -1) == [-1 0x7FFFFFFF_FFFFFFFF]
+; run: %iadd_imul_splat_i64x2([0 1], [0 0xFFFFFFFF_FFFFFFFF], 1) == [1 0]
+
+function %iadd_ineg_imul_i64x2(i64x2, i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64x2):
+    v3 = imul v0, v1
+    v4 = ineg v3
+    v5 = iadd v2, v4
+    return v5
+}
+; run: %iadd_ineg_imul_i64x2([0 1], [10 10], [20 20]) == [20 10]
+; run: %iadd_ineg_imul_i64x2([0 1], [0 0x80000000_00000000], [0 -1]) == [0 0x7FFFFFFF_FFFFFFFF]
+; run: %iadd_ineg_imul_i64x2([0 1], [0 0xFFFFFFFF_FFFFFFFF], [0 1]) == [0 2]
+
+function %iadd_ineg_imul_splat_i64x2(i64x2, i64x2, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64):
+    v3 = splat.i64x2 v2
+    v4 = imul v0, v1
+    v5 = ineg v4
+    v6 = iadd v5, v3
+    return v6
+}
+; run: %iadd_ineg_imul_splat_i64x2([0 1], [10 10], 20) == [20 10]
+; run: %iadd_ineg_imul_splat_i64x2([0 1], [0 0x80000000_00000000], -1) == [-1 0x7FFFFFFF_FFFFFFFF]
+; run: %iadd_ineg_imul_splat_i64x2([0 1], [0 0xFFFFFFFF_FFFFFFFF], 1) == [1 2]
+
+function %isub_imul_i64x2(i64x2, i64x2, i64x2) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64x2):
+    v3 = imul v0, v1
+    v4 = isub v2, v3
+    return v4
+}
+; run: %isub_imul_i64x2([0 1], [10 10], [20 20]) == [20 10]
+; run: %isub_imul_i64x2([0 1], [0 0x80000000_00000000], [0 -1]) == [0 0x7FFFFFFF_FFFFFFFF]
+; run: %isub_imul_i64x2([0 1], [0 0xFFFFFFFF_FFFFFFFF], [0 1]) == [0 2]
+
+
+function %isub_imul_splat_i64x2(i64x2, i64x2, i64) -> i64x2 {
+block0(v0: i64x2, v1: i64x2, v2: i64):
+    v3 = splat.i64x2 v2
+    v4 = imul v0, v1
+    v5 = isub v4, v3
+    return v5
+}
+; run: %isub_imul_splat_i64x2([0 1], [10 10], 20) == [-20 -10]
+; run: %isub_imul_splat_i64x2([0 1], [0 0x80000000_00000000], -1) == [1 0x80000000_00000001]
+; run: %isub_imul_splat_i64x2([0 1], [0 0xFFFFFFFF_FFFFFFFF], 1) == [-1 -2]


### PR DESCRIPTION
👋 Hey,

This PR adds support for SIMD integer fused multiply add/subtract instructions to RISC-V. These instructions modify one of the source registers, so I've added a new instruction format for it.

We have 4 variants of this instruction ([§11.13. Vector Single-Width Integer Multiply-Add Instructions](https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#1113-vector-single-width-integer-multiply-add-instructions)), I've only used two, since it looks like `vmadd`/`vnmsub` match the same pattern but just modify different registers. I'm not entirely sure how to expose this, since it looks like just a regalloc optimization.

Additionally I couldn't find a way to match `isub+imul`, It looks like `vnmsac` does not match that, but maybe I'm missing something!