### PR TITLE
wasmtime: Enable Relaxed SIMD testsuite for RISC-V

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -250,10 +250,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
         }
 
         "riscv64" => {
-            if testsuite.contains("relaxed_simd") {
-                return true;
-            }
-
             let known_failure = ["issue_3327_bnot_lowering"].contains(&testname);
 
             known_failure

--- a/build.rs
+++ b/build.rs
@@ -250,9 +250,13 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
         }
 
         "riscv64" => {
-            let known_failure = ["issue_3327_bnot_lowering"].contains(&testname);
-
-            known_failure
+            // This test case is disabled because it relies on `fvpromote_low`
+            // not flipping the sign bit of the input when it is a NaN. This
+            // is allowed by the spec. It's worth keeping the testcase as is
+            // since it is stressing a specific codegen bug in another arch.
+            //
+            // See #6961 for more details
+            testname == "issue_3327_bnot_lowering"
         }
 
         _ => false,


### PR DESCRIPTION
👋 Hey,

This PR enables the Relaxed SIMD testsuite on the RISC-V backend. This has been implemented for a while, but was hitting the codegen issue in #6954. While this is enabled, I haven't checked if we have the optimal lowerings for each of the relaxed instructions.

It also adds a comment explaining why we have the `issue_3327_bnot_lowering` test disabled.

Closes #6961