### PR TITLE
winch: Use type information to derive operand sizes

### DIFF
--- a/winch/codegen/src/codegen/call.rs
+++ b/winch/codegen/src/codegen/call.rs
@@ -183,13 +183,13 @@ impl<'a> FnCall<'a> {
                 .next()
                 .unwrap_or_else(|| panic!("expected stack value for function argument"));
             match &arg {
-                &ABIArg::Reg { ty, reg } => {
-                    context.move_val_to_reg(&val, *reg, masm, (*ty).into());
+                &ABIArg::Reg { ty: _, reg } => {
+                    context.move_val_to_reg(&val, *reg, masm);
                 }
                 &ABIArg::Stack { ty, offset } => {
                     let addr = masm.address_at_sp(*offset);
                     let size: OperandSize = (*ty).into();
-                    context.move_val_to_reg(val, scratch, masm, size);
+                    context.move_val_to_reg(val, scratch, masm);
                     masm.store(scratch.into(), addr, size);
                 }
             }

--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -185,7 +185,7 @@ impl ControlStackFrame {
                 ..
             } => {
                 // Pop the condition value.
-                let top = context.pop_to_reg(masm, None, OperandSize::S32);
+                let top = context.pop_to_reg(masm, None);
 
                 // Unconditionall spill before emitting control flow.
                 context.spill(masm);

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -318,7 +318,7 @@ impl Masm for MacroAssembler {
                 .stack
                 .pop_i32_const()
                 .expect("i32 const value at stack top");
-            let typed_reg = context.pop_to_reg(self, None, size);
+            let typed_reg = context.pop_to_reg(self, None);
 
             self.asm.shift_ir(val as u8, typed_reg.into(), kind, size);
 
@@ -328,15 +328,15 @@ impl Masm for MacroAssembler {
                 .stack
                 .pop_i64_const()
                 .expect("i64 const value at stack top");
-            let typed_reg = context.pop_to_reg(self, None, size);
+            let typed_reg = context.pop_to_reg(self, None);
 
             self.asm.shift_ir(val as u8, typed_reg.into(), kind, size);
 
             context.stack.push(typed_reg.into());
         } else {
             // Number of bits to shift must be in the CL register.
-            let src = context.pop_to_reg(self, Some(regs::rcx()), size);
-            let dst = context.pop_to_reg(self, None, size);
+            let src = context.pop_to_reg(self, Some(regs::rcx()));
+            let dst = context.pop_to_reg(self, None);
 
             self.asm.shift_rr(src.into(), dst.into(), kind, size);
 
@@ -351,12 +351,12 @@ impl Masm for MacroAssembler {
         let rax = context.reg(regs::rax(), self);
 
         // Allocate the divisor, which can be any gpr.
-        let divisor = context.pop_to_reg(self, None, size);
+        let divisor = context.pop_to_reg(self, None);
 
         // Mark rax as allocatable.
         context.free_reg(rax);
         // Move the top value to rax.
-        let rax = context.pop_to_reg(self, Some(rax), size);
+        let rax = context.pop_to_reg(self, Some(rax));
         self.asm.div(divisor.into(), (rax.into(), rdx), kind, size);
 
         // Free the divisor and rdx.
@@ -373,12 +373,12 @@ impl Masm for MacroAssembler {
         let rax = context.reg(regs::rax(), self);
 
         // Allocate the divisor, which can be any gpr.
-        let divisor = context.pop_to_reg(self, None, size);
+        let divisor = context.pop_to_reg(self, None);
 
         // Mark rax as allocatable.
         context.free_reg(rax);
         // Move the top value to rax.
-        let rax = context.pop_to_reg(self, Some(rax), size);
+        let rax = context.pop_to_reg(self, Some(rax));
         self.asm.rem(divisor.reg, (rax.into(), rdx), kind, size);
 
         // Free the divisor and rax.
@@ -508,7 +508,7 @@ impl Masm for MacroAssembler {
     }
 
     fn popcnt(&mut self, context: &mut CodeGenContext, size: OperandSize) {
-        let src = context.pop_to_reg(self, None, size);
+        let src = context.pop_to_reg(self, None);
         if self.flags.has_popcnt() {
             self.asm.popcnt(src.into(), size);
             context.stack.push(src.into());

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -570,7 +570,7 @@ where
         let top =
             self.context
                 .without::<TypedReg, M, _>(result.result_reg(), self.masm, |ctx, masm| {
-                    ctx.pop_to_reg(masm, None, OperandSize::S32)
+                    ctx.pop_to_reg(masm, None)
                 });
         self.context.pop_abi_results(result, self.masm);
         self.context.push_abi_results(result, self.masm);
@@ -632,7 +632,7 @@ where
         let addr = self
             .masm
             .address_at_reg(<M::ABI as ABI>::vmctx_reg(), offset);
-        let typed_reg = self.context.pop_to_reg(self.masm, None, ty.into());
+        let typed_reg = self.context.pop_to_reg(self.masm, None);
         self.context.free_reg(typed_reg.reg);
         self.masm.store(typed_reg.reg.into(), addr, ty.into());
     }

--- a/winch/filetests/filetests/aarch64/i32_add/locals.wat
+++ b/winch/filetests/filetests/aarch64/i32_add/locals.wat
@@ -33,7 +33,7 @@
 ;;   38:	 808340b8             	ldur	w0, [x28, #8]
 ;;   3c:	 81c340b8             	ldur	w1, [x28, #0xc]
 ;;   40:	 2160200b             	add	w1, w1, w0, uxtx
-;;   44:	 e00301aa             	mov	x0, x1
+;;   44:	 e003012a             	mov	w0, w1
 ;;   48:	 ff430091             	add	sp, sp, #0x10
 ;;   4c:	 fc030091             	mov	x28, sp
 ;;   50:	 fd7bc1a8             	ldp	x29, x30, [sp], #0x10

--- a/winch/filetests/filetests/aarch64/i32_add/params.wat
+++ b/winch/filetests/filetests/aarch64/i32_add/params.wat
@@ -18,7 +18,7 @@
 ;;   20:	 808340b8             	ldur	w0, [x28, #8]
 ;;   24:	 81c340b8             	ldur	w1, [x28, #0xc]
 ;;   28:	 2160200b             	add	w1, w1, w0, uxtx
-;;   2c:	 e00301aa             	mov	x0, x1
+;;   2c:	 e003012a             	mov	w0, w1
 ;;   30:	 ff430091             	add	sp, sp, #0x10
 ;;   34:	 fc030091             	mov	x28, sp
 ;;   38:	 fd7bc1a8             	ldp	x29, x30, [sp], #0x10

--- a/winch/filetests/filetests/aarch64/i32_mul/locals.wat
+++ b/winch/filetests/filetests/aarch64/i32_mul/locals.wat
@@ -33,7 +33,7 @@
 ;;   38:	 808340b8             	ldur	w0, [x28, #8]
 ;;   3c:	 81c340b8             	ldur	w1, [x28, #0xc]
 ;;   40:	 217c001b             	mul	w1, w1, w0
-;;   44:	 e00301aa             	mov	x0, x1
+;;   44:	 e003012a             	mov	w0, w1
 ;;   48:	 ff430091             	add	sp, sp, #0x10
 ;;   4c:	 fc030091             	mov	x28, sp
 ;;   50:	 fd7bc1a8             	ldp	x29, x30, [sp], #0x10

--- a/winch/filetests/filetests/aarch64/i32_mul/params.wat
+++ b/winch/filetests/filetests/aarch64/i32_mul/params.wat
@@ -18,7 +18,7 @@
 ;;   20:	 808340b8             	ldur	w0, [x28, #8]
 ;;   24:	 81c340b8             	ldur	w1, [x28, #0xc]
 ;;   28:	 217c001b             	mul	w1, w1, w0
-;;   2c:	 e00301aa             	mov	x0, x1
+;;   2c:	 e003012a             	mov	w0, w1
 ;;   30:	 ff430091             	add	sp, sp, #0x10
 ;;   34:	 fc030091             	mov	x28, sp
 ;;   38:	 fd7bc1a8             	ldp	x29, x30, [sp], #0x10

--- a/winch/filetests/filetests/aarch64/i32_sub/locals.wat
+++ b/winch/filetests/filetests/aarch64/i32_sub/locals.wat
@@ -33,7 +33,7 @@
 ;;   38:	 808340b8             	ldur	w0, [x28, #8]
 ;;   3c:	 81c340b8             	ldur	w1, [x28, #0xc]
 ;;   40:	 2160204b             	sub	w1, w1, w0, uxtx
-;;   44:	 e00301aa             	mov	x0, x1
+;;   44:	 e003012a             	mov	w0, w1
 ;;   48:	 ff430091             	add	sp, sp, #0x10
 ;;   4c:	 fc030091             	mov	x28, sp
 ;;   50:	 fd7bc1a8             	ldp	x29, x30, [sp], #0x10

--- a/winch/filetests/filetests/aarch64/i32_sub/params.wat
+++ b/winch/filetests/filetests/aarch64/i32_sub/params.wat
@@ -18,7 +18,7 @@
 ;;   20:	 808340b8             	ldur	w0, [x28, #8]
 ;;   24:	 81c340b8             	ldur	w1, [x28, #0xc]
 ;;   28:	 2160204b             	sub	w1, w1, w0, uxtx
-;;   2c:	 e00301aa             	mov	x0, x1
+;;   2c:	 e003012a             	mov	w0, w1
 ;;   30:	 ff430091             	add	sp, sp, #0x10
 ;;   34:	 fc030091             	mov	x28, sp
 ;;   38:	 fd7bc1a8             	ldp	x29, x30, [sp], #0x10

--- a/winch/filetests/filetests/x64/block/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/block/as_if_cond.wat
@@ -19,12 +19,12 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c001000000       	mov	rax, 1
-;;   13:	 85c0                 	test	eax, eax
-;;   15:	 0f840d000000         	je	0x28
-;;   1b:	 4883ec08             	sub	rsp, 8
-;;   1f:	 e800000000           	call	0x24
-;;   24:	 4883c408             	add	rsp, 8
-;;   28:	 4883c408             	add	rsp, 8
-;;   2c:	 5d                   	pop	rbp
-;;   2d:	 c3                   	ret	
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 85c0                 	test	eax, eax
+;;   13:	 0f840d000000         	je	0x26
+;;   19:	 4883ec08             	sub	rsp, 8
+;;   1d:	 e800000000           	call	0x22
+;;   22:	 4883c408             	add	rsp, 8
+;;   26:	 4883c408             	add	rsp, 8
+;;   2a:	 5d                   	pop	rbp
+;;   2b:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/as_if_else.wat
+++ b/winch/filetests/filetests/x64/block/as_if_else.wat
@@ -10,10 +10,10 @@
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
 ;;    c:	 b801000000           	mov	eax, 1
 ;;   11:	 85c0                 	test	eax, eax
-;;   13:	 0f840c000000         	je	0x25
-;;   19:	 48c7c002000000       	mov	rax, 2
-;;   20:	 e907000000           	jmp	0x2c
-;;   25:	 48c7c001000000       	mov	rax, 1
-;;   2c:	 4883c408             	add	rsp, 8
-;;   30:	 5d                   	pop	rbp
-;;   31:	 c3                   	ret	
+;;   13:	 0f840a000000         	je	0x23
+;;   19:	 b802000000           	mov	eax, 2
+;;   1e:	 e905000000           	jmp	0x28
+;;   23:	 b801000000           	mov	eax, 1
+;;   28:	 4883c408             	add	rsp, 8
+;;   2c:	 5d                   	pop	rbp
+;;   2d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/as_if_then.wat
+++ b/winch/filetests/filetests/x64/block/as_if_then.wat
@@ -10,10 +10,10 @@
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
 ;;    c:	 b801000000           	mov	eax, 1
 ;;   11:	 85c0                 	test	eax, eax
-;;   13:	 0f840c000000         	je	0x25
-;;   19:	 48c7c001000000       	mov	rax, 1
-;;   20:	 e907000000           	jmp	0x2c
-;;   25:	 48c7c002000000       	mov	rax, 2
-;;   2c:	 4883c408             	add	rsp, 8
-;;   30:	 5d                   	pop	rbp
-;;   31:	 c3                   	ret	
+;;   13:	 0f840a000000         	je	0x23
+;;   19:	 b801000000           	mov	eax, 1
+;;   1e:	 e905000000           	jmp	0x28
+;;   23:	 b802000000           	mov	eax, 2
+;;   28:	 4883c408             	add	rsp, 8
+;;   2c:	 5d                   	pop	rbp
+;;   2d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/deep.wat
+++ b/winch/filetests/filetests/x64/block/deep.wat
@@ -59,7 +59,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c096000000       	mov	rax, 0x96
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b896000000           	mov	eax, 0x96
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/nested.wat
+++ b/winch/filetests/filetests/x64/block/nested.wat
@@ -27,7 +27,7 @@
 ;;   19:	 4883ec08             	sub	rsp, 8
 ;;   1d:	 e800000000           	call	0x22
 ;;   22:	 4883c408             	add	rsp, 8
-;;   26:	 48c7c009000000       	mov	rax, 9
-;;   2d:	 4883c408             	add	rsp, 8
-;;   31:	 5d                   	pop	rbp
-;;   32:	 c3                   	ret	
+;;   26:	 b809000000           	mov	eax, 9
+;;   2b:	 4883c408             	add	rsp, 8
+;;   2f:	 5d                   	pop	rbp
+;;   30:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/singular.wat
+++ b/winch/filetests/filetests/x64/block/singular.wat
@@ -10,7 +10,7 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c007000000       	mov	rax, 7
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b807000000           	mov	eax, 7
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_block_value.wat
+++ b/winch/filetests/filetests/x64/br/as_block_value.wat
@@ -21,7 +21,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c002000000       	mov	rax, 2
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b802000000           	mov	eax, 2
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_br_value.wat
+++ b/winch/filetests/filetests/x64/br/as_br_value.wat
@@ -8,7 +8,7 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c009000000       	mov	rax, 9
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b809000000           	mov	eax, 9
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_call_all.wat
+++ b/winch/filetests/filetests/x64/br/as_call_all.wat
@@ -12,17 +12,16 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48b8ffffffff00000000 	
-;; 				movabs	rax, 0xffffffff
-;;   23:	 4883c418             	add	rsp, 0x18
-;;   27:	 5d                   	pop	rbp
-;;   28:	 c3                   	ret	
+;;   19:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   1e:	 4883c418             	add	rsp, 0x18
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c00f000000       	mov	rax, 0xf
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b80f000000           	mov	eax, 0xf
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_call_first.wat
+++ b/winch/filetests/filetests/x64/br/as_call_first.wat
@@ -15,17 +15,16 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48b8ffffffff00000000 	
-;; 				movabs	rax, 0xffffffff
-;;   23:	 4883c418             	add	rsp, 0x18
-;;   27:	 5d                   	pop	rbp
-;;   28:	 c3                   	ret	
+;;   19:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   1e:	 4883c418             	add	rsp, 0x18
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c00c000000       	mov	rax, 0xc
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b80c000000           	mov	eax, 0xc
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_call_last.wat
+++ b/winch/filetests/filetests/x64/br/as_call_last.wat
@@ -14,17 +14,16 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48b8ffffffff00000000 	
-;; 				movabs	rax, 0xffffffff
-;;   23:	 4883c418             	add	rsp, 0x18
-;;   27:	 5d                   	pop	rbp
-;;   28:	 c3                   	ret	
+;;   19:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   1e:	 4883c418             	add	rsp, 0x18
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c00e000000       	mov	rax, 0xe
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b80e000000           	mov	eax, 0xe
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_call_mid.wat
@@ -15,17 +15,16 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48b8ffffffff00000000 	
-;; 				movabs	rax, 0xffffffff
-;;   23:	 4883c418             	add	rsp, 0x18
-;;   27:	 5d                   	pop	rbp
-;;   28:	 c3                   	ret	
+;;   19:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   1e:	 4883c418             	add	rsp, 0x18
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c00d000000       	mov	rax, 0xd
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b80d000000           	mov	eax, 0xd
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/br/as_if_cond.wat
@@ -13,7 +13,7 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c002000000       	mov	rax, 2
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_if_else.wat
+++ b/winch/filetests/filetests/x64/br/as_if_else.wat
@@ -19,8 +19,8 @@
 ;;   18:	 85c0                 	test	eax, eax
 ;;   1a:	 0f8409000000         	je	0x29
 ;;   20:	 8b442408             	mov	eax, dword ptr [rsp + 8]
-;;   24:	 e907000000           	jmp	0x30
-;;   29:	 48c7c004000000       	mov	rax, 4
-;;   30:	 4883c410             	add	rsp, 0x10
-;;   34:	 5d                   	pop	rbp
-;;   35:	 c3                   	ret	
+;;   24:	 e905000000           	jmp	0x2e
+;;   29:	 b804000000           	mov	eax, 4
+;;   2e:	 4883c410             	add	rsp, 0x10
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_if_then.wat
+++ b/winch/filetests/filetests/x64/br/as_if_then.wat
@@ -17,10 +17,10 @@
 ;;   10:	 4c893424             	mov	qword ptr [rsp], r14
 ;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   18:	 85c0                 	test	eax, eax
-;;   1a:	 0f840c000000         	je	0x2c
-;;   20:	 48c7c003000000       	mov	rax, 3
-;;   27:	 e904000000           	jmp	0x30
-;;   2c:	 8b442408             	mov	eax, dword ptr [rsp + 8]
-;;   30:	 4883c410             	add	rsp, 0x10
-;;   34:	 5d                   	pop	rbp
-;;   35:	 c3                   	ret	
+;;   1a:	 0f840a000000         	je	0x2a
+;;   20:	 b803000000           	mov	eax, 3
+;;   25:	 e904000000           	jmp	0x2e
+;;   2a:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2e:	 4883c410             	add	rsp, 0x10
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_loop_first.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_first.wat
@@ -9,7 +9,7 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c003000000       	mov	rax, 3
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b803000000           	mov	eax, 3
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_last.wat
@@ -22,7 +22,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c005000000       	mov	rax, 5
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b805000000           	mov	eax, 5
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br/as_loop_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_mid.wat
@@ -23,7 +23,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c004000000       	mov	rax, 4
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b804000000           	mov	eax, 4
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_block_last_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_block_last_value.wat
@@ -23,9 +23,9 @@
 ;;   11:	 e800000000           	call	0x16
 ;;   16:	 e800000000           	call	0x1b
 ;;   1b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
-;;   1f:	 48c7c00b000000       	mov	rax, 0xb
-;;   26:	 85c9                 	test	ecx, ecx
-;;   28:	 0f8500000000         	jne	0x2e
-;;   2e:	 4883c410             	add	rsp, 0x10
-;;   32:	 5d                   	pop	rbp
-;;   33:	 c3                   	ret	
+;;   1f:	 b80b000000           	mov	eax, 0xb
+;;   24:	 85c9                 	test	ecx, ecx
+;;   26:	 0f8500000000         	jne	0x2c
+;;   2c:	 4883c410             	add	rsp, 0x10
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_br_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_br_value.wat
@@ -9,9 +9,9 @@
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
 ;;    c:	 b902000000           	mov	ecx, 2
-;;   11:	 48c7c001000000       	mov	rax, 1
-;;   18:	 85c9                 	test	ecx, ecx
-;;   1a:	 0f8500000000         	jne	0x20
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   11:	 b801000000           	mov	eax, 1
+;;   16:	 85c9                 	test	ecx, ecx
+;;   18:	 0f8500000000         	jne	0x1e
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_call_first.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_first.wat
@@ -16,26 +16,25 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48b8ffffffff00000000 	
-;; 				movabs	rax, 0xffffffff
-;;   23:	 4883c418             	add	rsp, 0x18
-;;   27:	 5d                   	pop	rbp
-;;   28:	 c3                   	ret	
+;;   19:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   1e:	 4883c418             	add	rsp, 0x18
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
 ;;    c:	 b901000000           	mov	ecx, 1
-;;   11:	 48c7c00c000000       	mov	rax, 0xc
-;;   18:	 85c9                 	test	ecx, ecx
-;;   1a:	 0f8517000000         	jne	0x37
-;;   20:	 50                   	push	rax
-;;   21:	 8b3c24               	mov	edi, dword ptr [rsp]
-;;   24:	 be02000000           	mov	esi, 2
-;;   29:	 ba03000000           	mov	edx, 3
-;;   2e:	 e800000000           	call	0x33
-;;   33:	 4883c408             	add	rsp, 8
-;;   37:	 4883c408             	add	rsp, 8
-;;   3b:	 5d                   	pop	rbp
-;;   3c:	 c3                   	ret	
+;;   11:	 b80c000000           	mov	eax, 0xc
+;;   16:	 85c9                 	test	ecx, ecx
+;;   18:	 0f8517000000         	jne	0x35
+;;   1e:	 50                   	push	rax
+;;   1f:	 8b3c24               	mov	edi, dword ptr [rsp]
+;;   22:	 be02000000           	mov	esi, 2
+;;   27:	 ba03000000           	mov	edx, 3
+;;   2c:	 e800000000           	call	0x31
+;;   31:	 4883c408             	add	rsp, 8
+;;   35:	 4883c408             	add	rsp, 8
+;;   39:	 5d                   	pop	rbp
+;;   3a:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_call_last.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_last.wat
@@ -16,26 +16,25 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48b8ffffffff00000000 	
-;; 				movabs	rax, 0xffffffff
-;;   23:	 4883c418             	add	rsp, 0x18
-;;   27:	 5d                   	pop	rbp
-;;   28:	 c3                   	ret	
+;;   19:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   1e:	 4883c418             	add	rsp, 0x18
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
 ;;    c:	 b901000000           	mov	ecx, 1
-;;   11:	 48c7c00e000000       	mov	rax, 0xe
-;;   18:	 85c9                 	test	ecx, ecx
-;;   1a:	 0f8517000000         	jne	0x37
-;;   20:	 50                   	push	rax
-;;   21:	 bf01000000           	mov	edi, 1
-;;   26:	 be02000000           	mov	esi, 2
-;;   2b:	 8b1424               	mov	edx, dword ptr [rsp]
-;;   2e:	 e800000000           	call	0x33
-;;   33:	 4883c408             	add	rsp, 8
-;;   37:	 4883c408             	add	rsp, 8
-;;   3b:	 5d                   	pop	rbp
-;;   3c:	 c3                   	ret	
+;;   11:	 b80e000000           	mov	eax, 0xe
+;;   16:	 85c9                 	test	ecx, ecx
+;;   18:	 0f8517000000         	jne	0x35
+;;   1e:	 50                   	push	rax
+;;   1f:	 bf01000000           	mov	edi, 1
+;;   24:	 be02000000           	mov	esi, 2
+;;   29:	 8b1424               	mov	edx, dword ptr [rsp]
+;;   2c:	 e800000000           	call	0x31
+;;   31:	 4883c408             	add	rsp, 8
+;;   35:	 4883c408             	add	rsp, 8
+;;   39:	 5d                   	pop	rbp
+;;   3a:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_mid.wat
@@ -16,26 +16,25 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48b8ffffffff00000000 	
-;; 				movabs	rax, 0xffffffff
-;;   23:	 4883c418             	add	rsp, 0x18
-;;   27:	 5d                   	pop	rbp
-;;   28:	 c3                   	ret	
+;;   19:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   1e:	 4883c418             	add	rsp, 0x18
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
 ;;    c:	 b901000000           	mov	ecx, 1
-;;   11:	 48c7c00d000000       	mov	rax, 0xd
-;;   18:	 85c9                 	test	ecx, ecx
-;;   1a:	 0f8517000000         	jne	0x37
-;;   20:	 50                   	push	rax
-;;   21:	 bf01000000           	mov	edi, 1
-;;   26:	 8b3424               	mov	esi, dword ptr [rsp]
-;;   29:	 ba03000000           	mov	edx, 3
-;;   2e:	 e800000000           	call	0x33
-;;   33:	 4883c408             	add	rsp, 8
-;;   37:	 4883c408             	add	rsp, 8
-;;   3b:	 5d                   	pop	rbp
-;;   3c:	 c3                   	ret	
+;;   11:	 b80d000000           	mov	eax, 0xd
+;;   16:	 85c9                 	test	ecx, ecx
+;;   18:	 0f8517000000         	jne	0x35
+;;   1e:	 50                   	push	rax
+;;   1f:	 bf01000000           	mov	edi, 1
+;;   24:	 8b3424               	mov	esi, dword ptr [rsp]
+;;   27:	 ba03000000           	mov	edx, 3
+;;   2c:	 e800000000           	call	0x31
+;;   31:	 4883c408             	add	rsp, 8
+;;   35:	 4883c408             	add	rsp, 8
+;;   39:	 5d                   	pop	rbp
+;;   3a:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/br_if/as_if_cond.wat
@@ -16,14 +16,14 @@
 ;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
 ;;   11:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
-;;   15:	 48c7c001000000       	mov	rax, 1
-;;   1c:	 85c9                 	test	ecx, ecx
-;;   1e:	 0f851b000000         	jne	0x3f
-;;   24:	 85c0                 	test	eax, eax
-;;   26:	 0f840c000000         	je	0x38
-;;   2c:	 48c7c002000000       	mov	rax, 2
-;;   33:	 e907000000           	jmp	0x3f
-;;   38:	 48c7c003000000       	mov	rax, 3
-;;   3f:	 4883c410             	add	rsp, 0x10
-;;   43:	 5d                   	pop	rbp
-;;   44:	 c3                   	ret	
+;;   15:	 b801000000           	mov	eax, 1
+;;   1a:	 85c9                 	test	ecx, ecx
+;;   1c:	 0f8517000000         	jne	0x39
+;;   22:	 85c0                 	test	eax, eax
+;;   24:	 0f840a000000         	je	0x34
+;;   2a:	 b802000000           	mov	eax, 2
+;;   2f:	 e905000000           	jmp	0x39
+;;   34:	 b803000000           	mov	eax, 3
+;;   39:	 4883c410             	add	rsp, 0x10
+;;   3d:	 5d                   	pop	rbp
+;;   3e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
@@ -14,12 +14,11 @@
 ;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;    c:	 4c893424             	mov	qword ptr [rsp], r14
 ;;   10:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
-;;   14:	 48c7c011000000       	mov	rax, 0x11
-;;   1b:	 85c9                 	test	ecx, ecx
-;;   1d:	 0f850e000000         	jne	0x31
-;;   23:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
-;;   27:	 48b8ffffffff00000000 	
-;; 				movabs	rax, 0xffffffff
-;;   31:	 4883c410             	add	rsp, 0x10
-;;   35:	 5d                   	pop	rbp
-;;   36:	 c3                   	ret	
+;;   14:	 b811000000           	mov	eax, 0x11
+;;   19:	 85c9                 	test	ecx, ecx
+;;   1b:	 0f8509000000         	jne	0x2a
+;;   21:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   25:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   2a:	 4883c410             	add	rsp, 0x10
+;;   2e:	 5d                   	pop	rbp
+;;   2f:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/call/params.wat
+++ b/winch/filetests/filetests/x64/call/params.wat
@@ -117,7 +117,7 @@
 ;;   50:	 01c1                 	add	ecx, eax
 ;;   52:	 8b4520               	mov	eax, dword ptr [rbp + 0x20]
 ;;   55:	 01c1                 	add	ecx, eax
-;;   57:	 4889c8               	mov	rax, rcx
-;;   5a:	 4883c420             	add	rsp, 0x20
-;;   5e:	 5d                   	pop	rbp
-;;   5f:	 c3                   	ret	
+;;   57:	 89c8                 	mov	eax, ecx
+;;   59:	 4883c420             	add	rsp, 0x20
+;;   5d:	 5d                   	pop	rbp
+;;   5e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/call/recursive.wat
+++ b/winch/filetests/filetests/x64/call/recursive.wat
@@ -34,7 +34,7 @@
 ;;   21:	 85c0                 	test	eax, eax
 ;;   23:	 0f8409000000         	je	0x32
 ;;   29:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
-;;   2d:	 e934000000           	jmp	0x66
+;;   2d:	 e933000000           	jmp	0x65
 ;;   32:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   36:	 83e801               	sub	eax, 1
 ;;   39:	 50                   	push	rax
@@ -51,7 +51,7 @@
 ;;   5c:	 4883c408             	add	rsp, 8
 ;;   60:	 59                   	pop	rcx
 ;;   61:	 01c1                 	add	ecx, eax
-;;   63:	 4889c8               	mov	rax, rcx
-;;   66:	 4883c410             	add	rsp, 0x10
-;;   6a:	 5d                   	pop	rbp
-;;   6b:	 c3                   	ret	
+;;   63:	 89c8                 	mov	eax, ecx
+;;   65:	 4883c410             	add	rsp, 0x10
+;;   69:	 5d                   	pop	rbp
+;;   6a:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/call/simple.wat
+++ b/winch/filetests/filetests/x64/call/simple.wat
@@ -44,7 +44,7 @@
 ;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   1c:	 0fafc8               	imul	ecx, eax
-;;   1f:	 4889c8               	mov	rax, rcx
-;;   22:	 4883c410             	add	rsp, 0x10
-;;   26:	 5d                   	pop	rbp
-;;   27:	 c3                   	ret	
+;;   1f:	 89c8                 	mov	eax, ecx
+;;   21:	 4883c410             	add	rsp, 0x10
+;;   25:	 5d                   	pop	rbp
+;;   26:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_add/locals.wat
+++ b/winch/filetests/filetests/x64/i32_add/locals.wat
@@ -29,7 +29,7 @@
 ;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   2f:	 01c1                 	add	ecx, eax
-;;   31:	 4889c8               	mov	rax, rcx
-;;   34:	 4883c410             	add	rsp, 0x10
-;;   38:	 5d                   	pop	rbp
-;;   39:	 c3                   	ret	
+;;   31:	 89c8                 	mov	eax, ecx
+;;   33:	 4883c410             	add	rsp, 0x10
+;;   37:	 5d                   	pop	rbp
+;;   38:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_add/params.wat
+++ b/winch/filetests/filetests/x64/i32_add/params.wat
@@ -16,7 +16,7 @@
 ;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   1c:	 01c1                 	add	ecx, eax
-;;   1e:	 4889c8               	mov	rax, rcx
-;;   21:	 4883c410             	add	rsp, 0x10
-;;   25:	 5d                   	pop	rbp
-;;   26:	 c3                   	ret	
+;;   1e:	 89c8                 	mov	eax, ecx
+;;   20:	 4883c410             	add	rsp, 0x10
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_and/locals.wat
+++ b/winch/filetests/filetests/x64/i32_and/locals.wat
@@ -29,7 +29,7 @@
 ;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   2f:	 21c1                 	and	ecx, eax
-;;   31:	 4889c8               	mov	rax, rcx
-;;   34:	 4883c410             	add	rsp, 0x10
-;;   38:	 5d                   	pop	rbp
-;;   39:	 c3                   	ret	
+;;   31:	 89c8                 	mov	eax, ecx
+;;   33:	 4883c410             	add	rsp, 0x10
+;;   37:	 5d                   	pop	rbp
+;;   38:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_and/params.wat
+++ b/winch/filetests/filetests/x64/i32_and/params.wat
@@ -16,7 +16,7 @@
 ;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   1c:	 21c1                 	and	ecx, eax
-;;   1e:	 4889c8               	mov	rax, rcx
-;;   21:	 4883c410             	add	rsp, 0x10
-;;   25:	 5d                   	pop	rbp
-;;   26:	 c3                   	ret	
+;;   1e:	 89c8                 	mov	eax, ecx
+;;   20:	 4883c410             	add	rsp, 0x10
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_eq/locals.wat
+++ b/winch/filetests/filetests/x64/i32_eq/locals.wat
@@ -30,7 +30,7 @@
 ;;   2f:	 39c1                 	cmp	ecx, eax
 ;;   31:	 b900000000           	mov	ecx, 0
 ;;   36:	 400f94c1             	sete	cl
-;;   3a:	 4889c8               	mov	rax, rcx
-;;   3d:	 4883c410             	add	rsp, 0x10
-;;   41:	 5d                   	pop	rbp
-;;   42:	 c3                   	ret	
+;;   3a:	 89c8                 	mov	eax, ecx
+;;   3c:	 4883c410             	add	rsp, 0x10
+;;   40:	 5d                   	pop	rbp
+;;   41:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_eq/params.wat
+++ b/winch/filetests/filetests/x64/i32_eq/params.wat
@@ -18,7 +18,7 @@
 ;;   1c:	 39c1                 	cmp	ecx, eax
 ;;   1e:	 b900000000           	mov	ecx, 0
 ;;   23:	 400f94c1             	sete	cl
-;;   27:	 4889c8               	mov	rax, rcx
-;;   2a:	 4883c410             	add	rsp, 0x10
-;;   2e:	 5d                   	pop	rbp
-;;   2f:	 c3                   	ret	
+;;   27:	 89c8                 	mov	eax, ecx
+;;   29:	 4883c410             	add	rsp, 0x10
+;;   2d:	 5d                   	pop	rbp
+;;   2e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ge_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ge_s/locals.wat
@@ -30,7 +30,7 @@
 ;;   2f:	 39c1                 	cmp	ecx, eax
 ;;   31:	 b900000000           	mov	ecx, 0
 ;;   36:	 400f9dc1             	setge	cl
-;;   3a:	 4889c8               	mov	rax, rcx
-;;   3d:	 4883c410             	add	rsp, 0x10
-;;   41:	 5d                   	pop	rbp
-;;   42:	 c3                   	ret	
+;;   3a:	 89c8                 	mov	eax, ecx
+;;   3c:	 4883c410             	add	rsp, 0x10
+;;   40:	 5d                   	pop	rbp
+;;   41:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ge_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_ge_s/params.wat
@@ -18,7 +18,7 @@
 ;;   1c:	 39c1                 	cmp	ecx, eax
 ;;   1e:	 b900000000           	mov	ecx, 0
 ;;   23:	 400f9dc1             	setge	cl
-;;   27:	 4889c8               	mov	rax, rcx
-;;   2a:	 4883c410             	add	rsp, 0x10
-;;   2e:	 5d                   	pop	rbp
-;;   2f:	 c3                   	ret	
+;;   27:	 89c8                 	mov	eax, ecx
+;;   29:	 4883c410             	add	rsp, 0x10
+;;   2d:	 5d                   	pop	rbp
+;;   2e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ge_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ge_u/locals.wat
@@ -30,7 +30,7 @@
 ;;   2f:	 39c1                 	cmp	ecx, eax
 ;;   31:	 b900000000           	mov	ecx, 0
 ;;   36:	 400f93c1             	setae	cl
-;;   3a:	 4889c8               	mov	rax, rcx
-;;   3d:	 4883c410             	add	rsp, 0x10
-;;   41:	 5d                   	pop	rbp
-;;   42:	 c3                   	ret	
+;;   3a:	 89c8                 	mov	eax, ecx
+;;   3c:	 4883c410             	add	rsp, 0x10
+;;   40:	 5d                   	pop	rbp
+;;   41:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ge_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_ge_u/params.wat
@@ -18,7 +18,7 @@
 ;;   1c:	 39c1                 	cmp	ecx, eax
 ;;   1e:	 b900000000           	mov	ecx, 0
 ;;   23:	 400f93c1             	setae	cl
-;;   27:	 4889c8               	mov	rax, rcx
-;;   2a:	 4883c410             	add	rsp, 0x10
-;;   2e:	 5d                   	pop	rbp
-;;   2f:	 c3                   	ret	
+;;   27:	 89c8                 	mov	eax, ecx
+;;   29:	 4883c410             	add	rsp, 0x10
+;;   2d:	 5d                   	pop	rbp
+;;   2e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_gt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_gt_s/locals.wat
@@ -30,7 +30,7 @@
 ;;   2f:	 39c1                 	cmp	ecx, eax
 ;;   31:	 b900000000           	mov	ecx, 0
 ;;   36:	 400f9fc1             	setg	cl
-;;   3a:	 4889c8               	mov	rax, rcx
-;;   3d:	 4883c410             	add	rsp, 0x10
-;;   41:	 5d                   	pop	rbp
-;;   42:	 c3                   	ret	
+;;   3a:	 89c8                 	mov	eax, ecx
+;;   3c:	 4883c410             	add	rsp, 0x10
+;;   40:	 5d                   	pop	rbp
+;;   41:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_gt_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_gt_s/params.wat
@@ -18,7 +18,7 @@
 ;;   1c:	 39c1                 	cmp	ecx, eax
 ;;   1e:	 b900000000           	mov	ecx, 0
 ;;   23:	 400f9fc1             	setg	cl
-;;   27:	 4889c8               	mov	rax, rcx
-;;   2a:	 4883c410             	add	rsp, 0x10
-;;   2e:	 5d                   	pop	rbp
-;;   2f:	 c3                   	ret	
+;;   27:	 89c8                 	mov	eax, ecx
+;;   29:	 4883c410             	add	rsp, 0x10
+;;   2d:	 5d                   	pop	rbp
+;;   2e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_gt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_gt_u/locals.wat
@@ -30,7 +30,7 @@
 ;;   2f:	 39c1                 	cmp	ecx, eax
 ;;   31:	 b900000000           	mov	ecx, 0
 ;;   36:	 400f97c1             	seta	cl
-;;   3a:	 4889c8               	mov	rax, rcx
-;;   3d:	 4883c410             	add	rsp, 0x10
-;;   41:	 5d                   	pop	rbp
-;;   42:	 c3                   	ret	
+;;   3a:	 89c8                 	mov	eax, ecx
+;;   3c:	 4883c410             	add	rsp, 0x10
+;;   40:	 5d                   	pop	rbp
+;;   41:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_gt_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_gt_u/params.wat
@@ -18,7 +18,7 @@
 ;;   1c:	 39c1                 	cmp	ecx, eax
 ;;   1e:	 b900000000           	mov	ecx, 0
 ;;   23:	 400f97c1             	seta	cl
-;;   27:	 4889c8               	mov	rax, rcx
-;;   2a:	 4883c410             	add	rsp, 0x10
-;;   2e:	 5d                   	pop	rbp
-;;   2f:	 c3                   	ret	
+;;   27:	 89c8                 	mov	eax, ecx
+;;   29:	 4883c410             	add	rsp, 0x10
+;;   2d:	 5d                   	pop	rbp
+;;   2e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_le_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_le_s/locals.wat
@@ -30,7 +30,7 @@
 ;;   2f:	 39c1                 	cmp	ecx, eax
 ;;   31:	 b900000000           	mov	ecx, 0
 ;;   36:	 400f9ec1             	setle	cl
-;;   3a:	 4889c8               	mov	rax, rcx
-;;   3d:	 4883c410             	add	rsp, 0x10
-;;   41:	 5d                   	pop	rbp
-;;   42:	 c3                   	ret	
+;;   3a:	 89c8                 	mov	eax, ecx
+;;   3c:	 4883c410             	add	rsp, 0x10
+;;   40:	 5d                   	pop	rbp
+;;   41:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_le_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_le_s/params.wat
@@ -18,7 +18,7 @@
 ;;   1c:	 39c1                 	cmp	ecx, eax
 ;;   1e:	 b900000000           	mov	ecx, 0
 ;;   23:	 400f9ec1             	setle	cl
-;;   27:	 4889c8               	mov	rax, rcx
-;;   2a:	 4883c410             	add	rsp, 0x10
-;;   2e:	 5d                   	pop	rbp
-;;   2f:	 c3                   	ret	
+;;   27:	 89c8                 	mov	eax, ecx
+;;   29:	 4883c410             	add	rsp, 0x10
+;;   2d:	 5d                   	pop	rbp
+;;   2e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_le_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_le_u/locals.wat
@@ -31,7 +31,7 @@
 ;;   2f:	 39c1                 	cmp	ecx, eax
 ;;   31:	 b900000000           	mov	ecx, 0
 ;;   36:	 400f96c1             	setbe	cl
-;;   3a:	 4889c8               	mov	rax, rcx
-;;   3d:	 4883c410             	add	rsp, 0x10
-;;   41:	 5d                   	pop	rbp
-;;   42:	 c3                   	ret	
+;;   3a:	 89c8                 	mov	eax, ecx
+;;   3c:	 4883c410             	add	rsp, 0x10
+;;   40:	 5d                   	pop	rbp
+;;   41:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_le_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_le_u/params.wat
@@ -18,7 +18,7 @@
 ;;   1c:	 39c1                 	cmp	ecx, eax
 ;;   1e:	 b900000000           	mov	ecx, 0
 ;;   23:	 400f96c1             	setbe	cl
-;;   27:	 4889c8               	mov	rax, rcx
-;;   2a:	 4883c410             	add	rsp, 0x10
-;;   2e:	 5d                   	pop	rbp
-;;   2f:	 c3                   	ret	
+;;   27:	 89c8                 	mov	eax, ecx
+;;   29:	 4883c410             	add	rsp, 0x10
+;;   2d:	 5d                   	pop	rbp
+;;   2e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_lt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_lt_s/locals.wat
@@ -30,7 +30,7 @@
 ;;   2f:	 39c1                 	cmp	ecx, eax
 ;;   31:	 b900000000           	mov	ecx, 0
 ;;   36:	 400f9cc1             	setl	cl
-;;   3a:	 4889c8               	mov	rax, rcx
-;;   3d:	 4883c410             	add	rsp, 0x10
-;;   41:	 5d                   	pop	rbp
-;;   42:	 c3                   	ret	
+;;   3a:	 89c8                 	mov	eax, ecx
+;;   3c:	 4883c410             	add	rsp, 0x10
+;;   40:	 5d                   	pop	rbp
+;;   41:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_lt_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_lt_s/params.wat
@@ -18,7 +18,7 @@
 ;;   1c:	 39c1                 	cmp	ecx, eax
 ;;   1e:	 b900000000           	mov	ecx, 0
 ;;   23:	 400f9cc1             	setl	cl
-;;   27:	 4889c8               	mov	rax, rcx
-;;   2a:	 4883c410             	add	rsp, 0x10
-;;   2e:	 5d                   	pop	rbp
-;;   2f:	 c3                   	ret	
+;;   27:	 89c8                 	mov	eax, ecx
+;;   29:	 4883c410             	add	rsp, 0x10
+;;   2d:	 5d                   	pop	rbp
+;;   2e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_lt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_lt_u/locals.wat
@@ -31,7 +31,7 @@
 ;;   2f:	 39c1                 	cmp	ecx, eax
 ;;   31:	 b900000000           	mov	ecx, 0
 ;;   36:	 400f92c1             	setb	cl
-;;   3a:	 4889c8               	mov	rax, rcx
-;;   3d:	 4883c410             	add	rsp, 0x10
-;;   41:	 5d                   	pop	rbp
-;;   42:	 c3                   	ret	
+;;   3a:	 89c8                 	mov	eax, ecx
+;;   3c:	 4883c410             	add	rsp, 0x10
+;;   40:	 5d                   	pop	rbp
+;;   41:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_lt_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_lt_u/params.wat
@@ -18,7 +18,7 @@
 ;;   1c:	 39c1                 	cmp	ecx, eax
 ;;   1e:	 b900000000           	mov	ecx, 0
 ;;   23:	 400f92c1             	setb	cl
-;;   27:	 4889c8               	mov	rax, rcx
-;;   2a:	 4883c410             	add	rsp, 0x10
-;;   2e:	 5d                   	pop	rbp
-;;   2f:	 c3                   	ret	
+;;   27:	 89c8                 	mov	eax, ecx
+;;   29:	 4883c410             	add	rsp, 0x10
+;;   2d:	 5d                   	pop	rbp
+;;   2e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_mul/locals.wat
+++ b/winch/filetests/filetests/x64/i32_mul/locals.wat
@@ -29,7 +29,7 @@
 ;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   2f:	 0fafc8               	imul	ecx, eax
-;;   32:	 4889c8               	mov	rax, rcx
-;;   35:	 4883c410             	add	rsp, 0x10
-;;   39:	 5d                   	pop	rbp
-;;   3a:	 c3                   	ret	
+;;   32:	 89c8                 	mov	eax, ecx
+;;   34:	 4883c410             	add	rsp, 0x10
+;;   38:	 5d                   	pop	rbp
+;;   39:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_mul/params.wat
+++ b/winch/filetests/filetests/x64/i32_mul/params.wat
@@ -16,7 +16,7 @@
 ;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   1c:	 0fafc8               	imul	ecx, eax
-;;   1f:	 4889c8               	mov	rax, rcx
-;;   22:	 4883c410             	add	rsp, 0x10
-;;   26:	 5d                   	pop	rbp
-;;   27:	 c3                   	ret	
+;;   1f:	 89c8                 	mov	eax, ecx
+;;   21:	 4883c410             	add	rsp, 0x10
+;;   25:	 5d                   	pop	rbp
+;;   26:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ne/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ne/locals.wat
@@ -30,7 +30,7 @@
 ;;   2f:	 39c1                 	cmp	ecx, eax
 ;;   31:	 b900000000           	mov	ecx, 0
 ;;   36:	 400f95c1             	setne	cl
-;;   3a:	 4889c8               	mov	rax, rcx
-;;   3d:	 4883c410             	add	rsp, 0x10
-;;   41:	 5d                   	pop	rbp
-;;   42:	 c3                   	ret	
+;;   3a:	 89c8                 	mov	eax, ecx
+;;   3c:	 4883c410             	add	rsp, 0x10
+;;   40:	 5d                   	pop	rbp
+;;   41:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_ne/params.wat
+++ b/winch/filetests/filetests/x64/i32_ne/params.wat
@@ -18,7 +18,7 @@
 ;;   1c:	 39c1                 	cmp	ecx, eax
 ;;   1e:	 b900000000           	mov	ecx, 0
 ;;   23:	 400f95c1             	setne	cl
-;;   27:	 4889c8               	mov	rax, rcx
-;;   2a:	 4883c410             	add	rsp, 0x10
-;;   2e:	 5d                   	pop	rbp
-;;   2f:	 c3                   	ret	
+;;   27:	 89c8                 	mov	eax, ecx
+;;   29:	 4883c410             	add	rsp, 0x10
+;;   2d:	 5d                   	pop	rbp
+;;   2e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_or/locals.wat
+++ b/winch/filetests/filetests/x64/i32_or/locals.wat
@@ -29,7 +29,7 @@
 ;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   2f:	 09c1                 	or	ecx, eax
-;;   31:	 4889c8               	mov	rax, rcx
-;;   34:	 4883c410             	add	rsp, 0x10
-;;   38:	 5d                   	pop	rbp
-;;   39:	 c3                   	ret	
+;;   31:	 89c8                 	mov	eax, ecx
+;;   33:	 4883c410             	add	rsp, 0x10
+;;   37:	 5d                   	pop	rbp
+;;   38:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_or/params.wat
+++ b/winch/filetests/filetests/x64/i32_or/params.wat
@@ -16,7 +16,7 @@
 ;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   1c:	 09c1                 	or	ecx, eax
-;;   1e:	 4889c8               	mov	rax, rcx
-;;   21:	 4883c410             	add	rsp, 0x10
-;;   25:	 5d                   	pop	rbp
-;;   26:	 c3                   	ret	
+;;   1e:	 89c8                 	mov	eax, ecx
+;;   20:	 4883c410             	add	rsp, 0x10
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rems/const.wat
+++ b/winch/filetests/filetests/x64/i32_rems/const.wat
@@ -19,7 +19,7 @@
 ;;   20:	 ba00000000           	mov	edx, 0
 ;;   25:	 e902000000           	jmp	0x2c
 ;;   2a:	 f7f9                 	idiv	ecx
-;;   2c:	 4889d0               	mov	rax, rdx
-;;   2f:	 4883c408             	add	rsp, 8
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89d0                 	mov	eax, edx
+;;   2e:	 4883c408             	add	rsp, 8
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rems/one_zero.wat
+++ b/winch/filetests/filetests/x64/i32_rems/one_zero.wat
@@ -19,7 +19,7 @@
 ;;   20:	 ba00000000           	mov	edx, 0
 ;;   25:	 e902000000           	jmp	0x2c
 ;;   2a:	 f7f9                 	idiv	ecx
-;;   2c:	 4889d0               	mov	rax, rdx
-;;   2f:	 4883c408             	add	rsp, 8
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89d0                 	mov	eax, edx
+;;   2e:	 4883c408             	add	rsp, 8
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rems/overflow.wat
+++ b/winch/filetests/filetests/x64/i32_rems/overflow.wat
@@ -19,7 +19,7 @@
 ;;   20:	 ba00000000           	mov	edx, 0
 ;;   25:	 e902000000           	jmp	0x2c
 ;;   2a:	 f7f9                 	idiv	ecx
-;;   2c:	 4889d0               	mov	rax, rdx
-;;   2f:	 4883c408             	add	rsp, 8
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89d0                 	mov	eax, edx
+;;   2e:	 4883c408             	add	rsp, 8
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rems/params.wat
+++ b/winch/filetests/filetests/x64/i32_rems/params.wat
@@ -21,7 +21,7 @@
 ;;   26:	 ba00000000           	mov	edx, 0
 ;;   2b:	 e902000000           	jmp	0x32
 ;;   30:	 f7f9                 	idiv	ecx
-;;   32:	 4889d0               	mov	rax, rdx
-;;   35:	 4883c410             	add	rsp, 0x10
-;;   39:	 5d                   	pop	rbp
-;;   3a:	 c3                   	ret	
+;;   32:	 89d0                 	mov	eax, edx
+;;   34:	 4883c410             	add	rsp, 0x10
+;;   38:	 5d                   	pop	rbp
+;;   39:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_rems/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i32_rems/zero_zero.wat
@@ -19,7 +19,7 @@
 ;;   20:	 ba00000000           	mov	edx, 0
 ;;   25:	 e902000000           	jmp	0x2c
 ;;   2a:	 f7f9                 	idiv	ecx
-;;   2c:	 4889d0               	mov	rax, rdx
-;;   2f:	 4883c408             	add	rsp, 8
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89d0                 	mov	eax, edx
+;;   2e:	 4883c408             	add	rsp, 8
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_remu/const.wat
+++ b/winch/filetests/filetests/x64/i32_remu/const.wat
@@ -15,7 +15,7 @@
 ;;   11:	 b807000000           	mov	eax, 7
 ;;   16:	 31d2                 	xor	edx, edx
 ;;   18:	 f7f1                 	div	ecx
-;;   1a:	 4889d0               	mov	rax, rdx
-;;   1d:	 4883c408             	add	rsp, 8
-;;   21:	 5d                   	pop	rbp
-;;   22:	 c3                   	ret	
+;;   1a:	 89d0                 	mov	eax, edx
+;;   1c:	 4883c408             	add	rsp, 8
+;;   20:	 5d                   	pop	rbp
+;;   21:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_remu/one_zero.wat
+++ b/winch/filetests/filetests/x64/i32_remu/one_zero.wat
@@ -15,7 +15,7 @@
 ;;   11:	 b801000000           	mov	eax, 1
 ;;   16:	 31d2                 	xor	edx, edx
 ;;   18:	 f7f1                 	div	ecx
-;;   1a:	 4889d0               	mov	rax, rdx
-;;   1d:	 4883c408             	add	rsp, 8
-;;   21:	 5d                   	pop	rbp
-;;   22:	 c3                   	ret	
+;;   1a:	 89d0                 	mov	eax, edx
+;;   1c:	 4883c408             	add	rsp, 8
+;;   20:	 5d                   	pop	rbp
+;;   21:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_remu/params.wat
+++ b/winch/filetests/filetests/x64/i32_remu/params.wat
@@ -17,7 +17,7 @@
 ;;   18:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   1c:	 31d2                 	xor	edx, edx
 ;;   1e:	 f7f1                 	div	ecx
-;;   20:	 4889d0               	mov	rax, rdx
-;;   23:	 4883c410             	add	rsp, 0x10
-;;   27:	 5d                   	pop	rbp
-;;   28:	 c3                   	ret	
+;;   20:	 89d0                 	mov	eax, edx
+;;   22:	 4883c410             	add	rsp, 0x10
+;;   26:	 5d                   	pop	rbp
+;;   27:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_remu/signed.wat
+++ b/winch/filetests/filetests/x64/i32_remu/signed.wat
@@ -15,7 +15,7 @@
 ;;   11:	 b8ffffffff           	mov	eax, 0xffffffff
 ;;   16:	 31d2                 	xor	edx, edx
 ;;   18:	 f7f1                 	div	ecx
-;;   1a:	 4889d0               	mov	rax, rdx
-;;   1d:	 4883c408             	add	rsp, 8
-;;   21:	 5d                   	pop	rbp
-;;   22:	 c3                   	ret	
+;;   1a:	 89d0                 	mov	eax, edx
+;;   1c:	 4883c408             	add	rsp, 8
+;;   20:	 5d                   	pop	rbp
+;;   21:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_remu/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i32_remu/zero_zero.wat
@@ -15,7 +15,7 @@
 ;;   11:	 b800000000           	mov	eax, 0
 ;;   16:	 31d2                 	xor	edx, edx
 ;;   18:	 f7f1                 	div	ecx
-;;   1a:	 4889d0               	mov	rax, rdx
-;;   1d:	 4883c408             	add	rsp, 8
-;;   21:	 5d                   	pop	rbp
-;;   22:	 c3                   	ret	
+;;   1a:	 89d0                 	mov	eax, edx
+;;   1c:	 4883c408             	add	rsp, 8
+;;   20:	 5d                   	pop	rbp
+;;   21:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_sub/locals.wat
+++ b/winch/filetests/filetests/x64/i32_sub/locals.wat
@@ -29,7 +29,7 @@
 ;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   2f:	 29c1                 	sub	ecx, eax
-;;   31:	 4889c8               	mov	rax, rcx
-;;   34:	 4883c410             	add	rsp, 0x10
-;;   38:	 5d                   	pop	rbp
-;;   39:	 c3                   	ret	
+;;   31:	 89c8                 	mov	eax, ecx
+;;   33:	 4883c410             	add	rsp, 0x10
+;;   37:	 5d                   	pop	rbp
+;;   38:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_sub/params.wat
+++ b/winch/filetests/filetests/x64/i32_sub/params.wat
@@ -16,7 +16,7 @@
 ;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   1c:	 29c1                 	sub	ecx, eax
-;;   1e:	 4889c8               	mov	rax, rcx
-;;   21:	 4883c410             	add	rsp, 0x10
-;;   25:	 5d                   	pop	rbp
-;;   26:	 c3                   	ret	
+;;   1e:	 89c8                 	mov	eax, ecx
+;;   20:	 4883c410             	add	rsp, 0x10
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_xor/locals.wat
+++ b/winch/filetests/filetests/x64/i32_xor/locals.wat
@@ -29,7 +29,7 @@
 ;;   27:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   2b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   2f:	 31c1                 	xor	ecx, eax
-;;   31:	 4889c8               	mov	rax, rcx
-;;   34:	 4883c410             	add	rsp, 0x10
-;;   38:	 5d                   	pop	rbp
-;;   39:	 c3                   	ret	
+;;   31:	 89c8                 	mov	eax, ecx
+;;   33:	 4883c410             	add	rsp, 0x10
+;;   37:	 5d                   	pop	rbp
+;;   38:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i32_xor/params.wat
+++ b/winch/filetests/filetests/x64/i32_xor/params.wat
@@ -16,7 +16,7 @@
 ;;   14:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   18:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;   1c:	 31c1                 	xor	ecx, eax
-;;   1e:	 4889c8               	mov	rax, rcx
-;;   21:	 4883c410             	add	rsp, 0x10
-;;   25:	 5d                   	pop	rbp
-;;   26:	 c3                   	ret	
+;;   1e:	 89c8                 	mov	eax, ecx
+;;   20:	 4883c410             	add	rsp, 0x10
+;;   24:	 5d                   	pop	rbp
+;;   25:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/as_binop.wat
+++ b/winch/filetests/filetests/x64/if/as_binop.wat
@@ -31,30 +31,28 @@
 ;;   10:	 4c893424             	mov	qword ptr [rsp], r14
 ;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   18:	 85c0                 	test	eax, eax
-;;   1a:	 0f8411000000         	je	0x31
+;;   1a:	 0f840f000000         	je	0x2f
 ;;   20:	 e800000000           	call	0x25
-;;   25:	 48c7c003000000       	mov	rax, 3
-;;   2c:	 e90f000000           	jmp	0x40
-;;   31:	 e800000000           	call	0x36
-;;   36:	 48b8fdffffff00000000 	
-;; 				movabs	rax, 0xfffffffd
-;;   40:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
-;;   44:	 50                   	push	rax
-;;   45:	 85c9                 	test	ecx, ecx
-;;   47:	 0f8419000000         	je	0x66
-;;   4d:	 4883ec08             	sub	rsp, 8
-;;   51:	 e800000000           	call	0x56
-;;   56:	 4883c408             	add	rsp, 8
-;;   5a:	 48c7c004000000       	mov	rax, 4
-;;   61:	 e917000000           	jmp	0x7d
-;;   66:	 4883ec08             	sub	rsp, 8
-;;   6a:	 e800000000           	call	0x6f
-;;   6f:	 4883c408             	add	rsp, 8
-;;   73:	 48b8fbffffff00000000 	
-;; 				movabs	rax, 0xfffffffb
-;;   7d:	 59                   	pop	rcx
-;;   7e:	 0fafc8               	imul	ecx, eax
-;;   81:	 4889c8               	mov	rax, rcx
-;;   84:	 4883c410             	add	rsp, 0x10
-;;   88:	 5d                   	pop	rbp
-;;   89:	 c3                   	ret	
+;;   25:	 b803000000           	mov	eax, 3
+;;   2a:	 e90a000000           	jmp	0x39
+;;   2f:	 e800000000           	call	0x34
+;;   34:	 b8fdffffff           	mov	eax, 0xfffffffd
+;;   39:	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
+;;   3d:	 50                   	push	rax
+;;   3e:	 85c9                 	test	ecx, ecx
+;;   40:	 0f8417000000         	je	0x5d
+;;   46:	 4883ec08             	sub	rsp, 8
+;;   4a:	 e800000000           	call	0x4f
+;;   4f:	 4883c408             	add	rsp, 8
+;;   53:	 b804000000           	mov	eax, 4
+;;   58:	 e912000000           	jmp	0x6f
+;;   5d:	 4883ec08             	sub	rsp, 8
+;;   61:	 e800000000           	call	0x66
+;;   66:	 4883c408             	add	rsp, 8
+;;   6a:	 b8fbffffff           	mov	eax, 0xfffffffb
+;;   6f:	 59                   	pop	rcx
+;;   70:	 0fafc8               	imul	ecx, eax
+;;   73:	 89c8                 	mov	eax, ecx
+;;   75:	 4883c410             	add	rsp, 0x10
+;;   79:	 5d                   	pop	rbp
+;;   7a:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/as_br_if_last.wat
+++ b/winch/filetests/filetests/x64/if/as_br_if_last.wat
@@ -29,20 +29,20 @@
 ;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
 ;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   15:	 85c0                 	test	eax, eax
-;;   17:	 0f8411000000         	je	0x2e
+;;   17:	 0f840f000000         	je	0x2c
 ;;   1d:	 e800000000           	call	0x22
-;;   22:	 48c7c001000000       	mov	rax, 1
-;;   29:	 e90c000000           	jmp	0x3a
-;;   2e:	 e800000000           	call	0x33
-;;   33:	 48c7c000000000       	mov	rax, 0
-;;   3a:	 50                   	push	rax
-;;   3b:	 59                   	pop	rcx
-;;   3c:	 48c7c002000000       	mov	rax, 2
-;;   43:	 85c9                 	test	ecx, ecx
-;;   45:	 0f850c000000         	jne	0x57
-;;   4b:	 50                   	push	rax
-;;   4c:	 48c7c003000000       	mov	rax, 3
-;;   53:	 4883c408             	add	rsp, 8
-;;   57:	 4883c410             	add	rsp, 0x10
-;;   5b:	 5d                   	pop	rbp
-;;   5c:	 c3                   	ret	
+;;   22:	 b801000000           	mov	eax, 1
+;;   27:	 e90a000000           	jmp	0x36
+;;   2c:	 e800000000           	call	0x31
+;;   31:	 b800000000           	mov	eax, 0
+;;   36:	 50                   	push	rax
+;;   37:	 59                   	pop	rcx
+;;   38:	 b802000000           	mov	eax, 2
+;;   3d:	 85c9                 	test	ecx, ecx
+;;   3f:	 0f850a000000         	jne	0x4f
+;;   45:	 50                   	push	rax
+;;   46:	 b803000000           	mov	eax, 3
+;;   4b:	 4883c408             	add	rsp, 8
+;;   4f:	 4883c410             	add	rsp, 0x10
+;;   53:	 5d                   	pop	rbp
+;;   54:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/if/as_if_cond.wat
@@ -27,17 +27,17 @@
 ;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
 ;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   15:	 85c0                 	test	eax, eax
-;;   17:	 0f840c000000         	je	0x29
-;;   1d:	 48c7c001000000       	mov	rax, 1
-;;   24:	 e907000000           	jmp	0x30
-;;   29:	 48c7c000000000       	mov	rax, 0
-;;   30:	 85c0                 	test	eax, eax
-;;   32:	 0f8411000000         	je	0x49
-;;   38:	 e800000000           	call	0x3d
-;;   3d:	 48c7c002000000       	mov	rax, 2
-;;   44:	 e90c000000           	jmp	0x55
-;;   49:	 e800000000           	call	0x4e
-;;   4e:	 48c7c003000000       	mov	rax, 3
-;;   55:	 4883c410             	add	rsp, 0x10
-;;   59:	 5d                   	pop	rbp
-;;   5a:	 c3                   	ret	
+;;   17:	 0f840a000000         	je	0x27
+;;   1d:	 b801000000           	mov	eax, 1
+;;   22:	 e905000000           	jmp	0x2c
+;;   27:	 b800000000           	mov	eax, 0
+;;   2c:	 85c0                 	test	eax, eax
+;;   2e:	 0f840f000000         	je	0x43
+;;   34:	 e800000000           	call	0x39
+;;   39:	 b802000000           	mov	eax, 2
+;;   3e:	 e90a000000           	jmp	0x4d
+;;   43:	 e800000000           	call	0x48
+;;   48:	 b803000000           	mov	eax, 3
+;;   4d:	 4883c410             	add	rsp, 0x10
+;;   51:	 5d                   	pop	rbp
+;;   52:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/as_testop.wat
+++ b/winch/filetests/filetests/x64/if/as_testop.wat
@@ -25,15 +25,15 @@
 ;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
 ;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   15:	 85c0                 	test	eax, eax
-;;   17:	 0f8411000000         	je	0x2e
+;;   17:	 0f840f000000         	je	0x2c
 ;;   1d:	 e800000000           	call	0x22
-;;   22:	 48c7c00d000000       	mov	rax, 0xd
-;;   29:	 e90c000000           	jmp	0x3a
-;;   2e:	 e800000000           	call	0x33
-;;   33:	 48c7c000000000       	mov	rax, 0
-;;   3a:	 83f800               	cmp	eax, 0
-;;   3d:	 b800000000           	mov	eax, 0
-;;   42:	 400f94c0             	sete	al
-;;   46:	 4883c410             	add	rsp, 0x10
-;;   4a:	 5d                   	pop	rbp
-;;   4b:	 c3                   	ret	
+;;   22:	 b80d000000           	mov	eax, 0xd
+;;   27:	 e90a000000           	jmp	0x36
+;;   2c:	 e800000000           	call	0x31
+;;   31:	 b800000000           	mov	eax, 0
+;;   36:	 83f800               	cmp	eax, 0
+;;   39:	 b800000000           	mov	eax, 0
+;;   3e:	 400f94c0             	sete	al
+;;   42:	 4883c410             	add	rsp, 0x10
+;;   46:	 5d                   	pop	rbp
+;;   47:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/break_value.wat
+++ b/winch/filetests/filetests/x64/if/break_value.wat
@@ -15,10 +15,10 @@
 ;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
 ;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   15:	 85c0                 	test	eax, eax
-;;   17:	 0f840c000000         	je	0x29
-;;   1d:	 48c7c012000000       	mov	rax, 0x12
-;;   24:	 e907000000           	jmp	0x30
-;;   29:	 48c7c015000000       	mov	rax, 0x15
-;;   30:	 4883c410             	add	rsp, 0x10
-;;   34:	 5d                   	pop	rbp
-;;   35:	 c3                   	ret	
+;;   17:	 0f840a000000         	je	0x27
+;;   1d:	 b812000000           	mov	eax, 0x12
+;;   22:	 e905000000           	jmp	0x2c
+;;   27:	 b815000000           	mov	eax, 0x15
+;;   2c:	 4883c410             	add	rsp, 0x10
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/nested.wat
+++ b/winch/filetests/filetests/x64/if/nested.wat
@@ -38,7 +38,7 @@
 ;;   10:	 4c893424             	mov	qword ptr [rsp], r14
 ;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   18:	 85c0                 	test	eax, eax
-;;   1a:	 0f8455000000         	je	0x75
+;;   1a:	 0f8451000000         	je	0x71
 ;;   20:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   24:	 85c0                 	test	eax, eax
 ;;   26:	 0f8405000000         	je	0x31
@@ -50,30 +50,30 @@
 ;;   42:	 e800000000           	call	0x47
 ;;   47:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;   4b:	 85c0                 	test	eax, eax
-;;   4d:	 0f8411000000         	je	0x64
+;;   4d:	 0f840f000000         	je	0x62
 ;;   53:	 e800000000           	call	0x58
-;;   58:	 48c7c009000000       	mov	rax, 9
-;;   5f:	 e961000000           	jmp	0xc5
-;;   64:	 e800000000           	call	0x69
-;;   69:	 48c7c00a000000       	mov	rax, 0xa
-;;   70:	 e950000000           	jmp	0xc5
-;;   75:	 8b442408             	mov	eax, dword ptr [rsp + 8]
-;;   79:	 85c0                 	test	eax, eax
-;;   7b:	 0f8405000000         	je	0x86
-;;   81:	 e800000000           	call	0x86
-;;   86:	 8b442408             	mov	eax, dword ptr [rsp + 8]
-;;   8a:	 85c0                 	test	eax, eax
-;;   8c:	 0f8405000000         	je	0x97
-;;   92:	 e905000000           	jmp	0x9c
-;;   97:	 e800000000           	call	0x9c
-;;   9c:	 8b442408             	mov	eax, dword ptr [rsp + 8]
-;;   a0:	 85c0                 	test	eax, eax
-;;   a2:	 0f8411000000         	je	0xb9
-;;   a8:	 e800000000           	call	0xad
-;;   ad:	 48c7c00a000000       	mov	rax, 0xa
-;;   b4:	 e90c000000           	jmp	0xc5
-;;   b9:	 e800000000           	call	0xbe
-;;   be:	 48c7c00b000000       	mov	rax, 0xb
-;;   c5:	 4883c410             	add	rsp, 0x10
-;;   c9:	 5d                   	pop	rbp
-;;   ca:	 c3                   	ret	
+;;   58:	 b809000000           	mov	eax, 9
+;;   5d:	 e95b000000           	jmp	0xbd
+;;   62:	 e800000000           	call	0x67
+;;   67:	 b80a000000           	mov	eax, 0xa
+;;   6c:	 e94c000000           	jmp	0xbd
+;;   71:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   75:	 85c0                 	test	eax, eax
+;;   77:	 0f8405000000         	je	0x82
+;;   7d:	 e800000000           	call	0x82
+;;   82:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   86:	 85c0                 	test	eax, eax
+;;   88:	 0f8405000000         	je	0x93
+;;   8e:	 e905000000           	jmp	0x98
+;;   93:	 e800000000           	call	0x98
+;;   98:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   9c:	 85c0                 	test	eax, eax
+;;   9e:	 0f840f000000         	je	0xb3
+;;   a4:	 e800000000           	call	0xa9
+;;   a9:	 b80a000000           	mov	eax, 0xa
+;;   ae:	 e90a000000           	jmp	0xbd
+;;   b3:	 e800000000           	call	0xb8
+;;   b8:	 b80b000000           	mov	eax, 0xb
+;;   bd:	 4883c410             	add	rsp, 0x10
+;;   c1:	 5d                   	pop	rbp
+;;   c2:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/singular.wat
+++ b/winch/filetests/filetests/x64/if/singular.wat
@@ -29,10 +29,10 @@
 ;;   23:	 0f8400000000         	je	0x29
 ;;   29:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   2d:	 85c0                 	test	eax, eax
-;;   2f:	 0f840c000000         	je	0x41
-;;   35:	 48c7c007000000       	mov	rax, 7
-;;   3c:	 e907000000           	jmp	0x48
-;;   41:	 48c7c008000000       	mov	rax, 8
-;;   48:	 4883c410             	add	rsp, 0x10
-;;   4c:	 5d                   	pop	rbp
-;;   4d:	 c3                   	ret	
+;;   2f:	 0f840a000000         	je	0x3f
+;;   35:	 b807000000           	mov	eax, 7
+;;   3a:	 e905000000           	jmp	0x44
+;;   3f:	 b808000000           	mov	eax, 8
+;;   44:	 4883c410             	add	rsp, 0x10
+;;   48:	 5d                   	pop	rbp
+;;   49:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_br_if_first.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_if_first.wat
@@ -9,9 +9,9 @@
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
 ;;    c:	 b902000000           	mov	ecx, 2
-;;   11:	 48c7c001000000       	mov	rax, 1
-;;   18:	 85c9                 	test	ecx, ecx
-;;   1a:	 0f8500000000         	jne	0x20
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   11:	 b801000000           	mov	eax, 1
+;;   16:	 85c9                 	test	ecx, ecx
+;;   18:	 0f8500000000         	jne	0x1e
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_br_if_last.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_if_last.wat
@@ -9,9 +9,9 @@
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
 ;;    c:	 b901000000           	mov	ecx, 1
-;;   11:	 48c7c002000000       	mov	rax, 2
-;;   18:	 85c9                 	test	ecx, ecx
-;;   1a:	 0f8500000000         	jne	0x20
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   11:	 b802000000           	mov	eax, 2
+;;   16:	 85c9                 	test	ecx, ecx
+;;   18:	 0f8500000000         	jne	0x1e
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_br_value.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_value.wat
@@ -8,7 +8,7 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c001000000       	mov	rax, 1
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_if_else.wat
+++ b/winch/filetests/filetests/x64/loop/as_if_else.wat
@@ -10,10 +10,10 @@
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
 ;;    c:	 b801000000           	mov	eax, 1
 ;;   11:	 85c0                 	test	eax, eax
-;;   13:	 0f840c000000         	je	0x25
-;;   19:	 48c7c002000000       	mov	rax, 2
-;;   20:	 e907000000           	jmp	0x2c
-;;   25:	 48c7c001000000       	mov	rax, 1
-;;   2c:	 4883c408             	add	rsp, 8
-;;   30:	 5d                   	pop	rbp
-;;   31:	 c3                   	ret	
+;;   13:	 0f840a000000         	je	0x23
+;;   19:	 b802000000           	mov	eax, 2
+;;   1e:	 e905000000           	jmp	0x28
+;;   23:	 b801000000           	mov	eax, 1
+;;   28:	 4883c408             	add	rsp, 8
+;;   2c:	 5d                   	pop	rbp
+;;   2d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/as_if_then.wat
+++ b/winch/filetests/filetests/x64/loop/as_if_then.wat
@@ -10,10 +10,10 @@
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
 ;;    c:	 b801000000           	mov	eax, 1
 ;;   11:	 85c0                 	test	eax, eax
-;;   13:	 0f840c000000         	je	0x25
-;;   19:	 48c7c001000000       	mov	rax, 1
-;;   20:	 e907000000           	jmp	0x2c
-;;   25:	 48c7c002000000       	mov	rax, 2
-;;   2c:	 4883c408             	add	rsp, 8
-;;   30:	 5d                   	pop	rbp
-;;   31:	 c3                   	ret	
+;;   13:	 0f840a000000         	je	0x23
+;;   19:	 b801000000           	mov	eax, 1
+;;   1e:	 e905000000           	jmp	0x28
+;;   23:	 b802000000           	mov	eax, 2
+;;   28:	 4883c408             	add	rsp, 8
+;;   2c:	 5d                   	pop	rbp
+;;   2d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/break_inner.wat
+++ b/winch/filetests/filetests/x64/loop/break_inner.wat
@@ -21,35 +21,35 @@
 ;;   1b:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
 ;;   1f:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;   24:	 4153                 	push	r11
-;;   26:	 48c7c001000000       	mov	rax, 1
-;;   2d:	 59                   	pop	rcx
-;;   2e:	 01c1                 	add	ecx, eax
-;;   30:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
-;;   34:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
-;;   39:	 4153                 	push	r11
-;;   3b:	 48c7c002000000       	mov	rax, 2
-;;   42:	 59                   	pop	rcx
-;;   43:	 01c1                 	add	ecx, eax
-;;   45:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
-;;   49:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
-;;   4e:	 4153                 	push	r11
-;;   50:	 48c7c004000000       	mov	rax, 4
-;;   57:	 59                   	pop	rcx
-;;   58:	 01c1                 	add	ecx, eax
-;;   5a:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
-;;   5e:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
-;;   63:	 4153                 	push	r11
-;;   65:	 48c7c008000000       	mov	rax, 8
-;;   6c:	 59                   	pop	rcx
-;;   6d:	 01c1                 	add	ecx, eax
-;;   6f:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
-;;   73:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
-;;   78:	 4153                 	push	r11
-;;   7a:	 48c7c010000000       	mov	rax, 0x10
-;;   81:	 59                   	pop	rcx
-;;   82:	 01c1                 	add	ecx, eax
-;;   84:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
-;;   88:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
-;;   8c:	 4883c410             	add	rsp, 0x10
-;;   90:	 5d                   	pop	rbp
-;;   91:	 c3                   	ret	
+;;   26:	 b801000000           	mov	eax, 1
+;;   2b:	 59                   	pop	rcx
+;;   2c:	 01c1                 	add	ecx, eax
+;;   2e:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
+;;   32:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   37:	 4153                 	push	r11
+;;   39:	 b802000000           	mov	eax, 2
+;;   3e:	 59                   	pop	rcx
+;;   3f:	 01c1                 	add	ecx, eax
+;;   41:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
+;;   45:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   4a:	 4153                 	push	r11
+;;   4c:	 b804000000           	mov	eax, 4
+;;   51:	 59                   	pop	rcx
+;;   52:	 01c1                 	add	ecx, eax
+;;   54:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
+;;   58:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   5d:	 4153                 	push	r11
+;;   5f:	 b808000000           	mov	eax, 8
+;;   64:	 59                   	pop	rcx
+;;   65:	 01c1                 	add	ecx, eax
+;;   67:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
+;;   6b:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   70:	 4153                 	push	r11
+;;   72:	 b810000000           	mov	eax, 0x10
+;;   77:	 59                   	pop	rcx
+;;   78:	 01c1                 	add	ecx, eax
+;;   7a:	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
+;;   7e:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   82:	 4883c410             	add	rsp, 0x10
+;;   86:	 5d                   	pop	rbp
+;;   87:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/deep.wat
+++ b/winch/filetests/filetests/x64/loop/deep.wat
@@ -61,7 +61,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c096000000       	mov	rax, 0x96
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b896000000           	mov	eax, 0x96
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/multi.wat
+++ b/winch/filetests/filetests/x64/loop/multi.wat
@@ -40,7 +40,7 @@
 ;;   5a:	 4883ec08             	sub	rsp, 8
 ;;   5e:	 e800000000           	call	0x63
 ;;   63:	 4883c408             	add	rsp, 8
-;;   67:	 48c7c008000000       	mov	rax, 8
-;;   6e:	 4883c408             	add	rsp, 8
-;;   72:	 5d                   	pop	rbp
-;;   73:	 c3                   	ret	
+;;   67:	 b808000000           	mov	eax, 8
+;;   6c:	 4883c408             	add	rsp, 8
+;;   70:	 5d                   	pop	rbp
+;;   71:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/nested.wat
+++ b/winch/filetests/filetests/x64/loop/nested.wat
@@ -26,7 +26,7 @@
 ;;   19:	 4883ec08             	sub	rsp, 8
 ;;   1d:	 e800000000           	call	0x22
 ;;   22:	 4883c408             	add	rsp, 8
-;;   26:	 48c7c009000000       	mov	rax, 9
-;;   2d:	 4883c408             	add	rsp, 8
-;;   31:	 5d                   	pop	rbp
-;;   32:	 c3                   	ret	
+;;   26:	 b809000000           	mov	eax, 9
+;;   2b:	 4883c408             	add	rsp, 8
+;;   2f:	 5d                   	pop	rbp
+;;   30:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/singular.wat
+++ b/winch/filetests/filetests/x64/loop/singular.wat
@@ -10,7 +10,7 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c007000000       	mov	rax, 7
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b807000000           	mov	eax, 7
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_block_value.wat
+++ b/winch/filetests/filetests/x64/return/as_block_value.wat
@@ -21,7 +21,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c002000000       	mov	rax, 2
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b802000000           	mov	eax, 2
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_br_value.wat
+++ b/winch/filetests/filetests/x64/return/as_br_value.wat
@@ -18,7 +18,7 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c009000000       	mov	rax, 9
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b809000000           	mov	eax, 9
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_call_fist.wat
+++ b/winch/filetests/filetests/x64/return/as_call_fist.wat
@@ -13,17 +13,16 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48b8ffffffff00000000 	
-;; 				movabs	rax, 0xffffffff
-;;   23:	 4883c418             	add	rsp, 0x18
-;;   27:	 5d                   	pop	rbp
-;;   28:	 c3                   	ret	
+;;   19:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   1e:	 4883c418             	add	rsp, 0x18
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c00c000000       	mov	rax, 0xc
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b80c000000           	mov	eax, 0xc
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_call_last.wat
+++ b/winch/filetests/filetests/x64/return/as_call_last.wat
@@ -13,17 +13,16 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48b8ffffffff00000000 	
-;; 				movabs	rax, 0xffffffff
-;;   23:	 4883c418             	add	rsp, 0x18
-;;   27:	 5d                   	pop	rbp
-;;   28:	 c3                   	ret	
+;;   19:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   1e:	 4883c418             	add	rsp, 0x18
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c00e000000       	mov	rax, 0xe
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b80e000000           	mov	eax, 0xe
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_call_mid.wat
@@ -13,17 +13,16 @@
 ;;    c:	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;   10:	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 48b8ffffffff00000000 	
-;; 				movabs	rax, 0xffffffff
-;;   23:	 4883c418             	add	rsp, 0x18
-;;   27:	 5d                   	pop	rbp
-;;   28:	 c3                   	ret	
+;;   19:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   1e:	 4883c418             	add	rsp, 0x18
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	
 ;;
 ;;    0:	 55                   	push	rbp
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c00d000000       	mov	rax, 0xd
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b80d000000           	mov	eax, 0xd
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_func_first.wat
+++ b/winch/filetests/filetests/x64/return/as_func_first.wat
@@ -18,7 +18,7 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c001000000       	mov	rax, 1
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_func_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_func_mid.wat
@@ -21,7 +21,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c002000000       	mov	rax, 2
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b802000000           	mov	eax, 2
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_func_value.wat
+++ b/winch/filetests/filetests/x64/return/as_func_value.wat
@@ -21,7 +21,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c003000000       	mov	rax, 3
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b803000000           	mov	eax, 3
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/return/as_if_cond.wat
@@ -20,7 +20,7 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c002000000       	mov	rax, 2
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b802000000           	mov	eax, 2
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_if_else.wat
+++ b/winch/filetests/filetests/x64/return/as_if_else.wat
@@ -27,8 +27,8 @@
 ;;   18:	 85c0                 	test	eax, eax
 ;;   1a:	 0f8409000000         	je	0x29
 ;;   20:	 8b442408             	mov	eax, dword ptr [rsp + 8]
-;;   24:	 e907000000           	jmp	0x30
-;;   29:	 48c7c004000000       	mov	rax, 4
-;;   30:	 4883c410             	add	rsp, 0x10
-;;   34:	 5d                   	pop	rbp
-;;   35:	 c3                   	ret	
+;;   24:	 e905000000           	jmp	0x2e
+;;   29:	 b804000000           	mov	eax, 4
+;;   2e:	 4883c410             	add	rsp, 0x10
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_if_then.wat
+++ b/winch/filetests/filetests/x64/return/as_if_then.wat
@@ -25,10 +25,10 @@
 ;;   10:	 4c893424             	mov	qword ptr [rsp], r14
 ;;   14:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   18:	 85c0                 	test	eax, eax
-;;   1a:	 0f840c000000         	je	0x2c
-;;   20:	 48c7c003000000       	mov	rax, 3
-;;   27:	 e904000000           	jmp	0x30
-;;   2c:	 8b442408             	mov	eax, dword ptr [rsp + 8]
-;;   30:	 4883c410             	add	rsp, 0x10
-;;   34:	 5d                   	pop	rbp
-;;   35:	 c3                   	ret	
+;;   1a:	 0f840a000000         	je	0x2a
+;;   20:	 b803000000           	mov	eax, 3
+;;   25:	 e904000000           	jmp	0x2e
+;;   2a:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;   2e:	 4883c410             	add	rsp, 0x10
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_loop_first.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_first.wat
@@ -18,7 +18,7 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c003000000       	mov	rax, 3
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b803000000           	mov	eax, 3
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_last.wat
@@ -21,7 +21,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c005000000       	mov	rax, 5
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b805000000           	mov	eax, 5
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/as_loop_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_mid.wat
@@ -21,7 +21,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c004000000       	mov	rax, 4
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b804000000           	mov	eax, 4
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/return/type_i32.wat
+++ b/winch/filetests/filetests/x64/return/type_i32.wat
@@ -19,7 +19,7 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec08             	sub	rsp, 8
 ;;    8:	 4c893424             	mov	qword ptr [rsp], r14
-;;    c:	 48c7c001000000       	mov	rax, 1
-;;   13:	 4883c408             	add	rsp, 8
-;;   17:	 5d                   	pop	rbp
-;;   18:	 c3                   	ret	
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_block_broke.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_broke.wat
@@ -21,7 +21,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c001000000       	mov	rax, 1
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b801000000           	mov	eax, 1
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/as_loop_broke.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_broke.wat
@@ -23,7 +23,7 @@
 ;;    c:	 4883ec08             	sub	rsp, 8
 ;;   10:	 e800000000           	call	0x15
 ;;   15:	 4883c408             	add	rsp, 8
-;;   19:	 48c7c001000000       	mov	rax, 1
-;;   20:	 4883c408             	add	rsp, 8
-;;   24:	 5d                   	pop	rbp
-;;   25:	 c3                   	ret	
+;;   19:	 b801000000           	mov	eax, 1
+;;   1e:	 4883c408             	add	rsp, 8
+;;   22:	 5d                   	pop	rbp
+;;   23:	 c3                   	ret	


### PR DESCRIPTION
This change is a small refactor to how we've been handling the operand size
parameter passed to some of the `CodeGenContext` operations, namely,
`pop_to_reg` and `move_val_to_reg`.

Given the more precise value tagging introduced in:
https://github.com/bytecodealliance/wasmtime/pull/6860,
it's now possible to derive the operand size from the type associated to a value
stack entry, which:

* Makes the usage of the functions mentioned above less error prone.
* Allows a simplification of the two function definitions mentioned above.
* Results in better instruction selection in some cases.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
