### PR TITLE
Migrated from deprecated `add_server_trust_anchors` in rustls to `ad…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2330,9 +2330,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.101.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
 dependencies = [
  "ring",
  "untrusted",
@@ -3896,12 +3896,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.23.0"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa54963694b65584e170cf5dc46aeb4dcaa5584e652ff5f3952e56d66aff0125"
-dependencies = [
- "rustls-webpki",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "which"

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -24,7 +24,7 @@ indexmap = { workspace = true }
 cfg-if = { workspace = true }
 rand = { version = "0.8.3", features = ['small_rng'] }
 anyhow = { workspace = true }
-memfd = "0.6.2"
+memfd = "0.6.3"
 paste = "1.0.3"
 encoding_rs = { version = "0.8.31", optional = true }
 sptr = "0.3.2"
@@ -61,9 +61,6 @@ async = ["wasmtime-fiber"]
 # Enables support for the pooling instance allocator
 pooling-allocator = []
 
-component-model = [
-  "wasmtime-environ/component-model",
-  "dep:encoding_rs",
-]
+component-model = ["wasmtime-environ/component-model", "dep:encoding_rs"]
 
 wmemcheck = []

--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -31,4 +31,4 @@ wasmtime = { workspace = true, features = ['component-model'] }
 [target.'cfg(not(any(target_arch = "riscv64", target_arch = "s390x")))'.dependencies]
 tokio-rustls = { version = "0.24.0" }
 rustls = { version = "0.21.0" }
-webpki-roots = { version = "0.23.0" }
+webpki-roots = { version = "0.25.2" }

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -127,15 +127,15 @@ impl<T: WasiHttpView> WasiHttpViewExt for T {
 
                 // derived from https://github.com/tokio-rs/tls/blob/master/tokio-rustls/examples/client/src/main.rs
                 let mut root_cert_store = rustls::RootCertStore::empty();
-                root_cert_store.add_server_trust_anchors(
-                    webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+                root_cert_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(
+                    |ta| {
                         OwnedTrustAnchor::from_subject_spki_name_constraints(
                             ta.subject,
                             ta.spki,
                             ta.name_constraints,
                         )
-                    }),
-                );
+                    },
+                ));
                 let config = rustls::ClientConfig::builder()
                     .with_safe_defaults()
                     .with_root_certificates(root_cert_store)


### PR DESCRIPTION
Replaces usage of deprecated `add_server_trust_anchors` with the replacement `add_trust_anchors`

Broken out into it's own PR, original discussion https://github.com/bytecodealliance/wasmtime/pull/6886#discussion_r1302255687