### PR TITLE
Make MachineEnv a per-ABI property

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -14,8 +14,9 @@ use crate::settings;
 use crate::{CodegenError, CodegenResult};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use regalloc2::{PRegSet, VReg};
+use regalloc2::{MachineEnv, PReg, PRegSet, VReg};
 use smallvec::{smallvec, SmallVec};
+use std::sync::OnceLock;
 
 // We use a generic implementation that factors out AArch64 and x64 ABI commonalities, because
 // these ABIs are very similar.
@@ -1111,6 +1112,16 @@ impl ABIMachineSpec for AArch64MachineDeps {
         s.nominal_sp_to_fp
     }
 
+    fn get_machine_env(flags: &settings::Flags, _call_conv: isa::CallConv) -> &MachineEnv {
+        if flags.enable_pinned_reg() {
+            static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
+            MACHINE_ENV.get_or_init(|| create_reg_env(true))
+        } else {
+            static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
+            MACHINE_ENV.get_or_init(|| create_reg_env(false))
+        }
+    }
+
     fn get_regs_clobbered_by_call(call_conv_of_callee: isa::CallConv) -> PRegSet {
         if call_conv_of_callee == isa::CallConv::Tail {
             TAIL_CLOBBERS
@@ -1573,3 +1584,102 @@ const TAIL_CLOBBERS: PRegSet = PRegSet::empty()
     .with(vreg_preg(29))
     .with(vreg_preg(30))
     .with(vreg_preg(31));
+
+fn create_reg_env(enable_pinned_reg: bool) -> MachineEnv {
+    fn preg(r: Reg) -> PReg {
+        r.to_real_reg().unwrap().into()
+    }
+
+    let mut env = MachineEnv {
+        preferred_regs_by_class: [
+            vec![
+                preg(xreg(0)),
+                preg(xreg(1)),
+                preg(xreg(2)),
+                preg(xreg(3)),
+                preg(xreg(4)),
+                preg(xreg(5)),
+                preg(xreg(6)),
+                preg(xreg(7)),
+                preg(xreg(8)),
+                preg(xreg(9)),
+                preg(xreg(10)),
+                preg(xreg(11)),
+                preg(xreg(12)),
+                preg(xreg(13)),
+                preg(xreg(14)),
+                preg(xreg(15)),
+                // x16 and x17 are spilltmp and tmp2 (see above).
+                // x18 could be used by the platform to carry inter-procedural state;
+                // conservatively assume so and make it not allocatable.
+                // x19-28 are callee-saved and so not preferred.
+                // x21 is the pinned register (if enabled) and not allocatable if so.
+                // x29 is FP, x30 is LR, x31 is SP/ZR.
+            ],
+            vec![
+                preg(vreg(0)),
+                preg(vreg(1)),
+                preg(vreg(2)),
+                preg(vreg(3)),
+                preg(vreg(4)),
+                preg(vreg(5)),
+                preg(vreg(6)),
+                preg(vreg(7)),
+                // v8-15 are callee-saved and so not preferred.
+                preg(vreg(16)),
+                preg(vreg(17)),
+                preg(vreg(18)),
+                preg(vreg(19)),
+                preg(vreg(20)),
+                preg(vreg(21)),
+                preg(vreg(22)),
+                preg(vreg(23)),
+                preg(vreg(24)),
+                preg(vreg(25)),
+                preg(vreg(26)),
+                preg(vreg(27)),
+                preg(vreg(28)),
+                preg(vreg(29)),
+                preg(vreg(30)),
+                preg(vreg(31)),
+            ],
+            // Vector Regclass is unused
+            vec![],
+        ],
+        non_preferred_regs_by_class: [
+            vec![
+                preg(xreg(19)),
+                preg(xreg(20)),
+                // x21 is pinned reg if enabled; we add to this list below if not.
+                preg(xreg(22)),
+                preg(xreg(23)),
+                preg(xreg(24)),
+                preg(xreg(25)),
+                preg(xreg(26)),
+                preg(xreg(27)),
+                preg(xreg(28)),
+            ],
+            vec![
+                preg(vreg(8)),
+                preg(vreg(9)),
+                preg(vreg(10)),
+                preg(vreg(11)),
+                preg(vreg(12)),
+                preg(vreg(13)),
+                preg(vreg(14)),
+                preg(vreg(15)),
+            ],
+            // Vector Regclass is unused
+            vec![],
+        ],
+        fixed_stack_slots: vec![],
+        scratch_by_class: [None, None, None],
+    };
+
+    if !enable_pinned_reg {
+        debug_assert_eq!(PINNED_REG, 21); // We assumed this above in hardcoded reg list.
+        env.non_preferred_regs_by_class[0].push(preg(xreg(PINNED_REG)));
+    }
+
+    env
+}

--- a/cranelift/codegen/src/isa/aarch64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/regs.rs
@@ -6,8 +6,6 @@ use crate::isa::aarch64::inst::VectorSize;
 use crate::machinst::AllocationConsumer;
 use crate::machinst::RealReg;
 use crate::machinst::{Reg, RegClass, Writable};
-use crate::settings;
-use regalloc2::MachineEnv;
 use regalloc2::PReg;
 use regalloc2::VReg;
 
@@ -143,106 +141,6 @@ pub fn tmp2_reg() -> Reg {
 /// Get a writable reference to the tmp2 reg.
 pub fn writable_tmp2_reg() -> Writable<Reg> {
     Writable::from_reg(tmp2_reg())
-}
-
-/// Create the register universe for AArch64.
-pub fn create_reg_env(flags: &settings::Flags) -> MachineEnv {
-    fn preg(r: Reg) -> PReg {
-        r.to_real_reg().unwrap().into()
-    }
-
-    let mut env = MachineEnv {
-        preferred_regs_by_class: [
-            vec![
-                preg(xreg(0)),
-                preg(xreg(1)),
-                preg(xreg(2)),
-                preg(xreg(3)),
-                preg(xreg(4)),
-                preg(xreg(5)),
-                preg(xreg(6)),
-                preg(xreg(7)),
-                preg(xreg(8)),
-                preg(xreg(9)),
-                preg(xreg(10)),
-                preg(xreg(11)),
-                preg(xreg(12)),
-                preg(xreg(13)),
-                preg(xreg(14)),
-                preg(xreg(15)),
-                // x16 and x17 are spilltmp and tmp2 (see above).
-                // x18 could be used by the platform to carry inter-procedural state;
-                // conservatively assume so and make it not allocatable.
-                // x19-28 are callee-saved and so not preferred.
-                // x21 is the pinned register (if enabled) and not allocatable if so.
-                // x29 is FP, x30 is LR, x31 is SP/ZR.
-            ],
-            vec![
-                preg(vreg(0)),
-                preg(vreg(1)),
-                preg(vreg(2)),
-                preg(vreg(3)),
-                preg(vreg(4)),
-                preg(vreg(5)),
-                preg(vreg(6)),
-                preg(vreg(7)),
-                // v8-15 are callee-saved and so not preferred.
-                preg(vreg(16)),
-                preg(vreg(17)),
-                preg(vreg(18)),
-                preg(vreg(19)),
-                preg(vreg(20)),
-                preg(vreg(21)),
-                preg(vreg(22)),
-                preg(vreg(23)),
-                preg(vreg(24)),
-                preg(vreg(25)),
-                preg(vreg(26)),
-                preg(vreg(27)),
-                preg(vreg(28)),
-                preg(vreg(29)),
-                preg(vreg(30)),
-                preg(vreg(31)),
-            ],
-            // Vector Regclass is unused
-            vec![],
-        ],
-        non_preferred_regs_by_class: [
-            vec![
-                preg(xreg(19)),
-                preg(xreg(20)),
-                // x21 is pinned reg if enabled; we add to this list below if not.
-                preg(xreg(22)),
-                preg(xreg(23)),
-                preg(xreg(24)),
-                preg(xreg(25)),
-                preg(xreg(26)),
-                preg(xreg(27)),
-                preg(xreg(28)),
-            ],
-            vec![
-                preg(vreg(8)),
-                preg(vreg(9)),
-                preg(vreg(10)),
-                preg(vreg(11)),
-                preg(vreg(12)),
-                preg(vreg(13)),
-                preg(vreg(14)),
-                preg(vreg(15)),
-            ],
-            // Vector Regclass is unused
-            vec![],
-        ],
-        fixed_stack_slots: vec![],
-        scratch_by_class: [None, None, None],
-    };
-
-    if !flags.enable_pinned_reg() {
-        debug_assert_eq!(PINNED_REG, 21); // We assumed this above in hardcoded reg list.
-        env.non_preferred_regs_by_class[0].push(preg(xreg(PINNED_REG)));
-    }
-
-    env
 }
 
 // PrettyPrint cannot be implemented for Reg; we need to invoke

--- a/cranelift/codegen/src/isa/aarch64/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/mod.rs
@@ -15,7 +15,6 @@ use crate::settings as shared_settings;
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 use cranelift_control::ControlPlane;
-use regalloc2::MachineEnv;
 use target_lexicon::{Aarch64Architecture, Architecture, OperatingSystem, Triple};
 
 // New backend:
@@ -24,8 +23,6 @@ pub mod inst;
 mod lower;
 pub mod settings;
 
-use inst::create_reg_env;
-
 use self::inst::EmitInfo;
 
 /// An AArch64 backend.
@@ -33,7 +30,6 @@ pub struct AArch64Backend {
     triple: Triple,
     flags: shared_settings::Flags,
     isa_flags: aarch64_settings::Flags,
-    machine_env: MachineEnv,
 }
 
 impl AArch64Backend {
@@ -43,12 +39,10 @@ impl AArch64Backend {
         flags: shared_settings::Flags,
         isa_flags: aarch64_settings::Flags,
     ) -> AArch64Backend {
-        let machine_env = create_reg_env(&flags);
         AArch64Backend {
             triple,
             flags,
             isa_flags,
-            machine_env,
         }
     }
 
@@ -110,10 +104,6 @@ impl TargetIsa for AArch64Backend {
 
     fn flags(&self) -> &shared_settings::Flags {
         &self.flags
-    }
-
-    fn machine_env(&self) -> &MachineEnv {
-        &self.machine_env
     }
 
     fn isa_flags(&self) -> Vec<shared_settings::Value> {

--- a/cranelift/codegen/src/isa/mod.rs
+++ b/cranelift/codegen/src/isa/mod.rs
@@ -254,9 +254,6 @@ pub trait TargetIsa: fmt::Display + Send + Sync {
     /// Get the ISA-independent flags that were used to make this trait object.
     fn flags(&self) -> &settings::Flags;
 
-    /// Get the ISA-dependent MachineEnv for managing register allocation.
-    fn machine_env(&self) -> &regalloc2::MachineEnv;
-
     /// Get the ISA-dependent flag values that were used to make this trait object.
     fn isa_flags(&self) -> Vec<settings::Value>;
 

--- a/cranelift/codegen/src/isa/riscv64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/regs.rs
@@ -1,8 +1,6 @@
 //! Riscv64 ISA definitions: registers.
 //!
 
-use crate::settings;
-
 use crate::machinst::{Reg, Writable};
 
 use crate::machinst::RealReg;
@@ -10,7 +8,7 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 use regalloc2::VReg;
-use regalloc2::{MachineEnv, PReg, RegClass};
+use regalloc2::{PReg, RegClass};
 
 // first argument of function call
 #[inline]
@@ -133,65 +131,6 @@ pub fn spilltmp_reg2() -> Reg {
 #[inline]
 pub fn writable_spilltmp_reg2() -> Writable<Reg> {
     Writable::from_reg(spilltmp_reg2())
-}
-
-pub fn crate_reg_eviroment(_flags: &settings::Flags) -> MachineEnv {
-    // Some C Extension instructions can only use a subset of the registers.
-    // x8 - x15, f8 - f15, v8 - v15 so we should prefer to use those since
-    // they allow us to emit C instructions more often.
-    //
-    // In general the order of preference is:
-    //   1. Compressible Caller Saved registers.
-    //   2. Non-Compressible Caller Saved registers.
-    //   3. Compressible Callee Saved registers.
-    //   4. Non-Compressible Callee Saved registers.
-
-    let preferred_regs_by_class: [Vec<PReg>; 3] = {
-        let x_registers: Vec<PReg> = (10..=15).map(px_reg).collect();
-        let f_registers: Vec<PReg> = (10..=15).map(pf_reg).collect();
-        let v_registers: Vec<PReg> = (8..=15).map(pv_reg).collect();
-
-        [x_registers, f_registers, v_registers]
-    };
-
-    let non_preferred_regs_by_class: [Vec<PReg>; 3] = {
-        // x0 - x4 are special registers, so we don't want to use them.
-        // Omit x30 and x31 since they are the spilltmp registers.
-
-        // Start with the Non-Compressible Caller Saved registers.
-        let x_registers: Vec<PReg> = (5..=7)
-            .chain(16..=17)
-            .chain(28..=29)
-            // The first Callee Saved register is x9 since its Compressible
-            // Omit x8 since it's the frame pointer.
-            .chain(9..=9)
-            // The rest of the Callee Saved registers are Non-Compressible
-            .chain(18..=27)
-            .map(px_reg)
-            .collect();
-
-        // Prefer Caller Saved registers.
-        let f_registers: Vec<PReg> = (0..=7)
-            .chain(16..=17)
-            .chain(28..=31)
-            // Once those are exhausted, we should prefer f8 and f9 since they are
-            // callee saved, but compressible.
-            .chain(8..=9)
-            .chain(18..=27)
-            .map(pf_reg)
-            .collect();
-
-        let v_registers = (0..=7).chain(16..=31).map(pv_reg).collect();
-
-        [x_registers, f_registers, v_registers]
-    };
-
-    MachineEnv {
-        preferred_regs_by_class,
-        non_preferred_regs_by_class,
-        fixed_stack_slots: vec![],
-        scratch_by_class: [None, None, None],
-    }
 }
 
 #[inline]

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -14,7 +14,6 @@ use crate::{ir, CodegenError};
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 use cranelift_control::ControlPlane;
-use regalloc2::MachineEnv;
 use target_lexicon::{Architecture, Triple};
 mod abi;
 pub(crate) mod inst;
@@ -23,8 +22,6 @@ mod settings;
 #[cfg(feature = "unwind")]
 use crate::isa::unwind::systemv;
 
-use inst::crate_reg_eviroment;
-
 use self::inst::EmitInfo;
 
 /// An riscv64 backend.
@@ -32,7 +29,6 @@ pub struct Riscv64Backend {
     triple: Triple,
     flags: shared_settings::Flags,
     isa_flags: riscv_settings::Flags,
-    mach_env: MachineEnv,
 }
 
 impl Riscv64Backend {
@@ -42,12 +38,10 @@ impl Riscv64Backend {
         flags: shared_settings::Flags,
         isa_flags: riscv_settings::Flags,
     ) -> Riscv64Backend {
-        let mach_env = crate_reg_eviroment(&flags);
         Riscv64Backend {
             triple,
             flags,
             isa_flags,
-            mach_env,
         }
     }
 
@@ -113,10 +107,6 @@ impl TargetIsa for Riscv64Backend {
 
     fn flags(&self) -> &shared_settings::Flags {
         &self.flags
-    }
-
-    fn machine_env(&self) -> &MachineEnv {
-        &self.mach_env
     }
 
     fn isa_flags(&self) -> Vec<shared_settings::Value> {

--- a/cranelift/codegen/src/isa/s390x/inst/regs.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/regs.rs
@@ -1,13 +1,11 @@
 //! S390x ISA definitions: registers.
 
 use alloc::string::String;
-use regalloc2::MachineEnv;
 use regalloc2::PReg;
 use regalloc2::VReg;
 
 use crate::isa::s390x::inst::{RegPair, WritableRegPair};
 use crate::machinst::*;
-use crate::settings;
 
 //=============================================================================
 // Registers, the Universe thereof, and printing
@@ -81,82 +79,6 @@ pub fn writable_spilltmp_reg() -> Writable<Reg> {
 
 pub fn zero_reg() -> Reg {
     gpr(0)
-}
-
-/// Create the register universe for AArch64.
-pub fn create_machine_env(_flags: &settings::Flags) -> MachineEnv {
-    fn preg(r: Reg) -> PReg {
-        r.to_real_reg().unwrap().into()
-    }
-
-    MachineEnv {
-        preferred_regs_by_class: [
-            vec![
-                // no r0; can't use for addressing?
-                // no r1; it is our spilltmp.
-                preg(gpr(2)),
-                preg(gpr(3)),
-                preg(gpr(4)),
-                preg(gpr(5)),
-            ],
-            vec![
-                preg(vr(0)),
-                preg(vr(1)),
-                preg(vr(2)),
-                preg(vr(3)),
-                preg(vr(4)),
-                preg(vr(5)),
-                preg(vr(6)),
-                preg(vr(7)),
-                preg(vr(16)),
-                preg(vr(17)),
-                preg(vr(18)),
-                preg(vr(19)),
-                preg(vr(20)),
-                preg(vr(21)),
-                preg(vr(22)),
-                preg(vr(23)),
-                preg(vr(24)),
-                preg(vr(25)),
-                preg(vr(26)),
-                preg(vr(27)),
-                preg(vr(28)),
-                preg(vr(29)),
-                preg(vr(30)),
-                preg(vr(31)),
-            ],
-            // Vector Regclass is unused
-            vec![],
-        ],
-        non_preferred_regs_by_class: [
-            vec![
-                preg(gpr(6)),
-                preg(gpr(7)),
-                preg(gpr(8)),
-                preg(gpr(9)),
-                preg(gpr(10)),
-                preg(gpr(11)),
-                preg(gpr(12)),
-                preg(gpr(13)),
-                preg(gpr(14)),
-                // no r15; it is the stack pointer.
-            ],
-            vec![
-                preg(vr(8)),
-                preg(vr(9)),
-                preg(vr(10)),
-                preg(vr(11)),
-                preg(vr(12)),
-                preg(vr(13)),
-                preg(vr(14)),
-                preg(vr(15)),
-            ],
-            // Vector Regclass is unused
-            vec![],
-        ],
-        fixed_stack_slots: vec![],
-        scratch_by_class: [None, None, None],
-    }
 }
 
 pub fn show_reg(reg: Reg) -> String {

--- a/cranelift/codegen/src/isa/s390x/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/mod.rs
@@ -15,7 +15,6 @@ use crate::settings as shared_settings;
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 use cranelift_control::ControlPlane;
-use regalloc2::MachineEnv;
 use target_lexicon::{Architecture, Triple};
 
 // New backend:
@@ -24,8 +23,6 @@ pub(crate) mod inst;
 mod lower;
 mod settings;
 
-use inst::create_machine_env;
-
 use self::inst::EmitInfo;
 
 /// A IBM Z backend.
@@ -33,7 +30,6 @@ pub struct S390xBackend {
     triple: Triple,
     flags: shared_settings::Flags,
     isa_flags: s390x_settings::Flags,
-    machine_env: MachineEnv,
 }
 
 impl S390xBackend {
@@ -43,12 +39,10 @@ impl S390xBackend {
         flags: shared_settings::Flags,
         isa_flags: s390x_settings::Flags,
     ) -> S390xBackend {
-        let machine_env = create_machine_env(&flags);
         S390xBackend {
             triple,
             flags,
             isa_flags,
-            machine_env,
         }
     }
 
@@ -111,10 +105,6 @@ impl TargetIsa for S390xBackend {
 
     fn flags(&self) -> &shared_settings::Flags {
         &self.flags
-    }
-
-    fn machine_env(&self) -> &MachineEnv {
-        &self.machine_env
     }
 
     fn isa_flags(&self) -> Vec<shared_settings::Value> {

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -11,9 +11,10 @@ use crate::{CodegenError, CodegenResult};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 use args::*;
-use regalloc2::{PReg, PRegSet, VReg};
+use regalloc2::{MachineEnv, PReg, PRegSet, VReg};
 use smallvec::{smallvec, SmallVec};
 use std::convert::TryFrom;
+use std::sync::OnceLock;
 
 /// This is the limit for the size of argument and return-value areas on the
 /// stack. We place a reasonable limit here to avoid integer overflow issues
@@ -785,6 +786,16 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         s.nominal_sp_to_fp()
     }
 
+    fn get_machine_env(flags: &settings::Flags, _call_conv: isa::CallConv) -> &MachineEnv {
+        if flags.enable_pinned_reg() {
+            static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
+            MACHINE_ENV.get_or_init(|| create_reg_env_systemv(true))
+        } else {
+            static MACHINE_ENV: OnceLock<MachineEnv> = OnceLock::new();
+            MACHINE_ENV.get_or_init(|| create_reg_env_systemv(false))
+        }
+    }
+
     fn get_regs_clobbered_by_call(call_conv_of_callee: isa::CallConv) -> PRegSet {
         if call_conv_of_callee == isa::CallConv::Tail {
             TAIL_CLOBBERS
@@ -1199,4 +1210,70 @@ const fn tail_clobbers() -> PRegSet {
         .with(regs::fpr_preg(13))
         .with(regs::fpr_preg(14))
         .with(regs::fpr_preg(15))
+}
+
+fn create_reg_env_systemv(enable_pinned_reg: bool) -> MachineEnv {
+    fn preg(r: Reg) -> PReg {
+        r.to_real_reg().unwrap().into()
+    }
+
+    let mut env = MachineEnv {
+        preferred_regs_by_class: [
+            // Preferred GPRs: caller-saved in the SysV ABI.
+            vec![
+                preg(regs::rsi()),
+                preg(regs::rdi()),
+                preg(regs::rax()),
+                preg(regs::rcx()),
+                preg(regs::rdx()),
+                preg(regs::r8()),
+                preg(regs::r9()),
+                preg(regs::r10()),
+                preg(regs::r11()),
+            ],
+            // Preferred XMMs: all of them.
+            vec![
+                preg(regs::xmm0()),
+                preg(regs::xmm1()),
+                preg(regs::xmm2()),
+                preg(regs::xmm3()),
+                preg(regs::xmm4()),
+                preg(regs::xmm5()),
+                preg(regs::xmm6()),
+                preg(regs::xmm7()),
+                preg(regs::xmm8()),
+                preg(regs::xmm9()),
+                preg(regs::xmm10()),
+                preg(regs::xmm11()),
+                preg(regs::xmm12()),
+                preg(regs::xmm13()),
+                preg(regs::xmm14()),
+                preg(regs::xmm15()),
+            ],
+            // The Vector Regclass is unused
+            vec![],
+        ],
+        non_preferred_regs_by_class: [
+            // Non-preferred GPRs: callee-saved in the SysV ABI.
+            vec![
+                preg(regs::rbx()),
+                preg(regs::r12()),
+                preg(regs::r13()),
+                preg(regs::r14()),
+            ],
+            // Non-preferred XMMs: none.
+            vec![],
+            // The Vector Regclass is unused
+            vec![],
+        ],
+        fixed_stack_slots: vec![],
+        scratch_by_class: [None, None, None],
+    };
+
+    debug_assert_eq!(regs::r15(), regs::pinned_reg());
+    if !enable_pinned_reg {
+        env.non_preferred_regs_by_class[0].push(preg(regs::r15()));
+    }
+
+    env
 }

--- a/cranelift/codegen/src/isa/x64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/x64/inst/regs.rs
@@ -6,9 +6,8 @@
 //! Note also that we make use of pinned VRegs to refer to PRegs.
 
 use crate::machinst::{AllocationConsumer, RealReg, Reg};
-use crate::settings;
 use alloc::string::ToString;
-use regalloc2::{MachineEnv, PReg, RegClass, VReg};
+use regalloc2::{PReg, RegClass, VReg};
 use std::string::String;
 
 // Hardware encodings (note the special rax, rcx, rdx, rbx order).
@@ -154,68 +153,6 @@ pub(crate) fn xmm14() -> Reg {
 }
 pub(crate) fn xmm15() -> Reg {
     fpr(15)
-}
-
-/// Create the register environment for x64.
-pub(crate) fn create_reg_env_systemv(flags: &settings::Flags) -> MachineEnv {
-    fn preg(r: Reg) -> PReg {
-        r.to_real_reg().unwrap().into()
-    }
-
-    let mut env = MachineEnv {
-        preferred_regs_by_class: [
-            // Preferred GPRs: caller-saved in the SysV ABI.
-            vec![
-                preg(rsi()),
-                preg(rdi()),
-                preg(rax()),
-                preg(rcx()),
-                preg(rdx()),
-                preg(r8()),
-                preg(r9()),
-                preg(r10()),
-                preg(r11()),
-            ],
-            // Preferred XMMs: all of them.
-            vec![
-                preg(xmm0()),
-                preg(xmm1()),
-                preg(xmm2()),
-                preg(xmm3()),
-                preg(xmm4()),
-                preg(xmm5()),
-                preg(xmm6()),
-                preg(xmm7()),
-                preg(xmm8()),
-                preg(xmm9()),
-                preg(xmm10()),
-                preg(xmm11()),
-                preg(xmm12()),
-                preg(xmm13()),
-                preg(xmm14()),
-                preg(xmm15()),
-            ],
-            // The Vector Regclass is unused
-            vec![],
-        ],
-        non_preferred_regs_by_class: [
-            // Non-preferred GPRs: callee-saved in the SysV ABI.
-            vec![preg(rbx()), preg(r12()), preg(r13()), preg(r14())],
-            // Non-preferred XMMs: none.
-            vec![],
-            // The Vector Regclass is unused
-            vec![],
-        ],
-        fixed_stack_slots: vec![],
-        scratch_by_class: [None, None, None],
-    };
-
-    debug_assert_eq!(r15(), pinned_reg());
-    if !flags.enable_pinned_reg() {
-        env.non_preferred_regs_by_class[0].push(preg(r15()));
-    }
-
-    env
 }
 
 /// Give the name of a RealReg.

--- a/cranelift/codegen/src/isa/x64/mod.rs
+++ b/cranelift/codegen/src/isa/x64/mod.rs
@@ -7,7 +7,7 @@ use crate::dominator_tree::DominatorTree;
 use crate::ir::{types, Function, Type};
 #[cfg(feature = "unwind")]
 use crate::isa::unwind::systemv;
-use crate::isa::x64::{inst::regs::create_reg_env_systemv, settings as x64_settings};
+use crate::isa::x64::settings as x64_settings;
 use crate::isa::{Builder as IsaBuilder, FunctionAlignment};
 use crate::machinst::{
     compile, CompiledCode, CompiledCodeStencil, MachInst, MachTextSectionBuilder, Reg, SigSet,
@@ -18,7 +18,6 @@ use crate::settings::{self as shared_settings, Flags};
 use alloc::{boxed::Box, vec::Vec};
 use core::fmt;
 use cranelift_control::ControlPlane;
-use regalloc2::MachineEnv;
 use target_lexicon::Triple;
 
 mod abi;
@@ -32,18 +31,15 @@ pub(crate) struct X64Backend {
     triple: Triple,
     flags: Flags,
     x64_flags: x64_settings::Flags,
-    reg_env: MachineEnv,
 }
 
 impl X64Backend {
     /// Create a new X64 backend with the given (shared) flags.
     fn new_with_flags(triple: Triple, flags: Flags, x64_flags: x64_settings::Flags) -> Self {
-        let reg_env = create_reg_env_systemv(&flags);
         Self {
             triple,
             flags,
             x64_flags,
-            reg_env,
         }
     }
 
@@ -97,10 +93,6 @@ impl TargetIsa for X64Backend {
 
     fn flags(&self) -> &Flags {
         &self.flags
-    }
-
-    fn machine_env(&self) -> &MachineEnv {
-        &self.reg_env
     }
 
     fn isa_flags(&self) -> Vec<shared_settings::Value> {

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -113,7 +113,7 @@ use crate::{ir, isa};
 use crate::{machinst::*, trace};
 use crate::{CodegenError, CodegenResult};
 use alloc::vec::Vec;
-use regalloc2::{PReg, PRegSet};
+use regalloc2::{MachineEnv, PReg, PRegSet};
 use smallvec::{smallvec, SmallVec};
 use std::collections::HashMap;
 use std::convert::TryFrom;
@@ -624,6 +624,9 @@ pub trait ABIMachineSpec {
 
     /// Get the "nominal SP to FP" offset from an instruction-emission state.
     fn get_nominal_sp_to_fp(s: &<Self::I as MachInstEmit>::State) -> i64;
+
+    /// Get the ABI-dependent MachineEnv for managing register allocation.
+    fn get_machine_env(flags: &settings::Flags, call_conv: isa::CallConv) -> &MachineEnv;
 
     /// Get all caller-save registers, that is, registers that we expect
     /// not to be saved across a call to a callee with the given ABI.
@@ -1450,6 +1453,11 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// Get the calling convention implemented by this ABI object.
     pub fn call_conv(&self, sigs: &SigSet) -> isa::CallConv {
         sigs[self.sig].call_conv
+    }
+
+    /// Get the ABI-dependent MachineEnv for managing register allocation.
+    pub fn machine_env(&self, sigs: &SigSet) -> &MachineEnv {
+        M::get_machine_env(&self.flags, self.call_conv(sigs))
     }
 
     /// The offsets of all sized stack slots (not spill slots) for debuginfo purposes.

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -21,7 +21,6 @@ use crate::machinst::{
 use crate::{trace, CodegenResult};
 use alloc::vec::Vec;
 use cranelift_control::ControlPlane;
-use regalloc2::{MachineEnv, PRegSet};
 use smallvec::{smallvec, SmallVec};
 use std::fmt::Debug;
 
@@ -153,9 +152,6 @@ pub trait LowerBackend {
 pub struct Lower<'func, I: VCodeInst> {
     /// The function to lower.
     f: &'func Function,
-
-    /// The set of allocatable registers.
-    allocatable: PRegSet,
 
     /// Lowered machine instructions.
     vcode: VCodeBuilder<I>,
@@ -329,7 +325,6 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
     /// Prepare a new lowering context for the given IR function.
     pub fn new(
         f: &'func Function,
-        machine_env: &MachineEnv,
         abi: Callee<I::ABIMachineSpec>,
         emit_info: I::Info,
         block_order: BlockLoweringOrder,
@@ -434,7 +429,6 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
 
         Ok(Lower {
             f,
-            allocatable: PRegSet::from(machine_env),
             vcode,
             vregs,
             value_regs,
@@ -1079,7 +1073,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
 
         // Now that we've emitted all instructions into the
         // VCodeBuilder, let's build the VCode.
-        let vcode = self.vcode.build(self.allocatable, self.vregs);
+        let vcode = self.vcode.build(self.vregs);
         trace!("built vcode: {:?}", vcode);
 
         Ok(vcode)


### PR DESCRIPTION
The MachineEnv structure contains the allocatable and preferred register sets.  This is currently fixed per TargetIsa - however, conceptually these register sets can differ between ABIs on the same ISA.

To allow for this, replace the TargetIsa machine_env routine with an ABIMachineSpec get_machine_env routine.  To ensure the structure is still only allocated once, cache it via static OnceLock variables.

No functional change intended.

FYI @cfallin - this is what I suggested in last week's meeting.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
