### PR TITLE
Update minimum `rust-version` listed

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ exclude = [
 version = "13.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
-rust-version = "1.66.0"
+rust-version = "1.71.0"
 
 [workspace.dependencies]
 wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=13.0.0" }


### PR DESCRIPTION
Previously 1.66.0 was listed, but as pointed out in #6870 we now rely on 1.71.0

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
