### PR TITLE
cranelift: Fix fuzzgen `iconst` encoding

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1375,9 +1375,9 @@ where
     /// Generates an instruction(`iconst`/`fconst`/etc...) to introduce a constant value
     fn generate_const(&mut self, builder: &mut FunctionBuilder, ty: Type) -> Result<Value> {
         Ok(match self.u.datavalue(ty)? {
-            DataValue::I8(i) => builder.ins().iconst(ty, i as i64),
-            DataValue::I16(i) => builder.ins().iconst(ty, i as i64),
-            DataValue::I32(i) => builder.ins().iconst(ty, i as i64),
+            DataValue::I8(i) => builder.ins().iconst(ty, i as u8 as i64),
+            DataValue::I16(i) => builder.ins().iconst(ty, i as u16 as i64),
+            DataValue::I32(i) => builder.ins().iconst(ty, i as u32 as i64),
             DataValue::I64(i) => builder.ins().iconst(ty, i as i64),
             DataValue::I128(i) => {
                 let hi = builder.ins().iconst(I64, (i >> 64) as i64);


### PR DESCRIPTION
#### If this work has been discussed elsewhere:

#6965

#### Explain why this change is needed:

Since #6850, the immediate of `iconst.i32 -2` is encoded in `UnaryImm::imm` as `0xffff_fffe`, and not `-2`, despite being stored in a signed 64-bit integer. The fuzzing generator for `iconst` has not been modified accordingly and is still encoding the previous example as `-2`. This PR fixes that.