### PR TITLE
winch: Support abs and neg for f32 and f64 on x64

### DIFF
--- a/fuzz/fuzz_targets/differential.rs
+++ b/fuzz/fuzz_targets/differential.rs
@@ -370,7 +370,11 @@ fn winch_supports_module(module: &[u8]) -> bool {
                         | Unreachable { .. }
                         | Return { .. }
                         | F32Const { .. }
-                        | F64Const { .. } => {}
+                        | F64Const { .. }
+                        | F32Abs { .. }
+                        | F64Abs { .. }
+                        | F32Neg { .. }
+                        | F64Neg { .. } => {}
                         _ => {
                             supported = false;
                             break 'main;

--- a/tests/misc_testsuite/winch/f32_bitwise.wast
+++ b/tests/misc_testsuite/winch/f32_bitwise.wast
@@ -1,0 +1,50 @@
+;; Test all the f32 bitwise operators on major boundary values and all special
+;; values.
+
+(module
+  (func (export "abs") (param $x f32) (result f32) (f32.abs (local.get $x)))
+  (func (export "neg") (param $x f32) (result f32) (f32.neg (local.get $x)))
+)
+
+(assert_return (invoke "abs" (f32.const -0x0p+0)) (f32.const 0x0p+0))
+(assert_return (invoke "abs" (f32.const 0x0p+0)) (f32.const 0x0p+0))
+(assert_return (invoke "abs" (f32.const -0x1p-149)) (f32.const 0x1p-149))
+(assert_return (invoke "abs" (f32.const 0x1p-149)) (f32.const 0x1p-149))
+(assert_return (invoke "abs" (f32.const -0x1p-126)) (f32.const 0x1p-126))
+(assert_return (invoke "abs" (f32.const 0x1p-126)) (f32.const 0x1p-126))
+(assert_return (invoke "abs" (f32.const -0x1p-1)) (f32.const 0x1p-1))
+(assert_return (invoke "abs" (f32.const 0x1p-1)) (f32.const 0x1p-1))
+(assert_return (invoke "abs" (f32.const -0x1p+0)) (f32.const 0x1p+0))
+(assert_return (invoke "abs" (f32.const 0x1p+0)) (f32.const 0x1p+0))
+(assert_return (invoke "abs" (f32.const -0x1.921fb6p+2)) (f32.const 0x1.921fb6p+2))
+(assert_return (invoke "abs" (f32.const 0x1.921fb6p+2)) (f32.const 0x1.921fb6p+2))
+(assert_return (invoke "abs" (f32.const -0x1.fffffep+127)) (f32.const 0x1.fffffep+127))
+(assert_return (invoke "abs" (f32.const 0x1.fffffep+127)) (f32.const 0x1.fffffep+127))
+(assert_return (invoke "abs" (f32.const -inf)) (f32.const inf))
+(assert_return (invoke "abs" (f32.const inf)) (f32.const inf))
+(assert_return (invoke "abs" (f32.const -nan)) (f32.const nan))
+(assert_return (invoke "abs" (f32.const nan)) (f32.const nan))
+(assert_return (invoke "neg" (f32.const -0x0p+0)) (f32.const 0x0p+0))
+(assert_return (invoke "neg" (f32.const 0x0p+0)) (f32.const -0x0p+0))
+(assert_return (invoke "neg" (f32.const -0x1p-149)) (f32.const 0x1p-149))
+(assert_return (invoke "neg" (f32.const 0x1p-149)) (f32.const -0x1p-149))
+(assert_return (invoke "neg" (f32.const -0x1p-126)) (f32.const 0x1p-126))
+(assert_return (invoke "neg" (f32.const 0x1p-126)) (f32.const -0x1p-126))
+(assert_return (invoke "neg" (f32.const -0x1p-1)) (f32.const 0x1p-1))
+(assert_return (invoke "neg" (f32.const 0x1p-1)) (f32.const -0x1p-1))
+(assert_return (invoke "neg" (f32.const -0x1p+0)) (f32.const 0x1p+0))
+(assert_return (invoke "neg" (f32.const 0x1p+0)) (f32.const -0x1p+0))
+(assert_return (invoke "neg" (f32.const -0x1.921fb6p+2)) (f32.const 0x1.921fb6p+2))
+(assert_return (invoke "neg" (f32.const 0x1.921fb6p+2)) (f32.const -0x1.921fb6p+2))
+(assert_return (invoke "neg" (f32.const -0x1.fffffep+127)) (f32.const 0x1.fffffep+127))
+(assert_return (invoke "neg" (f32.const 0x1.fffffep+127)) (f32.const -0x1.fffffep+127))
+(assert_return (invoke "neg" (f32.const -inf)) (f32.const inf))
+(assert_return (invoke "neg" (f32.const inf)) (f32.const -inf))
+(assert_return (invoke "neg" (f32.const -nan)) (f32.const nan))
+(assert_return (invoke "neg" (f32.const nan)) (f32.const -nan))
+
+
+;; Type check
+
+(assert_invalid (module (func (result f32) (f32.abs (i64.const 0)))) "type mismatch")
+(assert_invalid (module (func (result f32) (f32.neg (i64.const 0)))) "type mismatch")

--- a/tests/misc_testsuite/winch/f64_bitwise.wast
+++ b/tests/misc_testsuite/winch/f64_bitwise.wast
@@ -1,0 +1,50 @@
+;; Test all the f64 bitwise operators on major boundary values and all special
+;; values.
+
+(module
+  (func (export "abs") (param $x f64) (result f64) (f64.abs (local.get $x)))
+  (func (export "neg") (param $x f64) (result f64) (f64.neg (local.get $x)))
+)
+
+(assert_return (invoke "abs" (f64.const -0x0p+0)) (f64.const 0x0p+0))
+(assert_return (invoke "abs" (f64.const 0x0p+0)) (f64.const 0x0p+0))
+(assert_return (invoke "abs" (f64.const -0x0.0000000000001p-1022)) (f64.const 0x0.0000000000001p-1022))
+(assert_return (invoke "abs" (f64.const 0x0.0000000000001p-1022)) (f64.const 0x0.0000000000001p-1022))
+(assert_return (invoke "abs" (f64.const -0x1p-1022)) (f64.const 0x1p-1022))
+(assert_return (invoke "abs" (f64.const 0x1p-1022)) (f64.const 0x1p-1022))
+(assert_return (invoke "abs" (f64.const -0x1p-1)) (f64.const 0x1p-1))
+(assert_return (invoke "abs" (f64.const 0x1p-1)) (f64.const 0x1p-1))
+(assert_return (invoke "abs" (f64.const -0x1p+0)) (f64.const 0x1p+0))
+(assert_return (invoke "abs" (f64.const 0x1p+0)) (f64.const 0x1p+0))
+(assert_return (invoke "abs" (f64.const -0x1.921fb54442d18p+2)) (f64.const 0x1.921fb54442d18p+2))
+(assert_return (invoke "abs" (f64.const 0x1.921fb54442d18p+2)) (f64.const 0x1.921fb54442d18p+2))
+(assert_return (invoke "abs" (f64.const -0x1.fffffffffffffp+1023)) (f64.const 0x1.fffffffffffffp+1023))
+(assert_return (invoke "abs" (f64.const 0x1.fffffffffffffp+1023)) (f64.const 0x1.fffffffffffffp+1023))
+(assert_return (invoke "abs" (f64.const -inf)) (f64.const inf))
+(assert_return (invoke "abs" (f64.const inf)) (f64.const inf))
+(assert_return (invoke "abs" (f64.const -nan)) (f64.const nan))
+(assert_return (invoke "abs" (f64.const nan)) (f64.const nan))
+(assert_return (invoke "neg" (f64.const -0x0p+0)) (f64.const 0x0p+0))
+(assert_return (invoke "neg" (f64.const 0x0p+0)) (f64.const -0x0p+0))
+(assert_return (invoke "neg" (f64.const -0x0.0000000000001p-1022)) (f64.const 0x0.0000000000001p-1022))
+(assert_return (invoke "neg" (f64.const 0x0.0000000000001p-1022)) (f64.const -0x0.0000000000001p-1022))
+(assert_return (invoke "neg" (f64.const -0x1p-1022)) (f64.const 0x1p-1022))
+(assert_return (invoke "neg" (f64.const 0x1p-1022)) (f64.const -0x1p-1022))
+(assert_return (invoke "neg" (f64.const -0x1p-1)) (f64.const 0x1p-1))
+(assert_return (invoke "neg" (f64.const 0x1p-1)) (f64.const -0x1p-1))
+(assert_return (invoke "neg" (f64.const -0x1p+0)) (f64.const 0x1p+0))
+(assert_return (invoke "neg" (f64.const 0x1p+0)) (f64.const -0x1p+0))
+(assert_return (invoke "neg" (f64.const -0x1.921fb54442d18p+2)) (f64.const 0x1.921fb54442d18p+2))
+(assert_return (invoke "neg" (f64.const 0x1.921fb54442d18p+2)) (f64.const -0x1.921fb54442d18p+2))
+(assert_return (invoke "neg" (f64.const -0x1.fffffffffffffp+1023)) (f64.const 0x1.fffffffffffffp+1023))
+(assert_return (invoke "neg" (f64.const 0x1.fffffffffffffp+1023)) (f64.const -0x1.fffffffffffffp+1023))
+(assert_return (invoke "neg" (f64.const -inf)) (f64.const inf))
+(assert_return (invoke "neg" (f64.const inf)) (f64.const -inf))
+(assert_return (invoke "neg" (f64.const -nan)) (f64.const nan))
+(assert_return (invoke "neg" (f64.const nan)) (f64.const -nan))
+
+
+;; Type check
+
+(assert_invalid (module (func (result f64) (f64.abs (i64.const 0)))) "type mismatch")
+(assert_invalid (module (func (result f64) (f64.neg (i64.const 0)))) "type mismatch")

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -228,6 +228,10 @@ impl Masm for MacroAssembler {
         }
     }
 
+    fn float_abs(&mut self, _dst: Reg, _src: RegImm, _size: OperandSize) {
+        todo!()
+    }
+
     fn and(&mut self, _dst: RegImm, _lhs: RegImm, _rhs: RegImm, _size: OperandSize) {
         todo!()
     }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -228,6 +228,10 @@ impl Masm for MacroAssembler {
         }
     }
 
+    fn float_neg(&mut self, _dst: Reg, _src: RegImm, _size: OperandSize) {
+        todo!()
+    }
+
     fn float_abs(&mut self, _dst: Reg, _src: RegImm, _size: OperandSize) {
         todo!()
     }

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -1,7 +1,7 @@
 //! Assembler library implementation for x64.
 
 use crate::{
-    isa::reg::Reg,
+    isa::reg::{Reg, RegClass},
     masm::{CalleeKind, CmpKind, DivKind, OperandSize, RemKind, ShiftKind},
 };
 use cranelift_codegen::{
@@ -22,7 +22,6 @@ use cranelift_codegen::{
     settings, Final, MachBuffer, MachBufferFinalized, MachInstEmit, MachInstEmitState, MachLabel,
     VCodeConstantData, VCodeConstants, Writable,
 };
-use regalloc2::RegClass;
 
 use super::address::Address;
 use smallvec::{smallvec, SmallVec};

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -267,6 +267,7 @@ impl Masm for MacroAssembler {
 
     fn float_neg(&mut self, dst: Reg, src: RegImm, size: OperandSize) {
         Self::ensure_two_argument_form(&dst.into(), &src);
+        assert_eq!(dst.class(), RegClass::Float);
         let mask = match size {
             OperandSize::S32 => I::I32(0x80000000),
             OperandSize::S64 => I::I64(0x8000000000000000),
@@ -281,6 +282,7 @@ impl Masm for MacroAssembler {
 
     fn float_abs(&mut self, dst: Reg, src: RegImm, size: OperandSize) {
         Self::ensure_two_argument_form(&dst.into(), &src);
+        assert_eq!(dst.class(), RegClass::Float);
         let mask = match size {
             OperandSize::S32 => I::I32(0x7fffffff),
             OperandSize::S64 => I::I64(0x7fffffffffffffff),

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -265,6 +265,20 @@ impl Masm for MacroAssembler {
         }
     }
 
+    fn float_neg(&mut self, dst: Reg, src: RegImm, size: OperandSize) {
+        Self::ensure_two_argument_form(&dst.into(), &src);
+        let mask = match size {
+            OperandSize::S32 => I::I32(0x80000000),
+            OperandSize::S64 => I::I64(0x8000000000000000),
+            OperandSize::S128 => unreachable!(),
+        };
+        let scratch_gpr = regs::scratch();
+        self.load_constant(&mask, scratch_gpr, size);
+        let scratch_xmm = regs::scratch_xmm();
+        self.asm.gpr_to_xmm(scratch_gpr, scratch_xmm, size);
+        self.asm.xor_rr(scratch_xmm, dst, size);
+    }
+
     fn float_abs(&mut self, dst: Reg, src: RegImm, size: OperandSize) {
         Self::ensure_two_argument_form(&dst.into(), &src);
         let mask = match size {

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -265,6 +265,20 @@ impl Masm for MacroAssembler {
         }
     }
 
+    fn float_abs(&mut self, dst: Reg, src: RegImm, size: OperandSize) {
+        Self::ensure_two_argument_form(&dst.into(), &src);
+        let mask = match size {
+            OperandSize::S32 => I::I32(0x7fffffff),
+            OperandSize::S64 => I::I64(0x7fffffffffffffff),
+            OperandSize::S128 => unreachable!(),
+        };
+        let scratch_gpr = regs::scratch();
+        self.load_constant(&mask, scratch_gpr, size);
+        let scratch_xmm = regs::scratch_xmm();
+        self.asm.gpr_to_xmm(scratch_gpr, scratch_xmm, size);
+        self.asm.and_rr(scratch_xmm, dst, size);
+    }
+
     fn and(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize) {
         Self::ensure_two_argument_form(&dst, &lhs);
         match (rhs, dst) {

--- a/winch/codegen/src/isa/x64/regs.rs
+++ b/winch/codegen/src/isa/x64/regs.rs
@@ -166,6 +166,10 @@ pub(crate) fn xmm15() -> Reg {
     fpr(15)
 }
 
+pub(crate) fn scratch_xmm() -> Reg {
+    xmm15()
+}
+
 const GPR: u32 = 16;
 const FPR: u32 = 16;
 const ALLOCATABLE_GPR: u32 = (1 << GPR) - 1;
@@ -174,12 +178,15 @@ const ALLOCATABLE_FPR: u32 = (1 << FPR) - 1;
 // R14: Is a pinned register, used as the instance register.
 const NON_ALLOCATABLE_GPR: u32 = (1 << ENC_RBP) | (1 << ENC_RSP) | (1 << ENC_R11) | (1 << ENC_R14);
 
+// xmm15: Is used as the scratch register.
+const NON_ALLOCATABLE_FPR: u32 = 1 << 15;
+
 /// Bitmask to represent the available general purpose registers.
 pub(crate) const ALL_GPR: u32 = ALLOCATABLE_GPR & !NON_ALLOCATABLE_GPR;
 /// Bitmask to represent the available floating point registers.
 // Note: at the time of writing all floating point registers are allocatable,
 // but we might need a scratch register in the future.
-pub(crate) const ALL_FPR: u32 = ALLOCATABLE_FPR;
+pub(crate) const ALL_FPR: u32 = ALLOCATABLE_FPR & !NON_ALLOCATABLE_FPR;
 
 /// Returns the callee-saved registers according to a particular calling
 /// convention.

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -317,6 +317,9 @@ pub(crate) trait MacroAssembler {
     /// Perform multiplication operation.
     fn mul(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
 
+    /// Perform a floating point abs operation.
+    fn float_abs(&mut self, dst: Reg, src: RegImm, size: OperandSize);
+
     /// Perform logical and operation.
     fn and(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
 

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -320,6 +320,9 @@ pub(crate) trait MacroAssembler {
     /// Perform a floating point abs operation.
     fn float_abs(&mut self, dst: Reg, src: RegImm, size: OperandSize);
 
+    /// Perform a floating point negation operation.
+    fn float_neg(&mut self, dst: Reg, src: RegImm, size: OperandSize);
+
     /// Perform logical and operation.
     fn and(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -41,6 +41,8 @@ macro_rules! def_unsupported {
     (emit F64Const $($rest:tt)*) => {};
     (emit F32Abs $($rest:tt)*) => {};
     (emit F64Abs $($rest:tt)*) => {};
+    (emit F32Neg $($rest:tt)*) => {};
+    (emit F64Neg $($rest:tt)*) => {};
     (emit I32Add $($rest:tt)*) => {};
     (emit I64Add $($rest:tt)*) => {};
     (emit I32Sub $($rest:tt)*) => {};
@@ -155,6 +157,20 @@ where
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
                 masm.float_abs(reg, RegImm::Reg(reg), size);
+            });
+    }
+
+    fn visit_f32_neg(&mut self) {
+        self.context
+            .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
+                masm.float_neg(reg, RegImm::Reg(reg), size);
+            });
+    }
+
+    fn visit_f64_neg(&mut self) {
+        self.context
+            .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
+                masm.float_neg(reg, RegImm::Reg(reg), size);
             });
     }
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -39,6 +39,8 @@ macro_rules! def_unsupported {
     (emit I64Const $($rest:tt)*) => {};
     (emit F32Const $($rest:tt)*) => {};
     (emit F64Const $($rest:tt)*) => {};
+    (emit F32Abs $($rest:tt)*) => {};
+    (emit F64Abs $($rest:tt)*) => {};
     (emit I32Add $($rest:tt)*) => {};
     (emit I64Add $($rest:tt)*) => {};
     (emit I32Sub $($rest:tt)*) => {};
@@ -140,6 +142,20 @@ where
 
     fn visit_f64_const(&mut self, val: Ieee64) {
         self.context.stack.push(Val::f64(val));
+    }
+
+    fn visit_f32_abs(&mut self) {
+        self.context
+            .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
+                masm.float_abs(reg, RegImm::Reg(reg), size);
+            });
+    }
+
+    fn visit_f64_abs(&mut self) {
+        self.context
+            .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
+                masm.float_abs(reg, RegImm::Reg(reg), size);
+            });
     }
 
     fn visit_i32_add(&mut self) {

--- a/winch/filetests/filetests/x64/f32_abs/f32_abs_const.wat
+++ b/winch/filetests/filetests/x64/f32_abs/f32_abs_const.wat
@@ -1,0 +1,25 @@
+;;! target = "x86_64"
+
+(module
+    (func (result f32)
+        (f32.const -1.32)
+        (f32.abs)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 f30f10051c000000     	movss	xmm0, dword ptr [rip + 0x1c]
+;;   14:	 41bbffffff7f         	mov	r11d, 0x7fffffff
+;;   1a:	 66450f6efb           	movd	xmm15, r11d
+;;   1f:	 410f54c7             	andps	xmm0, xmm15
+;;   23:	 4883c408             	add	rsp, 8
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
+;;   29:	 0000                 	add	byte ptr [rax], al
+;;   2b:	 0000                 	add	byte ptr [rax], al
+;;   2d:	 0000                 	add	byte ptr [rax], al
+;;   2f:	 00c3                 	add	bl, al
+;;   31:	 f5                   	cmc	
+;;   32:	 a8bf                 	test	al, 0xbf

--- a/winch/filetests/filetests/x64/f32_abs/f32_abs_param.wat
+++ b/winch/filetests/filetests/x64/f32_abs/f32_abs_param.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (param f32) (result f32)
+        (local.get 0)
+        (f32.abs)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;    e:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   13:	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
+;;   19:	 41bbffffff7f         	mov	r11d, 0x7fffffff
+;;   1f:	 66450f6efb           	movd	xmm15, r11d
+;;   24:	 410f54c7             	andps	xmm0, xmm15
+;;   28:	 4883c410             	add	rsp, 0x10
+;;   2c:	 5d                   	pop	rbp
+;;   2d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/f32_neg/f32_neg_const.wat
+++ b/winch/filetests/filetests/x64/f32_neg/f32_neg_const.wat
@@ -1,0 +1,25 @@
+;;! target = "x86_64"
+
+(module
+    (func (result f32)
+        (f32.const -1.32)
+        (f32.neg)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 f30f10051c000000     	movss	xmm0, dword ptr [rip + 0x1c]
+;;   14:	 41bb00000080         	mov	r11d, 0x80000000
+;;   1a:	 66450f6efb           	movd	xmm15, r11d
+;;   1f:	 410f57c7             	xorps	xmm0, xmm15
+;;   23:	 4883c408             	add	rsp, 8
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	
+;;   29:	 0000                 	add	byte ptr [rax], al
+;;   2b:	 0000                 	add	byte ptr [rax], al
+;;   2d:	 0000                 	add	byte ptr [rax], al
+;;   2f:	 00c3                 	add	bl, al
+;;   31:	 f5                   	cmc	
+;;   32:	 a8bf                 	test	al, 0xbf

--- a/winch/filetests/filetests/x64/f32_neg/f32_neg_param.wat
+++ b/winch/filetests/filetests/x64/f32_neg/f32_neg_param.wat
@@ -1,0 +1,20 @@
+;;! target = "x86_64"
+
+(module
+    (func (param f32) (result f32)
+        (local.get 0)
+        (f32.neg)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;    e:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   13:	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
+;;   19:	 41bb00000080         	mov	r11d, 0x80000000
+;;   1f:	 66450f6efb           	movd	xmm15, r11d
+;;   24:	 410f57c7             	xorps	xmm0, xmm15
+;;   28:	 4883c410             	add	rsp, 0x10
+;;   2c:	 5d                   	pop	rbp
+;;   2d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/f64_abs/f64_abs_const.wat
+++ b/winch/filetests/filetests/x64/f64_abs/f64_abs_const.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (result f64)
+        (f64.const -1.32)
+        (f64.abs)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 f20f10051c000000     	movsd	xmm0, qword ptr [rip + 0x1c]
+;;   14:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   1e:	 664d0f6efb           	movq	xmm15, r11
+;;   23:	 66410f54c7           	andpd	xmm0, xmm15
+;;   28:	 4883c408             	add	rsp, 8
+;;   2c:	 5d                   	pop	rbp
+;;   2d:	 c3                   	ret	
+;;   2e:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f64_abs/f64_abs_param.wat
+++ b/winch/filetests/filetests/x64/f64_abs/f64_abs_param.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param f64) (result f64)
+        (local.get 0)
+        (f64.abs)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;    e:	 4c893424             	mov	qword ptr [rsp], r14
+;;   12:	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
+;;   18:	 49bbffffffffffffff7f 	
+;; 				movabs	r11, 0x7fffffffffffffff
+;;   22:	 664d0f6efb           	movq	xmm15, r11
+;;   27:	 66410f54c7           	andpd	xmm0, xmm15
+;;   2c:	 4883c410             	add	rsp, 0x10
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/f64_neg/f64_neg_const.wat
+++ b/winch/filetests/filetests/x64/f64_neg/f64_neg_const.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (result f64)
+        (f64.const -1.32)
+        (f64.neg)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 f20f10051c000000     	movsd	xmm0, qword ptr [rip + 0x1c]
+;;   14:	 49bb0000000000000080 	
+;; 				movabs	r11, 0x8000000000000000
+;;   1e:	 664d0f6efb           	movq	xmm15, r11
+;;   23:	 66410f57c7           	xorpd	xmm0, xmm15
+;;   28:	 4883c408             	add	rsp, 8
+;;   2c:	 5d                   	pop	rbp
+;;   2d:	 c3                   	ret	
+;;   2e:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f64_neg/f64_neg_param.wat
+++ b/winch/filetests/filetests/x64/f64_neg/f64_neg_param.wat
@@ -1,0 +1,21 @@
+;;! target = "x86_64"
+
+(module
+    (func (param f64) (result f64)
+        (local.get 0)
+        (f64.neg)
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;    e:	 4c893424             	mov	qword ptr [rsp], r14
+;;   12:	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
+;;   18:	 49bb0000000000000080 	
+;; 				movabs	r11, 0x8000000000000000
+;;   22:	 664d0f6efb           	movq	xmm15, r11
+;;   27:	 66410f57c7           	xorpd	xmm0, xmm15
+;;   2c:	 4883c410             	add	rsp, 0x10
+;;   30:	 5d                   	pop	rbp
+;;   31:	 c3                   	ret	


### PR DESCRIPTION
Adds support for `f32.abs`, `f64.abs`, `f32.neg`, and `f64.neg` to winch. Additionally, this adds a `gpr_to_xmm` function to the x64 backend to allow loading a constant and moving it to an xmm register. It also reserves `xmm15` as the scratch xmm register.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
