### PR TITLE
wiggle: generate offset accessors for structs

### DIFF
--- a/crates/wiggle/tests/records.rs
+++ b/crates/wiggle/tests/records.rs
@@ -551,3 +551,34 @@ proptest! {
         e.test()
     }
 }
+
+#[test]
+fn pair_ints_offsets() {
+    assert_eq!(types::PairInts::offset_of_first(), 0);
+    assert_eq!(types::PairInts::offset_of_second(), 4);
+}
+
+#[test]
+fn pair_different_ints_offsets() {
+    assert_eq!(types::PairDifferentInts::offset_of_first(), 0);
+    assert_eq!(types::PairDifferentInts::offset_of_second(), 8);
+    assert_eq!(types::PairDifferentInts::offset_of_third(), 10);
+    assert_eq!(types::PairDifferentInts::offset_of_fourth(), 12);
+}
+
+#[test]
+fn pair_int_ptrs_offsets() {
+    assert_eq!(types::PairIntPtrs::offset_of_first(), 0);
+    assert_eq!(types::PairIntPtrs::offset_of_second(), 4);
+}
+
+#[test]
+fn pair_int_and_ptr_offsets() {
+    assert_eq!(types::PairIntAndPtr::offset_of_first(), 0);
+    assert_eq!(types::PairIntAndPtr::offset_of_second(), 4);
+}
+
+#[test]
+fn pair_record_of_list_offset() {
+    assert_eq!(types::RecordOfList::offset_of_arr(), 0);
+}

--- a/crates/wiggle/tests/records.witx
+++ b/crates/wiggle/tests/records.witx
@@ -6,6 +6,13 @@
     (field $first s32)
     (field $second s32)))
 
+(typename $pair_different_ints
+  (record
+    (field $first s64)
+    (field $second s16)
+    (field $third s16)
+    (field $fourth s32)))
+
 (typename $pair_int_ptrs
   (record
     (field $first (@witx const_pointer s32))


### PR DESCRIPTION
Adds methods of the shape `GeneratedStruct::offset_of_<field_name>() -> u32` to allow clients to get the same offsets used in the generated `read` and `write` methods. I don't believe there is currently a way to get these otherwise for applications that wish to selectively read and write to fields.

I considered a couple alternatives to this:

1. Add methods like `read_<field_name>` and `write_<field_name>`. The interface to these ends up being awkward because the `GuestType` impls are currently for owned types, so these methods would be forced to either take ownership of the entire struct to write one field, or else silently clone the field.

2. Add `#[repr(C)]` to the generated struct definition so that clients could use tools like `memoffset` to calculate the offset themselves. I didn't want to depend on the witx offsets coinciding with `repr(C)`, though.

I extended the Wiggle `records` to exercise these new methods.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
