### PR TITLE
Add an API to detect precompiled modules/components

### DIFF
--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -629,12 +629,41 @@ impl Engine {
         code.publish()?;
         Ok(Arc::new(code))
     }
+
+    /// Detects whether the bytes provided are a precompiled object produced by
+    /// Wasmtime.
+    ///
+    /// This function will inspect the header of `bytes` to determine if it
+    /// looks like a precompiled core wasm module or a precompiled component.
+    /// This does not validate the full structure or guarantee that
+    /// deserialization will succeed, instead it helps higher-levels of the
+    /// stack make a decision about what to do next when presented with the
+    /// `bytes` as an input module.
+    ///
+    /// If the `bytes` looks like a precompiled object previously produced by
+    /// [`Module::serialize`](crate::Module::serialize),
+    /// [`Component::serialize`](crate::component::Component::serialize),
+    /// [`Engine::precompile_module`], or [`Engine::precompile_component`], then
+    /// this will return `Some(...)` indicating so. Otherwise `None` is
+    /// returned.
+    pub fn detect_precompiled(&self, bytes: &[u8]) -> Option<Precompiled> {
+        serialization::detect_precompiled(bytes)
+    }
 }
 
 impl Default for Engine {
     fn default() -> Engine {
         Engine::new(&Config::default()).unwrap()
     }
+}
+
+/// Return value from the [`Engine::detect_precompiled`] API.
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum Precompiled {
+    /// The input bytes look like a precompiled core wasm module.
+    Module,
+    /// The input bytes look like a precompiled wasm component.
+    Component,
 }
 
 #[cfg(test)]

--- a/tests/all/module_serialize.rs
+++ b/tests/all/module_serialize.rs
@@ -119,3 +119,20 @@ fn deserialize_from_serialized() -> Result<()> {
     assert!(buffer1 == buffer2);
     Ok(())
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn detect_precompiled() -> Result<()> {
+    let engine = Engine::default();
+    let buffer = serialize(
+        &engine,
+        "(module (func (export \"run\") (result i32) i32.const 42))",
+    )?;
+    assert_eq!(engine.detect_precompiled(&[]), None);
+    assert_eq!(engine.detect_precompiled(&buffer[..5]), None);
+    assert_eq!(
+        engine.detect_precompiled(&buffer),
+        Some(Precompiled::Module)
+    );
+    Ok(())
+}


### PR DESCRIPTION
This commit adds a new `Engine::detect_precompiled` API to inspect some bytes and determine if they look like a precompiled artifact of either a core wasm module or component. This is something I'll be using soon in an upcoming refactor of the Wasmtime CLI to support components, but it's something we've also talked about before which can be useful for systems storing both precompiled modules and components.

Implementation-wise this looks at the ELF header of the input and determines if it's got all the right flags that Wasmtime sets for the various bits and bobs of our object format.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
