### PR TITLE
Refactor prolog/epilog generation code

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -802,12 +802,14 @@
        (Args
         (args VecArgPair))
 
+       ;; A pseudo-instruction that moves vregs to return registers.
+       (Rets
+        (rets VecRetPair))
+
        ;; ---- branches (exactly one must appear at end of BB) ----
 
        ;; A machine return instruction.
-       (Ret
-        (rets VecRetPair)
-        (stack_bytes_to_pop u32))
+       (Ret)
 
        ;; A machine return instruction with pointer authentication using SP as the
        ;; modifier. This instruction requires pointer authentication support
@@ -816,9 +818,7 @@
        ;; the relevant support.
        (AuthenticatedRet
         (key APIKey)
-        (is_hint bool)
-        (rets VecRetPair)
-        (stack_bytes_to_pop u32))
+        (is_hint bool))
 
        ;; An unconditional branch.
        (Jump

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3109,52 +3109,14 @@ impl MachInstEmit for Inst {
                 // Emit the jump itself.
                 sink.put4(enc_jump26(0b000101, dest.as_offset26_or_zero()));
             }
-            &Inst::Args { .. } => {
+            &Inst::Args { .. } | &Inst::Rets { .. } => {
                 // Nothing: this is a pseudoinstruction that serves
                 // only to constrain registers at a certain point.
             }
-            &Inst::Ret {
-                stack_bytes_to_pop, ..
-            } => {
-                if stack_bytes_to_pop != 0 {
-                    // The requirement that `stack_bytes_to_pop` fit in an
-                    // `Imm12` isn't fundamental, but lifting it is left for
-                    // future PRs.
-                    let imm12 = Imm12::maybe_from_u64(u64::from(stack_bytes_to_pop))
-                        .expect("stack bytes to pop must fit in Imm12");
-                    Inst::AluRRImm12 {
-                        alu_op: ALUOp::Add,
-                        size: OperandSize::Size64,
-                        rd: writable_stack_reg(),
-                        rn: stack_reg(),
-                        imm12,
-                    }
-                    .emit(&[], sink, emit_info, state);
-                }
+            &Inst::Ret {} => {
                 sink.put4(0xd65f03c0);
             }
-            &Inst::AuthenticatedRet {
-                key,
-                is_hint,
-                stack_bytes_to_pop,
-                ..
-            } => {
-                if stack_bytes_to_pop != 0 {
-                    // The requirement that `stack_bytes_to_pop` fit in an
-                    // `Imm12` isn't fundamental, but lifting it is left for
-                    // future PRs.
-                    let imm12 = Imm12::maybe_from_u64(u64::from(stack_bytes_to_pop))
-                        .expect("stack bytes to pop must fit in Imm12");
-                    Inst::AluRRImm12 {
-                        alu_op: ALUOp::Add,
-                        size: OperandSize::Size64,
-                        rd: writable_stack_reg(),
-                        rn: stack_reg(),
-                        imm12,
-                    }
-                    .emit(&[], sink, emit_info, state);
-                }
-
+            &Inst::AuthenticatedRet { key, is_hint } => {
                 let (op2, is_hint) = match key {
                     APIKey::AZ => (0b100, true),
                     APIKey::ASP => (0b101, is_hint),
@@ -3164,11 +3126,7 @@ impl MachInstEmit for Inst {
 
                 if is_hint {
                     sink.put4(key.enc_auti_hint());
-                    Inst::Ret {
-                        rets: vec![],
-                        stack_bytes_to_pop: 0,
-                    }
-                    .emit(&[], sink, emit_info, state);
+                    Inst::Ret {}.emit(&[], sink, emit_info, state);
                 } else {
                     sink.put4(0xd65f0bff | (op2 << 9)); // reta{key}
                 }

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -37,28 +37,11 @@ fn test_aarch64_binemit() {
     // Then:
     //
     //      $ echo "mov x1, x2" | aarch64inst.sh
-    insns.push((
-        Inst::Ret {
-            rets: vec![],
-            stack_bytes_to_pop: 0,
-        },
-        "C0035FD6",
-        "ret",
-    ));
-    insns.push((
-        Inst::Ret {
-            rets: vec![],
-            stack_bytes_to_pop: 16,
-        },
-        "FF430091C0035FD6",
-        "add sp, sp, #16 ; ret",
-    ));
+    insns.push((Inst::Ret {}, "C0035FD6", "ret"));
     insns.push((
         Inst::AuthenticatedRet {
             key: APIKey::ASP,
             is_hint: true,
-            rets: vec![],
-            stack_bytes_to_pop: 0,
         },
         "BF2303D5C0035FD6",
         "autiasp ; ret",
@@ -67,21 +50,9 @@ fn test_aarch64_binemit() {
         Inst::AuthenticatedRet {
             key: APIKey::BSP,
             is_hint: false,
-            rets: vec![],
-            stack_bytes_to_pop: 0,
         },
         "FF0F5FD6",
         "retabsp",
-    ));
-    insns.push((
-        Inst::AuthenticatedRet {
-            key: APIKey::ASP,
-            is_hint: false,
-            rets: vec![],
-            stack_bytes_to_pop: 16,
-        },
-        "FF430091FF0B5FD6",
-        "add sp, sp, #16 ; retaasp",
     ));
     insns.push((Inst::Paci { key: APIKey::BSP }, "7F2303D5", "pacibsp"));
     insns.push((Inst::Xpaclri, "FF2003D5", "xpaclri"));

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -246,21 +246,12 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         specified
     }
 
-    fn gen_args(_isa_flags: &crate::isa::riscv64::settings::Flags, args: Vec<ArgPair>) -> Inst {
+    fn gen_args(args: Vec<ArgPair>) -> Inst {
         Inst::Args { args }
     }
 
-    fn gen_ret(
-        _setup_frame: bool,
-        _isa_flags: &Self::F,
-        _call_conv: isa::CallConv,
-        rets: Vec<RetPair>,
-        stack_bytes_to_pop: u32,
-    ) -> Inst {
-        Inst::Ret {
-            rets,
-            stack_bytes_to_pop,
-        }
+    fn gen_rets(rets: Vec<RetPair>) -> Inst {
+        Inst::Rets { rets }
     }
 
     fn get_stacklimit_reg(_call_conv: isa::CallConv) -> Reg {
@@ -341,54 +332,77 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         }
     }
 
-    fn gen_prologue_frame_setup(flags: &settings::Flags) -> (SmallInstVec<Self::I>, u32) {
-        // add  sp,sp,-16    ;; alloc stack space for fp.
-        // sd   ra,8(sp)     ;; save ra.
-        // sd   fp,0(sp)     ;; store old fp.
-        // mv   fp,sp        ;; set fp to sp.
+    fn gen_prologue_frame_setup(
+        _call_conv: isa::CallConv,
+        flags: &settings::Flags,
+        _isa_flags: &RiscvFlags,
+        frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Inst> {
         let mut insts = SmallVec::new();
-        insts.push(Inst::AdjustSp { amount: -16 });
-        insts.push(Self::gen_store_stack(
-            StackAMode::SPOffset(8, I64),
-            link_reg(),
-            I64,
-        ));
-        insts.push(Self::gen_store_stack(
-            StackAMode::SPOffset(0, I64),
-            fp_reg(),
-            I64,
-        ));
 
-        let setup_area_size = 16; // FP, LR
-        if flags.unwind_info() {
-            insts.push(Inst::Unwind {
-                inst: UnwindInst::PushFrameRegs {
-                    offset_upward_to_caller_sp: setup_area_size,
-                },
+        if frame_layout.setup_area_size > 0 {
+            // add  sp,sp,-16    ;; alloc stack space for fp.
+            // sd   ra,8(sp)     ;; save ra.
+            // sd   fp,0(sp)     ;; store old fp.
+            // mv   fp,sp        ;; set fp to sp.
+            insts.push(Inst::AdjustSp { amount: -16 });
+            insts.push(Self::gen_store_stack(
+                StackAMode::SPOffset(8, I64),
+                link_reg(),
+                I64,
+            ));
+            insts.push(Self::gen_store_stack(
+                StackAMode::SPOffset(0, I64),
+                fp_reg(),
+                I64,
+            ));
+
+            if flags.unwind_info() {
+                insts.push(Inst::Unwind {
+                    inst: UnwindInst::PushFrameRegs {
+                        offset_upward_to_caller_sp: frame_layout.setup_area_size,
+                    },
+                });
+            }
+            insts.push(Inst::Mov {
+                rd: writable_fp_reg(),
+                rm: stack_reg(),
+                ty: I64,
             });
         }
-        insts.push(Inst::Mov {
-            rd: writable_fp_reg(),
-            rm: stack_reg(),
-            ty: I64,
-        });
 
-        (insts, setup_area_size)
+        insts
     }
     /// reverse of gen_prologue_frame_setup.
-    fn gen_epilogue_frame_restore(_: &settings::Flags) -> SmallInstVec<Inst> {
+    fn gen_epilogue_frame_restore(
+        call_conv: isa::CallConv,
+        _flags: &settings::Flags,
+        _isa_flags: &RiscvFlags,
+        frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Inst> {
         let mut insts = SmallVec::new();
-        insts.push(Self::gen_load_stack(
-            StackAMode::SPOffset(8, I64),
-            writable_link_reg(),
-            I64,
-        ));
-        insts.push(Self::gen_load_stack(
-            StackAMode::SPOffset(0, I64),
-            writable_fp_reg(),
-            I64,
-        ));
-        insts.push(Inst::AdjustSp { amount: 16 });
+
+        if frame_layout.setup_area_size > 0 {
+            insts.push(Self::gen_load_stack(
+                StackAMode::SPOffset(8, I64),
+                writable_link_reg(),
+                I64,
+            ));
+            insts.push(Self::gen_load_stack(
+                StackAMode::SPOffset(0, I64),
+                writable_fp_reg(),
+                I64,
+            ));
+            insts.push(Inst::AdjustSp { amount: 16 });
+        }
+
+        if call_conv == isa::CallConv::Tail && frame_layout.stack_args_size > 0 {
+            insts.extend(Self::gen_sp_reg_adjust(
+                frame_layout.stack_args_size.try_into().unwrap(),
+            ));
+        }
+        insts.push(Inst::Ret {});
+
         insts
     }
 
@@ -410,28 +424,23 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             }),
         });
     }
-    // Returns stack bytes used as well as instructions. Does not adjust
-    // nominal SP offset; abi_impl generic code will do that.
+
     fn gen_clobber_save(
         _call_conv: isa::CallConv,
-        setup_frame: bool,
         flags: &settings::Flags,
-        clobbered_callee_saves: &[Writable<RealReg>],
-        fixed_frame_storage_size: u32,
-        _outgoing_args_size: u32,
-    ) -> (u64, SmallVec<[Inst; 16]>) {
+        frame_layout: &FrameLayout,
+    ) -> SmallVec<[Inst; 16]> {
         let mut insts = SmallVec::new();
-        let clobbered_size = compute_clobber_size(&clobbered_callee_saves);
         // Adjust the stack pointer downward for clobbers and the function fixed
         // frame (spillslots and storage slots).
-        let stack_size = fixed_frame_storage_size + clobbered_size;
-        if flags.unwind_info() && setup_frame {
+        let stack_size = frame_layout.fixed_frame_storage_size + frame_layout.clobber_size;
+        if flags.unwind_info() && frame_layout.setup_area_size > 0 {
             // The *unwind* frame (but not the actual frame) starts at the
             // clobbers, just below the saved FP/LR pair.
             insts.push(Inst::Unwind {
                 inst: UnwindInst::DefineNewFrame {
-                    offset_downward_to_clobbers: clobbered_size,
-                    offset_upward_to_caller_sp: 16, // FP, LR
+                    offset_downward_to_clobbers: frame_layout.clobber_size,
+                    offset_upward_to_caller_sp: frame_layout.setup_area_size,
                 },
             });
         }
@@ -440,7 +449,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         if stack_size > 0 {
             // since we use fp, we didn't need use UnwindInst::StackAlloc.
             let mut cur_offset = 8;
-            for reg in clobbered_callee_saves {
+            for reg in &frame_layout.clobbered_callee_saves {
                 let r_reg = reg.to_reg();
                 let ty = match r_reg.class() {
                     RegClass::Int => I64,
@@ -450,7 +459,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 if flags.unwind_info() {
                     insts.push(Inst::Unwind {
                         inst: UnwindInst::SaveReg {
-                            clobber_offset: clobbered_size - cur_offset,
+                            clobber_offset: frame_layout.clobber_size - cur_offset,
                             reg: r_reg,
                         },
                     });
@@ -466,28 +475,23 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 amount: -(stack_size as i64),
             });
         }
-        (clobbered_size as u64, insts)
+        insts
     }
 
     fn gen_clobber_restore(
-        call_conv: isa::CallConv,
-        sig: &Signature,
+        _call_conv: isa::CallConv,
         _flags: &settings::Flags,
-        clobbers: &[Writable<RealReg>],
-        fixed_frame_storage_size: u32,
-        _outgoing_args_size: u32,
+        frame_layout: &FrameLayout,
     ) -> SmallVec<[Inst; 16]> {
         let mut insts = SmallVec::new();
-        let clobbered_callee_saves =
-            Self::get_clobbered_callee_saves(call_conv, _flags, sig, clobbers);
-        let stack_size = fixed_frame_storage_size + compute_clobber_size(&clobbered_callee_saves);
+        let stack_size = frame_layout.fixed_frame_storage_size + frame_layout.clobber_size;
         if stack_size > 0 {
             insts.push(Inst::AdjustSp {
                 amount: stack_size as i64,
             });
         }
         let mut cur_offset = 8;
-        for reg in &clobbered_callee_saves {
+        for reg in &frame_layout.clobbered_callee_saves {
             let rreg = reg.to_reg();
             let ty = match rreg.class() {
                 RegClass::Int => I64,
@@ -636,12 +640,16 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         }
     }
 
-    fn get_clobbered_callee_saves(
+    fn compute_frame_layout(
         call_conv: isa::CallConv,
-        _flags: &settings::Flags,
+        flags: &settings::Flags,
         _sig: &Signature,
         regs: &[Writable<RealReg>],
-    ) -> Vec<Writable<RealReg>> {
+        is_leaf: bool,
+        stack_args_size: u32,
+        fixed_frame_storage_size: u32,
+        outgoing_args_size: u32,
+    ) -> FrameLayout {
         let mut regs: Vec<Writable<RealReg>> = regs
             .iter()
             .cloned()
@@ -649,21 +657,34 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             .collect();
 
         regs.sort();
-        regs
-    }
 
-    fn is_frame_setup_needed(
-        is_leaf: bool,
-        stack_args_size: u32,
-        num_clobbered_callee_saves: usize,
-        fixed_frame_storage_size: u32,
-    ) -> bool {
-        !is_leaf
+        // Compute clobber size.
+        let clobber_size = compute_clobber_size(&regs);
+
+        // Compute linkage frame size.
+        let setup_area_size = if flags.preserve_frame_pointers()
+            || !is_leaf
             // The function arguments that are passed on the stack are addressed
             // relative to the Frame Pointer.
             || stack_args_size > 0
-            || num_clobbered_callee_saves > 0
-        || fixed_frame_storage_size > 0
+            || clobber_size > 0
+            || fixed_frame_storage_size > 0
+        {
+            16 // FP, LR
+        } else {
+            0
+        };
+
+        // Return FrameLayout structure.
+        debug_assert!(outgoing_args_size == 0);
+        FrameLayout {
+            stack_args_size,
+            setup_area_size,
+            clobber_size,
+            fixed_frame_storage_size,
+            outgoing_args_size,
+            clobbered_callee_saves: regs,
+        }
     }
 
     fn gen_inline_probestack(

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -90,8 +90,11 @@
     (Args
       (args VecArgPair))
 
-    (Ret (rets VecRetPair)
-         (stack_bytes_to_pop u32))
+    ;; A pseudo-instruction that moves vregs to return registers.
+    (Rets
+      (rets VecRetPair))
+
+    (Ret)
 
      (Extend
       (rd WritableReg)

--- a/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
@@ -42,22 +42,7 @@ fn test_riscv64_binemit() {
 
     let mut insns = Vec::<TestUnit>::with_capacity(500);
 
-    insns.push(TestUnit::new(
-        Inst::Ret {
-            rets: vec![],
-            stack_bytes_to_pop: 0,
-        },
-        "ret",
-        0x00008067,
-    ));
-    insns.push(TestUnit::new(
-        Inst::Ret {
-            rets: vec![],
-            stack_bytes_to_pop: 16,
-        },
-        "add sp, sp, #16 ; ret",
-        "1301010167800000",
-    ));
+    insns.push(TestUnit::new(Inst::Ret {}, "ret", 0x00008067));
 
     insns.push(TestUnit::new(
         Inst::Mov {

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -436,22 +436,12 @@ impl ABIMachineSpec for S390xMachineDeps {
         }
     }
 
-    fn gen_args(_isa_flags: &s390x_settings::Flags, args: Vec<ArgPair>) -> Inst {
+    fn gen_args(args: Vec<ArgPair>) -> Inst {
         Inst::Args { args }
     }
 
-    fn gen_ret(
-        _setup_frame: bool,
-        _isa_flags: &s390x_settings::Flags,
-        _call_conv: isa::CallConv,
-        rets: Vec<RetPair>,
-        stack_bytes_to_pop: u32,
-    ) -> Inst {
-        Inst::Ret {
-            link: gpr(14),
-            rets,
-            stack_bytes_to_pop,
-        }
+    fn gen_rets(rets: Vec<RetPair>) -> Inst {
+        Inst::Rets { rets }
     }
 
     fn gen_add_imm(
@@ -556,12 +546,29 @@ impl ABIMachineSpec for S390xMachineDeps {
         }
     }
 
-    fn gen_prologue_frame_setup(_flags: &settings::Flags) -> (SmallInstVec<Inst>, u32) {
-        (SmallVec::new(), 0)
+    fn gen_prologue_frame_setup(
+        _call_conv: isa::CallConv,
+        _flags: &settings::Flags,
+        _isa_flags: &s390x_settings::Flags,
+        _frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Inst> {
+        SmallVec::new()
     }
 
-    fn gen_epilogue_frame_restore(_flags: &settings::Flags) -> SmallInstVec<Inst> {
-        SmallVec::new()
+    fn gen_epilogue_frame_restore(
+        call_conv: isa::CallConv,
+        _flags: &settings::Flags,
+        _isa_flags: &s390x_settings::Flags,
+        frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Inst> {
+        let mut insts = SmallVec::new();
+        if call_conv == isa::CallConv::Tail && frame_layout.stack_args_size > 0 {
+            insts.extend(Self::gen_sp_reg_adjust(
+                frame_layout.stack_args_size.try_into().unwrap(),
+            ));
+        }
+        insts.push(Inst::Ret { link: gpr(14) });
+        insts
     }
 
     fn gen_probestack(_insts: &mut SmallInstVec<Self::I>, _: u32) {
@@ -579,27 +586,21 @@ impl ABIMachineSpec for S390xMachineDeps {
         unimplemented!("Inline stack probing is unimplemented on S390x");
     }
 
-    // Returns stack bytes used as well as instructions. Does not adjust
-    // nominal SP offset; abi generic code will do that.
     fn gen_clobber_save(
         _call_conv: isa::CallConv,
-        _setup_frame: bool,
         flags: &settings::Flags,
-        clobbered_callee_saves: &[Writable<RealReg>],
-        fixed_frame_storage_size: u32,
-        mut outgoing_args_size: u32,
-    ) -> (u64, SmallVec<[Inst; 16]>) {
+        frame_layout: &FrameLayout,
+    ) -> SmallVec<[Inst; 16]> {
         let mut insts = SmallVec::new();
 
         // Collect clobbered registers.
         let (first_clobbered_gpr, clobbered_fpr) =
-            get_clobbered_gpr_fpr(flags, clobbered_callee_saves, &mut outgoing_args_size);
-        let clobber_size = clobbered_fpr.len() * 8;
+            get_clobbered_gpr_fpr(&frame_layout.clobbered_callee_saves);
         if flags.unwind_info() {
             insts.push(Inst::Unwind {
                 inst: UnwindInst::DefineNewFrame {
                     offset_upward_to_caller_sp: REG_SAVE_AREA_SIZE,
-                    offset_downward_to_clobbers: clobber_size as u32,
+                    offset_downward_to_clobbers: frame_layout.clobber_size,
                 },
             });
         }
@@ -617,7 +618,7 @@ impl ABIMachineSpec for S390xMachineDeps {
             for i in first_clobbered_gpr..16 {
                 insts.push(Inst::Unwind {
                     inst: UnwindInst::SaveReg {
-                        clobber_offset: clobber_size as u32 + (i * 8) as u32,
+                        clobber_offset: frame_layout.clobber_size + (i * 8) as u32,
                         reg: gpr(i).to_real_reg().unwrap(),
                     },
                 });
@@ -630,8 +631,9 @@ impl ABIMachineSpec for S390xMachineDeps {
         }
 
         // Decrement stack pointer.
-        let stack_size =
-            outgoing_args_size as i32 + clobber_size as i32 + fixed_frame_storage_size as i32;
+        let stack_size = frame_layout.outgoing_args_size as i32
+            + frame_layout.clobber_size as i32
+            + frame_layout.fixed_frame_storage_size as i32;
         insts.extend(Self::gen_sp_reg_adjust(-stack_size));
         if flags.unwind_info() {
             insts.push(Inst::Unwind {
@@ -641,7 +643,7 @@ impl ABIMachineSpec for S390xMachineDeps {
             });
         }
 
-        let sp_adj = outgoing_args_size as i32;
+        let sp_adj = frame_layout.outgoing_args_size as i32;
         if sp_adj > 0 {
             insts.push(Self::gen_nominal_sp_adj(sp_adj));
         }
@@ -661,7 +663,9 @@ impl ABIMachineSpec for S390xMachineDeps {
                 rd: reg.to_reg().into(),
                 mem: MemArg::reg_plus_off(
                     stack_reg(),
-                    (i * 8) as i64 + outgoing_args_size as i64 + fixed_frame_storage_size as i64,
+                    (i * 8) as i64
+                        + frame_layout.outgoing_args_size as i64
+                        + frame_layout.fixed_frame_storage_size as i64,
                     MemFlags::trusted(),
                 ),
                 lane_imm: 0,
@@ -676,25 +680,19 @@ impl ABIMachineSpec for S390xMachineDeps {
             }
         }
 
-        (clobber_size as u64, insts)
+        insts
     }
 
     fn gen_clobber_restore(
-        call_conv: isa::CallConv,
-        sig: &Signature,
-        flags: &settings::Flags,
-        clobbers: &[Writable<RealReg>],
-        fixed_frame_storage_size: u32,
-        mut outgoing_args_size: u32,
+        _call_conv: isa::CallConv,
+        _flags: &settings::Flags,
+        frame_layout: &FrameLayout,
     ) -> SmallVec<[Inst; 16]> {
         let mut insts = SmallVec::new();
-        let clobbered_callee_saves =
-            Self::get_clobbered_callee_saves(call_conv, flags, sig, clobbers);
 
         // Collect clobbered registers.
         let (first_clobbered_gpr, clobbered_fpr) =
-            get_clobbered_gpr_fpr(flags, &clobbered_callee_saves, &mut outgoing_args_size);
-        let clobber_size = clobbered_fpr.len() * 8;
+            get_clobbered_gpr_fpr(&frame_layout.clobbered_callee_saves);
 
         // Restore FPRs.
         for (i, reg) in clobbered_fpr.iter().enumerate() {
@@ -703,7 +701,9 @@ impl ABIMachineSpec for S390xMachineDeps {
                 rd: Writable::from_reg(reg.to_reg().into()),
                 mem: MemArg::reg_plus_off(
                     stack_reg(),
-                    (i * 8) as i64 + outgoing_args_size as i64 + fixed_frame_storage_size as i64,
+                    (i * 8) as i64
+                        + frame_layout.outgoing_args_size as i64
+                        + frame_layout.fixed_frame_storage_size as i64,
                     MemFlags::trusted(),
                 ),
                 lane_imm: 0,
@@ -711,8 +711,9 @@ impl ABIMachineSpec for S390xMachineDeps {
         }
 
         // Increment stack pointer unless it will be restored implicitly.
-        let stack_size =
-            outgoing_args_size as i32 + clobber_size as i32 + fixed_frame_storage_size as i32;
+        let stack_size = frame_layout.outgoing_args_size as i32
+            + frame_layout.clobber_size as i32
+            + frame_layout.fixed_frame_storage_size as i32;
         let implicit_sp_restore = first_clobbered_gpr < 16
             && SImm20::maybe_from_i64(8 * first_clobbered_gpr as i64 + stack_size as i64).is_some();
         if !implicit_sp_restore {
@@ -793,12 +794,16 @@ impl ABIMachineSpec for S390xMachineDeps {
         specified
     }
 
-    fn get_clobbered_callee_saves(
+    fn compute_frame_layout(
         call_conv: isa::CallConv,
         flags: &settings::Flags,
         _sig: &Signature,
         regs: &[Writable<RealReg>],
-    ) -> Vec<Writable<RealReg>> {
+        _is_leaf: bool,
+        stack_args_size: u32,
+        fixed_frame_storage_size: u32,
+        mut outgoing_args_size: u32,
+    ) -> FrameLayout {
         assert!(
             !flags.enable_pinned_reg(),
             "Pinned register not supported on s390x"
@@ -810,20 +815,54 @@ impl ABIMachineSpec for S390xMachineDeps {
             .filter(|r| is_reg_saved_in_prologue(call_conv, r.to_reg()))
             .collect();
 
+        // If the front end asks to preserve frame pointers (which we do not
+        // really have in the s390x ABI), we use the stack backchain instead.
+        // For this to work in all cases, we must allocate a stack frame with
+        // at least the outgoing register save area even in leaf functions.
+        // Update our caller's outgoing_args_size to reflect this.
+        if flags.preserve_frame_pointers() {
+            if outgoing_args_size < REG_SAVE_AREA_SIZE {
+                outgoing_args_size = REG_SAVE_AREA_SIZE;
+            }
+        }
+
+        // We need to save/restore the link register in non-leaf functions.
+        // This is not included in the clobber list because we have excluded
+        // call instructions via the is_included_in_clobbers callback.
+        // We also want to enforce saving the link register in leaf functions
+        // for stack unwinding, if we're asked to preserve frame pointers.
+        if outgoing_args_size > 0 {
+            let link_reg = Writable::from_reg(RealReg::from(gpr_preg(14)));
+            if !regs.contains(&link_reg) {
+                regs.push(link_reg);
+            }
+        }
+
         // Sort registers for deterministic code output. We can do an unstable
         // sort because the registers will be unique (there are no dups).
         regs.sort_unstable_by_key(|r| PReg::from(r.to_reg()).index());
-        regs
-    }
 
-    fn is_frame_setup_needed(
-        _is_leaf: bool,
-        _stack_args_size: u32,
-        _num_clobbered_callee_saves: usize,
-        _frame_storage_size: u32,
-    ) -> bool {
-        // The call frame set-up is handled by gen_clobber_save().
-        false
+        // Compute clobber size.  We only need to count FPR save slots.
+        let mut clobber_size = 0;
+        for reg in &regs {
+            match reg.to_reg().class() {
+                RegClass::Int => {}
+                RegClass::Float => {
+                    clobber_size += 8;
+                }
+                RegClass::Vector => unreachable!(),
+            }
+        }
+
+        // Return FrameLayout structure.
+        FrameLayout {
+            stack_args_size,
+            setup_area_size: 0,
+            clobber_size,
+            fixed_frame_storage_size,
+            outgoing_args_size,
+            clobbered_callee_saves: regs,
+        }
     }
 }
 
@@ -842,9 +881,7 @@ fn is_reg_saved_in_prologue(_call_conv: isa::CallConv, r: RealReg) -> bool {
 }
 
 fn get_clobbered_gpr_fpr(
-    flags: &settings::Flags,
     clobbered_callee_saves: &[Writable<RealReg>],
-    outgoing_args_size: &mut u32,
 ) -> (u8, SmallVec<[Writable<RealReg>; 8]>) {
     // Collect clobbered registers.  Note we save/restore GPR always as
     // a block of registers using LOAD MULTIPLE / STORE MULTIPLE, starting
@@ -852,26 +889,6 @@ fn get_clobbered_gpr_fpr(
     // return the number of that first GPR (or 16 if none is to be saved).
     let mut clobbered_fpr = SmallVec::new();
     let mut first_clobbered_gpr = 16;
-
-    // If the front end asks to preserve frame pointers (which we do not
-    // really have in the s390x ABI), we use the stack backchain instead.
-    // For this to work in all cases, we must allocate a stack frame with
-    // at least the outgoing register save area even in leaf functions.
-    // Update out caller's outgoing_args_size to reflect this.
-    if flags.preserve_frame_pointers() {
-        if *outgoing_args_size < REG_SAVE_AREA_SIZE {
-            *outgoing_args_size = REG_SAVE_AREA_SIZE;
-        }
-    }
-
-    // We need to save/restore the link register in non-leaf functions.
-    // This is not included in the clobber list because we have excluded
-    // call instructions via the is_included_in_clobbers callback.
-    // We also want to enforce saving the link register in leaf functions
-    // for stack unwinding, if we're asked to preserve frame pointers.
-    if *outgoing_args_size > 0 {
-        first_clobbered_gpr = 14;
-    }
 
     for &reg in clobbered_callee_saves.iter() {
         match reg.to_reg().class() {

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -901,13 +901,15 @@
     (Args
       (args VecArgPair))
 
+    ;; A pseudo-instruction that moves vregs to return registers.
+    (Rets
+      (rets VecRetPair))
+
     ;; ---- branches (exactly one must appear at end of BB) ----
 
     ;; A machine return instruction.
     (Ret
-      (link Reg)
-      (rets VecRetPair)
-      (stack_bytes_to_pop u32))
+      (link Reg))
 
     ;; An unconditional branch.
     (Jump

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -5,7 +5,7 @@ use crate::ir::{MemFlags, RelSourceLoc, TrapCode};
 use crate::isa::s390x::abi::S390xMachineDeps;
 use crate::isa::s390x::inst::*;
 use crate::isa::s390x::settings as s390x_settings;
-use crate::machinst::{ABIMachineSpec, Reg, RegClass};
+use crate::machinst::{Reg, RegClass};
 use crate::trace;
 use core::convert::TryFrom;
 use cranelift_control::ControlPlane;
@@ -3545,19 +3545,9 @@ impl Inst {
                 }
             }
             &Inst::Args { .. } => {}
-            &Inst::Ret {
-                link,
-                stack_bytes_to_pop,
-                ..
-            } => {
+            &Inst::Rets { .. } => {}
+            &Inst::Ret { link } => {
                 debug_assert_eq!(link, gpr(14));
-
-                for inst in
-                    S390xMachineDeps::gen_sp_reg_adjust(i32::try_from(stack_bytes_to_pop).unwrap())
-                {
-                    inst.emit(&[], sink, emit_info, state);
-                }
-
                 let opcode = 0x07; // BCR
                 put(sink, &enc_rr(opcode, gpr(15), link));
             }

--- a/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit_tests.rs
@@ -7018,25 +7018,7 @@ fn test_s390x_binemit() {
         "basr %r14, %r1",
     ));
 
-    insns.push((
-        Inst::Ret {
-            link: gpr(14),
-            rets: vec![],
-            stack_bytes_to_pop: 0,
-        },
-        "07FE",
-        "br %r14",
-    ));
-
-    insns.push((
-        Inst::Ret {
-            link: gpr(14),
-            rets: vec![],
-            stack_bytes_to_pop: 16,
-        },
-        "A7FB001007FE",
-        "aghi %r15, 16 ; br %r14",
-    ));
+    insns.push((Inst::Ret { link: gpr(14) }, "07FE", "br %r14"));
 
     insns.push((Inst::Debugtrap, "0001", ".word 0x0001 # debugtrap"));
 

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -65,15 +65,7 @@ pub struct CallIndInfo {
 fn inst_size_test() {
     // This test will help with unintentionally growing the size
     // of the Inst enum.
-    //
-    // TODO(#5879): see if we can make `VecRetPair` a box slice to get back to
-    // 32 here.
-    let expected_size = if cfg!(target_arch = "aarch64") || cfg!(target_arch = "riscv64") {
-        48
-    } else {
-        40
-    };
-    assert_eq!(expected_size, std::mem::size_of::<Inst>());
+    assert_eq!(32, std::mem::size_of::<Inst>());
 }
 
 /// A register pair. Enum so it can be destructured in ISLE.
@@ -240,6 +232,7 @@ impl Inst {
             | Inst::Call { .. }
             | Inst::CallInd { .. }
             | Inst::Args { .. }
+            | Inst::Rets { .. }
             | Inst::Ret { .. }
             | Inst::Jump { .. }
             | Inst::CondBr { .. }
@@ -953,12 +946,14 @@ fn s390x_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandC
                 collector.reg_fixed_def(arg.vreg, arg.preg);
             }
         }
-        &Inst::Ret { ref rets, .. } => {
-            // NOTE: we explicitly don't mark the link register as used here, as the use is only in
-            // the epilog where callee-save registers are restored.
+        &Inst::Rets { ref rets } => {
             for ret in rets {
                 collector.reg_fixed_use(ret.vreg, ret.preg);
             }
+        }
+        &Inst::Ret { .. } => {
+            // NOTE: we explicitly don't mark the link register as used here, as the use is only in
+            // the epilog where callee-save registers are restored.
         }
         &Inst::Jump { .. } => {}
         &Inst::IndirectBr { rn, .. } => {
@@ -1056,7 +1051,7 @@ impl MachInst for Inst {
 
     fn is_term(&self) -> MachTerminator {
         match self {
-            &Inst::Ret { .. } => MachTerminator::Ret,
+            &Inst::Rets { .. } => MachTerminator::Ret,
             &Inst::Jump { .. } => MachTerminator::Uncond,
             &Inst::CondBr { .. } => MachTerminator::Cond,
             &Inst::OneWayCondBr { .. } => {
@@ -3167,25 +3162,19 @@ impl Inst {
                 }
                 s
             }
-            &Inst::Ret {
-                link,
-                ref rets,
-                stack_bytes_to_pop,
-            } => {
-                debug_assert_eq!(link, gpr(14));
-                let link = show_reg(link);
-                let mut s = if stack_bytes_to_pop == 0 {
-                    format!("br {link}")
-                } else {
-                    let stack_reg = show_reg(stack_reg());
-                    format!("aghi {stack_reg}, {stack_bytes_to_pop} ; br {link}")
-                };
+            &Inst::Rets { ref rets } => {
+                let mut s = "rets".to_string();
                 for ret in rets {
                     let preg = pretty_print_reg(ret.preg, &mut empty_allocs);
                     let vreg = pretty_print_reg(ret.vreg, allocs);
                     write!(&mut s, " {}={}", vreg, preg).unwrap();
                 }
                 s
+            }
+            &Inst::Ret { link } => {
+                debug_assert_eq!(link, gpr(14));
+                let link = show_reg(link);
+                format!("br {link}")
             }
             &Inst::Jump { dest } => {
                 let dest = dest.to_string();

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -344,18 +344,12 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         }
     }
 
-    fn gen_args(_isa_flags: &x64_settings::Flags, args: Vec<ArgPair>) -> Inst {
+    fn gen_args(args: Vec<ArgPair>) -> Inst {
         Inst::Args { args }
     }
 
-    fn gen_ret(
-        _setup_frame: bool,
-        _isa_flags: &x64_settings::Flags,
-        _call_conv: isa::CallConv,
-        rets: Vec<RetPair>,
-        stack_bytes_to_pop: u32,
-    ) -> Self::I {
-        Inst::ret(rets, stack_bytes_to_pop)
+    fn gen_rets(rets: Vec<RetPair>) -> Inst {
+        Inst::Rets { rets }
     }
 
     fn gen_add_imm(
@@ -444,7 +438,12 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         }
     }
 
-    fn gen_prologue_frame_setup(flags: &settings::Flags) -> (SmallInstVec<Self::I>, u32) {
+    fn gen_prologue_frame_setup(
+        _call_conv: isa::CallConv,
+        flags: &settings::Flags,
+        _isa_flags: &x64_settings::Flags,
+        frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Self::I> {
         let r_rsp = regs::rsp();
         let r_rbp = regs::rbp();
         let w_rbp = Writable::from_reg(r_rbp);
@@ -453,11 +452,10 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         // RSP before the call will be 0 % 16.  So here, it is 8 % 16.
         insts.push(Inst::push64(RegMemImm::reg(r_rbp)));
 
-        let setup_area_size = 16; // RBP, return address
         if flags.unwind_info() {
             insts.push(Inst::Unwind {
                 inst: UnwindInst::PushFrameRegs {
-                    offset_upward_to_caller_sp: setup_area_size,
+                    offset_upward_to_caller_sp: frame_layout.setup_area_size,
                 },
             });
         }
@@ -466,10 +464,15 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         // RSP is now 0 % 16
         insts.push(Inst::mov_r_r(OperandSize::Size64, r_rsp, w_rbp));
 
-        (insts, setup_area_size)
+        insts
     }
 
-    fn gen_epilogue_frame_restore(_: &settings::Flags) -> SmallInstVec<Self::I> {
+    fn gen_epilogue_frame_restore(
+        call_conv: isa::CallConv,
+        _flags: &settings::Flags,
+        _isa_flags: &x64_settings::Flags,
+        frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Self::I> {
         let mut insts = SmallVec::new();
         // `mov %rbp, %rsp`
         insts.push(Inst::mov_r_r(
@@ -479,6 +482,13 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         ));
         // `pop %rbp`
         insts.push(Inst::pop64(Writable::from_reg(regs::rbp())));
+        // Emit return instruction.
+        let stack_bytes_to_pop = if call_conv == isa::CallConv::Tail {
+            frame_layout.stack_args_size
+        } else {
+            0
+        };
+        insts.push(Inst::ret(stack_bytes_to_pop));
         insts
     }
 
@@ -527,35 +537,31 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
     fn gen_clobber_save(
         call_conv: isa::CallConv,
-        setup_frame: bool,
         flags: &settings::Flags,
-        clobbered_callee_saves: &[Writable<RealReg>],
-        fixed_frame_storage_size: u32,
-        _outgoing_args_size: u32,
-    ) -> (u64, SmallVec<[Self::I; 16]>) {
+        frame_layout: &FrameLayout,
+    ) -> SmallVec<[Self::I; 16]> {
         if call_conv == isa::CallConv::Tail {
-            assert!(clobbered_callee_saves.is_empty());
+            assert!(frame_layout.clobbered_callee_saves.is_empty());
         }
 
         let mut insts = SmallVec::new();
-        let clobbered_size = compute_clobber_size(&clobbered_callee_saves);
 
-        if flags.unwind_info() && setup_frame {
+        if flags.unwind_info() && frame_layout.setup_area_size > 0 {
             // Emit unwind info: start the frame. The frame (from unwind
             // consumers' point of view) starts at clobbbers, just below
             // the FP and return address. Spill slots and stack slots are
             // part of our actual frame but do not concern the unwinder.
             insts.push(Inst::Unwind {
                 inst: UnwindInst::DefineNewFrame {
-                    offset_downward_to_clobbers: clobbered_size,
-                    offset_upward_to_caller_sp: 16, // RBP, return address
+                    offset_downward_to_clobbers: frame_layout.clobber_size,
+                    offset_upward_to_caller_sp: frame_layout.setup_area_size,
                 },
             });
         }
 
         // Adjust the stack pointer downward for clobbers and the function fixed
         // frame (spillslots and storage slots).
-        let stack_size = fixed_frame_storage_size + clobbered_size;
+        let stack_size = frame_layout.fixed_frame_storage_size + frame_layout.clobber_size;
         if stack_size > 0 {
             insts.push(Inst::alu_rmi_r(
                 OperandSize::Size64,
@@ -566,8 +572,8 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         }
         // Store each clobbered register in order at offsets from RSP,
         // placing them above the fixed frame slots.
-        let mut cur_offset = fixed_frame_storage_size;
-        for reg in clobbered_callee_saves {
+        let mut cur_offset = frame_layout.fixed_frame_storage_size;
+        for reg in &frame_layout.clobbered_callee_saves {
             let r_reg = reg.to_reg();
             let off = cur_offset;
             match r_reg.class() {
@@ -593,35 +599,30 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             if flags.unwind_info() {
                 insts.push(Inst::Unwind {
                     inst: UnwindInst::SaveReg {
-                        clobber_offset: off - fixed_frame_storage_size,
+                        clobber_offset: off - frame_layout.fixed_frame_storage_size,
                         reg: r_reg,
                     },
                 });
             }
         }
 
-        (clobbered_size as u64, insts)
+        insts
     }
 
     fn gen_clobber_restore(
-        call_conv: isa::CallConv,
-        sig: &Signature,
-        flags: &settings::Flags,
-        clobbers: &[Writable<RealReg>],
-        fixed_frame_storage_size: u32,
-        _outgoing_args_size: u32,
+        _call_conv: isa::CallConv,
+        _flags: &settings::Flags,
+        frame_layout: &FrameLayout,
     ) -> SmallVec<[Self::I; 16]> {
         let mut insts = SmallVec::new();
 
-        let clobbered_callee_saves =
-            Self::get_clobbered_callee_saves(call_conv, flags, sig, clobbers);
-        let stack_size = fixed_frame_storage_size + compute_clobber_size(&clobbered_callee_saves);
+        let stack_size = frame_layout.fixed_frame_storage_size + frame_layout.clobber_size;
 
         // Restore regs by loading from offsets of RSP. RSP will be
         // returned to nominal-RSP at this point, so we can use the
         // same offsets that we used when saving clobbers above.
-        let mut cur_offset = fixed_frame_storage_size;
-        for reg in &clobbered_callee_saves {
+        let mut cur_offset = frame_layout.fixed_frame_storage_size;
+        for reg in &frame_layout.clobbered_callee_saves {
             let rreg = reg.to_reg();
             match rreg.class() {
                 RegClass::Int => {
@@ -802,12 +803,16 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         ir::ArgumentExtension::None
     }
 
-    fn get_clobbered_callee_saves(
+    fn compute_frame_layout(
         call_conv: CallConv,
         flags: &settings::Flags,
         _sig: &Signature,
         regs: &[Writable<RealReg>],
-    ) -> Vec<Writable<RealReg>> {
+        _is_leaf: bool,
+        stack_args_size: u32,
+        fixed_frame_storage_size: u32,
+        outgoing_args_size: u32,
+    ) -> FrameLayout {
         let mut regs: Vec<Writable<RealReg>> = match call_conv {
             // The `tail` calling convention doesn't have any callee-save
             // registers.
@@ -828,16 +833,23 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         // Sort registers for deterministic code output. We can do an unstable sort because the
         // registers will be unique (there are no dups).
         regs.sort_unstable_by_key(|r| VReg::from(r.to_reg()).vreg());
-        regs
-    }
 
-    fn is_frame_setup_needed(
-        _is_leaf: bool,
-        _stack_args_size: u32,
-        _num_clobbered_callee_saves: usize,
-        _frame_storage_size: u32,
-    ) -> bool {
-        true
+        // Compute clobber size.
+        let clobber_size = compute_clobber_size(&regs);
+
+        // Compute setup area size.
+        let setup_area_size = 16; // RBP, return address
+
+        // Return FrameLayout structure.
+        debug_assert!(outgoing_args_size == 0);
+        FrameLayout {
+            stack_args_size,
+            setup_area_size,
+            clobber_size,
+            fixed_frame_storage_size,
+            outgoing_args_size,
+            clobbered_callee_saves: regs,
+        }
     }
 }
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -512,9 +512,12 @@
        (Args
         (args VecArgPair))
 
+       ;; A pseudo-instruction that moves vregs to return registers.
+       (Rets
+        (rets VecRetPair))
+
        ;; Return.
-       (Ret (rets VecRetPair)
-            (stack_bytes_to_pop u32))
+       (Ret (stack_bytes_to_pop u32))
 
        ;; Jump to a known target: jmp simm32.
        (JmpKnown (dst MachLabel))

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1722,15 +1722,13 @@ pub(crate) fn emit(
         }
 
         Inst::Args { .. } => {}
+        Inst::Rets { .. } => {}
 
         Inst::Ret {
             stack_bytes_to_pop: 0,
-            ..
         } => sink.put1(0xC3),
 
-        Inst::Ret {
-            stack_bytes_to_pop, ..
-        } => {
+        Inst::Ret { stack_bytes_to_pop } => {
             sink.put1(0xC2);
             sink.put2(u16::try_from(*stack_bytes_to_pop).unwrap());
         }

--- a/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_tests.rs
@@ -4215,8 +4215,8 @@ fn test_x64_emit() {
 
     // ========================================================
     // Ret
-    insns.push((Inst::ret(vec![], 0), "C3", "ret"));
-    insns.push((Inst::ret(vec![], 8), "C20800", "ret 8"));
+    insns.push((Inst::ret(0), "C3", "ret"));
+    insns.push((Inst::ret(8), "C20800", "ret 8"));
 
     // ========================================================
     // JmpKnown skipped for now

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -439,22 +439,11 @@ pub trait ABIMachineSpec {
 
     /// Generate an "args" pseudo-instruction to capture input args in
     /// registers.
-    fn gen_args(isa_flags: &Self::F, args: Vec<ArgPair>) -> Self::I;
+    fn gen_args(args: Vec<ArgPair>) -> Self::I;
 
-    /// Generate a return instruction.
-    ///
-    /// Optionally given non-zero number of additional stack bytes to pop after
-    /// popping the return address from the stack, if any, and just before the
-    /// actual return. This is used by the "tail" calling convention to clean up
-    /// stack arguments in the callee because we cannot rely on the caller to do
-    /// it.
-    fn gen_ret(
-        setup_frame: bool,
-        isa_flags: &Self::F,
-        call_conv: isa::CallConv,
-        rets: Vec<RetPair>,
-        stack_bytes_to_pop: u32,
-    ) -> Self::I;
+    /// Generate a "rets" pseudo-instruction that moves vregs to return
+    /// registers.
+    fn gen_rets(rets: Vec<RetPair>) -> Self::I;
 
     /// Generate an add-with-immediate. Note that even if this uses a scratch
     /// register, it must satisfy two requirements:
@@ -507,26 +496,39 @@ pub trait ABIMachineSpec {
     /// Generate a meta-instruction that adjusts the nominal SP offset.
     fn gen_nominal_sp_adj(amount: i32) -> Self::I;
 
-    /// Generates the mandatory part of the prologue, irrespective of whether
-    /// the usual frame-setup sequence for this architecture is required or not,
-    /// e.g. extra unwind instructions.
-    fn gen_prologue_start(
-        _setup_frame: bool,
-        _call_conv: isa::CallConv,
-        _flags: &settings::Flags,
-        _isa_flags: &Self::F,
-    ) -> SmallInstVec<Self::I> {
-        // By default, generates nothing.
-        smallvec![]
-    }
+    /// Compute a FrameLayout structure containing a sorted list of all clobbered
+    /// registers that are callee-saved according to the ABI, as well as the sizes
+    /// of all parts of the stack frame.  The result is used to emit the prologue
+    /// and epilogue routines.
+    fn compute_frame_layout(
+        call_conv: isa::CallConv,
+        flags: &settings::Flags,
+        sig: &Signature,
+        regs: &[Writable<RealReg>],
+        is_leaf: bool,
+        stack_args_size: u32,
+        fixed_frame_storage_size: u32,
+        outgoing_args_size: u32,
+    ) -> FrameLayout;
 
     /// Generate the usual frame-setup sequence for this architecture: e.g.,
     /// `push rbp / mov rbp, rsp` on x86-64, or `stp fp, lr, [sp, #-16]!` on
-    /// AArch64. Return generated instructions and stack size of the setup area.
-    fn gen_prologue_frame_setup(flags: &settings::Flags) -> (SmallInstVec<Self::I>, u32);
+    /// AArch64.
+    fn gen_prologue_frame_setup(
+        call_conv: isa::CallConv,
+        flags: &settings::Flags,
+        isa_flags: &Self::F,
+        frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Self::I>;
 
     /// Generate the usual frame-restore sequence for this architecture.
-    fn gen_epilogue_frame_restore(flags: &settings::Flags) -> SmallInstVec<Self::I>;
+    /// This includes generating the actual return instruction(s).
+    fn gen_epilogue_frame_restore(
+        call_conv: isa::CallConv,
+        flags: &settings::Flags,
+        isa_flags: &Self::F,
+        frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Self::I>;
 
     /// Generate a probestack call.
     fn gen_probestack(insts: &mut SmallInstVec<Self::I>, frame_size: u32);
@@ -539,40 +541,16 @@ pub trait ABIMachineSpec {
         guard_size: u32,
     );
 
-    /// Get all clobbered registers that are callee-saved according to the ABI; the result
-    /// contains the registers in a sorted order.
-    fn get_clobbered_callee_saves(
-        call_conv: isa::CallConv,
-        flags: &settings::Flags,
-        sig: &Signature,
-        regs: &[Writable<RealReg>],
-    ) -> Vec<Writable<RealReg>>;
-
-    /// Determine whether it is necessary to generate the usual frame-setup
-    /// sequence (refer to gen_prologue_frame_setup()).
-    fn is_frame_setup_needed(
-        is_leaf: bool,
-        stack_args_size: u32,
-        num_clobbered_callee_saves: usize,
-        fixed_frame_storage_size: u32,
-    ) -> bool;
-
     /// Generate a clobber-save sequence. The implementation here should return
     /// a sequence of instructions that "push" or otherwise save to the stack all
     /// registers written/modified by the function body that are callee-saved.
     /// The sequence of instructions should adjust the stack pointer downward,
     /// and should align as necessary according to ABI requirements.
-    ///
-    /// Returns stack bytes used as well as instructions. Does not adjust
-    /// nominal SP offset; caller will do that.
     fn gen_clobber_save(
         call_conv: isa::CallConv,
-        setup_frame: bool,
         flags: &settings::Flags,
-        clobbered_callee_saves: &[Writable<RealReg>],
-        fixed_frame_storage_size: u32,
-        outgoing_args_size: u32,
-    ) -> (u64, SmallVec<[Self::I; 16]>);
+        frame_layout: &FrameLayout,
+    ) -> SmallVec<[Self::I; 16]>;
 
     /// Generate a clobber-restore sequence. This sequence should perform the
     /// opposite of the clobber-save sequence generated above, assuming that SP
@@ -580,11 +558,8 @@ pub trait ABIMachineSpec {
     /// clobber-save sequence finished.
     fn gen_clobber_restore(
         call_conv: isa::CallConv,
-        sig: &Signature,
         flags: &settings::Flags,
-        clobbers: &[Writable<RealReg>],
-        fixed_frame_storage_size: u32,
-        outgoing_args_size: u32,
+        frame_layout: &FrameLayout,
     ) -> SmallVec<[Self::I; 16]>;
 
     /// Generate a call instruction/sequence. This method is provided one
@@ -995,6 +970,51 @@ impl std::ops::Index<Sig> for SigSet {
     }
 }
 
+/// Structure describing the layout of a function's stack frame.
+pub struct FrameLayout {
+    /// N.B. The areas whose sizes are given in this structure fully
+    /// cover the current function's stack frame, from high to low
+    /// stack addresses in the sequence below.  Each size contains
+    /// any alignment padding that may be required by the ABI.
+
+    /// Size of incoming arguments on the stack.  This is not technically
+    /// part of this function's frame, but code in the function will still
+    /// need to access it.  Depending on the ABI, we may need to set up a
+    /// frame pointer to do so; we also may need to pop this area from the
+    /// stack upon return.
+    pub stack_args_size: u32,
+
+    /// Size of the "setup area", typically holding the return address
+    /// and/or the saved frame pointer.  This may be written either during
+    /// the call itself (e.g. a pushed return address) or by code emitted
+    /// from gen_prologue_frame_setup.  In any case, after that code has
+    /// completed execution, the stack pointer is expected to point to the
+    /// bottom of this area.  The same holds at the start of code emitted
+    /// by gen_epilogue_frame_restore.
+    pub setup_area_size: u32,
+
+    /// Size of the area used to save callee-saved clobbered registers.
+    /// This area is accessed by code emitted from gen_clobber_save and
+    /// gen_clobber_restore.
+    pub clobber_size: u32,
+
+    /// Storage allocated for the fixed part of the stack frame.
+    /// This contains stack slots and spill slots.  The "nominal SP"
+    /// during execution of the function points to the bottom of this.
+    pub fixed_frame_storage_size: u32,
+
+    /// Stack size to be reserved for outgoing arguments, if used by
+    /// the current ABI, or 0 otherwise.  After gen_clobber_save and
+    /// before gen_clobber_restore, the stack pointer points to the
+    /// bottom of this area.
+    pub outgoing_args_size: u32,
+
+    /// Sorted list of callee-saved registers that are clobbered
+    /// according to the ABI.  These registers will be saved and
+    /// restored by gen_clobber_save and gen_clobber_restore.
+    pub clobbered_callee_saves: Vec<Writable<RealReg>>,
+}
+
 /// ABI object for a function body.
 pub struct Callee<M: ABIMachineSpec> {
     /// CLIF-level signature, possibly normalized.
@@ -1018,17 +1038,8 @@ pub struct Callee<M: ABIMachineSpec> {
     clobbered: Vec<Writable<RealReg>>,
     /// Total number of spillslots, including for 'dynamic' types, from regalloc.
     spillslots: Option<usize>,
-    /// Storage allocated for the fixed part of the stack frame.  This is
-    /// usually the same as the total frame size below.
-    fixed_frame_storage_size: u32,
-    /// Size of the area between the FP as defined in the prolog and caller's SP.
-    /// It will usually contain the saved FP/LR pair.
-    frame_setup_area_size: u32,
-    /// "Total frame size", as defined by "distance between FP and nominal SP".
-    /// Some items are pushed below nominal SP, so the function may actually use
-    /// more stack than this would otherwise imply. It is simply the initial
-    /// frame/allocation size needed for stackslots and spillslots.
-    total_frame_size: Option<u32>,
+    /// Finalized frame layout for this function.
+    frame_layout: Option<FrameLayout>,
     /// The register holding the return-area pointer, if needed.
     ret_area_ptr: Option<Writable<Reg>>,
     /// Temp registers required for argument setup, if needed.
@@ -1056,8 +1067,6 @@ pub struct Callee<M: ABIMachineSpec> {
     /// Are we to invoke the probestack function in the prologue? If so,
     /// what is the minimum size at which we must invoke it?
     probestack_min_frame: Option<u32>,
-    /// Whether it is necessary to generate the usual frame-setup sequence.
-    setup_frame: bool,
 
     _mach: PhantomData<M>,
 }
@@ -1187,9 +1196,7 @@ impl<M: ABIMachineSpec> Callee<M> {
             reg_args: vec![],
             clobbered: vec![],
             spillslots: None,
-            fixed_frame_storage_size: 0,
-            frame_setup_area_size: 0,
-            total_frame_size: None,
+            frame_layout: None,
             ret_area_ptr: None,
             arg_temp_reg: vec![],
             call_conv,
@@ -1198,7 +1205,6 @@ impl<M: ABIMachineSpec> Callee<M> {
             is_leaf: f.is_leaf(),
             stack_limit,
             probestack_min_frame,
-            setup_frame: true,
             _mach: PhantomData,
         })
     }
@@ -1714,23 +1720,8 @@ impl<M: ABIMachineSpec> Callee<M> {
     }
 
     /// Generate a return instruction.
-    pub fn gen_ret(&self, sigs: &SigSet, rets: Vec<RetPair>) -> M::I {
-        M::gen_ret(
-            self.setup_frame,
-            &self.isa_flags,
-            self.call_conv,
-            rets,
-            self.stack_bytes_to_pop(sigs),
-        )
-    }
-
-    fn stack_bytes_to_pop(&self, sigs: &SigSet) -> u32 {
-        let sig = &sigs[self.sig];
-        if sig.call_conv == isa::CallConv::Tail {
-            sig.sized_stack_arg_space
-        } else {
-            0
-        }
+    pub fn gen_rets(&self, rets: Vec<RetPair>) -> M::I {
+        M::gen_rets(rets)
     }
 
     /// Produce an instruction that computes a sized stackslot address.
@@ -1791,10 +1782,7 @@ impl<M: ABIMachineSpec> Callee<M> {
             // establishes live-ranges for in-register arguments and
             // constrains them at the start of the function to the
             // locations defined by the ABI.
-            Some(M::gen_args(
-                &self.isa_flags,
-                std::mem::take(&mut self.reg_args),
-            ))
+            Some(M::gen_args(std::mem::take(&mut self.reg_args)))
         } else {
             None
         }
@@ -1849,52 +1837,45 @@ impl<M: ABIMachineSpec> Callee<M> {
         StackMap::from_slice(&bits[..])
     }
 
-    /// Generate a prologue, post-regalloc.
+    /// Compute the final frame layout, post-regalloc.
     ///
-    /// This should include any stack frame or other setup necessary to use the
-    /// other methods (`load_arg`, `store_retval`, and spillslot accesses.)
-    /// `self` is mutable so that we can store information in it which will be
-    /// useful when creating the epilogue.
-    pub fn gen_prologue(&mut self, sigs: &SigSet) -> SmallInstVec<M::I> {
+    /// This must be called before gen_prologue or gen_epilogue.
+    pub fn compute_frame_layout(&mut self, sigs: &SigSet) {
         let bytes = M::word_bytes();
         let total_stacksize = self.stackslots_size + bytes * self.spillslots.unwrap() as u32;
         let mask = M::stack_align(self.call_conv) - 1;
         let total_stacksize = (total_stacksize + mask) & !mask; // 16-align the stack.
-        let clobbered_callee_saves = M::get_clobbered_callee_saves(
+        self.frame_layout = Some(M::compute_frame_layout(
             self.call_conv,
             &self.flags,
             self.signature(),
             &self.clobbered,
-        );
+            self.is_leaf,
+            self.stack_args_size(sigs),
+            total_stacksize,
+            self.outgoing_args_size,
+        ));
+    }
+
+    /// Generate a prologue, post-regalloc.
+    ///
+    /// This should include any stack frame or other setup necessary to use the
+    /// other methods (`load_arg`, `store_retval`, and spillslot accesses.)
+    pub fn gen_prologue(&self) -> SmallInstVec<M::I> {
+        let frame_layout = self.frame_layout.as_ref().unwrap();
         let mut insts = smallvec![];
 
-        self.fixed_frame_storage_size += total_stacksize;
-        self.setup_frame = self.flags.preserve_frame_pointers()
-            || M::is_frame_setup_needed(
-                self.is_leaf,
-                self.stack_args_size(sigs),
-                clobbered_callee_saves.len(),
-                self.fixed_frame_storage_size,
-            );
-
-        insts.extend(
-            M::gen_prologue_start(
-                self.setup_frame,
-                self.call_conv,
-                &self.flags,
-                &self.isa_flags,
-            )
-            .into_iter(),
-        );
-
-        if self.setup_frame {
-            let (setup_insts, setup_area_size) = M::gen_prologue_frame_setup(&self.flags);
-            insts.extend(setup_insts.into_iter());
-            self.frame_setup_area_size = setup_area_size;
-        }
+        // Set up frame.
+        insts.extend(M::gen_prologue_frame_setup(
+            self.call_conv,
+            &self.flags,
+            &self.isa_flags,
+            &frame_layout,
+        ));
 
         // Leaf functions with zero stack don't need a stack check if one's
         // specified, otherwise always insert the stack check.
+        let total_stacksize = frame_layout.fixed_frame_storage_size;
         if total_stacksize > 0 || !self.is_leaf {
             if let Some((reg, stack_limit_load)) = &self.stack_limit {
                 insts.extend(stack_limit_load.clone());
@@ -1922,15 +1903,11 @@ impl<M: ABIMachineSpec> Callee<M> {
         }
 
         // Save clobbered registers.
-        let (clobber_size, clobber_insts) = M::gen_clobber_save(
+        insts.extend(M::gen_clobber_save(
             self.call_conv,
-            self.setup_frame,
             &self.flags,
-            &clobbered_callee_saves,
-            self.fixed_frame_storage_size,
-            self.outgoing_args_size,
-        );
-        insts.extend(clobber_insts);
+            &frame_layout,
+        ));
 
         // N.B.: "nominal SP", which we use to refer to stackslots and
         // spillslots, is defined to be equal to the stack pointer at this point
@@ -1943,7 +1920,6 @@ impl<M: ABIMachineSpec> Callee<M> {
         // [crate::machinst::abi](this module) for more details
         // on stackframe layout and nominal SP maintenance.
 
-        self.total_frame_size = Some(total_stacksize + clobber_size as u32);
         insts
     }
 
@@ -1952,17 +1928,15 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// Note that this must generate the actual return instruction (rather than
     /// emitting this in the lowering logic), because the epilogue code comes
     /// before the return and the two are likely closely related.
-    pub fn gen_epilogue(&self, sigs: &SigSet) -> SmallInstVec<M::I> {
+    pub fn gen_epilogue(&self) -> SmallInstVec<M::I> {
+        let frame_layout = self.frame_layout.as_ref().unwrap();
         let mut insts = smallvec![];
 
         // Restore clobbered registers.
         insts.extend(M::gen_clobber_restore(
             self.call_conv,
-            self.signature(),
             &self.flags,
-            &self.clobbered,
-            self.fixed_frame_storage_size,
-            self.outgoing_args_size,
+            &frame_layout,
         ));
 
         // N.B.: we do *not* emit a nominal SP adjustment here, because (i) there will be no
@@ -1971,19 +1945,12 @@ impl<M: ABIMachineSpec> Callee<M> {
         // the CFG, so early returns in the middle of function bodies would cause an incorrect
         // offset for the rest of the body.
 
-        if self.setup_frame {
-            insts.extend(M::gen_epilogue_frame_restore(&self.flags));
-        }
-
-        // This `ret` doesn't need any return registers attached
-        // because we are post-regalloc and don't need to
-        // represent the implicit uses anymore.
-        insts.push(M::gen_ret(
-            self.setup_frame,
-            &self.isa_flags,
+        // Tear down frame and return.
+        insts.extend(M::gen_epilogue_frame_restore(
             self.call_conv,
-            vec![],
-            self.stack_bytes_to_pop(sigs),
+            &self.flags,
+            &self.isa_flags,
+            &frame_layout,
         ));
 
         trace!("Epilogue: {:?}", insts);
@@ -1996,13 +1963,22 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// not arguments arguments pushed at callsites within this function,
     /// or other ephemeral pushes.
     pub fn frame_size(&self) -> u32 {
-        self.total_frame_size
-            .expect("frame size not computed before prologue generation")
+        let frame_layout = self
+            .frame_layout
+            .as_ref()
+            .expect("frame size not computed before prologue generation");
+        frame_layout.clobber_size + frame_layout.fixed_frame_storage_size
     }
 
     /// Returns offset from the nominal SP to caller's SP.
     pub fn nominal_sp_to_caller_sp_offset(&self) -> u32 {
-        self.frame_size() + self.frame_setup_area_size
+        let frame_layout = self
+            .frame_layout
+            .as_ref()
+            .expect("frame size not computed before prologue generation");
+        frame_layout.clobber_size
+            + frame_layout.fixed_frame_storage_size
+            + frame_layout.setup_area_size
     }
 
     /// Returns the size of arguments expected on the stack.

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -2229,10 +2229,7 @@ mod test {
         inst.emit(&[], &mut buf, &info, &mut state);
 
         buf.bind_label(label(7), state.ctrl_plane_mut());
-        let inst = Inst::Ret {
-            rets: vec![],
-            stack_bytes_to_pop: 0,
-        };
+        let inst = Inst::Ret {};
         inst.emit(&[], &mut buf, &info, &mut state);
 
         let buf = buf.finish(&constants, state.ctrl_plane_mut());

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -655,7 +655,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             }
         }
 
-        let inst = self.abi().gen_ret(&self.sigs(), out_rets);
+        let inst = self.abi().gen_rets(out_rets);
         self.emit(inst);
     }
 

--- a/cranelift/filetests/filetests/isa/aarch64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/return-call.clif
@@ -187,7 +187,8 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   ldr x9, [fp, #16]
 ;   ldr x2, [fp, #24]
 ;   ldp fp, lr, [sp], #16
-;   add sp, sp, #16 ; ret
+;   add sp, sp, #16
+;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -331,7 +332,8 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   ldr x9, [fp, #16]
 ;   ldr x2, [fp, #24]
 ;   ldp fp, lr, [sp], #16
-;   add sp, sp, #16 ; ret
+;   add sp, sp, #16
+;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -357,7 +359,8 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   ldr x11, [fp, #24]
 ;   ldr x2, [fp, #32]
 ;   ldp fp, lr, [sp], #16
-;   add sp, sp, #32 ; ret
+;   add sp, sp, #32
+;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0

--- a/cranelift/filetests/filetests/isa/aarch64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tail-call-conv.clif
@@ -15,7 +15,8 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   ldr x9, [fp, #16]
 ;   ldr x2, [fp, #24]
 ;   ldp fp, lr, [sp], #16
-;   add sp, sp, #16 ; ret
+;   add sp, sp, #16
+;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -318,7 +319,8 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   ldr x9, [sp]
 ;   add sp, sp, #16
 ;   ldp fp, lr, [sp], #16
-;   add sp, sp, #16 ; ret
+;   add sp, sp, #16
+;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0

--- a/cranelift/filetests/filetests/isa/riscv64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/return-call.clif
@@ -229,7 +229,8 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
-;   add sp, sp, #48 ; ret
+;   add sp,+48
+;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -417,7 +418,8 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
-;   add sp, sp, #48 ; ret
+;   add sp,+48
+;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -457,7 +459,8 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
-;   add sp, sp, #48 ; ret
+;   add sp,+48
+;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0

--- a/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
@@ -22,7 +22,8 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
-;   add sp, sp, #48 ; ret
+;   add sp,+48
+;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -411,7 +412,8 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
-;   add sp, sp, #48 ; ret
+;   add sp,+48
+;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -197,10 +197,7 @@ impl Assembler {
 
     /// Return instruction.
     pub fn ret(&mut self) {
-        self.emit(Inst::Ret {
-            rets: vec![],
-            stack_bytes_to_pop: 0,
-        });
+        self.emit(Inst::Ret {});
     }
 
     // Helpers for ALU operations.

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -224,7 +224,6 @@ impl Assembler {
     /// Return instruction.
     pub fn ret(&mut self) {
         self.emit(Inst::Ret {
-            rets: vec![],
             stack_bytes_to_pop: 0,
         });
     }


### PR DESCRIPTION
This patch refactors all of the ISA/ABI specific prolog/epilog generation code around the following two ideas:

1. Separate *planning* of the function's frame layout from the actual *implementation* within prolog / epilog code.

2. No longer overload different purposes (middle-end register tracking, platform-specific details like authorization modes, and pop-stack-on-return) into a single return instruction.

As to 1., the new approach is based around a FrameLayout data structure, which collects all information needed to emit prolog and epilog code, specifically the list of clobbered registers, and the sizes of all areas of the function's stack frame.

This data structure is now computed *once*, before any code is emitted, and stored in the Callee data structure.  ABIs need to implement this via a new compute_frame_layout callback, which gets all data from common code needed to make all decisions around stack layout in one place.

The FrameLayout is then used going forward to answer all questions about frame sizes, and it is passed to all ABI routines involved in prolog / epilog code generation.  [ This removes a lot of duplicated calculation, e.g. the list of clobbered registers is now only computed once and re-used everywhere. ]

This in turn allows to reduce the number of distinct callbacks ABIs need to implement, and simplifies common code logic around how and when to call them.  In particular, we now only have the following four routines, which are always called in this order:

gen_prologue_frame_setup
gen_clobber_save

gen_clobber_restore
gen_epilogue_frame_restore

The main differences to before are:
- frame_setup/restore are now called unconditionally (the target ABI can look in the FrameLayout to detect the case where no frame setup is required and skip whatever it thinks appropriate in that case)
- there is no separate gen_prologue_start; if the target needs to do anything here, it can now just do it instead in gen_prologue_frame_setup
- common code no longer attempts to emit a return instruction; instead the target can do whatever is necessary/optimal in gen_epilogue_frame_restore

[ In principle we could also just have a single gen_prologue and gen_epilogue callback - I didn't implement this because then all the stack checking / probing logic would have to be moved to target code as well. ]

As to 2., currently targets are required to implement a single
"Ret" return instruction.   This is initially used during
register allocation to hold a list of return preg/vreg pairs.
During epilog emission, this is replaced by another copy of
the same "Ret" instruction that now carries various platform
specific data (e.g. authorization modes on aarch64), and is
also overloaded to handle the case where the ABI requires
that a number of bytes are popped during return.

This is a bit unfortunate in that it blows up the size of the instruction data, and also forces targets (that do not have a "ret N" instruction like Intel) into duplicated and possible sub-optimal implementations of stack adjustment during low-level emission of the return instruction.

The new approach separates these concerns.  Initially, common code emits a new "Rets" instruction that is completely parallel to the existing "Args", and is used only during register allocation holding the preg/vreg pairs.  That instruction -like now- is replaced during epilog emission - but unlike now the replacement is now completely up to the target, which can do whatever it needs in gen_epilogue_frame_restore.

This would typically emit some platform-specific low-level "Ret" instruction instead of the regalloc "Rets".  It also allows non-Intel targets to just create a normal (or even optimized) stack adjustment sequence before its low-level "Ret".

[ In particular, on riscv64 pop-stack-before-return currently emits two distinct stack adjustment instructions immediately after one another.  These could now be easily merged, but that's not yet done in this patch.  ]

No functional change intended on any target.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
