### PR TITLE
Only include `misc_testsuite/winch` when testing Winch

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -36,7 +36,13 @@ fn main() -> anyhow::Result<()> {
             test_directory_module(out, "tests/misc_testsuite/memory64", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/component-model", strategy)?;
             test_directory_module(out, "tests/misc_testsuite/function-references", strategy)?;
-            test_directory_module(out, "tests/misc_testsuite/winch", strategy)?;
+            // The testsuite of Winch is a subset of the official
+            // WebAssembly test suite, until parity is reached. This
+            // check is in place to prevent Cranelift from duplicating
+            // tests.
+            if *strategy == "Winch" {
+                test_directory_module(out, "tests/misc_testsuite/winch", strategy)?;
+            }
             Ok(())
         })?;
 


### PR DESCRIPTION
This commit optimizes the use of CI resources by avoiding unnecessary duplication of WebAssembly spec tests when using the Cranelift compiler strategy. Previously, Cranelift was tested against both the official spec test suite and Winch's test suite, the latter being a subset of the former. This commit eliminates this redundancy.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
