### PR TITLE
Update vet metadata on patch releases

### DIFF
--- a/.github/workflows/release-process.yml
+++ b/.github/workflows/release-process.yml
@@ -197,6 +197,8 @@ jobs:
           # patch release marker is already in there. Note that this commit
           # message indicates that on-merge a release will be made.
           ./publish bump-patch
+          # Update `cargo vet` entries for all the new crate versions
+          cargo vet
           sed -i "s/^Unreleased/Released $(date +'%Y-%m-%d')/" RELEASES.md
           num=$(./ci/print-current-version.sh)
           git commit -a -F-<<EOF


### PR DESCRIPTION
This should fix the CI error that cropped up on #6901

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
