### PR TITLE
wasi-nn: remove `BackendKind`, add wrapper `struct`s

### DIFF
--- a/crates/wasi-nn/src/backend/mod.rs
+++ b/crates/wasi-nn/src/backend/mod.rs
@@ -6,18 +6,18 @@ pub mod openvino;
 
 use self::openvino::OpenvinoBackend;
 use crate::wit::types::{ExecutionTarget, Tensor};
-use crate::{ExecutionContext, Graph};
+use crate::{Backend, ExecutionContext, Graph};
 use std::{error::Error, fmt, path::Path, str::FromStr};
 use thiserror::Error;
 use wiggle::GuestError;
 
 /// Return a list of all available backend frameworks.
-pub fn list() -> Vec<Box<dyn Backend>> {
-    vec![Box::new(OpenvinoBackend::default())]
+pub fn list() -> Vec<crate::Backend> {
+    vec![Backend::from(OpenvinoBackend::default())]
 }
 
 /// A [Backend] contains the necessary state to load [Graph]s.
-pub trait Backend: Send + Sync {
+pub trait BackendInner: Send + Sync {
     fn kind(&self) -> BackendKind;
     fn name(&self) -> &str;
     fn load(&mut self, builders: &[&[u8]], target: ExecutionTarget) -> Result<Graph, BackendError>;
@@ -27,7 +27,7 @@ pub trait Backend: Send + Sync {
 /// Some [Backend]s support loading a [Graph] from a directory on the
 /// filesystem; this is not a general requirement for backends but is useful for
 /// the Wasmtime CLI.
-pub trait BackendFromDir: Backend {
+pub trait BackendFromDir: BackendInner {
     fn load_from_dir(
         &mut self,
         builders: &Path,

--- a/crates/wasi-nn/src/backend/mod.rs
+++ b/crates/wasi-nn/src/backend/mod.rs
@@ -2,7 +2,7 @@
 //! this crate. The `Box<dyn ...>` types returned by these interfaces allow
 //! implementations to maintain backend-specific state between calls.
 
-mod openvino;
+pub mod openvino;
 
 use self::openvino::OpenvinoBackend;
 use crate::wit::types::{ExecutionTarget, Tensor};
@@ -12,12 +12,13 @@ use thiserror::Error;
 use wiggle::GuestError;
 
 /// Return a list of all available backend frameworks.
-pub fn list() -> Vec<(BackendKind, Box<dyn Backend>)> {
-    vec![(BackendKind::OpenVINO, Box::new(OpenvinoBackend::default()))]
+pub fn list() -> Vec<Box<dyn Backend>> {
+    vec![Box::new(OpenvinoBackend::default())]
 }
 
 /// A [Backend] contains the necessary state to load [Graph]s.
 pub trait Backend: Send + Sync {
+    fn kind(&self) -> BackendKind;
     fn name(&self) -> &str;
     fn load(&mut self, builders: &[&[u8]], target: ExecutionTarget) -> Result<Graph, BackendError>;
     fn as_dir_loadable<'a>(&'a mut self) -> Option<&'a mut dyn BackendFromDir>;

--- a/crates/wasi-nn/src/backend/mod.rs
+++ b/crates/wasi-nn/src/backend/mod.rs
@@ -35,13 +35,13 @@ pub trait BackendFromDir: BackendInner {
 }
 
 /// A [BackendGraph] can create [BackendExecutionContext]s; this is the backing
-/// implementation for a [crate::witx::types::Graph].
+/// implementation for the user-facing graph.
 pub trait BackendGraph: Send + Sync {
     fn init_execution_context(&self) -> Result<ExecutionContext, BackendError>;
 }
 
 /// A [BackendExecutionContext] performs the actual inference; this is the
-/// backing implementation for a [crate::witx::types::GraphExecutionContext].
+/// backing implementation for a user-facing execution context.
 pub trait BackendExecutionContext: Send + Sync {
     fn set_input(&mut self, index: u32, tensor: &Tensor) -> Result<(), BackendError>;
     fn compute(&mut self) -> Result<(), BackendError>;

--- a/crates/wasi-nn/src/backend/openvino.rs
+++ b/crates/wasi-nn/src/backend/openvino.rs
@@ -1,7 +1,7 @@
 //! Implements a `wasi-nn` [`Backend`] using OpenVINO.
 
 use super::{
-    Backend, BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendKind,
+    BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner, BackendKind,
 };
 use crate::wit::types::{ExecutionTarget, Tensor, TensorType};
 use crate::{ExecutionContext, Graph};
@@ -14,7 +14,7 @@ pub struct OpenvinoBackend(Option<openvino::Core>);
 unsafe impl Send for OpenvinoBackend {}
 unsafe impl Sync for OpenvinoBackend {}
 
-impl Backend for OpenvinoBackend {
+impl BackendInner for OpenvinoBackend {
     fn kind(&self) -> BackendKind {
         BackendKind::OpenVINO
     }

--- a/crates/wasi-nn/src/backend/openvino.rs
+++ b/crates/wasi-nn/src/backend/openvino.rs
@@ -1,6 +1,8 @@
 //! Implements a `wasi-nn` [`Backend`] using OpenVINO.
 
-use super::{Backend, BackendError, BackendExecutionContext, BackendFromDir, BackendGraph};
+use super::{
+    Backend, BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendKind,
+};
 use crate::wit::types::{ExecutionTarget, Tensor, TensorType};
 use crate::{ExecutionContext, Graph};
 use openvino::{InferenceError, Layout, Precision, SetupError, TensorDesc};
@@ -8,11 +10,15 @@ use std::sync::{Arc, Mutex};
 use std::{fs::File, io::Read, path::Path};
 
 #[derive(Default)]
-pub(crate) struct OpenvinoBackend(Option<openvino::Core>);
+pub struct OpenvinoBackend(Option<openvino::Core>);
 unsafe impl Send for OpenvinoBackend {}
 unsafe impl Sync for OpenvinoBackend {}
 
 impl Backend for OpenvinoBackend {
+    fn kind(&self) -> BackendKind {
+        BackendKind::OpenVINO
+    }
+
     fn name(&self) -> &str {
         "openvino"
     }

--- a/crates/wasi-nn/src/backend/openvino.rs
+++ b/crates/wasi-nn/src/backend/openvino.rs
@@ -1,9 +1,7 @@
 //! Implements a `wasi-nn` [`Backend`] using OpenVINO.
 
-use super::{
-    BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner, BackendKind,
-};
-use crate::wit::types::{ExecutionTarget, Tensor, TensorType};
+use super::{BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner};
+use crate::wit::types::{ExecutionTarget, GraphEncoding, Tensor, TensorType};
 use crate::{ExecutionContext, Graph};
 use openvino::{InferenceError, Layout, Precision, SetupError, TensorDesc};
 use std::sync::{Arc, Mutex};
@@ -15,12 +13,8 @@ unsafe impl Send for OpenvinoBackend {}
 unsafe impl Sync for OpenvinoBackend {}
 
 impl BackendInner for OpenvinoBackend {
-    fn kind(&self) -> BackendKind {
-        BackendKind::OpenVINO
-    }
-
-    fn name(&self) -> &str {
-        "openvino"
+    fn encoding(&self) -> GraphEncoding {
+        GraphEncoding::Openvino
     }
 
     fn load(&mut self, builders: &[&[u8]], target: ExecutionTarget) -> Result<Graph, BackendError> {

--- a/crates/wasi-nn/src/backend/openvino.rs
+++ b/crates/wasi-nn/src/backend/openvino.rs
@@ -1,4 +1,4 @@
-//! Implements a `wasi-nn` [`Backend`] using OpenVINO.
+//! Implements a `wasi-nn` [`BackendInner`] using OpenVINO.
 
 use super::{BackendError, BackendExecutionContext, BackendFromDir, BackendGraph, BackendInner};
 use crate::wit::types::{ExecutionTarget, GraphEncoding, Tensor, TensorType};

--- a/crates/wasi-nn/src/ctx.rs
+++ b/crates/wasi-nn/src/ctx.rs
@@ -1,14 +1,13 @@
 //! Implements the host state for the `wasi-nn` API: [WasiNnCtx].
 
-use crate::backend::{self, Backend, BackendError, BackendKind};
+use crate::backend::{self, BackendError, BackendKind};
 use crate::wit::types::GraphEncoding;
-use crate::{ExecutionContext, Graph, GraphRegistry, InMemoryRegistry};
+use crate::{Backend, ExecutionContext, Graph, InMemoryRegistry, Registry};
 use anyhow::anyhow;
 use std::{collections::HashMap, hash::Hash, path::Path};
 use thiserror::Error;
 use wiggle::GuestError;
 
-type Registry = Box<dyn GraphRegistry>;
 type GraphId = u32;
 type GraphExecutionContextId = u32;
 type BackendName = String;
@@ -20,7 +19,7 @@ type GraphDirectory = String;
 /// model types.
 pub fn preload(
     preload_graphs: &[(BackendName, GraphDirectory)],
-) -> anyhow::Result<(impl IntoIterator<Item = Box<dyn Backend>>, Registry)> {
+) -> anyhow::Result<(impl IntoIterator<Item = Backend>, Registry)> {
     let mut backends = backend::list();
     let mut registry = InMemoryRegistry::new();
     for (kind, path) in preload_graphs {
@@ -33,12 +32,12 @@ pub fn preload(
             .ok_or(anyhow!("{} does not support directory loading", kind))?;
         registry.load(backend, Path::new(path))?;
     }
-    Ok((backends, Box::new(registry)))
+    Ok((backends, Registry::from(registry)))
 }
 
 /// Capture the state necessary for calling into the backend ML libraries.
 pub struct WasiNnCtx {
-    pub(crate) backends: HashMap<BackendKind, Box<dyn Backend>>,
+    pub(crate) backends: HashMap<BackendKind, Backend>,
     pub(crate) registry: Registry,
     pub(crate) graphs: Table<GraphId, Graph>,
     pub(crate) executions: Table<GraphExecutionContextId, ExecutionContext>,
@@ -46,7 +45,7 @@ pub struct WasiNnCtx {
 
 impl WasiNnCtx {
     /// Make a new context from the default state.
-    pub fn new(backends: impl IntoIterator<Item = Box<dyn Backend>>, registry: Registry) -> Self {
+    pub fn new(backends: impl IntoIterator<Item = Backend>, registry: Registry) -> Self {
         let backends = backends.into_iter().map(|b| (b.kind(), b)).collect();
         Self {
             backends,
@@ -131,6 +130,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::registry::GraphRegistry;
 
     #[test]
     fn example() {
@@ -141,6 +141,6 @@ mod test {
             }
         }
 
-        let _ctx = WasiNnCtx::new([], Box::new(FakeRegistry));
+        let _ctx = WasiNnCtx::new([], Registry::from(FakeRegistry));
     }
 }

--- a/crates/wasi-nn/src/lib.rs
+++ b/crates/wasi-nn/src/lib.rs
@@ -1,4 +1,4 @@
-mod backend;
+pub mod backend;
 mod ctx;
 mod registry;
 

--- a/crates/wasi-nn/src/lib.rs
+++ b/crates/wasi-nn/src/lib.rs
@@ -1,7 +1,7 @@
-pub mod backend;
 mod ctx;
 mod registry;
 
+pub mod backend;
 pub use ctx::{preload, WasiNnCtx};
 pub use registry::{GraphRegistry, InMemoryRegistry};
 pub mod wit;

--- a/crates/wasi-nn/src/lib.rs
+++ b/crates/wasi-nn/src/lib.rs
@@ -9,6 +9,25 @@ pub mod witx;
 
 use std::sync::Arc;
 
+/// A machine learning backend.
+pub struct Backend(Box<dyn backend::BackendInner>);
+impl std::ops::Deref for Backend {
+    type Target = dyn backend::BackendInner;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+impl std::ops::DerefMut for Backend {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut()
+    }
+}
+impl<T: backend::BackendInner + 'static> From<T> for Backend {
+    fn from(value: T) -> Self {
+        Self(Box::new(value))
+    }
+}
+
 /// A backend-defined graph (i.e., ML model).
 #[derive(Clone)]
 pub struct Graph(Arc<dyn backend::BackendGraph>);
@@ -40,5 +59,27 @@ impl std::ops::Deref for ExecutionContext {
 impl std::ops::DerefMut for ExecutionContext {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.0.as_mut()
+    }
+}
+
+/// A container for graphs.
+pub struct Registry(Box<dyn GraphRegistry>);
+impl std::ops::Deref for Registry {
+    type Target = dyn GraphRegistry;
+    fn deref(&self) -> &Self::Target {
+        self.0.as_ref()
+    }
+}
+impl std::ops::DerefMut for Registry {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut()
+    }
+}
+impl<T> From<T> for Registry
+where
+    T: GraphRegistry + 'static,
+{
+    fn from(value: T) -> Self {
+        Self(Box::new(value))
     }
 }

--- a/crates/wasi-nn/src/wit.rs
+++ b/crates/wasi-nn/src/wit.rs
@@ -12,7 +12,7 @@
 //!    computation to a [`Backend`]
 //! 3. convert some types
 //!
-//! [`Backend`]: crate::backend::Backend
+//! [`Backend`]: crate::Backend
 //! [`types`]: crate::wit::types
 
 use crate::{ctx::UsageError, WasiNnCtx};

--- a/crates/wasi-nn/src/witx.rs
+++ b/crates/wasi-nn/src/witx.rs
@@ -58,7 +58,7 @@ impl<'a> gen::wasi_ephemeral_nn::WasiEphemeralNn for WasiNnCtx {
         encoding: gen::types::GraphEncoding,
         target: gen::types::ExecutionTarget,
     ) -> Result<gen::types::Graph> {
-        let graph = if let Some(backend) = self.backends.get_mut(&encoding.try_into()?) {
+        let graph = if let Some(backend) = self.backends.get_mut(&encoding.into()) {
             // Retrieve all of the "builder lists" from the Wasm memory (see
             // $graph_builder_array) as slices for a backend to operate on.
             let mut slices = vec![];
@@ -149,15 +149,6 @@ impl<'a> gen::wasi_ephemeral_nn::WasiEphemeralNn for WasiNnCtx {
 
 // Implement some conversion from `witx::types::*` to this crate's version.
 
-impl TryFrom<gen::types::GraphEncoding> for crate::backend::BackendKind {
-    type Error = UsageError;
-    fn try_from(value: gen::types::GraphEncoding) -> std::result::Result<Self, Self::Error> {
-        match value {
-            gen::types::GraphEncoding::Openvino => Ok(crate::backend::BackendKind::OpenVINO),
-            _ => Err(UsageError::InvalidEncoding(value.into())),
-        }
-    }
-}
 impl From<gen::types::ExecutionTarget> for crate::wit::types::ExecutionTarget {
     fn from(value: gen::types::ExecutionTarget) -> Self {
         match value {
@@ -177,7 +168,7 @@ impl From<gen::types::GraphEncoding> for crate::wit::types::GraphEncoding {
             gen::types::GraphEncoding::Tensorflowlite => {
                 crate::wit::types::GraphEncoding::Tensorflowlite
             }
-            gen::types::GraphEncoding::Autodetect => todo!("autodetect not supported"),
+            gen::types::GraphEncoding::Autodetect => crate::wit::types::GraphEncoding::Autodetect,
         }
     }
 }


### PR DESCRIPTION
One improvement that came from discussions with @geekbeast is that `BackendKind`, the enum used for differentiating between ML implementation, is no longer necessary. Instead, we can use the generated `GraphEncoding` type as the key to map to the right implementation.

Also, this PR adopts the `Wrapper(Box<dyn ...>)` pattern everywhere, which now includes backends and registries. Since wasi-nn accepts multiple implementations for all of these things, we need a way to virtually dispatch to the right implementation. Previously we used the `Box<dyn ...>` type explicitly in many places but this change opts to use a wrapper around this, expecting users to create the wrapper via `From` and `Into` and internally accessing the implementation via `Deref` and `DerefMut`. The idea is to eliminate some of the "type clutter;" let me know if you agree. 