### PR TITLE
Update in-tree wit-bindgen to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
 name = "arbitrary"
@@ -659,7 +659,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "toml",
- "wasmparser 0.112.0",
+ "wasmparser",
  "wat",
 ]
 
@@ -838,7 +838,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.112.0",
+ "wasmparser",
  "wasmtime-types",
  "wat",
 ]
@@ -2680,7 +2680,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wasmtime-wasi-http",
- "wit-component 0.14.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -2956,7 +2956,7 @@ name = "verify-component-adapter"
 version = "14.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.112.0",
+ "wasmparser",
  "wat",
 ]
 
@@ -3058,7 +3058,7 @@ dependencies = [
  "byte-array-literals",
  "object",
  "wasi",
- "wasm-encoder 0.32.0",
+ "wasm-encoder",
  "wit-bindgen",
 ]
 
@@ -3152,35 +3152,11 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f8e9778e04cbf44f58acc301372577375a666b966c50b03ef46144f80436a8"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba64e81215916eaeb48fee292f29401d69235d62d8b8fd92a7b2844ec5ae5f7"
 dependencies = [
  "leb128",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51db59397fc650b5f2fc778e4a5c4456cd856bed7fc1ec15f8d3e28229dc463"
-dependencies = [
- "anyhow",
- "indexmap 2.0.0",
- "serde",
- "serde_json",
- "spdx",
- "wasm-encoder 0.30.0",
- "wasmparser 0.108.0",
 ]
 
 [[package]]
@@ -3194,8 +3170,8 @@ dependencies = [
  "serde",
  "serde_json",
  "spdx",
- "wasm-encoder 0.32.0",
- "wasmparser 0.112.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3208,8 +3184,8 @@ dependencies = [
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.32.0",
- "wasmparser 0.112.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3222,8 +3198,8 @@ dependencies = [
  "flagset",
  "indexmap 2.0.0",
  "leb128",
- "wasm-encoder 0.32.0",
- "wasmparser 0.112.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3266,16 +3242,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.108.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76c956109dcb41436a39391139d9b6e2d0a5e0b158e1293ef352ec977e5e36c5"
-dependencies = [
- "indexmap 2.0.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e986b010f47fcce49cf8ea5d5f9e5d2737832f12b53ae8ae785bbe895d0877bf"
@@ -3300,7 +3266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ddf5892036cd4b780d505eff1194a0cbc10ed896097656fdcea3744b5e7c2f"
 dependencies = [
  "anyhow",
- "wasmparser 0.112.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3328,8 +3294,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-cap-std-sync",
- "wasm-encoder 0.32.0",
- "wasmparser 0.112.0",
+ "wasm-encoder",
+ "wasmparser",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -3444,8 +3410,8 @@ dependencies = [
  "test-programs",
  "tokio",
  "walkdir",
- "wasm-encoder 0.32.0",
- "wasmparser 0.112.0",
+ "wasm-encoder",
+ "wasmparser",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3489,7 +3455,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.11.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -3513,7 +3479,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.112.0",
+ "wasmparser",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
@@ -3550,8 +3516,8 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "thiserror",
- "wasm-encoder 0.32.0",
- "wasmparser 0.112.0",
+ "wasm-encoder",
+ "wasmparser",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3566,7 +3532,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger 0.10.0",
  "libfuzzer-sys",
- "wasmparser 0.112.0",
+ "wasmparser",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -3622,7 +3588,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.112.0",
+ "wasmparser",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -3642,12 +3608,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.32.0",
+ "wasm-encoder",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.112.0",
+ "wasmparser",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3717,7 +3683,7 @@ dependencies = [
  "rand",
  "rustix 0.38.8",
  "sptr",
- "wasm-encoder 0.32.0",
+ "wasm-encoder",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -3735,7 +3701,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "thiserror",
- "wasmparser 0.112.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3846,7 +3812,7 @@ dependencies = [
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser 0.112.0",
+ "wasmparser",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "winch-codegen",
@@ -3859,7 +3825,7 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap 2.0.0",
- "wit-parser 0.11.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -3884,7 +3850,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.32.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -4018,7 +3984,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.112.0",
+ "wasmparser",
  "wasmtime-environ",
 ]
 
@@ -4063,7 +4029,7 @@ dependencies = [
  "similar",
  "target-lexicon",
  "toml",
- "wasmparser 0.112.0",
+ "wasmparser",
  "wasmtime-environ",
  "wat",
  "winch-codegen",
@@ -4149,9 +4115,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c3d15a04ce994fad2c5442a754b404ab1fee23c903a04a560f84f94fdf63c0"
+checksum = "f8a3e8e965dc50e6eb4410d9a11720719fadc6a1713803ea5f3be390b81c8279"
 dependencies = [
  "bitflags 2.3.3",
  "wit-bindgen-rust-macro",
@@ -4159,33 +4125,34 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9658ec54d4a3c9e2f079bc65a131093337595b595fbf82f805008469838cdea"
+checksum = "77255512565dfbd0b61de466e854918041d1da53c7bc049d6188c6e02643dc1e"
 dependencies = [
  "anyhow",
- "wit-component 0.12.0",
- "wit-parser 0.9.2",
+ "wit-component",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21ae6a6198ba9765771b977e2af985a0d5ac71b59f999da5c4ee1c7bbd8ca8dc"
+checksum = "399c60e6ea8598d1380e792f13d557007834f0fb799fea6503408cbc5debb4ae"
 dependencies = [
+ "anyhow",
  "heck",
- "wasm-metadata 0.9.0",
+ "wasm-metadata",
  "wit-bindgen-core",
  "wit-bindgen-rust-lib",
- "wit-component 0.12.0",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-bindgen-rust-lib"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c31de8c6c77cac1fd4927c7584d1314cd5e838cfb40b53333d6dffc7a132dda"
+checksum = "cd9fb7a43c7dc28b0b727d6ae01bf369981229b7539e768fba2b7a4df13feeeb"
 dependencies = [
  "heck",
  "wit-bindgen-core",
@@ -4193,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.9.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2abe5c7c4c08468d01590aa96c8a684dd94fb9241a248af88eef7edac61e43"
+checksum = "44cea5ed784da06da0e55836a6c160e7502dbe28771c2368a595e8606243bf22"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4203,23 +4170,7 @@ dependencies = [
  "wit-bindgen-core",
  "wit-bindgen-rust",
  "wit-bindgen-rust-lib",
- "wit-component 0.12.0",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253bd426c532f1cae8c633c517c63719920535f3a7fada3589de40c5b734e393"
-dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "indexmap 2.0.0",
- "log",
- "wasm-encoder 0.30.0",
- "wasm-metadata 0.9.0",
- "wasmparser 0.108.0",
- "wit-parser 0.9.2",
+ "wit-component",
 ]
 
 [[package]]
@@ -4234,26 +4185,10 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "wasm-encoder 0.32.0",
- "wasm-metadata 0.10.3",
- "wasmparser 0.112.0",
- "wit-parser 0.11.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541efa2046e544de53a9da1e2f6299e63079840360c9e106f1f8275a97771318"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.0.0",
- "log",
- "pulldown-cmark",
- "semver",
- "unicode-xid",
- "url",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -207,7 +207,7 @@ io-extras = "0.18.0"
 rustix = "0.38.8"
 is-terminal = "0.4.0"
 # wit-bindgen:
-wit-bindgen = { version = "0.9.0", default-features = false }
+wit-bindgen = { version = "0.11.0", default-features = false }
 
 # wasm-tools family:
 wasmparser = "0.112.0"
@@ -328,3 +328,10 @@ debug-assertions = false
 # Omit integer overflow checks, which include failure messages which require
 # string initializers.
 overflow-checks = false
+
+# Same as `wasi-preview1-component-adapter` above
+[profile.dev.package.wit-bindgen]
+incremental = false
+debug-assertions = false
+overflow-checks = false
+opt-level = 's'

--- a/crates/test-programs/build.rs
+++ b/crates/test-programs/build.rs
@@ -61,7 +61,7 @@ fn build_and_generate_tests() {
 
     if BUILD_WASI_HTTP_TESTS {
         modules_rs(&meta, "wasi-http-tests", "bin", &out_dir);
-        components_rs(&meta, "wasi-http-tests", "bin", &reactor_adapter, &out_dir);
+        components_rs(&meta, "wasi-http-tests", "bin", &command_adapter, &out_dir);
     }
 
     components_rs(&meta, "command-tests", "bin", &command_adapter, &out_dir);

--- a/crates/test-programs/reactor-tests/src/lib.rs
+++ b/crates/test-programs/reactor-tests/src/lib.rs
@@ -1,12 +1,16 @@
-wit_bindgen::generate!("test-reactor" in "../../wasi/wit");
-
-export_test_reactor!(T);
+wit_bindgen::generate!({
+    world: "test-reactor",
+    path: "../../wasi/wit",
+    exports: {
+        world: T,
+    }
+});
 
 struct T;
 
 static mut STATE: Vec<String> = Vec::new();
 
-impl TestReactor for T {
+impl Guest for T {
     fn add_strings(ss: Vec<String>) -> u32 {
         for s in ss {
             match s.split_once("$") {

--- a/crates/test-programs/tests/wasi-http-modules.rs
+++ b/crates/test-programs/tests/wasi-http-modules.rs
@@ -69,7 +69,7 @@ async fn instantiate_module(module: Module, ctx: Ctx) -> Result<(Store<Ctx>, Fun
     let mut store = Store::new(&ENGINE, ctx);
 
     let instance = linker.instantiate_async(&mut store, &module).await?;
-    let command = instance.get_func(&mut store, "wasi:cli/run#run").unwrap();
+    let command = instance.get_func(&mut store, "_start").unwrap();
     Ok((store, command))
 }
 
@@ -103,9 +103,7 @@ async fn run(name: &str) -> anyhow::Result<()> {
             },
         )
         .await?;
-        command
-            .call_async(&mut store, &[], &mut [wasmtime::Val::null()])
-            .await
+        command.call_async(&mut store, &[], &mut []).await
     };
     r.map_err(move |trap: anyhow::Error| {
         let stdout = stdout.try_into_inner().expect("single ref to stdout");

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_get.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_get.rs
@@ -1,11 +1,11 @@
-use anyhow::{Context, Result};
+use anyhow::Context;
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
-struct Component;
+fn main() {
+    wasi_http_tests::in_tokio(async { run().await })
+}
 
-fn main() {}
-
-async fn run() -> Result<(), ()> {
+async fn run() {
     let res = wasi_http_tests::request(
         Method::Get,
         Scheme::Http,
@@ -28,14 +28,4 @@ async fn run() -> Result<(), ()> {
         "http://localhost:3000/get?some=arg&goes=here"
     );
     assert_eq!(res.body, b"");
-
-    Ok(())
 }
-
-impl wasi_http_tests::bindings::exports::wasi::cli::run::Run for Component {
-    fn run() -> Result<(), ()> {
-        wasi_http_tests::in_tokio(async { run().await })
-    }
-}
-
-wasi_http_tests::export_command_extended!(Component);

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_dnsname.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_dnsname.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
-struct Component;
+fn main() {
+    wasi_http_tests::in_tokio(async { run().await })
+}
 
-fn main() {}
-
-async fn run() -> Result<(), ()> {
+async fn run() {
     let res = wasi_http_tests::request(
         Method::Get,
         Scheme::Http,
@@ -18,14 +17,4 @@ async fn run() -> Result<(), ()> {
 
     let error = res.unwrap_err();
     assert_eq!(error.to_string(), "Error::InvalidUrl(\"invalid dnsname\")");
-
-    Ok(())
 }
-
-impl wasi_http_tests::bindings::exports::wasi::cli::run::Run for Component {
-    fn run() -> Result<(), ()> {
-        wasi_http_tests::in_tokio(async { run().await })
-    }
-}
-
-wasi_http_tests::export_command_extended!(Component);

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_port.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_port.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
-struct Component;
+fn main() {
+    wasi_http_tests::in_tokio(async { run().await })
+}
 
-fn main() {}
-
-async fn run() -> Result<(), ()> {
+async fn run() {
     let res = wasi_http_tests::request(
         Method::Get,
         Scheme::Http,
@@ -21,14 +20,4 @@ async fn run() -> Result<(), ()> {
         error.to_string(),
         "Error::InvalidUrl(\"invalid port value\")"
     );
-
-    Ok(())
 }
-
-impl wasi_http_tests::bindings::exports::wasi::cli::run::Run for Component {
-    fn run() -> Result<(), ()> {
-        wasi_http_tests::in_tokio(async { run().await })
-    }
-}
-
-wasi_http_tests::export_command_extended!(Component);

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_version.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_version.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
-struct Component;
+fn main() {
+    wasi_http_tests::in_tokio(async { run().await })
+}
 
-fn main() {}
-
-async fn run() -> Result<(), ()> {
+async fn run() {
     let res = wasi_http_tests::request(
         Method::Connect,
         Scheme::Http,
@@ -27,14 +26,4 @@ async fn run() -> Result<(), ()> {
             or `"Error::ProtocolError(\"operation was canceled\")"`)"#
         )
     }
-
-    Ok(())
 }
-
-impl wasi_http_tests::bindings::exports::wasi::cli::run::Run for Component {
-    fn run() -> Result<(), ()> {
-        wasi_http_tests::in_tokio(async { run().await })
-    }
-}
-
-wasi_http_tests::export_command_extended!(Component);

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_post.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_post.rs
@@ -1,11 +1,11 @@
-use anyhow::{Context, Result};
+use anyhow::Context;
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
-struct Component;
+fn main() {
+    wasi_http_tests::in_tokio(async { run().await })
+}
 
-fn main() {}
-
-async fn run() -> Result<(), ()> {
+async fn run() {
     let res = wasi_http_tests::request(
         Method::Post,
         Scheme::Http,
@@ -23,14 +23,4 @@ async fn run() -> Result<(), ()> {
     let method = res.header("x-wasmtime-test-method").unwrap();
     assert_eq!(std::str::from_utf8(method).unwrap(), "POST");
     assert_eq!(res.body, b"{\"foo\": \"bar\"}");
-
-    Ok(())
 }
-
-impl wasi_http_tests::bindings::exports::wasi::cli::run::Run for Component {
-    fn run() -> Result<(), ()> {
-        wasi_http_tests::in_tokio(async { run().await })
-    }
-}
-
-wasi_http_tests::export_command_extended!(Component);

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_post_large.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_post_large.rs
@@ -4,9 +4,11 @@ use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
 struct Component;
 
-fn main() {}
+fn main() {
+    wasi_http_tests::in_tokio(async { run().await })
+}
 
-async fn run() -> Result<(), ()> {
+async fn run() {
     const LEN: usize = 4000;
     let mut buffer = [0; LEN];
     io::repeat(0b001).read_exact(&mut buffer).unwrap();
@@ -27,14 +29,4 @@ async fn run() -> Result<(), ()> {
     let method = res.header("x-wasmtime-test-method").unwrap();
     assert_eq!(std::str::from_utf8(method).unwrap(), "POST");
     assert_eq!(res.body.len(), LEN);
-
-    Ok(())
 }
-
-impl wasi_http_tests::bindings::exports::wasi::cli::run::Run for Component {
-    fn run() -> Result<(), ()> {
-        wasi_http_tests::in_tokio(async { run().await })
-    }
-}
-
-wasi_http_tests::export_command_extended!(Component);

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_put.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_put.rs
@@ -1,11 +1,11 @@
-use anyhow::{Context, Result};
+use anyhow::Context;
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
-struct Component;
+fn main() {
+    wasi_http_tests::in_tokio(async { run().await })
+}
 
-fn main() {}
-
-async fn run() -> Result<(), ()> {
+async fn run() {
     let res = wasi_http_tests::request(
         Method::Put,
         Scheme::Http,
@@ -23,14 +23,4 @@ async fn run() -> Result<(), ()> {
     let method = res.header("x-wasmtime-test-method").unwrap();
     assert_eq!(std::str::from_utf8(method).unwrap(), "PUT");
     assert_eq!(res.body, b"");
-
-    Ok(())
 }
-
-impl wasi_http_tests::bindings::exports::wasi::cli::run::Run for Component {
-    fn run() -> Result<(), ()> {
-        wasi_http_tests::in_tokio(async { run().await })
-    }
-}
-
-wasi_http_tests::export_command_extended!(Component);

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_unknown_method.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_unknown_method.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
-struct Component;
+fn main() {
+    wasi_http_tests::in_tokio(async { run().await })
+}
 
-fn main() {}
-
-async fn run() -> Result<(), ()> {
+async fn run() {
     let res = wasi_http_tests::request(
         Method::Other("OTHER".to_owned()),
         Scheme::Http,
@@ -21,14 +20,4 @@ async fn run() -> Result<(), ()> {
         error.to_string(),
         "Error::InvalidUrl(\"unknown method OTHER\")"
     );
-
-    Ok(())
 }
-
-impl wasi_http_tests::bindings::exports::wasi::cli::run::Run for Component {
-    fn run() -> Result<(), ()> {
-        wasi_http_tests::in_tokio(async { run().await })
-    }
-}
-
-wasi_http_tests::export_command_extended!(Component);

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_unsupported_scheme.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_unsupported_scheme.rs
@@ -1,11 +1,10 @@
-use anyhow::Result;
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
-struct Component;
+fn main() {
+    wasi_http_tests::in_tokio(async { run().await })
+}
 
-fn main() {}
-
-async fn run() -> Result<(), ()> {
+async fn run() {
     let res = wasi_http_tests::request(
         Method::Get,
         Scheme::Other("WS".to_owned()),
@@ -21,14 +20,4 @@ async fn run() -> Result<(), ()> {
         error.to_string(),
         "Error::InvalidUrl(\"unsupported scheme WS\")"
     );
-
-    Ok(())
 }
-
-impl wasi_http_tests::bindings::exports::wasi::cli::run::Run for Component {
-    fn run() -> Result<(), ()> {
-        wasi_http_tests::in_tokio(async { run().await })
-    }
-}
-
-wasi_http_tests::export_command_extended!(Component);

--- a/crates/test-programs/wasi-http-tests/src/lib.rs
+++ b/crates/test-programs/wasi-http-tests/src/lib.rs
@@ -2,8 +2,8 @@ pub mod bindings {
     wit_bindgen::generate!({
         path: "../../wasi-http/wit",
         world: "wasmtime:wasi/command-extended",
-        macro_call_prefix: "::wasi_http_tests::bindings::",
-        macro_export,
+        // macro_call_prefix: "::wasi_http_tests::bindings::",
+        // macro_export,
     });
 }
 

--- a/crates/wasi-http/wit/command-extended.wit
+++ b/crates/wasi-http/wit/command-extended.wit
@@ -29,8 +29,6 @@ world command-extended {
   import wasi:cli/terminal-stdout
   import wasi:cli/terminal-stderr
 
-  export wasi:cli/run
-
   // We should replace all others with `include self.command`
   // as soon as the unioning of worlds is available:
   // https://github.com/WebAssembly/component-model/issues/169

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -25,7 +25,7 @@ compile_error!("only one of the `command` and `reactor` features may be selected
 mod macros;
 
 mod descriptors;
-use crate::descriptors::{Descriptor, Descriptors, IsATTY, StreamType, Streams};
+use crate::descriptors::{Descriptor, Descriptors, StreamType, Streams};
 
 pub mod bindings {
     #[cfg(feature = "command")]

--- a/crates/wasi/wit/command-extended.wit
+++ b/crates/wasi/wit/command-extended.wit
@@ -29,8 +29,6 @@ world command-extended {
   import wasi:cli/terminal-stdout
   import wasi:cli/terminal-stderr
 
-  export wasi:cli/run
-
   // We should replace all others with `include self.command`
   // as soon as the unioning of worlds is available:
   // https://github.com/WebAssembly/component-model/issues/169

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -2906,6 +2906,12 @@ user-id = 6743 # Ed Page (epage)
 start = "2023-03-08"
 end = "2024-07-14"
 
+[[trusted.anyhow]]
+criteria = "safe-to-deploy"
+user-id = 3618 # David Tolnay (dtolnay)
+start = "2019-10-05"
+end = "2024-09-01"
+
 [[trusted.async-trait]]
 criteria = "safe-to-deploy"
 user-id = 3618 # David Tolnay (dtolnay)

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -431,6 +431,13 @@ user-id = 6743
 user-login = "epage"
 user-name = "Ed Page"
 
+[[publisher.anyhow]]
+version = "1.0.75"
+when = "2023-08-17"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.arbitrary]]
 version = "1.3.0"
 when = "2023-03-13"
@@ -1769,9 +1776,23 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wit-bindgen]]
+version = "0.11.0"
+when = "2023-08-28"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wit-bindgen-core]]
 version = "0.9.0"
 when = "2023-07-15"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen-core]]
+version = "0.11.0"
+when = "2023-08-28"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1783,6 +1804,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wit-bindgen-rust]]
+version = "0.11.0"
+when = "2023-08-28"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wit-bindgen-rust-lib]]
 version = "0.9.0"
 when = "2023-07-15"
@@ -1790,9 +1818,23 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wit-bindgen-rust-lib]]
+version = "0.11.0"
+when = "2023-08-28"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wit-bindgen-rust-macro]]
 version = "0.9.0"
 when = "2023-07-15"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen-rust-macro]]
+version = "0.11.0"
+when = "2023-08-28"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"


### PR DESCRIPTION
This only affects tests and the adapter itself, but not in any breaking way. The tests for wasi-http are reorganized to be commands which is also required to not have any exports currently since wit-bindgen for Rust guests doesn't support generating bindings in one crate and exporting in another.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
