### PR TITLE
wasi-cap-std-sync: use std::io::Std{in,out,err} to impl {read,write}_vectored

### DIFF
--- a/crates/test-programs/tests/wasi-cap-std-sync.rs
+++ b/crates/test-programs/tests/wasi-cap-std-sync.rs
@@ -291,3 +291,7 @@ fn unlink_file_trailing_slashes() {
 fn path_open_preopen() {
     run("path_open_preopen", true).unwrap()
 }
+#[test_log::test]
+fn unicode_output() {
+    run("unicode_output", true).unwrap()
+}

--- a/crates/test-programs/tests/wasi-preview1-host-in-preview2.rs
+++ b/crates/test-programs/tests/wasi-preview1-host-in-preview2.rs
@@ -335,3 +335,7 @@ async fn unlink_file_trailing_slashes() {
 async fn path_open_preopen() {
     run("path_open_preopen", false).await.unwrap()
 }
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn unicode_output() {
+    run("unicode_output", true).await.unwrap()
+}

--- a/crates/test-programs/tests/wasi-preview2-components-sync.rs
+++ b/crates/test-programs/tests/wasi-preview2-components-sync.rs
@@ -312,3 +312,7 @@ fn unlink_file_trailing_slashes() {
 fn path_open_preopen() {
     run("path_open_preopen", false).unwrap()
 }
+#[test_log::test]
+fn unicode_output() {
+    run("unicode_output", true).unwrap()
+}

--- a/crates/test-programs/tests/wasi-preview2-components.rs
+++ b/crates/test-programs/tests/wasi-preview2-components.rs
@@ -320,3 +320,7 @@ async fn unlink_file_trailing_slashes() {
 async fn path_open_preopen() {
     run("path_open_preopen", false).await.unwrap()
 }
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn unicode_output() {
+    run("unicode_output", true).await.unwrap()
+}

--- a/crates/test-programs/tests/wasi-tokio.rs
+++ b/crates/test-programs/tests/wasi-tokio.rs
@@ -297,3 +297,7 @@ async fn unlink_file_trailing_slashes() {
 async fn path_open_preopen() {
     run("path_open_preopen", true).await.unwrap()
 }
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn unicode_output() {
+    run("unicode_output", true).await.unwrap()
+}

--- a/crates/test-programs/wasi-tests/src/bin/unicode_output.rs
+++ b/crates/test-programs/wasi-tests/src/bin/unicode_output.rs
@@ -1,0 +1,15 @@
+use wasi_tests::STDOUT_FD;
+fn main() {
+    let text = "مرحبا بكم\n";
+
+    let ciovecs = [wasi::Ciovec {
+        buf: text.as_bytes().as_ptr(),
+        buf_len: text.as_bytes().len(),
+    }];
+    let written = unsafe { wasi::fd_write(STDOUT_FD, &ciovecs) }.expect("write succeeds");
+    assert_eq!(
+        written,
+        text.as_bytes().len(),
+        "full contents should be written"
+    );
+}


### PR DESCRIPTION
I believe this fixes #6824. 

Unfortunately it does not appear that CI reproduces the behavior of an actual windows cmd.exe, so we'll need a windows user to test it manually to verify.


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
