### PR TITLE
Expose `target` and Cranelift settings in C API

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -244,13 +244,13 @@ WASMTIME_CONFIG_PROP(void, cranelift_debug_verifier, bool)
  * When Cranelift is used as a code generation backend this will configure
  * it to replace NaNs with a single canonical value. This is useful for users
  * requiring entirely deterministic WebAssembly computation.
- * 
+ *
  * This is not required by the WebAssembly spec, so it is not enabled by default.
- * 
+ *
  * The default value for this is `false`
  */
 WASMTIME_CONFIG_PROP(void, cranelift_nan_canonicalization, bool)
-  
+
 /**
  * \brief Configures Cranelift's optimization level for JIT code.
  *
@@ -330,6 +330,42 @@ WASMTIME_CONFIG_PROP(void, native_unwind_info, bool)
  * cache could not be enabled.
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_config_cache_config_load(wasm_config_t*, const char*);
+
+/**
+ * \brief Configures the target triple that this configuration will produce
+ * machine code for.
+ *
+ * This option defaults to the native host. Calling this method will
+ * additionally disable inference of the native features of the host (e.g.
+ * detection of SSE4.2 on x86_64 hosts). Native features can be reenabled with
+ * the `cranelift_flag_{set,enable}` properties.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.config
+ */
+WASMTIME_CONFIG_PROP(wasmtime_error_t*, target, const char*)
+
+/**
+ * \brief Enables a target-specific flag in Cranelift.
+ *
+ * This can be used, for example, to enable SSE4.2 on x86_64 hosts. Settings can
+ * be explored with `wasmtime settings` on the CLI.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.cranelift_flag_enable
+ */
+WASM_API_EXTERN void wasmtime_config_cranelift_flag_enable(wasm_config_t*, const char*);
+
+/**
+ * \brief Sets a target-specific flag in Cranelift to the specified value.
+ *
+ * This can be used, for example, to enable SSE4.2 on x86_64 hosts. Settings can
+ * be explored with `wasmtime settings` on the CLI.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.cranelift_flag_set
+ */
+WASM_API_EXTERN void wasmtime_config_cranelift_flag_set(wasm_config_t*, const char *key, const char *value);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -226,3 +226,32 @@ pub extern "C" fn wasmtime_config_dynamic_memory_reserved_for_growth_set(
 pub extern "C" fn wasmtime_config_native_unwind_info_set(c: &mut wasm_config_t, enabled: bool) {
     c.config.native_unwind_info(enabled);
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn wasmtime_config_target_set(
+    c: &mut wasm_config_t,
+    target: *const c_char,
+) -> Option<Box<wasmtime_error_t>> {
+    let target = CStr::from_ptr(target).to_str().expect("not valid utf-8");
+    handle_result(c.config.target(target), |_cfg| {})
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasmtime_config_cranelift_flag_enable(
+    c: &mut wasm_config_t,
+    flag: *const c_char,
+) {
+    let flag = CStr::from_ptr(flag).to_str().expect("not valid utf-8");
+    c.config.cranelift_flag_enable(flag);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasmtime_config_cranelift_flag_set(
+    c: &mut wasm_config_t,
+    flag: *const c_char,
+    value: *const c_char,
+) {
+    let flag = CStr::from_ptr(flag).to_str().expect("not valid utf-8");
+    let value = CStr::from_ptr(value).to_str().expect("not valid utf-8");
+    c.config.cranelift_flag_set(flag, value);
+}


### PR DESCRIPTION
This commit comes from discussion on #6932 and adds target settings to the C API to configure compilation artifacts.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
