### PR TITLE
Handle more failures with `--trap-on-grow-failure`

### DIFF
--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -20,7 +20,7 @@
     )
 )]
 
-use anyhow::Error;
+use anyhow::{Error, Result};
 use std::fmt;
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
@@ -132,7 +132,9 @@ pub unsafe trait Store {
     ) -> Result<bool, Error>;
     /// Callback invoked to notify the store's resource limiter that a memory
     /// grow operation has failed.
-    fn memory_grow_failed(&mut self, error: &Error);
+    ///
+    /// Note that this is not invoked if `memory_growing` returns an error.
+    fn memory_grow_failed(&mut self, error: Error) -> Result<()>;
     /// Callback invoked to allow the store's resource limiter to reject a
     /// table grow operation.
     fn table_growing(
@@ -143,7 +145,9 @@ pub unsafe trait Store {
     ) -> Result<bool, Error>;
     /// Callback invoked to notify the store's resource limiter that a table
     /// grow operation has failed.
-    fn table_grow_failed(&mut self, error: &Error);
+    ///
+    /// Note that this is not invoked if `table_growing` returns an error.
+    fn table_grow_failed(&mut self, error: Error) -> Result<()>;
     /// Callback invoked whenever fuel runs out by a wasm instance. If an error
     /// is returned that's raised as a trap. Otherwise wasm execution will
     /// continue as normal.

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -116,7 +116,7 @@ pub trait RuntimeLinearMemory: Send + Sync {
                     // to report the growth failure to but the error should not
                     // be dropped
                     // (https://github.com/bytecodealliance/wasmtime/issues/4240).
-                    store.memory_grow_failed(&format_err!("Memory maximum size exceeded"));
+                    store.memory_grow_failed(format_err!("Memory maximum size exceeded"))?;
                 }
                 return Ok(None);
             }
@@ -130,7 +130,7 @@ pub trait RuntimeLinearMemory: Send + Sync {
                 // dropped
                 // (https://github.com/bytecodealliance/wasmtime/issues/4240).
                 if let Some(store) = store {
-                    store.memory_grow_failed(&e);
+                    store.memory_grow_failed(e)?;
                 }
                 Ok(None)
             }

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -361,7 +361,10 @@ impl Table {
         let old_size = self.size();
         let new_size = match old_size.checked_add(delta) {
             Some(s) => s,
-            None => return Ok(None),
+            None => {
+                store.table_grow_failed(format_err!("overflow calculating new table size"))?;
+                return Ok(None);
+            }
         };
 
         if !store.table_growing(old_size, new_size, self.maximum())? {
@@ -370,7 +373,7 @@ impl Table {
 
         if let Some(max) = self.maximum() {
             if new_size > max {
-                store.table_grow_failed(&format_err!("Table maximum size exceeded"));
+                store.table_grow_failed(format_err!("Table maximum size exceeded"))?;
                 return Ok(None);
             }
         }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1992,7 +1992,7 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
         }
     }
 
-    fn memory_grow_failed(&mut self, error: &anyhow::Error) {
+    fn memory_grow_failed(&mut self, error: anyhow::Error) -> Result<()> {
         match self.limiter {
             Some(ResourceLimiterInner::Sync(ref mut limiter)) => {
                 limiter(&mut self.data).memory_grow_failed(error)
@@ -2001,7 +2001,10 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
             Some(ResourceLimiterInner::Async(ref mut limiter)) => {
                 limiter(&mut self.data).memory_grow_failed(error)
             }
-            None => {}
+            None => {
+                log::debug!("ignoring memory growth failure error: {error:?}");
+                Ok(())
+            }
         }
     }
 
@@ -2039,7 +2042,7 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
         }
     }
 
-    fn table_grow_failed(&mut self, error: &anyhow::Error) {
+    fn table_grow_failed(&mut self, error: anyhow::Error) -> Result<()> {
         match self.limiter {
             Some(ResourceLimiterInner::Sync(ref mut limiter)) => {
                 limiter(&mut self.data).table_grow_failed(error)
@@ -2048,7 +2051,10 @@ unsafe impl<T> wasmtime_runtime::Store for StoreInner<T> {
             Some(ResourceLimiterInner::Async(ref mut limiter)) => {
                 limiter(&mut self.data).table_grow_failed(error)
             }
-            None => {}
+            None => {
+                log::debug!("ignoring table growth failure: {error:?}");
+                Ok(())
+            }
         }
     }
 

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -831,3 +831,58 @@ fn run_precompiled_component() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn memory_growth_failure() -> Result<()> {
+    let output = get_wasmtime_command()?
+        .args(&[
+            "run",
+            "--wasm-features=memory64",
+            "--trap-on-grow-failure",
+            "tests/all/cli_tests/memory-grow-failure.wat",
+        ])
+        .output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("forcing a memory growth failure to be a trap"),
+        "bad stderr: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn table_growth_failure() -> Result<()> {
+    let output = get_wasmtime_command()?
+        .args(&[
+            "run",
+            "--trap-on-grow-failure",
+            "tests/all/cli_tests/table-grow-failure.wat",
+        ])
+        .output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("forcing trap when growing table"),
+        "bad stderr: {stderr}"
+    );
+    Ok(())
+}
+
+#[test]
+fn table_growth_failure2() -> Result<()> {
+    let output = get_wasmtime_command()?
+        .args(&[
+            "run",
+            "--trap-on-grow-failure",
+            "tests/all/cli_tests/table-grow-failure2.wat",
+        ])
+        .output()?;
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("forcing a table growth failure to be a trap"),
+        "bad stderr: {stderr}"
+    );
+    Ok(())
+}

--- a/tests/all/cli_tests/memory-grow-failure.wat
+++ b/tests/all/cli_tests/memory-grow-failure.wat
@@ -1,0 +1,8 @@
+(module
+  (memory i64 1)
+  (func (export "_start")
+    i64.const 0x0000800000000000
+    memory.grow
+    drop
+  )
+)

--- a/tests/all/cli_tests/table-grow-failure.wat
+++ b/tests/all/cli_tests/table-grow-failure.wat
@@ -1,0 +1,9 @@
+(module
+  (table 1 10 funcref)
+  (func (export "_start")
+    ref.null func
+    i32.const 11
+    table.grow
+    drop
+  )
+)

--- a/tests/all/cli_tests/table-grow-failure2.wat
+++ b/tests/all/cli_tests/table-grow-failure2.wat
@@ -1,0 +1,9 @@
+(module
+  (table 1 funcref)
+  (func (export "_start")
+    ref.null func
+    i32.const -1
+    table.grow
+    drop
+  )
+)

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -541,7 +541,6 @@ impl ResourceLimiterAsync for MemoryContext {
     ) -> Result<bool> {
         Ok(true)
     }
-    fn table_grow_failed(&mut self, _e: &anyhow::Error) {}
 }
 
 #[tokio::test]
@@ -724,16 +723,18 @@ impl ResourceLimiter for FailureDetector {
         self.memory_desired = desired;
         Ok(true)
     }
-    fn memory_grow_failed(&mut self, err: &anyhow::Error) {
+    fn memory_grow_failed(&mut self, err: anyhow::Error) -> Result<()> {
         self.memory_error = Some(err.to_string());
+        Ok(())
     }
     fn table_growing(&mut self, current: u32, desired: u32, _maximum: Option<u32>) -> Result<bool> {
         self.table_current = current;
         self.table_desired = desired;
         Ok(true)
     }
-    fn table_grow_failed(&mut self, err: &anyhow::Error) {
+    fn table_grow_failed(&mut self, err: anyhow::Error) -> Result<()> {
         self.table_error = Some(err.to_string());
+        Ok(())
     }
 }
 
@@ -826,8 +827,9 @@ impl ResourceLimiterAsync for FailureDetector {
         self.memory_desired = desired;
         Ok(true)
     }
-    fn memory_grow_failed(&mut self, err: &anyhow::Error) {
+    fn memory_grow_failed(&mut self, err: anyhow::Error) -> Result<()> {
         self.memory_error = Some(err.to_string());
+        Ok(())
     }
 
     async fn table_growing(
@@ -840,8 +842,9 @@ impl ResourceLimiterAsync for FailureDetector {
         self.table_desired = desired;
         Ok(true)
     }
-    fn table_grow_failed(&mut self, err: &anyhow::Error) {
+    fn table_grow_failed(&mut self, err: anyhow::Error) -> Result<()> {
         self.table_error = Some(err.to_string());
+        Ok(())
     }
 }
 

--- a/tests/rlimited-memory.rs
+++ b/tests/rlimited-memory.rs
@@ -23,8 +23,9 @@ impl ResourceLimiter for MemoryGrowFailureDetector {
         self.desired = desired;
         Ok(true)
     }
-    fn memory_grow_failed(&mut self, err: &anyhow::Error) {
+    fn memory_grow_failed(&mut self, err: anyhow::Error) -> Result<()> {
         self.error = Some(err.to_string());
+        Ok(())
     }
     fn table_growing(
         &mut self,


### PR DESCRIPTION
This debugging tool was missing a few cases about `memory.grow` or `table.grow` returning -1, namely when the OS reported failure in the `memory.grow` case or in the case for tables when the computation overflowed for the new table size. This commit updates the `*_grow_failed` methods, which were already hooking these errors, to return a `Result<()>` which enables returning a trap from them as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
