### PR TITLE
x64: Fix incorrect lowering of vector `bitselect`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -3327,12 +3327,6 @@
       (if-let $true (use_avx))
       (xmm_rmir_vex (AvxOpcode.Vdivpd) src1 src2))
 
-;; Helper for creating `blendvp{d,s}` and `pblendvb` instructions.
-(decl x64_blend (Type Xmm XmmMem Xmm) Xmm)
-(rule 1 (x64_blend $F32X4 mask src1 src2) (x64_blendvps src2 src1 mask))
-(rule 1 (x64_blend $F64X2 mask src1 src2) (x64_blendvpd src2 src1 mask))
-(rule 0 (x64_blend (multi_lane _ _) mask src1 src2) (x64_pblendvb src2 src1 mask))
-
 ;; Helper for creating `blendvpd` instructions.
 (decl x64_blendvpd (Xmm XmmMem Xmm) Xmm)
 (rule 0 (x64_blendvpd src1 src2 mask)

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1370,10 +1370,7 @@
                                     if_false)))
       (if-let $true (use_sse41))
       (if (all_ones_or_all_zeros condition))
-      (x64_blend ty
-                 condition
-                 if_true
-                 if_false))
+      (x64_pblendvb if_false if_true condition))
 
 (decl pure partial all_ones_or_all_zeros (Value) bool)
 (rule (all_ones_or_all_zeros (and (icmp _ _ _) (value_type (multi_lane _ _)))) $true)

--- a/cranelift/filetests/filetests/runtests/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitselect.clif
@@ -64,3 +64,11 @@ block0:
     return v11
 }
 ; run
+
+function %bitselect_vconst_f64x2(f64x2, f64x2) -> f64x2 {
+block0(v1: f64x2, v2: f64x2):
+  v0 = vconst.f64x2 0xFF00000000000000FF00000000000000
+  v3 = bitselect v0, v1, v2
+  return v3
+}
+; run: %bitselect_vconst_f64x2(0x11111111111111111111111111111111, 0x00000000000000000000000000000000) == 0x11000000000000001100000000000000


### PR DESCRIPTION
Unconditionally use `pblendvb` which will provide the semantics desired for `bitselect` since the `all_ones_or_all_zeros` predicate guarantees that byte-size-chunks are all-zeros-or-all-ones and `pblendvb` works at the byte level. As suggested by Jamey in #6890.

Closes #6890

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
