### PR TITLE
 Refactor Wasmtime CLI to support components 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ wasmtime-wasi = { workspace = true, features = ["exit"] }
 wasmtime-wasi-nn = { workspace = true, optional = true }
 wasmtime-wasi-threads = { workspace = true, optional = true }
 wasmtime-wasi-http = { workspace = true, optional = true }
+wasmtime-runtime = { workspace = true }
 clap = { workspace = true, features = ["color", "suggestions", "derive"] }
 anyhow = { workspace = true }
 target-lexicon = { workspace = true }

--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -4,6 +4,7 @@ cargo test \
     --features "test-programs/test_programs" \
     --features wasi-threads \
     --features wasi-http \
+    --features component-model \
     --workspace \
     --exclude 'wasmtime-wasi-*' \
     --exclude wasi-tests \

--- a/crates/test-programs/tests/wasi-http-modules.rs
+++ b/crates/test-programs/tests/wasi-http-modules.rs
@@ -63,7 +63,7 @@ impl WasiHttpView for Ctx {
 async fn instantiate_module(module: Module, ctx: Ctx) -> Result<(Store<Ctx>, Func), anyhow::Error> {
     let mut linker = Linker::new(&ENGINE);
     wasmtime_wasi_http::add_to_linker(&mut linker)?;
-    wasmtime_wasi::preview2::preview1::add_to_linker(&mut linker)?;
+    wasmtime_wasi::preview2::preview1::add_to_linker_async(&mut linker)?;
 
     let mut store = Store::new(&ENGINE, ctx);
 

--- a/crates/test-programs/tests/wasi-preview1-host-in-preview2.rs
+++ b/crates/test-programs/tests/wasi-preview1-host-in-preview2.rs
@@ -4,7 +4,7 @@ use tempfile::TempDir;
 use wasmtime::{Config, Engine, Linker, Store};
 use wasmtime_wasi::preview2::{
     pipe::MemoryOutputPipe,
-    preview1::{add_to_linker, WasiPreview1Adapter, WasiPreview1View},
+    preview1::{add_to_linker_async, WasiPreview1Adapter, WasiPreview1View},
     DirPerms, FilePerms, IsATTY, Table, WasiCtx, WasiCtxBuilder, WasiView,
 };
 
@@ -34,7 +34,7 @@ async fn run(name: &str, inherit_stdio: bool) -> Result<()> {
     let stderr = MemoryOutputPipe::new();
     let r = {
         let mut linker = Linker::new(&ENGINE);
-        add_to_linker(&mut linker)?;
+        add_to_linker_async(&mut linker)?;
 
         // Create our wasi context.
         // Additionally register any preopened directories if we have them.

--- a/crates/wasi-nn/src/wit.rs
+++ b/crates/wasi-nn/src/wit.rs
@@ -128,6 +128,10 @@ impl gen::inference::Host for WasiNnCtx {
     }
 }
 
+impl gen::errors::Host for WasiNnCtx {}
+
+impl gen::tensor::Host for WasiNnCtx {}
+
 impl TryFrom<gen::graph::GraphEncoding> for crate::backend::BackendKind {
     type Error = UsageError;
     fn try_from(value: gen::graph::GraphEncoding) -> Result<Self, Self::Error> {

--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -215,7 +215,7 @@ impl WasiPreview1Adapter {
 
 // Any context that needs to support preview 1 will impl this trait. They can
 // construct the needed member with WasiPreview1Adapter::new().
-pub trait WasiPreview1View: Send + Sync + WasiView {
+pub trait WasiPreview1View: WasiView {
     fn adapter(&self) -> &WasiPreview1Adapter;
     fn adapter_mut(&mut self) -> &mut WasiPreview1Adapter;
 }
@@ -390,21 +390,16 @@ trait WasiPreview1ViewExt:
 
 impl<T: WasiPreview1View + preopens::Host> WasiPreview1ViewExt for T {}
 
-pub fn add_to_linker<
-    T: WasiPreview1View
-        + bindings::cli::environment::Host
-        + bindings::cli::exit::Host
-        + bindings::filesystem::types::Host
-        + bindings::filesystem::preopens::Host
-        + bindings::sync_io::poll::poll::Host
-        + bindings::random::random::Host
-        + bindings::io::streams::Host
-        + bindings::clocks::monotonic_clock::Host
-        + bindings::clocks::wall_clock::Host,
->(
+pub fn add_to_linker_async<T: WasiPreview1View>(
     linker: &mut wasmtime::Linker<T>,
 ) -> anyhow::Result<()> {
     wasi_snapshot_preview1::add_to_linker(linker, |t| t)
+}
+
+pub fn add_to_linker_sync<T: WasiPreview1View>(
+    linker: &mut wasmtime::Linker<T>,
+) -> anyhow::Result<()> {
+    sync::add_wasi_snapshot_preview1_to_linker(linker, |t| t)
 }
 
 // Generate the wasi_snapshot_preview1::WasiSnapshotPreview1 trait,
@@ -424,6 +419,32 @@ wiggle::from_witx!({
     },
     errors: { errno => trappable Error },
 });
+
+mod sync {
+    use anyhow::Result;
+    use std::future::Future;
+
+    wiggle::wasmtime_integration!({
+        witx: ["$CARGO_MANIFEST_DIR/witx/wasi_snapshot_preview1.witx"],
+        target: super,
+        block_on[in_tokio]: {
+            wasi_snapshot_preview1::{
+                fd_advise, fd_close, fd_datasync, fd_fdstat_get, fd_filestat_get, fd_filestat_set_size,
+                fd_filestat_set_times, fd_read, fd_pread, fd_seek, fd_sync, fd_readdir, fd_write,
+                fd_pwrite, poll_oneoff, path_create_directory, path_filestat_get,
+                path_filestat_set_times, path_link, path_open, path_readlink, path_remove_directory,
+                path_rename, path_symlink, path_unlink_file
+            }
+        },
+        errors: { errno => trappable Error },
+    });
+
+    // Small wrapper around `in_tokio` to add a `Result` layer which is always
+    // `Ok`
+    fn in_tokio<F: Future>(future: F) -> Result<F::Output> {
+        Ok(crate::preview2::in_tokio(future))
+    }
+}
 
 impl wiggle::GuestErrorType for types::Errno {
     fn success() -> Self {

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -285,3 +285,9 @@ impl Table {
         })
     }
 }
+
+impl Default for Table {
+    fn default() -> Self {
+        Table::new()
+    }
+}

--- a/crates/wiggle/generate/src/wasmtime.rs
+++ b/crates/wiggle/generate/src/wasmtime.rs
@@ -142,14 +142,14 @@ fn generate_func(
             }
         }
 
-        Asyncness::Blocking => {
+        Asyncness::Blocking { block_with } => {
             quote! {
                 linker.func_wrap(
                     #module_str,
                     #field_str,
                     move |mut caller: wiggle::wasmtime_crate::Caller<'_, T> #(, #arg_decls)*| -> wiggle::anyhow::Result<#ret_ty> {
                         let result = async { #body };
-                        wiggle::run_in_dummy_executor(result)?
+                        #block_with(result)?
                     },
                 )?;
             }

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -98,25 +98,13 @@ impl CompileCommand {
             output
         });
 
-        // If the component-model proposal is enabled and the binary we're
-        // compiling looks like a component, tested by sniffing the first 8
-        // bytes with the current component model proposal.
-        #[cfg(feature = "component-model")]
-        {
-            if let Ok(wasmparser::Chunk::Parsed {
-                payload:
-                    wasmparser::Payload::Version {
-                        encoding: wasmparser::Encoding::Component,
-                        ..
-                    },
-                ..
-            }) = wasmparser::Parser::new(0).parse(&input, true)
-            {
-                fs::write(output, engine.precompile_component(&input)?)?;
-                return Ok(());
-            }
-        }
-        fs::write(output, engine.precompile_module(&input)?)?;
+        let output_bytes = if wasmparser::Parser::is_component(&input) {
+            engine.precompile_component(&input)?
+        } else {
+            engine.precompile_module(&input)?
+        };
+        fs::write(&output, output_bytes)
+            .with_context(|| format!("failed to write output: {}", output.display()))?;
 
         Ok(())
     }

--- a/tests/all/cli_tests/bad-syntax.wat
+++ b/tests/all/cli_tests/bad-syntax.wat
@@ -1,0 +1,1 @@
+(module ;; missing the close paren here

--- a/tests/all/cli_tests/component-basic.wat
+++ b/tests/all/cli_tests/component-basic.wat
@@ -1,0 +1,10 @@
+(component
+  (core module $m
+    (func (export "run") (result i32)
+      i32.const 0)
+  )
+  (core instance $i (instantiate $m))
+  (func (export "run") (result (result))
+    (canon lift (core func $i "run")))
+
+)

--- a/tests/all/cli_tests/empty-component.wat
+++ b/tests/all/cli_tests/empty-component.wat
@@ -1,0 +1,1 @@
+(component)


### PR DESCRIPTION
This commit refactors the `wasmtime` CLI executable to be able to
support not only compiling components but additionally executing
components. While I was doing this I've additionally added a new
`--preview2` argument to enable using the new experimental
implementation of preview1 based on preview2 type/structs. This is
off-by-default but is expected to become the default in the future.

Some notable features of this change are:

* The preview1-implemented-with-preview2 module now sports
  `add_to_linker_{async,sync}` to replace the previous `add_to_linker`
  which always did async.

* Some trait bounds in the preview1-implemented-with-preview2 module are
  simplified.

* Some minor changes were made to `wiggle`'s macros to support a "block
  on" that isn't the default wiggle dummy executor (as now we actually
  do need Tokio)

* Many options related to core wasm `Linker` configuration, such as
  `--default-values-unknown-imports`, are not implemented for components
  at this time. When used with components these options return an error.

* Construction of WASI contexts has been refactored to pass around fewer
  arguments to avoid threading through lots of values for both preview1
  and preview2.

* Reading the input to the Wasmtime CLI has been updated to read the
  input in the `run` subcommand before handing it off to the `wasmtime`
  crate's API to enable the CLI to use the contents of what's loaded to
  determine what to do next.

* Our generic `./ci/run-tests.sh` script has been updated to pass the
  `--features component-model` flag to ensure that this CLI support is
  tested during the normal test suite.
  
  
---

> ~~Procedural Note: this PR is based on https://github.com/bytecodealliance/wasmtime/pull/6833 and https://github.com/bytecodealliance/wasmtime/pull/6823 so the first few commits can be ignored.~~