### PR TITLE
riscv64: Use canonical move instruction

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -994,7 +994,7 @@ impl MachInstEmit for Inst {
 
                 match rm.class() {
                     RegClass::Int => Inst::AluRRImm12 {
-                        alu_op: AluOPRRI::Ori,
+                        alu_op: AluOPRRI::Addi,
                         rd: rd,
                         rs: rm,
                         imm12: Imm12::zero(),
@@ -1027,13 +1027,8 @@ impl MachInstEmit for Inst {
             &Inst::MovFromPReg { rd, rm } => {
                 debug_assert!([px_reg(2), px_reg(8)].contains(&rm));
                 let rd = allocs.next_writable(rd);
-                let x = Inst::AluRRImm12 {
-                    alu_op: AluOPRRI::Ori,
-                    rd,
-                    rs: Reg::from(rm),
-                    imm12: Imm12::zero(),
-                };
-                x.emit(&[], sink, emit_info, state);
+
+                Inst::gen_move(rd, Reg::from(rm), I64).emit(&[], sink, emit_info, state);
             }
 
             &Inst::BrTable {

--- a/cranelift/filetests/filetests/isa/riscv64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/amodes.clif
@@ -410,12 +410,12 @@ block0(v0: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld t2, 0(a0)
-;   ori a2, t2, 0
+;   mv a2, t2
 ;   ld a1, 8(a0)
-;   ori a3, a2, 0
+;   mv a3, a2
 ;   sd a3, 0(a0)
 ;   sd a1, 8(a0)
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   ret
 
 function %i128_imm_offset(i64) -> i128 {
@@ -439,12 +439,12 @@ block0(v0: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld t2, 0x10(a0)
-;   ori a2, t2, 0
+;   mv a2, t2
 ;   ld a1, 0x18(a0)
-;   ori a3, a2, 0
+;   mv a3, a2
 ;   sd a3, 0x10(a0)
 ;   sd a1, 0x18(a0)
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   ret
 
 function %i128_imm_offset_large(i64) -> i128 {
@@ -468,12 +468,12 @@ block0(v0: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld t2, 0x1f8(a0)
-;   ori a2, t2, 0
+;   mv a2, t2
 ;   ld a1, 0x200(a0)
-;   ori a3, a2, 0
+;   mv a3, a2
 ;   sd a3, 0x1f8(a0)
 ;   sd a1, 0x200(a0)
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   ret
 
 function %i128_imm_offset_negative_large(i64) -> i128 {
@@ -497,12 +497,12 @@ block0(v0: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ld t2, -0x200(a0)
-;   ori a2, t2, 0
+;   mv a2, t2
 ;   ld a1, -0x1f8(a0)
-;   ori a3, a2, 0
+;   mv a3, a2
 ;   sd a3, -0x200(a0)
 ;   sd a1, -0x1f8(a0)
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   ret
 
 function %i128_add_offset(i64) -> i128 {

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
@@ -693,9 +693,9 @@ block0(v0: i128, v1: i128):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sub a2, a0, a2
-;   ori a7, a2, 0
+;   mv a7, a2
 ;   sltu a4, a0, a7
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   sub a6, a1, a3
 ;   sub a1, a6, a4
 ;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/atomic-rmw.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/atomic-rmw.clif
@@ -117,8 +117,8 @@ block0(v0: i64, v1: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a3, a0, 0
-;   ori a2, a1, 0
+;   mv a3, a0
+;   mv a2, a1
 ;   lr.d.aqrl a0, (a3)
 ;   and a1, a2, a0
 ;   not a1, a1
@@ -141,8 +141,8 @@ block0(v0: i64, v1: i32):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a3, a0, 0
-;   ori a2, a1, 0
+;   mv a3, a0
+;   mv a2, a1
 ;   lr.w.aqrl a0, (a3)
 ;   and a1, a2, a0
 ;   not a1, a1

--- a/cranelift/filetests/filetests/isa/riscv64/bitops.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bitops.clif
@@ -16,8 +16,8 @@ block0(v0: i8):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a3, a0, 0
-;   ori a0, zero, 0
+;   mv a3, a0
+;   mv a0, zero
 ;   addi a1, zero, 8
 ;   addi t2, zero, 1
 ;   slli t2, t2, 7
@@ -54,8 +54,8 @@ block0(v0: i16):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a7, a0, 0
-;   ori a2, zero, 0
+;   mv a7, a0
+;   mv a2, zero
 ;   addi a1, zero, 0x10
 ;   addi t2, zero, 1
 ;   slli t2, t2, 0xf
@@ -74,8 +74,8 @@ block0(v0: i16):
 ;   j -0x28
 ;   slli a0, a0, 1
 ;   j -0x30
-;   ori a4, zero, 0
-;   ori a5, a2, 0
+;   mv a4, zero
+;   mv a5, a2
 ;   addi a6, zero, 0x38
 ;   bltz a6, 0x1c
 ;   andi t6, a5, 0xff
@@ -103,8 +103,8 @@ block0(v0: i32):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a7, a0, 0
-;   ori a2, zero, 0
+;   mv a7, a0
+;   mv a2, zero
 ;   addi a1, zero, 0x20
 ;   addi t2, zero, 1
 ;   slli t2, t2, 0x1f
@@ -123,8 +123,8 @@ block0(v0: i32):
 ;   j -0x28
 ;   slli a0, a0, 1
 ;   j -0x30
-;   ori a4, zero, 0
-;   ori a5, a2, 0
+;   mv a4, zero
+;   mv a5, a2
 ;   addi a6, zero, 0x38
 ;   bltz a6, 0x1c
 ;   andi t6, a5, 0xff
@@ -151,9 +151,9 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a6, a0, 0
-;   ori t2, zero, 0
-;   ori a0, a6, 0
+;   mv a6, a0
+;   mv t2, zero
+;   mv a0, a6
 ;   addi a1, zero, 0x38
 ;   bltz a1, 0x1c
 ;   andi t6, a0, 0xff
@@ -162,7 +162,7 @@ block0(v0: i64):
 ;   addi a1, a1, -8
 ;   srli a0, a0, 8
 ;   j -0x18
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   addi a5, zero, 0x40
 ;   addi a3, zero, 1
 ;   slli a3, a3, 0x3f
@@ -202,10 +202,10 @@ block0(v0: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a3, a0, 0
-;   ori a7, a1, 0
-;   ori a0, zero, 0
-;   ori a1, a3, 0
+;   mv a3, a0
+;   mv a7, a1
+;   mv a0, zero
+;   mv a1, a3
 ;   addi a2, zero, 0x38
 ;   bltz a2, 0x1c
 ;   andi t6, a1, 0xff
@@ -214,7 +214,7 @@ block0(v0: i128):
 ;   addi a2, a2, -8
 ;   srli a1, a1, 8
 ;   j -0x18
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   addi a6, zero, 0x40
 ;   addi a4, zero, 1
 ;   slli a4, a4, 0x3f
@@ -233,9 +233,9 @@ block0(v0: i128):
 ;   j -0x28
 ;   slli a5, a5, 1
 ;   j -0x30
-;   ori a3, a7, 0
-;   ori t4, zero, 0
-;   ori t0, a3, 0
+;   mv a3, a7
+;   mv t4, zero
+;   mv t0, a3
 ;   addi t1, zero, 0x38
 ;   bltz t1, 0x1c
 ;   andi t6, t0, 0xff
@@ -244,7 +244,7 @@ block0(v0: i128):
 ;   addi t1, t1, -8
 ;   srli t0, t0, 8
 ;   j -0x18
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   addi a2, zero, 0x40
 ;   addi a4, zero, 1
 ;   slli a4, a4, 0x3f
@@ -279,8 +279,8 @@ block0(v0: i8):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 8
 ;   addi t2, zero, 1
 ;   slli t2, t2, 7
@@ -307,8 +307,8 @@ block0(v0: i16):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 0x10
 ;   addi t2, zero, 1
 ;   slli t2, t2, 0xf
@@ -335,8 +335,8 @@ block0(v0: i32):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 0x20
 ;   addi t2, zero, 1
 ;   slli t2, t2, 0x1f
@@ -363,8 +363,8 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 0x40
 ;   addi t2, zero, 1
 ;   slli t2, t2, 0x3f
@@ -394,7 +394,7 @@ block0(v0: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, zero, 0
+;   mv a2, zero
 ;   addi a3, zero, 0x40
 ;   addi a4, zero, 1
 ;   slli a4, a4, 0x3f
@@ -405,7 +405,7 @@ block0(v0: i128):
 ;   addi a3, a3, -1
 ;   srli a4, a4, 1
 ;   j -0x18
-;   ori a6, zero, 0
+;   mv a6, zero
 ;   addi a5, zero, 0x40
 ;   addi a4, zero, 1
 ;   slli a4, a4, 0x3f
@@ -417,9 +417,9 @@ block0(v0: i128):
 ;   srli a4, a4, 1
 ;   j -0x18
 ;   beqz a1, 0xc
-;   ori t3, zero, 0
+;   mv t3, zero
 ;   j 8
-;   ori t3, a6, 0
+;   mv t3, a6
 ;   add a0, a2, t3
 ;   mv a1, zero
 ;   ret
@@ -446,10 +446,10 @@ block0(v0: i8):
 ;   srai a1, t2, 0x38
 ;   not a3, a1
 ;   bltz a1, 0xc
-;   ori a5, a1, 0
+;   mv a5, a1
 ;   j 8
-;   ori a5, a3, 0
-;   ori t4, zero, 0
+;   mv a5, a3
+;   mv t4, zero
 ;   addi t3, zero, 8
 ;   addi a7, zero, 1
 ;   slli a7, a7, 7
@@ -485,10 +485,10 @@ block0(v0: i16):
 ;   srai a1, t2, 0x30
 ;   not a3, a1
 ;   bltz a1, 0xc
-;   ori a5, a1, 0
+;   mv a5, a1
 ;   j 8
-;   ori a5, a3, 0
-;   ori t4, zero, 0
+;   mv a5, a3
+;   mv t4, zero
 ;   addi t3, zero, 0x10
 ;   addi a7, zero, 1
 ;   slli a7, a7, 0xf
@@ -522,10 +522,10 @@ block0(v0: i32):
 ;   sext.w t2, a0
 ;   not a1, t2
 ;   bltz t2, 0xc
-;   ori a3, t2, 0
+;   mv a3, t2
 ;   j 8
-;   ori a3, a1, 0
-;   ori a7, zero, 0
+;   mv a3, a1
+;   mv a7, zero
 ;   addi a6, zero, 0x20
 ;   addi a5, zero, 1
 ;   slli a5, a5, 0x1f
@@ -557,10 +557,10 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   not t2, a0
 ;   bltz a0, 0xc
-;   ori a1, a0, 0
+;   mv a1, a0
 ;   j 8
-;   ori a1, t2, 0
-;   ori a5, zero, 0
+;   mv a1, t2
+;   mv a5, zero
 ;   addi a4, zero, 0x40
 ;   addi a3, zero, 1
 ;   slli a3, a3, 0x3f
@@ -599,13 +599,13 @@ block0(v0: i128):
 ; block0: ; offset 0x0
 ;   not a2, a0
 ;   bltz a1, 8
-;   ori a2, a0, 0
+;   mv a2, a0
 ;   not a4, a1
 ;   bltz a1, 0xc
-;   ori a6, a1, 0
+;   mv a6, a1
 ;   j 8
-;   ori a6, a4, 0
-;   ori t0, zero, 0
+;   mv a6, a4
+;   mv t0, zero
 ;   addi t4, zero, 0x40
 ;   addi t3, zero, 1
 ;   slli t3, t3, 0x3f
@@ -616,7 +616,7 @@ block0(v0: i128):
 ;   addi t4, t4, -1
 ;   srli t3, t3, 1
 ;   j -0x18
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   addi a0, zero, 0x40
 ;   addi t2, zero, 1
 ;   slli t2, t2, 0x3f
@@ -628,9 +628,9 @@ block0(v0: i128):
 ;   srli t2, t2, 1
 ;   j -0x18
 ;   beqz a6, 0xc
-;   ori a3, zero, 0
+;   mv a3, zero
 ;   j 8
-;   ori a3, a1, 0
+;   mv a3, a1
 ;   add a5, t0, a3
 ;   mv a7, zero
 ;   addi a0, a5, -1
@@ -651,8 +651,8 @@ block0(v0: i8):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 8
 ;   addi t2, zero, 1
 ;   blez a1, 0x1c
@@ -678,8 +678,8 @@ block0(v0: i16):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 0x10
 ;   addi t2, zero, 1
 ;   blez a1, 0x1c
@@ -705,8 +705,8 @@ block0(v0: i32):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 0x20
 ;   addi t2, zero, 1
 ;   blez a1, 0x1c
@@ -732,8 +732,8 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 0x40
 ;   addi t2, zero, 1
 ;   blez a1, 0x1c
@@ -763,8 +763,8 @@ block0(v0: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori t4, a1, 0
-;   ori a2, zero, 0
+;   mv t4, a1
+;   mv a2, zero
 ;   addi a1, zero, 0x40
 ;   addi a3, zero, 1
 ;   blez a1, 0x1c
@@ -774,7 +774,7 @@ block0(v0: i128):
 ;   addi a1, a1, -1
 ;   slli a3, a3, 1
 ;   j -0x18
-;   ori a6, zero, 0
+;   mv a6, zero
 ;   addi a5, zero, 0x40
 ;   addi a4, zero, 1
 ;   blez a5, 0x1c
@@ -785,9 +785,9 @@ block0(v0: i128):
 ;   slli a4, a4, 1
 ;   j -0x18
 ;   beqz a0, 0xc
-;   ori t3, zero, 0
+;   mv t3, zero
 ;   j 8
-;   ori t3, a2, 0
+;   mv t3, a2
 ;   add a0, a6, t3
 ;   mv a1, zero
 ;   ret
@@ -809,8 +809,8 @@ block0(v0: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori t3, a0, 0
-;   ori a2, zero, 0
+;   mv t3, a0
+;   mv a2, zero
 ;   addi a3, zero, 0x40
 ;   addi a0, zero, 1
 ;   slli a0, a0, 0x3f
@@ -821,7 +821,7 @@ block0(v0: i128):
 ;   addi a3, a3, -1
 ;   srli a0, a0, 1
 ;   j -0x18
-;   ori a6, zero, 0
+;   mv a6, zero
 ;   addi a5, zero, 0x40
 ;   addi a4, zero, 1
 ;   slli a4, a4, 0x3f
@@ -850,8 +850,8 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 0x40
 ;   addi t2, zero, 1
 ;   slli t2, t2, 0x3f
@@ -878,8 +878,8 @@ block0(v0: i32):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 0x20
 ;   addi t2, zero, 1
 ;   slli t2, t2, 0x1f
@@ -906,8 +906,8 @@ block0(v0: i16):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 0x10
 ;   addi t2, zero, 1
 ;   slli t2, t2, 0xf
@@ -934,8 +934,8 @@ block0(v0: i8):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a0, 0
-;   ori a0, zero, 0
+;   mv a2, a0
+;   mv a0, zero
 ;   addi a1, zero, 8
 ;   addi t2, zero, 1
 ;   slli t2, t2, 7
@@ -1723,21 +1723,21 @@ block0(v0: i128, v1: i8):
 ;   sll a7, a0, a3
 ;   srl t4, a0, a5
 ;   beqz a3, 0xc
-;   ori t1, t4, 0
+;   mv t1, t4
 ;   j 8
-;   ori t1, zero, 0
+;   mv t1, zero
 ;   sll a0, a1, a3
 ;   or a3, t1, a0
 ;   addi a4, zero, 0x40
 ;   andi a6, a2, 0x7f
 ;   bgeu a6, a4, 0xc
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a6, a4, 0xc
-;   ori a1, a3, 0
+;   mv a1, a3
 ;   j 8
-;   ori a1, a7, 0
+;   mv a1, a7
 ;   ret
 
 function %ishl_i128_i128(i128, i128) -> i128 {
@@ -1770,21 +1770,21 @@ block0(v0: i128, v1: i128):
 ;   sll t3, a0, a3
 ;   srl t0, a0, a6
 ;   beqz a3, 0xc
-;   ori t2, t0, 0
+;   mv t2, t0
 ;   j 8
-;   ori t2, zero, 0
+;   mv t2, zero
 ;   sll a1, a1, a3
 ;   or a3, t2, a1
 ;   addi a5, zero, 0x40
 ;   andi a7, a2, 0x7f
 ;   bgeu a7, a5, 0xc
-;   ori a0, t3, 0
+;   mv a0, t3
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a7, a5, 0xc
-;   ori a1, a3, 0
+;   mv a1, a3
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 
 function %ushr_i128_i8(i128, i8) -> i128 {
@@ -1816,9 +1816,9 @@ block0(v0: i128, v1: i8):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
@@ -1826,11 +1826,11 @@ block0(v0: i128, v1: i8):
 ;   andi a6, a2, 0x7f
 ;   bgeu a6, a4, 8
 ;   j 8
-;   ori a0, a5, 0
+;   mv a0, a5
 ;   bgeu a6, a4, 0xc
-;   ori a1, a5, 0
+;   mv a1, a5
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 
 function %ushr_i128_i128(i128, i128) -> i128 {
@@ -1862,22 +1862,22 @@ block0(v0: i128, v1: i128):
 ;   sub a6, a4, a3
 ;   sll t3, a1, a6
 ;   beqz a3, 0xc
-;   ori t0, t3, 0
+;   mv t0, t3
 ;   j 8
-;   ori t0, zero, 0
+;   mv t0, zero
 ;   srl t2, a0, a3
 ;   or a5, t0, t2
 ;   addi a4, zero, 0x40
 ;   srl a6, a1, a3
 ;   andi a7, a2, 0x7f
 ;   bgeu a7, a4, 0xc
-;   ori a0, a5, 0
+;   mv a0, a5
 ;   j 8
-;   ori a0, a6, 0
+;   mv a0, a6
 ;   bgeu a7, a4, 0xc
-;   ori a1, a6, 0
+;   mv a1, a6
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 
 function %sshr_i128_i8(i128, i8) -> i128 {
@@ -1912,27 +1912,27 @@ block0(v0: i128, v1: i8):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
 ;   sra a4, a1, a3
 ;   addi a6, zero, -1
 ;   bltz a1, 0xc
-;   ori t3, zero, 0
+;   mv t3, zero
 ;   j 8
-;   ori t3, a6, 0
+;   mv t3, a6
 ;   addi t0, zero, 0x40
 ;   andi t2, a2, 0x7f
 ;   bgeu t2, t0, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu t2, t0, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 
 function %sshr_i128_i128(i128, i128) -> i128 {
@@ -1967,27 +1967,27 @@ block0(v0: i128, v1: i128):
 ;   sub a6, a4, a3
 ;   sll t3, a1, a6
 ;   beqz a3, 0xc
-;   ori t0, t3, 0
+;   mv t0, t3
 ;   j 8
-;   ori t0, zero, 0
+;   mv t0, zero
 ;   srl t2, a0, a3
 ;   or a4, t0, t2
 ;   addi a5, zero, 0x40
 ;   sra a5, a1, a3
 ;   addi a7, zero, -1
 ;   bltz a1, 0xc
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   j 8
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   addi t1, zero, 0x40
 ;   andi a1, a2, 0x7f
 ;   bgeu a1, t1, 0xc
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   j 8
-;   ori a0, a5, 0
+;   mv a0, a5
 ;   bgeu a1, t1, 0xc
-;   ori a1, a5, 0
+;   mv a1, a5
 ;   j 8
-;   ori a1, t4, 0
+;   mv a1, t4
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/bswap-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bswap-zbb.clif
@@ -69,7 +69,7 @@ block0(v0: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a3, a0, 0
+;   mv a3, a0
 ;   .byte 0x13, 0xd5, 0x85, 0x6b
 ;   .byte 0x93, 0xd5, 0x86, 0x6b
 ;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/bswap.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/bswap.clif
@@ -230,7 +230,7 @@ block0(v0: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   sd s11, -8(sp)
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x18
@@ -265,7 +265,7 @@ block0(v0: i128):
 ;   slli a4, a3, 0x20
 ;   srli a6, a4, 0x20
 ;   or t3, a2, a6
-;   ori s11, t3, 0
+;   mv s11, t3
 ;   slli t0, a0, 8
 ;   srli t2, a0, 8
 ;   andi a1, t2, 0xff
@@ -297,7 +297,7 @@ block0(v0: i128):
 ;   slli a1, t2, 0x20
 ;   srli a3, a1, 0x20
 ;   or a1, t0, a3
-;   ori a0, s11, 0
+;   mv a0, s11
 ;   addi sp, sp, 0x10
 ;   ld s11, -8(sp)
 ;   ld ra, 8(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call-indirect.clif
@@ -26,7 +26,7 @@ block0(v0: i64, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   jalr a1
 ;   ld ra, 8(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -28,7 +28,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   auipc a1, 0
 ;   ld a1, 0xc(a1)
@@ -68,7 +68,7 @@ block0(v0: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   slli a0, a0, 0x20
 ;   srli a0, a0, 0x20
@@ -126,7 +126,7 @@ block0(v0: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   slli a0, a0, 0x20
 ;   srai a0, a0, 0x20
@@ -198,7 +198,7 @@ block0(v0: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   addi a7, zero, 0x2a
 ;   addi sp, sp, -0x10
@@ -210,13 +210,13 @@ block0(v0: i8):
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ori a0, a7, 0
-;   ori a1, a7, 0
-;   ori a2, a7, 0
-;   ori a3, a7, 0
-;   ori a4, a7, 0
-;   ori a5, a7, 0
-;   ori a6, a7, 0
+;   mv a0, a7
+;   mv a1, a7
+;   mv a2, a7
+;   mv a3, a7
+;   mv a4, a7
+;   mv a5, a7
+;   mv a6, a7
 ;   jalr t3
 ;   addi sp, sp, 0x10
 ;   ld ra, 8(sp)
@@ -248,9 +248,9 @@ block0(v0: i8):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a2, a1, 0
+;   mv a2, a1
 ;   addi a1, zero, 0x2a
-;   ori a3, a2, 0
+;   mv a3, a2
 ;   sw a1, 0(a3)
 ;   sw a1, 8(a3)
 ;   sw a1, 0x10(a3)
@@ -260,7 +260,7 @@ block0(v0: i8):
 ;   slli a7, a0, 0x38
 ;   srai a7, a7, 0x38
 ;   sd a0, 0x30(a3)
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %f8() {
@@ -325,7 +325,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   fsd fs2, -8(sp)
 ;   fsd fs3, -0x10(sp)
 ;   fsd fs11, -0x18(sp)
@@ -401,7 +401,7 @@ block0(v0: i128, v1: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %f11_call(i64) -> i64 {
@@ -435,16 +435,16 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
-;   ori a1, a0, 0
+;   mv a1, a0
 ;   addi a2, zero, 0x2a
 ;   auipc a3, 0
 ;   ld a3, 0xc(a3)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f11 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   jalr a3
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -464,7 +464,7 @@ block0(v0: i64, v1: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %f12_call(i64) -> i64 {
@@ -498,16 +498,16 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
-;   ori a1, a0, 0
+;   mv a1, a0
 ;   addi a2, zero, 0x2a
 ;   auipc a3, 0
 ;   ld a3, 0xc(a3)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f12 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   jalr a3
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -527,7 +527,7 @@ block0(v0: i64, v1: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %f13_call(i64) -> i64 {
@@ -561,16 +561,16 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
-;   ori a1, a0, 0
+;   mv a1, a0
 ;   addi a2, zero, 0x2a
 ;   auipc a3, 0
 ;   ld a3, 0xc(a3)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f13 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   jalr a3
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -600,9 +600,9 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   ld a1, 0x10(s0)
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -648,23 +648,23 @@ block0(v0: i128, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
-;   ori a7, a0, 0
-;   ori a6, a2, 0
+;   mv a7, a0
+;   mv a6, a2
 ;   addi sp, sp, -0x10
 ;   sd a1, 0(sp)
-;   ori a5, a1, 0
+;   mv a5, a1
 ;   auipc t3, 0
 ;   ld t3, 0xc(t3)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f14 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ori a1, a5, 0
-;   ori a3, a5, 0
-;   ori a0, a7, 0
-;   ori a2, a7, 0
-;   ori a4, a7, 0
+;   mv a1, a5
+;   mv a3, a5
+;   mv a0, a7
+;   mv a2, a7
+;   mv a4, a7
 ;   jalr t3
 ;   addi sp, sp, 0x10
 ;   ld ra, 8(sp)
@@ -695,9 +695,9 @@ block0(v0: i128, v1: i128, v2: i128, v3: i64, v4: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   ld a1, 0x10(s0)
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -743,23 +743,23 @@ block0(v0: i128, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
-;   ori a7, a0, 0
-;   ori a6, a2, 0
+;   mv a7, a0
+;   mv a6, a2
 ;   addi sp, sp, -0x10
 ;   sd a1, 0(sp)
-;   ori a5, a1, 0
+;   mv a5, a1
 ;   auipc t3, 0
 ;   ld t3, 0xc(t3)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f15 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ori a1, a5, 0
-;   ori a3, a5, 0
-;   ori a0, a7, 0
-;   ori a2, a7, 0
-;   ori a4, a7, 0
+;   mv a1, a5
+;   mv a3, a5
+;   mv a0, a7
+;   mv a2, a7
+;   mv a4, a7
 ;   jalr t3
 ;   addi sp, sp, 0x10
 ;   ld ra, 8(sp)
@@ -818,14 +818,14 @@ block0(v0: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   sd s3, -8(sp)
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x18
-;   ori s3, a0, 0
+;   mv s3, a0
 ;   auipc ra, 0 ; reloc_external RiscvCall u0:0 0
 ;   jalr ra
-;   ori a0, s3, 0
+;   mv a0, s3
 ;   addi sp, sp, 0x10
 ;   ld s3, -8(sp)
 ;   ld ra, 8(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/cls-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/cls-zbb.clif
@@ -25,9 +25,9 @@ block0(v0: i8):
 ;   .byte 0x93, 0x13, 0x45, 0x60
 ;   not a1, t2
 ;   bltz t2, 0xc
-;   ori a3, t2, 0
+;   mv a3, t2
 ;   j 8
-;   ori a3, a1, 0
+;   mv a3, a1
 ;   andi a5, a3, 0xff
 ;   .byte 0x93, 0x98, 0x07, 0x60
 ;   addi t4, a7, -0x38
@@ -56,9 +56,9 @@ block0(v0: i16):
 ;   .byte 0x93, 0x13, 0x55, 0x60
 ;   not a1, t2
 ;   bltz t2, 0xc
-;   ori a3, t2, 0
+;   mv a3, t2
 ;   j 8
-;   ori a3, a1, 0
+;   mv a3, a1
 ;   .byte 0xbb, 0xc7, 0x06, 0x08
 ;   .byte 0x93, 0x98, 0x07, 0x60
 ;   addi t4, a7, -0x30
@@ -85,9 +85,9 @@ block0(v0: i32):
 ;   sext.w t2, a0
 ;   not a1, t2
 ;   bltz t2, 0xc
-;   ori a3, t2, 0
+;   mv a3, t2
 ;   j 8
-;   ori a3, a1, 0
+;   mv a3, a1
 ;   .byte 0x9b, 0x97, 0x06, 0x60
 ;   addi a0, a5, -1
 ;   ret
@@ -110,9 +110,9 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   not t2, a0
 ;   bltz a0, 0xc
-;   ori a1, a0, 0
+;   mv a1, a0
 ;   j 8
-;   ori a1, t2, 0
+;   mv a1, t2
 ;   .byte 0x93, 0x96, 0x05, 0x60
 ;   addi a0, a3, -1
 ;   ret
@@ -142,18 +142,18 @@ block0(v0: i128):
 ; block0: ; offset 0x0
 ;   not a2, a0
 ;   bltz a1, 8
-;   ori a2, a0, 0
+;   mv a2, a0
 ;   not a4, a1
 ;   bltz a1, 0xc
-;   ori a6, a1, 0
+;   mv a6, a1
 ;   j 8
-;   ori a6, a4, 0
+;   mv a6, a4
 ;   .byte 0x13, 0x1e, 0x08, 0x60
 ;   .byte 0x93, 0x12, 0x06, 0x60
 ;   beqz a6, 0xc
-;   ori t2, zero, 0
+;   mv t2, zero
 ;   j 8
-;   ori t2, t0, 0
+;   mv t2, t0
 ;   add a1, t3, t2
 ;   mv a3, zero
 ;   addi a0, a1, -1

--- a/cranelift/filetests/filetests/isa/riscv64/clz-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/clz-zbb.clif
@@ -94,9 +94,9 @@ block0(v0: i128):
 ;   .byte 0x13, 0x96, 0x05, 0x60
 ;   .byte 0x93, 0x16, 0x05, 0x60
 ;   beqz a1, 0xc
-;   ori a4, zero, 0
+;   mv a4, zero
 ;   j 8
-;   ori a4, a3, 0
+;   mv a4, a3
 ;   add a0, a2, a4
 ;   mv a1, zero
 ;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/condops.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/condops.clif
@@ -24,9 +24,9 @@ block0(v0: i8, v1: i64, v2: i64):
 ;   andi a3, a0, 0xff
 ;   andi a4, a4, 0xff
 ;   beq a3, a4, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %g(i8) -> i8 {
@@ -93,9 +93,9 @@ block0(v0: i8, v1: i8, v2: i8):
 ; block0: ; offset 0x0
 ;   andi a3, a0, 0xff
 ;   beqz a3, 0xc
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   j 8
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   ret
 
 function %i(i32, i8, i8) -> i8 {
@@ -124,9 +124,9 @@ block0(v0: i32, v1: i8, v2: i8):
 ;   slli a6, a6, 0x20
 ;   srli t3, a6, 0x20
 ;   beq a4, t3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %i128_select(i8, i128, i128) -> i128 {
@@ -144,13 +144,13 @@ block0(v0: i8, v1: i128, v2: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a7, a1, 0
+;   mv a7, a1
 ;   andi a5, a0, 0xff
 ;   beqz a5, 0x10
-;   ori a0, a7, 0
-;   ori a1, a2, 0
+;   mv a0, a7
+;   mv a1, a2
 ;   j 0xc
-;   ori a0, a3, 0
-;   ori a1, a4, 0
+;   mv a0, a3
+;   mv a1, a4
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/ctz-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/ctz-zbb.clif
@@ -93,9 +93,9 @@ block0(v0: i128):
 ;   .byte 0x93, 0x95, 0x15, 0x60
 ;   .byte 0x13, 0x16, 0x15, 0x60
 ;   beqz a0, 0xc
-;   ori a4, zero, 0
+;   mv a4, zero
 ;   j 8
-;   ori a4, a1, 0
+;   mv a4, a1
 ;   add a0, a2, a4
 ;   mv a1, zero
 ;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/fuzzbug-60035.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fuzzbug-60035.clif
@@ -78,7 +78,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   sd s1, -8(sp)
 ;   sd s2, -0x10(sp)
 ;   sd s3, -0x18(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/i128-bmask.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/i128-bmask.clif
@@ -21,7 +21,7 @@ block0(v0: i128):
 ;   or a0, a0, a1
 ;   snez a2, a0
 ;   neg a1, a2
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %bmask_i128_i64(i128) -> i64 {
@@ -121,7 +121,7 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   snez t2, a0
 ;   neg a1, t2
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %bmask_i32_i128(i32) -> i128 {
@@ -145,7 +145,7 @@ block0(v0: i32):
 ;   srli a1, t2, 0x20
 ;   snez a3, a1
 ;   neg a1, a3
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %bmask_i16_i128(i16) -> i128 {
@@ -169,7 +169,7 @@ block0(v0: i16):
 ;   srli a1, t2, 0x30
 ;   snez a3, a1
 ;   neg a1, a3
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %bmask_i8_i128(i8) -> i128 {
@@ -191,6 +191,6 @@ block0(v0: i8):
 ;   andi t2, a0, 0xff
 ;   snez a1, t2
 ;   neg a1, a1
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/iabs.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/iabs.clif
@@ -21,9 +21,9 @@ block0(v0: i8):
 ;   srai a1, t2, 0x38
 ;   neg a3, a1
 ;   blt a3, a1, 0xc
-;   ori a0, a3, 0
+;   mv a0, a3
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %iabs_i16(i16) -> i16 {
@@ -46,9 +46,9 @@ block0(v0: i16):
 ;   srai a1, t2, 0x30
 ;   neg a3, a1
 ;   blt a3, a1, 0xc
-;   ori a0, a3, 0
+;   mv a0, a3
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %iabs_i32(i32) -> i32 {
@@ -69,9 +69,9 @@ block0(v0: i32):
 ;   sext.w t2, a0
 ;   neg a1, t2
 ;   blt a1, t2, 0xc
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   j 8
-;   ori a0, t2, 0
+;   mv a0, t2
 ;   ret
 
 function %iabs_i64(i64) -> i64 {
@@ -90,6 +90,6 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   neg t2, a0
 ;   blt t2, a0, 8
-;   ori a0, t2, 0
+;   mv a0, t2
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/ishl-const.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/ishl-const.clif
@@ -380,21 +380,21 @@ block0(v0: i128):
 ;   sll a7, a0, a2
 ;   srl t4, a0, a5
 ;   beqz a2, 0xc
-;   ori t1, t4, 0
+;   mv t1, t4
 ;   j 8
-;   ori t1, zero, 0
+;   mv t1, zero
 ;   sll a0, a1, a2
 ;   or a2, t1, a0
 ;   addi a4, zero, 0x40
 ;   andi a6, t2, 0x7f
 ;   bgeu a6, a4, 0xc
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a6, a4, 0xc
-;   ori a1, a2, 0
+;   mv a1, a2
 ;   j 8
-;   ori a1, a7, 0
+;   mv a1, a7
 ;   ret
 
 function %ishl_i128_const_i16(i128) -> i128 {
@@ -430,21 +430,21 @@ block0(v0: i128):
 ;   sll a7, a0, a2
 ;   srl t4, a0, a5
 ;   beqz a2, 0xc
-;   ori t1, t4, 0
+;   mv t1, t4
 ;   j 8
-;   ori t1, zero, 0
+;   mv t1, zero
 ;   sll a0, a1, a2
 ;   or a2, t1, a0
 ;   addi a4, zero, 0x40
 ;   andi a6, t2, 0x7f
 ;   bgeu a6, a4, 0xc
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a6, a4, 0xc
-;   ori a1, a2, 0
+;   mv a1, a2
 ;   j 8
-;   ori a1, a7, 0
+;   mv a1, a7
 ;   ret
 
 function %ishl_i128_const_i32(i128) -> i128 {
@@ -480,21 +480,21 @@ block0(v0: i128):
 ;   sll a7, a0, a2
 ;   srl t4, a0, a5
 ;   beqz a2, 0xc
-;   ori t1, t4, 0
+;   mv t1, t4
 ;   j 8
-;   ori t1, zero, 0
+;   mv t1, zero
 ;   sll a0, a1, a2
 ;   or a2, t1, a0
 ;   addi a4, zero, 0x40
 ;   andi a6, t2, 0x7f
 ;   bgeu a6, a4, 0xc
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a6, a4, 0xc
-;   ori a1, a2, 0
+;   mv a1, a2
 ;   j 8
-;   ori a1, a7, 0
+;   mv a1, a7
 ;   ret
 
 function %ishl_i128_const_i64(i128) -> i128 {
@@ -530,21 +530,21 @@ block0(v0: i128):
 ;   sll a7, a0, a2
 ;   srl t4, a0, a5
 ;   beqz a2, 0xc
-;   ori t1, t4, 0
+;   mv t1, t4
 ;   j 8
-;   ori t1, zero, 0
+;   mv t1, zero
 ;   sll a0, a1, a2
 ;   or a2, t1, a0
 ;   addi a4, zero, 0x40
 ;   andi a6, t2, 0x7f
 ;   bgeu a6, a4, 0xc
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a6, a4, 0xc
-;   ori a1, a2, 0
+;   mv a1, a2
 ;   j 8
-;   ori a1, a7, 0
+;   mv a1, a7
 ;   ret
 
 function %ishl_i128_const_i128(i128) -> i128 {
@@ -583,20 +583,20 @@ block0(v0: i128):
 ;   sll t3, a0, a3
 ;   srl t0, a0, a6
 ;   beqz a3, 0xc
-;   ori t2, t0, 0
+;   mv t2, t0
 ;   j 8
-;   ori t2, zero, 0
+;   mv t2, zero
 ;   sll a1, a1, a3
 ;   or a3, t2, a1
 ;   addi a5, zero, 0x40
 ;   andi a7, a2, 0x7f
 ;   bgeu a7, a5, 0xc
-;   ori a0, t3, 0
+;   mv a0, t3
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a7, a5, 0xc
-;   ori a1, a3, 0
+;   mv a1, a3
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/ishl.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/ishl.clif
@@ -373,21 +373,21 @@ block0(v0: i128, v1: i8):
 ;   sll a7, a0, a3
 ;   srl t4, a0, a5
 ;   beqz a3, 0xc
-;   ori t1, t4, 0
+;   mv t1, t4
 ;   j 8
-;   ori t1, zero, 0
+;   mv t1, zero
 ;   sll a0, a1, a3
 ;   or a3, t1, a0
 ;   addi a4, zero, 0x40
 ;   andi a6, a2, 0x7f
 ;   bgeu a6, a4, 0xc
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a6, a4, 0xc
-;   ori a1, a3, 0
+;   mv a1, a3
 ;   j 8
-;   ori a1, a7, 0
+;   mv a1, a7
 ;   ret
 
 function %ishl_i128_i16(i128, i16) -> i128 {
@@ -420,21 +420,21 @@ block0(v0: i128, v1: i16):
 ;   sll a7, a0, a3
 ;   srl t4, a0, a5
 ;   beqz a3, 0xc
-;   ori t1, t4, 0
+;   mv t1, t4
 ;   j 8
-;   ori t1, zero, 0
+;   mv t1, zero
 ;   sll a0, a1, a3
 ;   or a3, t1, a0
 ;   addi a4, zero, 0x40
 ;   andi a6, a2, 0x7f
 ;   bgeu a6, a4, 0xc
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a6, a4, 0xc
-;   ori a1, a3, 0
+;   mv a1, a3
 ;   j 8
-;   ori a1, a7, 0
+;   mv a1, a7
 ;   ret
 
 function %ishl_i128_i32(i128, i32) -> i128 {
@@ -467,21 +467,21 @@ block0(v0: i128, v1: i32):
 ;   sll a7, a0, a3
 ;   srl t4, a0, a5
 ;   beqz a3, 0xc
-;   ori t1, t4, 0
+;   mv t1, t4
 ;   j 8
-;   ori t1, zero, 0
+;   mv t1, zero
 ;   sll a0, a1, a3
 ;   or a3, t1, a0
 ;   addi a4, zero, 0x40
 ;   andi a6, a2, 0x7f
 ;   bgeu a6, a4, 0xc
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a6, a4, 0xc
-;   ori a1, a3, 0
+;   mv a1, a3
 ;   j 8
-;   ori a1, a7, 0
+;   mv a1, a7
 ;   ret
 
 function %ishl_i128_i64(i128, i64) -> i128 {
@@ -514,21 +514,21 @@ block0(v0: i128, v1: i64):
 ;   sll a7, a0, a3
 ;   srl t4, a0, a5
 ;   beqz a3, 0xc
-;   ori t1, t4, 0
+;   mv t1, t4
 ;   j 8
-;   ori t1, zero, 0
+;   mv t1, zero
 ;   sll a0, a1, a3
 ;   or a3, t1, a0
 ;   addi a4, zero, 0x40
 ;   andi a6, a2, 0x7f
 ;   bgeu a6, a4, 0xc
-;   ori a0, a7, 0
+;   mv a0, a7
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a6, a4, 0xc
-;   ori a1, a3, 0
+;   mv a1, a3
 ;   j 8
-;   ori a1, a7, 0
+;   mv a1, a7
 ;   ret
 
 function %ishl_i128_i128(i128, i128) -> i128 {
@@ -561,20 +561,20 @@ block0(v0: i128, v1: i128):
 ;   sll t3, a0, a3
 ;   srl t0, a0, a6
 ;   beqz a3, 0xc
-;   ori t2, t0, 0
+;   mv t2, t0
 ;   j 8
-;   ori t2, zero, 0
+;   mv t2, zero
 ;   sll a1, a1, a3
 ;   or a3, t2, a1
 ;   addi a5, zero, 0x40
 ;   andi a7, a2, 0x7f
 ;   bgeu a7, a5, 0xc
-;   ori a0, t3, 0
+;   mv a0, t3
 ;   j 8
-;   ori a0, zero, 0
+;   mv a0, zero
 ;   bgeu a7, a5, 0xc
-;   ori a1, a3, 0
+;   mv a1, a3
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/prologue.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/prologue.clif
@@ -177,7 +177,7 @@ block0(v0: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   fsd fs0, -8(sp)
 ;   fsd fs2, -0x10(sp)
 ;   fsd fs3, -0x18(sp)
@@ -382,7 +382,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   sd s5, -8(sp)
 ;   sd s6, -0x10(sp)
 ;   sd s7, -0x18(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
@@ -133,16 +133,16 @@ block3(v7: r64, v8: r64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   sd s3, -8(sp)
 ;   sd s7, -0x10(sp)
 ;   addi sp, sp, -0x30
 ; block1: ; offset 0x1c
-;   ori t3, a0, 0
+;   mv t3, a0
 ;   sd a1, 0x10(sp)
-;   ori s3, a2, 0
-;   ori a0, t3, 0
-;   ori s7, t3, 0
+;   mv s3, a2
+;   mv a0, t3
+;   mv s7, t3
 ;   auipc t0, 0
 ;   ld t0, 0xc(t0)
 ;   j 0xc
@@ -151,21 +151,21 @@ block3(v7: r64, v8: r64):
 ;   sd s7, 8(sp)
 ;   jalr t0
 ;   mv t4, sp
-;   ori t3, s7, 0
+;   mv t3, s7
 ;   sd t3, 0(t4)
 ;   andi t0, a0, 0xff
 ;   bnez t0, 0x10
 ; block2: ; offset 0x60
-;   ori a1, s7, 0
+;   mv a1, s7
 ;   ld a0, 0x10(sp)
 ;   j 0xc
 ; block3: ; offset 0x6c
-;   ori a0, s7, 0
+;   mv a0, s7
 ;   ld a1, 0x10(sp)
 ; block4: ; offset 0x74
 ;   mv a2, sp
 ;   ld a2, 0(a2)
-;   ori t3, s3, 0
+;   mv t3, s3
 ;   sd a2, 0(t3)
 ;   addi sp, sp, 0x30
 ;   ld s3, -8(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/return-call.clif
@@ -41,7 +41,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   auipc t2, 0
 ;   ld t2, 0xc(t2)
@@ -51,7 +51,7 @@ block0(v0: i64):
 ;   ld ra, 8(s0)
 ;   ld t6, 0(s0)
 ;   addi sp, s0, 0x10
-;   ori s0, t6, 0
+;   mv s0, t6
 ;   jr t2
 
 ;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -76,12 +76,12 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   ld ra, 8(s0)
 ;   ld t6, 0(s0)
 ;   addi sp, s0, 0x10
-;   ori s0, t6, 0
+;   mv s0, t6
 ;   auipc t6, 0 ; reloc_external RiscvCall %callee_i64 0
 ;   jr t6
 
@@ -133,7 +133,7 @@ block0(v0: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   auipc t2, 0
 ;   ld t2, 0xc(t2)
@@ -143,7 +143,7 @@ block0(v0: f64):
 ;   ld ra, 8(s0)
 ;   ld t6, 0(s0)
 ;   addi sp, s0, 0x10
-;   ori s0, t6, 0
+;   mv s0, t6
 ;   jr t2
 
 ;;;; Test passing `i8`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -195,7 +195,7 @@ block0(v0: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   auipc t2, 0
 ;   ld t2, 0xc(t2)
@@ -205,7 +205,7 @@ block0(v0: i8):
 ;   ld ra, 8(s0)
 ;   ld t6, 0(s0)
 ;   addi sp, s0, 0x10
-;   ori s0, t6, 0
+;   mv s0, t6
 ;   jr t2
 
 ;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -236,7 +236,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   ld a6, 0x10(s0)
 ;   ld t3, 0x18(s0)
@@ -334,7 +334,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
 ;   addi s1, zero, 0xa
@@ -393,7 +393,7 @@ block0:
 ;   ld t5, 0(sp)
 ;   sd t5, -0x20(s0)
 ;   addi sp, s0, -0x20
-;   ori s0, t6, 0
+;   mv s0, t6
 ;   jr t0
 
 ;;;; Test diff blocks with diff return calls with diff # of stack args ;;;;;;;;;
@@ -424,7 +424,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   ld a6, 0x10(s0)
 ;   ld t3, 0x18(s0)
@@ -464,7 +464,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   ld a6, 0x10(s0)
 ;   ld t3, 0x18(s0)
@@ -590,7 +590,7 @@ block2:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x20
 ; block1: ; offset 0x14
 ;   addi a1, zero, 0xa
@@ -655,7 +655,7 @@ block2:
 ;   ld t5, 0(sp)
 ;   sd t5, -0x20(s0)
 ;   addi sp, s0, -0x20
-;   ori s0, t6, 0
+;   mv s0, t6
 ;   jr t0
 ; block3: ; offset 0x110
 ;   ld s1, 0x10(sp)
@@ -687,5 +687,6 @@ block2:
 ;   ld t5, 0(sp)
 ;   sd t5, -0x20(s0)
 ;   addi sp, s0, -0x20
-;   ori s0, t6, 0
+;   mv s0, t6
 ;   jr t0
+

--- a/cranelift/filetests/filetests/isa/riscv64/rotl.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/rotl.clif
@@ -35,27 +35,27 @@ block0(v0: i128, v1: i128):
 ;   sub a6, a4, a3
 ;   sll t3, a0, a3
 ;   srl t0, a1, a6
-;   ori t1, a1, 0
+;   mv t1, a1
 ;   beqz a3, 0xc
-;   ori t2, t0, 0
+;   mv t2, t0
 ;   j 8
-;   ori t2, zero, 0
+;   mv t2, zero
 ;   or a1, t3, t2
 ;   sll a4, t1, a3
 ;   srl a5, a0, a6
 ;   beqz a3, 0xc
-;   ori a7, a5, 0
+;   mv a7, a5
 ;   j 8
-;   ori a7, zero, 0
+;   mv a7, zero
 ;   or t4, a4, a7
 ;   addi t1, zero, 0x40
 ;   andi a2, a2, 0x7f
 ;   bgeu a2, t1, 0xc
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   j 8
-;   ori a0, t4, 0
+;   mv a0, t4
 ;   bgeu a2, t1, 8
-;   ori a1, t4, 0
+;   mv a1, t4
 ;   ret
 
 function %f4(i64, i64) -> i64 {
@@ -79,17 +79,17 @@ block0(v0: i64, v1: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a7, a0, 0
+;   mv a7, a0
 ;   andi a0, a1, 0x3f
 ;   addi a2, zero, 0x40
 ;   sub a4, a2, a0
-;   ori t0, a7, 0
+;   mv t0, a7
 ;   sll a6, t0, a0
 ;   srl t3, t0, a4
 ;   beqz a0, 0xc
-;   ori t0, t3, 0
+;   mv t0, t3
 ;   j 8
-;   ori t0, zero, 0
+;   mv t0, zero
 ;   or a0, a6, t0
 ;   ret
 
@@ -122,9 +122,9 @@ block0(v0: i32, v1: i32):
 ;   sll t0, a2, a4
 ;   srl t2, a2, t3
 ;   beqz a4, 0xc
-;   ori a1, t2, 0
+;   mv a1, t2
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   or a0, t0, a1
 ;   ret
 
@@ -157,9 +157,9 @@ block0(v0: i16, v1: i16):
 ;   sll t0, a2, a4
 ;   srl t2, a2, t3
 ;   beqz a4, 0xc
-;   ori a1, t2, 0
+;   mv a1, t2
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   or a0, t0, a1
 ;   ret
 
@@ -190,9 +190,9 @@ block0(v0: i8, v1: i8):
 ;   sll t3, a0, a2
 ;   srl t0, a0, a6
 ;   beqz a2, 0xc
-;   ori t2, t0, 0
+;   mv t2, t0
 ;   j 8
-;   ori t2, zero, 0
+;   mv t2, zero
 ;   or a0, t3, t2
 ;   ret
 
@@ -224,9 +224,9 @@ block0(v0: i64):
 ;   sll a6, a0, a1
 ;   srl t3, a0, a4
 ;   beqz a1, 0xc
-;   ori t0, t3, 0
+;   mv t0, t3
 ;   j 8
-;   ori t0, zero, 0
+;   mv t0, zero
 ;   or a0, a6, t0
 ;   ret
 
@@ -262,9 +262,9 @@ block0(v0: i32):
 ;   sll t0, a2, a4
 ;   srl t2, a2, t3
 ;   beqz a4, 0xc
-;   ori a1, t2, 0
+;   mv a1, t2
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   or a0, t0, a1
 ;   ret
 
@@ -300,9 +300,9 @@ block0(v0: i16):
 ;   sll t0, a2, a4
 ;   srl t2, a2, t3
 ;   beqz a4, 0xc
-;   ori a1, t2, 0
+;   mv a1, t2
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   or a0, t0, a1
 ;   ret
 
@@ -336,9 +336,9 @@ block0(v0: i8):
 ;   sll t3, a0, a2
 ;   srl t0, a0, a6
 ;   beqz a2, 0xc
-;   ori t2, t0, 0
+;   mv t2, t0
 ;   j 8
-;   ori t2, zero, 0
+;   mv t2, zero
 ;   or a0, t3, t2
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/rotr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/rotr.clif
@@ -35,27 +35,27 @@ block0(v0: i128, v1: i128):
 ;   sub a6, a4, a3
 ;   srl t3, a0, a3
 ;   sll t0, a1, a6
-;   ori t1, a1, 0
+;   mv t1, a1
 ;   beqz a3, 0xc
-;   ori t2, t0, 0
+;   mv t2, t0
 ;   j 8
-;   ori t2, zero, 0
+;   mv t2, zero
 ;   or a1, t3, t2
 ;   srl a4, t1, a3
 ;   sll a5, a0, a6
 ;   beqz a3, 0xc
-;   ori a7, a5, 0
+;   mv a7, a5
 ;   j 8
-;   ori a7, zero, 0
+;   mv a7, zero
 ;   or t4, a4, a7
 ;   addi t1, zero, 0x40
 ;   andi a2, a2, 0x7f
 ;   bgeu a2, t1, 0xc
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   j 8
-;   ori a0, t4, 0
+;   mv a0, t4
 ;   bgeu a2, t1, 8
-;   ori a1, t4, 0
+;   mv a1, t4
 ;   ret
 
 function %f0(i64, i64) -> i64 {
@@ -79,17 +79,17 @@ block0(v0: i64, v1: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a7, a0, 0
+;   mv a7, a0
 ;   andi a0, a1, 0x3f
 ;   addi a2, zero, 0x40
 ;   sub a4, a2, a0
-;   ori t0, a7, 0
+;   mv t0, a7
 ;   srl a6, t0, a0
 ;   sll t3, t0, a4
 ;   beqz a0, 0xc
-;   ori t0, t3, 0
+;   mv t0, t3
 ;   j 8
-;   ori t0, zero, 0
+;   mv t0, zero
 ;   or a0, a6, t0
 ;   ret
 
@@ -122,9 +122,9 @@ block0(v0: i32, v1: i32):
 ;   srl t0, a2, a4
 ;   sll t2, a2, t3
 ;   beqz a4, 0xc
-;   ori a1, t2, 0
+;   mv a1, t2
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   or a0, t0, a1
 ;   ret
 
@@ -157,9 +157,9 @@ block0(v0: i16, v1: i16):
 ;   srl t0, a2, a4
 ;   sll t2, a2, t3
 ;   beqz a4, 0xc
-;   ori a1, t2, 0
+;   mv a1, t2
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   or a0, t0, a1
 ;   ret
 
@@ -190,9 +190,9 @@ block0(v0: i8, v1: i8):
 ;   srl t3, a0, a2
 ;   sll t0, a0, a6
 ;   beqz a2, 0xc
-;   ori t2, t0, 0
+;   mv t2, t0
 ;   j 8
-;   ori t2, zero, 0
+;   mv t2, zero
 ;   or a0, t3, t2
 ;   ret
 
@@ -224,9 +224,9 @@ block0(v0: i64):
 ;   srl a6, a0, a1
 ;   sll t3, a0, a4
 ;   beqz a1, 0xc
-;   ori t0, t3, 0
+;   mv t0, t3
 ;   j 8
-;   ori t0, zero, 0
+;   mv t0, zero
 ;   or a0, a6, t0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/select.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/select.clif
@@ -24,9 +24,9 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   andi a3, a0, 0xff
 ;   andi a4, a4, 0xff
 ;   beq a3, a4, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i8_i16(i8, i16, i16) -> i16 {
@@ -51,9 +51,9 @@ block0(v0: i8, v1: i16, v2: i16):
 ;   andi a3, a0, 0xff
 ;   andi a4, a4, 0xff
 ;   beq a3, a4, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i8_i32(i8, i32, i32) -> i32 {
@@ -78,9 +78,9 @@ block0(v0: i8, v1: i32, v2: i32):
 ;   andi a3, a0, 0xff
 ;   andi a4, a4, 0xff
 ;   beq a3, a4, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i8_i64(i8, i64, i64) -> i64 {
@@ -105,9 +105,9 @@ block0(v0: i8, v1: i64, v2: i64):
 ;   andi a3, a0, 0xff
 ;   andi a4, a4, 0xff
 ;   beq a3, a4, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i8_i128(i8, i128, i128) -> i128 {
@@ -131,7 +131,7 @@ block0(v0: i8, v1: i128, v2: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a5, a1, 0
+;   mv a5, a1
 ;   addi t4, zero, 0x2a
 ;   andi a7, a0, 0xff
 ;   andi t4, t4, 0xff
@@ -141,11 +141,11 @@ block0(v0: i8, v1: i128, v2: i128):
 ;   mv t1, zero
 ;   andi a7, t1, 0xff
 ;   beqz a7, 0x10
-;   ori a0, a5, 0
-;   ori a1, a2, 0
+;   mv a0, a5
+;   mv a1, a2
 ;   j 0xc
-;   ori a0, a3, 0
-;   ori a1, a4, 0
+;   mv a0, a3
+;   mv a1, a4
 ;   ret
 
 function %select_icmp_i16_i8(i16, i8, i8) -> i8 {
@@ -174,9 +174,9 @@ block0(v0: i16, v1: i8, v2: i8):
 ;   slli a6, a6, 0x30
 ;   srli t3, a6, 0x30
 ;   beq a4, t3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i16_i16(i16, i16, i16) -> i16 {
@@ -205,9 +205,9 @@ block0(v0: i16, v1: i16, v2: i16):
 ;   slli a6, a6, 0x30
 ;   srli t3, a6, 0x30
 ;   beq a4, t3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i16_i32(i16, i32, i32) -> i32 {
@@ -236,9 +236,9 @@ block0(v0: i16, v1: i32, v2: i32):
 ;   slli a6, a6, 0x30
 ;   srli t3, a6, 0x30
 ;   beq a4, t3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i16_i64(i16, i64, i64) -> i64 {
@@ -267,9 +267,9 @@ block0(v0: i16, v1: i64, v2: i64):
 ;   slli a6, a6, 0x30
 ;   srli t3, a6, 0x30
 ;   beq a4, t3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i16_i128(i16, i128, i128) -> i128 {
@@ -295,7 +295,7 @@ block0(v0: i16, v1: i128, v2: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a6, a1, 0
+;   mv a6, a1
 ;   addi t1, zero, 0x2a
 ;   slli a7, a0, 0x30
 ;   srli t4, a7, 0x30
@@ -307,11 +307,11 @@ block0(v0: i16, v1: i128, v2: i128):
 ;   mv a5, zero
 ;   andi t4, a5, 0xff
 ;   beqz t4, 0x10
-;   ori a0, a6, 0
-;   ori a1, a2, 0
+;   mv a0, a6
+;   mv a1, a2
 ;   j 0xc
-;   ori a0, a3, 0
-;   ori a1, a4, 0
+;   mv a0, a3
+;   mv a1, a4
 ;   ret
 
 function %select_icmp_i32_i8(i32, i8, i8) -> i8 {
@@ -340,9 +340,9 @@ block0(v0: i32, v1: i8, v2: i8):
 ;   slli a6, a6, 0x20
 ;   srli t3, a6, 0x20
 ;   beq a4, t3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i32_i16(i32, i16, i16) -> i16 {
@@ -371,9 +371,9 @@ block0(v0: i32, v1: i16, v2: i16):
 ;   slli a6, a6, 0x20
 ;   srli t3, a6, 0x20
 ;   beq a4, t3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i32_i32(i32, i32, i32) -> i32 {
@@ -402,9 +402,9 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   slli a6, a6, 0x20
 ;   srli t3, a6, 0x20
 ;   beq a4, t3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i32_i64(i32, i64, i64) -> i64 {
@@ -433,9 +433,9 @@ block0(v0: i32, v1: i64, v2: i64):
 ;   slli a6, a6, 0x20
 ;   srli t3, a6, 0x20
 ;   beq a4, t3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i32_i128(i32, i128, i128) -> i128 {
@@ -461,7 +461,7 @@ block0(v0: i32, v1: i128, v2: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a6, a1, 0
+;   mv a6, a1
 ;   addi t1, zero, 0x2a
 ;   slli a7, a0, 0x20
 ;   srli t4, a7, 0x20
@@ -473,11 +473,11 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   mv a5, zero
 ;   andi t4, a5, 0xff
 ;   beqz t4, 0x10
-;   ori a0, a6, 0
-;   ori a1, a2, 0
+;   mv a0, a6
+;   mv a1, a2
 ;   j 0xc
-;   ori a0, a3, 0
-;   ori a1, a4, 0
+;   mv a0, a3
+;   mv a1, a4
 ;   ret
 
 function %select_icmp_i64_i8(i64, i8, i8) -> i8 {
@@ -498,9 +498,9 @@ block0(v0: i64, v1: i8, v2: i8):
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
 ;   beq a0, a3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i64_i16(i64, i16, i16) -> i16 {
@@ -521,9 +521,9 @@ block0(v0: i64, v1: i16, v2: i16):
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
 ;   beq a0, a3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i64_i32(i64, i32, i32) -> i32 {
@@ -544,9 +544,9 @@ block0(v0: i64, v1: i32, v2: i32):
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
 ;   beq a0, a3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i64_i64(i64, i64, i64) -> i64 {
@@ -567,9 +567,9 @@ block0(v0: i64, v1: i64, v2: i64):
 ; block0: ; offset 0x0
 ;   addi a3, zero, 0x2a
 ;   beq a0, a3, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a1, 0
+;   mv a0, a1
 ;   ret
 
 function %select_icmp_i64_i128(i64, i128, i128) -> i128 {
@@ -591,7 +591,7 @@ block0(v0: i64, v1: i128, v2: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori t1, a1, 0
+;   mv t1, a1
 ;   addi a7, zero, 0x2a
 ;   bne a0, a7, 0xc
 ;   addi a7, zero, 1
@@ -599,11 +599,11 @@ block0(v0: i64, v1: i128, v2: i128):
 ;   mv a7, zero
 ;   andi a5, a7, 0xff
 ;   beqz a5, 0x10
-;   ori a0, t1, 0
-;   ori a1, a2, 0
+;   mv a0, t1
+;   mv a1, a2
 ;   j 0xc
-;   ori a0, a3, 0
-;   ori a1, a4, 0
+;   mv a0, a3
+;   mv a1, a4
 ;   ret
 
 function %select_icmp_i128_i8(i128, i8, i8) -> i8 {
@@ -635,9 +635,9 @@ block0(v0: i128, v1: i8, v2: i8):
 ;   mv a6, zero
 ;   andi a5, a6, 0xff
 ;   beqz a5, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a3, 0
+;   mv a0, a3
 ;   ret
 
 function %select_icmp_i128_i16(i128, i16, i16) -> i16 {
@@ -669,9 +669,9 @@ block0(v0: i128, v1: i16, v2: i16):
 ;   mv a6, zero
 ;   andi a5, a6, 0xff
 ;   beqz a5, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a3, 0
+;   mv a0, a3
 ;   ret
 
 function %select_icmp_i128_i32(i128, i32, i32) -> i32 {
@@ -703,9 +703,9 @@ block0(v0: i128, v1: i32, v2: i32):
 ;   mv a6, zero
 ;   andi a5, a6, 0xff
 ;   beqz a5, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a3, 0
+;   mv a0, a3
 ;   ret
 
 function %select_icmp_i128_i64(i128, i64, i64) -> i64 {
@@ -737,9 +737,9 @@ block0(v0: i128, v1: i64, v2: i64):
 ;   mv a6, zero
 ;   andi a5, a6, 0xff
 ;   beqz a5, 0xc
-;   ori a0, a2, 0
+;   mv a0, a2
 ;   j 8
-;   ori a0, a3, 0
+;   mv a0, a3
 ;   ret
 
 function %select_icmp_i128_i128(i128, i128, i128) -> i128 {
@@ -771,10 +771,10 @@ block0(v0: i128, v1: i128, v2: i128):
 ;   mv t4, zero
 ;   andi a7, t4, 0xff
 ;   beqz a7, 0x10
-;   ori a0, a2, 0
-;   ori a1, a3, 0
+;   mv a0, a2
+;   mv a1, a3
 ;   j 0xc
-;   ori a0, a4, 0
-;   ori a1, a5, 0
+;   mv a0, a4
+;   mv a1, a5
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-abi-large-spill.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-abi-large-spill.clif
@@ -42,11 +42,11 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   sd s7, -8(sp)
 ;   addi sp, sp, -0x410
 ; block1: ; offset 0x18
-;   ori s7, a0, 0
+;   mv s7, a0
 ;   .byte 0x57, 0x70, 0x84, 0xcc
 ;   auipc t6, 0
 ;   addi t6, t6, 0x40
@@ -55,7 +55,7 @@ block0:
 ;   .byte 0xa7, 0x01, 0x01, 0x02
 ;   auipc ra, 0 ; reloc_external RiscvCall u2:0 0
 ;   jalr ra
-;   ori a0, s7, 0
+;   mv a0, s7
 ;   .byte 0x87, 0x01, 0x01, 0x02
 ;   .byte 0xa7, 0x01, 0x05, 0x02
 ;   addi sp, sp, 0x410

--- a/cranelift/filetests/filetests/isa/riscv64/simd-abi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-abi.clif
@@ -122,7 +122,7 @@ block0(
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x100
 ; block1: ; offset 0x14
 ;   .byte 0x57, 0x70, 0x08, 0xcc

--- a/cranelift/filetests/filetests/isa/riscv64/simd-avg_round.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-avg_round.clif
@@ -25,13 +25,13 @@ block0(v0: i8x16, v1: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -71,13 +71,13 @@ block0(v0: i16x8, v1: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -119,13 +119,13 @@ block0(v0: i32x4, v1: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -167,13 +167,13 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-band.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-band.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -196,7 +196,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -235,7 +235,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -276,7 +276,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -317,7 +317,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -357,7 +357,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -395,7 +395,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -435,7 +435,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -475,7 +475,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -518,7 +518,7 @@ block0(v0: f32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -563,7 +563,7 @@ block0(v0: f64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bitselect.clif
@@ -32,7 +32,7 @@ block0(v0: i64x2, v1: i64x2, v2: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -83,7 +83,7 @@ block0(v0: i32x4, v1: i32x4, v2: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -134,7 +134,7 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -185,7 +185,7 @@ block0(v0: i8x16, v1: i8x16, v2: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -203,8 +203,6 @@ block0(v0: i8x16, v1: i8x16, v2: i8x16):
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
 ;   ret
-
-
 
 function %bitselect_icmp_i64x2(i64x2, i64x2, i64x2, i64x2) -> i64x2 {
 block0(v0: i64x2, v1: i64x2, v2: i64x2, v3: i64x2):
@@ -236,7 +234,7 @@ block0(v0: i64x2, v1: i64x2, v2: i64x2, v3: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -287,7 +285,7 @@ block0(v0: f64x2, v1: f64x2, v2: i64x2, v3: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -339,7 +337,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2, v3: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -391,7 +389,7 @@ block0(v0: i64x2, v1: i64x2, v2: f64x2, v3: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bnot.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bnot.clif
@@ -28,7 +28,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -65,7 +65,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -104,7 +104,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -143,7 +143,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bor.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bor.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -196,7 +196,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -235,7 +235,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -276,7 +276,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -317,7 +317,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -357,7 +357,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -395,7 +395,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -435,7 +435,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -475,7 +475,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -518,7 +518,7 @@ block0(v0: f32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -563,7 +563,7 @@ block0(v0: f64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bxor.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bxor.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -196,7 +196,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -235,7 +235,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -276,7 +276,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -317,7 +317,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -357,7 +357,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -395,7 +395,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -435,7 +435,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -475,7 +475,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -518,7 +518,7 @@ block0(v0: f32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -563,7 +563,7 @@ block0(v0: f64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ceil.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ceil.clif
@@ -39,7 +39,7 @@ block0(v0: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -100,7 +100,7 @@ block0(v0: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-extractlane.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-extractlane.clif
@@ -26,7 +26,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -61,7 +61,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -97,7 +97,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -133,7 +133,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -169,7 +169,7 @@ block0(v0: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -205,7 +205,7 @@ block0(v0: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -242,7 +242,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -279,7 +279,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -317,7 +317,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -355,7 +355,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -393,7 +393,7 @@ block0(v0: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -431,7 +431,7 @@ block0(v0: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fabs.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fabs.clif
@@ -28,7 +28,7 @@ block0(v0: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -67,7 +67,7 @@ block0(v0: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fadd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fadd.clif
@@ -29,7 +29,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -71,7 +71,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -151,7 +151,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -193,7 +193,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -233,7 +233,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-eq.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-eq.clif
@@ -30,7 +30,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -76,7 +76,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -164,7 +164,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -210,7 +210,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -254,7 +254,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ge.clif
@@ -30,7 +30,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -76,7 +76,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -164,7 +164,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -210,7 +210,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -254,7 +254,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-gt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-gt.clif
@@ -30,7 +30,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -76,7 +76,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -164,7 +164,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -210,7 +210,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -254,7 +254,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-le.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-le.clif
@@ -30,7 +30,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -76,7 +76,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -164,7 +164,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -210,7 +210,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -254,7 +254,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-lt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-lt.clif
@@ -30,7 +30,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -76,7 +76,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -164,7 +164,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -210,7 +210,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -254,7 +254,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ne.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ne.clif
@@ -30,7 +30,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -76,7 +76,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -164,7 +164,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -210,7 +210,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -254,7 +254,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-one.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-one.clif
@@ -32,7 +32,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -82,7 +82,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -130,7 +130,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -178,7 +178,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -228,7 +228,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -276,7 +276,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ord.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ord.clif
@@ -32,7 +32,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -83,7 +83,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -133,7 +133,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -182,7 +182,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -233,7 +233,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -283,7 +283,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ueq.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ueq.clif
@@ -32,7 +32,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -82,7 +82,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -130,7 +130,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -178,7 +178,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -228,7 +228,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -276,7 +276,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-uge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-uge.clif
@@ -31,7 +31,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -79,7 +79,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -125,7 +125,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -171,7 +171,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -219,7 +219,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -265,7 +265,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ugt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ugt.clif
@@ -31,7 +31,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -79,7 +79,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -125,7 +125,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -171,7 +171,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -219,7 +219,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -265,7 +265,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ule.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ule.clif
@@ -31,7 +31,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -79,7 +79,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -125,7 +125,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -171,7 +171,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -219,7 +219,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -265,7 +265,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ult.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-ult.clif
@@ -31,7 +31,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -79,7 +79,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -125,7 +125,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -171,7 +171,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -219,7 +219,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -265,7 +265,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-uno.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcmp-uno.clif
@@ -32,7 +32,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -83,7 +83,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -133,7 +133,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -182,7 +182,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -233,7 +233,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -283,7 +283,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcopysign.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcopysign.clif
@@ -29,7 +29,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -71,7 +71,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-from-sint.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-from-sint.clif
@@ -27,7 +27,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-from-uint.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-from-uint.clif
@@ -27,7 +27,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-to-sint-sat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-to-sint-sat.clif
@@ -29,7 +29,7 @@ block0(v0:f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-to-uint-sat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fcvt-to-uint-sat.clif
@@ -29,7 +29,7 @@ block0(v0:f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fdiv.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fdiv.clif
@@ -29,7 +29,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -71,7 +71,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -151,7 +151,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -193,7 +193,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -233,7 +233,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-floor.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-floor.clif
@@ -39,7 +39,7 @@ block0(v0: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -100,7 +100,7 @@ block0(v0: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fma.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fma.clif
@@ -29,7 +29,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: f64, v1: f64x2, v2: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -118,7 +118,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -164,7 +164,7 @@ block0(v0: f64, v1: f64x2, v2: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -209,7 +209,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -256,7 +256,7 @@ block0(v0: f64, v1: f64x2, v2: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -300,7 +300,7 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -346,7 +346,7 @@ block0(v0: f64, v1: f64x2, v2: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fmax.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fmax.clif
@@ -34,7 +34,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -91,7 +91,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fmin.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fmin.clif
@@ -34,7 +34,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -91,7 +91,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fmul.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fmul.clif
@@ -29,7 +29,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -71,7 +71,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -151,7 +151,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -193,7 +193,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -233,7 +233,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fneg.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fneg.clif
@@ -28,7 +28,7 @@ block0(v0: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -67,7 +67,7 @@ block0(v0: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fsub.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fsub.clif
@@ -29,7 +29,7 @@ block0(v0: f32x4, v1: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -71,7 +71,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -151,7 +151,7 @@ block0(v0: f64x2, v1: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -193,7 +193,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -233,7 +233,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fvdemote.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fvdemote.clif
@@ -29,7 +29,7 @@ block0(v0: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-fvpromote-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-fvpromote-low.clif
@@ -27,7 +27,7 @@ block0(v0: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iabs.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iabs.clif
@@ -22,13 +22,13 @@ block0(v0: i8x16):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -61,13 +61,13 @@ block0(v0: i16x8):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -102,13 +102,13 @@ block0(v0: i32x4):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -143,13 +143,13 @@ block0(v0: i64x2):
 ;   ld fp,0(sp)
 ;   add sp,+16
 ;   ret
-; 
+;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-big.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-big.clif
@@ -30,7 +30,7 @@ block0(v0:i64x4, v1:i64x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x88, 0xcc
 ;   addi t6, s0, 0x10
@@ -72,7 +72,7 @@ block0(v0:i64x8, v1:i64x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcd
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-small.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-small.clif
@@ -29,7 +29,7 @@ block0(v0:i8x8, v1:i8x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x04, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0:i16x4, v1:i16x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x04, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0:i32x2, v1:i32x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x04, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-splat-extend.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-splat-extend.clif
@@ -29,7 +29,7 @@ block0(v0: i16x8, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -70,7 +70,7 @@ block0(v0: i32x4, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i64x2, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -152,7 +152,7 @@ block0(v0: i16x8, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -193,7 +193,7 @@ block0(v0: i32x4, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -234,7 +234,7 @@ block0(v0: i64x2, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-high.clif
@@ -32,7 +32,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -81,7 +81,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -130,7 +130,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -177,7 +177,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -222,7 +222,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -267,7 +267,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -310,7 +310,7 @@ block0(v0: i32x4, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -356,7 +356,7 @@ block0(v0: i16x8, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -402,7 +402,7 @@ block0(v0: i8x16, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-low.clif
@@ -30,7 +30,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -118,7 +118,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -162,7 +162,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -204,7 +204,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -246,7 +246,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -287,7 +287,7 @@ block0(v0: i32x4, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -330,7 +330,7 @@ block0(v0: i16x8, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -373,7 +373,7 @@ block0(v0: i8x16, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -416,7 +416,7 @@ block0(v0: i8x16, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-mix.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-swiden-mix.clif
@@ -31,7 +31,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -78,7 +78,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -125,7 +125,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -171,7 +171,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -218,7 +218,7 @@ block0(v0: i16x8, v1:i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -265,7 +265,7 @@ block0(v0: i8x16, v1:i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-high.clif
@@ -33,7 +33,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -82,7 +82,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -131,7 +131,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -178,7 +178,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -223,7 +223,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -268,7 +268,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -311,7 +311,7 @@ block0(v0: i32x4, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -357,7 +357,7 @@ block0(v0: i16x8, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -403,7 +403,7 @@ block0(v0: i8x16, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-low.clif
@@ -31,7 +31,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -75,7 +75,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -119,7 +119,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -163,7 +163,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -205,7 +205,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -247,7 +247,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -288,7 +288,7 @@ block0(v0: i32x4, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -331,7 +331,7 @@ block0(v0: i16x8, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -374,7 +374,7 @@ block0(v0: i8x16, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -389,3 +389,4 @@ block0(v0: i8x16, v1: i16x8):
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
 ;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-mix.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd-uwiden-mix.clif
@@ -33,7 +33,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -80,7 +80,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -127,7 +127,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -173,7 +173,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -220,7 +220,7 @@ block0(v0: i16x8, v1:i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -267,7 +267,7 @@ block0(v0: i8x16, v1:i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -196,7 +196,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -235,7 +235,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -276,7 +276,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -317,7 +317,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -357,7 +357,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -395,7 +395,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -435,7 +435,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -475,7 +475,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-iadd_pairwise.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-iadd_pairwise.clif
@@ -38,7 +38,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -109,7 +109,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -180,7 +180,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-eq.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-eq.clif
@@ -30,7 +30,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -166,7 +166,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -183,10 +183,6 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
 ;   ret
-
-
-
-
 
 function %simd_icmp_splat_rhs_eq_i64(i64x2, i64) -> i64x2 {
 block0(v0: i64x2, v1: i64):
@@ -216,7 +212,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -260,7 +256,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -305,7 +301,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -350,7 +346,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ne.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ne.clif
@@ -30,7 +30,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -166,7 +166,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -212,7 +212,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -256,7 +256,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -301,7 +301,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -346,7 +346,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sge.clif
@@ -30,7 +30,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -166,7 +166,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -213,7 +213,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -258,7 +258,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -304,7 +304,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -350,7 +350,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sgt.clif
@@ -30,7 +30,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -166,7 +166,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -212,7 +212,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -256,7 +256,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -301,7 +301,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -347,7 +347,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sle.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-sle.clif
@@ -30,7 +30,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -166,7 +166,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -212,7 +212,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -257,7 +257,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -303,7 +303,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -349,7 +349,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-slt.clif
@@ -30,7 +30,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -166,7 +166,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -212,7 +212,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -256,7 +256,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -302,7 +302,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -348,7 +348,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-uge.clif
@@ -30,7 +30,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -166,7 +166,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -213,7 +213,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -258,7 +258,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -304,7 +304,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -350,7 +350,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ugt.clif
@@ -30,7 +30,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -166,7 +166,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -212,7 +212,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -256,7 +256,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -301,7 +301,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -347,7 +347,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ule.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ule.clif
@@ -30,7 +30,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -166,7 +166,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -212,7 +212,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -257,7 +257,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -303,7 +303,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -349,7 +349,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-icmp-ult.clif
@@ -30,7 +30,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -166,7 +166,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -212,7 +212,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -256,7 +256,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -302,7 +302,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -348,7 +348,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ifma.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ifma.clif
@@ -31,7 +31,7 @@ block0(v0: i64x2, v1: i64x2, v2: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -78,7 +78,7 @@ block0(v0: i64x2, v1: i64x2, v2: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -124,7 +124,7 @@ block0(v0: i64x2, v1: i64x2, v2: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -172,7 +172,7 @@ block0(v0: i64x2, v1: i64x2, v2: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -218,7 +218,7 @@ block0(v0: i64x2, v1: i64x2, v2: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -266,7 +266,7 @@ block0(v0: i64x2, v1: i64x2, v2: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-imul.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-imul.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -195,7 +195,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -233,7 +233,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -273,7 +273,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -313,7 +313,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ineg.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ineg.clif
@@ -28,7 +28,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -65,7 +65,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -104,7 +104,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -143,7 +143,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-insertlane.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-insertlane.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -72,7 +72,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -115,7 +115,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -157,7 +157,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -198,7 +198,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -239,7 +239,7 @@ block0(v0: f64x2, v1: f64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -280,7 +280,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -322,7 +322,7 @@ block0(v0: f32x4, v1: f32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -366,7 +366,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -410,7 +410,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -454,7 +454,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -497,7 +497,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ishl-const.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ishl-const.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -67,7 +67,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -105,7 +105,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -143,7 +143,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -182,7 +182,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -220,7 +220,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -260,7 +260,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -300,7 +300,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -340,7 +340,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -381,7 +381,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -421,7 +421,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -461,7 +461,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -501,7 +501,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -541,7 +541,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -582,7 +582,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -622,7 +622,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -662,7 +662,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -702,7 +702,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -742,7 +742,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -783,7 +783,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ishl.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ishl.clif
@@ -27,7 +27,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -64,7 +64,7 @@ block0(v0: i8x16, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -101,7 +101,7 @@ block0(v0: i8x16, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -138,7 +138,7 @@ block0(v0: i8x16, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -175,7 +175,7 @@ block0(v0: i8x16, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -212,7 +212,7 @@ block0(v0: i16x8, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -251,7 +251,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -290,7 +290,7 @@ block0(v0: i16x8, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -329,7 +329,7 @@ block0(v0: i16x8, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -368,7 +368,7 @@ block0(v0: i16x8, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -407,7 +407,7 @@ block0(v0: i32x4, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -446,7 +446,7 @@ block0(v0: i32x4, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -485,7 +485,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -524,7 +524,7 @@ block0(v0: i32x4, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -563,7 +563,7 @@ block0(v0: i32x4, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -602,7 +602,7 @@ block0(v0: i64x2, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -641,7 +641,7 @@ block0(v0: i64x2, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -680,7 +680,7 @@ block0(v0: i64x2, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -719,7 +719,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -758,7 +758,7 @@ block0(v0: i64x2, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-splat.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -67,7 +67,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -107,7 +107,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -187,7 +187,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -225,7 +225,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -265,7 +265,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -305,7 +305,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -347,7 +347,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -388,7 +388,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -431,7 +431,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -474,7 +474,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -516,7 +516,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -555,7 +555,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -596,7 +596,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -637,7 +637,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -678,7 +678,7 @@ block0(v0: i16x8, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -719,7 +719,7 @@ block0(v0: i32x4, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -760,7 +760,7 @@ block0(v0: i64x2, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -801,7 +801,7 @@ block0(v0: i16x8, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -842,7 +842,7 @@ block0(v0: i32x4, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -883,7 +883,7 @@ block0(v0: i64x2, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-high.clif
@@ -32,7 +32,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -81,7 +81,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -130,7 +130,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -177,7 +177,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -222,7 +222,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -267,7 +267,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -310,7 +310,7 @@ block0(v0: i32x4, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -356,7 +356,7 @@ block0(v0: i16x8, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -402,7 +402,7 @@ block0(v0: i8x16, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-swiden-low.clif
@@ -30,7 +30,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -118,7 +118,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -162,7 +162,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -204,7 +204,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -246,7 +246,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -287,7 +287,7 @@ block0(v0: i32x4, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -330,7 +330,7 @@ block0(v0: i16x8, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -373,7 +373,7 @@ block0(v0: i8x16, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-high.clif
@@ -32,7 +32,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -81,7 +81,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -130,7 +130,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -177,7 +177,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -222,7 +222,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -267,7 +267,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -310,7 +310,7 @@ block0(v0: i32x4, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -356,7 +356,7 @@ block0(v0: i16x8, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -402,7 +402,7 @@ block0(v0: i8x16, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-uwiden-low.clif
@@ -30,7 +30,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -74,7 +74,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -118,7 +118,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -162,7 +162,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -204,7 +204,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -246,7 +246,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -287,7 +287,7 @@ block0(v0: i32x4, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -330,7 +330,7 @@ block0(v0: i16x8, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -373,7 +373,7 @@ block0(v0: i8x16, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -195,7 +195,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -235,7 +235,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-nearest.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-nearest.clif
@@ -39,7 +39,7 @@ block0(v0: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -100,7 +100,7 @@ block0(v0: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-popcnt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-popcnt.clif
@@ -43,7 +43,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -115,7 +115,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -193,7 +193,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -268,7 +268,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-saddsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-saddsat.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -196,7 +196,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -235,7 +235,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -276,7 +276,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -317,7 +317,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -357,7 +357,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -395,7 +395,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -435,7 +435,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -475,7 +475,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-select.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-select.clif
@@ -28,7 +28,7 @@ block0(v0: i64, v1: i64x2, v2: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -73,7 +73,7 @@ block0(v0: i32, v1: i32x4, v2: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -120,7 +120,7 @@ block0(v0: i16, v1: i16x8, v2: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -166,7 +166,7 @@ block0(v0: i8, v1: i8x16, v2: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -210,7 +210,7 @@ block0(v0: i64, v1: f64x2, v2: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -253,7 +253,7 @@ block0(v0: i64, v1: f32x4, v2: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-shuffle.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-shuffle.clif
@@ -32,7 +32,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smax.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smax.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -197,7 +197,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -238,7 +238,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -281,7 +281,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -324,7 +324,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -365,7 +365,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -403,7 +403,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -443,7 +443,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -483,7 +483,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smin.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smin.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -197,7 +197,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -238,7 +238,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -281,7 +281,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -324,7 +324,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -365,7 +365,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -403,7 +403,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -443,7 +443,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -483,7 +483,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-smulhi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-smulhi.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -168,7 +168,6 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
 ;   ret
-
 
 function %smulhi_splat_i8x16(i8x16, i8) -> i8x16 {
 block0(v0: i8x16, v1: i8):
@@ -196,7 +195,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -234,7 +233,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -274,7 +273,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -314,7 +313,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-snarrow.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-snarrow.clif
@@ -30,7 +30,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -76,7 +76,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -123,7 +123,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-sqmulroundsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-sqmulroundsat.clif
@@ -28,7 +28,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -70,7 +70,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -112,7 +112,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -152,7 +152,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-sqrt.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-sqrt.clif
@@ -28,7 +28,7 @@ block0(v0: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -67,7 +67,7 @@ block0(v0: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-sshr-const.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-sshr-const.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -67,7 +67,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -105,7 +105,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -143,7 +143,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -182,7 +182,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -220,7 +220,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -260,7 +260,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -300,7 +300,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -340,7 +340,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -381,7 +381,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -421,7 +421,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -461,7 +461,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -501,7 +501,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -541,7 +541,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -582,7 +582,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -622,7 +622,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -662,7 +662,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -702,7 +702,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -742,7 +742,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -783,7 +783,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-sshr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-sshr.clif
@@ -27,7 +27,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -64,7 +64,7 @@ block0(v0: i8x16, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -101,7 +101,7 @@ block0(v0: i8x16, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -138,7 +138,7 @@ block0(v0: i8x16, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -175,7 +175,7 @@ block0(v0: i8x16, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -212,7 +212,7 @@ block0(v0: i16x8, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -251,7 +251,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -290,7 +290,7 @@ block0(v0: i16x8, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -329,7 +329,7 @@ block0(v0: i16x8, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -368,7 +368,7 @@ block0(v0: i16x8, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -407,7 +407,7 @@ block0(v0: i32x4, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -446,7 +446,7 @@ block0(v0: i32x4, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -485,7 +485,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -524,7 +524,7 @@ block0(v0: i32x4, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -563,7 +563,7 @@ block0(v0: i32x4, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -602,7 +602,7 @@ block0(v0: i64x2, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -641,7 +641,7 @@ block0(v0: i64x2, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -680,7 +680,7 @@ block0(v0: i64x2, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -719,7 +719,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -758,7 +758,7 @@ block0(v0: i64x2, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ssubsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ssubsat.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -197,7 +197,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -238,7 +238,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -281,7 +281,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -324,7 +324,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -365,7 +365,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -403,7 +403,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -443,7 +443,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -484,7 +484,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-stores.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-stores.clif
@@ -27,7 +27,7 @@ block0(v0: i64, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -62,7 +62,7 @@ block0(v0: i64, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -98,7 +98,7 @@ block0(v0: i64, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -134,7 +134,7 @@ block0(v0: i64, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-swiden_high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-swiden_high.clif
@@ -28,7 +28,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -154,7 +154,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -196,7 +196,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -240,7 +240,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-swiden_low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-swiden_low.clif
@@ -27,7 +27,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -66,7 +66,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -105,7 +105,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -145,7 +145,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -185,7 +185,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -226,7 +226,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-swizzle.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-swizzle.clif
@@ -28,7 +28,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -68,7 +68,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -107,7 +107,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-trunc.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-trunc.clif
@@ -37,7 +37,7 @@ block0(v0: f32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -94,7 +94,7 @@ block0(v0: f64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-uaddsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-uaddsat.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -196,7 +196,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -235,7 +235,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -276,7 +276,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -317,7 +317,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -357,7 +357,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -395,7 +395,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -435,7 +435,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -475,7 +475,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umax.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umax.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -197,7 +197,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -238,7 +238,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -281,7 +281,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -324,7 +324,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -365,7 +365,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -403,7 +403,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -443,7 +443,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -483,7 +483,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umin.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umin.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -197,7 +197,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -238,7 +238,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -281,7 +281,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -324,7 +324,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -365,7 +365,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -403,7 +403,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -443,7 +443,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -483,7 +483,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-umulhi.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-umulhi.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -168,8 +168,6 @@ block0(v0: i64x2, v1: i64x2):
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
 ;   ret
-
-
 
 function %umulhi_splat_i8x16(i8x16, i8) -> i8x16 {
 block0(v0: i8x16, v1: i8):
@@ -197,7 +195,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -235,7 +233,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -275,7 +273,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -315,7 +313,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-unarrow.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-unarrow.clif
@@ -32,7 +32,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -83,7 +83,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -135,7 +135,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ushr-const.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ushr-const.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -67,7 +67,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -105,7 +105,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -143,7 +143,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -182,7 +182,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -220,7 +220,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -260,7 +260,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -300,7 +300,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -340,7 +340,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -381,7 +381,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -421,7 +421,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -461,7 +461,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -501,7 +501,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -541,7 +541,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -582,7 +582,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -622,7 +622,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -662,7 +662,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -702,7 +702,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -742,7 +742,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -783,7 +783,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-ushr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-ushr.clif
@@ -27,7 +27,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -64,7 +64,7 @@ block0(v0: i8x16, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -101,7 +101,7 @@ block0(v0: i8x16, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -138,7 +138,7 @@ block0(v0: i8x16, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -175,7 +175,7 @@ block0(v0: i8x16, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -212,7 +212,7 @@ block0(v0: i16x8, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -251,7 +251,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -290,7 +290,7 @@ block0(v0: i16x8, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -329,7 +329,7 @@ block0(v0: i16x8, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -368,7 +368,7 @@ block0(v0: i16x8, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -407,7 +407,7 @@ block0(v0: i32x4, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -446,7 +446,7 @@ block0(v0: i32x4, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -485,7 +485,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -524,7 +524,7 @@ block0(v0: i32x4, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -563,7 +563,7 @@ block0(v0: i32x4, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -602,7 +602,7 @@ block0(v0: i64x2, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -641,7 +641,7 @@ block0(v0: i64x2, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -680,7 +680,7 @@ block0(v0: i64x2, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -719,7 +719,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -758,7 +758,7 @@ block0(v0: i64x2, v1: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-usubsat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-usubsat.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16, v1: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -69,7 +69,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -111,7 +111,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -153,7 +153,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -197,7 +197,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -238,7 +238,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -281,7 +281,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -324,7 +324,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -365,7 +365,7 @@ block0(v0: i8x16, v1: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -403,7 +403,7 @@ block0(v0: i16x8, v1: i16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -443,7 +443,7 @@ block0(v0: i32x4, v1: i32):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -484,7 +484,7 @@ block0(v0: i64x2, v1: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-uunarrow.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-uunarrow.clif
@@ -30,7 +30,7 @@ block0(v0: i16x8, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -76,7 +76,7 @@ block0(v0: i32x4, v1: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -123,7 +123,7 @@ block0(v0: i64x2, v1: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-uwiden_high.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-uwiden_high.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -70,7 +70,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -112,7 +112,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -155,7 +155,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -197,7 +197,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -241,7 +241,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-uwiden_low.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-uwiden_low.clif
@@ -28,7 +28,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -67,7 +67,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -106,7 +106,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -146,7 +146,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -186,7 +186,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -227,7 +227,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-valltrue.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-valltrue.clif
@@ -28,7 +28,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -67,7 +67,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -107,7 +107,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -147,7 +147,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vanytrue.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vanytrue.clif
@@ -29,7 +29,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -68,7 +68,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -108,7 +108,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -148,7 +148,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vhighbits.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vhighbits.clif
@@ -31,7 +31,7 @@ block0(v0: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -73,7 +73,7 @@ block0(v0: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -114,7 +114,7 @@ block0(v0: i32x4):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -155,7 +155,7 @@ block0(v0: i64x2):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/simd-vstate.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-vstate.clif
@@ -34,7 +34,7 @@ block0(v0: i8x16, v1: i16x8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
@@ -96,7 +96,7 @@ block2(v6: i8x16, v7: i8x16):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/sshr-const.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/sshr-const.clif
@@ -422,27 +422,27 @@ block0(v0: i128):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
 ;   sra a4, a1, a3
 ;   addi a6, zero, -1
 ;   bltz a1, 0xc
-;   ori t3, zero, 0
+;   mv t3, zero
 ;   j 8
-;   ori t3, a6, 0
+;   mv t3, a6
 ;   addi t0, zero, 0x40
 ;   andi t2, a2, 0x7f
 ;   bgeu t2, t0, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu t2, t0, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 
 function %sshr_i128_const_i16(i128) -> i128 {
@@ -480,27 +480,27 @@ block0(v0: i128):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
 ;   sra a4, a1, a3
 ;   addi a6, zero, -1
 ;   bltz a1, 0xc
-;   ori t3, zero, 0
+;   mv t3, zero
 ;   j 8
-;   ori t3, a6, 0
+;   mv t3, a6
 ;   addi t0, zero, 0x40
 ;   andi t2, a2, 0x7f
 ;   bgeu t2, t0, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu t2, t0, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 
 function %sshr_i128_const_i32(i128) -> i128 {
@@ -538,27 +538,27 @@ block0(v0: i128):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
 ;   sra a4, a1, a3
 ;   addi a6, zero, -1
 ;   bltz a1, 0xc
-;   ori t3, zero, 0
+;   mv t3, zero
 ;   j 8
-;   ori t3, a6, 0
+;   mv t3, a6
 ;   addi t0, zero, 0x40
 ;   andi t2, a2, 0x7f
 ;   bgeu t2, t0, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu t2, t0, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 
 function %sshr_i128_const_i64(i128) -> i128 {
@@ -596,27 +596,27 @@ block0(v0: i128):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
 ;   sra a4, a1, a3
 ;   addi a6, zero, -1
 ;   bltz a1, 0xc
-;   ori t3, zero, 0
+;   mv t3, zero
 ;   j 8
-;   ori t3, a6, 0
+;   mv t3, a6
 ;   addi t0, zero, 0x40
 ;   andi t2, a2, 0x7f
 ;   bgeu t2, t0, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu t2, t0, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 
 function %sshr_i128_const_i128(i128) -> i128 {
@@ -657,27 +657,27 @@ block0(v0: i128):
 ;   sub a6, a4, a2
 ;   sll t3, a1, a6
 ;   beqz a2, 0xc
-;   ori t0, t3, 0
+;   mv t0, t3
 ;   j 8
-;   ori t0, zero, 0
+;   mv t0, zero
 ;   srl t2, a0, a2
 ;   or a4, t0, t2
 ;   addi a5, zero, 0x40
 ;   sra a5, a1, a2
 ;   addi a7, zero, -1
 ;   bltz a1, 0xc
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   j 8
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   addi t1, zero, 0x40
 ;   andi a1, a3, 0x7f
 ;   bgeu a1, t1, 0xc
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   j 8
-;   ori a0, a5, 0
+;   mv a0, a5
 ;   bgeu a1, t1, 0xc
-;   ori a1, a5, 0
+;   mv a1, a5
 ;   j 8
-;   ori a1, t4, 0
+;   mv a1, t4
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/sshr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/sshr.clif
@@ -415,27 +415,27 @@ block0(v0: i128, v1: i8):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
 ;   sra a4, a1, a3
 ;   addi a6, zero, -1
 ;   bltz a1, 0xc
-;   ori t3, zero, 0
+;   mv t3, zero
 ;   j 8
-;   ori t3, a6, 0
+;   mv t3, a6
 ;   addi t0, zero, 0x40
 ;   andi t2, a2, 0x7f
 ;   bgeu t2, t0, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu t2, t0, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 
 function %sshr_i128_i16(i128, i16) -> i128 {
@@ -470,27 +470,27 @@ block0(v0: i128, v1: i16):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
 ;   sra a4, a1, a3
 ;   addi a6, zero, -1
 ;   bltz a1, 0xc
-;   ori t3, zero, 0
+;   mv t3, zero
 ;   j 8
-;   ori t3, a6, 0
+;   mv t3, a6
 ;   addi t0, zero, 0x40
 ;   andi t2, a2, 0x7f
 ;   bgeu t2, t0, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu t2, t0, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 
 function %sshr_i128_i32(i128, i32) -> i128 {
@@ -525,27 +525,27 @@ block0(v0: i128, v1: i32):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
 ;   sra a4, a1, a3
 ;   addi a6, zero, -1
 ;   bltz a1, 0xc
-;   ori t3, zero, 0
+;   mv t3, zero
 ;   j 8
-;   ori t3, a6, 0
+;   mv t3, a6
 ;   addi t0, zero, 0x40
 ;   andi t2, a2, 0x7f
 ;   bgeu t2, t0, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu t2, t0, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 
 function %sshr_i128_i64(i128, i64) -> i128 {
@@ -580,27 +580,27 @@ block0(v0: i128, v1: i64):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
 ;   sra a4, a1, a3
 ;   addi a6, zero, -1
 ;   bltz a1, 0xc
-;   ori t3, zero, 0
+;   mv t3, zero
 ;   j 8
-;   ori t3, a6, 0
+;   mv t3, a6
 ;   addi t0, zero, 0x40
 ;   andi t2, a2, 0x7f
 ;   bgeu t2, t0, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu t2, t0, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, t3, 0
+;   mv a1, t3
 ;   ret
 
 function %sshr_i128_i128(i128, i128) -> i128 {
@@ -635,27 +635,27 @@ block0(v0: i128, v1: i128):
 ;   sub a6, a4, a3
 ;   sll t3, a1, a6
 ;   beqz a3, 0xc
-;   ori t0, t3, 0
+;   mv t0, t3
 ;   j 8
-;   ori t0, zero, 0
+;   mv t0, zero
 ;   srl t2, a0, a3
 ;   or a4, t0, t2
 ;   addi a5, zero, 0x40
 ;   sra a5, a1, a3
 ;   addi a7, zero, -1
 ;   bltz a1, 0xc
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   j 8
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   addi t1, zero, 0x40
 ;   andi a1, a2, 0x7f
 ;   bgeu a1, t1, 0xc
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   j 8
-;   ori a0, a5, 0
+;   mv a0, a5
 ;   bgeu a1, t1, 0xc
-;   ori a1, a5, 0
+;   mv a1, a5
 ;   j 8
-;   ori a1, t4, 0
+;   mv a1, t4
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
@@ -72,7 +72,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   bgeu sp, a0, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 ; block1: ; offset 0x18
@@ -119,7 +119,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   ld t6, 0(a0)
 ;   ld t6, 4(t6)
 ;   bgeu sp, t6, 8
@@ -162,7 +162,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi t6, a0, 0xb0
 ;   bgeu sp, t6, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
@@ -206,7 +206,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   bgeu sp, a0, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
 ;   lui t5, 0x62
@@ -266,7 +266,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   ld t6, 0(a0)
 ;   ld t6, 4(t6)
 ;   addi t6, t6, 0x20
@@ -318,7 +318,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   ld t6, 0(a0)
 ;   ld t6, 4(t6)
 ;   bgeu sp, t6, 8
@@ -378,7 +378,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   lui t6, 0x62
 ;   addi t6, t6, -0x580
 ;   add t6, t6, a0

--- a/cranelift/filetests/filetests/isa/riscv64/stack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack.clif
@@ -30,7 +30,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
 ;   mv a0, sp
@@ -71,7 +71,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   lui a0, 0x18
 ;   addi a0, a0, 0x6b0
 ;   auipc t5, 0
@@ -121,7 +121,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
 ;   mv t1, sp
@@ -164,7 +164,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   lui a0, 0x18
 ;   addi a0, a0, 0x6b0
 ;   auipc t5, 0
@@ -215,7 +215,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
 ;   mv t2, sp
@@ -258,7 +258,7 @@ block0(v0: i64):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   lui a0, 0x18
 ;   addi a0, a0, 0x6b0
 ;   auipc t5, 0
@@ -642,7 +642,7 @@ block0(v0: i8):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   sd s1, -8(sp)
 ;   sd s2, -0x10(sp)
 ;   sd s3, -0x18(sp)
@@ -873,10 +873,10 @@ block0(v0: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
-;   ori a2, a0, 0
+;   mv a2, a0
 ;   mv a0, sp
 ;   sd a2, 0(a0)
 ;   sd a1, 8(a0)
@@ -917,10 +917,10 @@ block0(v0: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x20
 ; block1: ; offset 0x14
-;   ori a2, a0, 0
+;   mv a2, a0
 ;   addi a0, sp, 0x20
 ;   sd a2, 0(a0)
 ;   sd a1, 8(a0)
@@ -964,7 +964,7 @@ block0(v0: i128):
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   lui a0, 0x18
 ;   addi a0, a0, 0x6b0
 ;   auipc t5, 0
@@ -977,7 +977,7 @@ block0(v0: i128):
 ;   addi t6, t6, -0x6b0
 ;   add sp, t6, sp
 ; block1: ; offset 0x3c
-;   ori a2, a0, 0
+;   mv a2, a0
 ;   mv a0, sp
 ;   sd a2, 0(a0)
 ;   sd a1, 8(a0)
@@ -1018,7 +1018,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
 ;   mv t2, sp
@@ -1060,7 +1060,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x20
 ; block1: ; offset 0x14
 ;   addi t2, sp, 0x20
@@ -1105,7 +1105,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   lui a0, 0x18
 ;   addi a0, a0, 0x6b0
 ;   auipc t5, 0

--- a/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
@@ -29,7 +29,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   ld a6, 0x10(s0)
 ;   ld t3, 0x18(s0)
@@ -133,7 +133,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
 ;   addi s1, zero, 0xa
@@ -272,7 +272,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x20
 ; block1: ; offset 0x14
 ;   addi t1, zero, 0xa
@@ -354,7 +354,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ; block1: ; offset 0x10
 ;   addi sp, sp, -0x30
 ;   mv s1, sp
@@ -418,7 +418,7 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x20
 ; block1: ; offset 0x14
 ;   sd a3, 0(sp)
@@ -545,7 +545,7 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
-;   ori s0, sp, 0
+;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
 ;   addi s1, zero, 0xa

--- a/cranelift/filetests/filetests/isa/riscv64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/uadd_overflow_trap.clif
@@ -112,7 +112,7 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a4, a0, 0
+;   mv a4, a0
 ;   addi a1, zero, 0x7f
 ;   add a0, a4, a1
 ;   bgeu a0, a4, 0xc
@@ -168,12 +168,12 @@ block0(v0: i64, v1: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   add a1, a0, a1
-;   ori a3, a1, 0
+;   mv a3, a1
 ;   bgeu a3, a0, 0xc
 ;   addi a2, zero, 1
 ;   j 8
 ;   mv a2, zero
-;   ori a0, a3, 0
+;   mv a0, a3
 ;   beqz a2, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
 ;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/ushr-const.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/ushr-const.clif
@@ -409,9 +409,9 @@ block0(v0: i128):
 ;   sub a5, a3, a2
 ;   sll a7, a1, a5
 ;   beqz a2, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a2
 ;   or a0, t4, t1
 ;   addi a3, zero, 0x40
@@ -419,11 +419,11 @@ block0(v0: i128):
 ;   andi a6, t2, 0x7f
 ;   bgeu a6, a3, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu a6, a3, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 
 function %ushr_i128_const_i16(i128) -> i128 {
@@ -458,9 +458,9 @@ block0(v0: i128):
 ;   sub a5, a3, a2
 ;   sll a7, a1, a5
 ;   beqz a2, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a2
 ;   or a0, t4, t1
 ;   addi a3, zero, 0x40
@@ -468,11 +468,11 @@ block0(v0: i128):
 ;   andi a6, t2, 0x7f
 ;   bgeu a6, a3, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu a6, a3, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 
 function %ushr_i128_const_i32(i128) -> i128 {
@@ -507,9 +507,9 @@ block0(v0: i128):
 ;   sub a5, a3, a2
 ;   sll a7, a1, a5
 ;   beqz a2, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a2
 ;   or a0, t4, t1
 ;   addi a3, zero, 0x40
@@ -517,11 +517,11 @@ block0(v0: i128):
 ;   andi a6, t2, 0x7f
 ;   bgeu a6, a3, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu a6, a3, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 
 function %ushr_i128_const_i64(i128) -> i128 {
@@ -556,9 +556,9 @@ block0(v0: i128):
 ;   sub a5, a3, a2
 ;   sll a7, a1, a5
 ;   beqz a2, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a2
 ;   or a0, t4, t1
 ;   addi a3, zero, 0x40
@@ -566,11 +566,11 @@ block0(v0: i128):
 ;   andi a6, t2, 0x7f
 ;   bgeu a6, a3, 8
 ;   j 8
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   bgeu a6, a3, 0xc
-;   ori a1, a4, 0
+;   mv a1, a4
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 
 function %ushr_i128_const_i128(i128) -> i128 {
@@ -603,7 +603,7 @@ block0(v0: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a3, a0, 0
+;   mv a3, a0
 ;   addi a0, zero, 5
 ;   mv a2, zero
 ;   andi a2, a0, 0x3f
@@ -611,22 +611,22 @@ block0(v0: i128):
 ;   sub a6, a4, a2
 ;   sll t3, a1, a6
 ;   beqz a2, 0xc
-;   ori t0, t3, 0
+;   mv t0, t3
 ;   j 8
-;   ori t0, zero, 0
-;   ori t3, a3, 0
+;   mv t0, zero
+;   mv t3, a3
 ;   srl t2, t3, a2
 ;   or a4, t0, t2
 ;   addi a3, zero, 0x40
 ;   srl a5, a1, a2
 ;   andi a7, a0, 0x7f
 ;   bgeu a7, a3, 0xc
-;   ori a0, a4, 0
+;   mv a0, a4
 ;   j 8
-;   ori a0, a5, 0
+;   mv a0, a5
 ;   bgeu a7, a3, 0xc
-;   ori a1, a5, 0
+;   mv a1, a5
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/ushr.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/ushr.clif
@@ -99,7 +99,7 @@ block0(v0: i8, v1: i128):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   ori a5, a1, 0
+;   mv a5, a1
 ;   andi a1, a0, 0xff
 ;   andi a3, a5, 7
 ;   srlw a0, a1, a3
@@ -404,9 +404,9 @@ block0(v0: i128, v1: i8):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
@@ -414,11 +414,11 @@ block0(v0: i128, v1: i8):
 ;   andi a6, a2, 0x7f
 ;   bgeu a6, a4, 8
 ;   j 8
-;   ori a0, a5, 0
+;   mv a0, a5
 ;   bgeu a6, a4, 0xc
-;   ori a1, a5, 0
+;   mv a1, a5
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 
 function %ushr_i128_i16(i128, i16) -> i128 {
@@ -450,9 +450,9 @@ block0(v0: i128, v1: i16):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
@@ -460,11 +460,11 @@ block0(v0: i128, v1: i16):
 ;   andi a6, a2, 0x7f
 ;   bgeu a6, a4, 8
 ;   j 8
-;   ori a0, a5, 0
+;   mv a0, a5
 ;   bgeu a6, a4, 0xc
-;   ori a1, a5, 0
+;   mv a1, a5
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 
 function %ushr_i128_i32(i128, i32) -> i128 {
@@ -496,9 +496,9 @@ block0(v0: i128, v1: i32):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
@@ -506,11 +506,11 @@ block0(v0: i128, v1: i32):
 ;   andi a6, a2, 0x7f
 ;   bgeu a6, a4, 8
 ;   j 8
-;   ori a0, a5, 0
+;   mv a0, a5
 ;   bgeu a6, a4, 0xc
-;   ori a1, a5, 0
+;   mv a1, a5
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 
 function %ushr_i128_i64(i128, i64) -> i128 {
@@ -542,9 +542,9 @@ block0(v0: i128, v1: i64):
 ;   sub a5, a4, a3
 ;   sll a7, a1, a5
 ;   beqz a3, 0xc
-;   ori t4, a7, 0
+;   mv t4, a7
 ;   j 8
-;   ori t4, zero, 0
+;   mv t4, zero
 ;   srl t1, a0, a3
 ;   or a0, t4, t1
 ;   addi a4, zero, 0x40
@@ -552,11 +552,11 @@ block0(v0: i128, v1: i64):
 ;   andi a6, a2, 0x7f
 ;   bgeu a6, a4, 8
 ;   j 8
-;   ori a0, a5, 0
+;   mv a0, a5
 ;   bgeu a6, a4, 0xc
-;   ori a1, a5, 0
+;   mv a1, a5
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 
 function %ushr_i128_i128(i128, i128) -> i128 {
@@ -588,21 +588,21 @@ block0(v0: i128, v1: i128):
 ;   sub a6, a4, a3
 ;   sll t3, a1, a6
 ;   beqz a3, 0xc
-;   ori t0, t3, 0
+;   mv t0, t3
 ;   j 8
-;   ori t0, zero, 0
+;   mv t0, zero
 ;   srl t2, a0, a3
 ;   or a5, t0, t2
 ;   addi a4, zero, 0x40
 ;   srl a6, a1, a3
 ;   andi a7, a2, 0x7f
 ;   bgeu a7, a4, 0xc
-;   ori a0, a5, 0
+;   mv a0, a5
 ;   j 8
-;   ori a0, a6, 0
+;   mv a0, a6
 ;   bgeu a7, a4, 0xc
-;   ori a1, a6, 0
+;   mv a1, a6
 ;   j 8
-;   ori a1, zero, 0
+;   mv a1, zero
 ;   ret
 


### PR DESCRIPTION
👋 Hey,

The canonical move instruction on RISC-V is `addi rd, rs, 0`, however we currently emit `ori ...` which while it achieves the same thing is technically not optimal as some processors may miss the renaming opportunity. It also disassembles better.

This seems to be a leftover of the AArch64 port that does use `or` as it's move instruction.