### PR TITLE
wmemcheck: update docs.

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -28,6 +28,7 @@
     - [Linking Modules](./examples-c-linking.md)
     - [Debugging](./examples-c-debugging.md)
     - [Using Multi-Value](./examples-c-multi-value.md)
+  - [Checking Guests' Memory Accesses](./wmemcheck.md)
 - [Using WebAssembly from your language](./lang.md)
   - [Rust](./lang-rust.md)
   - [C](./lang-c.md)

--- a/docs/wmemcheck.md
+++ b/docs/wmemcheck.md
@@ -17,7 +17,7 @@ If your program executes an invalid operation (load or store to non-allocated
 address, double-free, or an internal error in malloc that allocates the same
 memory twice) you will see an error that looks like a Wasm trap. For example, given the program
 
-```
+```c
 #include <stdlib.h>
 
 int main() {
@@ -30,13 +30,13 @@ int main() {
 
 compiled with WASI-SDK via
 
-```
+```plain
 $ /opt/wasi-sdk/bin/clang -o test.wasm test.c
 ```
 
 you can observe the memory checker working like so:
 
-```
+```plain
 $ wasmtime run --wmemcheck ./test.wasm
 Error: failed to run main module `./test.wasm`
 

--- a/docs/wmemcheck.md
+++ b/docs/wmemcheck.md
@@ -1,8 +1,50 @@
+# Wasm memcheck (wmemcheck)
 
-Wmemcheck provides debug output for invalid mallocs, reads, and writes.
+wmemcheck provides the ability to check for invalid mallocs, reads, and writes
+inside a Wasm module, as long as Wasmtime is able to make certain assumptions
+(`malloc` and `free` functions are visible and your program uses only the
+default allocator). This is analogous to the Valgrind tool's memory checker
+(memcheck) tool for native programs.
 
 How to use:
+
 1. When building Wasmtime, add the CLI flag "--features wmemcheck" to compile with wmemcheck configured.
     > cargo build --features wmemcheck
 2. When running your wasm module, add the CLI flag "--wmemcheck".
     > wasmtime run --wmemcheck test.wasm
+
+If your program executes an invalid operation (load or store to non-allocated
+address, double-free, or an internal error in malloc that allocates the same
+memory twice) you will see an error that looks like a Wasm trap. For example, given the program
+
+```
+#include <stdlib.h>
+
+int main() {
+    char* p = malloc(1024);
+    *p = 0;
+    free(p);
+    *p = 0;
+}
+```
+
+compiled with WASI-SDK via
+
+```
+$ /opt/wasi-sdk/bin/clang -o test.wasm test.c
+```
+
+you can observe the memory checker working like so:
+
+```
+$ wasmtime run --wmemcheck ./test.wasm
+Error: failed to run main module `./test.wasm`
+
+Caused by:
+    0: failed to invoke command default
+    1: error while executing at wasm backtrace:
+           0:  0x103 - <unknown>!__original_main
+           1:   0x87 - <unknown>!_start
+           2: 0x2449 - <unknown>!_start.command_export
+    2: Invalid store at addr 0x10610 of size 1
+```


### PR DESCRIPTION
This PR expands the documentation for the Wasm memchecker (`wmemcheck`) feature significantly, and also links it from the top-level documentation hierarchy.

Thanks to folks in the Wasmtime biweekly for pointing out this omission and @abrown for noting that the docs should include example of outputs/error messages.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
