### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -143,9 +143,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -595,7 +595,7 @@ dependencies = [
  "cranelift-isle",
  "criterion",
  "gimli",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "log",
  "regalloc2",
  "serde",
@@ -665,7 +665,7 @@ name = "cranelift-frontend"
 version = "0.100.0"
 dependencies = [
  "cranelift-codegen",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "log",
  "similar",
  "smallvec",
@@ -735,7 +735,7 @@ dependencies = [
  "anyhow",
  "cranelift-codegen",
  "cranelift-control",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "serde",
 ]
 
@@ -827,7 +827,7 @@ dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
- "hashbrown 0.13.2",
+ "hashbrown 0.14.0",
  "itertools",
  "log",
  "serde",
@@ -1112,9 +1112,9 @@ version = "0.0.0"
 
 [[package]]
 name = "fallible-iterator"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
@@ -1332,12 +1332,12 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 dependencies = [
  "fallible-iterator",
- "indexmap 1.9.1",
+ "indexmap 2.0.0",
  "stable_deref_trait",
 ]
 
@@ -1392,6 +1392,9 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "heck"
@@ -1871,13 +1874,13 @@ checksum = "17b02fc0ff9a9e4b35b3342880f48e896ebf69f2967921fe8646bf5b7125956a"
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
 dependencies = [
  "crc32fast",
- "hashbrown 0.13.2",
- "indexmap 1.9.1",
+ "hashbrown 0.14.0",
+ "indexmap 2.0.0",
  "memchr",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,7 +2967,7 @@ name = "verify-component-adapter"
 version = "13.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.92.0",
+ "wasmparser 0.111.0",
  "wat",
 ]
 
@@ -3273,15 +3273,6 @@ dependencies = [
  "downcast-rs",
  "libm",
  "num-traits",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.92.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da34cec2a8c23db906cdf8b26e988d7a7f0d549eb5d51299129647af61a1b37"
-dependencies = [
- "indexmap 1.9.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -217,14 +217,14 @@ wit-component = "0.13.2"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
-object = { version = "0.31.1", default-features = false, features = ['read_core', 'elf', 'std'] }
-gimli = { version = "0.27.0", default-features = false, features = ['read', 'std'] }
+object = { version = "0.32", default-features = false, features = ['read_core', 'elf', 'std'] }
+gimli = { version = "0.28.0", default-features = false, features = ['read', 'std'] }
 anyhow = "1.0.22"
 windows-sys = "0.48.0"
 env_logger = "0.10"
 log = { version = "0.4.8", default-features = false }
 clap = { version = "4.3.12", features = ["color", "suggestions", "derive"] }
-hashbrown = "0.13.2"
+hashbrown = { version = "0.14", default-features = false }
 capstone = "0.9.0"
 once_cell = "1.12.0"
 smallvec = { version = "1.6.1", features = ["union"] }

--- a/cranelift/filetests/src/test_unwind.rs
+++ b/cranelift/filetests/src/test_unwind.rs
@@ -562,8 +562,14 @@ mod systemv {
                     ArgsSize { size } => {
                         writeln!(w, "                DW_CFA_GNU_args_size ({})", size)?;
                     }
+                    NegateRaState => {
+                        writeln!(w, "                DW_CFA_AARCH64_negate_ra_state")?;
+                    }
                     Nop => {
                         writeln!(w, "                DW_CFA_nop")?;
+                    }
+                    _ => {
+                        writeln!(w, "                DW_CFA_<unknown>")?;
                     }
                 },
             }

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -20,7 +20,7 @@ cfg-if = { workspace = true }
 gimli = { workspace = true }
 object = { workspace = true }
 serde = { version = "1.0.94", features = ["derive"] }
-addr2line = { version = "0.20.0", default-features = false }
+addr2line = { version = "0.21.0", default-features = false }
 bincode = "1.2.1"
 rustc-demangle = "0.1.16"
 cpp_demangle = "0.3.2"

--- a/crates/wasi-preview1-component-adapter/verify/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/verify/Cargo.toml
@@ -6,6 +6,6 @@ authors.workspace = true
 publish = false
 
 [dependencies]
-wasmparser = "0.92.0"
-wat = "1.0.62"
-anyhow = "1"
+wasmparser = { workspace = true }
+wat = { workspace = true }
+anyhow = { workspace = true }

--- a/crates/wasi-preview1-component-adapter/verify/src/main.rs
+++ b/crates/wasi-preview1-component-adapter/verify/src/main.rs
@@ -72,7 +72,7 @@ fn main() -> Result<()> {
             | Payload::ComponentInstanceSection(_)
             | Payload::ComponentAliasSection(_)
             | Payload::ComponentCanonicalSection(_)
-            | Payload::ComponentStartSection(_)
+            | Payload::ComponentStartSection { .. }
             | Payload::ComponentImportSection(_)
             | Payload::CoreTypeSection(_)
             | Payload::ComponentExportSection(_)


### PR DESCRIPTION
Update `object`, `gimli` and `addr2line` to latest versions.

There are still users of old `hashbrown` and `indexmap`:
- `wasmparser`: an old version is used in `wit-component`
- `regalloc2`:  https://github.com/bytecodealliance/regalloc2/pull/164 
- `h2`: used for HTTP https://github.com/hyperium/h2/pull/698
- `egg` (used in `wasm-mutate`)

This needs a separated audit for these new versions 