### PR TITLE
Remove clippy configuration from repo and crates

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,0 @@
-doc-valid-idents = [ "WebAssembly", "NaN", "SetCC" ]

--- a/cranelift/bforest/src/lib.rs
+++ b/cranelift/bforest/src/lib.rs
@@ -15,20 +15,6 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 #![no_std]
 
 #[cfg(test)]

--- a/cranelift/bforest/src/map.rs
+++ b/cranelift/bforest/src/map.rs
@@ -284,7 +284,6 @@ where
     ///
     /// If the cursor reaches the end, return `None` and leave the cursor at the off-the-end
     /// position.
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::should_implement_trait))]
     pub fn next(&mut self) -> Option<(K, V)> {
         self.path.next(self.pool)
     }

--- a/cranelift/bforest/src/pool.rs
+++ b/cranelift/bforest/src/pool.rs
@@ -63,7 +63,6 @@ impl<F: Forest> NodePool<F> {
     pub fn free_tree(&mut self, node: Node) {
         if let NodeData::Inner { size, tree, .. } = self[node] {
             // Note that we have to capture `tree` by value to avoid borrow checker trouble.
-            #[cfg_attr(feature = "cargo-clippy", allow(clippy::needless_range_loop))]
             for i in 0..usize::from(size + 1) {
                 // Recursively free sub-trees. This recursion can never be deeper than `MAX_PATH`,
                 // and since most trees have less than a handful of nodes, it is worthwhile to

--- a/cranelift/bforest/src/set.rs
+++ b/cranelift/bforest/src/set.rs
@@ -225,7 +225,6 @@ where
     ///
     /// If the cursor reaches the end, return `None` and leave the cursor at the off-the-end
     /// position.
-    #[cfg_attr(feature = "cargo-clippy", allow(clippy::should_implement_trait))]
     pub fn next(&mut self) -> Option<K> {
         self.path.next(self.pool).map(|(k, _)| k)
     }

--- a/cranelift/codegen/meta/src/constant_hash.rs
+++ b/cranelift/codegen/meta/src/constant_hash.rs
@@ -12,7 +12,6 @@ use std::iter;
 /// Compute an open addressed, quadratically probed hash table containing
 /// `items`. The returned table is a list containing the elements of the
 /// iterable `items` and `None` in unused slots.
-#[allow(clippy::float_arithmetic)]
 pub fn generate_table<'cont, T, I: iter::Iterator<Item = &'cont T>, H: Fn(&T) -> usize>(
     items: I,
     num_items: usize,

--- a/cranelift/codegen/meta/src/gen_inst.rs
+++ b/cranelift/codegen/meta/src/gen_inst.rs
@@ -798,7 +798,6 @@ fn gen_type_constraints(all_inst: &AllInstructions, fmt: &mut Formatter) {
     let mut operand_seqs = UniqueSeqTable::new();
 
     // Preload table with constraints for typical binops.
-    #[allow(clippy::useless_vec)]
     operand_seqs.add(&vec!["Same".to_string(); 3]);
 
     fmt.comment("Table of opcode constraints.");

--- a/cranelift/codegen/meta/src/shared/instructions.rs
+++ b/cranelift/codegen/meta/src/shared/instructions.rs
@@ -616,7 +616,6 @@ fn define_simd_arithmetic(
     );
 }
 
-#[allow(clippy::many_single_char_names)]
 pub(crate) fn define(
     all_instructions: &mut AllInstructions,
     formats: &Formats,

--- a/cranelift/codegen/shared/src/lib.rs
+++ b/cranelift/codegen/shared/src/lib.rs
@@ -4,20 +4,6 @@
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 pub mod constant_hash;
 pub mod constants;

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -2,40 +2,6 @@
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature="cargo-clippy", allow(
-// Produces only a false positive:
-                clippy::while_let_loop,
-// Produces many false positives, but did produce some valid lints, now fixed:
-                clippy::needless_lifetimes,
-// Generated code makes some style transgressions, but readability doesn't suffer much:
-                clippy::many_single_char_names,
-                clippy::identity_op,
-                clippy::needless_borrow,
-                clippy::cast_lossless,
-                clippy::unreadable_literal,
-                clippy::assign_op_pattern,
-                clippy::empty_line_after_outer_attr,
-// Hard to avoid in generated code:
-                clippy::cognitive_complexity,
-                clippy::too_many_arguments,
-// Code generator doesn't have a way to collapse identical arms:
-                clippy::match_same_arms,
-// These are relatively minor style issues, but would be easy to fix:
-                clippy::new_without_default,
-                clippy::should_implement_trait,
-                clippy::len_without_is_empty))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 #![no_std]
 // Various bits and pieces of this crate might only be used for one platform or
 // another, but it's not really too useful to learn about that all the time. On

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -31,20 +31,6 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 #![no_std]
 
 extern crate alloc;

--- a/cranelift/filetests/src/lib.rs
+++ b/cranelift/filetests/src/lib.rs
@@ -10,17 +10,6 @@
     unstable_features
 )]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::type_complexity))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 pub use crate::function_runner::TestFileCompiler;
 use crate::runner::TestRunner;

--- a/cranelift/filetests/src/test_unwind.rs
+++ b/cranelift/filetests/src/test_unwind.rs
@@ -1,7 +1,6 @@
 //! Test command for verifying the unwind emitted for each function.
 //!
 //! The `unwind` test command runs each function through the full code generator pipeline.
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
 
 use crate::subtest::{run_filecheck, Context, SubTest};
 use cranelift_codegen::{self, ir, isa::unwind::UnwindInfo};
@@ -379,7 +378,6 @@ mod systemv {
         Ok(())
     }
 
-    #[allow(clippy::unneeded_field_pattern)]
     fn dump_cfi_instructions<R: Reader, W: Write>(
         w: &mut W,
         mut insns: gimli::CallFrameInstructionIter<R>,

--- a/cranelift/frontend/src/lib.rs
+++ b/cranelift/frontend/src/lib.rs
@@ -163,19 +163,6 @@
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 #![no_std]
 
 #[allow(unused_imports)] // #[macro_use] is required for no_std

--- a/cranelift/jit/src/compiled_blob.rs
+++ b/cranelift/jit/src/compiled_blob.rs
@@ -40,7 +40,6 @@ impl CompiledBlob {
                 Reloc::Abs4 => {
                     let base = get_address(name);
                     let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
-                    #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
                     unsafe {
                         write_unaligned(at as *mut u32, u32::try_from(what as usize).unwrap())
                     };
@@ -48,7 +47,6 @@ impl CompiledBlob {
                 Reloc::Abs8 => {
                     let base = get_address(name);
                     let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
-                    #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
                     unsafe {
                         write_unaligned(at as *mut u64, u64::try_from(what as usize).unwrap())
                     };
@@ -57,37 +55,25 @@ impl CompiledBlob {
                     let base = get_address(name);
                     let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
                     let pcrel = i32::try_from((what as isize) - (at as isize)).unwrap();
-                    #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
-                    unsafe {
-                        write_unaligned(at as *mut i32, pcrel)
-                    };
+                    unsafe { write_unaligned(at as *mut i32, pcrel) };
                 }
                 Reloc::X86GOTPCRel4 => {
                     let base = get_got_entry(name);
                     let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
                     let pcrel = i32::try_from((what as isize) - (at as isize)).unwrap();
-                    #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
-                    unsafe {
-                        write_unaligned(at as *mut i32, pcrel)
-                    };
+                    unsafe { write_unaligned(at as *mut i32, pcrel) };
                 }
                 Reloc::X86CallPLTRel4 => {
                     let base = get_plt_entry(name);
                     let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
                     let pcrel = i32::try_from((what as isize) - (at as isize)).unwrap();
-                    #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
-                    unsafe {
-                        write_unaligned(at as *mut i32, pcrel)
-                    };
+                    unsafe { write_unaligned(at as *mut i32, pcrel) };
                 }
                 Reloc::S390xPCRel32Dbl | Reloc::S390xPLTRel32Dbl => {
                     let base = get_address(name);
                     let what = unsafe { base.offset(isize::try_from(addend).unwrap()) };
                     let pcrel = i32::try_from(((what as isize) - (at as isize)) >> 1).unwrap();
-                    #[cfg_attr(feature = "cargo-clippy", allow(clippy::cast_ptr_alignment))]
-                    unsafe {
-                        write_unaligned(at as *mut i32, pcrel)
-                    };
+                    unsafe { write_unaligned(at as *mut i32, pcrel) };
                 }
                 Reloc::Arm64Call => {
                     let base = get_address(name);

--- a/cranelift/jit/src/lib.rs
+++ b/cranelift/jit/src/lib.rs
@@ -11,20 +11,6 @@
     unreachable_pub
 )]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 mod backend;
 mod compiled_blob;

--- a/cranelift/module/src/lib.rs
+++ b/cranelift/module/src/lib.rs
@@ -3,20 +3,6 @@
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 #![no_std]
 
 #[cfg(not(feature = "std"))]

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -8,20 +8,6 @@
     unstable_features
 )]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 use cranelift_codegen::isa;
 use cranelift_codegen::settings::Configurable;

--- a/cranelift/object/src/lib.rs
+++ b/cranelift/object/src/lib.rs
@@ -9,20 +9,6 @@
     unstable_features
 )]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 mod backend;
 

--- a/cranelift/reader/src/lexer.rs
+++ b/cranelift/reader/src/lexer.rs
@@ -458,7 +458,6 @@ impl<'a> Lexer<'a> {
     /// Get the next token or a lexical error.
     ///
     /// Return None when the end of the source is encountered.
-    #[allow(clippy::cognitive_complexity)]
     pub fn next(&mut self) -> Option<Result<LocatedToken<'a>, LocatedError>> {
         loop {
             let loc = self.loc();

--- a/cranelift/reader/src/lib.rs
+++ b/cranelift/reader/src/lib.rs
@@ -10,20 +10,6 @@
     unstable_features
 )]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 pub use crate::error::{Location, ParseError, ParseResult};
 pub use crate::isaspec::{parse_option, parse_options, IsaSpec, ParseOptionError};

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -483,10 +483,6 @@ impl<'a> Parser<'a> {
 
     // Get the current lookahead token, after making sure there is one.
     fn token(&mut self) -> Option<Token<'a>> {
-        // clippy says self.lookahead is immutable so this loop is either infinite or never
-        // running. I don't think this is true - self.lookahead is mutated in the loop body - so
-        // maybe this is a clippy bug? Either way, disable clippy for this.
-        #[cfg_attr(feature = "cargo-clippy", allow(clippy::while_immutable_condition))]
         while self.lookahead.is_none() {
             match self.lex.next() {
                 Some(Ok(LocatedToken { token, location })) => {

--- a/cranelift/serde/src/clif-json.rs
+++ b/cranelift/serde/src/clif-json.rs
@@ -7,19 +7,6 @@
     unstable_features
 )]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 use clap::Parser;
 use cranelift_codegen::ir::Function;

--- a/cranelift/src/bugpoint.rs
+++ b/cranelift/src/bugpoint.rs
@@ -465,7 +465,6 @@ impl Mutator for RemoveUnusedEntities {
         4
     }
 
-    #[allow(clippy::cognitive_complexity)]
     fn mutate(&mut self, mut func: Function) -> Option<(Function, String, ProgressStatus)> {
         let name = match self.kind {
             0 => {

--- a/cranelift/src/clif-util.rs
+++ b/cranelift/src/clif-util.rs
@@ -1,16 +1,5 @@
 #![deny(trivial_numeric_casts)]
 #![warn(unused_import_braces, unstable_features, unused_extern_crates)]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 use clap::Parser;
 use std::path::PathBuf;

--- a/cranelift/src/wasm.rs
+++ b/cranelift/src/wasm.rs
@@ -2,10 +2,6 @@
 //! crate.
 //!
 //! Reads Wasm binary/text files, translates the functions' code to Cranelift IR.
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(clippy::too_many_arguments, clippy::cognitive_complexity)
-)]
 
 use crate::disasm::print_all;
 use anyhow::{Context as _, Result};

--- a/cranelift/umbrella/src/lib.rs
+++ b/cranelift/umbrella/src/lib.rs
@@ -7,20 +7,6 @@
     unstable_features
 )]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 #![no_std]
 
 /// Provide these crates, renamed to reduce stutter.

--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -114,11 +114,6 @@ macro_rules! unwrap_or_return_unreachable_state {
     };
 }
 
-// Clippy warns about "align: _" but its important to document that the flags field is ignored
-#[cfg_attr(
-    feature = "cargo-clippy",
-    allow(clippy::unneeded_field_pattern, clippy::cognitive_complexity)
-)]
 /// Translates wasm operators into Cranelift IR instructions.
 pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
     validator: &mut FuncValidator<impl WasmModuleResources>,
@@ -2513,8 +2508,6 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
     Ok(())
 }
 
-// Clippy warns us of some fields we are deliberately ignoring
-#[cfg_attr(feature = "cargo-clippy", allow(clippy::unneeded_field_pattern))]
 /// Deals with a Wasm instruction located in an unreachable portion of the code. Most of them
 /// are dropped but special ones like `End` or `Else` signal the potential end of the unreachable
 /// portion so the translation state must be updated accordingly.

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -196,7 +196,6 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// The signature `sig_ref` was previously created by `make_indirect_sig()`.
     ///
     /// Return the call instruction whose results are the WebAssembly return values.
-    #[allow(clippy::too_many_arguments)]
     fn translate_call_indirect(
         &mut self,
         builder: &mut FunctionBuilder,
@@ -237,7 +236,6 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// `i32`.
     ///
     /// The signature `sig_ref` was previously created by `make_indirect_sig()`.
-    #[allow(clippy::too_many_arguments)]
     fn translate_return_call_indirect(
         &mut self,
         builder: &mut FunctionBuilder,
@@ -349,7 +347,6 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// The `index` provided identifies the linear memory to query, and `heap` is the heap reference
     /// returned by `make_heap` for the same index. `seg_index` is the index of the segment to copy
     /// from.
-    #[allow(clippy::too_many_arguments)]
     fn translate_memory_init(
         &mut self,
         pos: FuncCursor,
@@ -402,7 +399,6 @@ pub trait FuncEnvironment: TargetEnvironment {
     ) -> WasmResult<()>;
 
     /// Translate a `table.copy` WebAssembly instruction.
-    #[allow(clippy::too_many_arguments)]
     fn translate_table_copy(
         &mut self,
         pos: FuncCursor,
@@ -426,7 +422,6 @@ pub trait FuncEnvironment: TargetEnvironment {
     ) -> WasmResult<()>;
 
     /// Translate a `table.init` WebAssembly instruction.
-    #[allow(clippy::too_many_arguments)]
     fn translate_table_init(
         &mut self,
         pos: FuncCursor,

--- a/cranelift/wasm/src/lib.rs
+++ b/cranelift/wasm/src/lib.rs
@@ -12,20 +12,6 @@
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 #![no_std]
 
 #[cfg(not(feature = "std"))]

--- a/crates/cache/src/worker.rs
+++ b/crates/cache/src/worker.rs
@@ -684,7 +684,6 @@ impl WorkerThread {
                             stats_path
                         );
                         // .into() called for the SystemTimeStub if cfg(test)
-                        #[allow(clippy::identity_conversion)]
                         vec.push(CacheEntry::Recognized {
                             path: mod_path.to_path_buf(),
                             mtime: stats_mtime.into(),
@@ -702,7 +701,6 @@ impl WorkerThread {
                             mod_path
                         );
                         // .into() called for the SystemTimeStub if cfg(test)
-                        #[allow(clippy::identity_conversion)]
                         vec.push(CacheEntry::Recognized {
                             path: mod_path.to_path_buf(),
                             mtime: mod_mtime.into(),

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -2,19 +2,6 @@
 
 #![deny(trivial_numeric_casts, unused_extern_crates, unstable_features)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 use anyhow::{bail, Result};
 use clap::Parser;

--- a/crates/cranelift/src/debug.rs
+++ b/crates/cranelift/src/debug.rs
@@ -1,7 +1,5 @@
 //! Debug utils for WebAssembly using Cranelift.
 
-#![allow(clippy::cast_ptr_alignment)]
-
 /// Memory definition offset in the VMContext structure.
 #[derive(Debug, Clone)]
 pub enum ModuleMemoryOffset {

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -5,23 +5,6 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(clippy::new_without_default, clippy::new_without_default)
-)]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 mod address_map;
 mod builtin;

--- a/crates/environ/src/vmoffsets.rs
+++ b/crates/environ/src/vmoffsets.rs
@@ -108,28 +108,24 @@ pub trait PtrSize {
     }
 
     /// The offset of the `native_call` field.
-    #[allow(clippy::erasing_op)]
     #[inline]
     fn vm_func_ref_native_call(&self) -> u8 {
         0 * self.size()
     }
 
     /// The offset of the `array_call` field.
-    #[allow(clippy::erasing_op)]
     #[inline]
     fn vm_func_ref_array_call(&self) -> u8 {
         1 * self.size()
     }
 
     /// The offset of the `wasm_call` field.
-    #[allow(clippy::erasing_op)]
     #[inline]
     fn vm_func_ref_wasm_call(&self) -> u8 {
         2 * self.size()
     }
 
     /// The offset of the `type_index` field.
-    #[allow(clippy::identity_op)]
     #[inline]
     fn vm_func_ref_type_index(&self) -> u8 {
         3 * self.size()
@@ -192,14 +188,12 @@ pub trait PtrSize {
     // Offsets within `VMMemoryDefinition`
 
     /// The offset of the `base` field.
-    #[allow(clippy::erasing_op)]
     #[inline]
     fn vmmemory_definition_base(&self) -> u8 {
         0 * self.size()
     }
 
     /// The offset of the `current_length` field.
-    #[allow(clippy::identity_op)]
     #[inline]
     fn vmmemory_definition_current_length(&self) -> u8 {
         1 * self.size()
@@ -481,28 +475,24 @@ impl<P: PtrSize> From<VMOffsetsFields<P>> for VMOffsets<P> {
 
 impl<P: PtrSize> VMOffsets<P> {
     /// The offset of the `wasm_call` field.
-    #[allow(clippy::erasing_op)]
     #[inline]
     pub fn vmfunction_import_wasm_call(&self) -> u8 {
         0 * self.pointer_size()
     }
 
     /// The offset of the `native_call` field.
-    #[allow(clippy::erasing_op)]
     #[inline]
     pub fn vmfunction_import_native_call(&self) -> u8 {
         1 * self.pointer_size()
     }
 
     /// The offset of the `array_call` field.
-    #[allow(clippy::erasing_op)]
     #[inline]
     pub fn vmfunction_import_array_call(&self) -> u8 {
         2 * self.pointer_size()
     }
 
     /// The offset of the `vmctx` field.
-    #[allow(clippy::identity_op)]
     #[inline]
     pub fn vmfunction_import_vmctx(&self) -> u8 {
         3 * self.pointer_size()
@@ -518,7 +508,6 @@ impl<P: PtrSize> VMOffsets<P> {
 /// Offsets for `*const VMFunctionBody`.
 impl<P: PtrSize> VMOffsets<P> {
     /// The size of the `current_elements` field.
-    #[allow(clippy::identity_op)]
     pub fn size_of_vmfunction_body_ptr(&self) -> u8 {
         1 * self.pointer_size()
     }
@@ -527,14 +516,12 @@ impl<P: PtrSize> VMOffsets<P> {
 /// Offsets for `VMTableImport`.
 impl<P: PtrSize> VMOffsets<P> {
     /// The offset of the `from` field.
-    #[allow(clippy::erasing_op)]
     #[inline]
     pub fn vmtable_import_from(&self) -> u8 {
         0 * self.pointer_size()
     }
 
     /// The offset of the `vmctx` field.
-    #[allow(clippy::identity_op)]
     #[inline]
     pub fn vmtable_import_vmctx(&self) -> u8 {
         1 * self.pointer_size()
@@ -550,14 +537,12 @@ impl<P: PtrSize> VMOffsets<P> {
 /// Offsets for `VMTableDefinition`.
 impl<P: PtrSize> VMOffsets<P> {
     /// The offset of the `base` field.
-    #[allow(clippy::erasing_op)]
     #[inline]
     pub fn vmtable_definition_base(&self) -> u8 {
         0 * self.pointer_size()
     }
 
     /// The offset of the `current_elements` field.
-    #[allow(clippy::identity_op)]
     pub fn vmtable_definition_current_elements(&self) -> u8 {
         1 * self.pointer_size()
     }
@@ -578,14 +563,12 @@ impl<P: PtrSize> VMOffsets<P> {
 /// Offsets for `VMMemoryImport`.
 impl<P: PtrSize> VMOffsets<P> {
     /// The offset of the `from` field.
-    #[allow(clippy::erasing_op)]
     #[inline]
     pub fn vmmemory_import_from(&self) -> u8 {
         0 * self.pointer_size()
     }
 
     /// The offset of the `vmctx` field.
-    #[allow(clippy::identity_op)]
     #[inline]
     pub fn vmmemory_import_vmctx(&self) -> u8 {
         1 * self.pointer_size()
@@ -601,14 +584,12 @@ impl<P: PtrSize> VMOffsets<P> {
 /// Offsets for `VMGlobalImport`.
 impl<P: PtrSize> VMOffsets<P> {
     /// The offset of the `from` field.
-    #[allow(clippy::erasing_op)]
     #[inline]
     pub fn vmglobal_import_from(&self) -> u8 {
         0 * self.pointer_size()
     }
 
     /// Return the size of `VMGlobalImport`.
-    #[allow(clippy::identity_op)]
     #[inline]
     pub fn size_of_vmglobal_import(&self) -> u8 {
         1 * self.pointer_size()
@@ -669,14 +650,12 @@ impl<P: PtrSize> VMOffsets<P> {
     }
 
     /// The offset of the `tables` array.
-    #[allow(clippy::erasing_op)]
     #[inline]
     pub fn vmctx_imported_functions_begin(&self) -> u32 {
         self.imported_functions
     }
 
     /// The offset of the `tables` array.
-    #[allow(clippy::identity_op)]
     #[inline]
     pub fn vmctx_imported_tables_begin(&self) -> u32 {
         self.imported_tables

--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -2,23 +2,6 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(clippy::new_without_default, clippy::new_without_default)
-)]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 mod code_memory;
 mod debug;

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -153,7 +153,6 @@ pub struct Instance {
     vmctx: VMContext,
 }
 
-#[allow(clippy::cast_ptr_alignment)]
 impl Instance {
     /// Create an instance at the given memory address.
     ///

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -2,23 +2,6 @@
 
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(clippy::new_without_default, clippy::new_without_default)
-)]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 use anyhow::{Error, Result};
 use std::fmt;

--- a/crates/runtime/src/parking_spot.rs
+++ b/crates/runtime/src/parking_spot.rs
@@ -9,8 +9,6 @@
 //! - *Unparking* refers to dequeuing a thread from a queue keyed by some address
 //! and resuming it.
 
-#![deny(clippy::all)]
-#![deny(clippy::pedantic)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -433,133 +433,111 @@ impl VMGlobalDefinition {
     }
 
     /// Return a reference to the value as an i32.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_i32(&self) -> &i32 {
         &*(self.storage.as_ref().as_ptr().cast::<i32>())
     }
 
     /// Return a mutable reference to the value as an i32.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_i32_mut(&mut self) -> &mut i32 {
         &mut *(self.storage.as_mut().as_mut_ptr().cast::<i32>())
     }
 
     /// Return a reference to the value as a u32.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u32(&self) -> &u32 {
         &*(self.storage.as_ref().as_ptr().cast::<u32>())
     }
 
     /// Return a mutable reference to the value as an u32.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u32_mut(&mut self) -> &mut u32 {
         &mut *(self.storage.as_mut().as_mut_ptr().cast::<u32>())
     }
 
     /// Return a reference to the value as an i64.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_i64(&self) -> &i64 {
         &*(self.storage.as_ref().as_ptr().cast::<i64>())
     }
 
     /// Return a mutable reference to the value as an i64.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_i64_mut(&mut self) -> &mut i64 {
         &mut *(self.storage.as_mut().as_mut_ptr().cast::<i64>())
     }
 
     /// Return a reference to the value as an u64.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u64(&self) -> &u64 {
         &*(self.storage.as_ref().as_ptr().cast::<u64>())
     }
 
     /// Return a mutable reference to the value as an u64.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u64_mut(&mut self) -> &mut u64 {
         &mut *(self.storage.as_mut().as_mut_ptr().cast::<u64>())
     }
 
     /// Return a reference to the value as an f32.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f32(&self) -> &f32 {
         &*(self.storage.as_ref().as_ptr().cast::<f32>())
     }
 
     /// Return a mutable reference to the value as an f32.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f32_mut(&mut self) -> &mut f32 {
         &mut *(self.storage.as_mut().as_mut_ptr().cast::<f32>())
     }
 
     /// Return a reference to the value as f32 bits.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f32_bits(&self) -> &u32 {
         &*(self.storage.as_ref().as_ptr().cast::<u32>())
     }
 
     /// Return a mutable reference to the value as f32 bits.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f32_bits_mut(&mut self) -> &mut u32 {
         &mut *(self.storage.as_mut().as_mut_ptr().cast::<u32>())
     }
 
     /// Return a reference to the value as an f64.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f64(&self) -> &f64 {
         &*(self.storage.as_ref().as_ptr().cast::<f64>())
     }
 
     /// Return a mutable reference to the value as an f64.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f64_mut(&mut self) -> &mut f64 {
         &mut *(self.storage.as_mut().as_mut_ptr().cast::<f64>())
     }
 
     /// Return a reference to the value as f64 bits.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f64_bits(&self) -> &u64 {
         &*(self.storage.as_ref().as_ptr().cast::<u64>())
     }
 
     /// Return a mutable reference to the value as f64 bits.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_f64_bits_mut(&mut self) -> &mut u64 {
         &mut *(self.storage.as_mut().as_mut_ptr().cast::<u64>())
     }
 
     /// Return a reference to the value as an u128.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u128(&self) -> &u128 {
         &*(self.storage.as_ref().as_ptr().cast::<u128>())
     }
 
     /// Return a mutable reference to the value as an u128.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u128_mut(&mut self) -> &mut u128 {
         &mut *(self.storage.as_mut().as_mut_ptr().cast::<u128>())
     }
 
     /// Return a reference to the value as u128 bits.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u128_bits(&self) -> &[u8; 16] {
         &*(self.storage.as_ref().as_ptr().cast::<[u8; 16]>())
     }
 
     /// Return a mutable reference to the value as u128 bits.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_u128_bits_mut(&mut self) -> &mut [u8; 16] {
         &mut *(self.storage.as_mut().as_mut_ptr().cast::<[u8; 16]>())
     }
 
     /// Return a reference to the value as an externref.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_externref(&self) -> &Option<VMExternRef> {
         &*(self.storage.as_ref().as_ptr().cast::<Option<VMExternRef>>())
     }
 
     /// Return a mutable reference to the value as an externref.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_externref_mut(&mut self) -> &mut Option<VMExternRef> {
         &mut *(self
             .storage
@@ -569,13 +547,11 @@ impl VMGlobalDefinition {
     }
 
     /// Return a reference to the value as a `VMFuncRef`.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_func_ref(&self) -> *mut VMFuncRef {
         *(self.storage.as_ref().as_ptr().cast::<*mut VMFuncRef>())
     }
 
     /// Return a mutable reference to the value as a `VMFuncRef`.
-    #[allow(clippy::cast_ptr_alignment)]
     pub unsafe fn as_func_ref_mut(&mut self) -> &mut *mut VMFuncRef {
         &mut *(self.storage.as_mut().as_mut_ptr().cast::<*mut VMFuncRef>())
     }

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -3,23 +3,6 @@
 #![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
 #![warn(unused_import_braces)]
 #![deny(unstable_features)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../../clippy.toml")))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    allow(clippy::new_without_default, clippy::new_without_default)
-)]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::print_stdout,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 #[cfg(feature = "component-model")]
 mod component;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,19 +9,6 @@
     unstable_features
 )]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "clippy", plugin(clippy(conf_file = "../clippy.toml")))]
-#![cfg_attr(feature = "cargo-clippy", allow(clippy::new_without_default))]
-#![cfg_attr(
-    feature = "cargo-clippy",
-    warn(
-        clippy::float_arithmetic,
-        clippy::mut_mut,
-        clippy::nonminimal_bool,
-        clippy::map_unwrap_or,
-        clippy::unicode_not_nfc,
-        clippy::use_self
-    )
-)]
 
 use once_cell::sync::Lazy;
 use wasmtime_cli_flags::{SUPPORTED_WASI_MODULES, SUPPORTED_WASM_FEATURES};


### PR DESCRIPTION
Wasmtime's CI does not run clippy so there's no enforcement of this configuration. Additionally the configuration per-crate is not uniformly applied across all of the Wasmtime workspace and is only on some historical crates. Because we don't run clippy in CI this commit removes all of the clippy annotations for allow/warn/deny from the source.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
