### PR TITLE
Some minor fixes and features for WASI and sockets

### DIFF
--- a/crates/test-programs/tests/reactor.rs
+++ b/crates/test-programs/tests/reactor.rs
@@ -71,24 +71,9 @@ async fn instantiate(
     wasi_ctx: ReactorCtx,
 ) -> Result<(Store<ReactorCtx>, TestReactor)> {
     let mut linker = Linker::new(&ENGINE);
-
-    // All of the imports available to the world are provided by the wasi-common crate:
-    preview2::bindings::filesystem::types::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::filesystem::preopens::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::io::streams::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::environment::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::exit::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::stdin::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::stdout::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::stderr::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::terminal_input::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::terminal_output::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::terminal_stdin::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::terminal_stdout::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::terminal_stderr::add_to_linker(&mut linker, |x| x)?;
+    preview2::command::add_to_linker(&mut linker)?;
 
     let mut store = Store::new(&ENGINE, wasi_ctx);
-
     let (testreactor, _instance) =
         TestReactor::instantiate_async(&mut store, &component, &linker).await?;
     Ok((store, testreactor))

--- a/crates/test-programs/tests/wasi-sockets.rs
+++ b/crates/test-programs/tests/wasi-sockets.rs
@@ -45,24 +45,7 @@ async fn run(name: &str) -> anyhow::Result<()> {
     let component = get_component(name);
     let mut linker = Linker::new(&ENGINE);
 
-    preview2::bindings::io::streams::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::poll::poll::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::exit::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::stdin::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::stdout::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::stderr::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::terminal_input::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::terminal_output::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::terminal_stdin::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::terminal_stdout::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::terminal_stderr::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::cli::environment::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::filesystem::types::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::filesystem::preopens::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::sockets::tcp::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::sockets::tcp_create_socket::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::sockets::network::add_to_linker(&mut linker, |x| x)?;
-    preview2::bindings::sockets::instance_network::add_to_linker(&mut linker, |x| x)?;
+    preview2::command::add_to_linker(&mut linker)?;
 
     // Create our wasi context.
     let mut table = Table::new();

--- a/crates/wasi/src/preview2/command.rs
+++ b/crates/wasi/src/preview2/command.rs
@@ -37,7 +37,6 @@ pub fn add_to_linker<T: WasiView>(l: &mut wasmtime::component::Linker<T>) -> any
     crate::preview2::bindings::clocks::timezone::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::filesystem::types::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::filesystem::preopens::add_to_linker(l, |t| t)?;
-    crate::preview2::bindings::sockets::tcp::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::poll::poll::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::io::streams::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::random::random::add_to_linker(l, |t| t)?;
@@ -51,6 +50,10 @@ pub fn add_to_linker<T: WasiView>(l: &mut wasmtime::component::Linker<T>) -> any
     crate::preview2::bindings::cli::terminal_stdin::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::cli::terminal_stdout::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::cli::terminal_stderr::add_to_linker(l, |t| t)?;
+    crate::preview2::bindings::sockets::tcp::add_to_linker(l, |t| t)?;
+    crate::preview2::bindings::sockets::tcp_create_socket::add_to_linker(l, |t| t)?;
+    crate::preview2::bindings::sockets::instance_network::add_to_linker(l, |t| t)?;
+    crate::preview2::bindings::sockets::network::add_to_linker(l, |t| t)?;
     Ok(())
 }
 
@@ -110,6 +113,9 @@ pub mod sync {
         crate::preview2::bindings::cli::terminal_stdout::add_to_linker(l, |t| t)?;
         crate::preview2::bindings::cli::terminal_stderr::add_to_linker(l, |t| t)?;
         crate::preview2::bindings::sockets::tcp::add_to_linker(l, |t| t)?;
+        crate::preview2::bindings::sockets::tcp_create_socket::add_to_linker(l, |t| t)?;
+        crate::preview2::bindings::sockets::instance_network::add_to_linker(l, |t| t)?;
+        crate::preview2::bindings::sockets::network::add_to_linker(l, |t| t)?;
         Ok(())
     }
 }

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -179,3 +179,13 @@ pub(crate) fn in_tokio<F: std::future::Future>(f: F) -> F::Output {
         }
     }
 }
+
+fn with_ambient_tokio_runtime<R>(f: impl FnOnce() -> R) -> R {
+    match tokio::runtime::Handle::try_current() {
+        Ok(_) => f(),
+        Err(_) => {
+            let _enter = RUNTIME.enter();
+            f()
+        }
+    }
+}

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -293,6 +293,11 @@ pub struct RunCommand {
     /// removed. For now this is primarily here for testing.
     #[clap(long)]
     preview2: bool,
+
+    /// Flag for WASI preview2 to inherit the host's network within the guest so
+    /// it has full access to all addresses/ports/etc.
+    #[clap(long)]
+    inherit_network: bool,
 }
 
 #[derive(Clone)]
@@ -1059,6 +1064,10 @@ impl RunCommand {
                 preview2::FilePerms::all(),
                 name,
             );
+        }
+
+        if self.inherit_network {
+            builder.inherit_network(ambient_authority());
         }
 
         let data = store.data_mut();


### PR DESCRIPTION
* Use `command::add_to_linker` in tests to reduce the number of times all the `add_to_linker` are listed.
* Add all `wasi:sockets` interfaces currently implemented to both the sync and async `command` functions (this enables all the interfaces in the CLI for example).
* Use `tokio::net::TcpStream::try_io` whenever I/O is performed on a socket, ensuring that readable/writable flags are set/cleared appropriately (otherwise once readable a socket is infinitely readable).
* Add a `with_ambient_tokio_runtime` helper function to use when creating a `tokio::net::TcpStream` since otherwise it panics due to a lack of active runtime in a synchronous context.
* Add `WouldBlock` handling to return a 0-length read.
* Add an `--inherit-network` CLI flag to enable basic usage of sockets in the CLI.

This will conflict a small amount with #6877 but should be easy to resolve, and otherwise this targets different usability points/issues than that PR.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
