### PR TITLE
x64: Implement `bitselect` for scalars

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -300,7 +300,8 @@
 
 ;; `i128`.
 
-(rule 7 (lower (has_type $I128 (band x y)))
+(decl and_i128 (ValueRegs ValueRegs) ValueRegs)
+(rule (and_i128 x y)
       (let ((x_regs ValueRegs x)
             (x_lo Gpr (value_regs_get_gpr x_regs 0))
             (x_hi Gpr (value_regs_get_gpr x_regs 1))
@@ -309,6 +310,9 @@
             (y_hi Gpr (value_regs_get_gpr y_regs 1)))
         (value_gprs (x64_and $I64 x_lo y_lo)
                     (x64_and $I64 x_hi y_hi))))
+
+(rule 7 (lower (has_type $I128 (band x y)))
+      (and_i128 x y))
 
 ;; Specialized lowerings for `(band x (bnot y))` which is additionally produced
 ;; by Cranelift's `band_not` instruction that is legalized into the simpler
@@ -1397,6 +1401,18 @@
         (x64_maxps x y))
 (rule 3 (lower (has_type $F64X2 (bitselect (bitcast _ (fcmp (FloatCC.LessThan) y x)) x y)))
         (x64_maxpd x y))
+
+;; Scalar rules
+
+(rule 3 (lower (has_type $I128 (bitselect c t f)))
+      (let ((a ValueRegs (and_i128 c t))
+            (b ValueRegs (and_i128 (i128_not c) f)))
+        (or_i128 a b)))
+
+(rule 4 (lower (has_type (ty_int_ref_scalar_64 ty) (bitselect c t f)))
+      (let ((a Gpr (x64_and ty c t))
+            (b Gpr (x64_and ty (x64_not ty c) f)))
+        (x64_or ty a b)))
 
 ;;;; Rules for `x86_blendv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1414,6 +1414,12 @@
             (b Gpr (x64_and ty (x64_not ty c) f)))
         (x64_or ty a b)))
 
+(rule 5 (lower (has_type (ty_scalar_float ty) (bitselect c t f)))
+      (let ((a Xmm (sse_and ty c t))
+            (c_neg Xmm (x64_xor_vector ty c (vector_all_ones)))
+            (b Xmm (sse_and ty c_neg f)))
+        (sse_or ty a b)))
+
 ;;;; Rules for `x86_blendv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $I8X16

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -4,12 +4,14 @@ target aarch64
 target s390x
 target riscv64
 target s390x has_mie2
+target x86_64
+
 set opt_level=speed
 target aarch64
 target s390x
 target riscv64
 target s390x has_mie2
-; target x86_64 TODO: Not yet implemented on x86_64
+target x86_64
 
 function %bnot_band() -> i8 {
 block0:
@@ -20,48 +22,6 @@ block0:
     return v4
 }
 ; run
-
-function %bitselect_i8(i8, i8, i8) -> i8 {
-block0(v0: i8, v1: i8, v2: i8):
-    v3 = bitselect v0, v1, v2
-    return v3
-}
-
-; run: %bitselect_i8(0, 0, 0xFF) == 0xFF
-; run: %bitselect_i8(0x55, 0, 0xFF) == 0xAA
-; run: %bitselect_i8(0xF0, 32, 13) == 45
-; run: %bitselect_i8(0xFF, 0xFF, 0) == 0xFF
-
-function %bitselect_i16(i16, i16, i16) -> i16 {
-block0(v0: i16, v1: i16, v2: i16):
-    v3 = bitselect v0, v1, v2
-    return v3
-}
-
-; run: %bitselect_i16(0, 0, 0xFFFF) == 0xFFFF
-; run: %bitselect_i16(0x5555, 0, 0xFFFF) == 0xAAAA
-; run: %bitselect_i16(0xFFFF, 0xFFFF, 0) == 0xFFFF
-
-function %bitselect_i32(i32, i32, i32) -> i32 {
-block0(v0: i32, v1: i32, v2: i32):
-    v3 = bitselect v0, v1, v2
-    return v3
-}
-
-; run: %bitselect_i32(0, 0, 0xFFFFFFFF) == 0xFFFFFFFF
-; run: %bitselect_i32(0x55555555, 0, 0xFFFFFFFF) == 0xAAAAAAAA
-; run: %bitselect_i32(0xFFFFFFFF, 0xFFFFFFFF, 0) == 0xFFFFFFFF
-
-function %bitselect_i64(i64, i64, i64) -> i64 {
-block0(v0: i64, v1: i64, v2: i64):
-    v3 = bitselect v0, v1, v2
-    return v3
-}
-
-; run: %bitselect_i64(0, 0, 0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF
-; run: %bitselect_i64(0x5555555555555555, 0, 0xFFFFFFFFFFFFFFFF) == 0xAAAAAAAAAAAAAAAA
-; run: %bitselect_i64(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0) == 0xFFFFFFFFFFFFFFFF
-
 
 ;; We have a optimization rule in the midend that turns this into a bmask
 ;; It's easier to have a runtest to ensure that it is correct than to inspect the output.

--- a/cranelift/filetests/filetests/runtests/bitselect-float.clif
+++ b/cranelift/filetests/filetests/runtests/bitselect-float.clif
@@ -1,0 +1,20 @@
+test run
+target x86_64
+
+function %bitselect_f32(f32, f32, f32) -> f32 {
+block0(v0: f32, v1: f32, v2: f32):
+    v3 = bitselect v0, v1, v2
+    return v3
+}
+
+; run: %bitselect_f32(0x0.0, 0x0.0, 0x1.0) == 0x1.0
+; run: %bitselect_f32(0x1.3, 0x2.2, 0x3.3) == 0x1.98p1
+
+function %bitselect_f64(f64, f64, f64) -> f64 {
+block0(v0: f64, v1: f64, v2: f64):
+    v3 = bitselect v0, v1, v2
+    return v3
+}
+
+; run: %bitselect_f64(0x0.0, 0x0.0, 0x1.0) == 0x1.0
+; run: %bitselect_f64(0x1.3, 0x2.2, 0x3.3) == 0x1.98p1

--- a/cranelift/filetests/filetests/runtests/bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/bitselect.clif
@@ -1,0 +1,55 @@
+test run
+set opt_level=none
+target aarch64
+target s390x
+target s390x has_mie2
+target riscv64
+target x86_64
+
+set opt_level=speed
+target aarch64
+target s390x
+target s390x has_mie2
+target riscv64
+target x86_64
+
+function %bitselect_i8(i8, i8, i8) -> i8 {
+block0(v0: i8, v1: i8, v2: i8):
+    v3 = bitselect v0, v1, v2
+    return v3
+}
+
+; run: %bitselect_i8(0, 0, 0xFF) == 0xFF
+; run: %bitselect_i8(0x55, 0, 0xFF) == 0xAA
+; run: %bitselect_i8(0xF0, 32, 13) == 45
+; run: %bitselect_i8(0xFF, 0xFF, 0) == 0xFF
+
+function %bitselect_i16(i16, i16, i16) -> i16 {
+block0(v0: i16, v1: i16, v2: i16):
+    v3 = bitselect v0, v1, v2
+    return v3
+}
+
+; run: %bitselect_i16(0, 0, 0xFFFF) == 0xFFFF
+; run: %bitselect_i16(0x5555, 0, 0xFFFF) == 0xAAAA
+; run: %bitselect_i16(0xFFFF, 0xFFFF, 0) == 0xFFFF
+
+function %bitselect_i32(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+    v3 = bitselect v0, v1, v2
+    return v3
+}
+
+; run: %bitselect_i32(0, 0, 0xFFFFFFFF) == 0xFFFFFFFF
+; run: %bitselect_i32(0x55555555, 0, 0xFFFFFFFF) == 0xAAAAAAAA
+; run: %bitselect_i32(0xFFFFFFFF, 0xFFFFFFFF, 0) == 0xFFFFFFFF
+
+function %bitselect_i64(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+    v3 = bitselect v0, v1, v2
+    return v3
+}
+
+; run: %bitselect_i64(0, 0, 0xFFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF
+; run: %bitselect_i64(0x5555555555555555, 0, 0xFFFFFFFFFFFFFFFF) == 0xAAAAAAAAAAAAAAAA
+; run: %bitselect_i64(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF, 0) == 0xFFFFFFFFFFFFFFFF

--- a/cranelift/filetests/filetests/runtests/i128-bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitselect.clif
@@ -1,0 +1,16 @@
+test run
+set opt_level=none
+set enable_llvm_abi_extensions=true
+target s390x
+target s390x has_mie2
+target x86_64
+
+function %bitselect_i128(i128, i128, i128) -> i128 {
+block0(v0: i128, v1: i128, v2: i128):
+    v3 = bitselect v0, v1, v2
+    return v3
+}
+
+; run: %bitselect_i128(0, 0, 0xFFFFFFFFFFFFFFFF_FFFFFFFFFFFFFFFF) == 0xFFFFFFFFFFFFFFFF_FFFFFFFFFFFFFFFF
+; run: %bitselect_i128(0x5555555555555555_5555555555555555, 0, 0xFFFFFFFFFFFFFFFF_FFFFFFFFFFFFFFFF) == 0xAAAAAAAAAAAAAAAA_AAAAAAAAAAAAAAAA
+; run: %bitselect_i128(0xFFFFFFFFFFFFFFFF_FFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF_FFFFFFFFFFFFFFFF, 0) == 0xFFFFFFFFFFFFFFFF_FFFFFFFFFFFFFFFF

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -541,15 +541,6 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
                 (Opcode::Cls, &[I32], &[I32]),
                 (Opcode::Cls, &[I64], &[I64]),
                 (Opcode::Cls, &[I128], &[I128]),
-                // https://github.com/bytecodealliance/wasmtime/issues/5197
-                (
-                    Opcode::Bitselect,
-                    &([I8, I8, I8]
-                        | [I16, I16, I16]
-                        | [I32, I32, I32]
-                        | [I64, I64, I64]
-                        | [I128, I128, I128])
-                ),
                 // https://github.com/bytecodealliance/wasmtime/issues/4897
                 // https://github.com/bytecodealliance/wasmtime/issues/4899
                 (

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -519,22 +519,6 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
                     Opcode::Smin | Opcode::Umin | Opcode::Smax | Opcode::Umax,
                     &[I128, I128]
                 ),
-                // https://github.com/bytecodealliance/wasmtime/issues/4870
-                (Opcode::Bnot, &[F32 | F64]),
-                (
-                    Opcode::Band
-                        | Opcode::Bor
-                        | Opcode::Bxor
-                        | Opcode::BandNot
-                        | Opcode::BorNot
-                        | Opcode::BxorNot,
-                    &([F32, F32] | [F64, F64])
-                ),
-                // https://github.com/bytecodealliance/wasmtime/issues/5041
-                (
-                    Opcode::BandNot | Opcode::BorNot | Opcode::BxorNot,
-                    &([I8, I8] | [I16, I16] | [I32, I32] | [I64, I64] | [I128, I128])
-                ),
                 // https://github.com/bytecodealliance/wasmtime/issues/5107
                 (Opcode::Cls, &[I8], &[I8]),
                 (Opcode::Cls, &[I16], &[I16]),


### PR DESCRIPTION
👋 Hey,

This PR Implements `bitselect` for all scalars in the x64 backend.

It also enables bitwise ops on floats for fuzzgen since they have been implemented (#4870, #5041)

Closes #5197