### PR TITLE
doc: add ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,18 @@
+# wasmCloud adopters
+
+_If you are using wasmtime in production at your organization, please add your company name to this list.
+The list is in alphabetical order._
+
+Wasmtime is used in many different production use-cases. This list has grown significantly since the [first major version release in 2022](https://bytecodealliance.org/articles/wasmtime-1-0-fast-safe-and-production-ready).
+
+| Organization | Contact | Status | Description of Use |
+| - | - | - | - |
+| [Cosmonic](https://www.cosmonic.com) | [@ricochet](https://github.com/ricochet) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | Cosmonic is a distributed app platform built on CNCF wasmCloud for wasmCloud apps. |
+| [DFINITY](https://dfinity.org/) | [@ulan](https://github.com/ulan) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | Internet Computer blockchain uses Wasmtime to run canister smart contracts. |
+| [Embark Studios](https://www.embark-studios.com/) | [@repi](https://github.com/repi) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | Rust game engine |
+| [Fastly](https://fastly.com/) | [@fitzgen](https://github.com/fitzgen) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | The Compute@Edge platform helps you compile your custom code to WebAssembly and runs it at the Fastly edge using the WebAssembly System Interface for each compute request. |
+| [Fermyon](https://fermyon.com) | [@tschneidereit](https://github.com/tschneidereit) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | Fermyon Cloud is a cloud application platform for WebAssembly-based serverless functions and microservices. |
+| [InfinyOn](https://infinyon.com/) | [@sehz](https://github.com/sehz) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | InfinyOn leverages the power of WebAssembly SmartModules to execute real-time data transformations. |
+| [Microsoft](https://microsoft.com/) | [@devigned](https://gist.github.com/devigned) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | Microsoft has had Wasmtime in preview for its WebAssembly System Interface (WASI) node pools in Azure Kubernetes Service since October 2021. |
+| [Shopify](https://www.shopify.com/) | [@saulecabrera](https://github.com/saulecabrera) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | Shopify Functions allow developers to customize the backend logic of Shopify. |
+| [SingleStore](https://www.singlestore.com/) | [@Kylebrown9](https://github.com/Kylebrown9) | ![production](https://img.shields.io/badge/-production-blue?style=flat) | SingleStoreDB Cloud embeds wasmtime to bring developers' code to the data, safely and with speed and scale. |


### PR DESCRIPTION
Similar to `CONTRIBUTING.md`, `ADOPTERS.md` is a common file to include in projects. The goal is to indicate production-readiness and usage of a given project. This was discussed in a recent TSC meeting as a best practice for production-ready projects like wasmtime.

Other examples of `ADOPTERS.md` for reference:
- https://github.com/backstage/backstage/blob/master/ADOPTERS.md
- https://github.com/openfaas/faas/blob/master/ADOPTERS.md

This list is based on the [wasmtime 1.0](https://bytecodealliance.org/articles/wasmtime-1-0-fast-safe-and-production-ready) blog.