### PR TITLE
Decouple `serde` from its `derive` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -599,6 +599,7 @@ dependencies = [
  "log",
  "regalloc2",
  "serde",
+ "serde_derive",
  "sha2",
  "similar",
  "smallvec",
@@ -629,6 +630,7 @@ name = "cranelift-entity"
 version = "0.100.0"
 dependencies = [
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -652,6 +654,7 @@ dependencies = [
  "log",
  "num_cpus",
  "serde",
+ "serde_derive",
  "similar",
  "target-lexicon",
  "thiserror",
@@ -737,6 +740,7 @@ dependencies = [
  "cranelift-control",
  "hashbrown 0.14.0",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -831,6 +835,7 @@ dependencies = [
  "itertools",
  "log",
  "serde",
+ "serde_derive",
  "smallvec",
  "target-lexicon",
  "wasmparser 0.112.0",
@@ -3334,6 +3339,7 @@ dependencies = [
  "psm",
  "rayon",
  "serde",
+ "serde_derive",
  "serde_json",
  "target-lexicon",
  "tempfile",
@@ -3416,6 +3422,7 @@ dependencies = [
  "pretty_env_logger 0.5.0",
  "rustix 0.38.8",
  "serde",
+ "serde_derive",
  "sha2",
  "tempfile",
  "toml",
@@ -3556,6 +3563,7 @@ dependencies = [
  "log",
  "object",
  "serde",
+ "serde_derive",
  "target-lexicon",
  "thiserror",
  "wasm-encoder 0.32.0",
@@ -3587,6 +3595,7 @@ dependencies = [
  "anyhow",
  "capstone",
  "serde",
+ "serde_derive",
  "serde_json",
  "target-lexicon",
  "wasmprinter",
@@ -3677,6 +3686,7 @@ dependencies = [
  "rustc-demangle",
  "rustix 0.38.8",
  "serde",
+ "serde_derive",
  "target-lexicon",
  "wasmtime-environ",
  "wasmtime-jit-debug",
@@ -3739,6 +3749,7 @@ version = "13.0.0"
 dependencies = [
  "cranelift-entity",
  "serde",
+ "serde_derive",
  "thiserror",
  "wasmparser 0.112.0",
 ]
@@ -4034,6 +4045,7 @@ dependencies = [
  "capstone",
  "cranelift-codegen",
  "serde",
+ "serde_derive",
  "similar",
  "target-lexicon",
  "toml",

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -23,7 +23,8 @@ cranelift-control = { workspace = true }
 hashbrown = { workspace = true, features = ["raw"] }
 target-lexicon = { workspace = true }
 log = { workspace = true }
-serde = { version = "1.0.94", features = ["derive"], optional = true }
+serde = { version = "1.0.188", optional = true }
+serde_derive = { version = "1.0.188", optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { workspace = true, features = ["write"], optional = true }
 smallvec = { workspace = true }
@@ -87,6 +88,7 @@ all-arch = [
 # For dependent crates that want to serialize some parts of cranelift
 enable-serde = [
     "serde",
+    "serde_derive",
     "cranelift-entity/enable-serde",
     "regalloc2/enable-serde",
     "smallvec/serde"

--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -502,7 +502,7 @@ fn gen_opcodes(all_inst: &AllInstructions, fmt: &mut Formatter) {
     fmt.line(
         r#"#[cfg_attr(
             feature = "enable-serde",
-            derive(serde::Serialize, serde::Deserialize)
+            derive(serde_derive::Serialize, serde_derive::Deserialize)
         )]"#,
     );
 

--- a/cranelift/codegen/src/binemit/mod.rs
+++ b/cranelift/codegen/src/binemit/mod.rs
@@ -8,7 +8,7 @@ mod stack_map;
 pub use self::stack_map::StackMap;
 use core::fmt;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Offset in bytes from the beginning of the function.
 ///

--- a/cranelift/codegen/src/binemit/stack_map.rs
+++ b/cranelift/codegen/src/binemit/stack_map.rs
@@ -67,7 +67,10 @@ const NUM_BITS: usize = core::mem::size_of::<Num>() * 8;
 /// live GC references in these slots. We record the `IncomingArg`s in the
 /// callee's stack map.
 #[derive(Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
 pub struct StackMap {
     bitmap: Vec<BitSet<Num>>,
     mapped_words: u32,

--- a/cranelift/codegen/src/bitset.rs
+++ b/cranelift/codegen/src/bitset.rs
@@ -12,7 +12,10 @@ use core::ops::{Add, BitOr, Shl, Sub};
 
 /// A small bitset built on a single primitive integer type
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct BitSet<T>(pub T);
 
 impl<T> BitSet<T>

--- a/cranelift/codegen/src/incremental_cache.rs
+++ b/cranelift/codegen/src/incremental_cache.rs
@@ -118,7 +118,7 @@ impl std::fmt::Display for CacheKeyHash {
     }
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
+#[derive(serde_derive::Serialize, serde_derive::Deserialize)]
 struct CachedFunc {
     // Note: The version marker must be first to ensure deserialization stops in case of a version
     // mismatch before attempting to deserialize the actual compiled code.
@@ -139,7 +139,7 @@ struct CacheKey<'a> {
     parameters: CompileParameters,
 }
 
-#[derive(Clone, PartialEq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Clone, PartialEq, Hash, serde_derive::Serialize, serde_derive::Deserialize)]
 struct CompileParameters {
     isa: String,
     triple: String,

--- a/cranelift/codegen/src/ir/atomic_rmw_op.rs
+++ b/cranelift/codegen/src/ir/atomic_rmw_op.rs
@@ -2,7 +2,7 @@
 use core::fmt::{self, Display, Formatter};
 use core::str::FromStr;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]

--- a/cranelift/codegen/src/ir/condcodes.rs
+++ b/cranelift/codegen/src/ir/condcodes.rs
@@ -8,7 +8,7 @@ use core::fmt::{self, Display, Formatter};
 use core::str::FromStr;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Common traits of condition codes.
 pub trait CondCode: Copy {

--- a/cranelift/codegen/src/ir/constant.rs
+++ b/cranelift/codegen/src/ir/constant.rs
@@ -19,7 +19,7 @@ use core::str::{from_utf8, FromStr};
 use cranelift_entity::EntityRef;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// This type describes the actual constant data. Note that the bytes stored in this structure are
 /// expected to be in little-endian order; this is due to ease-of-use when interacting with

--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -20,7 +20,7 @@ use core::u16;
 
 use alloc::collections::BTreeMap;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use smallvec::SmallVec;
 
 /// Storage for instructions within the DFG.

--- a/cranelift/codegen/src/ir/dynamic_type.rs
+++ b/cranelift/codegen/src/ir/dynamic_type.rs
@@ -7,7 +7,7 @@ use crate::ir::PrimaryMap;
 use crate::ir::Type;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A dynamic type object which has a base vector type and a scaling factor.
 #[derive(Clone, PartialEq, Hash)]

--- a/cranelift/codegen/src/ir/entities.rs
+++ b/cranelift/codegen/src/ir/entities.rs
@@ -23,7 +23,7 @@ use crate::entity::entity_impl;
 use core::fmt;
 use core::u32;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// An opaque reference to a [basic block](https://en.wikipedia.org/wiki/Basic_block) in a
 /// [`Function`](super::function::Function).

--- a/cranelift/codegen/src/ir/extfunc.rs
+++ b/cranelift/codegen/src/ir/extfunc.rs
@@ -11,7 +11,7 @@ use alloc::vec::Vec;
 use core::fmt;
 use core::str::FromStr;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use super::function::FunctionParameters;
 

--- a/cranelift/codegen/src/ir/extname.rs
+++ b/cranelift/codegen/src/ir/extname.rs
@@ -11,7 +11,7 @@ use core::str::FromStr;
 
 use cranelift_entity::EntityRef as _;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use super::entities::UserExternalNameRef;
 use super::function::FunctionParameters;

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -64,7 +64,10 @@ impl<'de> Deserialize<'de> for VersionMarker {
 /// Function parameters used when creating this function, and that will become applied after
 /// compilation to materialize the final `CompiledCode`.
 #[derive(Clone, PartialEq)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct FunctionParameters {
     /// The first `SourceLoc` appearing in the function, serving as a base for every relative
     /// source loc in the function.
@@ -146,7 +149,10 @@ impl FunctionParameters {
 /// Additionally, these fields can be the same for two functions that would be compiled the same
 /// way, and finalized by applying `FunctionParameters` onto their `CompiledCodeStencil`.
 #[derive(Clone, PartialEq, Hash)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct FunctionStencil {
     /// A version marker used to ensure that serialized clif ir is never deserialized with a
     /// different version of Cranelift.

--- a/cranelift/codegen/src/ir/globalvalue.rs
+++ b/cranelift/codegen/src/ir/globalvalue.rs
@@ -6,7 +6,7 @@ use crate::isa::TargetIsa;
 use core::fmt;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Information about a global value declaration.
 #[derive(Clone, PartialEq, Hash)]

--- a/cranelift/codegen/src/ir/immediates.rs
+++ b/cranelift/codegen/src/ir/immediates.rs
@@ -12,7 +12,7 @@ use core::ops::{Add, BitAnd, BitOr, BitXor, Div, Mul, Neg, Not, Sub};
 use core::str::FromStr;
 use core::{i32, u32};
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Convert a type into a vector of bytes; all implementors in this file must use little-endian
 /// orderings of bytes to match WebAssembly's little-endianness.

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -12,7 +12,7 @@ use core::ops::{Deref, DerefMut};
 use core::str::FromStr;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::bitset::BitSet;
 use crate::entity;

--- a/cranelift/codegen/src/ir/jumptable.rs
+++ b/cranelift/codegen/src/ir/jumptable.rs
@@ -10,7 +10,7 @@ use core::fmt::{self, Display, Formatter};
 use core::slice::{Iter, IterMut};
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Contents of a jump table.
 ///

--- a/cranelift/codegen/src/ir/known_symbol.rs
+++ b/cranelift/codegen/src/ir/known_symbol.rs
@@ -1,7 +1,7 @@
 use core::fmt;
 use core::str::FromStr;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A well-known symbol.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/cranelift/codegen/src/ir/libcall.rs
+++ b/cranelift/codegen/src/ir/libcall.rs
@@ -7,7 +7,7 @@ use crate::{
 use core::fmt;
 use core::str::FromStr;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The name of a runtime library routine.
 ///

--- a/cranelift/codegen/src/ir/memflags.rs
+++ b/cranelift/codegen/src/ir/memflags.rs
@@ -3,7 +3,7 @@
 use core::fmt;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 enum FlagBit {
     Notrap,

--- a/cranelift/codegen/src/ir/mod.rs
+++ b/cranelift/codegen/src/ir/mod.rs
@@ -26,7 +26,7 @@ mod trapcode;
 pub mod types;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 pub use crate::ir::atomic_rmw_op::AtomicRmwOp;
 pub use crate::ir::builder::{

--- a/cranelift/codegen/src/ir/sourceloc.rs
+++ b/cranelift/codegen/src/ir/sourceloc.rs
@@ -5,7 +5,7 @@
 
 use core::fmt;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A source location.
 ///

--- a/cranelift/codegen/src/ir/stackslot.rs
+++ b/cranelift/codegen/src/ir/stackslot.rs
@@ -17,7 +17,7 @@ use crate::ir::{DynamicTypeData, GlobalValueData};
 use crate::ir::types::*;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The size of an object on the stack, or the size of a stack frame.
 ///

--- a/cranelift/codegen/src/ir/table.rs
+++ b/cranelift/codegen/src/ir/table.rs
@@ -5,7 +5,7 @@ use crate::ir::{GlobalValue, Type};
 use core::fmt;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Information about a table declaration.
 #[derive(Clone, PartialEq, Hash)]

--- a/cranelift/codegen/src/ir/trapcode.rs
+++ b/cranelift/codegen/src/ir/trapcode.rs
@@ -3,7 +3,7 @@
 use core::fmt::{self, Display, Formatter};
 use core::str::FromStr;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A trap code describing the reason for a trap.
 ///

--- a/cranelift/codegen/src/ir/types.rs
+++ b/cranelift/codegen/src/ir/types.rs
@@ -4,7 +4,7 @@ use core::default::Default;
 use core::fmt::{self, Debug, Display, Formatter};
 use cranelift_codegen_shared::constants;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use target_lexicon::{PointerWidth, Triple};
 
 /// The type of an SSA value.

--- a/cranelift/codegen/src/isa/call_conv.rs
+++ b/cranelift/codegen/src/isa/call_conv.rs
@@ -4,7 +4,7 @@ use core::str;
 use target_lexicon::{CallingConvention, Triple};
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Calling convention identifiers.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]

--- a/cranelift/codegen/src/isa/unwind.rs
+++ b/cranelift/codegen/src/isa/unwind.rs
@@ -3,7 +3,7 @@
 use crate::machinst::RealReg;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[cfg(feature = "unwind")]
 pub mod systemv;

--- a/cranelift/codegen/src/isa/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/unwind/systemv.rs
@@ -8,7 +8,7 @@ use alloc::vec::Vec;
 use gimli::write::{Address, FrameDescriptionEntry};
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 type Register = u16;
 

--- a/cranelift/codegen/src/isa/unwind/winx64.rs
+++ b/cranelift/codegen/src/isa/unwind/winx64.rs
@@ -4,7 +4,7 @@ use crate::result::{CodegenError, CodegenResult};
 use alloc::vec::Vec;
 use log::warn;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 use crate::binemit::CodeOffset;
 use crate::isa::unwind::UnwindInst;

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -335,7 +335,10 @@ impl MachBufferFinalized<Stencil> {
 /// A `MachBuffer` once emission is completed: holds generated code and records,
 /// without fixups. This allows the type to be independent of the backend.
 #[derive(PartialEq, Debug, Clone)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct MachBufferFinalized<T: CompilePhase> {
     /// The buffer contents, as raw bytes.
     pub(crate) data: SmallVec<[u8; 1024]>,
@@ -1713,7 +1716,10 @@ impl<I: VCodeInst> Ord for MachLabelFixup<I> {
 
 /// A relocation resulting from a compilation.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct MachReloc {
     /// The offset at which the relocation applies, *relative to the
     /// containing section*.
@@ -1728,7 +1734,10 @@ pub struct MachReloc {
 
 /// A trap record resulting from a compilation.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct MachTrap {
     /// The offset at which the trap instruction occurs, *relative to the
     /// containing section*.
@@ -1739,7 +1748,10 @@ pub struct MachTrap {
 
 /// A call site record resulting from a compilation.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct MachCallSite {
     /// The offset of the call's return address, *relative to the containing section*.
     pub ret_addr: CodeOffset,
@@ -1749,7 +1761,10 @@ pub struct MachCallSite {
 
 /// A source-location mapping resulting from a compilation.
 #[derive(PartialEq, Debug, Clone)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct MachSrcLoc<T: CompilePhase> {
     /// The start of the region of code corresponding to a source location.
     /// This is relative to the start of the function, not to the start of the
@@ -1775,7 +1790,10 @@ impl MachSrcLoc<Stencil> {
 
 /// Record of stack map metadata: stack offsets containing references.
 #[derive(Clone, Debug, PartialEq)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct MachStackMap {
     /// The code offset at which this stack map applies.
     pub offset: CodeOffset,

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -61,7 +61,7 @@ use smallvec::{smallvec, SmallVec};
 use std::string::String;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 #[macro_use]
 pub mod isle;

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -9,7 +9,7 @@ use regalloc2::{
 };
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// The first 192 vregs (64 int, 64 float, 64 vec) are "pinned" to
 /// physical registers: this means that they are always constrained to

--- a/cranelift/codegen/src/value_label.rs
+++ b/cranelift/codegen/src/value_label.rs
@@ -4,7 +4,7 @@ use crate::HashMap;
 use alloc::vec::Vec;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Value location range.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -12,7 +12,8 @@ keywords = ["entity", "set", "map"]
 edition.workspace = true
 
 [dependencies]
-serde = { version = "1.0.94", features = ["derive"], optional = true }
+serde = { version = "1.0.188", optional = true }
+serde_derive = { version = "1.0.188", optional = true }
 
 [features]
-enable-serde = ["serde"]
+enable-serde = ["serde", "serde_derive"]

--- a/cranelift/entity/src/list.rs
+++ b/cranelift/entity/src/list.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 use core::mem;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A small list of entity references allocated from a pool.
 ///

--- a/cranelift/entity/src/packed_option.rs
+++ b/cranelift/entity/src/packed_option.rs
@@ -11,7 +11,7 @@ use core::fmt;
 use core::mem;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Types that have a reserved value which can't be created any other way.
 pub trait ReservedValue {

--- a/cranelift/entity/src/primary.rs
+++ b/cranelift/entity/src/primary.rs
@@ -10,7 +10,7 @@ use core::marker::PhantomData;
 use core::ops::{Index, IndexMut};
 use core::slice;
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A primary mapping `K -> V` allocating dense entity references.
 ///

--- a/cranelift/entity/src/sparse.rs
+++ b/cranelift/entity/src/sparse.rs
@@ -15,7 +15,7 @@ use core::slice;
 use core::u32;
 
 #[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Trait for extracting keys from values stored in a `SparseMap`.
 ///

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -30,6 +30,7 @@ similar ={ workspace = true }
 wat.workspace = true
 toml = { workspace = true }
 serde = { workspace = true }
+serde_derive = { workspace = true }
 cranelift-wasm.workspace = true
 wasmparser.workspace = true
 cranelift.workspace = true

--- a/cranelift/filetests/src/test_wasm/config.rs
+++ b/cranelift/filetests/src/test_wasm/config.rs
@@ -4,7 +4,7 @@
 
 use anyhow::{bail, ensure, Result};
 use cranelift_codegen::ir;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -15,7 +15,8 @@ cranelift-codegen = { workspace = true }
 cranelift-control = { workspace = true }
 hashbrown = { workspace = true, optional = true }
 anyhow = { workspace = true }
-serde = { version = "1.0.94", features = ["derive"], optional = true }
+serde = { version = "1.0.188", optional = true }
+serde_derive = { version = "1.0.188", optional = true }
 
 [features]
 default = ["std"]
@@ -23,4 +24,4 @@ std = ["cranelift-codegen/std"]
 core = ["hashbrown", "cranelift-codegen/core"]
 
 # For dependent crates that want to serialize some parts of cranelift
-enable-serde = ["serde", "cranelift-codegen/enable-serde"]
+enable-serde = ["serde", "serde_derive", "cranelift-codegen/enable-serde"]

--- a/cranelift/module/src/data_context.rs
+++ b/cranelift/module/src/data_context.rs
@@ -13,7 +13,10 @@ use crate::ModuleExtName;
 
 /// This specifies how data is to be initialized.
 #[derive(Clone, PartialEq, Eq, Debug)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub enum Init {
     /// This indicates that no initialization has been specified yet.
     Uninitialized,
@@ -42,7 +45,10 @@ impl Init {
 
 /// A description of a data object.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct DataDescription {
     /// How the data should be initialized.
     pub init: Init,

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -55,7 +55,10 @@ impl ModuleReloc {
 
 /// A function identifier for use in the `Module` interface.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct FuncId(u32);
 entity_impl!(FuncId, "funcid");
 
@@ -83,7 +86,10 @@ impl FuncId {
 
 /// A data object identifier for use in the `Module` interface.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct DataId(u32);
 entity_impl!(DataId, "dataid");
 
@@ -111,7 +117,10 @@ impl DataId {
 
 /// Linkage refers to where an entity is defined and who can see it.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub enum Linkage {
     /// Defined outside of a module.
     Import,
@@ -170,7 +179,10 @@ impl Linkage {
 
 /// A declared name may refer to either a function or data declaration
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Debug)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub enum FuncOrDataId {
     /// When it's a FuncId
     Func(FuncId),
@@ -190,7 +202,10 @@ impl From<FuncOrDataId> for ModuleExtName {
 
 /// Information about a function which can be called.
 #[derive(Debug)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct FunctionDeclaration {
     #[allow(missing_docs)]
     pub name: Option<String>,
@@ -348,7 +363,10 @@ pub type ModuleResult<T> = Result<T, ModuleError>;
 
 /// Information about a data object which can be accessed.
 #[derive(Debug)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct DataDeclaration {
     #[allow(missing_docs)]
     pub name: Option<String>,
@@ -386,7 +404,10 @@ impl DataDeclaration {
 
 /// A translated `ExternalName` into something global we can handle.
 #[derive(Clone, Debug)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub enum ModuleExtName {
     /// User defined function, converted from `ExternalName::User`.
     User {

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -20,7 +20,8 @@ wasmtime-types = { workspace = true }
 hashbrown = { workspace = true, optional = true }
 itertools = "0.10.0"
 log = { workspace = true }
-serde = { version = "1.0.94", features = ["derive"], optional = true }
+serde = { version = "1.0.188", optional = true }
+serde_derive = { version = "1.0.188", optional = true }
 smallvec = { workspace = true }
 
 [dev-dependencies]
@@ -31,4 +32,4 @@ target-lexicon = { workspace = true }
 default = ["std"]
 std = ["cranelift-codegen/std", "cranelift-frontend/std"]
 core = ["hashbrown", "cranelift-codegen/core", "cranelift-frontend/core"]
-enable-serde = ["serde"]
+enable-serde = ["serde", "serde_derive"]

--- a/cranelift/wasm/src/heap.rs
+++ b/cranelift/wasm/src/heap.rs
@@ -7,7 +7,10 @@ use cranelift_entity::entity_impl;
 ///
 /// While the order is stable, it is arbitrary.
 #[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct Heap(u32);
 entity_impl!(Heap, "heap");
 
@@ -59,7 +62,10 @@ entity_impl!(Heap, "heap");
 /// when the heap is resized. The bound of a dynamic heap is stored in a global
 /// value.
 #[derive(Clone, PartialEq, Hash)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub struct HeapData {
     /// The address of the start of the heap's storage.
     pub base: GlobalValue,
@@ -80,7 +86,10 @@ pub struct HeapData {
 
 /// Style of heap including style-specific information.
 #[derive(Clone, PartialEq, Hash)]
-#[cfg_attr(feature = "enable-serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    feature = "enable-serde",
+    derive(serde_derive::Serialize, serde_derive::Deserialize)
+)]
 pub enum HeapStyle {
     /// A dynamic heap can be relocated to a different base address when it is
     /// grown.

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -4,8 +4,6 @@ use crate::WasmResult;
 use core::u32;
 use cranelift_codegen::ir;
 use cranelift_frontend::FunctionBuilder;
-#[cfg(feature = "enable-serde")]
-use serde::{Deserialize, Serialize};
 use wasmparser::{FuncValidator, WasmFuncType, WasmModuleResources};
 
 /// Get the parameter and result types for the given Wasm blocktype.

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -14,7 +14,8 @@ base64 = "0.21.0"
 bincode = "1.1.4"
 directories-next = "2.0"
 log = { workspace = true }
-serde = { version = "1.0.94", features = ["derive"] }
+serde = "1.0.188"
+serde_derive = "1.0.188"
 sha2 = "0.10.2"
 toml = "0.5.5"
 zstd = { version = "0.11.1", default-features = false }

--- a/crates/cache/src/config.rs
+++ b/crates/cache/src/config.rs
@@ -17,14 +17,14 @@ use std::time::Duration;
 
 // wrapped, so we have named section in config,
 // also, for possible future compatibility
-#[derive(Deserialize, Debug)]
+#[derive(serde_derive::Deserialize, Debug)]
 #[serde(deny_unknown_fields)]
 struct Config {
     cache: CacheConfig,
 }
 
 /// Global configuration for how the cache is managed
-#[derive(Deserialize, Debug, Clone)]
+#[derive(serde_derive::Deserialize, Debug, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct CacheConfig {
     enabled: bool,
@@ -137,7 +137,7 @@ pub fn create_new_config<P: AsRef<Path> + Debug>(config_file: Option<P>) -> Resu
 enabled = true
 ";
 
-    fs::write(&config_file, &content).with_context(|| {
+    fs::write(&config_file, content).with_context(|| {
         format!(
             "Failed to flush config to the disk, path: {}",
             config_file.display(),

--- a/crates/cache/src/worker.rs
+++ b/crates/cache/src/worker.rs
@@ -7,7 +7,7 @@
 
 use super::{fs_write_atomic, CacheConfig};
 use log::{debug, info, trace, warn};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::cmp;
 use std::collections::HashMap;
 use std::ffi::OsStr;

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -17,7 +17,8 @@ wasmtime-types = { workspace = true }
 wasmparser = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
-serde = { version = "1.0.94", features = ["derive"] }
+serde = "1.0.188"
+serde_derive = "1.0.188"
 log = { workspace = true }
 gimli = { workspace = true, features = ["write"] }
 object = { workspace = true, features = ['write_core'] }

--- a/crates/environ/src/address_map.rs
+++ b/crates/environ/src/address_map.rs
@@ -3,7 +3,7 @@
 use crate::obj::ELF_WASMTIME_ADDRMAP;
 use object::write::{Object, StandardSegment};
 use object::{Bytes, LittleEndian, SectionKind, U32Bytes};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::ops::Range;
 

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -9,7 +9,7 @@ use crate::{
 use anyhow::Result;
 use object::write::{Object, SymbolId};
 use object::{Architecture, BinaryFormat, FileFlags};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::any::Any;
 use std::borrow::Cow;
 use std::collections::BTreeMap;

--- a/crates/environ/src/component/compiler.rs
+++ b/crates/environ/src/component/compiler.rs
@@ -1,6 +1,6 @@
 use crate::component::{ComponentTranslation, ComponentTypes, TrampolineIndex};
 use anyhow::Result;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::any::Any;
 
 /// A triple of related functions/trampolines variants with differing calling

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -49,7 +49,7 @@
 use crate::component::*;
 use crate::{EntityIndex, PrimaryMap, SignatureIndex, WasmType};
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Metadata as a result of compiling a component.
 pub struct ComponentTranslation {

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -6,7 +6,7 @@ use crate::{
 use anyhow::{bail, Result};
 use cranelift_entity::EntityRef;
 use indexmap::{IndexMap, IndexSet};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::ops::Index;

--- a/crates/environ/src/fact/transcode.rs
+++ b/crates/environ/src/fact/transcode.rs
@@ -1,6 +1,6 @@
 use crate::fact::core_types::CoreTypes;
 use crate::MemoryIndex;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use wasm_encoder::{EntityType, ValType};
 
 #[derive(Copy, Clone, Hash, Eq, PartialEq)]

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -3,7 +3,7 @@
 use crate::{ModuleTranslation, PrimaryMap, Tunables, WasmHeapType, WASM_PAGE_SIZE};
 use cranelift_entity::{packed_option::ReservedValue, EntityRef};
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::mem;

--- a/crates/environ/src/module_types.rs
+++ b/crates/environ/src/module_types.rs
@@ -1,5 +1,5 @@
 use crate::{PrimaryMap, SignatureIndex, WasmFuncType};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ops::Index;
 

--- a/crates/environ/src/stack_map.rs
+++ b/crates/environ/src/stack_map.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// A map for determining where live GC references live in a stack frame.
 ///

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 
 /// Tunable parameters for WebAssembly compilation.
 #[derive(Clone, Hash, Serialize, Deserialize)]

--- a/crates/explorer/Cargo.toml
+++ b/crates/explorer/Cargo.toml
@@ -12,6 +12,7 @@ version.workspace = true
 anyhow = { workspace = true }
 capstone = { workspace = true }
 serde = { workspace = true }
+serde_derive = { workspace = true }
 serde_json = { workspace = true }
 target-lexicon = { workspace = true }
 wasmprinter = { workspace = true }

--- a/crates/explorer/src/lib.rs
+++ b/crates/explorer/src/lib.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use capstone::arch::BuildsCapstone;
-use serde::Serialize;
+use serde_derive::Serialize;
 use std::{io::Write, str::FromStr};
 
 pub fn generate(

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -19,7 +19,8 @@ anyhow = { workspace = true }
 cfg-if = { workspace = true }
 gimli = { workspace = true }
 object = { workspace = true }
-serde = { version = "1.0.94", features = ["derive"] }
+serde = "1.0.188"
+serde_derive = "1.0.188"
 addr2line = { version = "0.21.0", default-features = false }
 bincode = "1.2.1"
 rustc-demangle = "0.1.16"

--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -9,7 +9,7 @@ use crate::profiling::ProfilingAgent;
 use anyhow::{bail, Context, Error, Result};
 use object::write::{Object, SectionId, StandardSegment, WritableBuffer};
 use object::SectionKind;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::ops::Range;
 use std::str;

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -10,6 +10,7 @@ edition.workspace = true
 
 [dependencies]
 cranelift-entity = { workspace = true, features = ['enable-serde'] }
-serde = { version = "1.0.94", features = ["derive"] }
+serde = "1.0.188"
+serde_derive = "1.0.188"
 thiserror = { workspace = true }
 wasmparser = { workspace = true }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -4,7 +4,7 @@
 pub use wasmparser;
 
 use cranelift_entity::entity_impl;
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::fmt;
 
 mod error;

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -35,7 +35,8 @@ libc = "0.2"
 cfg-if = { workspace = true }
 log = { workspace = true }
 wat = { workspace = true, optional = true }
-serde = { version = "1.0.94", features = ["derive"] }
+serde = "1.0.188"
+serde_derive = "1.0.188"
 serde_json = { workspace = true }
 bincode = "1.2.1"
 indexmap = { workspace = true }

--- a/crates/wasmtime/src/component/component.rs
+++ b/crates/wasmtime/src/component/component.rs
@@ -2,7 +2,7 @@ use crate::code::CodeObject;
 use crate::signatures::SignatureCollection;
 use crate::{Engine, Module, ResourcesRequired};
 use anyhow::{bail, Context, Result};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::fs;
 use std::mem;
 use std::path::Path;

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1,7 +1,7 @@
 use crate::memory::MemoryCreator;
 use crate::trampoline::MemoryCreatorProxy;
 use anyhow::{bail, ensure, Result};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 #[cfg(any(feature = "cache", feature = "cranelift", feature = "winch"))]

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -25,7 +25,7 @@ use crate::{Engine, ModuleVersionStrategy, Precompiled};
 use anyhow::{anyhow, bail, Context, Result};
 use object::write::{Object, StandardSegment};
 use object::{File, FileFlags, Object as _, ObjectSection, SectionKind};
-use serde::{Deserialize, Serialize};
+use serde_derive::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::str::FromStr;
 use wasmtime_environ::obj;

--- a/src/commands/settings.rs
+++ b/src/commands/settings.rs
@@ -36,7 +36,7 @@ impl Serialize for SettingData {
 }
 
 // Gather together all of the setting data to displays
-#[derive(Serialize)]
+#[derive(serde_derive::Serialize)]
 struct Settings {
     triple: String,
 

--- a/tests/all/wasi_testsuite.rs
+++ b/tests/all/wasi_testsuite.rs
@@ -7,7 +7,7 @@
 
 use crate::cli_tests::get_wasmtime_command;
 use anyhow::{anyhow, Result};
-use serde::Deserialize;
+use serde_derive::Deserialize;
 use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs;

--- a/winch/filetests/Cargo.toml
+++ b/winch/filetests/Cargo.toml
@@ -18,5 +18,6 @@ wat = { workspace = true }
 similar = { workspace = true }
 toml = { workspace = true }
 serde = { workspace = true }
+serde_derive = { workspace = true }
 cranelift-codegen = { workspace = true }
 capstone = { workspace = true }

--- a/winch/filetests/src/lib.rs
+++ b/winch/filetests/src/lib.rs
@@ -5,7 +5,7 @@ mod test {
     use super::disasm::disasm;
     use anyhow::Context;
     use cranelift_codegen::settings::{self, Configurable};
-    use serde::{Deserialize, Serialize};
+    use serde_derive::{Deserialize, Serialize};
     use similar::TextDiff;
     use std::str::FromStr;
     use target_lexicon::Triple;


### PR DESCRIPTION
By not activating the `derive` feature on `serde`, the compilation speed can be improved by a lot. This is because `serde` can then compile in parallel to `serde_derive`, allowing it to finish compilation possibly even before `serde_derive`, unblocking all the crates waiting for `serde` to start compiling much sooner.

As it turns out the main deciding factor for how long the compile time of a project is, is primarly determined by the depth of dependencies rather than the width. In other words, a crate's compile times aren't affected by how many crates it depends on, but rather by the longest chain of dependencies that it needs to wait on. In many cases `serde` is part of that long chain, as it is part of a long chain if the `derive` feature is active:

`proc-macro2` compile build script > `proc-macro2` run build script > `proc-macro2` > `quote` > `syn` > `serde_derive` > `serde` > `serde_json` (or any crate that depends on serde)

By decoupling it from `serde_derive`, the chain is shortened and compile times get much better.

Check this issue for a deeper elaboration:
https://github.com/serde-rs/serde/issues/2584

For `wasmtime` I'm seeing a reduction from 24.75s to 22.45s when compiling in `release` mode. This is because wasmtime through `gimli` has a dependency on `indexmap` which can only start compiling when `serde` is finished, which you want to happen as early as possible so some of wasmtime's dependencies can start compiling.

To measure the full effect, the dependencies can't by themselves activate the `derive` feature. I've upstreamed a patch for `fxprof-processed-profile` which was the only dependency that activated it for `wasmtime` (not yet published to crates.io). `wasmtime-cli` and co. may need patches for their dependencies to see a similar improvement.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
