### PR TITLE
egraphs: Delete `select+fcmp` to `f{min,max}_pseudo` transform

### DIFF
--- a/cranelift/codegen/src/opts/selects.isle
+++ b/cranelift/codegen/src/opts/selects.isle
@@ -44,20 +44,3 @@
 (rule (simplify (bitselect ty @ (multi_lane _ _) (ugt _ x y) y x)) (umin ty x y))
 (rule (simplify (bitselect ty @ (multi_lane _ _) (uge _ x y) y x)) (umin ty x y))
 
-;; For floats convert fcmp lt into pseudo_min and gt into pseudo_max
-;;
-;; fmax_pseudo docs state:
-;; The behaviour for this operations is defined as  fmax_pseudo(a, b) = (a < b) ? b : a, and the behaviour for zero
-;; or NaN inputs follows from the behaviour of < with such inputs.
-;;
-;; That is exactly the operation that we match here!
-(rule (simplify
-       (select ty (fcmp _ (FloatCC.LessThan) x y) x y))
-      (fmin_pseudo ty x y))
-(rule (simplify
-       (select ty (fcmp _ (FloatCC.GreaterThan) x y) x y))
-      (fmax_pseudo ty x y))
-
-;; TODO: perform this same optimization to `f{min,max}_pseudo` for vectors
-;; with the `bitselect` instruction, but the pattern is a bit more complicated
-;; due to most bitselects-over-floats having bitcasts.

--- a/cranelift/filetests/filetests/egraph/select.clif
+++ b/cranelift/filetests/filetests/egraph/select.clif
@@ -141,28 +141,3 @@ block0(v0: i32, v1: i32, v2: i32, v3: i32):
 ; check:    v4 = icmp ule v0, v1
 ; check:    v5 = select v4, v2, v3
 ; check:    return v5
-
-
-
-
-function %select_fcmp_gt_to_fmax_pseudo(f32, f32) -> f32 {
-block0(v0: f32, v1: f32):
-    v2 = fcmp gt v0, v1
-    v3 = select v2, v0, v1
-    return v3
-}
-
-; check: block0(v0: f32, v1: f32):
-; check:    v4 = fmax_pseudo v0, v1
-; check:    return v4
-
-function %select_fcmp_lt_to_fmin_pseudo(f32, f32) -> f32 {
-block0(v0: f32, v1: f32):
-    v2 = fcmp lt v0, v1
-    v3 = select v2, v0, v1
-    return v3
-}
-
-; check: block0(v0: f32, v1: f32):
-; check:    v4 = fmin_pseudo v0, v1
-; check:    return v4

--- a/cranelift/filetests/filetests/runtests/issue-6859.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6859.clif
@@ -1,0 +1,16 @@
+test interpret
+test run
+set opt_level=speed
+target x86_64
+target x86_64 has_avx
+target aarch64
+target s390x
+target riscv64
+
+function %a(f32, f32) -> f32 fast {
+block0(v0: f32, v1: f32):
+    v2 = fcmp lt v0, v1
+    v3 = select v2, v0, v1
+    return v3
+}
+; run: %a(0.0, NaN) == NaN


### PR DESCRIPTION
👋 Hey,

This transform is wrong for the inputs in the attached testcase. Both of these instructions differ with their NaN behaviours.

It was introduced in #5546 and has been sort of unnoticed until #6843 caused some wasmtime testcode to fire this optimization rule and produce this counterexample.

@jameysharp has also a [nice example](https://github.com/bytecodealliance/wasmtime/pull/6843#issuecomment-1684226551 ) of how the testcode now fires this rule (with #6843) where it hadn't before.

I have no idea how fuzzgen hasn't found this yet! It's a really simple input so it should have been found pretty much instantly.

I've been trying to look at why over the past week but haven't come to any conclusions yet. Right now I'm trying to look into the nan canonicalization pass and trying to check if it would mask this behavior.

CC: @alexcrichton 