### PR TITLE
docs: add Perl's Wasm package to PL list

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Languages supported by the Bytecode Alliance:
 Languages supported by the community:
 
 * **[Elixir]** - the [`wasmex` hex package]
+* **Perl** - the [`Wasm` Perl package's `Wasm::Wasmtime`]
 
 [Rust]: https://bytecodealliance.github.io/wasmtime/lang-rust.html
 [C]: https://bytecodealliance.github.io/wasmtime/examples-c-embed.html
@@ -146,6 +147,7 @@ Languages supported by the community:
 [`wasmtime` gem]: https://rubygems.org/gems/wasmtime
 [Elixir]: https://docs.wasmtime.dev/lang-elixir.html
 [`wasmex` hex package]: https://hex.pm/packages/wasmex
+[`Wasm` Perl package's `Wasm::Wasmtime`]: https://metacpan.org/pod/Wasm::Wasmtime
 
 ## Documentation
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

This PR adds mention of the now-stale Wasmtime support in Perl via the `Wasm` package, [notably `Wasm::Wasmtime`](https://metacpan.org/pod/Wasm::Wasmtime)

This was discussed in https://github.com/bytecodealliance/wasmtime/issues/6748

Thanks @jonassmedegaard for filing the issue and providing the link!

