### PR TITLE
egraphs: Disable bitwise `splat` transform for floats

### DIFF
--- a/cranelift/codegen/src/opts/extends.isle
+++ b/cranelift/codegen/src/opts/extends.isle
@@ -32,10 +32,3 @@
 ;; actually doing the extend in the first place.
 (rule (simplify (ireduce ty (sextend _ x @ (value_type ty)))) x)
 (rule (simplify (ireduce ty (uextend _ x @ (value_type ty)))) x)
-
-;; {u,s}widen_{low,high}+splat is the same as splat+{u,s}extend
-(rule (simplify (swiden_high wide (splat _ x))) (splat wide (sextend (lane_type wide) x)))
-(rule (simplify (swiden_low wide (splat _ x))) (splat wide (sextend (lane_type wide) x)))
-
-(rule (simplify (uwiden_high wide (splat _ x))) (splat wide (uextend (lane_type wide) x)))
-(rule (simplify (uwiden_low wide (splat _ x))) (splat wide (uextend (lane_type wide) x)))

--- a/cranelift/codegen/src/opts/vector.isle
+++ b/cranelift/codegen/src/opts/vector.isle
@@ -8,16 +8,23 @@
 (rule (simplify (fcvt_from_sint float_vector_ty (splat _ x)))
       (splat float_vector_ty (fcvt_from_sint (lane_type float_vector_ty) x)))
 
+;; Scalar bitwise ops are usually not implemented in the backends for floats, so
+;; disable this transform.
+
 (rule (simplify (band ty (splat ty x) (splat ty y)))
+      (if (ty_vector_not_float ty))
       (splat ty (band (lane_type ty) x y)))
 
 (rule (simplify (bor ty (splat ty x) (splat ty y)))
+      (if (ty_vector_not_float ty))
       (splat ty (bor (lane_type ty) x y)))
 
 (rule (simplify (bxor ty (splat ty x) (splat ty y)))
+      (if (ty_vector_not_float ty))
       (splat ty (bxor (lane_type ty) x y)))
 
 (rule (simplify (bnot ty (splat ty x)))
+      (if (ty_vector_not_float ty))
       (splat ty (bnot (lane_type ty) x)))
 
 (rule (simplify (iadd ty (splat ty x) (splat ty y)))

--- a/cranelift/codegen/src/opts/vector.isle
+++ b/cranelift/codegen/src/opts/vector.isle
@@ -72,3 +72,10 @@
 
 (rule (simplify (sshr ty (splat ty x) y))
       (splat ty (sshr (lane_type ty) x y)))
+
+;; {u,s}widen_{low,high}+splat is the same as splat+{u,s}extend
+(rule (simplify (swiden_high wide (splat _ x))) (splat wide (sextend (lane_type wide) x)))
+(rule (simplify (swiden_low wide (splat _ x))) (splat wide (sextend (lane_type wide) x)))
+
+(rule (simplify (uwiden_high wide (splat _ x))) (splat wide (uextend (lane_type wide) x)))
+(rule (simplify (uwiden_low wide (splat _ x))) (splat wide (uextend (lane_type wide) x)))

--- a/cranelift/filetests/filetests/runtests/issue-6916.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6916.clif
@@ -1,0 +1,43 @@
+test interpret
+test run
+set opt_level=speed
+target x86_64
+target x86_64 has_avx
+target aarch64
+target s390x
+target riscv64 has_v
+
+function %simd_band(f32, f32) -> f32x4 fast {
+block0(v0: f32, v1: f32):
+    v2 = splat.f32x4 v0
+    v3 = splat.f32x4 v1
+    v4 = band v2, v3
+    return v4
+}
+; run: %simd_band(0x1.0, 0x1.0) == [0x1.0 0x1.0 0x1.0 0x1.0]
+
+function %simd_bor(f32, f32) -> f32x4 fast {
+block0(v0: f32, v1: f32):
+    v2 = splat.f32x4 v0
+    v3 = splat.f32x4 v1
+    v4 = bor v2, v3
+    return v4
+}
+; run: %simd_bor(0x1.0, 0x1.0) == [0x1.0 0x1.0 0x1.0 0x1.0]
+
+function %simd_bxor(f32, f32) -> f32x4 fast {
+block0(v0: f32, v1: f32):
+    v2 = splat.f32x4 v0
+    v3 = splat.f32x4 v1
+    v4 = bxor v2, v3
+    return v4
+}
+; run: %simd_bxor(0x1.0, 0x1.0) == [0x0.0 0x0.0 0x0.0 0x0.0]
+
+function %simd_bnot(f32) -> f32x4 fast {
+block0(v0: f32):
+    v1 = splat.f32x4 v0
+    v2 = bnot v1
+    return v2
+}
+; run: %simd_bnot(0x1.0) == [-0x1.fffffep1 -0x1.fffffep1 -0x1.fffffep1 -0x1.fffffep1]


### PR DESCRIPTION
👋 Hey,

This is a follow up to #6851 that disables this transform for floats when used with bitwise ops. This transform is valid, but some backends (S390X and AArch64) do not support these operations for scalar floats.

This was found by the `icache` fuzzer, so it might show up in oss-fuzz as well.

Additionally this PR also moves the rules for `{u,s}widen_{low,high}+splat` into the `vector.isle` file so that they are next to the rest of the `splat` rules.

