### PR TITLE
tcp tests: need a blocking_read to get messages

### DIFF
--- a/crates/test-programs/wasi-sockets-tests/src/bin/tcp_v4.rs
+++ b/crates/test-programs/wasi-sockets-tests/src/bin/tcp_v4.rs
@@ -67,7 +67,7 @@ fn main() {
     assert!(empty_data.is_empty());
     assert_eq!(status, streams::StreamStatus::Open);
 
-    let (data, status) = streams::read(input, first_message.len() as u64).unwrap();
+    let (data, status) = streams::blocking_read(input, first_message.len() as u64).unwrap();
     assert_eq!(status, streams::StreamStatus::Open);
 
     tcp::drop_tcp_socket(accepted);
@@ -96,7 +96,7 @@ fn main() {
 
     wait(sub);
     let (accepted, input, output) = tcp::accept(sock).unwrap();
-    let (data, status) = streams::read(input, second_message.len() as u64).unwrap();
+    let (data, status) = streams::blocking_read(input, second_message.len() as u64).unwrap();
     assert_eq!(status, streams::StreamStatus::Open);
 
     streams::drop_input_stream(input);

--- a/crates/test-programs/wasi-sockets-tests/src/bin/tcp_v6.rs
+++ b/crates/test-programs/wasi-sockets-tests/src/bin/tcp_v6.rs
@@ -69,7 +69,7 @@ fn main() {
     assert!(empty_data.is_empty());
     assert_eq!(status, streams::StreamStatus::Open);
 
-    let (data, status) = streams::read(input, first_message.len() as u64).unwrap();
+    let (data, status) = streams::blocking_read(input, first_message.len() as u64).unwrap();
     assert_eq!(status, streams::StreamStatus::Open);
 
     tcp::drop_tcp_socket(accepted);
@@ -98,7 +98,7 @@ fn main() {
 
     wait(sub);
     let (accepted, input, output) = tcp::accept(sock).unwrap();
-    let (data, status) = streams::read(input, second_message.len() as u64).unwrap();
+    let (data, status) = streams::blocking_read(input, second_message.len() as u64).unwrap();
     assert_eq!(status, streams::StreamStatus::Open);
 
     streams::drop_input_stream(input);


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
