### PR TITLE
Add a note about `_NO_DEBUG_HEAP` to the WASM debugging document

### DIFF
--- a/docs/examples-debugging.md
+++ b/docs/examples-debugging.md
@@ -36,3 +36,6 @@ If you run into trouble, the following discussions might help:
   (lldb) p *foo
   ```
 - The address of the start of instance memory can be found in `__vmctx->memory`
+- On Windows you may experience degraded WASM compilation throughput due to the
+  enablement of additional native heap checks when under the debugger by default.
+  You can set the environment variable `_NO_DEBUG_HEAP` to `1` to disable them.


### PR DESCRIPTION
This is a little speculative, as `_NO_DEBUG_HEAP` is not WASM-related at all, and this document should not become a kitchen sink of "native debugging tips", still, the truly massive slowdown (~_65x_ for my machine and sample module, 10 seconds -> 11 minutes) is experience-breaking for Windows wasmtime+LLDB users, so I would expect it to be worth adding nevertheless.