### PR TITLE
Enable component support in Wasmtime's CI-based binaries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -701,9 +701,9 @@ jobs:
         rustup target add ${{ matrix.target }}
       if: matrix.target != ''
 
-    # Build `wasmtime` and executables. Note that we include `all-arch` so our
-    # release artifacts can be used to compile `.cwasm`s for other targets.
-    - run: $CENTOS cargo build --release --bin wasmtime --features all-arch
+    # Build `wasmtime` and executables. Note that we include some non-default
+    # features so the # release artifacts can be maximally feature-ful.
+    - run: $CENTOS cargo build --release --bin wasmtime --features all-arch,component-model
 
     # Build `libwasmtime.so`
     - run: $CENTOS cargo build --release --manifest-path crates/c-api/Cargo.toml


### PR DESCRIPTION
This commit enables the `component-model` feature at compile time for our CI-originating binaries in the same manner that `all-arch` is enabled for CI as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
