### PR TITLE
winch: Simplify the MacroAssembler and Assembler interfaces

### DIFF
--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -119,8 +119,8 @@ impl<'a> CodeGenContext<'a> {
     ) {
         match src {
             Val::Reg(src) => masm.mov(RegImm::reg(*src), RegImm::reg(dst), size),
-            Val::I32(imm) => masm.mov(RegImm::imm((*imm).into()), RegImm::reg(dst), size),
-            Val::I64(imm) => masm.mov(RegImm::imm(*imm), RegImm::reg(dst), size),
+            Val::I32(imm) => masm.mov(RegImm::i32((*imm).into()), RegImm::reg(dst), size),
+            Val::I64(imm) => masm.mov(RegImm::i64(*imm), RegImm::reg(dst), size),
             Val::Local(index) => {
                 let slot = self
                     .frame
@@ -161,12 +161,7 @@ impl<'a> CodeGenContext<'a> {
                 .pop_i32_const()
                 .expect("i32 const value at stack top");
             let reg = self.pop_to_reg(masm, None, OperandSize::S32);
-            emit(
-                masm,
-                RegImm::reg(reg),
-                RegImm::imm(val as i64),
-                OperandSize::S32,
-            );
+            emit(masm, RegImm::reg(reg), RegImm::i32(val), OperandSize::S32);
             self.stack.push(Val::reg(reg));
         } else {
             let src = self.pop_to_reg(masm, None, OperandSize::S32);
@@ -190,7 +185,7 @@ impl<'a> CodeGenContext<'a> {
                 .pop_i64_const()
                 .expect("i64 const value at stack top");
             let reg = self.pop_to_reg(masm, None, OperandSize::S64);
-            emit(masm, RegImm::reg(reg), RegImm::imm(val), OperandSize::S64);
+            emit(masm, RegImm::reg(reg), RegImm::i64(val), OperandSize::S64);
             self.stack.push(Val::reg(reg));
         } else {
             let src = self.pop_to_reg(masm, None, OperandSize::S64);

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -303,7 +303,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S32, &mut |masm, reg, size| {
-            masm.cmp_with_set(RegImm::imm(0), reg.into(), CmpKind::Eq, size);
+            masm.cmp_with_set(RegImm::i64(0), reg.into(), CmpKind::Eq, size);
         });
     }
 
@@ -311,7 +311,7 @@ where
         use OperandSize::*;
 
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
-            masm.cmp_with_set(RegImm::imm(0), reg.into(), CmpKind::Eq, size);
+            masm.cmp_with_set(RegImm::i64(0), reg.into(), CmpKind::Eq, size);
         });
     }
 
@@ -633,14 +633,14 @@ where
 {
     fn cmp_i32s(&mut self, kind: CmpKind) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.cmp_with_set(src, dst, kind, size);
+            masm.cmp_with_set(src, dst.get_reg().unwrap(), kind, size);
         });
     }
 
     fn cmp_i64s(&mut self, kind: CmpKind) {
         self.context
             .i64_binop(self.masm, move |masm, dst, src, size| {
-                masm.cmp_with_set(src, dst, kind, size);
+                masm.cmp_with_set(src, dst.get_reg().unwrap(), kind, size);
             });
     }
 }

--- a/winch/filetests/filetests/aarch64/i32_add/max_one.wat
+++ b/winch/filetests/filetests/aarch64/i32_add/max_one.wat
@@ -13,9 +13,9 @@
 ;;    c:	 ff2300d1             	sub	sp, sp, #8
 ;;   10:	 fc030091             	mov	x28, sp
 ;;   14:	 890300f8             	stur	x9, [x28]
-;;   18:	 f08361b2             	orr	x16, xzr, #0xffffffff80000000
+;;   18:	 1000b0d2             	mov	x16, #0x80000000
 ;;   1c:	 e003102a             	mov	w0, w16
-;;   20:	 10008092             	mov	x16, #-1
+;;   20:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   24:	 0060300b             	add	w0, w0, w16, uxtx
 ;;   28:	 ff230091             	add	sp, sp, #8
 ;;   2c:	 fc030091             	mov	x28, sp

--- a/winch/filetests/filetests/aarch64/i32_add/mixed.wat
+++ b/winch/filetests/filetests/aarch64/i32_add/mixed.wat
@@ -13,7 +13,7 @@
 ;;    c:	 ff2300d1             	sub	sp, sp, #8
 ;;   10:	 fc030091             	mov	x28, sp
 ;;   14:	 890300f8             	stur	x9, [x28]
-;;   18:	 10008092             	mov	x16, #-1
+;;   18:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   1c:	 e003102a             	mov	w0, w16
 ;;   20:	 00040011             	add	w0, w0, #1
 ;;   24:	 ff230091             	add	sp, sp, #8

--- a/winch/filetests/filetests/aarch64/i32_add/signed.wat
+++ b/winch/filetests/filetests/aarch64/i32_add/signed.wat
@@ -13,9 +13,9 @@
 ;;    c:	 ff2300d1             	sub	sp, sp, #8
 ;;   10:	 fc030091             	mov	x28, sp
 ;;   14:	 890300f8             	stur	x9, [x28]
-;;   18:	 10008092             	mov	x16, #-1
+;;   18:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   1c:	 e003102a             	mov	w0, w16
-;;   20:	 10008092             	mov	x16, #-1
+;;   20:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   24:	 0060300b             	add	w0, w0, w16, uxtx
 ;;   28:	 ff230091             	add	sp, sp, #8
 ;;   2c:	 fc030091             	mov	x28, sp

--- a/winch/filetests/filetests/aarch64/i32_mul/max.wat
+++ b/winch/filetests/filetests/aarch64/i32_mul/max.wat
@@ -15,7 +15,7 @@
 ;;   14:	 890300f8             	stur	x9, [x28]
 ;;   18:	 f07b40b2             	orr	x16, xzr, #0x7fffffff
 ;;   1c:	 e003102a             	mov	w0, w16
-;;   20:	 10008092             	mov	x16, #-1
+;;   20:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   24:	 007c101b             	mul	w0, w0, w16
 ;;   28:	 ff230091             	add	sp, sp, #8
 ;;   2c:	 fc030091             	mov	x28, sp

--- a/winch/filetests/filetests/aarch64/i32_mul/max_one.wat
+++ b/winch/filetests/filetests/aarch64/i32_mul/max_one.wat
@@ -13,9 +13,9 @@
 ;;    c:	 ff2300d1             	sub	sp, sp, #8
 ;;   10:	 fc030091             	mov	x28, sp
 ;;   14:	 890300f8             	stur	x9, [x28]
-;;   18:	 f08361b2             	orr	x16, xzr, #0xffffffff80000000
+;;   18:	 1000b0d2             	mov	x16, #0x80000000
 ;;   1c:	 e003102a             	mov	w0, w16
-;;   20:	 10008092             	mov	x16, #-1
+;;   20:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   24:	 007c101b             	mul	w0, w0, w16
 ;;   28:	 ff230091             	add	sp, sp, #8
 ;;   2c:	 fc030091             	mov	x28, sp

--- a/winch/filetests/filetests/aarch64/i32_mul/mixed.wat
+++ b/winch/filetests/filetests/aarch64/i32_mul/mixed.wat
@@ -13,7 +13,7 @@
 ;;    c:	 ff2300d1             	sub	sp, sp, #8
 ;;   10:	 fc030091             	mov	x28, sp
 ;;   14:	 890300f8             	stur	x9, [x28]
-;;   18:	 10008092             	mov	x16, #-1
+;;   18:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   1c:	 e003102a             	mov	w0, w16
 ;;   20:	 300080d2             	mov	x16, #1
 ;;   24:	 007c101b             	mul	w0, w0, w16

--- a/winch/filetests/filetests/aarch64/i32_mul/signed.wat
+++ b/winch/filetests/filetests/aarch64/i32_mul/signed.wat
@@ -13,9 +13,9 @@
 ;;    c:	 ff2300d1             	sub	sp, sp, #8
 ;;   10:	 fc030091             	mov	x28, sp
 ;;   14:	 890300f8             	stur	x9, [x28]
-;;   18:	 10008092             	mov	x16, #-1
+;;   18:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   1c:	 e003102a             	mov	w0, w16
-;;   20:	 10008092             	mov	x16, #-1
+;;   20:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   24:	 007c101b             	mul	w0, w0, w16
 ;;   28:	 ff230091             	add	sp, sp, #8
 ;;   2c:	 fc030091             	mov	x28, sp

--- a/winch/filetests/filetests/aarch64/i32_sub/max.wat
+++ b/winch/filetests/filetests/aarch64/i32_sub/max.wat
@@ -14,7 +14,7 @@
 ;;   14:	 890300f8             	stur	x9, [x28]
 ;;   18:	 f07b40b2             	orr	x16, xzr, #0x7fffffff
 ;;   1c:	 e003102a             	mov	w0, w16
-;;   20:	 10008092             	mov	x16, #-1
+;;   20:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   24:	 0060304b             	sub	w0, w0, w16, uxtx
 ;;   28:	 ff230091             	add	sp, sp, #8
 ;;   2c:	 fc030091             	mov	x28, sp

--- a/winch/filetests/filetests/aarch64/i32_sub/max_one.wat
+++ b/winch/filetests/filetests/aarch64/i32_sub/max_one.wat
@@ -13,7 +13,7 @@
 ;;    c:	 ff2300d1             	sub	sp, sp, #8
 ;;   10:	 fc030091             	mov	x28, sp
 ;;   14:	 890300f8             	stur	x9, [x28]
-;;   18:	 f08361b2             	orr	x16, xzr, #0xffffffff80000000
+;;   18:	 1000b0d2             	mov	x16, #0x80000000
 ;;   1c:	 e003102a             	mov	w0, w16
 ;;   20:	 00040051             	sub	w0, w0, #1
 ;;   24:	 ff230091             	add	sp, sp, #8

--- a/winch/filetests/filetests/aarch64/i32_sub/mixed.wat
+++ b/winch/filetests/filetests/aarch64/i32_sub/mixed.wat
@@ -13,7 +13,7 @@
 ;;    c:	 ff2300d1             	sub	sp, sp, #8
 ;;   10:	 fc030091             	mov	x28, sp
 ;;   14:	 890300f8             	stur	x9, [x28]
-;;   18:	 10008092             	mov	x16, #-1
+;;   18:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   1c:	 e003102a             	mov	w0, w16
 ;;   20:	 00040051             	sub	w0, w0, #1
 ;;   24:	 ff230091             	add	sp, sp, #8

--- a/winch/filetests/filetests/aarch64/i32_sub/signed.wat
+++ b/winch/filetests/filetests/aarch64/i32_sub/signed.wat
@@ -13,9 +13,9 @@
 ;;    c:	 ff2300d1             	sub	sp, sp, #8
 ;;   10:	 fc030091             	mov	x28, sp
 ;;   14:	 890300f8             	stur	x9, [x28]
-;;   18:	 10008092             	mov	x16, #-1
+;;   18:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   1c:	 e003102a             	mov	w0, w16
-;;   20:	 10008092             	mov	x16, #-1
+;;   20:	 f07f40b2             	orr	x16, xzr, #0xffffffff
 ;;   24:	 0060304b             	sub	w0, w0, w16, uxtx
 ;;   28:	 ff230091             	add	sp, sp, #8
 ;;   2c:	 fc030091             	mov	x28, sp

--- a/winch/filetests/filetests/x64/br/as_call_all.wat
+++ b/winch/filetests/filetests/x64/br/as_call_all.wat
@@ -12,10 +12,11 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
-;;   20:	 4883c418             	add	rsp, 0x18
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 48b8ffffffff00000000 	
+;; 				movabs	rax, 0xffffffff
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp

--- a/winch/filetests/filetests/x64/br/as_call_first.wat
+++ b/winch/filetests/filetests/x64/br/as_call_first.wat
@@ -15,10 +15,11 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
-;;   20:	 4883c418             	add	rsp, 0x18
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 48b8ffffffff00000000 	
+;; 				movabs	rax, 0xffffffff
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp

--- a/winch/filetests/filetests/x64/br/as_call_last.wat
+++ b/winch/filetests/filetests/x64/br/as_call_last.wat
@@ -14,10 +14,11 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
-;;   20:	 4883c418             	add	rsp, 0x18
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 48b8ffffffff00000000 	
+;; 				movabs	rax, 0xffffffff
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp

--- a/winch/filetests/filetests/x64/br/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_call_mid.wat
@@ -15,10 +15,11 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
-;;   20:	 4883c418             	add	rsp, 0x18
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 48b8ffffffff00000000 	
+;; 				movabs	rax, 0xffffffff
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp

--- a/winch/filetests/filetests/x64/br_if/as_call_first.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_first.wat
@@ -16,10 +16,11 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
-;;   20:	 4883c418             	add	rsp, 0x18
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 48b8ffffffff00000000 	
+;; 				movabs	rax, 0xffffffff
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp

--- a/winch/filetests/filetests/x64/br_if/as_call_last.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_last.wat
@@ -16,10 +16,11 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
-;;   20:	 4883c418             	add	rsp, 0x18
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 48b8ffffffff00000000 	
+;; 				movabs	rax, 0xffffffff
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp

--- a/winch/filetests/filetests/x64/br_if/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_mid.wat
@@ -16,10 +16,11 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
-;;   20:	 4883c418             	add	rsp, 0x18
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 48b8ffffffff00000000 	
+;; 				movabs	rax, 0xffffffff
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp

--- a/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
@@ -16,9 +16,10 @@
 ;;   10:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   14:	 48c7c011000000       	mov	rax, 0x11
 ;;   1b:	 85c9                 	test	ecx, ecx
-;;   1d:	 0f850b000000         	jne	0x2e
+;;   1d:	 0f850e000000         	jne	0x31
 ;;   23:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
-;;   27:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
-;;   2e:	 4883c410             	add	rsp, 0x10
-;;   32:	 5d                   	pop	rbp
-;;   33:	 c3                   	ret	
+;;   27:	 48b8ffffffff00000000 	
+;; 				movabs	rax, 0xffffffff
+;;   31:	 4883c410             	add	rsp, 0x10
+;;   35:	 5d                   	pop	rbp
+;;   36:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/as_binop.wat
+++ b/winch/filetests/filetests/x64/if/as_binop.wat
@@ -34,25 +34,27 @@
 ;;   1a:	 0f8411000000         	je	0x31
 ;;   20:	 e800000000           	call	0x25
 ;;   25:	 48c7c003000000       	mov	rax, 3
-;;   2c:	 e90c000000           	jmp	0x3d
+;;   2c:	 e90f000000           	jmp	0x40
 ;;   31:	 e800000000           	call	0x36
-;;   36:	 48c7c0fdffffff       	mov	rax, 0xfffffffffffffffd
-;;   3d:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
-;;   41:	 50                   	push	rax
-;;   42:	 85c9                 	test	ecx, ecx
-;;   44:	 0f8419000000         	je	0x63
-;;   4a:	 4883ec08             	sub	rsp, 8
-;;   4e:	 e800000000           	call	0x53
-;;   53:	 4883c408             	add	rsp, 8
-;;   57:	 48c7c004000000       	mov	rax, 4
-;;   5e:	 e914000000           	jmp	0x77
-;;   63:	 4883ec08             	sub	rsp, 8
-;;   67:	 e800000000           	call	0x6c
-;;   6c:	 4883c408             	add	rsp, 8
-;;   70:	 48c7c0fbffffff       	mov	rax, 0xfffffffffffffffb
-;;   77:	 59                   	pop	rcx
-;;   78:	 0fafc8               	imul	ecx, eax
-;;   7b:	 4889c8               	mov	rax, rcx
-;;   7e:	 4883c410             	add	rsp, 0x10
-;;   82:	 5d                   	pop	rbp
-;;   83:	 c3                   	ret	
+;;   36:	 48b8fdffffff00000000 	
+;; 				movabs	rax, 0xfffffffd
+;;   40:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   44:	 50                   	push	rax
+;;   45:	 85c9                 	test	ecx, ecx
+;;   47:	 0f8419000000         	je	0x66
+;;   4d:	 4883ec08             	sub	rsp, 8
+;;   51:	 e800000000           	call	0x56
+;;   56:	 4883c408             	add	rsp, 8
+;;   5a:	 48c7c004000000       	mov	rax, 4
+;;   61:	 e917000000           	jmp	0x7d
+;;   66:	 4883ec08             	sub	rsp, 8
+;;   6a:	 e800000000           	call	0x6f
+;;   6f:	 4883c408             	add	rsp, 8
+;;   73:	 48b8fbffffff00000000 	
+;; 				movabs	rax, 0xfffffffb
+;;   7d:	 59                   	pop	rcx
+;;   7e:	 0fafc8               	imul	ecx, eax
+;;   81:	 4889c8               	mov	rax, rcx
+;;   84:	 4883c410             	add	rsp, 0x10
+;;   88:	 5d                   	pop	rbp
+;;   89:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_call_fist.wat
+++ b/winch/filetests/filetests/x64/return/as_call_fist.wat
@@ -13,10 +13,11 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
-;;   20:	 4883c418             	add	rsp, 0x18
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 48b8ffffffff00000000 	
+;; 				movabs	rax, 0xffffffff
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp

--- a/winch/filetests/filetests/x64/return/as_call_last.wat
+++ b/winch/filetests/filetests/x64/return/as_call_last.wat
@@ -13,10 +13,11 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
-;;   20:	 4883c418             	add	rsp, 0x18
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 48b8ffffffff00000000 	
+;; 				movabs	rax, 0xffffffff
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp

--- a/winch/filetests/filetests/x64/return/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_call_mid.wat
@@ -13,10 +13,11 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
-;;   20:	 4883c418             	add	rsp, 0x18
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 48b8ffffffff00000000 	
+;; 				movabs	rax, 0xffffffff
+;;   23:	 4883c418             	add	rsp, 0x18
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp


### PR DESCRIPTION
This commit prepares for the introduction of float support to Winch. Initially, I intended to include this change as part of the original change supporting floats, but that change is already sizable enough.

This modification simplifies the Assembler and MacroAssembler interfaces, as well as the interaction and responsibilities between them, by:

* Eliminating the `Operand` abstraction, which didn't offer a substantial benefit over simply using the MacroAssembler's `RegImm` and `Address` abstractions as operands where necessary. This approach also reduces the number of conversions required prior to emission.

* Shifting the instruction dispatch responsibility solely to the MacroAssembler, rather than having this responsibility shared across both abstractions. This was always the original intention behind the MacroAssembler. As a result, function definitions at the Assembler layer become simpler.

This change also introduces richer type information for immediates, which results in better instruction selection in some cases, and it's also needed to support floats.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
