### PR TITLE
Fix some more fuzz-test cases from pooling changes 

### DIFF
--- a/crates/jit/src/unwind/miri.rs
+++ b/crates/jit/src/unwind/miri.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 pub struct UnwindRegistration {}
 
 impl UnwindRegistration {
-    pub const SECTION_NAME: &str = ".eh_frame";
+    pub const SECTION_NAME: &'static str = ".eh_frame";
 
     pub unsafe fn new(
         _base_address: *const u8,

--- a/crates/jit/src/unwind/systemv.rs
+++ b/crates/jit/src/unwind/systemv.rs
@@ -14,7 +14,7 @@ extern "C" {
 }
 
 impl UnwindRegistration {
-    pub const SECTION_NAME: &str = ".eh_frame";
+    pub const SECTION_NAME: &'static str = ".eh_frame";
 
     /// Registers precompiled unwinding information with the system.
     ///

--- a/crates/jit/src/unwind/winx64.rs
+++ b/crates/jit/src/unwind/winx64.rs
@@ -10,7 +10,7 @@ pub struct UnwindRegistration {
 }
 
 impl UnwindRegistration {
-    pub const SECTION_NAME: &str = ".pdata";
+    pub const SECTION_NAME: &'static str = ".pdata";
 
     pub unsafe fn new(
         base_address: *const u8,

--- a/fuzz/fuzz_targets/instantiate-many.rs
+++ b/fuzz/fuzz_targets/instantiate-many.rs
@@ -12,7 +12,7 @@ const MAX_MODULES: usize = 5;
 fuzz_target!(|data: &[u8]| {
     // errors in `run` have to do with not enough input in `data`, which we
     // ignore here since it doesn't affect how we'd like to fuzz.
-    drop(execute_one(data));
+    let _ = execute_one(data);
 });
 
 fn execute_one(data: &[u8]) -> Result<()> {


### PR DESCRIPTION
This commit addresses some more fallout from https://github.com/bytecodealliance/wasmtime/pull/6835 by updating some
error messages and adding clauses for new conditions. Namely:

* Module compilation is now allowed to fail when the module may have
  more memories/tables than the pooling allocator allows per-module.
* The error message for the core instance limit being reached has been
  updated.