### PR TITLE
cranelift: Validate `iconst` ranges

### DIFF
--- a/cranelift/filetests/filetests/egraph/extends.clif
+++ b/cranelift/filetests/filetests/egraph/extends.clif
@@ -4,7 +4,7 @@ target x86_64
 
 function %f1() -> i64 {
 block0:
-  v0 = iconst.i32 0xffff_ffff_9876_5432
+  v0 = iconst.i32 0x9876_5432
   v1 = uextend.i64 v0
   return v1
   ; check: v2 = iconst.i64 0x9876_5432

--- a/cranelift/filetests/filetests/isa/s390x/constants.clif
+++ b/cranelift/filetests/filetests/isa/s390x/constants.clif
@@ -9,12 +9,12 @@ block0:
 
 ; VCode:
 ; block0:
-;   lhi %r2, -1
+;   lhi %r2, 255
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lhi %r2, -1
+;   lhi %r2, 0xff
 ;   br %r14
 
 function %f() -> i16 {
@@ -189,11 +189,11 @@ block0:
 
 ; VCode:
 ; block0:
-;   lhi %r2, -1
+;   iilf %r2, 4294967295
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lhi %r2, -1
+;   iilf %r2, 0xffffffff
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-lane-access-compile.clif
@@ -193,7 +193,7 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $-1, %ecx
+;   movl    $65535, %ecx
 ;   movd    %ecx, %xmm1
 ;   pshuflw $0, %xmm1, %xmm3
 ;   pshufd  $0, %xmm3, %xmm0
@@ -206,7 +206,7 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movl $0xffffffff, %ecx
+;   movl $0xffff, %ecx
 ;   movd %ecx, %xmm1
 ;   pshuflw $0, %xmm1, %xmm3
 ;   pshufd $0, %xmm3, %xmm0

--- a/cranelift/filetests/filetests/parser/tiny.clif
+++ b/cranelift/filetests/filetests/parser/tiny.clif
@@ -36,7 +36,7 @@ block0:
 }
 ; sameln: function %bvalues() fast {
 ; nextln: block0:
-; nextln:     v0 = iconst.i32 -1
+; nextln:     v0 = iconst.i32 0xffff_ffff
 ; nextln:     v1 = iconst.i8 0
 ; nextln:     v2 = sextend.i32 v1
 ; nextln:     v3 = bxor v0, v2

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -12,6 +12,7 @@ use cranelift_codegen::entity::{EntityRef, PrimaryMap};
 use cranelift_codegen::ir::entities::{AnyEntity, DynamicType};
 use cranelift_codegen::ir::immediates::{Ieee32, Ieee64, Imm64, Offset32, Uimm32, Uimm64};
 use cranelift_codegen::ir::instructions::{InstructionData, InstructionFormat, VariableArgs};
+use cranelift_codegen::ir::types;
 use cranelift_codegen::ir::types::INVALID;
 use cranelift_codegen::ir::types::*;
 use cranelift_codegen::ir::{self, UserExternalNameRef};
@@ -2456,10 +2457,25 @@ impl<'a> Parser<'a> {
                 opcode,
                 arg: self.match_value("expected SSA value operand")?,
             },
-            InstructionFormat::UnaryImm => InstructionData::UnaryImm {
-                opcode,
-                imm: self.match_imm64("expected immediate integer operand")?,
-            },
+            InstructionFormat::UnaryImm => {
+                let msg = |bits| format!("expected immediate {bits}-bit integer operand");
+                let unsigned = match explicit_control_type {
+                    Some(types::I8) => self.match_imm8(&msg(8))? as u8 as i64,
+                    Some(types::I16) => self.match_imm16(&msg(16))? as u16 as i64,
+                    Some(types::I32) => self.match_imm32(&msg(32))? as u32 as i64,
+                    Some(types::I64) => self.match_imm64(&msg(64))?.bits(),
+                    _ => {
+                        return err!(
+                            self.loc,
+                            "expected one of the following type: i8, i16, i32 or i64"
+                        )
+                    }
+                };
+                InstructionData::UnaryImm {
+                    opcode,
+                    imm: Imm64::new(unsigned),
+                }
+            }
             InstructionFormat::UnaryIeee32 => InstructionData::UnaryIeee32 {
                 opcode,
                 imm: self.match_ieee32("expected immediate 32-bit float operand")?,

--- a/cranelift/tests/bugpoint_test.clif
+++ b/cranelift/tests/bugpoint_test.clif
@@ -910,7 +910,7 @@ block51:
     v428 = iadd_imm.i64 v28, 8
     v429 = load.i16 v428
         v435 -> v429
-    v430 = iconst.i16 0xffff_ffff_ffff_8000
+    v430 = iconst.i16 0x8000
     v431 = icmp eq v429, v430
     v433 = uextend.i32 v431
     brif v433, block154, block52

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -928,7 +928,9 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
             translate_store(memarg, ir::Opcode::Store, builder, state, environ)?;
         }
         /****************************** Nullary Operators ************************************/
-        Operator::I32Const { value } => state.push1(builder.ins().iconst(I32, i64::from(*value))),
+        Operator::I32Const { value } => {
+            state.push1(builder.ins().iconst(I32, *value as u32 as i64))
+        }
         Operator::I64Const { value } => state.push1(builder.ins().iconst(I64, *value)),
         Operator::F32Const { value } => {
             state.push1(builder.ins().f32const(f32_translation(*value)));

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -509,7 +509,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         _heap: Heap,
         _val: ir::Value,
     ) -> WasmResult<ir::Value> {
-        Ok(pos.ins().iconst(I32, -1))
+        Ok(pos.ins().iconst(I32, -1i32 as u32 as i64))
     }
 
     fn translate_memory_size(
@@ -518,7 +518,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         _index: MemoryIndex,
         _heap: Heap,
     ) -> WasmResult<ir::Value> {
-        Ok(pos.ins().iconst(I32, -1))
+        Ok(pos.ins().iconst(I32, -1i32 as u32 as i64))
     }
 
     fn translate_memory_copy(
@@ -570,7 +570,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         _index: TableIndex,
         _table: ir::Table,
     ) -> WasmResult<ir::Value> {
-        Ok(pos.ins().iconst(I32, -1))
+        Ok(pos.ins().iconst(I32, -1i32 as u32 as i64))
     }
 
     fn translate_table_grow(
@@ -581,7 +581,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         _delta: ir::Value,
         _init_value: ir::Value,
     ) -> WasmResult<ir::Value> {
-        Ok(pos.ins().iconst(I32, -1))
+        Ok(pos.ins().iconst(I32, -1i32 as u32 as i64))
     }
 
     fn translate_table_get(
@@ -660,7 +660,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         mut pos: FuncCursor,
         _global_index: GlobalIndex,
     ) -> WasmResult<ir::Value> {
-        Ok(pos.ins().iconst(I32, -1))
+        Ok(pos.ins().iconst(I32, -1i32 as u32 as i64))
     }
 
     fn translate_custom_global_set(
@@ -681,7 +681,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         _expected: ir::Value,
         _timeout: ir::Value,
     ) -> WasmResult<ir::Value> {
-        Ok(pos.ins().iconst(I32, -1))
+        Ok(pos.ins().iconst(I32, -1i32 as u32 as i64))
     }
 
     fn translate_atomic_notify(


### PR DESCRIPTION
Add the following checks:
    
* `iconst.i8`  immediate must be within 0 .. 2^8-1
* `iconst.i16` immediate must be within 0 .. 2^16-1
* `iconst.i32` immediate must be within 0 .. 2^32-1
    
Resolves #3059

### Explain why this change is needed:

As mentioned in #3059, `iconst` currently allows any immediate within the range of an `i64`, even for `iconst.i8`, `iconst.i16` or `iconst.i32`.

### This breaks some tests!

Running `cargo test` in `/cranelift/codegen` returns successfully. I also added a few tests concerning the new checks.

Running `cargo test` in `/cranelift` returns some failures. For example:

```
1: - inst1 (v1 = iconst.i8 -1): constant immediate is out of bounds
[...]
failures:
    bugpoint::tests::test_reduce
    run::test::nop
```

Which is expected if we forbid negative immediates, @jameysharp could you please confirm?

Running `cargo test` at the root of this repo returns a lot of failures, possibly related to negative immediates.

#### This is my first contribution so this patch is probably broken.