### PR TITLE
Update Rust in CI to 1.72.0, clarify Wasmtime's MSRV

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -18,14 +18,9 @@ runs:
       shell: bash
       id: select
       run: |
-        # This is Wasmtime's minimum supported rust version (MSRV). This is
-        # expressed as N in a version `1.N.0`. Wasmtime's current policy is that
-        # this number can be no larger than the current stable release of Rust
-        # minus 2.
-        #
-        # NB: when updating this additionally update `rust-version` in
-        # `Cargo.toml`.
-        msrv=70
+        # Determine MSRV as N in `1.N.0` by looking at the `rust-version`
+        # located in the root `Cargo.toml`.
+        msrv=$(grep 'rust-version.*1' Cargo.toml | sed 's/.*\.\([0-9]*\)\..*/\1/')
 
         if [ "${{ inputs.toolchain }}" = "default" ]; then
           echo "version=1.$((msrv+2)).0" >> "$GITHUB_OUTPUT"

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -5,8 +5,7 @@ inputs:
   toolchain:
     description: 'Default toolchan to install'
     required: false
-    # NB: when updating this additionally update `rust-version` in `Cargo.toml`.
-    default: '1.72.0'
+    default: 'default'
   lockfiles:
     description: 'Path glob for Cargo.lock files to use as cache keys'
     required: false
@@ -15,13 +14,33 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install Rust
+      shell: bash
+      id: select
+      run: |
+        # This is Wasmtime's minimum supported rust version (MSRV). This is
+        # expressed as N in a version `1.N.0`. Wasmtime's current policy is that
+        # this number can be no larger than the current stable release of Rust
+        # minus 2.
+        #
+        # NB: when updating this additionally update `rust-version` in
+        # `Cargo.toml`.
+        msrv=70
+
+        if [ "${{ inputs.toolchain }}" = "default" ]; then
+          echo "version=1.$((msrv+2)).0"
+        elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
+          echo "version=1.$msrv.0"
+        else
+          echo "version=${{ inputs.toolchain }}"
+        fi
 
     - name: Install Rust
       shell: bash
       run: |
         rustup set profile minimal
-        rustup update "${{ inputs.toolchain }}" --no-self-update
-        rustup default "${{ inputs.toolchain }}"
+        rustup update "${{ steps.select.outputs.version }}" --no-self-update
+        rustup default "${{ steps.select.outputs.version }}"
 
         # Save disk space by avoiding incremental compilation. Also turn down
         # debuginfo from 2 to 0 to help save disk space.
@@ -32,11 +51,7 @@ runs:
         EOF
 
         # Deny warnings on CI to keep our code warning-free as it lands in-tree.
-        # Don't do this on nightly though, since there's a fair amount of
-        # warning churn there.
-        if [[ "${{ inputs.toolchain }}" != nightly* ]]; then
-          echo RUSTFLAGS="-D warnings" >> "$GITHUB_ENV"
-        fi
+        echo RUSTFLAGS="-D warnings" >> "$GITHUB_ENV"
 
         if [[ "${{ runner.os }}" = "macOS" ]]; then
           cat >> "$GITHUB_ENV" <<EOF

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -28,11 +28,11 @@ runs:
         msrv=70
 
         if [ "${{ inputs.toolchain }}" = "default" ]; then
-          echo "version=1.$((msrv+2)).0"
+          echo "version=1.$((msrv+2)).0" >> "$GITHUB_OUTPUT"
         elif [ "${{ inputs.toolchain }}" = "msrv" ]; then
-          echo "version=1.$msrv.0"
+          echo "version=1.$msrv.0" >> "$GITHUB_OUTPUT"
         else
-          echo "version=${{ inputs.toolchain }}"
+          echo "version=${{ inputs.toolchain }}" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Install Rust

--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -5,7 +5,8 @@ inputs:
   toolchain:
     description: 'Default toolchan to install'
     required: false
-    default: '1.71.0'
+    # NB: when updating this additionally update `rust-version` in `Cargo.toml`.
+    default: '1.72.0'
   lockfiles:
     description: 'Path glob for Cargo.lock files to use as cache keys'
     required: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -383,6 +383,8 @@ jobs:
       with:
         submodules: true
     - uses: ./.github/actions/install-rust
+      with:
+        toolchain: ${{ matrix.rust }}
 
     # Install targets in order to build various tests throughout the repo
     - run: rustup target add wasm32-wasi wasm32-unknown-unknown ${{ matrix.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ exclude = [
 version = "13.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
-rust-version = "1.72.0"
+rust-version = "1.70.0"
 
 [workspace.dependencies]
 wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=13.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,8 @@ exclude = [
 version = "13.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
+# Wasmtime's current policy is that this number can be no larger than the
+# current stable release of Rust minus 2.
 rust-version = "1.70.0"
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ exclude = [
 version = "13.0.0"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
-rust-version = "1.71.0"
+rust-version = "1.72.0"
 
 [workspace.dependencies]
 wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=13.0.0" }

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -32,12 +32,21 @@ const names = fs.readFileSync(process.argv[3]).toString();
 //   on CI.
 // * `isa` - changes to `cranelift/codegen/src/$isa` will automatically run this
 //   test suite.
+// * `rust` - the Rust version to install, and if unset this'll be set to
+//   `default`
 const array = [
   {
     "os": "ubuntu-latest",
     "name": "Test Linux x86_64",
     "filter": "linux-x64",
     "isa": "x64"
+  },
+  {
+    "os": "ubuntu-latest",
+    "name": "Test MSRV on Linux x86_64",
+    "filter": "linux-x64",
+    "isa": "x64",
+    "rust": "msrv",
   },
   {
     "os": "macos-latest",
@@ -89,6 +98,12 @@ const array = [
     "isa": "riscv64"
   }
 ];
+
+for (let config of array) {
+  if (config.rust === undefined) {
+    config.rust = 'default';
+  }
+}
 
 function myFilter(item) {
   if (item.isa && names.includes(`cranelift/codegen/src/isa/${item.isa}`)) {

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -132,4 +132,4 @@ component-model = [
   "dep:encoding_rs",
 ]
 
-wmemcheck = ["wasmtime-runtime/wmemcheck", "wasmtime-cranelift/wmemcheck"]
+wmemcheck = ["wasmtime-runtime/wmemcheck", "wasmtime-cranelift?/wmemcheck"]

--- a/docs/contributing-coding-guidelines.md
+++ b/docs/contributing-coding-guidelines.md
@@ -21,13 +21,13 @@ your editor.
 
 ### Minimum Supported `rustc` Version
 
-Wasmtime supports the current stable version of Rust.
+Wasmtime supports the latest three stable releases of Rust.
 
 Cranelift supports stable Rust, and follows the [Rust Update Policy for
 Firefox].
 
-Some of the developer scripts depend on nightly Rust, for example to run
-clippy and other tools, however we avoid depending on these for the main
-build.
+Some of the CI jobs depend on nightly Rust, for example to run rustdoc with
+nightly features, however these use pinned versions in CI that are updated
+periodically and the general repository does not depend on nightly features.
 
 [Rust Update Policy for Firefox]: https://wiki.mozilla.org/Rust_Update_Policy_for_Firefox#Schedule

--- a/docs/contributing-coding-guidelines.md
+++ b/docs/contributing-coding-guidelines.md
@@ -21,7 +21,7 @@ your editor.
 
 ### Minimum Supported `rustc` Version
 
-Wasmtime and Cranelift supports the latest three stable releases of Rust. This
+Wasmtime and Cranelift support the latest three stable releases of Rust. This
 means that if the latest version of Rust is 1.72.0 then Wasmtime supports Rust
 1.70.0, 1.71.0, and 1.72.0. CI will test by default with 1.72.0 and there will
 be one job running the full test suite on Linux x86\_64 on 1.70.0.

--- a/docs/contributing-coding-guidelines.md
+++ b/docs/contributing-coding-guidelines.md
@@ -21,13 +21,16 @@ your editor.
 
 ### Minimum Supported `rustc` Version
 
-Wasmtime supports the latest three stable releases of Rust.
-
-Cranelift supports stable Rust, and follows the [Rust Update Policy for
-Firefox].
+Wasmtime and Cranelift supports the latest three stable releases of Rust. This
+means that if the latest version of Rust is 1.72.0 then Wasmtime supports Rust
+1.70.0, 1.71.0, and 1.72.0. CI will test by default with 1.72.0 and there will
+be one job running the full test suite on Linux x86\_64 on 1.70.0.
 
 Some of the CI jobs depend on nightly Rust, for example to run rustdoc with
 nightly features, however these use pinned versions in CI that are updated
 periodically and the general repository does not depend on nightly features.
+
+Updating Wasmtime's MSRV is done by editing the `rust-version` field in the
+workspace root's `Cargo.toml`
 
 [Rust Update Policy for Firefox]: https://wiki.mozilla.org/Rust_Update_Policy_for_Firefox#Schedule


### PR DESCRIPTION
This PR updates Rust in CI to 1.72.0. Additionally this implements the outcome of the latest Wasmtime meeting's discussion about an MSRV policy which is to support the latest 3 releases of Rust. CI now primarily tests against the latest release of Rust but a single Linux x86_64 builder runs the full test suite on the minimum Rust version supported.