### PR TITLE
Add component call micro-benchmarks

### DIFF
--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -319,6 +319,7 @@ macro_rules! impl_index {
     ($(impl Index<$ty:ident> for ComponentTypes { $output:ident => $field:ident })*) => ($(
         impl std::ops::Index<$ty> for ComponentTypes {
             type Output = $output;
+            #[inline]
             fn index(&self, idx: $ty) -> &$output {
                 &self.$field[idx]
             }

--- a/crates/runtime/src/component.rs
+++ b/crates/runtime/src/component.rs
@@ -244,6 +244,7 @@ impl ComponentInstance {
 
     /// Returns a pointer to the "may leave" flag for this instance specified
     /// for canonical lowering and lifting operations.
+    #[inline]
     pub fn instance_flags(&self, instance: RuntimeComponentInstanceIndex) -> InstanceFlags {
         unsafe {
             let ptr = self
@@ -560,6 +561,7 @@ impl ComponentInstance {
     }
 
     /// Returns the runtime state of resources associated with this component.
+    #[inline]
     pub fn component_resource_tables(
         &mut self,
     ) -> &mut PrimaryMap<TypeResourceTableIndex, ResourceTable> {

--- a/crates/runtime/src/component/resources.rs
+++ b/crates/runtime/src/component/resources.rs
@@ -246,6 +246,7 @@ impl ResourceTables<'_> {
 
     /// Enters a new calling context, starting a fresh count of borrows and
     /// such.
+    #[inline]
     pub fn enter_call(&mut self) {
         self.calls.scopes.push(CallContext::default());
     }
@@ -255,6 +256,7 @@ impl ResourceTables<'_> {
     /// This requires all information to be available within this
     /// `ResourceTables` and is only called during lowering/lifting operations
     /// at this time.
+    #[inline]
     pub fn exit_call(&mut self) -> Result<()> {
         let cx = self.calls.scopes.pop().unwrap();
         if cx.borrow_count > 0 {

--- a/crates/wasmtime/src/component/component.rs
+++ b/crates/wasmtime/src/component/component.rs
@@ -291,6 +291,7 @@ impl Component {
         &self.inner.static_modules[idx]
     }
 
+    #[inline]
     pub(crate) fn types(&self) -> &Arc<ComponentTypes> {
         self.inner.component_types()
     }

--- a/crates/wasmtime/src/component/func.rs
+++ b/crates/wasmtime/src/component/func.rs
@@ -564,6 +564,7 @@ impl Func {
     ///
     /// Panics if this is called on a function in an asynchronous store.
     /// This only works with functions defined within a synchronous store.
+    #[inline]
     pub fn post_return(&self, mut store: impl AsContextMut) -> Result<()> {
         let store = store.as_context_mut();
         assert!(
@@ -596,6 +597,7 @@ impl Func {
         store.on_fiber(|store| self.post_return_impl(store)).await?
     }
 
+    #[inline]
     fn post_return_impl(&self, mut store: impl AsContextMut) -> Result<()> {
         let mut store = store.as_context_mut();
         let data = &mut store.0[self.0];

--- a/crates/wasmtime/src/component/func/options.rs
+++ b/crates/wasmtime/src/component/func/options.rs
@@ -348,12 +348,14 @@ impl<'a, T> LowerContext<'a, T> {
 
     /// Begins a call into the component instance, starting recording of
     /// metadata related to resource borrowing.
+    #[inline]
     pub fn enter_call(&mut self) {
         self.resource_tables().enter_call()
     }
 
     /// Completes a call into the component instance, validating that it's ok to
     /// complete by ensuring the are no remaining active borrows.
+    #[inline]
     pub fn exit_call(&mut self) -> Result<()> {
         self.resource_tables().exit_call()
     }
@@ -389,6 +391,7 @@ impl<'a> LiftContext<'a> {
     ///
     /// This is unsafe for the same reasons as `LowerContext::new` where the
     /// validity of `instance` is required to be upheld by the caller.
+    #[inline]
     pub unsafe fn new(
         store: &'a mut StoreOpaque,
         options: &'a Options,
@@ -499,11 +502,13 @@ impl<'a> LiftContext<'a> {
     }
 
     /// Same as `LowerContext::enter_call`
+    #[inline]
     pub fn enter_call(&mut self) {
         self.resource_tables().enter_call()
     }
 
     /// Same as `LiftContext::enter_call`
+    #[inline]
     pub fn exit_call(&mut self) -> Result<()> {
         self.resource_tables().exit_call()
     }

--- a/crates/wasmtime/src/component/func/typed.rs
+++ b/crates/wasmtime/src/component/func/typed.rs
@@ -613,10 +613,12 @@ forward_lowers! {
 macro_rules! forward_string_lifts {
     ($($a:ty,)*) => ($(
         unsafe impl Lift for $a {
+            #[inline]
             fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
                 Ok(<WasmStr as Lift>::lift(cx, ty, src)?.to_str_from_memory(cx.memory())?.into())
             }
 
+            #[inline]
             fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
                 Ok(<WasmStr as Lift>::load(cx, ty, bytes)?.to_str_from_memory(cx.memory())?.into())
             }
@@ -672,6 +674,7 @@ macro_rules! integers {
         }
 
         unsafe impl Lower for $primitive {
+            #[inline]
             fn lower<T>(
                 &self,
                 _cx: &mut LowerContext<'_, T>,
@@ -683,6 +686,7 @@ macro_rules! integers {
                 Ok(())
             }
 
+            #[inline]
             fn store<T>(
                 &self,
                 cx: &mut LowerContext<'_, T>,
@@ -753,6 +757,7 @@ macro_rules! floats {
         }
 
         unsafe impl Lower for $float {
+            #[inline]
             fn lower<T>(
                 &self,
                 _cx: &mut LowerContext<'_, T>,
@@ -764,6 +769,7 @@ macro_rules! floats {
                 Ok(())
             }
 
+            #[inline]
             fn store<T>(
                 &self,
                 cx: &mut LowerContext<'_, T>,
@@ -872,6 +878,7 @@ unsafe impl ComponentType for char {
 }
 
 unsafe impl Lower for char {
+    #[inline]
     fn lower<T>(
         &self,
         _cx: &mut LowerContext<'_, T>,
@@ -883,6 +890,7 @@ unsafe impl Lower for char {
         Ok(())
     }
 
+    #[inline]
     fn store<T>(
         &self,
         cx: &mut LowerContext<'_, T>,
@@ -1205,6 +1213,7 @@ unsafe impl ComponentType for WasmStr {
 }
 
 unsafe impl Lift for WasmStr {
+    #[inline]
     fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
         debug_assert!(matches!(ty, InterfaceType::String));
         // FIXME: needs memory64 treatment
@@ -1214,6 +1223,7 @@ unsafe impl Lift for WasmStr {
         WasmStr::new(ptr, len, cx)
     }
 
+    #[inline]
     fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
         debug_assert!(matches!(ty, InterfaceType::String));
         debug_assert!((bytes.as_ptr() as usize) % (Self::ALIGN32 as usize) == 0);
@@ -2050,6 +2060,7 @@ where
     T: Lift,
     E: Lift,
 {
+    #[inline]
     fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
         let (ok, err) = match ty {
             InterfaceType::Result(ty) => {
@@ -2084,6 +2095,7 @@ where
         })
     }
 
+    #[inline]
     fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
         debug_assert!((bytes.as_ptr() as usize) % (Self::ALIGN32 as usize) == 0);
         let discrim = bytes[0];
@@ -2218,6 +2230,7 @@ macro_rules! impl_component_ty_for_tuples {
         unsafe impl<$($t,)*> Lift for ($($t,)*)
             where $($t: Lift),*
         {
+            #[inline]
             fn lift(cx: &mut LiftContext<'_>, ty: InterfaceType, _src: &Self::Lower) -> Result<Self> {
                 let types = match ty {
                     InterfaceType::Tuple(t) => &cx.types[t].types,
@@ -2233,6 +2246,7 @@ macro_rules! impl_component_ty_for_tuples {
                 )*))
             }
 
+            #[inline]
             fn load(cx: &mut LiftContext<'_>, ty: InterfaceType, bytes: &[u8]) -> Result<Self> {
                 debug_assert!((bytes.as_ptr() as usize) % (Self::ALIGN32 as usize) == 0);
                 let types = match ty {

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -194,18 +194,22 @@ impl InstanceData {
         instance.get_export_by_index(idx)
     }
 
+    #[inline]
     pub fn instance(&self) -> &ComponentInstance {
         &self.state
     }
 
+    #[inline]
     pub fn instance_ptr(&self) -> *mut ComponentInstance {
         self.state.instance_ptr()
     }
 
+    #[inline]
     pub fn component_types(&self) -> &Arc<ComponentTypes> {
         self.component.types()
     }
 
+    #[inline]
     pub fn ty(&self) -> InstanceType<'_> {
         InstanceType::new(self.instance())
     }

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -1580,6 +1580,7 @@ at https://bytecodealliance.org/security.
         std::process::abort();
     }
 
+    #[inline]
     #[cfg(feature = "component-model")]
     pub(crate) fn component_calls_and_host_table(
         &mut self,


### PR DESCRIPTION
This commit adds the component equivalents of the existing core Wasm call micro-benchmarks. This also adds a sprinkling of `#[inline]` to some functions that I noticed when glancing at some profiles.

The two most important numbers:

```
sync/no-hook/component - host-to-wasm - typed - nop
                        time:   [75.849 ns 76.476 ns 77.247 ns]

sync/no-hook/component - wasm-to-host - typed - nop
                        time:   [33.614 ns 33.872 ns 34.170 ns]
```

The full benchmark results are in here:

<details>

```
$ cargo bench --features component-model --bench call 'component'
    Finished bench [optimized] target(s) in 0.19s
     Running benches/call.rs (target/release/deps/call-4d8d1585dd2825a2)
sync/no-hook/component - host-to-wasm - typed - nop
                        time:   [75.849 ns 76.476 ns 77.247 ns]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
sync/no-hook/component - host-to-wasm - untyped - nop
                        time:   [108.29 ns 109.66 ns 111.51 ns]
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
sync/no-hook/component - host-to-wasm - typed - nop-params-and-results
                        time:   [79.968 ns 80.756 ns 81.728 ns]
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high severe
sync/no-hook/component - host-to-wasm - untyped - nop-params-and-results
                        time:   [210.27 ns 211.72 ns 213.34 ns]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

sync/hook-sync/component - host-to-wasm - typed - nop
                        time:   [76.840 ns 77.295 ns 77.770 ns]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
sync/hook-sync/component - host-to-wasm - untyped - nop
                        time:   [109.63 ns 110.42 ns 111.26 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
sync/hook-sync/component - host-to-wasm - typed - nop-params-and-results
                        time:   [81.324 ns 82.344 ns 83.663 ns]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
sync/hook-sync/component - host-to-wasm - untyped - nop-params-and-results
                        time:   [211.84 ns 215.06 ns 219.22 ns]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

async/no-hook/component - host-to-wasm - typed - nop
                        time:   [23.759 µs 23.969 µs 24.221 µs]
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) high mild
  10 (10.00%) high severe
async/no-hook/component - host-to-wasm - untyped - nop
                        time:   [23.941 µs 24.093 µs 24.254 µs]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
async/no-hook/component - host-to-wasm - typed - nop-params-and-results
                        time:   [24.286 µs 24.459 µs 24.629 µs]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
async/no-hook/component - host-to-wasm - untyped - nop-params-and-results
                        time:   [24.258 µs 24.390 µs 24.528 µs]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

async/hook-sync/component - host-to-wasm - typed - nop
                        time:   [24.055 µs 24.224 µs 24.408 µs]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe
async/hook-sync/component - host-to-wasm - untyped - nop
                        time:   [24.217 µs 24.364 µs 24.517 µs]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
async/hook-sync/component - host-to-wasm - typed - nop-params-and-results
                        time:   [24.207 µs 24.331 µs 24.463 µs]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
async/hook-sync/component - host-to-wasm - untyped - nop-params-and-results
                        time:   [24.607 µs 24.767 µs 24.936 µs]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

async-pool/no-hook/component - host-to-wasm - typed - nop
                        time:   [456.89 ns 459.65 ns 462.68 ns]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
async-pool/no-hook/component - host-to-wasm - untyped - nop
                        time:   [490.07 ns 492.87 ns 495.88 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
async-pool/no-hook/component - host-to-wasm - typed - nop-params-and-results
                        time:   [471.68 ns 475.01 ns 478.59 ns]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
async-pool/no-hook/component - host-to-wasm - untyped - nop-params-and-results
                        time:   [597.02 ns 600.61 ns 604.53 ns]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe

async-pool/hook-sync/component - host-to-wasm - typed - nop
                        time:   [458.06 ns 460.82 ns 463.77 ns]
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high severe
async-pool/hook-sync/component - host-to-wasm - untyped - nop
                        time:   [494.20 ns 497.65 ns 501.48 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
async-pool/hook-sync/component - host-to-wasm - typed - nop-params-and-results
                        time:   [472.40 ns 476.08 ns 480.10 ns]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
async-pool/hook-sync/component - host-to-wasm - untyped - nop-params-and-results
                        time:   [598.55 ns 603.79 ns 610.18 ns]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

sync/no-hook/component - wasm-to-host - typed - nop
                        time:   [33.614 ns 33.872 ns 34.170 ns]
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe
sync/no-hook/component - wasm-to-host - typed - nop-params-and-results
                        time:   [37.416 ns 37.700 ns 38.002 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
sync/no-hook/component - wasm-to-host - untyped - nop
                        time:   [58.126 ns 58.478 ns 58.846 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
sync/no-hook/component - wasm-to-host - untyped - nop-params-and-results
                        time:   [170.14 ns 171.33 ns 172.68 ns]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

sync/hook-sync/component - wasm-to-host - typed - nop
                        time:   [33.336 ns 33.556 ns 33.796 ns]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
sync/hook-sync/component - wasm-to-host - typed - nop-params-and-results
                        time:   [37.399 ns 37.654 ns 37.904 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
sync/hook-sync/component - wasm-to-host - untyped - nop
                        time:   [58.438 ns 58.924 ns 59.485 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
sync/hook-sync/component - wasm-to-host - untyped - nop-params-and-results
                        time:   [169.36 ns 170.44 ns 171.60 ns]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

async/no-hook/component - wasm-to-host - typed - nop
                        time:   [33.882 ns 34.198 ns 34.573 ns]
Found 11 outliers among 100 measurements (11.00%)
  6 (6.00%) high mild
  5 (5.00%) high severe
async/no-hook/component - wasm-to-host - typed - nop-params-and-results
                        time:   [37.407 ns 37.820 ns 38.371 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
async/no-hook/component - wasm-to-host - untyped - nop
                        time:   [58.400 ns 58.937 ns 59.537 ns]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
async/no-hook/component - wasm-to-host - untyped - nop-params-and-results
                        time:   [170.15 ns 171.72 ns 173.52 ns]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
async/no-hook/component - wasm-to-host - async-typed - nop
                        time:   [48.383 ns 48.801 ns 49.317 ns]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
async/no-hook/component - wasm-to-host - async-typed - nop-params-and-results
                        time:   [59.723 ns 60.158 ns 60.657 ns]
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

async/hook-sync/component - wasm-to-host - typed - nop
                        time:   [33.537 ns 34.056 ns 34.742 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
async/hook-sync/component - wasm-to-host - typed - nop-params-and-results
                        time:   [37.390 ns 37.888 ns 38.562 ns]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
async/hook-sync/component - wasm-to-host - untyped - nop
                        time:   [58.506 ns 58.906 ns 59.361 ns]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
async/hook-sync/component - wasm-to-host - untyped - nop-params-and-results
                        time:   [170.70 ns 172.62 ns 174.80 ns]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) high mild
  3 (3.00%) high severe
async/hook-sync/component - wasm-to-host - async-typed - nop
                        time:   [48.308 ns 48.764 ns 49.267 ns]
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
async/hook-sync/component - wasm-to-host - async-typed - nop-params-and-results
                        time:   [57.503 ns 57.887 ns 58.307 ns]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

async-pool/no-hook/component - wasm-to-host - typed - nop
                        time:   [33.473 ns 33.792 ns 34.142 ns]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
async-pool/no-hook/component - wasm-to-host - typed - nop-params-and-results
                        time:   [37.523 ns 38.040 ns 38.638 ns]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
async-pool/no-hook/component - wasm-to-host - untyped - nop
                        time:   [57.989 ns 58.350 ns 58.737 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
async-pool/no-hook/component - wasm-to-host - untyped - nop-params-and-results
                        time:   [169.55 ns 170.93 ns 172.48 ns]
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
async-pool/no-hook/component - wasm-to-host - async-typed - nop
                        time:   [48.323 ns 48.700 ns 49.144 ns]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe
async-pool/no-hook/component - wasm-to-host - async-typed - nop-params-and-results
                        time:   [57.521 ns 58.090 ns 58.739 ns]
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

async-pool/hook-sync/component - wasm-to-host - typed - nop
                        time:   [33.379 ns 33.602 ns 33.838 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
async-pool/hook-sync/component - wasm-to-host - typed - nop-params-and-results
                        time:   [37.361 ns 37.608 ns 37.857 ns]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
async-pool/hook-sync/component - wasm-to-host - untyped - nop
                        time:   [58.523 ns 58.848 ns 59.180 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
async-pool/hook-sync/component - wasm-to-host - untyped - nop-params-and-results
                        time:   [170.59 ns 171.57 ns 172.63 ns]
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
async-pool/hook-sync/component - wasm-to-host - async-typed - nop
                        time:   [48.265 ns 48.520 ns 48.794 ns]
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe
async-pool/hook-sync/component - wasm-to-host - async-typed - nop-params-and-results
                        time:   [57.619 ns 57.918 ns 58.234 ns]
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
```

</details>

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
