### PR TITLE
Fuzzing tweaks in wake of the pooling allocator refactor

### DIFF
--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -75,9 +75,11 @@ impl Config {
             // One single-page memory
             pooling.total_memories = config.max_memories as u32;
             pooling.memory_pages = 10;
+            pooling.max_memories_per_module = config.max_memories as u32;
 
             pooling.total_tables = config.max_tables as u32;
             pooling.table_elements = 1_000;
+            pooling.max_tables_per_module = config.max_tables as u32;
 
             pooling.core_instance_size = 1_000_000;
         }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -328,8 +328,11 @@ pub fn instantiate_with_dummy(store: &mut Store<StoreLimits>, module: &Module) -
         return None;
     }
 
-    // Also allow failures to instantiate as a result of hitting instance limits
-    if string.contains("maximum concurrent instance limit") {
+    // Also allow failures to instantiate as a result of hitting pooling limits.
+    if string.contains("maximum concurrent instance limit")
+        || string.contains("maximum concurrent memory limit")
+        || string.contains("maximum concurrent table limit")
+    {
         log::debug!("failed to instantiate: {}", string);
         return None;
     }

--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -62,7 +62,7 @@ fuzz_target!(|data: &[u8]| {
 
     // Errors in `run` have to do with not enough input in `data`, which we
     // ignore here since it doesn't affect how we'd like to fuzz.
-    drop(execute_one(&data));
+    let _ = execute_one(&data);
 });
 
 fn execute_one(data: &[u8]) -> Result<()> {


### PR DESCRIPTION
Some fuzzing-related follow ups to https://github.com/bytecodealliance/wasmtime/pull/6835

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61614 and https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61589