### PR TITLE
riscv64: Remove support for fixed offset jumps from Jump instructions

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -132,7 +132,7 @@
 
     (Jal
       ;; (rd WritableReg) don't use
-      (dest BranchTarget))
+      (label MachLabel))
 
     (CondBr
       (taken BranchTarget)
@@ -2664,21 +2664,6 @@
         (test XReg (rv_srli sum (imm12_const (ty_bits ty)))))
     (value_regs sum test)))
 
-(decl label_to_br_target (MachLabel) BranchTarget)
-(extern constructor label_to_br_target label_to_br_target)
-
-(decl gen_jump (MachLabel) MInst)
-(rule
-  (gen_jump v)
-  (MInst.Jal (label_to_br_target v)))
-
-(decl vec_label_get (VecMachLabel u8) MachLabel )
-(extern constructor vec_label_get vec_label_get)
-
-(decl partial lower_branch (Inst VecMachLabel) Unit)
-(rule (lower_branch (jump _) targets )
-      (emit_side_effect (SideEffectNoResult.Inst (gen_jump (vec_label_get targets 0)))))
-
 ;;; cc a b targets Type
 (decl lower_br_icmp (IntCC ValueRegs ValueRegs VecMachLabel Type) Unit)
 (extern constructor lower_br_icmp lower_br_icmp)
@@ -2721,6 +2706,17 @@
       (let ((lo XReg (value_regs_get regs 0))
             (hi XReg (value_regs_get regs 1)))
         (rv_or lo hi)))
+
+
+(decl label_to_br_target (MachLabel) BranchTarget)
+(extern constructor label_to_br_target label_to_br_target)
+
+(decl vec_label_get (VecMachLabel u8) MachLabel )
+(extern constructor vec_label_get vec_label_get)
+
+(decl partial lower_branch (Inst VecMachLabel) Unit)
+(rule (lower_branch (jump _) targets )
+      (emit_side_effect (SideEffectNoResult.Inst (MInst.Jal (vec_label_get targets 0)))))
 
 ;; Default behavior for branching based on an input value.
 (rule

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -231,7 +231,7 @@
       (index Reg)
       (tmp1 WritableReg)
       (tmp2 WritableReg)
-      (targets VecBranchTarget))
+      (targets VecMachLabel))
 
     ;; atomic compare and set operation
     (AtomicCas
@@ -767,7 +767,6 @@
 ;;;; lowest four bit are used.
 (type FenceReq (primitive u8))
 
-(type VecBranchTarget (primitive VecBranchTarget))
 (type BoxCallInfo (primitive BoxCallInfo))
 (type BoxCallIndInfo (primitive BoxCallIndInfo))
 (type BoxReturnCallInfo (primitive BoxReturnCallInfo))
@@ -2711,7 +2710,7 @@
 (decl label_to_br_target (MachLabel) BranchTarget)
 (extern constructor label_to_br_target label_to_br_target)
 
-(decl vec_label_get (VecMachLabel u8) MachLabel )
+(decl vec_label_get (VecMachLabel u8) MachLabel)
 (extern constructor vec_label_get vec_label_get)
 
 (decl partial lower_branch (Inst VecMachLabel) Unit)
@@ -2750,12 +2749,11 @@
         (else BranchTarget (label_to_br_target (vec_label_get targets 1))))
     (emit_side_effect (cond_br (emit_fcmp cc ty a b) then else))))
 
-;;;
+
 (decl lower_br_table (Reg VecMachLabel) Unit)
 (extern constructor lower_br_table lower_br_table)
 
-(rule
-  (lower_branch (br_table index _) targets)
+(rule (lower_branch (br_table index _) targets)
   (lower_br_table index targets))
 
 (decl load_ra () Reg)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -135,8 +135,8 @@
       (label MachLabel))
 
     (CondBr
-      (taken BranchTarget)
-      (not_taken BranchTarget)
+      (taken CondBrTarget)
+      (not_taken CondBrTarget)
       (kind IntegerCompare))
 
     ;; Load an inline symbol reference.
@@ -780,7 +780,7 @@
 (type Imm5 (primitive Imm5))
 (type Imm20 (primitive Imm20))
 (type Imm3 (primitive Imm3))
-(type BranchTarget (primitive BranchTarget))
+(type CondBrTarget (primitive CondBrTarget))
 (type OptionFloatRoundingMode (primitive OptionFloatRoundingMode))
 (type VecU8 (primitive VecU8))
 (type AMO (primitive AMO))
@@ -2707,7 +2707,7 @@
         (rv_or lo hi)))
 
 
-(decl label_to_br_target (MachLabel) BranchTarget)
+(decl label_to_br_target (MachLabel) CondBrTarget)
 (extern constructor label_to_br_target label_to_br_target)
 
 (decl vec_label_get (VecMachLabel u8) MachLabel)
@@ -2738,15 +2738,15 @@
 (rule 1
   (lower_branch (brif (maybe_uextend (fcmp cc a @ (value_type ty) b)) _ _) targets)
   (if-let $true (floatcc_unordered cc))
-  (let ((then BranchTarget (label_to_br_target (vec_label_get targets 0)))
-        (else BranchTarget (label_to_br_target (vec_label_get targets 1))))
+  (let ((then CondBrTarget (label_to_br_target (vec_label_get targets 0)))
+        (else CondBrTarget (label_to_br_target (vec_label_get targets 1))))
     (emit_side_effect (cond_br (emit_fcmp (floatcc_complement cc) ty a b) else then))))
 
 (rule 1
   (lower_branch (brif (maybe_uextend (fcmp cc a @ (value_type ty) b)) _ _) targets)
   (if-let $false (floatcc_unordered cc))
-  (let ((then BranchTarget (label_to_br_target (vec_label_get targets 0)))
-        (else BranchTarget (label_to_br_target (vec_label_get targets 1))))
+  (let ((then CondBrTarget (label_to_br_target (vec_label_get targets 0)))
+        (else CondBrTarget (label_to_br_target (vec_label_get targets 1))))
     (emit_side_effect (cond_br (emit_fcmp cc ty a b) then else))))
 
 
@@ -2981,7 +2981,7 @@
 (rule (cmp_result_invert result) (CmpResult.Result result $true))
 
 ;; Consume a CmpResult, producing a branch on its result.
-(decl cond_br (CmpResult BranchTarget BranchTarget) SideEffectNoResult)
+(decl cond_br (CmpResult CondBrTarget CondBrTarget) SideEffectNoResult)
 (rule (cond_br cmp then else)
       (SideEffectNoResult.Inst
         (MInst.CondBr then else (cmp_integer_compare cmp))))

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1084,11 +1084,8 @@ impl MachInstEmit for Inst {
                     },
                 }
                 .emit(&[], sink, emit_info, state);
-                sink.use_label_at_offset(
-                    sink.cur_offset(),
-                    default_target.as_label().unwrap(),
-                    LabelUse::PCRel32,
-                );
+
+                sink.use_label_at_offset(sink.cur_offset(), default_target, LabelUse::PCRel32);
                 Inst::construct_auipc_and_jalr(None, tmp2, 0)
                     .iter()
                     .for_each(|i| i.emit(&[], sink, emit_info, state));
@@ -1148,11 +1145,7 @@ impl MachInstEmit for Inst {
 
                 // Emit the jumps back to back
                 for target in targets.iter() {
-                    sink.use_label_at_offset(
-                        sink.cur_offset(),
-                        target.as_label().unwrap(),
-                        LabelUse::PCRel32,
-                    );
+                    sink.use_label_at_offset(sink.cur_offset(), *target, LabelUse::PCRel32);
 
                     Inst::construct_auipc_and_jalr(None, tmp2, 0)
                         .iter()

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -930,7 +930,7 @@ impl MachInstEmit for Inst {
                         sink.add_cond_branch(start_off, start_off + 4, label, &code_inverse);
                         sink.put4(code);
                     }
-                    CondBrTarget::Fallthrough => {}
+                    CondBrTarget::Fallthrough => panic!("Cannot fallthrough in taken target"),
                 }
 
                 match not_taken {

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -102,10 +102,9 @@ pub struct ReturnCallInfo {
     pub new_stack_arg_size: u32,
 }
 
-/// A branch target. Either unresolved (basic-block index) or resolved (offset
-/// from end of current instruction).
+/// A conditional branch target.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum BranchTarget {
+pub enum CondBrTarget {
     /// An unresolved reference to a Label, as passed into
     /// `lower_branch_group()`.
     Label(MachLabel),
@@ -113,25 +112,25 @@ pub enum BranchTarget {
     Fallthrough,
 }
 
-impl BranchTarget {
+impl CondBrTarget {
     /// Return the target's label, if it is a label-based target.
     pub(crate) fn as_label(self) -> Option<MachLabel> {
         match self {
-            BranchTarget::Label(l) => Some(l),
+            CondBrTarget::Label(l) => Some(l),
             _ => None,
         }
     }
 
     pub(crate) fn is_fallthrouh(&self) -> bool {
-        self == &BranchTarget::Fallthrough
+        self == &CondBrTarget::Fallthrough
     }
 }
 
-impl Display for BranchTarget {
+impl Display for CondBrTarget {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            BranchTarget::Label(l) => write!(f, "{}", l.to_string()),
-            BranchTarget::Fallthrough => write!(f, "0"),
+            CondBrTarget::Label(l) => write!(f, "{}", l.to_string()),
+            CondBrTarget::Fallthrough => write!(f, "0"),
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -46,7 +46,6 @@ use std::fmt::{Display, Formatter};
 
 pub(crate) type OptionReg = Option<Reg>;
 pub(crate) type OptionImm12 = Option<Imm12>;
-pub(crate) type VecBranchTarget = Vec<BranchTarget>;
 pub(crate) type OptionUimm5 = Option<UImm5>;
 pub(crate) type OptionFloatRoundingMode = Option<FRM>;
 pub(crate) type VecU8 = Vec<u8>;
@@ -1363,7 +1362,6 @@ impl Inst {
                 tmp2,
                 ref targets,
             } => {
-                let targets: Vec<_> = targets.iter().map(|x| x.as_label().unwrap()).collect();
                 format!(
                     "{} {},{}##tmp1={},tmp2={}",
                     "br_table",

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -201,8 +201,8 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
             *cc,
             a,
             self.int_zero_reg(ty),
-            BranchTarget::Label(targets[0]),
-            BranchTarget::Label(targets[1]),
+            CondBrTarget::Label(targets[0]),
+            CondBrTarget::Label(targets[1]),
             ty,
         )
         .iter()
@@ -218,8 +218,8 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     ) -> Unit {
         let test = generated_code::constructor_lower_icmp(self, cc, a, b, ty);
         self.emit(&MInst::CondBr {
-            taken: BranchTarget::Label(targets[0]),
-            not_taken: BranchTarget::Label(targets[1]),
+            taken: CondBrTarget::Label(targets[0]),
+            not_taken: CondBrTarget::Label(targets[1]),
             kind: IntegerCompare {
                 kind: IntCC::NotEqual,
                 rs1: test,
@@ -254,8 +254,8 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         val[x as usize]
     }
 
-    fn label_to_br_target(&mut self, label: MachLabel) -> BranchTarget {
-        BranchTarget::Label(label)
+    fn label_to_br_target(&mut self, label: MachLabel) -> CondBrTarget {
+        CondBrTarget::Label(label)
     }
 
     fn vec_writable_clone(&mut self, v: &VecWritableReg) -> VecWritableReg {

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -514,16 +514,11 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     fn lower_br_table(&mut self, index: Reg, targets: &VecMachLabel) -> Unit {
         let tmp1 = self.temp_writable_reg(I64);
         let tmp2 = self.temp_writable_reg(I64);
-        let targets: Vec<BranchTarget> = targets
-            .into_iter()
-            .copied()
-            .map(BranchTarget::Label)
-            .collect();
         self.emit(&MInst::BrTable {
             index,
             tmp1,
             tmp2,
-            targets,
+            targets: targets.clone(),
         });
     }
 


### PR DESCRIPTION
👋 Hey,

This PR removes fixed offset jumps from some instructions in the RISC-V backend. Fixed offset jumps were replaced with labels in #6955. But we still have support for them.

Currently all branch instructions use the `BranchTarget` struct, that allows a label based jump, or a fixed offset jump.

This PR does the following changes:
* `Jal` now takes a single `MachLabel` as it's target
* `BrTable` similarly now takes a `Vec<MachLabel>`
* `CondBr` still uses `BranchTarget`, but it can only do a label jump, or fallthrough. It can no longer do a fixed offset jump

Since `BranchTarget` is now only used in `CondBr`, I've renamed it `CondBrTarget`.