### PR TITLE
Avoid spawn_blocking and poll and asyncfd.

### DIFF
--- a/crates/wasi/src/preview2/tcp.rs
+++ b/crates/wasi/src/preview2/tcp.rs
@@ -42,9 +42,7 @@ pub(crate) enum HostTcpState {
 /// A host TCP socket, plus associated bookkeeping.
 ///
 /// The inner state is wrapped in an Arc because the same underlying socket is
-/// used for implementing the stream types. Also needed for [`spawn_blocking`].
-///
-/// [`spawn_blocking`]: Self::spawn_blocking
+/// used for implementing the stream types.
 pub(crate) struct HostTcpSocket {
     /// The part of a `HostTcpSocket` which is reference-counted so that we
     /// can pass it to async tasks.
@@ -113,20 +111,6 @@ impl HostTcpSocketInner {
         let tcp_socket = &self.tcp_socket;
 
         tcp_socket
-    }
-
-    /// Spawn a task on tokio's blocking thread for performing blocking
-    /// syscalls on the underlying [`cap_std::net::TcpListener`].
-    #[cfg(not(unix))]
-    pub(crate) async fn spawn_blocking<F, R>(self: &Arc<Self>, body: F) -> R
-    where
-        F: FnOnce(&cap_std::net::TcpListener) -> R + Send + 'static,
-        R: Send + 'static,
-    {
-        let s = Arc::clone(self);
-        tokio::task::spawn_blocking(move || body(s.tcp_socket()))
-            .await
-            .unwrap()
     }
 }
 


### PR DESCRIPTION
Replace the Unix-specific AsyncFd and Windows poll code using tokio::net::TcpStream.

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
