### PR TITLE
riscv64: Check that the minimum set of feature flags is enabled

### DIFF
--- a/cranelift/codegen/meta/src/isa/riscv64.rs
+++ b/cranelift/codegen/meta/src/isa/riscv64.rs
@@ -1,5 +1,5 @@
 use crate::cdsl::isa::TargetIsa;
-use crate::cdsl::settings::SettingGroupBuilder;
+use crate::cdsl::settings::{PredicateNode, SettingGroupBuilder};
 
 macro_rules! define_zvl_ext {
     (DEF: $settings:expr, $size:expr) => {{
@@ -38,12 +38,32 @@ pub(crate) fn define() -> TargetIsa {
     // * Zicsr (control and status register instructions)
     // * Zifencei (instruction-fetch fence)
 
-    let _has_m = setting.add_bool("has_m", "has extension M?", "", true);
-    let _has_a = setting.add_bool("has_a", "has extension A?", "", true);
-    let _has_f = setting.add_bool("has_f", "has extension F?", "", true);
-    let _has_d = setting.add_bool("has_d", "has extension D?", "", true);
-    let _has_v = setting.add_bool("has_v", "has extension V?", "", false);
-    let _has_c = setting.add_bool("has_c", "has extension C?", "", true);
+    let has_m = setting.add_bool(
+        "has_m",
+        "has extension M?",
+        "Integer multiplication and division",
+        true,
+    );
+    let has_a = setting.add_bool("has_a", "has extension A?", "Atomic instructions", true);
+    let has_f = setting.add_bool(
+        "has_f",
+        "has extension F?",
+        "Single-precision floating point",
+        true,
+    );
+    let has_d = setting.add_bool(
+        "has_d",
+        "has extension D?",
+        "Double-precision floating point",
+        true,
+    );
+    let _has_v = setting.add_bool(
+        "has_v",
+        "has extension V?",
+        "Vector instruction support",
+        false,
+    );
+    let _has_c = setting.add_bool("has_c", "has extension C?", "Compressed instructions", true);
 
     let _has_zbkb = setting.add_bool(
         "has_zbkb",
@@ -76,13 +96,13 @@ pub(crate) fn define() -> TargetIsa {
         false,
     );
 
-    let _has_zicsr = setting.add_bool(
+    let has_zicsr = setting.add_bool(
         "has_zicsr",
         "has extension zicsr?",
         "Zicsr: Control and Status Register (CSR) Instructions",
         true,
     );
-    let _has_zifencei = setting.add_bool(
+    let has_zifencei = setting.add_bool(
         "has_zifencei",
         "has extension zifencei?",
         "Zifencei: Instruction-Fetch Fence",
@@ -107,6 +127,11 @@ pub(crate) fn define() -> TargetIsa {
     let (_, zvl16384b) = define_zvl_ext!(setting, 16384, zvl8192b);
     let (_, zvl32768b) = define_zvl_ext!(setting, 32768, zvl16384b);
     let (_, _zvl65536b) = define_zvl_ext!(setting, 65536, zvl32768b);
+
+    setting.add_predicate(
+        "has_g",
+        predicate!(has_m && has_a && has_f && has_d && has_zicsr && has_zifencei),
+    );
 
     TargetIsa::new("riscv64", setting.build())
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1150,7 +1150,7 @@ impl MachInstEmit for Inst {
                 Inst::Jalr {
                     rd: writable_zero_reg(),
                     base: tmp1.to_reg(),
-                    offset: Imm12::from_bits((4 * Inst::INSTRUCTION_SIZE) as i16),
+                    offset: Imm12::from_bits((4 * Inst::UNCOMPRESSED_INSTRUCTION_SIZE) as i16),
                 }
                 .emit(&[], sink, emit_info, state);
 
@@ -1161,7 +1161,8 @@ impl MachInstEmit for Inst {
 
                 // Each entry in the jump table is 2 instructions, so 8 bytes. Check if
                 // we need to emit a jump table here to support that jump.
-                let distance = (targets.len() * 2 * Inst::INSTRUCTION_SIZE as usize) as u32;
+                let distance =
+                    (targets.len() * 2 * Inst::UNCOMPRESSED_INSTRUCTION_SIZE as usize) as u32;
                 if sink.island_needed(distance) {
                     sink.emit_island(distance, &mut state.ctrl_plane);
                 }
@@ -3072,7 +3073,7 @@ fn emit_return_call_common_sequence(
     // instructions per word of stack argument space.
     let new_stack_words = new_stack_arg_size / 8;
     let insts = 4 + 2 + 2 * new_stack_words;
-    let space_needed = insts * u32::try_from(Inst::INSTRUCTION_SIZE).unwrap();
+    let space_needed = insts * u32::try_from(Inst::UNCOMPRESSED_INSTRUCTION_SIZE).unwrap();
     if sink.island_needed(space_needed) {
         let jump_around_label = sink.get_label();
         Inst::Jal {

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -181,7 +181,10 @@ pub(crate) fn gen_moves(rd: &[Writable<Reg>], src: &[Reg]) -> SmallInstVec<Inst>
 }
 
 impl Inst {
-    const INSTRUCTION_SIZE: i32 = 4;
+    /// RISC-V can have multiple instruction sizes. 2 bytes for compressed
+    /// instructions, 4 for regular instructions, 6 and 8 byte instructions
+    /// are also being considered.
+    const UNCOMPRESSED_INSTRUCTION_SIZE: i32 = 4;
 
     #[inline]
     pub(crate) fn load_imm12(rd: Writable<Reg>, imm: Imm12) -> Inst {
@@ -1390,7 +1393,7 @@ impl Inst {
                 let mut buf = String::new();
                 write!(&mut buf, "auipc {},0; ", rd).unwrap();
                 write!(&mut buf, "ld {},12({}); ", rd, rd).unwrap();
-                write!(&mut buf, "j {}; ", Inst::INSTRUCTION_SIZE + 8).unwrap();
+                write!(&mut buf, "j {}; ", Inst::UNCOMPRESSED_INSTRUCTION_SIZE + 8).unwrap();
                 write!(&mut buf, ".8byte 0x{:x}", imm).unwrap();
                 buf
             }

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -243,7 +243,7 @@ fn isa_constructor(
     // Ensure that those combination of features is enabled.
     if !isa_flags.has_g() {
         return Err(CodegenError::Unsupported(
-            "The RISC-V Backend requires all the features in the G Extension enabled".into(),
+            "The RISC-V Backend currently requires all the features in the G Extension enabled".into(),
         ));
     }
 

--- a/cranelift/codegen/src/isa/riscv64/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/mod.rs
@@ -243,7 +243,8 @@ fn isa_constructor(
     // Ensure that those combination of features is enabled.
     if !isa_flags.has_g() {
         return Err(CodegenError::Unsupported(
-            "The RISC-V Backend currently requires all the features in the G Extension enabled".into(),
+            "The RISC-V Backend currently requires all the features in the G Extension enabled"
+                .into(),
         ));
     }
 


### PR DESCRIPTION
👋 Hey,

This PR Is a follow up to #6955 where @alexcrichton suggested that we check that all the flags the backend currently expects.

Most of the backend does not even check these flags, so to avoid emitting instructions where there is no support for them, we reject building the ISA when they aren't present.

This PR also renames the `INSTRUCTION_SIZE` constant to something more suitable, since we are going to have varying instruction lengths.