### PR TITLE
Use generated bindings to run components in the CLI

### DIFF
--- a/tests/all/cli_tests/component-basic.wat
+++ b/tests/all/cli_tests/component-basic.wat
@@ -4,7 +4,9 @@
       i32.const 0)
   )
   (core instance $i (instantiate $m))
-  (func (export "run") (result (result))
+  (func $run (result (result))
     (canon lift (core func $i "run")))
 
+  (instance (export (interface "wasi:cli/run"))
+    (export "run" (func $run)))
 )


### PR DESCRIPTION
This commit updates the component support in the `wasmtime` CLI from #6836 to use the generated bindings for the "command" style of components rather than having that custom-written in the CLI.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
