### PR TITLE
riscv64: Refactor constant emission

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -285,7 +285,6 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             insts.extend(Inst::load_constant_u32(
                 writable_spilltmp_reg2(),
                 imm as u64,
-                &mut |_| writable_spilltmp_reg2(),
             ));
             insts.push(Inst::AluRRR {
                 alu_op: AluOPRRR::Add,
@@ -391,11 +390,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
     }
 
     fn gen_probestack(insts: &mut SmallInstVec<Self::I>, frame_size: u32) {
-        insts.extend(Inst::load_constant_u32(
-            writable_a0(),
-            frame_size as u64,
-            &mut |_| writable_a0(),
-        ));
+        insts.extend(Inst::load_constant_u32(writable_a0(), frame_size as u64));
         insts.push(Inst::Call {
             info: Box::new(CallInfo {
                 dest: ExternalName::LibCall(LibCall::Probestack),
@@ -578,7 +573,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         let arg1 = Writable::from_reg(x_reg(11));
         let arg2 = Writable::from_reg(x_reg(12));
         let tmp = alloc_tmp(Self::word_type());
-        insts.extend(Inst::load_constant_u64(tmp, size as u64, &mut alloc_tmp).into_iter());
+        insts.extend(Inst::load_constant_u64(tmp, size as u64).into_iter());
         insts.push(Inst::Call {
             info: Box::new(CallInfo {
                 dest: ExternalName::LibCall(LibCall::Memcpy),

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1557,12 +1557,13 @@
 
 ;; Helper to go directly from a `Value`, when it's an `iconst`, to an `Imm12`.
 (decl imm12_from_value (Imm12) Value)
-(extractor
-  (imm12_from_value n)
-  (def_inst (iconst (u64_from_imm64 (imm12_from_u64 n)))))
+(extractor (imm12_from_value n) (i64_from_iconst (imm12_from_i64 n)))
 
 (decl imm12_from_u64 (Imm12) u64)
 (extern extractor imm12_from_u64 imm12_from_u64)
+
+(decl imm12_from_i64 (Imm12) i64)
+(extern extractor imm12_from_i64 imm12_from_i64)
 
 (decl pure partial u64_to_imm12 (u64) Imm12)
 (rule (u64_to_imm12 (imm12_from_u64 n)) n)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1575,8 +1575,8 @@
 (extern extractor imm5_from_u64 imm5_from_u64)
 
 ;; Construct a Imm5 from an i8
-(decl pure partial imm5_from_i8 (i8) Imm5)
-(extern constructor imm5_from_i8 imm5_from_i8)
+(decl pure partial i8_to_imm5 (i8) Imm5)
+(extern constructor i8_to_imm5 i8_to_imm5)
 
 ;; Extractor that matches a `Value` equivalent to a replicated Imm5 on all lanes.
 ;; TODO(#6527): Try matching vconst here as well

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1549,10 +1549,6 @@
 (decl imm12_and (Imm12 u64) Imm12)
 (extern constructor imm12_and imm12_and)
 
-;; Helper for get negative of Imm12
-(decl neg_imm12 (Imm12) Imm12)
-(extern constructor neg_imm12 neg_imm12)
-
 ;; Imm12 Extractors
 
 ;; Helper to go directly from a `Value`, when it's an `iconst`, to an `Imm12`.

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1517,19 +1517,19 @@
 (decl pure shift_mask (Type) u64)
 (rule (shift_mask ty) (u64_sub (ty_bits (lane_type ty)) 1))
 
-(decl generate_imm (Imm20 Imm12) u64)
-(extern extractor generate_imm generate_imm)
+;; Helper for generating a i64 from a pair of Imm20 and Imm12 constants
+(decl i64_generate_imm (Imm20 Imm12) i64)
+(extern extractor i64_generate_imm i64_generate_imm)
 
 
 ;; Immediate Loading rules
-;; TODO: Loading the zero reg directly causes
-;; a bunch of regalloc errors, we should look into it.
-;; (rule (imm (ty_int ty) 0) (zero_reg))
+;; TODO: Loading the zero reg directly causes a bunch of regalloc errors, we should look into it.
+;; TODO: We can load constants like 0x3ff0000000000000 by loading the bits then doing a shift left.
 (decl imm (Type u64) Reg)
 
-;; Refs are also loaded as integers
-(rule 4 (imm $R32 c) (gen_bitcast (imm $I32 c) $I32 $R32))
-(rule 4 (imm $R64 c) (gen_bitcast (imm $I64 c) $I64 $R64))
+;; Refs get loaded as integers.
+(rule 4 (imm $R32 c) (imm $I32 c))
+(rule 4 (imm $R64 c) (imm $I64 c))
 
 ;; Floats get loaded as integers and then moved into an F register.
 (rule 4 (imm $F32 c) (gen_bitcast (imm $I32 c) $I32 $F32))
@@ -1537,34 +1537,26 @@
 
 ;; Try to match just an imm12
 (rule 3 (imm (ty_int ty) c)
-  (if-let (generate_imm (imm20_is_zero) imm12) (i64_as_u64 (i64_sextend_u64 ty c)))
+  (if-let (i64_generate_imm (imm20_is_zero) imm12) (i64_sextend_u64 ty c))
   (rv_addi (zero_reg) imm12))
 
 ;; We can also try to load using a single LUI.
 ;; LUI takes a 20 bit immediate, places it on bits 13 to 32 of the register.
 ;; In RV64 this value is then sign extended to 64bits.
 (rule 2 (imm (ty_int ty) c)
-  (if-let (generate_imm imm20 (imm12_is_zero)) (i64_as_u64 (i64_sextend_u64 ty c)))
+  (if-let (i64_generate_imm imm20 (imm12_is_zero)) (i64_sextend_u64 ty c))
   (rv_lui imm20))
 
 ;; We can combo addi + lui to represent all 32-bit immediates
 ;; And some 64-bit immediates as well.
 (rule 1 (imm (ty_int ty) c)
-  (if-let (generate_imm imm20 imm12) (i64_as_u64 (i64_sextend_u64 ty c)))
+  (if-let (i64_generate_imm imm20 imm12) (i64_sextend_u64 ty c))
   (rv_addi (rv_lui imm20) imm12))
-
-
-;; (rule 0 (imm (ty_int ty) c)
-;;   ;; The bottom 12 bits must be 0
-;;   (if-let $true (u64_eq (u64_and c 0xFFF) 0))
-;;   ;; The top 32 bits must be equal to the sign bit
-;;   (if-let $true (u64_eq (u64_sshr c 63) (u64_sshr (u64_shl c 32) 63))
-;;   (rv_addi (zero_reg) imm))
 
 ;; Otherwise we fall back to loading the immediate from memory
 ;; TODO: This doesen't yet emit the constant into the memory pool, but it would
 ;; be pretty neat if it did.
-(rule (imm (ty_int ty) c) (emit_load_const_64 c))
+(rule 0 (imm (ty_int ty) c) (emit_load_const_64 c))
 
 ;; Imm12 Rules
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1604,9 +1604,6 @@
 
 ;; Imm20
 
-(decl pure partial u64_to_imm20 (u64) Imm20)
-(extern constructor u64_to_imm20 u64_to_imm20)
-
 ;; Extractor that matches if a Imm20 is zero
 (decl pure imm20_is_zero () Imm20)
 (extern extractor imm20_is_zero imm20_is_zero)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1574,6 +1574,9 @@
 (decl imm5_from_u64 (Imm5) u64)
 (extern extractor imm5_from_u64 imm5_from_u64)
 
+(decl imm5_from_i64 (Imm5) i64)
+(extern extractor imm5_from_i64 imm5_from_i64)
+
 ;; Construct a Imm5 from an i8
 (decl pure partial i8_to_imm5 (i8) Imm5)
 (extern constructor i8_to_imm5 i8_to_imm5)
@@ -1582,7 +1585,7 @@
 ;; TODO(#6527): Try matching vconst here as well
 (decl replicated_imm5 (Imm5) Value)
 (extractor (replicated_imm5 n)
-  (def_inst (splat (iconst (u64_from_imm64 (imm5_from_u64 n))))))
+  (def_inst (splat (i64_from_iconst (imm5_from_i64 n)))))
 
 ;; UImm5 Helpers
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1517,16 +1517,59 @@
 (decl pure shift_mask (Type) u64)
 (rule (shift_mask ty) (u64_sub (ty_bits (lane_type ty)) 1))
 
-;; for load immediate
+(decl generate_imm (Imm20 Imm12) u64)
+(extern extractor generate_imm generate_imm)
+
+
+;; Immediate Loading rules
+;; TODO: Loading the zero reg directly causes
+;; a bunch of regalloc errors, we should look into it.
+;; (rule (imm (ty_int ty) 0) (zero_reg))
 (decl imm (Type u64) Reg)
-(extern constructor imm imm)
+
+;; Refs are also loaded as integers
+(rule 4 (imm $R32 c) (gen_bitcast (imm $I32 c) $I32 $R32))
+(rule 4 (imm $R64 c) (gen_bitcast (imm $I64 c) $I64 $R64))
+
+;; Floats get loaded as integers and then moved into an F register.
+(rule 4 (imm $F32 c) (gen_bitcast (imm $I32 c) $I32 $F32))
+(rule 4 (imm $F64 c) (gen_bitcast (imm $I64 c) $I64 $F64))
+
+;; Try to match just an imm12
+(rule 3 (imm (ty_int ty) c)
+  (if-let (generate_imm (imm20_is_zero) imm12) (i64_as_u64 (i64_sextend_u64 ty c)))
+  (rv_addi (zero_reg) imm12))
+
+;; We can also try to load using a single LUI.
+;; LUI takes a 20 bit immediate, places it on bits 13 to 32 of the register.
+;; In RV64 this value is then sign extended to 64bits.
+(rule 2 (imm (ty_int ty) c)
+  (if-let (generate_imm imm20 (imm12_is_zero)) (i64_as_u64 (i64_sextend_u64 ty c)))
+  (rv_lui imm20))
+
+;; We can combo addi + lui to represent all 32-bit immediates
+;; And some 64-bit immediates as well.
+(rule 1 (imm (ty_int ty) c)
+  (if-let (generate_imm imm20 imm12) (i64_as_u64 (i64_sextend_u64 ty c)))
+  (rv_addi (rv_lui imm20) imm12))
+
+
+;; (rule 0 (imm (ty_int ty) c)
+;;   ;; The bottom 12 bits must be 0
+;;   (if-let $true (u64_eq (u64_and c 0xFFF) 0))
+;;   ;; The top 32 bits must be equal to the sign bit
+;;   (if-let $true (u64_eq (u64_sshr c 63) (u64_sshr (u64_shl c 32) 63))
+;;   (rv_addi (zero_reg) imm))
+
+;; Otherwise we fall back to loading the immediate from memory
+;; TODO: This doesen't yet emit the constant into the memory pool, but it would
+;; be pretty neat if it did.
+(rule (imm (ty_int ty) c) (emit_load_const_64 c))
 
 ;; Imm12 Rules
 
 (decl pure imm12_zero () Imm12)
-(rule
-  (imm12_zero)
-  (imm12_const 0))
+(rule (imm12_zero) (imm12_const 0))
 
 (decl pure imm12_const (i32) Imm12)
 (extern constructor imm12_const imm12_const)
@@ -1563,6 +1606,18 @@
 
 (decl pure partial u64_to_imm12 (u64) Imm12)
 (rule (u64_to_imm12 (imm12_from_u64 n)) n)
+
+(decl pure imm12_is_zero () Imm12)
+(extern extractor imm12_is_zero imm12_is_zero)
+
+;; Imm20
+
+(decl pure partial u64_to_imm20 (u64) Imm20)
+(extern constructor u64_to_imm20 u64_to_imm20)
+
+;; Extractor that matches if a Imm20 is zero
+(decl pure imm20_is_zero () Imm20)
+(extern extractor imm20_is_zero imm20_is_zero)
 
 
 ;; Imm5 Extractors
@@ -1669,6 +1724,24 @@
       (let ((dst WritableXReg (temp_writable_xreg))
             (_ Unit (emit (MInst.AluRRImm12 op dst src (imm12_zero)))))
         dst))
+
+;; Helper for emitting the `LoadConst64` instruction.
+(decl emit_load_const_64 (u64) XReg)
+(rule (emit_load_const_64 imm)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.LoadConst64 dst imm))))
+        dst))
+
+;; Helper for emitting the `Lui` instruction.
+;; TODO: This should be something like `emit_u_type`. And should share the
+;; `MInst` with `auipc` since these instructions share the U-Type format.
+(decl rv_lui (Imm20) XReg)
+(rule (rv_lui imm)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.Lui dst imm))))
+        dst))
+
+
 
 (decl select_addi (Type) AluOPRRI)
 (rule 1 (select_addi (fits_in_32 ty)) (AluOPRRI.Addiw))
@@ -1989,7 +2062,7 @@
 (rule 3 (extend val (ExtendOp.Zero) (fits_in_64 from_ty) $I128)
   (let ((val XReg (value_regs_get val 0))
         (low XReg (zext val from_ty $I64))
-        (high XReg (load_u64_constant 0)))
+        (high XReg (imm $I64 0)))
     (value_regs low high)))
 
 ;; Catch all rule for ignoring extensions of the same type.
@@ -2127,7 +2200,7 @@
 (rule (gen_bseti val bit)
   (if-let $false (has_zbs))
   (if-let $false (u64_le bit 12))
-  (let ((const XReg (load_u64_constant (u64_shl 1 bit))))
+  (let ((const XReg (imm $I64 (u64_shl 1 bit))))
     (rv_or val const)))
 
 (rule (gen_bseti val bit)
@@ -2169,7 +2242,7 @@
       (high XReg (lower_popcnt (value_regs_get a 1) $I64))
       ;; add toghter.
       (result XReg (rv_add low high)))
-    (value_regs result (load_u64_constant 0))))
+    (value_regs result (imm $I64 0))))
 
 (decl lower_i128_rotl (ValueRegs ValueRegs) ValueRegs)
 (rule
@@ -2190,7 +2263,7 @@
       (high_part3 XReg (gen_select_reg (IntCC.Equal) shamt (zero_reg) (zero_reg) high_part2))
       (high XReg (rv_or high_part1 high_part3))
       ;;
-      (const64 XReg (load_u64_constant 64))
+      (const64 XReg (imm $I64 64))
       (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
     ;; right now we only rotate less than 64 bits.
     ;; if shamt is greater than or equal 64 , we should switch low and high.
@@ -2220,7 +2293,7 @@
       (high XReg (rv_or high_part1 high_part3))
 
       ;;
-      (const64 XReg (load_u64_constant 64))
+      (const64 XReg (imm $I64 64))
       (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
     ;; right now we only rotate less than 64 bits.
     ;; if shamt is greater than or equal 64 , we should switch low and high.
@@ -2401,10 +2474,6 @@
 ;; Parameters are "intcc compare_a compare_b rs1 rs2".
 (decl gen_select_reg (IntCC XReg XReg Reg Reg) Reg)
 (extern constructor gen_select_reg gen_select_reg)
-
-;; load a constant into reg.
-(decl load_u64_constant (u64) Reg)
-(extern constructor load_u64_constant load_u64_constant)
 
 ;;; clone WritableReg
 ;;; if not rust compiler will complain about use moved value.
@@ -2733,8 +2802,8 @@
 (rule
   (gen_div_overflow rs1 rs2 ty)
   (let
-    ((r_const_neg_1 XReg (load_imm12 -1))
-      (r_const_min XReg (rv_slli (load_imm12 1) (imm12_const 63)))
+    ((r_const_neg_1 XReg (imm $I64 (i64_as_u64 -1)))
+      (r_const_min XReg (rv_slli (imm $I64 1) (imm12_const 63)))
       (tmp_rs1 XReg (shift_int_to_most_significant rs1 ty))
       (t1 XReg (gen_icmp (IntCC.Equal) r_const_neg_1 rs2 ty))
       (t2 XReg (gen_icmp (IntCC.Equal) r_const_min tmp_rs1 ty))

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -177,18 +177,6 @@ impl MachInstEmitState<Inst> for EmitState {
 }
 
 impl Inst {
-    /// construct a "imm - rs".
-    pub(crate) fn construct_imm_sub_rs(rd: Writable<Reg>, imm: u64, rs: Reg) -> SmallInstVec<Inst> {
-        let mut insts = Inst::load_constant_u64(rd, imm, &mut |_| rd);
-        insts.push(Inst::AluRRR {
-            alu_op: AluOPRRR::Sub,
-            rd,
-            rs1: rd.to_reg(),
-            rs2: rs,
-        });
-        insts
-    }
-
     /// Load int mask.
     /// If ty is int then 0xff in rd.
     pub(crate) fn load_int_mask(rd: Writable<Reg>, ty: Type) -> SmallInstVec<Inst> {

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -664,7 +664,7 @@ impl MachInstEmit for Inst {
 
                 let base = from.get_base_register();
                 let offset = from.get_offset_with_state(state);
-                let offset_imm12 = Imm12::maybe_from_u64(offset as u64);
+                let offset_imm12 = Imm12::maybe_from_i64(offset);
 
                 let (addr, imm12) = match (base, offset_imm12) {
                     // If the offset fits into an imm12 we can directly encode it.
@@ -691,7 +691,7 @@ impl MachInstEmit for Inst {
 
                 let base = to.get_base_register();
                 let offset = to.get_offset_with_state(state);
-                let offset_imm12 = Imm12::maybe_from_u64(offset as u64);
+                let offset_imm12 = Imm12::maybe_from_i64(offset);
 
                 let (addr, imm12) = match (base, offset_imm12) {
                     // If the offset fits into an imm12 we can directly encode it.
@@ -773,7 +773,7 @@ impl MachInstEmit for Inst {
                     .for_each(|i| i.emit(&[], sink, emit_info, state));
             }
             &Inst::AdjustSp { amount } => {
-                if let Some(imm) = Imm12::maybe_from_u64(amount as u64) {
+                if let Some(imm) = Imm12::maybe_from_i64(amount) {
                     Inst::AluRRImm12 {
                         alu_op: AluOPRRI::Addi,
                         rd: writable_stack_reg(),
@@ -1252,7 +1252,7 @@ impl MachInstEmit for Inst {
 
                 let base = mem.get_base_register();
                 let offset = mem.get_offset_with_state(state);
-                let offset_imm12 = Imm12::maybe_from_u64(offset as u64);
+                let offset_imm12 = Imm12::maybe_from_i64(offset);
 
                 match (mem, base, offset_imm12) {
                     (_, Some(rs), Some(imm12)) => {
@@ -3188,7 +3188,7 @@ fn emit_return_call_common_sequence(
         alu_op: AluOPRRI::Addi,
         rd: regs::writable_stack_reg(),
         rs: regs::fp_reg(),
-        imm12: Imm12::maybe_from_u64(fp_to_callee_sp as u64).unwrap(),
+        imm12: Imm12::maybe_from_i64(fp_to_callee_sp).unwrap(),
     }
     .emit(&[], sink, emit_info, state);
 

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -783,7 +783,7 @@ impl MachInstEmit for Inst {
                     .emit(&[], sink, emit_info, state);
                 } else {
                     let tmp = writable_spilltmp_reg();
-                    let mut insts = Inst::load_constant_u64(tmp, amount as u64, &mut |_| tmp);
+                    let mut insts = Inst::load_constant_u64(tmp, amount as u64);
                     insts.push(Inst::AluRRR {
                         alu_op: AluOPRRR::Add,
                         rd: writable_stack_reg(),
@@ -1107,7 +1107,7 @@ impl MachInstEmit for Inst {
                 // Check if the index passed in is larger than the number of jumptable
                 // entries that we have. If it is, we fallthrough to a jump into the
                 // default block.
-                Inst::load_constant_u32(tmp2, targets.len() as u64, &mut |_| tmp2)
+                Inst::load_constant_u32(tmp2, targets.len() as u64)
                     .iter()
                     .for_each(|i| i.emit(&[], sink, emit_info, state));
                 Inst::CondBr {
@@ -1902,7 +1902,6 @@ impl MachInstEmit for Inst {
                             // I8
                             (u8::MAX >> 1) as u64
                         },
-                        &mut |_| writable_spilltmp_reg2(),
                     )
                     .into_iter()
                     .for_each(|x| x.emit(&[], sink, emit_info, state));
@@ -2779,14 +2778,10 @@ impl MachInstEmit for Inst {
                 tmp: guard_size_tmp,
             } => {
                 let step = writable_spilltmp_reg();
-                Inst::load_constant_u64(
-                    step,
-                    (guard_size as u64) * (probe_count as u64),
-                    &mut |_| step,
-                )
-                .iter()
-                .for_each(|i| i.emit(&[], sink, emit_info, state));
-                Inst::load_constant_u64(guard_size_tmp, guard_size as u64, &mut |_| guard_size_tmp)
+                Inst::load_constant_u64(step, (guard_size as u64) * (probe_count as u64))
+                    .iter()
+                    .for_each(|i| i.emit(&[], sink, emit_info, state));
+                Inst::load_constant_u64(guard_size_tmp, guard_size as u64)
                     .iter()
                     .for_each(|i| i.emit(&[], sink, emit_info, state));
 

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -188,14 +188,10 @@ impl Inst {
     ///
     /// `value` must be between `imm_min()` and `imm_max()`, or else
     /// this helper returns `None`.
-    pub(crate) fn generate_imm<R>(
-        value: u64,
-        mut handle_imm: impl FnMut(Option<Imm20>, Option<Imm12>) -> R,
-    ) -> Option<R> {
+    pub(crate) fn generate_imm(value: u64) -> Option<(Imm20, Imm12)> {
         if let Some(imm12) = Imm12::maybe_from_u64(value) {
             // can be load using single imm12.
-            let r = handle_imm(None, Some(imm12));
-            return Some(r);
+            return Some((Imm20::from_bits(0), imm12));
         }
         let value = value as i64;
         if !(value >= Self::imm_min() && value <= Self::imm_max()) {
@@ -227,17 +223,9 @@ impl Inst {
         };
         assert!(imm20 >= -(0x7_ffff + 1) && imm20 <= 0x7_ffff);
         assert!(imm20 != 0 || imm12 != 0);
-        Some(handle_imm(
-            if imm20 != 0 {
-                Some(Imm20::from_bits(imm20 as i32))
-            } else {
-                None
-            },
-            if imm12 != 0 {
-                Some(Imm12::from_bits(imm12 as i16))
-            } else {
-                None
-            },
+        Some((
+            Imm20::from_bits(imm20 as i32),
+            Imm12::from_bits(imm12 as i16),
         ))
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -79,14 +79,6 @@ impl Imm20 {
         }
     }
 
-    pub fn maybe_from_u64(bits: u64) -> Option<Self> {
-        if (bits & 0xF_FFFF) != 0 {
-            None
-        } else {
-            Some(Self::from_bits(bits as i32))
-        }
-    }
-
     #[inline]
     pub fn as_u32(&self) -> u32 {
         (self.bits as u32) & 0xf_ffff

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -13,6 +13,7 @@ pub struct Imm12 {
 impl Imm12 {
     pub(crate) const FALSE: Self = Self { bits: 0 };
     pub(crate) const TRUE: Self = Self { bits: 1 };
+
     pub fn maybe_from_u64(val: u64) -> Option<Imm12> {
         let sign_bit = 1 << 11;
         if val == 0 {
@@ -29,6 +30,15 @@ impl Imm12 {
             None
         }
     }
+
+    pub fn maybe_from_i64(val: i64) -> Option<Imm12> {
+        if val >= -2048 && val <= 2047 {
+            Some(Imm12 { bits: val as i16 })
+        } else {
+            None
+        }
+    }
+
     #[inline]
     pub fn from_bits(bits: i16) -> Self {
         Self { bits: bits & 0xfff }

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -91,6 +91,15 @@ impl Imm20 {
             bits: bits & 0xf_ffff,
         }
     }
+
+    pub fn maybe_from_u64(bits: u64) -> Option<Self> {
+        if (bits & 0xF_FFFF) != 0 {
+            None
+        } else {
+            Some(Self::from_bits(bits as i32))
+        }
+    }
+
     #[inline]
     pub fn as_u32(&self) -> u32 {
         (self.bits as u32) & 0xf_ffff

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -15,20 +15,7 @@ impl Imm12 {
     pub(crate) const TRUE: Self = Self { bits: 1 };
 
     pub fn maybe_from_u64(val: u64) -> Option<Imm12> {
-        let sign_bit = 1 << 11;
-        if val == 0 {
-            Some(Imm12 { bits: 0 })
-        } else if (val & sign_bit) != 0 && (val >> 12) == 0xffff_ffff_ffff_f {
-            Some(Imm12 {
-                bits: (val & 0xffff) as i16,
-            })
-        } else if (val & sign_bit) == 0 && (val >> 12) == 0 {
-            Some(Imm12 {
-                bits: (val & 0xffff) as i16,
-            })
-        } else {
-            None
-        }
+        Self::maybe_from_i64(val as i64)
     }
 
     pub fn maybe_from_i64(val: i64) -> Option<Imm12> {

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -200,18 +200,22 @@ impl Inst {
         value: u64,
         alloc_tmp: &mut F,
     ) -> Option<SmallInstVec<Inst>> {
-        Inst::generate_imm(value, |imm20, imm12| {
+        Inst::generate_imm(value).map(|(imm20, imm12)| {
             let mut insts = SmallVec::new();
 
-            let rs = if let Some(imm) = imm20 {
-                let rd = if imm12.is_some() { alloc_tmp(I64) } else { rd };
-                insts.push(Inst::Lui { rd, imm });
+            let rs = if imm20.as_u32() != 0 {
+                let rd = if imm12.as_i16() != 0 {
+                    alloc_tmp(I64)
+                } else {
+                    rd
+                };
+                insts.push(Inst::Lui { rd, imm: imm20 });
                 rd.to_reg()
             } else {
                 zero_reg()
             };
 
-            if let Some(imm12) = imm12 {
+            if imm12.as_i16() != 0 {
                 insts.push(Inst::AluRRImm12 {
                     alu_op: AluOPRRI::Addi,
                     rd,
@@ -252,19 +256,20 @@ impl Inst {
         tmp: Writable<Reg>,
         offset: i64,
     ) -> [Inst; 2] {
-        Inst::generate_imm(offset as u64, |imm20, imm12| {
-            let a = Inst::Auipc {
-                rd: tmp,
-                imm: imm20.unwrap_or_default(),
-            };
-            let b = Inst::Jalr {
-                rd: link.unwrap_or(writable_zero_reg()),
-                base: tmp.to_reg(),
-                offset: imm12.unwrap_or_default(),
-            };
-            [a, b]
-        })
-        .expect("code range is too big.")
+        Inst::generate_imm(offset as u64)
+            .map(|(imm20, imm12)| {
+                let a = Inst::Auipc {
+                    rd: tmp,
+                    imm: imm20,
+                };
+                let b = Inst::Jalr {
+                    rd: link.unwrap_or(writable_zero_reg()),
+                    base: tmp.to_reg(),
+                    offset: imm12,
+                };
+                [a, b]
+            })
+            .expect("code range is too big.")
     }
 
     /// Create instructions that load a 32-bit floating-point constant.
@@ -2071,22 +2076,21 @@ impl LabelUse {
             }
             LabelUse::PCRel32 => {
                 let insn2 = u32::from_le_bytes([buffer[4], buffer[5], buffer[6], buffer[7]]);
-                Inst::generate_imm(offset as u64, |imm20, imm12| {
-                    let imm20 = imm20.unwrap_or_default();
-                    let imm12 = imm12.unwrap_or_default();
-                    // Encode the OR-ed-in value with zero_reg(). The
-                    // register parameter must be in the original
-                    // encoded instruction and or'ing in zeroes does not
-                    // change it.
-                    buffer[0..4].clone_from_slice(&u32::to_le_bytes(
-                        insn | enc_auipc(writable_zero_reg(), imm20),
-                    ));
-                    buffer[4..8].clone_from_slice(&u32::to_le_bytes(
-                        insn2 | enc_jalr(writable_zero_reg(), zero_reg(), imm12),
-                    ));
-                })
-                // expect make sure we handled.
-                .expect("we have check the range before,this is a compiler error.");
+                Inst::generate_imm(offset as u64)
+                    .map(|(imm20, imm12)| {
+                        // Encode the OR-ed-in value with zero_reg(). The
+                        // register parameter must be in the original
+                        // encoded instruction and or'ing in zeroes does not
+                        // change it.
+                        buffer[0..4].clone_from_slice(&u32::to_le_bytes(
+                            insn | enc_auipc(writable_zero_reg(), imm20),
+                        ));
+                        buffer[4..8].clone_from_slice(&u32::to_le_bytes(
+                            insn2 | enc_jalr(writable_zero_reg(), zero_reg(), imm12),
+                        ));
+                    })
+                    // expect make sure we handled.
+                    .expect("we have check the range before,this is a compiler error.");
             }
 
             LabelUse::B12 => {

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -807,7 +807,7 @@
 ;; This is just a mnemonic for `vxor.vi vd, vs, -1`
 (decl rv_vnot_v (VReg VecOpMasking VState) VReg)
 (rule (rv_vnot_v vs2 mask vstate)
-  (if-let neg1 (imm5_from_i8 -1))
+  (if-let neg1 (i8_to_imm5 -1))
   (rv_vxor_vi vs2 neg1 mask vstate))
 
 ;; Helper for emitting the `vmax.vv` instruction.
@@ -1505,8 +1505,8 @@
 ;; lanes are set to all zeros.
 (decl gen_expand_mask (Type VReg) VReg)
 (rule (gen_expand_mask ty mask)
-  (if-let zero (imm5_from_i8 0))
-  (if-let neg1 (imm5_from_i8 -1))
+  (if-let zero (i8_to_imm5 0))
+  (if-let neg1 (i8_to_imm5 -1))
   (rv_vmerge_vim (rv_vmv_vi zero ty) neg1 mask ty))
 
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -156,7 +156,7 @@
   (if-let $true (ty_equal (lane_type in_ty) sext_ty))
   (rv_vwadd_vx x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 14 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (sextend x @ (value_type sext_ty)))
+(rule 15 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (sextend x @ (value_type sext_ty)))
                                                             (swiden_low y @ (value_type in_ty)))))
   (if-let $true (ty_equal (lane_type in_ty) sext_ty))
   (rv_vwadd_vx y x (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
@@ -179,7 +179,7 @@
   (if-let $true (ty_equal (lane_type in_ty) sext_ty))
   (rv_vwadd_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 14 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (sextend x @ (value_type sext_ty)))
+(rule 15 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (sextend x @ (value_type sext_ty)))
                                                             (swiden_high y @ (value_type in_ty)))))
   (if-let $true (ty_equal (lane_type in_ty) sext_ty))
   (rv_vwadd_vx (gen_slidedown_half in_ty y) x (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
@@ -201,7 +201,7 @@
   (if-let $true (ty_equal (lane_type in_ty) uext_ty))
   (rv_vwaddu_vx x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 14 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (uextend x @ (value_type uext_ty)))
+(rule 15 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (uextend x @ (value_type uext_ty)))
                                                             (uwiden_low y @ (value_type in_ty)))))
   (if-let $true (ty_equal (lane_type in_ty) uext_ty))
   (rv_vwaddu_vx y x (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
@@ -224,7 +224,7 @@
   (if-let $true (ty_equal (lane_type in_ty) uext_ty))
   (rv_vwaddu_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 14 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (uextend y @ (value_type uext_ty)))
+(rule 15 (lower (has_type (ty_vec_fits_in_register _) (iadd (splat (uextend y @ (value_type uext_ty)))
                                                             (uwiden_high x @ (value_type in_ty)))))
   (if-let $true (ty_equal (lane_type in_ty) uext_ty))
   (rv_vwaddu_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1773,7 +1773,7 @@
 ;; If we are inserting from an Imm5 const we can use the immediate
 ;; variant of vmerge.
 (rule 2 (lower (insertlane vec @ (value_type (ty_vec_fits_in_register ty))
-                           (iconst (u64_from_imm64 (imm5_from_u64 imm)))
+                           (i64_from_iconst (imm5_from_i64 imm))
                            (u8_from_uimm8 lane)))
   (let ((mask VReg (gen_vec_mask (u64_shl 1 lane))))
     (rv_vmerge_vim vec imm mask ty)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -888,7 +888,7 @@
         (high_part3 XReg (rv_sll (value_regs_get x 1) shamt))
         (high XReg (rv_or high_part2 high_part3))
         ;;
-        (const64 XReg (load_u64_constant 64))
+        (const64 XReg (imm $I64 64))
         (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
     (value_regs
       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 (zero_reg) low)
@@ -940,7 +940,7 @@
         (low_part3 XReg (rv_srl (value_regs_get x 0) shamt))
         (low XReg (rv_or low_part2 low_part3))
         ;;
-        (const64 XReg (load_u64_constant 64))
+        (const64 XReg (imm $I64 64))
         ;;
         (high XReg (rv_srl (value_regs_get x 1) shamt))
         (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
@@ -994,14 +994,14 @@
         (low_part3 XReg (rv_srl (value_regs_get x 0) shamt))
         (low XReg (rv_or low_part2 low_part3))
         ;;
-        (const64 XReg (load_u64_constant 64))
+        (const64 XReg (imm $I64 64))
         ;;
         (high XReg (rv_sra (value_regs_get x 1) shamt))
         ;;
-        (const_neg_1 XReg (load_imm12 -1))
+        (const_neg_1 XReg (imm $I64 (i64_as_u64 -1)))
         ;;
         (high_replacement XReg (gen_select_reg (IntCC.SignedLessThan) (value_regs_get x 1) (zero_reg) const_neg_1 (zero_reg)))
-        (const64 XReg (load_u64_constant 64))
+        (const64 XReg (imm $I64 64))
         (shamt_128 XReg (rv_andi (value_regs_get y 0) (imm12_const 127))))
     (value_regs
       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 high low)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1854,7 +1854,7 @@
 ;; The reduce operation leaves the result in the lowest lane, we then move it
 ;; into the destination X register.
 (rule (lower (vall_true x @ (value_type (ty_vec_fits_in_register ty))))
-  (if-let one (imm5_from_i8 1))
+  (if-let one (i8_to_imm5 1))
   ;; We don't need to broadcast the immediate into all lanes, only into lane 0.
   ;; I did it this way since it uses one less instruction than with a vmv.s.x.
   (let ((fixed VReg (rv_vmv_vi one ty))
@@ -1912,7 +1912,7 @@
 ;; vrgather will insert a 0 for lanes that are out of bounds, so we can let it load
 ;; negative and out of bounds indexes.
 (rule (lower (has_type (ty_vec_fits_in_register ty @ $I8X16) (shuffle x y (vconst_from_immediate mask))))
-  (if-let neg16 (imm5_from_i8 -16))
+  (if-let neg16 (i8_to_imm5 -16))
   (let ((x_mask VReg (gen_constant ty mask))
         (x_lanes VReg (rv_vrgather_vv x x_mask (unmasked) ty))
         (y_mask VReg (rv_vadd_vi x_mask neg16 (unmasked) ty))

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -357,7 +357,7 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     }
     #[inline]
     fn imm_from_neg_bits(&mut self, val: i64) -> Imm12 {
-        Imm12::maybe_from_u64(val as u64).unwrap()
+        Imm12::maybe_from_i64(val).unwrap()
     }
 
     fn gen_default_frm(&mut self) -> OptionFloatRoundingMode {
@@ -383,14 +383,14 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     }
 
     fn imm12_const(&mut self, val: i32) -> Imm12 {
-        if let Some(res) = Imm12::maybe_from_u64(val as u64) {
+        if let Some(res) = Imm12::maybe_from_i64(val as i64) {
             res
         } else {
             panic!("Unable to make an Imm12 value from {}", val)
         }
     }
     fn imm12_const_add(&mut self, val: i32, add: i32) -> Imm12 {
-        Imm12::maybe_from_u64((val + add) as u64).unwrap()
+        Imm12::maybe_from_i64((val + add) as i64).unwrap()
     }
 
     //

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -307,6 +307,10 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         Imm12::maybe_from_u64(arg0)
     }
     #[inline]
+    fn imm12_from_i64(&mut self, arg0: i64) -> Option<Imm12> {
+        Imm12::maybe_from_i64(arg0)
+    }
+    #[inline]
     fn imm5_from_u64(&mut self, arg0: u64) -> Option<Imm5> {
         Imm5::maybe_from_i8(i8::try_from(arg0 as i64).ok()?)
     }

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -306,11 +306,6 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     }
 
     #[inline]
-    fn u64_to_imm20(&mut self, imm: u64) -> Option<Imm20> {
-        Imm20::maybe_from_u64(imm)
-    }
-
-    #[inline]
     fn imm20_is_zero(&mut self, imm: Imm20) -> Option<()> {
         if imm.as_u32() == 0 {
             Some(())

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -315,7 +315,7 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         Imm5::maybe_from_i8(i8::try_from(arg0 as i64).ok()?)
     }
     #[inline]
-    fn imm5_from_i8(&mut self, arg0: i8) -> Option<Imm5> {
+    fn i8_to_imm5(&mut self, arg0: i8) -> Option<Imm5> {
         Imm5::maybe_from_i8(arg0)
     }
     #[inline]

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -315,6 +315,10 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         Imm5::maybe_from_i8(i8::try_from(arg0 as i64).ok()?)
     }
     #[inline]
+    fn imm5_from_i64(&mut self, arg0: i64) -> Option<Imm5> {
+        Imm5::maybe_from_i8(i8::try_from(arg0).ok()?)
+    }
+    #[inline]
     fn i8_to_imm5(&mut self, arg0: i8) -> Option<Imm5> {
         Imm5::maybe_from_i8(arg0)
     }

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -339,10 +339,6 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         writable_zero_reg()
     }
     #[inline]
-    fn neg_imm12(&mut self, arg0: Imm12) -> Imm12 {
-        -arg0
-    }
-    #[inline]
     fn zero_reg(&mut self) -> Reg {
         zero_reg()
     }

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -280,8 +280,8 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         }
     }
 
-    fn generate_imm(&mut self, imm: u64) -> Option<(Imm20, Imm12)> {
-        MInst::generate_imm(imm)
+    fn i64_generate_imm(&mut self, imm: i64) -> Option<(Imm20, Imm12)> {
+        MInst::generate_imm(imm as u64)
     }
 
     #[inline]

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -170,6 +170,12 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn i64_sextend_u64(&mut self, ty: Type, x: u64) -> i64 {
+            let shift_amt = std::cmp::max(0, 64 - ty.bits());
+            ((x as i64) << shift_amt) >> shift_amt
+        }
+
+        #[inline]
         fn i64_sextend_imm64(&mut self, ty: Type, mut x: Imm64) -> i64 {
             x.sign_extend_from_width(ty.bits());
             x.bits()

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -209,6 +209,15 @@ macro_rules! isle_lower_prelude_methods {
             self.lower_ctx.dfg().value_def(val).inst()
         }
 
+        #[inline]
+        fn i64_from_iconst(&mut self, val: Value) -> Option<i64> {
+            let inst = self.def_inst(val)?;
+            let constant = self.lower_ctx.get_constant(inst)? as i64;
+            let ty = self.lower_ctx.output_ty(inst, 0);
+            let shift_amt = std::cmp::max(0, 64 - self.ty_bits(ty));
+            Some((constant << shift_amt) >> shift_amt)
+        }
+
         fn zero_value(&mut self, value: Value) -> Option<Value> {
             let insn = self.def_inst(value);
             if insn.is_some() {

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -184,6 +184,10 @@
 (decl pure u64_lt (u64 u64) bool)
 (extern constructor u64_lt u64_lt)
 
+;; Sign extends a u64 from ty bits up to 64bits
+(decl pure i64_sextend_u64 (Type u64) i64)
+(extern constructor i64_sextend_u64 i64_sextend_u64)
+
 (decl pure i64_sextend_imm64 (Type Imm64) i64)
 (extern constructor i64_sextend_imm64 i64_sextend_imm64)
 

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -253,6 +253,11 @@
 (extractor (u64_from_iconst x)
            (def_inst (iconst (u64_from_imm64 x))))
 
+;; Extract a constant `i64` from a value defined by an `iconst`.
+;; The value is sign extended to 64 bits.
+(decl i64_from_iconst (i64) Value)
+(extern extractor i64_from_iconst i64_from_iconst)
+
 ;; Match any zero value for iconst, fconst32, fconst64, vconst and splat.
 (decl pure partial zero_value (Value) Value)
 (extern constructor zero_value zero_value)

--- a/cranelift/filetests/filetests/isa/riscv64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/amodes.clif
@@ -142,21 +142,21 @@ block0(v0: i64, v1: i64, v2: i64):
 
 ; VCode:
 ; block0:
-;   lui a6,1
-;   addi a6,a6,4
-;   add a7,a0,a1
-;   add a7,a7,a2
-;   add a6,a7,a6
+;   lui a5,1
+;   addi a7,a5,4
+;   add a6,a0,a1
+;   add a6,a6,a2
+;   add a6,a6,a7
 ;   lw a0,0(a6)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a6, 1
-;   addi a6, a6, 4
-;   add a7, a0, a1
-;   add a7, a7, a2
-;   add a6, a7, a6
+;   lui a5, 1
+;   addi a7, a5, 4
+;   add a6, a0, a1
+;   add a6, a6, a2
+;   add a6, a6, a7
 ;   lw a0, 0(a6)
 ;   ret
 
@@ -231,17 +231,17 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   lui a2,244141
-;   addi a2,a2,2560
-;   add a2,a0,a2
+;   lui a1,244141
+;   addi a3,a1,2560
+;   add a2,a0,a3
 ;   lw a0,0(a2)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a2, 0x3b9ad
-;   addi a2, a2, -0x600
-;   add a2, a0, a2
+;   lui a1, 0x3b9ad
+;   addi a3, a1, -0x600
+;   add a2, a0, a3
 ;   lw a0, 0(a2)
 ;   ret
 
@@ -299,18 +299,18 @@ block0(v0: i64, v1: i64, v2: i64):
 
 ; VCode:
 ; block0:
-;   lui a5,1048575
-;   addi a5,a5,4094
-;   slli a4,a5,32
+;   lui a4,1048575
+;   addi a6,a4,4094
+;   slli a4,a6,32
 ;   srli a6,a4,32
 ;   lh a0,0(a6)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a5, 0xfffff
-;   addi a5, a5, -2
-;   slli a4, a5, 0x20
+;   lui a4, 0xfffff
+;   addi a6, a4, -2
+;   slli a4, a6, 0x20
 ;   srli a6, a4, 0x20
 ;   lh a0, 0(a6)
 ;   ret
@@ -325,18 +325,18 @@ block0(v0: i64, v1: i64, v2: i64):
 
 ; VCode:
 ; block0:
-;   lui a5,1
-;   addi a5,a5,2
-;   slli a4,a5,32
+;   lui a4,1
+;   addi a6,a4,2
+;   slli a4,a6,32
 ;   srli a6,a4,32
 ;   lh a0,0(a6)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a5, 1
-;   addi a5, a5, 2
-;   slli a4, a5, 0x20
+;   lui a4, 1
+;   addi a6, a4, 2
+;   slli a4, a6, 0x20
 ;   srli a6, a4, 0x20
 ;   lh a0, 0(a6)
 ;   ret
@@ -351,17 +351,17 @@ block0(v0: i64, v1: i64, v2: i64):
 
 ; VCode:
 ; block0:
-;   lui a4,1048575
-;   addi a4,a4,4094
-;   sext.w a4,a4
+;   lui a3,1048575
+;   addi a5,a3,4094
+;   sext.w a4,a5
 ;   lh a0,0(a4)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a4, 0xfffff
-;   addi a4, a4, -2
-;   sext.w a4, a4
+;   lui a3, 0xfffff
+;   addi a5, a3, -2
+;   sext.w a4, a5
 ;   lh a0, 0(a4)
 ;   ret
 
@@ -375,17 +375,17 @@ block0(v0: i64, v1: i64, v2: i64):
 
 ; VCode:
 ; block0:
-;   lui a4,1
-;   addi a4,a4,2
-;   sext.w a4,a4
+;   lui a3,1
+;   addi a5,a3,2
+;   sext.w a4,a5
 ;   lh a0,0(a4)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a4, 1
-;   addi a4, a4, 2
-;   sext.w a4, a4
+;   lui a3, 1
+;   addi a5, a3, 2
+;   sext.w a4, a5
 ;   lh a0, 0(a4)
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
@@ -882,3 +882,37 @@ block0(v0: i64):
 ;   div a0, a0, a6
 ;   ret
 
+
+function %i8_iadd_const_neg1(i8) -> i8 {
+block0(v0: i8):
+  v1 = iconst.i8 -1
+  v2 = iadd.i8 v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   addiw a0,a0,-1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addiw a0, a0, -1
+;   ret
+
+function %i8_iadd_const_ff(i8) -> i8 {
+block0(v0: i8):
+  v1 = iconst.i8 0xFF
+  v2 = iadd.i8 v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   addiw a0,a0,-1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addiw a0, a0, -1
+;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/atomic_store.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/atomic_store.clif
@@ -53,15 +53,15 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   lui a1,3
-;   addi a1,a1,57
+;   lui t2,3
+;   addi a1,t2,57
 ;   atomic_store.i64 a1,(a0)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a1, 3
-;   addi a1, a1, 0x39
+;   lui t2, 3
+;   addi a1, t2, 0x39
 ;   fence rw, w
 ;   sd a1, 0(a0)
 ;   ret
@@ -117,15 +117,15 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   lui a1,3
-;   addi a1,a1,57
+;   lui t2,3
+;   addi a1,t2,57
 ;   atomic_store.i32 a1,(a0)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a1, 3
-;   addi a1, a1, 0x39
+;   lui t2, 3
+;   addi a1, t2, 0x39
 ;   fence rw, w
 ;   sw a1, 0(a0)
 ;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/bitops-float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitops-float.clif
@@ -22,9 +22,9 @@ block1(v4: f32):
 ; VCode:
 ; block0:
 ;   li a0,0
-;   li t1,0
-;   fmv.w.x fa6,t1
-;   fmv.x.w t4,fa6
+;   li t0,0
+;   fmv.w.x fa7,t0
+;   fmv.x.w t4,fa7
 ;   not t1,t4
 ;   fmv.w.x ft8,t1
 ;   fmv.x.w t3,ft8
@@ -35,7 +35,7 @@ block1(v4: f32):
 ; block1:
 ;   j label3
 ; block2:
-;   fmv.d fa1,fa6
+;   fmv.d fa1,fa7
 ;   j label3
 ; block3:
 ;   ret
@@ -43,9 +43,9 @@ block1(v4: f32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv a0, zero
-;   mv t1, zero
-;   fmv.w.x fa6, t1
-;   fmv.x.w t4, fa6
+;   mv t0, zero
+;   fmv.w.x fa7, t0
+;   fmv.x.w t4, fa7
 ;   not t1, t4
 ;   fmv.w.x ft8, t1
 ;   fmv.x.w t3, ft8
@@ -67,7 +67,7 @@ block1(v4: f32):
 ; block1: ; offset 0x58
 ;   j 8
 ; block2: ; offset 0x5c
-;   fmv.d fa1, fa6
+;   fmv.d fa1, fa7
 ; block3: ; offset 0x60
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/constants.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/constants.clif
@@ -58,14 +58,14 @@ block0:
 
 ; VCode:
 ; block0:
-;   lui t1,16
-;   addi a0,t1,4095
+;   lui t0,16
+;   addi a0,t0,4095
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui t1, 0x10
-;   addi a0, t1, -1
+;   lui t0, 0x10
+;   addi a0, t0, -1
 ;   ret
 
 function %f() -> i64 {
@@ -304,16 +304,12 @@ block0:
 
 ; VCode:
 ; block0:
-;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0xfffffff7
+;   li a0,-9
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   auipc a0, 0
-;   ld a0, 0xc(a0)
-;   j 0xc
-;   .byte 0xf7, 0xff, 0xff, 0xff
-;   .byte 0x00, 0x00, 0x00, 0x00
+;   addi a0, zero, -9
 ;   ret
 
 function %f() -> i64 {
@@ -360,18 +356,18 @@ block0:
 
 ; VCode:
 ; block0:
-;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0x3ff0000000000000
-;   fmv.d.x fa0,t1
+;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0x3ff0000000000000
+;   fmv.d.x fa0,t0
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   auipc t1, 0
-;   ld t1, 0xc(t1)
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   .byte 0x00, 0x00, 0xf0, 0x3f
-;   fmv.d.x fa0, t1
+;   fmv.d.x fa0, t0
 ;   ret
 
 function %f() -> f32 {
@@ -382,14 +378,14 @@ block0:
 
 ; VCode:
 ; block0:
-;   lui t1,264704
-;   fmv.w.x fa0,t1
+;   lui t0,264704
+;   fmv.w.x fa0,t0
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui t1, 0x40a00
-;   fmv.w.x fa0, t1
+;   lui t0, 0x40a00
+;   fmv.w.x fa0, t0
 ;   ret
 
 function %f() -> f64 {
@@ -400,18 +396,18 @@ block0:
 
 ; VCode:
 ; block0:
-;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0x4049000000000000
-;   fmv.d.x fa0,t1
+;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0x4049000000000000
+;   fmv.d.x fa0,t0
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   auipc t1, 0
-;   ld t1, 0xc(t1)
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   .byte 0x00, 0x00, 0x49, 0x40
-;   fmv.d.x fa0, t1
+;   fmv.d.x fa0, t0
 ;   ret
 
 function %f() -> f32 {
@@ -422,14 +418,14 @@ block0:
 
 ; VCode:
 ; block0:
-;   lui t1,271488
-;   fmv.w.x fa0,t1
+;   lui t0,271488
+;   fmv.w.x fa0,t0
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui t1, 0x42480
-;   fmv.w.x fa0, t1
+;   lui t0, 0x42480
+;   fmv.w.x fa0, t0
 ;   ret
 
 function %f() -> f64 {
@@ -440,14 +436,14 @@ block0:
 
 ; VCode:
 ; block0:
-;   li t1,0
-;   fmv.d.x fa0,t1
+;   li t0,0
+;   fmv.d.x fa0,t0
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mv t1, zero
-;   fmv.d.x fa0, t1
+;   mv t0, zero
+;   fmv.d.x fa0, t0
 ;   ret
 
 function %f() -> f32 {
@@ -458,14 +454,14 @@ block0:
 
 ; VCode:
 ; block0:
-;   li t1,0
-;   fmv.w.x fa0,t1
+;   li t0,0
+;   fmv.w.x fa0,t0
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mv t1, zero
-;   fmv.w.x fa0, t1
+;   mv t0, zero
+;   fmv.w.x fa0, t0
 ;   ret
 
 function %f() -> f64 {
@@ -476,18 +472,18 @@ block0:
 
 ; VCode:
 ; block0:
-;   auipc t1,0; ld t1,12(t1); j 12; .8byte 0xc030000000000000
-;   fmv.d.x fa0,t1
+;   auipc t0,0; ld t0,12(t0); j 12; .8byte 0xc030000000000000
+;   fmv.d.x fa0,t0
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   auipc t1, 0
-;   ld t1, 0xc(t1)
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   .byte 0x00, 0x00, 0x30, 0xc0
-;   fmv.d.x fa0, t1
+;   fmv.d.x fa0, t0
 ;   ret
 
 function %f() -> f32 {
@@ -498,16 +494,64 @@ block0:
 
 ; VCode:
 ; block0:
-;   auipc t1,0; ld t1,12(t1); j 8; .4byte 0xc1800000
-;   fmv.w.x fa0,t1
+;   lui t0,792576
+;   fmv.w.x fa0,t0
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   auipc t1, 0
-;   lwu t1, 0xc(t1)
-;   j 8
-;   .byte 0x00, 0x00, 0x80, 0xc1
-;   fmv.w.x fa0, t1
+;   lui t0, 0xc1800
+;   fmv.w.x fa0, t0
 ;   ret
 
+function %addi_1() -> i64 {
+block0:
+  v0 = iconst.i64 0xfff
+  return v0
+}
+
+; VCode:
+; block0:
+;   lui t0,1
+;   addi a0,t0,4095
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lui t0, 1
+;   addi a0, t0, -1
+;   ret
+
+function %addi_2() -> i64 {
+block0:
+  v0 = iconst.i64 0x800
+  return v0
+}
+
+; VCode:
+; block0:
+;   lui t0,1
+;   addi a0,t0,2048
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lui t0, 1
+;   addi a0, t0, -0x800
+;   ret
+
+function %addi_3() -> i64 {
+block0:
+  v0 = iconst.i64 0x7ff
+  return v0
+}
+
+; VCode:
+; block0:
+;   li a0,2047
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a0, zero, 0x7ff
+;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
@@ -14,9 +14,9 @@ block1:
 
 ; VCode:
 ; block0:
-;   li t2,0
-;   fmv.d.x ft2,t2
-;   fle.d t2,ft2,ft2
+;   li t1,0
+;   fmv.d.x ft3,t1
+;   fle.d t2,ft3,ft3
 ;   bne t2,zero,taken(label2),not_taken(label1)
 ; block1:
 ;   j label3
@@ -27,9 +27,9 @@ block1:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mv t2, zero
-;   fmv.d.x ft2, t2
-;   fle.d t2, ft2, ft2
+;   mv t1, zero
+;   fmv.d.x ft3, t1
+;   fle.d t2, ft3, ft3
 ; block1: ; offset 0xc
 ;   ret
 
@@ -45,9 +45,9 @@ block1:
 
 ; VCode:
 ; block0:
-;   li t2,0
-;   fmv.d.x ft2,t2
-;   fle.d t2,ft2,ft2
+;   li t1,0
+;   fmv.d.x ft3,t1
+;   fle.d t2,ft3,ft3
 ;   bne t2,zero,taken(label2),not_taken(label1)
 ; block1:
 ;   j label3
@@ -58,9 +58,9 @@ block1:
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mv t2, zero
-;   fmv.d.x ft2, t2
-;   fle.d t2, ft2, ft2
+;   mv t1, zero
+;   fmv.d.x ft3, t1
+;   fle.d t2, ft3, ft3
 ; block1: ; offset 0xc
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/iconst-icmp-small.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/iconst-icmp-small.clif
@@ -12,22 +12,22 @@ block0:
 
 ; VCode:
 ; block0:
-;   lui a3,14
-;   addi a3,a3,3532
-;   slli t2,a3,48
+;   lui a2,1048574
+;   addi a4,a2,3532
+;   slli t2,a4,48
 ;   srli a1,t2,48
-;   slli a3,a3,48
+;   slli a3,a4,48
 ;   srli a5,a3,48
 ;   ne a0,a1,a5##ty=i16
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a3, 0xe
-;   addi a3, a3, -0x234
-;   slli t2, a3, 0x30
+;   lui a2, 0xffffe
+;   addi a4, a2, -0x234
+;   slli t2, a4, 0x30
 ;   srli a1, t2, 0x30
-;   slli a3, a3, 0x30
+;   slli a3, a4, 0x30
 ;   srli a5, a3, 0x30
 ;   beq a1, a5, 0xc
 ;   addi a0, zero, 1

--- a/cranelift/filetests/filetests/isa/riscv64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/return-call.clif
@@ -96,20 +96,20 @@ block0(v0: f64):
 
 ; VCode:
 ; block0:
-;   auipc a1,0; ld a1,12(a1); j 12; .8byte 0x4030000000000000
-;   fmv.d.x ft4,a1
-;   fadd.d ft0,ft0,ft4
+;   auipc a0,0; ld a0,12(a0); j 12; .8byte 0x4030000000000000
+;   fmv.d.x ft5,a0
+;   fadd.d ft0,ft0,ft5
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   auipc a1, 0
-;   ld a1, 0xc(a1)
+;   auipc a0, 0
+;   ld a0, 0xc(a0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   .byte 0x00, 0x00, 0x30, 0x40
-;   fmv.d.x ft4, a1
-;   fadd.d ft0, ft0, ft4
+;   fmv.d.x ft5, a0
+;   fadd.d ft0, ft0, ft5
 ;   ret
 
 function %call_f64(f64) -> f64 tail {

--- a/cranelift/filetests/filetests/isa/riscv64/simd-popcnt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-popcnt.clif
@@ -84,22 +84,22 @@ block0(v0: i16x8):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   lui a2,5
-;   addi a2,a2,1365
+;   lui a1,5
+;   addi a3,a1,1365
 ;   vsrl.vi v8,v1,1 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vand.vx v10,v8,a2 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vand.vx v10,v8,a3 #avl=8, #vtype=(e16, m1, ta, ma)
 ;   vsub.vv v12,v1,v10 #avl=8, #vtype=(e16, m1, ta, ma)
-;   lui t2,3
-;   addi t2,t2,819
+;   lui t1,3
+;   addi a1,t1,819
 ;   vsrl.vi v18,v12,2 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vand.vx v20,v18,t2 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vand.vx v22,v12,t2 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vand.vx v20,v18,a1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vand.vx v22,v12,a1 #avl=8, #vtype=(e16, m1, ta, ma)
 ;   vadd.vv v24,v22,v20 #avl=8, #vtype=(e16, m1, ta, ma)
-;   lui t1,1
-;   addi t1,t1,3855
+;   lui t0,1
+;   addi t2,t0,3855
 ;   vsrl.vi v30,v24,4 #avl=8, #vtype=(e16, m1, ta, ma)
 ;   vadd.vv v0,v24,v30 #avl=8, #vtype=(e16, m1, ta, ma)
-;   vand.vx v2,v0,t1 #avl=8, #vtype=(e16, m1, ta, ma)
+;   vand.vx v2,v0,t2 #avl=8, #vtype=(e16, m1, ta, ma)
 ;   li a7,257
 ;   vmul.vx v6,v2,a7 #avl=8, #vtype=(e16, m1, ta, ma)
 ;   li t1,8
@@ -120,23 +120,23 @@ block0(v0: i16x8):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
-;   lui a2, 5
-;   addi a2, a2, 0x555
+;   lui a1, 5
+;   addi a3, a1, 0x555
 ;   .byte 0x57, 0x70, 0x84, 0xcc
 ;   .byte 0x57, 0xb4, 0x10, 0xa2
-;   .byte 0x57, 0x45, 0x86, 0x26
+;   .byte 0x57, 0xc5, 0x86, 0x26
 ;   .byte 0x57, 0x06, 0x15, 0x0a
-;   lui t2, 3
-;   addi t2, t2, 0x333
+;   lui t1, 3
+;   addi a1, t1, 0x333
 ;   .byte 0x57, 0x39, 0xc1, 0xa2
-;   .byte 0x57, 0xca, 0x23, 0x27
-;   .byte 0x57, 0xcb, 0xc3, 0x26
+;   .byte 0x57, 0xca, 0x25, 0x27
+;   .byte 0x57, 0xcb, 0xc5, 0x26
 ;   .byte 0x57, 0x0c, 0x6a, 0x03
-;   lui t1, 1
-;   addi t1, t1, -0xf1
+;   lui t0, 1
+;   addi t2, t0, -0xf1
 ;   .byte 0x57, 0x3f, 0x82, 0xa3
 ;   .byte 0x57, 0x00, 0x8f, 0x03
-;   .byte 0x57, 0x41, 0x03, 0x26
+;   .byte 0x57, 0xc1, 0x03, 0x26
 ;   addi a7, zero, 0x101
 ;   .byte 0x57, 0xe3, 0x28, 0x96
 ;   addi t1, zero, 8
@@ -161,25 +161,25 @@ block0(v0: i32x4):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v1,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   lui a2,349525
-;   addi a2,a2,1365
+;   lui a1,349525
+;   addi a3,a1,1365
 ;   vsrl.vi v8,v1,1 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vand.vx v10,v8,a2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vand.vx v10,v8,a3 #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vsub.vv v12,v1,v10 #avl=4, #vtype=(e32, m1, ta, ma)
-;   lui t2,209715
-;   addi t2,t2,819
+;   lui t1,209715
+;   addi a1,t1,819
 ;   vsrl.vi v18,v12,2 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vand.vx v20,v18,t2 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vand.vx v22,v12,t2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vand.vx v20,v18,a1 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vand.vx v22,v12,a1 #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vadd.vv v24,v22,v20 #avl=4, #vtype=(e32, m1, ta, ma)
-;   lui t1,61681
-;   addi t1,t1,3855
+;   lui t0,61681
+;   addi t2,t0,3855
 ;   vsrl.vi v30,v24,4 #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vadd.vv v0,v24,v30 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vand.vx v2,v0,t1 #avl=4, #vtype=(e32, m1, ta, ma)
-;   lui t3,4112
-;   addi t3,t3,257
-;   vmul.vx v8,v2,t3 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vand.vx v2,v0,t2 #avl=4, #vtype=(e32, m1, ta, ma)
+;   lui a7,4112
+;   addi t4,a7,257
+;   vmul.vx v8,v2,t4 #avl=4, #vtype=(e32, m1, ta, ma)
 ;   li a1,24
 ;   vsrl.vx v12,v8,a1 #avl=4, #vtype=(e32, m1, ta, ma)
 ;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
@@ -198,26 +198,26 @@ block0(v0: i32x4):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x80, 0x0f, 0x02
-;   lui a2, 0x55555
-;   addi a2, a2, 0x555
+;   lui a1, 0x55555
+;   addi a3, a1, 0x555
 ;   .byte 0x57, 0x70, 0x02, 0xcd
 ;   .byte 0x57, 0xb4, 0x10, 0xa2
-;   .byte 0x57, 0x45, 0x86, 0x26
+;   .byte 0x57, 0xc5, 0x86, 0x26
 ;   .byte 0x57, 0x06, 0x15, 0x0a
-;   lui t2, 0x33333
-;   addi t2, t2, 0x333
+;   lui t1, 0x33333
+;   addi a1, t1, 0x333
 ;   .byte 0x57, 0x39, 0xc1, 0xa2
-;   .byte 0x57, 0xca, 0x23, 0x27
-;   .byte 0x57, 0xcb, 0xc3, 0x26
+;   .byte 0x57, 0xca, 0x25, 0x27
+;   .byte 0x57, 0xcb, 0xc5, 0x26
 ;   .byte 0x57, 0x0c, 0x6a, 0x03
-;   lui t1, 0xf0f1
-;   addi t1, t1, -0xf1
+;   lui t0, 0xf0f1
+;   addi t2, t0, -0xf1
 ;   .byte 0x57, 0x3f, 0x82, 0xa3
 ;   .byte 0x57, 0x00, 0x8f, 0x03
-;   .byte 0x57, 0x41, 0x03, 0x26
-;   lui t3, 0x1010
-;   addi t3, t3, 0x101
-;   .byte 0x57, 0x64, 0x2e, 0x96
+;   .byte 0x57, 0xc1, 0x03, 0x26
+;   lui a7, 0x1010
+;   addi t4, a7, 0x101
+;   .byte 0x57, 0xe4, 0x2e, 0x96
 ;   addi a1, zero, 0x18
 ;   .byte 0x57, 0xc6, 0x85, 0xa2
 ;   .byte 0x57, 0x70, 0x08, 0xcc

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vhighbits.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vhighbits.clif
@@ -18,9 +18,9 @@ block0(v0: i8x16):
 ;   vle8.v v0,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vmslt.vx v2,v0,zero #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vmv.x.s a1,v2 #avl=2, #vtype=(e64, m1, ta, ma)
-;   lui a4,16
-;   addi a4,a4,4095
-;   and a0,a1,a4
+;   lui a3,16
+;   addi a5,a3,4095
+;   and a0,a1,a5
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -39,9 +39,9 @@ block0(v0: i8x16):
 ;   .byte 0x57, 0x41, 0x00, 0x6e
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0xd7, 0x25, 0x20, 0x42
-;   lui a4, 0x10
-;   addi a4, a4, -1
-;   and a0, a1, a4
+;   lui a3, 0x10
+;   addi a5, a3, -1
+;   and a0, a1, a5
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -44,8 +44,8 @@
 ;;   slli t0,a0,32
 ;;   srli t2,t0,32
 ;;   ld t1,8(a2)
-;;   lui a0,1048575
-;;   addi a0,a0,4092
+;;   lui t0,1048575
+;;   addi a0,t0,4092
 ;;   add t1,t1,a0
 ;;   ugt t1,t2,t1##ty=i64
 ;;   bne t1,zero,taken(label3),not_taken(label1)
@@ -66,8 +66,8 @@
 ;;   slli t0,a0,32
 ;;   srli t2,t0,32
 ;;   ld t1,8(a1)
-;;   lui a0,1048575
-;;   addi a0,a0,4092
+;;   lui t0,1048575
+;;   addi a0,t0,4092
 ;;   add t1,t1,a0
 ;;   ugt t1,t2,t1##ty=i64
 ;;   bne t1,zero,taken(label3),not_taken(label1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -44,8 +44,8 @@
 ;;   slli t0,a0,32
 ;;   srli t2,t0,32
 ;;   ld t1,8(a2)
-;;   lui a0,1048575
-;;   addi a0,a0,4095
+;;   lui t0,1048575
+;;   addi a0,t0,4095
 ;;   add t1,t1,a0
 ;;   ugt t1,t2,t1##ty=i64
 ;;   bne t1,zero,taken(label3),not_taken(label1)
@@ -66,8 +66,8 @@
 ;;   slli t0,a0,32
 ;;   srli t2,t0,32
 ;;   ld t1,8(a1)
-;;   lui a0,1048575
-;;   addi a0,a0,4095
+;;   lui t0,1048575
+;;   addi a0,t0,4095
 ;;   add t1,t1,a0
 ;;   ugt t1,t2,t1##ty=i64
 ;;   bne t1,zero,taken(label3),not_taken(label1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -44,8 +44,8 @@
 ;;   slli a5,a0,32
 ;;   srli a7,a5,32
 ;;   ld a6,8(a2)
-;;   lui t3,1048575
-;;   addi t3,t3,4092
+;;   lui a5,1048575
+;;   addi t3,a5,4092
 ;;   add a6,a6,t3
 ;;   ugt t3,a7,a6##ty=i64
 ;;   ld a6,0(a2)
@@ -70,8 +70,8 @@
 ;;   slli a5,a0,32
 ;;   srli a7,a5,32
 ;;   ld a6,8(a1)
-;;   lui t3,1048575
-;;   addi t3,t3,4092
+;;   lui a5,1048575
+;;   addi t3,a5,4092
 ;;   add a6,a6,t3
 ;;   ugt t3,a7,a6##ty=i64
 ;;   ld a6,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -44,8 +44,8 @@
 ;;   slli a5,a0,32
 ;;   srli a7,a5,32
 ;;   ld a6,8(a2)
-;;   lui t3,1048575
-;;   addi t3,t3,4095
+;;   lui a5,1048575
+;;   addi t3,a5,4095
 ;;   add a6,a6,t3
 ;;   ugt t3,a7,a6##ty=i64
 ;;   ld a6,0(a2)
@@ -70,8 +70,8 @@
 ;;   slli a5,a0,32
 ;;   srli a7,a5,32
 ;;   ld a6,8(a1)
-;;   lui t3,1048575
-;;   addi t3,t3,4095
+;;   lui a5,1048575
+;;   addi t3,a5,4095
 ;;   add a6,a6,t3
 ;;   ugt t3,a7,a6##ty=i64
 ;;   ld a6,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -42,8 +42,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld t4,8(a2)
-;;   lui t0,1048575
-;;   addi t0,t0,4092
+;;   lui t3,1048575
+;;   addi t0,t3,4092
 ;;   add t4,t4,t0
 ;;   ugt t4,a0,t4##ty=i64
 ;;   bne t4,zero,taken(label3),not_taken(label1)
@@ -62,8 +62,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld t4,8(a1)
-;;   lui t0,1048575
-;;   addi t0,t0,4092
+;;   lui t3,1048575
+;;   addi t0,t3,4092
 ;;   add t4,t4,t0
 ;;   ugt t4,a0,t4##ty=i64
 ;;   bne t4,zero,taken(label3),not_taken(label1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -42,8 +42,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld t4,8(a2)
-;;   lui t0,1048575
-;;   addi t0,t0,4095
+;;   lui t3,1048575
+;;   addi t0,t3,4095
 ;;   add t4,t4,t0
 ;;   ugt t4,a0,t4##ty=i64
 ;;   bne t4,zero,taken(label3),not_taken(label1)
@@ -62,8 +62,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld t4,8(a1)
-;;   lui t0,1048575
-;;   addi t0,t0,4095
+;;   lui t3,1048575
+;;   addi t0,t3,4095
 ;;   add t4,t4,t0
 ;;   ugt t4,a0,t4##ty=i64
 ;;   bne t4,zero,taken(label3),not_taken(label1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -42,8 +42,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a4,8(a2)
-;;   lui a5,1048575
-;;   addi a5,a5,4092
+;;   lui a3,1048575
+;;   addi a5,a3,4092
 ;;   add a4,a4,a5
 ;;   ugt a5,a0,a4##ty=i64
 ;;   ld a4,0(a2)
@@ -66,8 +66,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a4,8(a1)
-;;   lui a5,1048575
-;;   addi a5,a5,4092
+;;   lui a3,1048575
+;;   addi a5,a3,4092
 ;;   add a4,a4,a5
 ;;   ugt a5,a0,a4##ty=i64
 ;;   ld a4,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -42,8 +42,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a4,8(a2)
-;;   lui a5,1048575
-;;   addi a5,a5,4095
+;;   lui a3,1048575
+;;   addi a5,a3,4095
 ;;   add a4,a4,a5
 ;;   ugt a5,a0,a4##ty=i64
 ;;   ld a4,0(a2)
@@ -66,8 +66,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a4,8(a1)
-;;   lui a5,1048575
-;;   addi a5,a5,4095
+;;   lui a3,1048575
+;;   addi a5,a3,4095
 ;;   add a4,a4,a5
 ;;   ugt a5,a0,a4##ty=i64
 ;;   ld a4,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -41,9 +41,9 @@
 ;; block0:
 ;;   slli a6,a0,32
 ;;   srli t3,a6,32
-;;   lui a7,65536
-;;   addi a7,a7,4092
-;;   ugt a7,t3,a7##ty=i64
+;;   lui a6,65536
+;;   addi t4,a6,4092
+;;   ugt a7,t3,t4##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t4,0(a2)
@@ -59,9 +59,9 @@
 ;; block0:
 ;;   slli a6,a0,32
 ;;   srli t3,a6,32
-;;   lui a7,65536
-;;   addi a7,a7,4092
-;;   ugt a7,t3,a7##ty=i64
+;;   lui a6,65536
+;;   addi t4,a6,4092
+;;   ugt a7,t3,t4##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t4,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -41,9 +41,9 @@
 ;; block0:
 ;;   slli t3,a0,32
 ;;   srli t0,t3,32
-;;   lui t4,65535
-;;   addi t4,t4,4092
-;;   ugt t4,t0,t4##ty=i64
+;;   lui t3,65535
+;;   addi t1,t3,4092
+;;   ugt t4,t0,t1##ty=i64
 ;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t1,0(a2)
@@ -61,9 +61,9 @@
 ;; block0:
 ;;   slli t3,a0,32
 ;;   srli t0,t3,32
-;;   lui t4,65535
-;;   addi t4,t4,4092
-;;   ugt t4,t0,t4##ty=i64
+;;   lui t3,65535
+;;   addi t1,t3,4092
+;;   ugt t4,t0,t1##ty=i64
 ;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t1,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -41,9 +41,9 @@
 ;; block0:
 ;;   slli a6,a0,32
 ;;   srli t3,a6,32
-;;   lui a7,65536
-;;   addi a7,a7,4095
-;;   ugt a7,t3,a7##ty=i64
+;;   lui a6,65536
+;;   addi t4,a6,4095
+;;   ugt a7,t3,t4##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t4,0(a2)
@@ -59,9 +59,9 @@
 ;; block0:
 ;;   slli a6,a0,32
 ;;   srli t3,a6,32
-;;   lui a7,65536
-;;   addi a7,a7,4095
-;;   ugt a7,t3,a7##ty=i64
+;;   lui a6,65536
+;;   addi t4,a6,4095
+;;   ugt a7,t3,t4##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t4,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -41,9 +41,9 @@
 ;; block0:
 ;;   slli t3,a0,32
 ;;   srli t0,t3,32
-;;   lui t4,65535
-;;   addi t4,t4,4095
-;;   ugt t4,t0,t4##ty=i64
+;;   lui t3,65535
+;;   addi t1,t3,4095
+;;   ugt t4,t0,t1##ty=i64
 ;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t1,0(a2)
@@ -61,9 +61,9 @@
 ;; block0:
 ;;   slli t3,a0,32
 ;;   srli t0,t3,32
-;;   lui t4,65535
-;;   addi t4,t4,4095
-;;   ugt t4,t0,t4##ty=i64
+;;   lui t3,65535
+;;   addi t1,t3,4095
+;;   ugt t4,t0,t1##ty=i64
 ;;   bne t4,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t1,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -64,8 +64,8 @@
 ;;   slli a2,a0,32
 ;;   srli a3,a2,32
 ;;   lui a2,65536
-;;   addi a2,a2,4092
-;;   ugt a4,a3,a2##ty=i64
+;;   addi a4,a2,4092
+;;   ugt a4,a3,a4##ty=i64
 ;;   ld a2,0(a1)
 ;;   add a2,a2,a3
 ;;   li a3,0

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -41,9 +41,9 @@
 ;; block0:
 ;;   slli a3,a0,32
 ;;   srli a6,a3,32
-;;   lui a4,65535
-;;   addi a4,a4,4092
-;;   ugt a5,a6,a4##ty=i64
+;;   lui a3,65535
+;;   addi a5,a3,4092
+;;   ugt a5,a6,a5##ty=i64
 ;;   ld a4,0(a2)
 ;;   add a4,a4,a6
 ;;   lui a6,1
@@ -65,9 +65,9 @@
 ;; block0:
 ;;   slli a3,a0,32
 ;;   srli a6,a3,32
-;;   lui a4,65535
-;;   addi a4,a4,4092
-;;   ugt a5,a6,a4##ty=i64
+;;   lui a3,65535
+;;   addi a5,a3,4092
+;;   ugt a5,a6,a5##ty=i64
 ;;   ld a4,0(a1)
 ;;   add a4,a4,a6
 ;;   lui a6,1

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -64,8 +64,8 @@
 ;;   slli a2,a0,32
 ;;   srli a3,a2,32
 ;;   lui a2,65536
-;;   addi a2,a2,4095
-;;   ugt a4,a3,a2##ty=i64
+;;   addi a4,a2,4095
+;;   ugt a4,a3,a4##ty=i64
 ;;   ld a2,0(a1)
 ;;   add a2,a2,a3
 ;;   li a3,0

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -41,9 +41,9 @@
 ;; block0:
 ;;   slli a3,a0,32
 ;;   srli a6,a3,32
-;;   lui a4,65535
-;;   addi a4,a4,4095
-;;   ugt a5,a6,a4##ty=i64
+;;   lui a3,65535
+;;   addi a5,a3,4095
+;;   ugt a5,a6,a5##ty=i64
 ;;   ld a4,0(a2)
 ;;   add a4,a4,a6
 ;;   lui a6,1
@@ -65,9 +65,9 @@
 ;; block0:
 ;;   slli a3,a0,32
 ;;   srli a6,a3,32
-;;   lui a4,65535
-;;   addi a4,a4,4095
-;;   ugt a5,a6,a4##ty=i64
+;;   lui a3,65535
+;;   addi a5,a3,4095
+;;   ugt a5,a6,a5##ty=i64
 ;;   ld a4,0(a1)
 ;;   add a4,a4,a6
 ;;   lui a6,1

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -39,9 +39,9 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a5,65536
-;;   addi a5,a5,4092
-;;   ugt a5,a0,a5##ty=i64
+;;   lui a4,65536
+;;   addi a6,a4,4092
+;;   ugt a5,a0,a6##ty=i64
 ;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a6,0(a2)
@@ -55,9 +55,9 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a5,65536
-;;   addi a5,a5,4092
-;;   ugt a5,a0,a5##ty=i64
+;;   lui a4,65536
+;;   addi a6,a4,4092
+;;   ugt a5,a0,a6##ty=i64
 ;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a6,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -39,9 +39,9 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a7,65535
-;;   addi a7,a7,4092
-;;   ugt a7,a0,a7##ty=i64
+;;   lui a6,65535
+;;   addi t3,a6,4092
+;;   ugt a7,a0,t3##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t3,0(a2)
@@ -57,9 +57,9 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a7,65535
-;;   addi a7,a7,4092
-;;   ugt a7,a0,a7##ty=i64
+;;   lui a6,65535
+;;   addi t3,a6,4092
+;;   ugt a7,a0,t3##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t3,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -39,9 +39,9 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a5,65536
-;;   addi a5,a5,4095
-;;   ugt a5,a0,a5##ty=i64
+;;   lui a4,65536
+;;   addi a6,a4,4095
+;;   ugt a5,a0,a6##ty=i64
 ;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a6,0(a2)
@@ -55,9 +55,9 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a5,65536
-;;   addi a5,a5,4095
-;;   ugt a5,a0,a5##ty=i64
+;;   lui a4,65536
+;;   addi a6,a4,4095
+;;   ugt a5,a0,a6##ty=i64
 ;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a6,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -39,9 +39,9 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a7,65535
-;;   addi a7,a7,4095
-;;   ugt a7,a0,a7##ty=i64
+;;   lui a6,65535
+;;   addi t3,a6,4095
+;;   ugt a7,a0,t3##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t3,0(a2)
@@ -57,9 +57,9 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a7,65535
-;;   addi a7,a7,4095
-;;   ugt a7,a0,a7##ty=i64
+;;   lui a6,65535
+;;   addi t3,a6,4095
+;;   ugt a7,a0,t3##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t3,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -40,8 +40,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   mv a4,a2
-;;   lui a2,65536
-;;   addi a2,a2,4092
+;;   lui t2,65536
+;;   addi a2,t2,4092
 ;;   ugt a2,a0,a2##ty=i64
 ;;   ld a3,0(a4)
 ;;   add a0,a3,a0
@@ -61,8 +61,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   mv a4,a1
-;;   lui a1,65536
-;;   addi a1,a1,4092
+;;   lui t2,65536
+;;   addi a1,t2,4092
 ;;   ugt a1,a0,a1##ty=i64
 ;;   ld a2,0(a4)
 ;;   add a0,a2,a0

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -62,8 +62,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   lui a2,65535
-;;   addi a2,a2,4092
-;;   ugt a3,a0,a2##ty=i64
+;;   addi a3,a2,4092
+;;   ugt a3,a0,a3##ty=i64
 ;;   ld a2,0(a1)
 ;;   add a2,a2,a0
 ;;   lui a4,1

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -40,8 +40,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   mv a4,a2
-;;   lui a2,65536
-;;   addi a2,a2,4095
+;;   lui t2,65536
+;;   addi a2,t2,4095
 ;;   ugt a2,a0,a2##ty=i64
 ;;   ld a3,0(a4)
 ;;   add a0,a3,a0
@@ -61,8 +61,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   mv a4,a1
-;;   lui a1,65536
-;;   addi a1,a1,4095
+;;   lui t2,65536
+;;   addi a1,t2,4095
 ;;   ugt a1,a0,a1##ty=i64
 ;;   ld a2,0(a4)
 ;;   add a0,a2,a0

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -62,8 +62,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   lui a2,65535
-;;   addi a2,a2,4095
-;;   ugt a3,a0,a2##ty=i64
+;;   addi a3,a2,4095
+;;   ugt a3,a0,a3##ty=i64
 ;;   ld a2,0(a1)
 ;;   add a2,a2,a0
 ;;   lui a4,1

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -39,9 +39,9 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a5,65536
-;;   addi a5,a5,4092
-;;   ugt a5,a0,a5##ty=i64
+;;   lui a4,65536
+;;   addi a6,a4,4092
+;;   ugt a5,a0,a6##ty=i64
 ;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a6,0(a2)
@@ -55,9 +55,9 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a5,65536
-;;   addi a5,a5,4092
-;;   ugt a5,a0,a5##ty=i64
+;;   lui a4,65536
+;;   addi a6,a4,4092
+;;   ugt a5,a0,a6##ty=i64
 ;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a6,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -39,9 +39,9 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a7,65535
-;;   addi a7,a7,4092
-;;   ugt a7,a0,a7##ty=i64
+;;   lui a6,65535
+;;   addi t3,a6,4092
+;;   ugt a7,a0,t3##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t3,0(a2)
@@ -57,9 +57,9 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a7,65535
-;;   addi a7,a7,4092
-;;   ugt a7,a0,a7##ty=i64
+;;   lui a6,65535
+;;   addi t3,a6,4092
+;;   ugt a7,a0,t3##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t3,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -39,9 +39,9 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a5,65536
-;;   addi a5,a5,4095
-;;   ugt a5,a0,a5##ty=i64
+;;   lui a4,65536
+;;   addi a6,a4,4095
+;;   ugt a5,a0,a6##ty=i64
 ;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a6,0(a2)
@@ -55,9 +55,9 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a5,65536
-;;   addi a5,a5,4095
-;;   ugt a5,a0,a5##ty=i64
+;;   lui a4,65536
+;;   addi a6,a4,4095
+;;   ugt a5,a0,a6##ty=i64
 ;;   bne a5,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a6,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -39,9 +39,9 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a7,65535
-;;   addi a7,a7,4095
-;;   ugt a7,a0,a7##ty=i64
+;;   lui a6,65535
+;;   addi t3,a6,4095
+;;   ugt a7,a0,t3##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t3,0(a2)
@@ -57,9 +57,9 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a7,65535
-;;   addi a7,a7,4095
-;;   ugt a7,a0,a7##ty=i64
+;;   lui a6,65535
+;;   addi t3,a6,4095
+;;   ugt a7,a0,t3##ty=i64
 ;;   bne a7,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld t3,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -40,8 +40,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   mv a4,a2
-;;   lui a2,65536
-;;   addi a2,a2,4092
+;;   lui t2,65536
+;;   addi a2,t2,4092
 ;;   ugt a2,a0,a2##ty=i64
 ;;   ld a3,0(a4)
 ;;   add a0,a3,a0
@@ -61,8 +61,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   mv a4,a1
-;;   lui a1,65536
-;;   addi a1,a1,4092
+;;   lui t2,65536
+;;   addi a1,t2,4092
 ;;   ugt a1,a0,a1##ty=i64
 ;;   ld a2,0(a4)
 ;;   add a0,a2,a0

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -62,8 +62,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   lui a2,65535
-;;   addi a2,a2,4092
-;;   ugt a3,a0,a2##ty=i64
+;;   addi a3,a2,4092
+;;   ugt a3,a0,a3##ty=i64
 ;;   ld a2,0(a1)
 ;;   add a2,a2,a0
 ;;   lui a4,1

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -40,8 +40,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   mv a4,a2
-;;   lui a2,65536
-;;   addi a2,a2,4095
+;;   lui t2,65536
+;;   addi a2,t2,4095
 ;;   ugt a2,a0,a2##ty=i64
 ;;   ld a3,0(a4)
 ;;   add a0,a3,a0
@@ -61,8 +61,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   mv a4,a1
-;;   lui a1,65536
-;;   addi a1,a1,4095
+;;   lui t2,65536
+;;   addi a1,t2,4095
 ;;   ugt a1,a0,a1##ty=i64
 ;;   ld a2,0(a4)
 ;;   add a0,a2,a0

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -62,8 +62,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   lui a2,65535
-;;   addi a2,a2,4095
-;;   ugt a3,a0,a2##ty=i64
+;;   addi a3,a2,4095
+;;   ugt a3,a0,a3##ty=i64
 ;;   ld a2,0(a1)
 ;;   add a2,a2,a0
 ;;   lui a4,1


### PR DESCRIPTION
👋 Hey,

This PR fixes the RISC-V issues that #6850 exposed. It does a bit of a refactor in our constant emission infrastructure, and also moves some of it into ISLE. 

The issues that that PR exposed are that we sometimes would match or not match a particular constant generation strategy based on the upper bits that shouldn't really matter. The main fix is to sign extend constants before trying to match them. 

Moving the constant emission into ISLE also means that we have a bunch of neutral regalloc changes. There are a few cases where we have actual changes in the instructions emitted.
  
This PR contains a lot of stuff, and I would recommend reviewing it commit by commit.