### PR TITLE
Remove CLI flags ordering from release notes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -68,13 +68,6 @@ Unreleased.
 
 ### Changed
 
-* Options to the `wasmtime` CLI for Wasmtime itself must now come before the
-  WebAssembly module. For example `wasmtime run foo.wasm --disable-cache` now
-  must be specified as `wasmtime run --disable-cache foo.wasm`. Any
-  argument/option after the WebAssembly module is now interpreted as an argument
-  to the wasm module itself.
-  [#6737](https://github.com/bytecodealliance/wasmtime/pull/6737)
-
 * Empty types are no longer allowed in the component model.
   [#6777](https://github.com/bytecodealliance/wasmtime/pull/6777)
 


### PR DESCRIPTION
That commit was backed out.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
