### PR TITLE
stream wit definition eliminates stream-error

### DIFF
--- a/crates/wasi/src/preview2/command.rs
+++ b/crates/wasi/src/preview2/command.rs
@@ -6,7 +6,6 @@ wasmtime::component::bindgen!({
     async: true,
     trappable_error_type: {
         "wasi:filesystem/types"::"error-code": Error,
-        "wasi:io/streams"::"stream-error": Error,
     },
     with: {
        "wasi:filesystem/types": crate::preview2::bindings::filesystem::types,
@@ -61,7 +60,6 @@ pub mod sync {
         async: false,
         trappable_error_type: {
             "wasi:filesystem/types"::"error-code": Error,
-            "wasi:io/streams"::"stream-error": Error,
         },
         with: {
            "wasi:filesystem/types": crate::preview2::bindings::sync_io::filesystem::types,

--- a/crates/wasi/src/preview2/filesystem.rs
+++ b/crates/wasi/src/preview2/filesystem.rs
@@ -157,15 +157,7 @@ fn read_result(r: Result<usize, std::io::Error>) -> Result<(usize, StreamState),
         Ok(0) => Ok((0, StreamState::Closed)),
         Ok(n) => Ok((n, StreamState::Open)),
         Err(e) if e.kind() == std::io::ErrorKind::Interrupted => Ok((0, StreamState::Open)),
-        Err(e)
-            if matches!(
-                rustix::io::Errno::from_io_error(&e),
-                Some(rustix::io::Errno::IO)
-            ) =>
-        {
-            Err(StreamRuntimeError::from(anyhow::anyhow!(e)).into())
-        }
-        Err(e) => Err(e.into()),
+        Err(e) => Err(StreamRuntimeError::from(anyhow::anyhow!(e)).into()),
     }
 }
 
@@ -173,15 +165,7 @@ fn write_result(r: Result<usize, std::io::Error>) -> Result<(usize, StreamState)
     match r {
         Ok(0) => Ok((0, StreamState::Closed)),
         Ok(n) => Ok((n, StreamState::Open)),
-        Err(e)
-            if matches!(
-                rustix::io::Errno::from_io_error(&e),
-                Some(rustix::io::Errno::IO)
-            ) =>
-        {
-            Err(StreamRuntimeError::from(anyhow::anyhow!(e)).into())
-        }
-        Err(e) => Err(e.into()),
+        Err(e) => Err(StreamRuntimeError::from(anyhow::anyhow!(e)).into()),
     }
 }
 

--- a/crates/wasi/src/preview2/filesystem.rs
+++ b/crates/wasi/src/preview2/filesystem.rs
@@ -1,4 +1,4 @@
-use crate::preview2::{StreamState, Table, TableError};
+use crate::preview2::{StreamRuntimeError, StreamState, Table, TableError};
 use bytes::{Bytes, BytesMut};
 use std::sync::Arc;
 
@@ -152,24 +152,36 @@ impl FileInputStream {
     }
 }
 
-pub(crate) fn read_result(
-    r: Result<usize, std::io::Error>,
-) -> Result<(usize, StreamState), std::io::Error> {
+fn read_result(r: Result<usize, std::io::Error>) -> Result<(usize, StreamState), anyhow::Error> {
     match r {
         Ok(0) => Ok((0, StreamState::Closed)),
         Ok(n) => Ok((n, StreamState::Open)),
         Err(e) if e.kind() == std::io::ErrorKind::Interrupted => Ok((0, StreamState::Open)),
-        Err(e) => Err(e),
+        Err(e)
+            if matches!(
+                rustix::io::Errno::from_io_error(&e),
+                Some(rustix::io::Errno::IO)
+            ) =>
+        {
+            Err(StreamRuntimeError::from(anyhow::anyhow!(e)).into())
+        }
+        Err(e) => Err(e.into()),
     }
 }
 
-pub(crate) fn write_result(
-    r: Result<usize, std::io::Error>,
-) -> Result<(usize, StreamState), std::io::Error> {
+fn write_result(r: Result<usize, std::io::Error>) -> Result<(usize, StreamState), anyhow::Error> {
     match r {
         Ok(0) => Ok((0, StreamState::Closed)),
         Ok(n) => Ok((n, StreamState::Open)),
-        Err(e) => Err(e),
+        Err(e)
+            if matches!(
+                rustix::io::Errno::from_io_error(&e),
+                Some(rustix::io::Errno::IO)
+            ) =>
+        {
+            Err(StreamRuntimeError::from(anyhow::anyhow!(e)).into())
+        }
+        Err(e) => Err(e.into()),
     }
 }
 

--- a/crates/wasi/src/preview2/host/filesystem.rs
+++ b/crates/wasi/src/preview2/host/filesystem.rs
@@ -209,7 +209,10 @@ impl<T: WasiView> types::Host for T {
             })
             .await;
 
-        let (bytes_read, state) = crate::preview2::filesystem::read_result(r)?;
+        let (bytes_read, state) = match r? {
+            0 => (0, true),
+            n => (n, false),
+        };
 
         buffer.truncate(
             bytes_read
@@ -217,7 +220,7 @@ impl<T: WasiView> types::Host for T {
                 .expect("bytes read into memory as u64 fits in usize"),
         );
 
-        Ok((buffer, state.is_closed()))
+        Ok((buffer, state))
     }
 
     async fn write(

--- a/crates/wasi/wit/deps/io/streams.wit
+++ b/crates/wasi/wit/deps/io/streams.wit
@@ -8,16 +8,6 @@ package wasi:io
 interface streams {
     use wasi:poll/poll.{pollable}
 
-    /// An error type returned from a stream operation.
-    ///
-    /// TODO: need to figure out the actual contents of this error. Used to be
-    /// an empty record but that's no longer allowed. The `dummy` field is
-    /// only here to have this be a valid in the component model by being
-    /// non-empty.
-    record stream-error {
-      dummy: u32,
-    }
-
     /// Streams provide a sequence of data and then end; once they end, they
     /// no longer provide any further data.
     ///
@@ -37,15 +27,12 @@ interface streams {
     /// An input bytestream. In the future, this will be replaced by handle
     /// types.
     ///
-    /// This conceptually represents a `stream<u8, _>`. It's temporary
-    /// scaffolding until component-model's async features are ready.
-    ///
     /// `input-stream`s are *non-blocking* to the extent practical on underlying
     /// platforms. I/O operations always return promptly; if fewer bytes are
     /// promptly available than requested, they return the number of bytes promptly
     /// available, which could even be zero. To wait for data to be available,
     /// use the `subscribe-to-input-stream` function to obtain a `pollable` which
-    /// can be polled for using `wasi_poll`.
+    /// can be polled for using `wasi:poll/poll.poll_oneoff`.
     ///
     /// And at present, it is a `u32` instead of being an actual handle, until
     /// the wit-bindgen implementation of handles and resources is ready.
@@ -58,40 +45,36 @@ interface streams {
     /// This function returns a list of bytes containing the data that was
     /// read, along with a `stream-status` which, indicates whether further
     /// reads are expected to produce data. The returned list will contain up to
-    /// `len` bytes; it may return fewer than requested, but not more.
-    ///
-    /// Once a stream has reached the end, subsequent calls to read or
-    /// `skip` will always report end-of-stream rather than producing more
+    /// `len` bytes; it may return fewer than requested, but not more. An
+    /// empty list and `stream-status:open` indicates no more data is
+    /// available at this time, and that the pollable given by
+    /// `subscribe-to-input-stream` will be ready when more data is available.
+    /// 
+    /// Once a stream has reached the end, subsequent calls to `read` or
+    /// `skip` will always report `stream-status:ended` rather than producing more
     /// data.
     ///
-    /// If `len` is 0, it represents a request to read 0 bytes, which should
-    /// always succeed, assuming the stream hasn't reached its end yet, and
-    /// return an empty list.
+    /// When the caller gives a `len` of 0, it represents a request to read 0
+    /// bytes. This read should  always succeed and return an empty list and
+    /// the current `stream-status`.
     ///
-    /// The len here is a `u64`, but some callees may not be able to allocate
-    /// a buffer as large as that would imply.
-    /// FIXME: describe what happens if allocation fails.
-    ///
-    /// When the returned `stream-status` is `open`, the length of the returned
-    /// value may be less than `len`. When an empty list is returned, this
-    /// indicates that no more bytes were available from the stream at that
-    /// time. In that case the subscribe-to-input-stream pollable will indicate
-    /// when additional bytes are available for reading.
+    /// The `len` parameter is a `u64`, which could represent a list of u8 which
+    /// is not possible to allocate in wasm32, or not desirable to allocate as
+    /// as a return value by the callee. The callee may return a list of bytes
+    /// less than `len` in size while more bytes are available for reading.
     read: func(
         this: input-stream,
         /// The maximum number of bytes to read
         len: u64
-    ) -> result<tuple<list<u8>, stream-status>, stream-error>
+    ) -> result<tuple<list<u8>, stream-status>>
 
-    /// Read bytes from a stream, with blocking.
-    ///
-    /// This is similar to `read`, except that it blocks until at least one
-    /// byte can be read.
+    /// Read bytes from a stream, after blocking until at least one byte can
+    /// be read. Except for blocking, identical to `read`.
     blocking-read: func(
         this: input-stream,
         /// The maximum number of bytes to read
         len: u64
-    ) -> result<tuple<list<u8>, stream-status>, stream-error>
+    ) -> result<tuple<list<u8>, stream-status>>
 
     /// Skip bytes from a stream.
     ///
@@ -102,39 +85,41 @@ interface streams {
     /// `skip` will always report end-of-stream rather than producing more
     /// data.
     ///
-    /// This function returns the number of bytes skipped, along with a bool
-    /// indicating whether the end of the stream was reached. The returned
-    /// value will be at most `len`; it may be less.
+    /// This function returns the number of bytes skipped, along with a
+    /// `stream-status` indicating whether the end of the stream was
+    /// reached. The returned value will be at most `len`; it may be less.
     skip: func(
         this: input-stream,
         /// The maximum number of bytes to skip.
         len: u64,
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
-    /// Skip bytes from a stream, with blocking.
-    ///
-    /// This is similar to `skip`, except that it blocks until at least one
-    /// byte can be consumed.
+    /// Skip bytes from a stream, after blocking until at least one byte
+    /// can be skipped. Except for blocking behavior, identical to `skip`.
     blocking-skip: func(
         this: input-stream,
         /// The maximum number of bytes to skip.
         len: u64,
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Create a `pollable` which will resolve once either the specified stream
     /// has bytes available to read or the other end of the stream has been
     /// closed.
+    /// The created `pollable` is a child resource of the `input-stream`.
+    /// Implementations may trap if the `input-stream` is dropped before
+    /// all derived `pollable`s created with this function are dropped.
     subscribe-to-input-stream: func(this: input-stream) -> pollable
 
     /// Dispose of the specified `input-stream`, after which it may no longer
     /// be used.
+    /// Implementations may trap if this `input-stream` is dropped while child
+    /// `pollable` resources are still alive.
+    /// After this `input-stream` is dropped, implementations may report any
+    /// corresponding `output-stream` has `stream-state.closed`.
     drop-input-stream: func(this: input-stream)
 
     /// An output bytestream. In the future, this will be replaced by handle
     /// types.
-    ///
-    /// This conceptually represents a `stream<u8, _>`. It's temporary
-    /// scaffolding until component-model's async features are ready.
     ///
     /// `output-stream`s are *non-blocking* to the extent practical on
     /// underlying platforms. Except where specified otherwise, I/O operations also
@@ -159,17 +144,18 @@ interface streams {
     /// When the returned `stream-status` is `open`, the `u64` return value may
     /// be less than the length of `buf`. This indicates that no more bytes may
     /// be written to the stream promptly. In that case the
-    /// subscribe-to-output-stream pollable will indicate when additional bytes
+    /// `subscribe-to-output-stream` pollable will indicate when additional bytes
     /// may be promptly written.
     ///
-    /// TODO: document what happens when an empty list is written
+    /// Writing an empty list must return a non-error result with `0` for the
+    /// `u64` return value, and the current `stream-status`.
     write: func(
         this: output-stream,
         /// Data to write
         buf: list<u8>
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
-    /// Write bytes to a stream, with blocking.
+    /// Blocking write of bytes to a stream.
     ///
     /// This is similar to `write`, except that it blocks until at least one
     /// byte can be written.
@@ -177,27 +163,29 @@ interface streams {
         this: output-stream,
         /// Data to write
         buf: list<u8>
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
-    /// Write multiple zero bytes to a stream.
+    /// Write multiple zero-bytes to a stream.
     ///
-    /// This function returns a `u64` indicating the number of zero bytes
-    /// that were written; it may be less than `len`.
+    /// This function returns a `u64` indicating the number of zero-bytes
+    /// that were written; it may be less than `len`. Equivelant to a call to
+    /// `write` with a list of zeroes of the given length.
     write-zeroes: func(
         this: output-stream,
-        /// The number of zero bytes to write
+        /// The number of zero-bytes to write
         len: u64
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Write multiple zero bytes to a stream, with blocking.
     ///
     /// This is similar to `write-zeroes`, except that it blocks until at least
-    /// one byte can be written.
+    /// one byte can be written. Equivelant to a call to `blocking-write` with
+    /// a list of zeroes of the given length.
     blocking-write-zeroes: func(
         this: output-stream,
         /// The number of zero bytes to write
         len: u64
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Read from one stream and write to another.
     ///
@@ -212,7 +200,7 @@ interface streams {
         src: input-stream,
         /// The number of bytes to splice
         len: u64,
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Read from one stream and write to another, with blocking.
     ///
@@ -224,7 +212,7 @@ interface streams {
         src: input-stream,
         /// The number of bytes to splice
         len: u64,
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Forward the entire contents of an input stream to an output stream.
     ///
@@ -242,13 +230,24 @@ interface streams {
         this: output-stream,
         /// The stream to read from
         src: input-stream
-    ) -> result<tuple<u64, stream-status>, stream-error>
+    ) -> result<tuple<u64, stream-status>>
 
     /// Create a `pollable` which will resolve once either the specified stream
-    /// is ready to accept bytes or the other end of the stream has been closed.
+    /// is ready to accept bytes or the `stream-state` has become closed.
+    ///
+    /// Once the stream-state is closed, this pollable is always ready
+    /// immediately.
+    ///
+    /// The created `pollable` is a child resource of the `output-stream`.
+    /// Implementations may trap if the `output-stream` is dropped before
+    /// all derived `pollable`s created with this function are dropped.
     subscribe-to-output-stream: func(this: output-stream) -> pollable
 
     /// Dispose of the specified `output-stream`, after which it may no longer
     /// be used.
+    /// Implementations may trap if this `output-stream` is dropped while
+    /// child `pollable` resources are still alive.
+    /// After this `output-stream` is dropped, implementations may report any
+    /// corresponding `input-stream` has `stream-state.closed`.
     drop-output-stream: func(this: output-stream)
 }


### PR DESCRIPTION
In https://github.com/WebAssembly/wasi-io/pull/38 we got review feedback to eliminate the stream-error in favor of the empty error (wit `result<a>`). Although upstream PR 38 is not merged yet, we are downstreaming this interface change now, expecting it will merge upstream soon.

The wit change means we cant use wasmtime-wit-bindgen's `trappable_error` functionality anymore, so the signature of the streams binding trait its call sites are much less idiomatic than before. We'll fix the wasmtime-wit-bindgen macro to support this case better in the future, but for now we can live with this code being a little ugly, since most users will be using the (much nicer) `HostInputStream` and `HostOutputStream` types.

As we made this change, it occurred to us that the host stream trait design doesn't distinguish between an error to be returned via a stream method at runtime, and an error that traps execution. We defined the `StreamRuntimeError` type for runtime errors, and all other errors trap.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
