### PR TITLE
fuzzgen: Enable SIMD fuzzing for RISC-V

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::cranelift_arbitrary::CraneliftArbitrary;
+use crate::target_isa_extras::TargetIsaExtras;
 use anyhow::Result;
 use arbitrary::{Arbitrary, Unstructured};
 use cranelift::codegen::data_value::DataValue;
@@ -717,12 +718,6 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
         }
 
         Architecture::Riscv64(_) => {
-            // RISC-V Does not support SIMD at all
-            let is_simd = args.iter().chain(rets).any(|t| t.is_vector());
-            if is_simd {
-                return false;
-            }
-
             exceptions!(
                 op,
                 args,
@@ -761,9 +756,17 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
                 (Opcode::Bitcast, &[I128], &[_]),
                 (Opcode::Bitcast, &[_], &[I128]),
                 // TODO
-                (Opcode::SelectSpectreGuard, &[_, _, _], &[F32 | F64]),
+                (
+                    Opcode::SelectSpectreGuard,
+                    &[_, _, _],
+                    &[F32 | F64 | I8X16 | I16X8 | I32X4 | I64X2 | F64X2 | F32X4]
+                ),
                 // TODO
                 (Opcode::Bitselect, &[_, _, _], &[F32 | F64]),
+                (
+                    Opcode::Rotr | Opcode::Rotl,
+                    &[I8X16 | I16X8 | I32X4 | I64X2, _]
+                ),
             )
         }
 
@@ -1823,7 +1826,7 @@ where
 
         let mut params = Vec::with_capacity(param_count);
         for _ in 0..param_count {
-            params.push(self.u._type(self.isa.triple().architecture)?);
+            params.push(self.u._type((&*self.isa).supports_simd())?);
         }
         Ok(params)
     }
@@ -1843,7 +1846,7 @@ where
 
         // Create a pool of vars that are going to be used in this function
         for _ in 0..self.param(&self.config.vars_per_function)? {
-            let ty = self.u._type(self.isa.triple().architecture)?;
+            let ty = self.u._type((&*self.isa).supports_simd())?;
             let value = self.generate_const(builder, ty)?;
             vars.push((ty, value));
         }

--- a/cranelift/fuzzgen/src/target_isa_extras.rs
+++ b/cranelift/fuzzgen/src/target_isa_extras.rs
@@ -1,0 +1,21 @@
+use cranelift::prelude::isa::TargetIsa;
+use target_lexicon::Architecture;
+
+pub trait TargetIsaExtras {
+    fn supports_simd(&self) -> bool;
+}
+
+impl TargetIsaExtras for &dyn TargetIsa {
+    fn supports_simd(&self) -> bool {
+        match self.triple().architecture {
+            // RISC-V only supports SIMD with the V extension.
+            Architecture::Riscv64(_) => self
+                .isa_flags()
+                .iter()
+                .find(|f| f.name == "has_v")
+                .and_then(|f| f.as_bool())
+                .unwrap_or(false),
+            _ => true,
+        }
+    }
+}

--- a/fuzz/fuzz_targets/cranelift-icache.rs
+++ b/fuzz/fuzz_targets/cranelift-icache.rs
@@ -69,7 +69,7 @@ impl FunctionWithIsa {
         let usercalls = (0..func_count)
             .map(|i| {
                 let name = UserExternalName::new(2, i as u32);
-                let sig = gen.generate_signature(architecture)?;
+                let sig = gen.generate_signature(&*isa)?;
                 Ok((name, sig))
             })
             .collect::<anyhow::Result<Vec<(UserExternalName, Signature)>>>()


### PR DESCRIPTION
👋 Hey,

This PR enables fuzzing SIMD instructions for the RISC-V backend. This is the only backend that requires a extension (`has_v`) for SIMD to work, so we need to check that it has been enabled before allowing SIMD types and instructions.

I've ran this for a while with `icache` and It's no longer crashing. But I haven't been able to run `fuzzgen` very well since I don't have a machine with the V extension, and running it with QEMU is quite slow.