### PR TITLE
Include Wasm-defined globals and memories in core dumps

### DIFF
--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -5,7 +5,6 @@ use crate::{
     SharedMemory, TableType, Val, ValType,
 };
 use anyhow::{anyhow, bail, Result};
-use runtime::ExportGlobal;
 use std::mem;
 use std::ptr;
 use wasmtime_runtime::{self as runtime};
@@ -247,10 +246,6 @@ impl Global {
             let wasmtime_export = generate_global_export(store, ty, val);
             Ok(Global::from_wasmtime_global(wasmtime_export, store))
         }
-    }
-
-    pub(crate) fn from_stored(stored: Stored<ExportGlobal>) -> Global {
-        Global(stored)
     }
 
     /// Returns the underlying type of this `global`.

--- a/crates/wasmtime/src/instance.rs
+++ b/crates/wasmtime/src/instance.rs
@@ -42,6 +42,15 @@ pub(crate) struct InstanceData {
     exports: Vec<Option<Extern>>,
 }
 
+impl InstanceData {
+    pub fn from_id(id: InstanceId) -> InstanceData {
+        InstanceData {
+            id,
+            exports: vec![],
+        }
+    }
+}
+
 impl Instance {
     /// Creates a new [`Instance`] from the previously compiled [`Module`] and
     /// list of `imports` specified.
@@ -289,7 +298,7 @@ impl Instance {
         // conflicts with the borrow on `store.engine`) but this doesn't
         // matter in practice since initialization isn't even running any
         // code here anyway.
-        let id = store.add_instance(instance_handle.clone(), false);
+        let id = store.add_instance(instance_handle.clone());
 
         // Additionally, before we start doing fallible instantiation, we
         // do one more step which is to insert an `InstanceData`
@@ -329,9 +338,6 @@ impl Instance {
         )?;
 
         Ok((instance, compiled_module.module().start_func))
-    }
-    pub(crate) fn from_stored(stored: Stored<InstanceData>) -> Instance {
-        Instance(stored)
     }
 
     pub(crate) fn from_wasmtime(handle: InstanceData, store: &mut StoreOpaque) -> Instance {

--- a/crates/wasmtime/src/memory.rs
+++ b/crates/wasmtime/src/memory.rs
@@ -9,7 +9,7 @@ use std::ops::Range;
 use std::slice;
 use std::time::Instant;
 use wasmtime_environ::MemoryPlan;
-use wasmtime_runtime::{ExportMemory, RuntimeLinearMemory, VMMemoryImport};
+use wasmtime_runtime::{RuntimeLinearMemory, VMMemoryImport};
 
 pub use wasmtime_runtime::WaitResult;
 
@@ -269,10 +269,6 @@ impl Memory {
             let export = generate_memory_export(store, &ty, None)?;
             Ok(Memory::from_wasmtime_memory(export, store))
         }
-    }
-
-    pub(crate) fn from_stored(stored: Stored<ExportMemory>) -> Memory {
-        Memory(stored)
     }
 
     /// Returns the underlying type of this memory.

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -96,9 +96,9 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use wasmtime_runtime::{
-    ExportGlobal, ExportMemory, InstanceAllocationRequest, InstanceAllocator, InstanceHandle,
-    ModuleInfo, OnDemandInstanceAllocator, SignalHandler, StoreBox, StorePtr, VMContext,
-    VMExternRef, VMExternRefActivationsTable, VMFuncRef, VMRuntimeLimits, WasmFault,
+    ExportGlobal, InstanceAllocationRequest, InstanceAllocator, InstanceHandle, ModuleInfo,
+    OnDemandInstanceAllocator, SignalHandler, StoreBox, StorePtr, VMContext, VMExternRef,
+    VMExternRefActivationsTable, VMFuncRef, VMRuntimeLimits, WasmFault,
 };
 
 mod context;
@@ -433,8 +433,14 @@ where
 /// instance allocator.
 struct StoreInstance {
     handle: InstanceHandle,
-    // Stores whether or not to use the on-demand allocator to deallocate the instance
-    ondemand: bool,
+
+    /// Whether or not this is a dummy instance that is just an implementation
+    /// detail for something else. For example, host-created memories internally
+    /// create a dummy instance.
+    ///
+    /// Regardless of the configured instance allocator for this engine, dummy
+    /// instances always use the on-demand allocator to deallocate the instance.
+    dummy: bool,
 }
 
 #[derive(Copy, Clone)]
@@ -1247,10 +1253,23 @@ impl StoreOpaque {
         &mut self.host_globals
     }
 
-    pub unsafe fn add_instance(&mut self, handle: InstanceHandle, ondemand: bool) -> InstanceId {
+    pub unsafe fn add_instance(&mut self, handle: InstanceHandle) -> InstanceId {
         self.instances.push(StoreInstance {
             handle: handle.clone(),
-            ondemand,
+            dummy: false,
+        });
+        InstanceId(self.instances.len() - 1)
+    }
+
+    /// Add a dummy instance that to the store.
+    ///
+    /// These are instances that are just implementation details of something
+    /// else (e.g. host-created memories that are not actually defined in any
+    /// Wasm module) and therefore shouldn't show up in things like core dumps.
+    pub unsafe fn add_dummy_instance(&mut self, handle: InstanceHandle) -> InstanceId {
+        self.instances.push(StoreInstance {
+            handle: handle.clone(),
+            dummy: true,
         });
         InstanceId(self.instances.len() - 1)
     }
@@ -1263,22 +1282,64 @@ impl StoreOpaque {
         &mut self.instances[id.0].handle
     }
 
-    pub fn all_instances(&self) -> impl ExactSizeIterator<Item = Instance> {
-        self.store_data()
-            .iter::<InstanceData>()
-            .map(Instance::from_stored)
+    /// Get all instances (ignoring dummy instances) within this store.
+    pub fn all_instances<'a>(&'a mut self) -> impl ExactSizeIterator<Item = Instance> + 'a {
+        let instances = self
+            .instances
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, inst)| {
+                let id = InstanceId::from_index(idx);
+                if inst.dummy {
+                    None
+                } else {
+                    Some(InstanceData::from_id(id))
+                }
+            })
+            .collect::<Vec<_>>();
+        instances
+            .into_iter()
+            .map(|i| Instance::from_wasmtime(i, self))
     }
 
-    pub fn all_memories(&self) -> impl ExactSizeIterator<Item = Memory> {
-        self.store_data()
-            .iter::<ExportMemory>()
-            .map(Memory::from_stored)
+    /// Get all memories (host- or Wasm-defined) within this store.
+    pub fn all_memories<'a>(&'a mut self) -> impl Iterator<Item = Memory> + 'a {
+        unsafe {
+            let mems = self
+                .instances
+                .iter_mut()
+                .flat_map(|instance| instance.handle.defined_memories())
+                .collect::<Vec<_>>();
+            mems.into_iter()
+                .map(|memory| Memory::from_wasmtime_memory(memory, self))
+        }
     }
 
-    pub fn all_globals(&self) -> impl ExactSizeIterator<Item = Global> {
-        self.store_data()
-            .iter::<ExportGlobal>()
-            .map(Global::from_stored)
+    /// Iterate over all globals (host- or Wasm-defined) within this store.
+    pub fn all_globals<'a>(&'a mut self) -> impl Iterator<Item = Global> + 'a {
+        unsafe {
+            // First gather all the host-created globals.
+            let mut globals = self
+                .host_globals()
+                .iter()
+                .map(|global| ExportGlobal {
+                    definition: &mut (*global.get()).global as *mut _,
+                    global: (*global.get()).ty.to_wasm_type(),
+                })
+                .collect::<Vec<_>>();
+
+            // Then iterate over all instances and yield each of their defined
+            // globals.
+            globals.extend(
+                self.instances.iter_mut().flat_map(|instance| {
+                    instance.handle.defined_globals().map(|(_i, global)| global)
+                }),
+            );
+
+            globals
+                .into_iter()
+                .map(|g| Global::from_wasmtime_global(g, self))
+        }
     }
 
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))] // not used on all platforms
@@ -2207,7 +2268,7 @@ impl Drop for StoreOpaque {
             let allocator = self.engine.allocator();
             let ondemand = OnDemandInstanceAllocator::default();
             for instance in self.instances.iter_mut() {
-                if instance.ondemand {
+                if instance.dummy {
                     ondemand.deallocate_module(&mut instance.handle);
                 } else {
                     allocator.deallocate_module(&mut instance.handle);

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1304,15 +1304,13 @@ impl StoreOpaque {
 
     /// Get all memories (host- or Wasm-defined) within this store.
     pub fn all_memories<'a>(&'a mut self) -> impl Iterator<Item = Memory> + 'a {
-        unsafe {
-            let mems = self
-                .instances
-                .iter_mut()
-                .flat_map(|instance| instance.handle.defined_memories())
-                .collect::<Vec<_>>();
-            mems.into_iter()
-                .map(|memory| Memory::from_wasmtime_memory(memory, self))
-        }
+        let mems = self
+            .instances
+            .iter_mut()
+            .flat_map(|instance| instance.handle.defined_memories())
+            .collect::<Vec<_>>();
+        mems.into_iter()
+            .map(|memory| unsafe { Memory::from_wasmtime_memory(memory, self) })
     }
 
     /// Iterate over all globals (host- or Wasm-defined) within this store.

--- a/crates/wasmtime/src/store/data.rs
+++ b/crates/wasmtime/src/store/data.rs
@@ -13,6 +13,12 @@ use std::sync::atomic::{AtomicU64, Ordering::Relaxed};
 #[derive(Copy, Clone)]
 pub struct InstanceId(pub(super) usize);
 
+impl InstanceId {
+    pub fn from_index(idx: usize) -> InstanceId {
+        InstanceId(idx)
+    }
+}
+
 pub struct StoreData {
     id: StoreId,
     funcs: Vec<crate::func::FuncData>,

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -50,7 +50,7 @@ fn create_handle(
                 wmemcheck: false,
             })?;
 
-        Ok(store.add_instance(handle, true))
+        Ok(store.add_dummy_instance(handle))
     }
 }
 

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -5,8 +5,8 @@ use wasmtime_runtime::{StoreBox, VMGlobalDefinition};
 
 #[repr(C)]
 pub struct VMHostGlobalContext {
-    ty: GlobalType,
-    global: VMGlobalDefinition,
+    pub(crate) ty: GlobalType,
+    pub(crate) global: VMGlobalDefinition,
 }
 
 impl Drop for VMHostGlobalContext {

--- a/crates/wasmtime/src/trampoline/memory.rs
+++ b/crates/wasmtime/src/trampoline/memory.rs
@@ -71,7 +71,7 @@ pub fn create_memory(
             ondemand: OnDemandInstanceAllocator::default(),
         }
         .allocate_module(request)?;
-        let instance_id = store.add_instance(handle.clone(), true);
+        let instance_id = store.add_dummy_instance(handle.clone());
         Ok(instance_id)
     }
 }

--- a/crates/wasmtime/src/trap.rs
+++ b/crates/wasmtime/src/trap.rs
@@ -77,7 +77,7 @@ pub(crate) unsafe fn raise(error: anyhow::Error) -> ! {
 
 #[cold] // traps are exceptional, this helps move handling off the main path
 pub(crate) fn from_runtime_box(
-    store: &StoreOpaque,
+    store: &mut StoreOpaque,
     runtime_trap: Box<wasmtime_runtime::Trap>,
 ) -> Error {
     let wasmtime_runtime::Trap {

--- a/crates/wasmtime/src/types.rs
+++ b/crates/wasmtime/src/types.rs
@@ -272,6 +272,15 @@ impl GlobalType {
         self.mutability
     }
 
+    pub(crate) fn to_wasm_type(&self) -> Global {
+        let wasm_ty = self.content().to_wasm_type();
+        let mutability = matches!(self.mutability(), Mutability::Var);
+        Global {
+            wasm_ty,
+            mutability,
+        }
+    }
+
     /// Returns `None` if the wasmtime global has a type that we can't
     /// represent, but that should only very rarely happen and indicate a bug.
     pub(crate) fn from_wasmtime_global(global: &Global) -> GlobalType {

--- a/tests/all/coredump.rs
+++ b/tests/all/coredump.rs
@@ -3,17 +3,17 @@ use wasmtime::*;
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn test_coredump_attached_to_error() -> Result<()> {
+fn coredump_attached_to_error() -> Result<()> {
     let mut config = Config::default();
     config.coredump_on_trap(true);
     let engine = Engine::new(&config).unwrap();
     let mut store = Store::<()>::new(&engine, ());
 
     let wat = r#"
-      (module
-      (func $hello (import "" "hello"))
-      (func (export "run") (call $hello))
-      )
+        (module
+            (func $hello (import "" "hello"))
+            (func (export "run") (call $hello))
+        )
     "#;
 
     let module = Module::new(store.engine(), wat)?;
@@ -36,7 +36,7 @@ fn test_coredump_attached_to_error() -> Result<()> {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn test_coredump_has_stack() -> Result<()> {
+fn coredump_has_stack() -> Result<()> {
     let mut config = Config::default();
     config.coredump_on_trap(true);
     let engine = Engine::new(&config).unwrap();
@@ -44,15 +44,15 @@ fn test_coredump_has_stack() -> Result<()> {
 
     let wat = r#"
       (module
-        (func $a (export "a")
-            call $b
-        )
-        (func $b
-            call $c
-        )
-        (func $c 
-            unreachable
-        )
+          (func $a (export "a")
+              call $b
+          )
+          (func $b
+              call $c
+          )
+          (func $c
+              unreachable
+          )
       )
     "#;
 
@@ -71,7 +71,7 @@ fn test_coredump_has_stack() -> Result<()> {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn test_coredump_has_modules_and_instances() -> Result<()> {
+fn coredump_has_modules_and_instances() -> Result<()> {
     let mut config = Config::default();
     config.coredump_on_trap(true);
     let engine = Engine::new(&config).unwrap();
@@ -79,19 +79,19 @@ fn test_coredump_has_modules_and_instances() -> Result<()> {
     let mut store = Store::<()>::new(&engine, ());
 
     let wat1 = r#"
-      (module $foo
-        (import "bar" "b" (func $b))
-        (func (export "a")
-            call $b
+        (module $foo
+            (import "bar" "b" (func $b))
+            (func (export "a")
+                call $b
+            )
         )
-      )
     "#;
     let wat2 = r#"
-      (module $bar
-        (func (export "b")
-            unreachable
+        (module $bar
+            (func (export "b")
+                unreachable
+            )
         )
-      )
     "#;
     let module1 = Module::new(store.engine(), wat1)?;
     let module2 = Module::new(store.engine(), wat2)?;
@@ -110,38 +110,145 @@ fn test_coredump_has_modules_and_instances() -> Result<()> {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn test_coredump_has_import_globals_and_memory() -> Result<()> {
+fn coredump_has_host_globals_and_memory() -> Result<()> {
     let mut config = Config::default();
+    config.coredump_on_trap(true);
+    let engine = Engine::new(&config).unwrap();
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (import "memory" "memory" (memory 1))
+                (global $myglobal (import "global" "global") (mut i32))
+                (func (export "a") (result i32)
+                    unreachable
+                )
+                (export "memory" (memory 0))
+                (export "global" (global 0))
+            )
+        "#,
+    )?;
+
+    let mut store = Store::<()>::new(&engine, ());
+    let mut linker = Linker::new(&engine);
+
+    let memory = Memory::new(&mut store, MemoryType::new(1, None))?;
+    linker.define(&mut store, "memory", "memory", memory)?;
+
+    let global = Global::new(
+        &mut store,
+        GlobalType::new(ValType::I32, Mutability::Var),
+        Val::I32(0),
+    )?;
+    linker.define(&mut store, "global", "global", global)?;
+
+    let instance = linker.instantiate(&mut store, &module)?;
+
+    // Each time we extract the exports, it puts them in the `StoreData`. Our
+    // core dumps need to be robust to duplicate entries in the `StoreData`.
+    for _ in 0..10 {
+        let _ = instance.get_global(&mut store, "global").unwrap();
+        let _ = instance.get_memory(&mut store, "memory").unwrap();
+    }
+
+    let a_func = instance.get_typed_func::<(), i32>(&mut store, "a")?;
+    let err = a_func.call(&mut store, ()).unwrap_err();
+    let core_dump = err.downcast_ref::<WasmCoreDump>().unwrap();
+    assert_eq!(core_dump.globals().len(), 1);
+    assert_eq!(core_dump.memories().len(), 1);
+    assert_eq!(core_dump.instances().len(), 1);
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn coredump_has_defined_globals_and_memory() -> Result<()> {
+    let mut config = Config::default();
+    config.coredump_on_trap(true);
+    let engine = Engine::new(&config).unwrap();
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (global (mut i32) (i32.const 42))
+                (memory 1)
+                (func (export "a")
+                    unreachable
+                )
+            )
+        "#,
+    )?;
+
+    let mut store = Store::<()>::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[])?;
+
+    let a_func = instance.get_typed_func::<(), ()>(&mut store, "a")?;
+    let err = a_func.call(&mut store, ()).unwrap_err();
+    let core_dump = err.downcast_ref::<WasmCoreDump>().unwrap();
+    assert_eq!(core_dump.globals().len(), 1);
+    assert_eq!(core_dump.memories().len(), 1);
+    assert_eq!(core_dump.instances().len(), 1);
+
+    Ok(())
+}
+
+#[test]
+fn multiple_globals_memories_and_instances() -> Result<()> {
+    let mut config = Config::default();
+    config.wasm_multi_memory(true);
     config.coredump_on_trap(true);
     let engine = Engine::new(&config).unwrap();
     let mut store = Store::<()>::new(&engine, ());
     let mut linker = Linker::new(&engine);
 
-    let wat = r#"
-      (module
-        (import "memory" "memory" (memory 1))
-        (global $myglobal (import "js" "global") (mut i32))
-        (func (export "a") (result i32)
-          unreachable
-        )
-      )
-    "#;
+    let memory = Memory::new(&mut store, MemoryType::new(1, None))?;
+    linker.define(&mut store, "host", "memory", memory)?;
 
-    let module = Module::new(store.engine(), wat)?;
-    let m = wasmtime::Memory::new(&mut store, MemoryType::new(1, None))?;
-    linker.define(&mut store, "memory", "memory", m)?;
-    let g = wasmtime::Global::new(
+    let global = Global::new(
         &mut store,
         GlobalType::new(ValType::I32, Mutability::Var),
         Val::I32(0),
     )?;
-    linker.define(&mut store, "js", "global", g)?;
-    let instance = linker.instantiate(&mut store, &module)?;
-    let a_func = instance.get_typed_func::<(), i32>(&mut store, "a")?;
-    let e = a_func.call(&mut store, ()).unwrap_err();
-    let cd = e.downcast_ref::<WasmCoreDump>().unwrap();
-    assert_eq!(cd.store_globals().len(), 1);
-    assert_eq!(cd.store_memories().len(), 1);
+    linker.define(&mut store, "host", "global", global)?;
+
+    let module_a = Module::new(
+        &engine,
+        r#"
+            (module
+                (memory (export "memory") 1)
+                (global (export "global") (mut i32) (i32.const 0))
+            )
+        "#,
+    )?;
+    let instance_a = linker.instantiate(&mut store, &module_a)?;
+    linker.instance(&mut store, "a", instance_a)?;
+
+    let module_b = Module::new(
+        &engine,
+        r#"
+            (module
+                (import "host" "memory" (memory 1))
+                (import "host" "global" (global (mut i32)))
+                (import "a" "memory" (memory 1))
+                (import "a" "global" (global (mut i32)))
+
+                (func (export "trap")
+                    unreachable
+                )
+            )
+        "#,
+    )?;
+    let instance_b = linker.instantiate(&mut store, &module_b)?;
+
+    let trap_func = instance_b.get_typed_func::<(), ()>(&mut store, "trap")?;
+    let err = trap_func.call(&mut store, ()).unwrap_err();
+    let core_dump = err.downcast_ref::<WasmCoreDump>().unwrap();
+    assert_eq!(core_dump.globals().len(), 2);
+    assert_eq!(core_dump.memories().len(), 2);
+    assert_eq!(core_dump.instances().len(), 2);
 
     Ok(())
 }

--- a/tests/all/coredump.rs
+++ b/tests/all/coredump.rs
@@ -196,6 +196,7 @@ fn coredump_has_defined_globals_and_memory() -> Result<()> {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)]
 fn multiple_globals_memories_and_instances() -> Result<()> {
     let mut config = Config::default();
     config.wasm_multi_memory(true);


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
