### PR TITLE
[s390x] Improve handling of negative i32 constants

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -2989,7 +2989,7 @@
         dst))
 
 ;; 32-bit result type, value fits in i16
-(rule 6 (imm (gpr32_ty ty) (i16_from_u64 n))
+(rule 6 (imm (gpr32_ty ty) (u32_pair _ (i16_from_u32 n)))
       (let ((dst WritableReg (temp_writable_reg ty))
             (_ Unit (emit (MInst.Mov32SImm16 dst n))))
         dst))

--- a/cranelift/filetests/filetests/isa/s390x/constants.clif
+++ b/cranelift/filetests/filetests/isa/s390x/constants.clif
@@ -189,11 +189,11 @@ block0:
 
 ; VCode:
 ; block0:
-;   iilf %r2, 4294967295
+;   lhi %r2, -1
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   iilf %r2, 0xffffffff
+;   lhi %r2, -1
 ;   br %r14
 


### PR DESCRIPTION
After https://github.com/bytecodealliance/wasmtime/pull/6850 was merged, the s390x back-end now always uses iilf instead of lhi to load negative constants, which is a small code size regression.

Fix the isle predicate to get back lhi whenever possible.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
