### PR TITLE
Remove the unused `file-per-thread-logger` dependencies from `wasmtime-cache`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3416,7 +3416,6 @@ dependencies = [
  "base64",
  "bincode",
  "directories-next",
- "file-per-thread-logger",
  "filetime",
  "log",
  "once_cell",

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -13,7 +13,6 @@ anyhow = { workspace = true }
 base64 = "0.21.0"
 bincode = "1.1.4"
 directories-next = "2.0"
-file-per-thread-logger = { workspace = true }
 log = { workspace = true }
 serde = { version = "1.0.94", features = ["derive"] }
 sha2 = "0.10.2"

--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -366,7 +366,7 @@ impl CacheConfig {
 
     fn spawn_worker(&mut self) {
         if self.enabled {
-            self.worker = Some(Worker::start_new(self, None));
+            self.worker = Some(Worker::start_new(self));
         }
     }
 

--- a/crates/cache/src/worker/tests.rs
+++ b/crates/cache/src/worker/tests.rs
@@ -19,7 +19,7 @@ fn test_on_get_create_stats_file() {
         cache_dir
     );
     assert!(cache_config.enabled());
-    let worker = Worker::start_new(&cache_config, None);
+    let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
     worker.on_cache_get_async(mod_file);
@@ -47,7 +47,7 @@ fn test_on_get_update_usage_counter() {
         cache_dir
     );
     assert!(cache_config.enabled());
-    let worker = Worker::start_new(&cache_config, None);
+    let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
     let stats_file = cache_dir.join("some-mod.stats");
@@ -84,7 +84,7 @@ fn test_on_get_recompress_no_mod_file() {
         cache_dir
     );
     assert!(cache_config.enabled());
-    let worker = Worker::start_new(&cache_config, None);
+    let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
     let stats_file = cache_dir.join("some-mod.stats");
@@ -126,7 +126,7 @@ fn test_on_get_recompress_with_mod_file() {
         cache_dir
     );
     assert!(cache_config.enabled());
-    let worker = Worker::start_new(&cache_config, None);
+    let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
     let mod_data = "some test data to be compressed";
@@ -203,7 +203,7 @@ fn test_on_get_recompress_lock() {
         cache_dir
     );
     assert!(cache_config.enabled());
-    let worker = Worker::start_new(&cache_config, None);
+    let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
     let mod_data = "some test data to be compressed";
@@ -271,7 +271,7 @@ fn test_on_update_fresh_stats_file() {
         cache_dir
     );
     assert!(cache_config.enabled());
-    let worker = Worker::start_new(&cache_config, None);
+    let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
     let stats_file = cache_dir.join("some-mod.stats");
@@ -325,7 +325,7 @@ fn test_on_update_cleanup_limits_trash_locks() {
         cache_dir
     );
     assert!(cache_config.enabled());
-    let worker = Worker::start_new(&cache_config, None);
+    let worker = Worker::start_new(&cache_config);
     let content_1k = "a".repeat(1_000);
     let content_10k = "a".repeat(10_000);
 
@@ -462,7 +462,7 @@ fn test_on_update_cleanup_lru_policy() {
         cache_dir
     );
     assert!(cache_config.enabled());
-    let worker = Worker::start_new(&cache_config, None);
+    let worker = Worker::start_new(&cache_config);
     let content_1k = "a".repeat(1_000);
     let content_5k = "a".repeat(5_000);
     let content_10k = "a".repeat(10_000);
@@ -595,7 +595,7 @@ fn test_on_update_cleanup_future_files() {
         cache_dir
     );
     assert!(cache_config.enabled());
-    let worker = Worker::start_new(&cache_config, None);
+    let worker = Worker::start_new(&cache_config);
     let content_1k = "a".repeat(1_000);
 
     let mods_files_dir = cache_dir.join("target-triple").join("compiler-version");
@@ -700,7 +700,7 @@ fn test_on_update_cleanup_self_lock() {
         cache_dir
     );
     assert!(cache_config.enabled());
-    let worker = Worker::start_new(&cache_config, None);
+    let worker = Worker::start_new(&cache_config);
 
     let mod_file = cache_dir.join("some-mod");
     let trash_file = cache_dir.join("trash-file.txt");


### PR DESCRIPTION
`wasmtime-cache` depends on `file-per-thread-logger`, but never really used it.
This removes it from the dependency list.
