### PR TITLE
Fix testing cli-flags crate with component-model feature

### DIFF
--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -25,4 +25,4 @@ default = [
     "wasmtime/parallel-compilation",
 ]
 pooling-allocator = []
-component-model = []
+component-model = ["wasmtime/component-model"]

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -613,6 +613,8 @@ mod test {
             multi_memory,
             memory64,
             function_references,
+            #[cfg(feature = "component-model")]
+            component_model,
         } = options.wasm_features.unwrap();
 
         assert_eq!(reference_types, Some(true));
@@ -625,6 +627,8 @@ mod test {
         assert_eq!(memory64, Some(true));
         assert_eq!(function_references, Some(true));
         assert_eq!(relaxed_simd, Some(true));
+        #[cfg(feature = "component-model")]
+        assert_eq!(component_model, Some(true));
 
         Ok(())
     }
@@ -644,6 +648,8 @@ mod test {
             multi_memory,
             memory64,
             function_references,
+            #[cfg(feature = "component-model")]
+            component_model,
         } = options.wasm_features.unwrap();
 
         assert_eq!(reference_types, Some(false));
@@ -656,6 +662,8 @@ mod test {
         assert_eq!(memory64, Some(false));
         assert_eq!(function_references, Some(false));
         assert_eq!(relaxed_simd, Some(false));
+        #[cfg(feature = "component-model")]
+        assert_eq!(component_model, Some(false));
 
         Ok(())
     }
@@ -678,6 +686,8 @@ mod test {
             multi_memory,
             memory64,
             function_references,
+            #[cfg(feature = "component-model")]
+            component_model,
         } = options.wasm_features.unwrap();
 
         assert_eq!(reference_types, Some(false));
@@ -690,6 +700,8 @@ mod test {
         assert_eq!(memory64, Some(true));
         assert_eq!(function_references, None);
         assert_eq!(relaxed_simd, None);
+        #[cfg(feature = "component-model")]
+        assert_eq!(component_model, None);
 
         Ok(())
     }


### PR DESCRIPTION
Not used on CI yet but it's part of an upcoming change I figured I'd split out.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
