### PR TITLE
[c-api]: Expose more configuration options

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -300,6 +300,24 @@ WASMTIME_CONFIG_PROP(void, static_memory_guard_size, uint64_t)
 WASMTIME_CONFIG_PROP(void, dynamic_memory_guard_size, uint64_t)
 
 /**
+ * \brief Configures the size, in bytes, of the extra virtual memory space reserved after a “dynamic” memory for growing into.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.dynamic_memory_reserved_for_growth
+ */
+WASMTIME_CONFIG_PROP(void, dynamic_memory_reserved_for_growth, uint64_t)
+
+/**
+ * \brief Configures whether to generate native unwind information (e.g. .eh_frame on Linux).
+ *
+ * This option defaults to true.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.native_unwind_info
+ */
+WASMTIME_CONFIG_PROP(void, native_unwind_info, bool)
+
+/**
  * \brief Enables Wasmtime's cache and loads configuration from the specified
  * path.
  *

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -213,3 +213,16 @@ pub extern "C" fn wasmtime_config_static_memory_guard_size_set(c: &mut wasm_conf
 pub extern "C" fn wasmtime_config_dynamic_memory_guard_size_set(c: &mut wasm_config_t, size: u64) {
     c.config.dynamic_memory_guard_size(size);
 }
+
+#[no_mangle]
+pub extern "C" fn wasmtime_config_dynamic_memory_reserved_for_growth_set(
+    c: &mut wasm_config_t,
+    size: u64,
+) {
+    c.config.dynamic_memory_reserved_for_growth(size);
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_config_native_unwind_info_set(c: &mut wasm_config_t, enabled: bool) {
+    c.config.native_unwind_info(enabled);
+}


### PR DESCRIPTION
Specifically dynamic_memory_reserved_for_growth and native_unwind_info

