### PR TITLE
riscv64: Introduce Compressed Instructions

### DIFF
--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -91,7 +91,7 @@ const array = [
     "target": "riscv64gc-unknown-linux-gnu",
     "gcc_package": "gcc-riscv64-linux-gnu",
     "gcc": "riscv64-linux-gnu-gcc",
-    "qemu": "qemu-riscv64 -cpu rv64,v=true,vlen=256,vext_spec=v1.0,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true,zcb=true -L /usr/riscv64-linux-gnu",
+    "qemu": "qemu-riscv64 -cpu rv64,v=true,vlen=256,vext_spec=v1.0,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true -L /usr/riscv64-linux-gnu",
     "qemu_target": "riscv64-linux-user",
     "name": "Test Linux riscv64",
     "filter": "linux-riscv64",

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -91,7 +91,7 @@ const array = [
     "target": "riscv64gc-unknown-linux-gnu",
     "gcc_package": "gcc-riscv64-linux-gnu",
     "gcc": "riscv64-linux-gnu-gcc",
-    "qemu": "qemu-riscv64 -cpu rv64,v=true,vlen=256,vext_spec=v1.0,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true -L /usr/riscv64-linux-gnu",
+    "qemu": "qemu-riscv64 -cpu rv64,v=true,vlen=256,vext_spec=v1.0,zba=true,zbb=true,zbc=true,zbs=true,zbkb=true,zcb=true -L /usr/riscv64-linux-gnu",
     "qemu_target": "riscv64-linux-user",
     "name": "Test Linux riscv64",
     "filter": "linux-riscv64",

--- a/cranelift/codegen/meta/src/isa/riscv64.rs
+++ b/cranelift/codegen/meta/src/isa/riscv64.rs
@@ -28,13 +28,12 @@ macro_rules! define_zvl_ext {
 pub(crate) fn define() -> TargetIsa {
     let mut setting = SettingGroupBuilder::new("riscv64");
 
-    // We target a minimum of riscv64gc. That means that we have the following extensions by default:
+    // We target a minimum of riscv64g. That means that we have the following extensions by default:
     //
     // * M (integer multiplication and division)
     // * A (atomic instructions)
     // * F (single-precision floating point)
     // * D (double-precision floating point)
-    // * C (compressed instructions)
     // * Zicsr (control and status register instructions)
     // * Zifencei (instruction-fetch fence)
 
@@ -63,7 +62,31 @@ pub(crate) fn define() -> TargetIsa {
         "Vector instruction support",
         false,
     );
-    let _has_c = setting.add_bool("has_c", "has extension C?", "Compressed instructions", true);
+
+    let has_zca = setting.add_bool(
+        "has_zca",
+        "has extension Zca?",
+        "Zca is the C extension without floating point loads",
+        false,
+    );
+    let has_zcd = setting.add_bool(
+        "has_zcd",
+        "has extension Zcd?",
+        "Zcd contains only the double precision floating point loads from the C extension",
+        false,
+    );
+    setting.add_preset(
+        "has_c",
+        "Support for compressed instructions",
+        preset!(has_zca && has_zcd),
+    );
+
+    let _has_zcb = setting.add_bool(
+        "has_zcb",
+        "has extension Zcb?",
+        "Zcb: Extra compressed instructions",
+        false,
+    );
 
     let _has_zbkb = setting.add_bool(
         "has_zbkb",

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -699,6 +699,20 @@
   (Bseti)
 ))
 
+(type COpcodeSpace (enum
+  (C0)
+  (C1)
+  (C2)
+))
+
+
+;; Opcodes for the CR compressed instruction format
+(type CrOp (enum
+  (CMv)
+  (CAdd)
+))
+
+
 (type CsrRegOP (enum
   ;; Atomic Read/Write CSR
   (CsrRW)

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -6,6 +6,7 @@ use super::*;
 use crate::ir::condcodes::CondCode;
 
 use crate::isa::riscv64::inst::{reg_name, reg_to_gpr_num};
+use crate::isa::riscv64::lower::isle::generated_code::{COpcodeSpace, CrOp};
 use crate::machinst::isle::WritableReg;
 
 use std::fmt::{Display, Formatter, Result};
@@ -1896,5 +1897,32 @@ impl CSR {
 impl Display for CSR {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}", self.name())
+    }
+}
+
+impl COpcodeSpace {
+    pub fn bits(&self) -> u32 {
+        match self {
+            COpcodeSpace::C0 => 0b00,
+            COpcodeSpace::C1 => 0b01,
+            COpcodeSpace::C2 => 0b10,
+        }
+    }
+}
+
+impl CrOp {
+    pub fn funct4(&self) -> u32 {
+        // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
+        match self {
+            CrOp::CMv => 0b1000,
+            CrOp::CAdd => 0b1001,
+        }
+    }
+
+    pub fn op(&self) -> COpcodeSpace {
+        // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
+        match self {
+            CrOp::CMv | CrOp::CAdd => COpcodeSpace::C2,
+        }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -468,6 +468,20 @@ impl Inst {
                 sink.put2(encode_cr_type(CrOp::CAdd, rd, rs2));
             }
 
+            // C.MV
+            Inst::AluRRImm12 {
+                alu_op: AluOPRRI::Addi | AluOPRRI::Ori,
+                rd,
+                rs,
+                imm12,
+            } if has_zca
+                && rd.to_reg() != rs
+                && rd.to_reg() != zero_reg()
+                && rs != zero_reg()
+                && imm12.as_i16() == 0 =>
+            {
+                sink.put2(encode_cr_type(CrOp::CMv, rd, rs));
+            }
             _ => return false,
         }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1058,7 +1058,10 @@ impl Inst {
                     rd: tmp1,
                     imm: Imm20::from_bits(0),
                 }
-                .emit(&[], sink, emit_info, state);
+                .emit_uncompressed(sink, emit_info, state, start_off);
+
+                // These instructions must be emitted as uncompressed since we
+                // are manually computing the offset from the PC.
 
                 // Multiply the index by 8, since that is the size in
                 // bytes of each jump table entry
@@ -1068,7 +1071,7 @@ impl Inst {
                     rs: ext_index.to_reg(),
                     imm12: Imm12::from_bits(3),
                 }
-                .emit(&[], sink, emit_info, state);
+                .emit_uncompressed(sink, emit_info, state, start_off);
 
                 // Calculate the base of the jump, PC + the offset from above.
                 Inst::AluRRR {
@@ -1077,7 +1080,7 @@ impl Inst {
                     rs1: tmp1.to_reg(),
                     rs2: tmp2.to_reg(),
                 }
-                .emit(&[], sink, emit_info, state);
+                .emit_uncompressed(sink, emit_info, state, start_off);
 
                 // Jump to the middle of the jump table.
                 // We add a 16 byte offset here, since we used 4 instructions
@@ -1087,7 +1090,7 @@ impl Inst {
                     base: tmp1.to_reg(),
                     offset: Imm12::from_bits((4 * Inst::UNCOMPRESSED_INSTRUCTION_SIZE) as i16),
                 }
-                .emit(&[], sink, emit_info, state);
+                .emit_uncompressed(sink, emit_info, state, start_off);
 
                 // Emit the jump table.
                 //
@@ -1108,7 +1111,7 @@ impl Inst {
 
                     Inst::construct_auipc_and_jalr(None, tmp2, 0)
                         .iter()
-                        .for_each(|i| i.emit(&[], sink, emit_info, state));
+                        .for_each(|i| i.emit_uncompressed(sink, emit_info, state, start_off));
                 }
 
                 // We've just emitted an island that is safe up to *here*.

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -419,6 +419,51 @@ impl MachInstEmit for Inst {
         // to allow disabling the check for `JTSequence`, which is always
         // emitted following an `EmitIsland`.
         let mut start_off = sink.cur_offset();
+
+        // First try to emit this as a compressed instruction
+        let success = self.try_emit_compressed(&mut allocs, sink, emit_info, state, &mut start_off);
+        if !success {
+            // If we can't lets emit it as a normal instruction
+            self.emit_uncompressed(&mut allocs, sink, emit_info, state, &mut start_off);
+        }
+
+        let end_off = sink.cur_offset();
+        assert!(
+            (end_off - start_off) <= Inst::worst_case_size(),
+            "Inst:{:?} length:{} worst_case_size:{}",
+            self,
+            end_off - start_off,
+            Inst::worst_case_size()
+        );
+    }
+
+    fn pretty_print_inst(&self, allocs: &[Allocation], state: &mut Self::State) -> String {
+        let mut allocs = AllocationConsumer::new(allocs);
+        self.print_with_state(state, &mut allocs)
+    }
+}
+
+impl Inst {
+    /// Tries to emit an instruction as compressed, if we can't return false.
+    fn try_emit_compressed(
+        &self,
+        _allocs: &mut AllocationConsumer,
+        _sink: &mut MachBuffer<Inst>,
+        _emit_info: &EmitInfo,
+        _state: &mut EmitState,
+        _start_off: &mut u32,
+    ) -> bool {
+        false
+    }
+
+    fn emit_uncompressed(
+        &self,
+        mut allocs: &mut AllocationConsumer,
+        sink: &mut MachBuffer<Inst>,
+        emit_info: &EmitInfo,
+        state: &mut EmitState,
+        start_off: &mut u32,
+    ) {
         match self {
             &Inst::Nop0 => {
                 // do nothing
@@ -866,7 +911,7 @@ impl MachInstEmit for Inst {
                 // `emit_return_call_common_sequence` emits an island if
                 // necessary, so we can safely disable the worst-case-size check
                 // in this case.
-                start_off = sink.cur_offset();
+                *start_off = sink.cur_offset();
             }
 
             &Inst::ReturnCallInd { callee, ref info } => {
@@ -892,12 +937,11 @@ impl MachInstEmit for Inst {
                 // `emit_return_call_common_sequence` emits an island if
                 // necessary, so we can safely disable the worst-case-size check
                 // in this case.
-                start_off = sink.cur_offset();
+                *start_off = sink.cur_offset();
             }
-
             &Inst::Jal { label } => {
-                sink.use_label_at_offset(start_off, label, LabelUse::Jal20);
-                sink.add_uncond_branch(start_off, start_off + 4, label);
+                sink.use_label_at_offset(*start_off, label, LabelUse::Jal20);
+                sink.add_uncond_branch(*start_off, *start_off + 4, label);
                 sink.put4(0b1101111);
             }
             &Inst::CondBr {
@@ -911,8 +955,8 @@ impl MachInstEmit for Inst {
                     CondBrTarget::Label(label) => {
                         let code = kind.emit();
                         let code_inverse = kind.inverse().emit().to_le_bytes();
-                        sink.use_label_at_offset(start_off, label, LabelUse::B12);
-                        sink.add_cond_branch(start_off, start_off + 4, label, &code_inverse);
+                        sink.use_label_at_offset(*start_off, label, LabelUse::B12);
+                        sink.add_cond_branch(*start_off, *start_off + 4, label, &code_inverse);
                         sink.put4(code);
                     }
                     CondBrTarget::Fallthrough => panic!("Cannot fallthrough in taken target"),
@@ -1118,7 +1162,7 @@ impl MachInstEmit for Inst {
 
                 // We've just emitted an island that is safe up to *here*.
                 // Mark it as such so that we don't needlessly emit additional islands.
-                start_off = sink.cur_offset();
+                *start_off = sink.cur_offset();
             }
 
             &Inst::VirtualSPOffsetAdj { amount } => {
@@ -2919,19 +2963,6 @@ impl MachInstEmit for Inst {
                 ));
             }
         };
-        let end_off = sink.cur_offset();
-        assert!(
-            (end_off - start_off) <= Inst::worst_case_size(),
-            "Inst:{:?} length:{} worst_case_size:{}",
-            self,
-            end_off - start_off,
-            Inst::worst_case_size()
-        );
-    }
-
-    fn pretty_print_inst(&self, allocs: &[Allocation], state: &mut Self::State) -> String {
-        let mut allocs = AllocationConsumer::new(allocs);
-        self.print_with_state(state, &mut allocs)
     }
 }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -9,7 +9,7 @@
 use super::*;
 use crate::isa::riscv64::inst::reg_to_gpr_num;
 use crate::isa::riscv64::lower::isle::generated_code::{
-    VecAluOpRImm5, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecAluOpRRRImm5, VecAluOpRRRR,
+    CrOp, VecAluOpRImm5, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecAluOpRRRImm5, VecAluOpRRRR,
     VecElementWidth, VecOpCategory, VecOpMasking,
 };
 use crate::machinst::isle::WritableReg;
@@ -323,4 +323,17 @@ pub fn encode_csr_imm(op: CsrImmOP, rd: WritableReg, csr: CSR, imm: UImm5) -> u3
         imm.bits(),
         csr.bits().as_u32(),
     )
+}
+
+// Encode a CR type instruction.
+//
+// 0--1-2-----6-7-------11-12-------15
+// |op |  rs2  |  rd/rs1  |  funct4  |
+pub fn encode_cr_type(op: CrOp, rd: WritableReg, rs2: Reg) -> u16 {
+    let mut bits = 0;
+    bits |= unsigned_field_width(op.op().bits(), 2);
+    bits |= reg_to_gpr_num(rs2) << 2;
+    bits |= reg_to_gpr_num(rd.to_reg()) << 7;
+    bits |= unsigned_field_width(op.funct4(), 5) << 12;
+    bits.try_into().unwrap()
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -1980,8 +1980,8 @@ impl MachInstLabelUse for LabelUse {
 
     /// Perform the patch.
     fn patch(self, buffer: &mut [u8], use_offset: CodeOffset, label_offset: CodeOffset) {
-        assert!(use_offset % 4 == 0);
-        assert!(label_offset % 4 == 0);
+        assert!(use_offset % 2 == 0);
+        assert!(label_offset % 2 == 0);
         let offset = (label_offset as i64) - (use_offset as i64);
 
         // re-check range

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -965,7 +965,7 @@ impl MachInst for Inst {
 
     fn function_alignment() -> FunctionAlignment {
         FunctionAlignment {
-            minimum: 4,
+            minimum: 2,
             preferred: 4,
         }
     }

--- a/cranelift/codegen/src/isa/riscv64/inst/unwind/systemv.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/unwind/systemv.rs
@@ -16,7 +16,7 @@ pub fn create_cie() -> CommonInformationEntry {
             format: Format::Dwarf32,
             version: 1,
         },
-        4,  // Code alignment factor
+        2,  // Code alignment factor
         -8, // Data alignment factor
         Register(regs::link_reg().to_real_reg().unwrap().hw_enc() as u16),
     );

--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -235,6 +235,7 @@ impl VecOpCategory {
     }
 }
 
+impl Copy for VecOpMasking {}
 impl VecOpMasking {
     pub fn is_enabled(&self) -> bool {
         match self {

--- a/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
@@ -1,5 +1,5 @@
 test compile precise-output
-target riscv64gc has_v has_c has_zbkb has_zba has_zbb has_zbc has_zbs
+target riscv64gc has_v has_zbkb has_zba has_zbb has_zbc has_zbs
 
 
 function %a(i16 sext, f32, f64x2, i32 sext, i8 sext, i64x2, i8, f32x4, i16x8, i8 sext, i8 sext) -> f64x2, i16x8, i8, f64x2, i16x8, i16x8, i16x8, i16x8 {

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -1,0 +1,20 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_zca
+
+function %c_add(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = iadd.i64 v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   add a0,a0,a1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.add a0, a1
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -18,3 +18,36 @@ block0(v0: i64, v1: i64):
 ;   c.add a0, a1
 ;   ret
 
+
+function %c_mv(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  return v1
+}
+
+; VCode:
+; block0:
+;   mv a0,a1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.mv a0, a1
+;   ret
+
+
+function %c_mv_ori(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = bor_imm.i64 v1, 0
+  return v2
+}
+
+; VCode:
+; block0:
+;   ori a0,a1,0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.mv a0, a1
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/arithmetic-extends.clif
+++ b/cranelift/filetests/filetests/runtests/arithmetic-extends.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target riscv64
 target riscv64 has_zba
+target riscv64 has_c has_zcb
 
 ;; Various runtests intended to target the instructions encoded by the RISC-V `Zba` Extension
 ;; Although other targets may also benefit from these tests and may implement similar optimizations

--- a/cranelift/filetests/filetests/runtests/arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/arithmetic.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64 has_m
+target riscv64 has_c has_zcb
 
 function %add_i64(i64, i64) -> i64 {
 block0(v0: i64,v1: i64):

--- a/cranelift/filetests/filetests/runtests/atomic-cas-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-cas-little.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target s390x
 target riscv64 has_a
+target riscv64 has_c has_zcb
 
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly

--- a/cranelift/filetests/filetests/runtests/atomic-cas-subword-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-cas-subword-little.clif
@@ -5,6 +5,7 @@ target aarch64
 target aarch64 has_lse
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly

--- a/cranelift/filetests/filetests/runtests/atomic-cas.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-cas.clif
@@ -4,6 +4,7 @@ target aarch64 has_lse
 target x86_64
 target s390x
 target riscv64 has_a
+target riscv64 has_c has_zcb
 
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly

--- a/cranelift/filetests/filetests/runtests/atomic-load-store.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-load-store.clif
@@ -3,6 +3,7 @@ test run
 target x86_64
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %i64_atomic_store_load(i64) -> i64 {

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-little.clif
@@ -6,6 +6,7 @@ target aarch64
 target aarch64 has_lse
 target x86_64
 target riscv64 has_a
+target riscv64 has_c has_zcb
 
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly

--- a/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
+++ b/cranelift/filetests/filetests/runtests/atomic-rmw-subword-little.clif
@@ -6,6 +6,7 @@ target aarch64
 target aarch64 has_lse
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 ; We can't test that these instructions are right regarding atomicity, but we can
 ; test if they perform their operation correctly

--- a/cranelift/filetests/filetests/runtests/bb-padding.clif
+++ b/cranelift/filetests/filetests/runtests/bb-padding.clif
@@ -5,6 +5,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %ret_big_number() -> i64x2 {
 block0:

--- a/cranelift/filetests/filetests/runtests/bitcast-ref64.clif
+++ b/cranelift/filetests/filetests/runtests/bitcast-ref64.clif
@@ -3,6 +3,7 @@ target aarch64
 target x86_64
 target s390x
 target riscv64gc
+target riscv64 has_c has_zcb
 ; the interpreter does not support bitcasting to/from references
 
 function %bitcast_ir64(i64) -> i8 {

--- a/cranelift/filetests/filetests/runtests/bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/bitcast.clif
@@ -4,6 +4,8 @@ target aarch64
 target x86_64
 target x86_64 has_avx
 target s390x
+target riscv64
+target riscv64 has_c has_zcb
 
 function %bitcast_if32(i32) -> f32 {
 block0(v0: i32):

--- a/cranelift/filetests/filetests/runtests/bitops.clif
+++ b/cranelift/filetests/filetests/runtests/bitops.clif
@@ -3,6 +3,7 @@ set opt_level=none
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 target s390x has_mie2
 target x86_64
 
@@ -10,6 +11,7 @@ set opt_level=speed
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 target s390x has_mie2
 target x86_64
 

--- a/cranelift/filetests/filetests/runtests/bitrev.clif
+++ b/cranelift/filetests/filetests/runtests/bitrev.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %bitrev_i8(i8) -> i8 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/runtests/bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/bitselect.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target s390x has_mie2
 target riscv64
+target riscv64 has_c has_zcb
 target x86_64
 
 set opt_level=speed

--- a/cranelift/filetests/filetests/runtests/bmask.clif
+++ b/cranelift/filetests/filetests/runtests/bmask.clif
@@ -4,6 +4,7 @@ target x86_64
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %bmask_i64_i64(i64) -> i64 {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/runtests/bnot.clif
+++ b/cranelift/filetests/filetests/runtests/bnot.clif
@@ -4,6 +4,8 @@ target x86_64
 target x86_64 has_bmi1
 target aarch64
 target s390x
+target riscv64
+target riscv64 has_c has_zcb
 
 function %bnot_i8(i8) -> i8 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/runtests/br.clif
+++ b/cranelift/filetests/filetests/runtests/br.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %jump() -> i8 {
 block0:

--- a/cranelift/filetests/filetests/runtests/br_table.clif
+++ b/cranelift/filetests/filetests/runtests/br_table.clif
@@ -5,6 +5,7 @@ target aarch64 use_bti
 target x86_64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %br_table_i32(i32) -> i32 {
 block0(v0: i32):

--- a/cranelift/filetests/filetests/runtests/brif.clif
+++ b/cranelift/filetests/filetests/runtests/brif.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %brif_value(i8) -> i64 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/runtests/bswap.clif
+++ b/cranelift/filetests/filetests/runtests/bswap.clif
@@ -5,6 +5,7 @@ target aarch64
 target s390x
 target riscv64
 target riscv64 has_zbb
+target riscv64 has_c has_zcb
 
 function %bswap_i16(i16) -> i16 {
 block0(v0: i16):

--- a/cranelift/filetests/filetests/runtests/call.clif
+++ b/cranelift/filetests/filetests/runtests/call.clif
@@ -6,6 +6,7 @@ target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 
 function %callee_i64(i64) -> i64 {

--- a/cranelift/filetests/filetests/runtests/call_indirect.clif
+++ b/cranelift/filetests/filetests/runtests/call_indirect.clif
@@ -5,7 +5,8 @@ target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target s390x
-target riscv64gc
+target riscv64
+target riscv64 has_c has_zcb
 
 
 function %callee_indirect(i64) -> i64 {

--- a/cranelift/filetests/filetests/runtests/call_libcall.clif
+++ b/cranelift/filetests/filetests/runtests/call_libcall.clif
@@ -3,6 +3,7 @@ target x86_64
 ; AArch64 Does not have these libcalls
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 
 function %libcall_ceilf32(f32) -> f32 {

--- a/cranelift/filetests/filetests/runtests/ceil.clif
+++ b/cranelift/filetests/filetests/runtests/ceil.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %ceil_f32(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/runtests/cls.clif
+++ b/cranelift/filetests/filetests/runtests/cls.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target riscv64
 target riscv64 has_zbb
+target riscv64 has_c has_zcb
 target s390x
 ; not implemented on `x86_64`
 

--- a/cranelift/filetests/filetests/runtests/clz.clif
+++ b/cranelift/filetests/filetests/runtests/clz.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 has_lzcnt
 target riscv64
 target riscv64 has_zbb
+target riscv64 has_c has_zcb
 
 function %clz_i8(i8) -> i8 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/runtests/const.clif
+++ b/cranelift/filetests/filetests/runtests/const.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %i8_iconst_0() -> i8 {
 block0:

--- a/cranelift/filetests/filetests/runtests/conversion.clif
+++ b/cranelift/filetests/filetests/runtests/conversion.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target x86_64 has_avx
+target riscv64 has_c has_zcb
 target riscv64
 
 function %fcvt_to_sint(f32) -> i32 {

--- a/cranelift/filetests/filetests/runtests/ctz.clif
+++ b/cranelift/filetests/filetests/runtests/ctz.clif
@@ -7,6 +7,7 @@ target x86_64 has_bmi1
 target riscv64
 target riscv64 has_zbb
 target riscv64 has_zbb has_zbs
+target riscv64 has_c has_zcb
 
 function %ctz_i8(i8) -> i8 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/runtests/div-checks.clif
+++ b/cranelift/filetests/filetests/runtests/div-checks.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):

--- a/cranelift/filetests/filetests/runtests/extend.clif
+++ b/cranelift/filetests/filetests/runtests/extend.clif
@@ -7,6 +7,7 @@ target riscv64
 target riscv64 has_zba
 target riscv64 has_zbb
 target riscv64 has_zbkb
+target riscv64 has_c has_zcb
 
 ;;;; basic uextend
 

--- a/cranelift/filetests/filetests/runtests/fabs.clif
+++ b/cranelift/filetests/filetests/runtests/fabs.clif
@@ -5,6 +5,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fabs_f32(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/runtests/fadd.clif
+++ b/cranelift/filetests/filetests/runtests/fadd.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fadd_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-eq.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_eq_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ge.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ge.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_ge_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-gt.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-gt.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_gt_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-le.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-le.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_le_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-lt.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-lt.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_lt_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ne.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_ne_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-one.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-one.clif
@@ -4,6 +4,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_one_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ord.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ord.clif
@@ -4,6 +4,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_ord_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ueq.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ueq.clif
@@ -4,6 +4,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_ueq_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-uge.clif
@@ -4,6 +4,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_uge_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ugt.clif
@@ -4,6 +4,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_ugt_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ule.clif
@@ -4,6 +4,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_ule_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-ult.clif
@@ -4,6 +4,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcmp_ult_f32(f32, f32) -> i8 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fcmp-uno.clif
+++ b/cranelift/filetests/filetests/runtests/fcmp-uno.clif
@@ -4,6 +4,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 
 function %fcmp_uno_f32(f32, f32) -> i8 {

--- a/cranelift/filetests/filetests/runtests/fcopysign.clif
+++ b/cranelift/filetests/filetests/runtests/fcopysign.clif
@@ -5,6 +5,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fcopysign_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fdiv.clif
+++ b/cranelift/filetests/filetests/runtests/fdiv.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fdiv_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fence.clif
+++ b/cranelift/filetests/filetests/runtests/fence.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 ; Check that the fence instruction doesn't crash. Testing anything else would
 ; require multiple threads, which requires a runtime like Wasmtime.

--- a/cranelift/filetests/filetests/runtests/fibonacci.clif
+++ b/cranelift/filetests/filetests/runtests/fibonacci.clif
@@ -5,6 +5,8 @@ target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target s390x
+target riscv64
+target riscv64 has_c has_zcb
 
 ; A non-recursive fibonacci implementation.
 function %fibonacci(i32) -> i32 {

--- a/cranelift/filetests/filetests/runtests/float-bitops.clif
+++ b/cranelift/filetests/filetests/runtests/float-bitops.clif
@@ -2,6 +2,8 @@ test interpret
 test run
 target x86_64
 target x86_64 has_avx
+target riscv64
+target riscv64 has_c has_zcb
 
 function %bnot_f32(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/runtests/floor.clif
+++ b/cranelift/filetests/filetests/runtests/floor.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %floor_f32(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/runtests/fma.clif
+++ b/cranelift/filetests/filetests/runtests/fma.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64 has_avx has_fma
 target x86_64 has_avx=false has_fma=false
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fma_f32(f32, f32, f32) -> f32 {
 block0(v0: f32, v1: f32, v2: f32):

--- a/cranelift/filetests/filetests/runtests/fmax-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/fmax-pseudo.clif
@@ -4,6 +4,7 @@ target x86_64
 target x86_64 has_avx
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 ; target s390x FIXME: This currently fails under qemu due to a qemu bug
 
 function %fmax_p_f32(f32, f32) -> f32 {

--- a/cranelift/filetests/filetests/runtests/fmax.clif
+++ b/cranelift/filetests/filetests/runtests/fmax.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fmax_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fmin-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/fmin-pseudo.clif
@@ -4,6 +4,7 @@ target x86_64
 target x86_64 has_avx
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 ; target s390x FIXME: This currently fails under qemu due to a qemu bug
 
 function %fmin_p_f32(f32, f32) -> f32 {

--- a/cranelift/filetests/filetests/runtests/fmin.clif
+++ b/cranelift/filetests/filetests/runtests/fmin.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fmin_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fmul.clif
+++ b/cranelift/filetests/filetests/runtests/fmul.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fmul_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fneg.clif
+++ b/cranelift/filetests/filetests/runtests/fneg.clif
@@ -5,6 +5,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fneg_f32(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/runtests/fpromote.clif
+++ b/cranelift/filetests/filetests/runtests/fpromote.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target s390x
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 
 
 function %fpromote(f32) -> f64 {

--- a/cranelift/filetests/filetests/runtests/fsub.clif
+++ b/cranelift/filetests/filetests/runtests/fsub.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %fsub_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/global_value.clif
+++ b/cranelift/filetests/filetests/runtests/global_value.clif
@@ -4,6 +4,7 @@ target x86_64
 target s390x
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 
 
 

--- a/cranelift/filetests/filetests/runtests/i128-arithmetic-extends.clif
+++ b/cranelift/filetests/filetests/runtests/i128-arithmetic-extends.clif
@@ -6,6 +6,7 @@ target s390x
 target x86_64
 target riscv64
 target riscv64 has_zba
+target riscv64 has_c has_zcb
 
 function %sext_sshr_i32_i128(i32, i128) -> i64 {
 block0(v0: i32, v1: i128):

--- a/cranelift/filetests/filetests/runtests/i128-arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/i128-arithmetic.clif
@@ -5,6 +5,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %add_i128(i128, i128) -> i128 {
 block0(v0: i128,v1: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bandnot.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bandnot.clif
@@ -2,6 +2,7 @@ test run
 target aarch64
 target riscv64
 target s390x
+target riscv64 has_c has_zcb
 
 function %band_not_i128(i128, i128) -> i128 {
 block0(v0: i128, v1: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bitops-count.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitops-count.clif
@@ -6,6 +6,7 @@ target x86_64
 target riscv64
 target riscv64 has_zbb
 target riscv64 has_zbb has_zbs
+target riscv64 has_c has_zcb
 
 function %ctz_i128(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bitops.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitops.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 
 function %bnot_i128(i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-bitrev.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bitrev.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %reverse_bits_zero() -> i8 {
 block0:

--- a/cranelift/filetests/filetests/runtests/i128-bmask.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bmask.clif
@@ -4,6 +4,7 @@ set enable_llvm_abi_extensions
 target x86_64
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %bmask_i128_i128(i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-bnot.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bnot.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
 target s390x
+target riscv64
+target riscv64 has_c has_zcb
 
 function %bnot_i128(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bornot.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bornot.clif
@@ -1,6 +1,7 @@
 test run
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %bor_not_i128(i128, i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-br.clif
+++ b/cranelift/filetests/filetests/runtests/i128-br.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %i128_brif_false(i128) -> i8 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bswap.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bswap.clif
@@ -6,6 +6,7 @@ target aarch64
 target s390x
 target riscv64
 target riscv64 has_zbb
+target riscv64 has_c has_zcb
 
 function %bswap_i128(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-bxornot.clif
+++ b/cranelift/filetests/filetests/runtests/i128-bxornot.clif
@@ -1,6 +1,7 @@
 test run
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %bxor_not_i128(i128, i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-call.clif
+++ b/cranelift/filetests/filetests/runtests/i128-call.clif
@@ -6,6 +6,8 @@ target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target s390x
+target riscv64
+target riscv64 has_c has_zcb
 
 
 function %callee_i128(i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-cls.clif
+++ b/cranelift/filetests/filetests/runtests/i128-cls.clif
@@ -2,6 +2,7 @@ test run
 target aarch64
 target riscv64
 target riscv64 has_zbb
+target riscv64 has_c has_zcb
 target s390x
 
 function %cls_i128(i128) -> i128 {

--- a/cranelift/filetests/filetests/runtests/i128-concat-split.clif
+++ b/cranelift/filetests/filetests/runtests/i128-concat-split.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %iconcat_isplit(i64, i64) -> i64, i64 {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/runtests/i128-extend.clif
+++ b/cranelift/filetests/filetests/runtests/i128-extend.clif
@@ -8,6 +8,7 @@ target riscv64
 target riscv64 has_zba
 target riscv64 has_zbb
 target riscv64 has_zbkb
+target riscv64 has_c has_zcb
 
 function %i128_uextend_i64(i64) -> i128 {
 block0(v0: i64):

--- a/cranelift/filetests/filetests/runtests/i128-icmp.clif
+++ b/cranelift/filetests/filetests/runtests/i128-icmp.clif
@@ -5,6 +5,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %icmp_eq_i128(i128, i128) -> i8 {
 block0(v0: i128, v1: i128):

--- a/cranelift/filetests/filetests/runtests/i128-ineg.clif
+++ b/cranelift/filetests/filetests/runtests/i128-ineg.clif
@@ -5,6 +5,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %ineg_i128(i128) -> i128 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-ireduce.clif
+++ b/cranelift/filetests/filetests/runtests/i128-ireduce.clif
@@ -5,6 +5,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %ireduce_128_64(i128) -> i64 {
 block0(v0: i128):

--- a/cranelift/filetests/filetests/runtests/i128-load-store.clif
+++ b/cranelift/filetests/filetests/runtests/i128-load-store.clif
@@ -5,6 +5,7 @@ set enable_probestack=false
 target x86_64
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %i128_stack_store_load(i128) -> i8 {

--- a/cranelift/filetests/filetests/runtests/i128-min-max.clif
+++ b/cranelift/filetests/filetests/runtests/i128-min-max.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 

--- a/cranelift/filetests/filetests/runtests/i128-rotate.clif
+++ b/cranelift/filetests/filetests/runtests/i128-rotate.clif
@@ -5,6 +5,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %rotl(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):

--- a/cranelift/filetests/filetests/runtests/i128-select-float.clif
+++ b/cranelift/filetests/filetests/runtests/i128-select-float.clif
@@ -5,6 +5,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %select_icmp_i128_f32(i128, f32, f32) -> f32 {
 block0(v0: i128, v1: f32, v2: f32):

--- a/cranelift/filetests/filetests/runtests/i128-select.clif
+++ b/cranelift/filetests/filetests/runtests/i128-select.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %i128_select(i8, i128, i128) -> i128 {
 block0(v0: i8, v1: i128, v2: i128):

--- a/cranelift/filetests/filetests/runtests/i128-shifts.clif
+++ b/cranelift/filetests/filetests/runtests/i128-shifts.clif
@@ -5,6 +5,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %ishl_i128_i128(i128, i8) -> i128 {
 block0(v0: i128, v1: i8):

--- a/cranelift/filetests/filetests/runtests/iabs.clif
+++ b/cranelift/filetests/filetests/runtests/iabs.clif
@@ -2,8 +2,9 @@ test interpret
 test run
 target aarch64
 target s390x
-target riscv64 has_zbb=false
-target riscv64 has_zbb=true
+target riscv64
+target riscv64 has_zbb
+target riscv64 has_c has_zcb
 target x86_64
 
 function %iabs_i8(i8) -> i8 {

--- a/cranelift/filetests/filetests/runtests/icmp-eq-imm.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-eq-imm.clif
@@ -4,6 +4,7 @@ target aarch64
 target x86_64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %icmp_imm_eq_i8(i8) -> i8 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/runtests/icmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-eq.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %icmp_eq_i8(i8, i8) -> i8 {

--- a/cranelift/filetests/filetests/runtests/icmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ne.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %icmp_ne_i8(i8, i8) -> i8 {

--- a/cranelift/filetests/filetests/runtests/icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sge.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 

--- a/cranelift/filetests/filetests/runtests/icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sgt.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 

--- a/cranelift/filetests/filetests/runtests/icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-sle.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 

--- a/cranelift/filetests/filetests/runtests/icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-slt.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %icmp_slt_i8(i8, i8) -> i8 {

--- a/cranelift/filetests/filetests/runtests/icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-uge.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %icmp_uge_i8(i8, i8) -> i8 {

--- a/cranelift/filetests/filetests/runtests/icmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ugt.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %icmp_ugt_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):

--- a/cranelift/filetests/filetests/runtests/icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ule.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %icmp_ule_i8(i8, i8) -> i8 {

--- a/cranelift/filetests/filetests/runtests/icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-ult.clif
@@ -3,6 +3,8 @@ test run
 target aarch64
 target x86_64
 target s390x
+target riscv64
+target riscv64 has_c has_zcb
 
 function %icmp_ult_i8(i8, i8) -> i8 {
 block0(v0: i8, v1: i8):

--- a/cranelift/filetests/filetests/runtests/icmp.clif
+++ b/cranelift/filetests/filetests/runtests/icmp.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 ; This test is also a regression test for aarch64.
 ; We were not correctly handling the fact that the rhs constant value

--- a/cranelift/filetests/filetests/runtests/ineg.clif
+++ b/cranelift/filetests/filetests/runtests/ineg.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %ineg_i8(i8) -> i8 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/runtests/inline-probestack.clif
+++ b/cranelift/filetests/filetests/runtests/inline-probestack.clif
@@ -7,10 +7,15 @@ set probestack_strategy=inline
 set probestack_size_log2=12
 target x86_64
 target aarch64
+target riscv64
+target riscv64 has_c has_zcb
+
 ; Test also with 64k pages
 set probestack_size_log2=16
 target x86_64
 target aarch64
+target riscv64
+target riscv64 has_c has_zcb
 
 ; Create a huge stack slot (1MB), way larger than PAGE_SIZE and touch the end of it.
 ; This guarantees that we bypass the guard page, cause a page fault the OS isn't expecting

--- a/cranelift/filetests/filetests/runtests/integer-minmax.clif
+++ b/cranelift/filetests/filetests/runtests/integer-minmax.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 
 ; sort three signed i8s with smin and smax only

--- a/cranelift/filetests/filetests/runtests/ireduce.clif
+++ b/cranelift/filetests/filetests/runtests/ireduce.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %ireduce_i16_i8(i16) -> i8 {
 block0(v0: i16):

--- a/cranelift/filetests/filetests/runtests/issue-5498.clif
+++ b/cranelift/filetests/filetests/runtests/issue-5498.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(i16, i8) -> i16 {
 block0(v0: i16, v1: i8):

--- a/cranelift/filetests/filetests/runtests/issue-5690.clif
+++ b/cranelift/filetests/filetests/runtests/issue-5690.clif
@@ -8,6 +8,8 @@ set machine_code_cfg_info=true
 set enable_table_access_spectre_mitigation=false
 target aarch64
 target x86_64
+target riscv64
+target riscv64 has_c has_zcb
 
 function %u1() -> i64 sext, f64, i8, i8 sext, i8 sext system_v {
 block0:

--- a/cranelift/filetests/filetests/runtests/issue-6581.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6581.clif
@@ -8,6 +8,7 @@ target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target riscv64
+target riscv64 has_c has_zcb
 
 function %b(f64, i128, i128, i128, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8) -> i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 tail {
 block0(v0: f64, v1: i128, v2: i128, v3: i128, v4: i8, v5: i8, v6: i8, v7: i8, v8: i8, v9: i8, v10: i8, v11: i8, v12: i8, v13: i8, v14: i8, v15: i8):

--- a/cranelift/filetests/filetests/runtests/issue-6582.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6582.clif
@@ -5,6 +5,7 @@ target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(i8, i8, i8, i8, i8, i8, i8, i8) -> i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 tail {
 block0(v0: i8, v1: i8, v2: i8, v3: i8, v4: i8, v5: i8, v6: i8, v7: i8):

--- a/cranelift/filetests/filetests/runtests/issue-6635.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6635.clif
@@ -1,6 +1,8 @@
 test run
 set preserve_frame_pointers=true
 target x86_64
+target riscv64
+target riscv64 has_c has_zcb
 
 function %b(i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8) -> i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8, i8 tail {
 block0(v0: i8, v1: i8, v2: i8, v3: i8, v4: i8, v5: i8, v6: i8, v7: i8, v8: i8, v9: i8, v10: i8, v11: i8, v12: i8, v13: i8, v14: i8, v15: i8):

--- a/cranelift/filetests/filetests/runtests/issue-6640.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6640.clif
@@ -6,7 +6,8 @@ set probestack_strategy=inline
 set enable_probestack=true
 target x86_64
 target aarch64
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %a(i8, i8, i8, i8, i8, i8, i8, i8, i128) -> i128 tail {
     ss0 = explicit_slot 321

--- a/cranelift/filetests/filetests/runtests/issue-6859.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6859.clif
@@ -6,6 +6,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(f32, f32) -> f32 fast {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/issue-6916.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6916.clif
@@ -6,6 +6,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_band(f32, f32) -> f32x4 fast {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/issue-6954.clif
+++ b/cranelift/filetests/filetests/runtests/issue-6954.clif
@@ -1,6 +1,6 @@
 test interpret
 test run
-target riscv64gc has_v has_c has_zbkb has_zba has_zbb has_zbc has_zbs
+target riscv64 has_v has_c has_zbkb has_zba has_zbb has_zbc has_zbs
 target aarch64
 target s390x
 target x86_64

--- a/cranelift/filetests/filetests/runtests/issue5497.clif
+++ b/cranelift/filetests/filetests/runtests/issue5497.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(i16, i128) -> i128 system_v {
 block0(v0: i16, v1: i128):

--- a/cranelift/filetests/filetests/runtests/issue5523.clif
+++ b/cranelift/filetests/filetests/runtests/issue5523.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 set enable_llvm_abi_extensions=true
 target riscv64
+target riscv64 has_c has_zcb
 target aarch64
 target s390x
 target x86_64

--- a/cranelift/filetests/filetests/runtests/issue5524.clif
+++ b/cranelift/filetests/filetests/runtests/issue5524.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(i128, i8, i8, i8, i32, i32, i8, i8, i64, i8) -> i8, i8, i8, i128 system_v {
 block0(v0: i128, v1: i8, v2: i8, v3: i8, v4: i32, v5: i32, v6: i8, v7: i8, v8: i64, v9: i8):

--- a/cranelift/filetests/filetests/runtests/issue5525.clif
+++ b/cranelift/filetests/filetests/runtests/issue5525.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(i16) -> i128 system_v {
 block0(v0: i16):

--- a/cranelift/filetests/filetests/runtests/issue5526.clif
+++ b/cranelift/filetests/filetests/runtests/issue5526.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(i128, i8, i8, i8, i16, i32, i8, i8, i64, i8) -> i8, i8, i8, i128, i8, i8, i64, i128, i8 system_v {
     ss0 = explicit_slot 90

--- a/cranelift/filetests/filetests/runtests/issue5528.clif
+++ b/cranelift/filetests/filetests/runtests/issue5528.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(f32) -> i8 system_v {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/runtests/issue5569.clif
+++ b/cranelift/filetests/filetests/runtests/issue5569.clif
@@ -1,5 +1,6 @@
 test run
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(i16, f64, i32, i64, i16, i128, f32) -> i16 {
     ss0 = explicit_slot 24

--- a/cranelift/filetests/filetests/runtests/issue5714.clif
+++ b/cranelift/filetests/filetests/runtests/issue5714.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(i32 sext, f64, f32, i64 uext) -> f32, i8, i8 system_v {
 block0(v0: i32, v1: f64, v2: f32, v3: i64):

--- a/cranelift/filetests/filetests/runtests/issue5839.clif
+++ b/cranelift/filetests/filetests/runtests/issue5839.clif
@@ -5,6 +5,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(i8, i8) -> i32 {
 block0(v0: i8, v1: i8):

--- a/cranelift/filetests/filetests/runtests/issue5884.clif
+++ b/cranelift/filetests/filetests/runtests/issue5884.clif
@@ -2,6 +2,7 @@ test run
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 

--- a/cranelift/filetests/filetests/runtests/issue5901.clif
+++ b/cranelift/filetests/filetests/runtests/issue5901.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(i8) -> i8 sext system_v {
     ss2 = explicit_slot 2

--- a/cranelift/filetests/filetests/runtests/issue5952.clif
+++ b/cranelift/filetests/filetests/runtests/issue5952.clif
@@ -4,6 +4,7 @@ target aarch64
 target x86_64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %a(i16 uext) -> f32 {
 block0(v0: i16):

--- a/cranelift/filetests/filetests/runtests/nearest.clif
+++ b/cranelift/filetests/filetests/runtests/nearest.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %nearest_f32(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/runtests/or-and-y-with-not-y.clif
+++ b/cranelift/filetests/filetests/runtests/or-and-y-with-not-y.clif
@@ -5,6 +5,7 @@ test run
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %or_and_y_with_not_y(i8, i8) -> i8 {

--- a/cranelift/filetests/filetests/runtests/popcnt.clif
+++ b/cranelift/filetests/filetests/runtests/popcnt.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 has_popcnt
 target riscv64
+target riscv64 has_c has_zcb
 
 function %popcnt_i8(i8) -> i8 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/runtests/ref64-invalid-null.clif
+++ b/cranelift/filetests/filetests/runtests/ref64-invalid-null.clif
@@ -3,7 +3,8 @@ test run
 target aarch64
 target x86_64
 target s390x
-target riscv64gc
+target riscv64
+target riscv64 has_c has_zcb
 
 function %is_null_true_r64() -> i8 {
 block0:

--- a/cranelift/filetests/filetests/runtests/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/runtests/return-call-indirect.clif
@@ -8,6 +8,7 @@ target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target riscv64
+target riscv64 has_c has_zcb
 ;; target s390x
 
 ;;;; Test passing `i64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/filetests/filetests/runtests/return-call-loop.clif
+++ b/cranelift/filetests/filetests/runtests/return-call-loop.clif
@@ -5,6 +5,7 @@ target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target riscv64
+target riscv64 has_c has_zcb
 ;; target s390x
 
 ;;;; Tail-Recursive Loop ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/filetests/filetests/runtests/return-call.clif
+++ b/cranelift/filetests/filetests/runtests/return-call.clif
@@ -8,6 +8,7 @@ target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target riscv64
+target riscv64 has_c has_zcb
 ;; target s390x
 
 ;;;; Test passing `i64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/filetests/filetests/runtests/riscv64_issue_4996.clif
+++ b/cranelift/filetests/filetests/runtests/riscv64_issue_4996.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 set enable_llvm_abi_extensions=true
 target riscv64
+target riscv64 has_c has_zcb
 
 ; This is a regression test for https://github.com/bytecodealliance/wasmtime/issues/4996.
 function %issue4996() -> i128, i64 system_v {

--- a/cranelift/filetests/filetests/runtests/rotl.clif
+++ b/cranelift/filetests/filetests/runtests/rotl.clif
@@ -4,6 +4,7 @@ target aarch64
 target x86_64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %rotl_i64_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/runtests/rotr.clif
+++ b/cranelift/filetests/filetests/runtests/rotr.clif
@@ -4,6 +4,7 @@ target aarch64
 target x86_64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 
 function %rotr_i64_i64(i64, i64) -> i64 {

--- a/cranelift/filetests/filetests/runtests/select-float.clif
+++ b/cranelift/filetests/filetests/runtests/select-float.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %select_icmp_i8_f32(i8, f32, f32) -> f32 {
 block0(v0: i8, v1: f32, v2: f32):

--- a/cranelift/filetests/filetests/runtests/select.clif
+++ b/cranelift/filetests/filetests/runtests/select.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %select_eq_f32(f32, f32) -> i32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/selectif-spectre-guard.clif
+++ b/cranelift/filetests/filetests/runtests/selectif-spectre-guard.clif
@@ -5,6 +5,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %select_spectre_guard_i8_eq(i8, i8, i8) -> i8 {
 block0(v0: i8, v1: i8, v2: i8):

--- a/cranelift/filetests/filetests/runtests/shift-right-left.clif
+++ b/cranelift/filetests/filetests/runtests/shift-right-left.clif
@@ -5,6 +5,7 @@ test run
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 function %unsigned_shift_right_shift_left_i8(i8) -> i8 {

--- a/cranelift/filetests/filetests/runtests/shifts.clif
+++ b/cranelift/filetests/filetests/runtests/shifts.clif
@@ -4,6 +4,7 @@ target aarch64
 target x86_64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %ishl_i64_i64(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):

--- a/cranelift/filetests/filetests/runtests/simd-arithmetic.clif
+++ b/cranelift/filetests/filetests/runtests/simd-arithmetic.clif
@@ -6,6 +6,8 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %sadd_sat_i8x16(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-avg-round-small.clif
+++ b/cranelift/filetests/filetests/runtests/simd-avg-round-small.clif
@@ -2,6 +2,7 @@
 test run
 target aarch64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 ; x86_64 and s390x do not currently support 64-bit vectors, or
 ; `avg_round` on `i64x2` values.
 ; x86_64 also does not currently support `avg_round.i32x4`.

--- a/cranelift/filetests/filetests/runtests/simd-avg-round.clif
+++ b/cranelift/filetests/filetests/runtests/simd-avg-round.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64
 target x86_64 skylake
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %average_rounding_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-band-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-band-splat.clif
@@ -7,6 +7,7 @@ target x86_64 ssse3
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %band_splat_const_i8x16(i8x16) -> i8x16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-band.clif
+++ b/cranelift/filetests/filetests/runtests/simd-band.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %band_i8x16(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-bitcast-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitcast-aarch64.clif
@@ -1,7 +1,8 @@
 test interpret
 test run
 target aarch64
-;; 64-bit vector types only supported on aarch64
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %bitcast_if32x2(i32x2) -> f32x2 {
 block0(v0: i32x2):

--- a/cranelift/filetests/filetests/runtests/simd-bitcast.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitcast.clif
@@ -4,6 +4,8 @@ target aarch64
 target x86_64
 target x86_64 has_avx
 target s390x
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %bitcast_if32x4(i32x4) -> f32x4 {
 block0(v0: i32x4):

--- a/cranelift/filetests/filetests/runtests/simd-bitselect-to-vselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitselect-to-vselect.clif
@@ -4,6 +4,8 @@ target s390x
 set opt_level=speed_and_size
 target x86_64
 target x86_64 skylake
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %mask_from_icmp(i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4):

--- a/cranelift/filetests/filetests/runtests/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bitselect.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 set opt_level=speed
 target aarch64
@@ -11,6 +12,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %bitselect_i64x2(i64x2, i64x2, i64x2) -> i64x2 {
 block0(v0: i64x2, v1: i64x2, v2: i64x2):

--- a/cranelift/filetests/filetests/runtests/simd-bnot.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bnot.clif
@@ -7,6 +7,7 @@ target x86_64 ssse3
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %bnot_i8x16(i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-bor-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bor-splat.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %bor_splat_const_i8x16(i8x16) -> i8x16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-bor.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bor.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %bor_i8x16(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-bxor-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bxor-splat.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %bxor_splat_const_i8x16(i8x16) -> i8x16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-bxor.clif
+++ b/cranelift/filetests/filetests/runtests/simd-bxor.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %bxor_i8x16(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-ceil.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ceil.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %ceil_f32x4(f32x4) -> f32x4 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-extractlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-extractlane.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %extractlane_4(i8x16) -> i8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-fabs.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fabs.clif
@@ -3,6 +3,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fabs_f32x4(f32x4) -> f32x4 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd-splat.clif
@@ -6,6 +6,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %splat_f32x4_2(f32x4) -> f32x4 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fadd.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fadd.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %fadd_f32x4(f32x4, f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-eq.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_eq_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ge.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_ge_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-gt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-gt.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_gt_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-le.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-le.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_le_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-lt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-lt.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_lt_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ne.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_ne_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-one.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-one.clif
@@ -1,6 +1,7 @@
 test run
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_one_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ord.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ord.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_ord_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ueq.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ueq.clif
@@ -1,6 +1,7 @@
 test run
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_ueq_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-uge.clif
@@ -3,6 +3,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_uge_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ugt.clif
@@ -3,6 +3,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_ugt_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ule.clif
@@ -3,6 +3,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_ule_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-ult.clif
@@ -3,6 +3,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_ult_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcmp-uno.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcmp-uno.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_fcmp_uno_f32(f32x4, f32x4) -> i32x4 {
 block0(v0: f32x4, v1: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcopysign-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcopysign-64bit.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 ; x86_64 and s390x do not support 64-bit vectors in `fcopysign`.
 
 function %fcopysign_f32x2(f32x2, f32x2) -> f32x2 {

--- a/cranelift/filetests/filetests/runtests/simd-fcopysign.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcopysign.clif
@@ -3,6 +3,7 @@ test run
 target s390x
 target aarch64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 ; x86_64 does not support SIMD fcopysign.
 
 function %fcopysign_f32x4(f32x4, f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-fcvt-from-sint.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcvt-from-sint.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fcvt_from_sint(i32x4) -> f32x4 {
 block0(v0: i32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcvt-from-uint.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcvt-from-uint.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fcvt_from_uint(i32x4) -> f32x4 {
 block0(v0: i32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcvt-to-sint-sat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcvt-to-sint-sat.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fcvt_to_sint_sat(f32x4) -> i32x4 {
 block0(v0:f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fcvt-to-uint-sat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcvt-to-uint-sat.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fcvt_to_uint_sat(f32x4) -> i32x4 {
 block0(v0:f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fdiv.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fdiv.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %fdiv_f32x4(f32x4, f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-floor.clif
+++ b/cranelift/filetests/filetests/runtests/simd-floor.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %floor_f32x4(f32x4) -> f32x4 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fma-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fma-64bit.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 ; x86_64 panics: `not implemented: unable to move type: f32x2`
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fma_f32x2(f32x2, f32x2, f32x2) -> f32x2 {
 block0(v0: f32x2, v1: f32x2, v2: f32x2):

--- a/cranelift/filetests/filetests/runtests/simd-fma-neg.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fma-neg.clif
@@ -3,6 +3,7 @@ target x86_64 has_avx has_fma
 target x86_64 has_avx=false has_fma=false
 target aarch64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 ;; This file is not enabled in the interpreter since SIMD fneg is currently broken
 ;; there.

--- a/cranelift/filetests/filetests/runtests/simd-fma.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fma.clif
@@ -4,6 +4,7 @@ target x86_64 has_avx has_fma
 target x86_64 has_avx=false has_fma=false
 target aarch64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fma_f32x4(f32x4, f32x4, f32x4) -> f32x4 {
 block0(v0: f32x4, v1: f32x4, v2: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fmax-fmin-nondeterministic-riscv64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmax-fmin-nondeterministic-riscv64.clif
@@ -2,7 +2,8 @@
 ; If you change this file, you should most likely update
 ; simd-arithmetic-nondeterministic*.clif as well.
 test run
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 ;; With the current implementation on RISC-V we always return a positive Canonical NaN
 ;; if any input is NaN. This is compatible with the spec but different from the

--- a/cranelift/filetests/filetests/runtests/simd-fmax-fmin.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmax-fmin.clif
@@ -3,7 +3,8 @@ target aarch64
 target s390x
 target x86_64
 target x86_64 skylake
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fmax_f64x2(f64x2, f64x2) -> f64x2 {
 block0(v0: f64x2, v1: f64x2):

--- a/cranelift/filetests/filetests/runtests/simd-fmin-max-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmin-max-pseudo.clif
@@ -3,7 +3,8 @@ target aarch64
 ; target s390x FIXME: This currently fails under qemu due to a qemu bug
 target x86_64
 target x86_64 skylake
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fmin_pseudo_f32x4(f32x4, f32x4) -> f32x4 {
 block0(v0:f32x4, v1:f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fmul.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmul.clif
@@ -6,6 +6,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %fmul_f32x4(f32x4, f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-fneg.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fneg.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fneg_f32x4(f32x4) -> f32x4 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-fsub.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fsub.clif
@@ -6,6 +6,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %fsub_f32x4(f32x4, f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-fvdemote.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fvdemote.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fvdemote(f64x2) -> f32x4 {
 block0(v0: f64x2):

--- a/cranelift/filetests/filetests/runtests/simd-fvpromote-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fvpromote-low.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %fvpromote_low(f32x4) -> f64x2 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-iabs.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iabs.clif
@@ -8,6 +8,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %iabs_i8x16(i8x16) -> i8x16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-iadd-small.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-small.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 ;; We only test 64bit values here since the interpreter does not support anything smaller.
 

--- a/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-splat.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %iadd_splat_const_i8x16(i8x16) -> i8x16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-high.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %iadd_swidenhigh_i32x4(i32x4, i32x4) -> i64x2 {

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-low.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %iadd_swidenlow_i32x4(i32x4, i32x4) -> i64x2 {

--- a/cranelift/filetests/filetests/runtests/simd-iadd-swiden-mix.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-swiden-mix.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %iadd_swiden_high_low_i32x4(i32x4, i32x4) -> i64x2 {

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-high.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %iadd_uwidenhigh_i32x4(i32x4, i32x4) -> i64x2 {

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-low.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %iadd_uwidenlow_i32x4(i32x4, i32x4) -> i64x2 {

--- a/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-mix.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd-uwiden-mix.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %iadd_uwiden_high_low_i32x4(i32x4, i32x4) -> i64x2 {

--- a/cranelift/filetests/filetests/runtests/simd-iadd.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iadd.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 skylake
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %iadd_i8x16(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-iaddpairwise-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iaddpairwise-64bit.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %iaddp_i8x8(i8x8, i8x8) -> i8x8 {
 block0(v0: i8x8, v1: i8x8):

--- a/cranelift/filetests/filetests/runtests/simd-iaddpairwise.clif
+++ b/cranelift/filetests/filetests/runtests/simd-iaddpairwise.clif
@@ -8,6 +8,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %iaddp_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-eq.clif
@@ -5,6 +5,7 @@ target x86_64 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_icmp_eq_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ne.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_icmp_ne_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sge.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_icmp_sge_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sgt.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_icmp_sgt_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-sle.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_icmp_sle_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-slt.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_icmp_slt_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-uge.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_icmp_uge_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ugt.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_icmp_ugt_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ule.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_icmp_ule_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
+++ b/cranelift/filetests/filetests/runtests/simd-icmp-ult.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_icmp_ult_i8(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-ifma.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ifma.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64
 target x86_64 skylake
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 ;; These tests test integer fused multiply add/subtract instructions.
 

--- a/cranelift/filetests/filetests/runtests/simd-imul-i8x16.clif
+++ b/cranelift/filetests/filetests/runtests/simd-imul-i8x16.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %imul_i8x16(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-imul.clif
+++ b/cranelift/filetests/filetests/runtests/simd-imul.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 skylake
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %imul_i16x8(i16x8, i16x8) -> i16x8 {
 block0(v0:i16x8, v1:i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-ineg.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ineg.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 skylake
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %ineg_i8x16(i8x16) -> i8x16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-insert-extract-lane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-insert-extract-lane.clif
@@ -6,6 +6,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %insertlane_preserves_upper_bits(f64) -> i64 fast {
 block0(v5: f64):

--- a/cranelift/filetests/filetests/runtests/simd-insertlane.clif
+++ b/cranelift/filetests/filetests/runtests/simd-insertlane.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %insertlane_i8x16_0(i8x16, i8) -> i8x16 {
 block0(v0: i8x16, v1: i8):

--- a/cranelift/filetests/filetests/runtests/simd-ishl.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ishl.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 skylake
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %ishl_i8x16(i8x16, i32) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-isub-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-splat.clif
@@ -6,6 +6,7 @@ target x86_64
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %isub_splat_reverse_i8x16(i8x16, i8) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-isub-swiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-swiden-high.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %isub_swidenhigh_i32x4(i32x4, i32x4) -> i64x2 {

--- a/cranelift/filetests/filetests/runtests/simd-isub-swiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-swiden-low.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %isub_swidenlow_i32x4(i32x4, i32x4) -> i64x2 {

--- a/cranelift/filetests/filetests/runtests/simd-isub-uwiden-high.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-uwiden-high.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %isub_uwidenhigh_i32x4(i32x4, i32x4) -> i64x2 {

--- a/cranelift/filetests/filetests/runtests/simd-isub-uwiden-low.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub-uwiden-low.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %isub_uwidenlow_i32x4(i32x4, i32x4) -> i64x2 {

--- a/cranelift/filetests/filetests/runtests/simd-isub.clif
+++ b/cranelift/filetests/filetests/runtests/simd-isub.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 skylake
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %isub_i8x16(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-lane-access.clif
+++ b/cranelift/filetests/filetests/runtests/simd-lane-access.clif
@@ -3,6 +3,8 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 ;; shuffle
 

--- a/cranelift/filetests/filetests/runtests/simd-logical.clif
+++ b/cranelift/filetests/filetests/runtests/simd-logical.clif
@@ -3,6 +3,8 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %bnot() -> i32 {
 block0:

--- a/cranelift/filetests/filetests/runtests/simd-min-max.clif
+++ b/cranelift/filetests/filetests/runtests/simd-min-max.clif
@@ -8,6 +8,7 @@ target x86_64 sse42
 target x86_64 sse42 has_avx
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %smin_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-nearest.clif
+++ b/cranelift/filetests/filetests/runtests/simd-nearest.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %nearest_f32x4(f32x4) -> f32x4 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-popcnt-large.clif
+++ b/cranelift/filetests/filetests/runtests/simd-popcnt-large.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 ;; This file contains tests for the popcnt instruction with element sizes larger than i8.
 ;; X86 does not support these yet, but we should merge this with the main file once it does.

--- a/cranelift/filetests/filetests/runtests/simd-popcnt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-popcnt.clif
@@ -7,6 +7,7 @@ target x86_64 ssse3
 target x86_64 sse42
 target x86_64 sse42 has_avx has_avx512vl has_avx512bitalg
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %popcnt_i8x16(i8x16) -> i8x16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-saddsat-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-saddsat-aarch64.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %saddsat_i32x4(i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4):

--- a/cranelift/filetests/filetests/runtests/simd-saddsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-saddsat.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %saddsat_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-scalartovector-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-scalartovector-aarch64.clif
@@ -3,6 +3,7 @@ test interpret
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 ; i8 and i16 are invalid source sizes for x86_64
 
 function %scalartovector_i8(i8) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
+++ b/cranelift/filetests/filetests/runtests/simd-scalartovector.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %scalartovector_i32(i32) -> i32x4 {
 block0(v0: i32):

--- a/cranelift/filetests/filetests/runtests/simd-select.clif
+++ b/cranelift/filetests/filetests/runtests/simd-select.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %select_i64x2(i64, i64x2, i64x2) -> i64x2 {
 block0(v0: i64, v1: i64x2, v2: i64x2):

--- a/cranelift/filetests/filetests/runtests/simd-shuffle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-shuffle.clif
@@ -8,7 +8,8 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target x86_64 sse42 has_avx has_avx512vl has_avx512vbmi
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %shuffle_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-smulhi.clif
+++ b/cranelift/filetests/filetests/runtests/simd-smulhi.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 ; The AArch64 and x86_64 backends only support scalar values.
 
 function %smulhi_i8x16(i8x16, i8x16) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-snarrow-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-snarrow-aarch64.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 ; x86_64 considers the case `i64x2` -> `i32x4` to be 'unreachable'
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %snarrow_i64x2(i64x2, i64x2) -> i32x4 {
 block0(v0: i64x2, v1: i64x2):

--- a/cranelift/filetests/filetests/runtests/simd-snarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-snarrow.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %snarrow_i16x8(i16x8, i16x8) -> i8x16 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-splat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-splat.clif
@@ -8,6 +8,7 @@ target x86_64 sse41
 target x86_64 sse41 has_avx
 target x86_64 sse41 has_avx has_avx2
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %splat_i8x16(i8) -> i8x16 {
 block0(v0: i8):

--- a/cranelift/filetests/filetests/runtests/simd-sqmulroundsat-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqmulroundsat-aarch64.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 ;; x86_64 hasn't implemented this for `i32x4`
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %sqmulrs_i32x4(i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4):

--- a/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqmulroundsat.clif
@@ -7,6 +7,7 @@ target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %sqmulrs_i16x8(i16x8, i16x8) -> i16x8 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-sqrt.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sqrt.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %sqrt_f32x4(f32x4) -> f32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-sshr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-sshr.clif
@@ -10,6 +10,7 @@ target x86_64 sse42 has_avx
 target x86_64 sse42 has_avx has_avx2
 target x86_64 sse42 has_avx has_avx2 has_avx512f has_avx512vl
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %sshr_i8x16(i8x16, i32) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-ssubsat-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ssubsat-aarch64.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %ssubsat_i32x4(i32x4, i32x4) -> i32x4 {
 block0(v0: i32x4, v1: i32x4):

--- a/cranelift/filetests/filetests/runtests/simd-ssubsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ssubsat.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %ssubsat_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenhigh.clif
@@ -6,7 +6,8 @@ target x86_64
 target x86_64 sse41 has_ssse3=false
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %swidenhigh_i8x16(i8x16) -> i16x8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-swidenlow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swidenlow.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %swidenlow_i8x16(i8x16) -> i16x8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-swizzle.clif
+++ b/cranelift/filetests/filetests/runtests/simd-swizzle.clif
@@ -6,7 +6,8 @@ target x86_64
 target x86_64 ssse3
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %swizzle_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-trunc.clif
+++ b/cranelift/filetests/filetests/runtests/simd-trunc.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %trunc_f32x4(f32x4) -> f32x4 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-uaddsat-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uaddsat-aarch64.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 ; i32x4 vectors aren't supported in `uadd_sat` outside AArch64 at the moment
 function %uaddsat_i32x4(i32x4, i32x4) -> i32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-uaddsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uaddsat.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %uaddsat_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-umulhi.clif
+++ b/cranelift/filetests/filetests/runtests/simd-umulhi.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 ; x86_64 only supports `i16`, `i32`, and `i64`
 
 function %umulhi_i8(i8, i8) -> i8 {

--- a/cranelift/filetests/filetests/runtests/simd-unarrow-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-unarrow-aarch64.clif
@@ -3,6 +3,7 @@ test run
 target aarch64
 ; x86_64 considers the case `i64x2 -> i32x4` to be 'unreachable'
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %unarrow_i64x2(i64x2, i64x2) -> i32x4 {
 block0(v0: i64x2, v1: i64x2):

--- a/cranelift/filetests/filetests/runtests/simd-unarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-unarrow.clif
@@ -7,6 +7,7 @@ target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %unarrow_i16x8(i16x8, i16x8) -> i8x16 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-ushr.clif
+++ b/cranelift/filetests/filetests/runtests/simd-ushr.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64 skylake
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %ushr_i8x16(i8x16, i32) -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-usubsat-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/simd-usubsat-aarch64.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 ; i32x4 vectors aren't supported in `usub_sat` outside AArch64 at the moment
 function %usubsat_i32x4(i32x4, i32x4) -> i32x4 {

--- a/cranelift/filetests/filetests/runtests/simd-usubsat.clif
+++ b/cranelift/filetests/filetests/runtests/simd-usubsat.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %usubsat_i8x16(i8x16, i8x16) -> i8x16 {
 block0(v0: i8x16, v1: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-uunarrow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uunarrow.clif
@@ -5,6 +5,7 @@ target s390x
 ; x86_64 panics: `Did not match fcvt input!
 ; thread 'worker #0' panicked at 'register allocation: Analysis(EntryLiveinValues([v2V]))', cranelift/codegen/src/machinst/compile.rs:96:10`
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %uunarrow_i16x8(i16x8, i16x8) -> i8x16 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd-uwidenhigh.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uwidenhigh.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %uwidenhigh_i8x16(i8x16) -> i16x8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-uwidenlow.clif
+++ b/cranelift/filetests/filetests/runtests/simd-uwidenlow.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %uwidenlow_i8x16(i8x16) -> i16x8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-valltrue-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-valltrue-64bit.clif
@@ -1,7 +1,8 @@
 test interpret
 test run
 target aarch64
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 ; s390x and x86_64 do not support 64-bit vectors.
 
 function %valltrue_i8x8_f() -> i8 {

--- a/cranelift/filetests/filetests/runtests/simd-valltrue.clif
+++ b/cranelift/filetests/filetests/runtests/simd-valltrue.clif
@@ -6,7 +6,8 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %vall_true_i8x16(i8x16) -> i8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-vanytrue-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vanytrue-64bit.clif
@@ -1,7 +1,8 @@
 test interpret
 test run
 target aarch64
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 ; s390x and x86_64 do not support 64-bit vectors.
 
 function %vanytrue_i8x8_f() -> i8 {

--- a/cranelift/filetests/filetests/runtests/simd-vanytrue.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vanytrue.clif
@@ -5,7 +5,8 @@ target s390x
 target x86_64
 target x86_64 sse41
 target x86_64 sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %vany_true_i8x16(i8x16) -> i8 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-vconst-64bit.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vconst-64bit.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 ; x86_64 and s390x do not support 64-bit vectors.
 
 function %vconst_zeroes() -> i8x8 {

--- a/cranelift/filetests/filetests/runtests/simd-vconst-large.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vconst-large.clif
@@ -4,6 +4,7 @@ target aarch64
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 ;; This tests that vconst correctly loads large offsets into the constant pool

--- a/cranelift/filetests/filetests/runtests/simd-vconst.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vconst.clif
@@ -4,6 +4,7 @@ target aarch64
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 
 function %vconst_zeroes_i8x16() -> i8x16 {

--- a/cranelift/filetests/filetests/runtests/simd-vhighbits-float.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vhighbits-float.clif
@@ -3,7 +3,8 @@ test run
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %vhighbits_f32x4(f32x4) -> i8 {
 block0(v0: f32x4):

--- a/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
+++ b/cranelift/filetests/filetests/runtests/simd-vhighbits.clif
@@ -4,7 +4,8 @@ target aarch64
 target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
-target riscv64gc has_v
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %vhighbits_i8x16(i8x16) -> i16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/simd-wideningpairwisedotproducts.clif
+++ b/cranelift/filetests/filetests/runtests/simd-wideningpairwisedotproducts.clif
@@ -4,6 +4,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %wpdps(i16x8, i16x8) -> i32x4 {
 block0(v0: i16x8, v1: i16x8):

--- a/cranelift/filetests/filetests/runtests/simd_compare_zero.clif
+++ b/cranelift/filetests/filetests/runtests/simd_compare_zero.clif
@@ -1,6 +1,8 @@
 test run
 target aarch64
 target s390x
+target riscv64 has_v
+target riscv64 has_v has_c has_zcb
 
 function %simd_icmp_eq_i8(i8x16) -> i8x16 {
 block0(v0: i8x16):

--- a/cranelift/filetests/filetests/runtests/smulhi-aarch64.clif
+++ b/cranelift/filetests/filetests/runtests/smulhi-aarch64.clif
@@ -2,6 +2,7 @@ test interpret
 test run
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 ; x86_64 backend only supports `i16`, `i32`, and `i64` types.
 

--- a/cranelift/filetests/filetests/runtests/smulhi.clif
+++ b/cranelift/filetests/filetests/runtests/smulhi.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64 has_sse3 has_ssse3 has_sse41
 target x86_64 has_sse3 has_ssse3 has_sse41 has_avx
 target riscv64
+target riscv64 has_c has_zcb
 
 
 function %smulhi_i16(i16, i16) -> i16 {

--- a/cranelift/filetests/filetests/runtests/spill-reload.clif
+++ b/cranelift/filetests/filetests/runtests/spill-reload.clif
@@ -3,6 +3,7 @@ target s390x
 target aarch64
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %f(i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> i64 {
 block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v8: i32, v9: i32, v10: i32, v11: i32, v12: i32, v13: i32, v14: i32, v15: i32, v16: i32, v17: i32, v18: i32, v19: i32):

--- a/cranelift/filetests/filetests/runtests/sqrt.clif
+++ b/cranelift/filetests/filetests/runtests/sqrt.clif
@@ -5,6 +5,7 @@ target x86_64
 target x86_64 has_avx
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %sqrt_f32(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/runtests/srem.clif
+++ b/cranelift/filetests/filetests/runtests/srem.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %srem_i64(i64, i64) -> i64 {
 block0(v0: i64,v1: i64):

--- a/cranelift/filetests/filetests/runtests/stack-addr-64.clif
+++ b/cranelift/filetests/filetests/runtests/stack-addr-64.clif
@@ -4,6 +4,7 @@ target x86_64
 target s390x
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %stack_addr_iadd(i64) -> i8 {
     ss0 = explicit_slot 16

--- a/cranelift/filetests/filetests/runtests/stack.clif
+++ b/cranelift/filetests/filetests/runtests/stack.clif
@@ -6,6 +6,7 @@ target x86_64
 target s390x
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %stack_simple(i64) -> i64 {
     ss0 = explicit_slot 8

--- a/cranelift/filetests/filetests/runtests/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/runtests/tail-call-conv.clif
@@ -5,6 +5,7 @@ target aarch64
 target aarch64 sign_return_address
 target aarch64 has_pauth sign_return_address
 target riscv64
+target riscv64 has_c has_zcb
 
 ;; TODO(#6530): s390x doesn't support the `tail` calling convention yet.
 ;;

--- a/cranelift/filetests/filetests/runtests/trunc.clif
+++ b/cranelift/filetests/filetests/runtests/trunc.clif
@@ -7,6 +7,7 @@ target x86_64 sse42 has_avx
 target aarch64
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %trunc_f32(f32) -> f32 {
 block0(v0: f32):

--- a/cranelift/filetests/filetests/runtests/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/runtests/uadd_overflow_trap.clif
@@ -3,6 +3,7 @@ test interpret
 target x86_64
 target aarch64
 target riscv64
+target riscv64 has_c has_zcb
 target s390x
 
 ; NOTE: we don't currently have infrastructure for testing for traps, so these

--- a/cranelift/filetests/filetests/runtests/umulhi.clif
+++ b/cranelift/filetests/filetests/runtests/umulhi.clif
@@ -4,6 +4,7 @@ target aarch64
 target x86_64 has_sse3 has_ssse3 has_sse41
 target s390x
 target riscv64
+target riscv64 has_c has_zcb
 
 function %umulhi_i16(i16, i16) -> i16 {
 block0(v0: i16, v1: i16):

--- a/cranelift/filetests/filetests/runtests/urem.clif
+++ b/cranelift/filetests/filetests/runtests/urem.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_c has_zcb
 
 function %urem_i64(i64, i64) -> i64 {
 block0(v0: i64,v1: i64):

--- a/cranelift/filetests/filetests/runtests/x64-bmi1.clif
+++ b/cranelift/filetests/filetests/runtests/x64-bmi1.clif
@@ -5,6 +5,7 @@ target s390x
 target x86_64
 target x86_64 has_bmi1
 target riscv64
+target riscv64 has_c has_zcb
 
 function %blsi32(i32) -> i32 {
 block0(v0: i32):


### PR DESCRIPTION
👋 Hey,

This PR makes introduces compressed instructions to the RISC-V backend as part of the C extension.

### C extension introduction

The C Extension adds encodings for 16 bit instructions. These are allowed to be freely interleaved with uncompressed instructions (i.e. we don't  need a mode switch like Thumb2).

Some C instruction formats cannot encode all registers, so they may only be emitted if they get assigned a certain physical register. Additionally C instructions (almost) always have an equivalent uncompressed instruction.

### Implementation

I've implemented this as an encoding only change. So our VCode instructions remain the same, but if we happen to get the correct registers and all the stars line up we emit a compressed instruction instead of a full sized instruction. 

`Inst::emit` is now split into 3 stages:

1. First we run the instruction through `Inst::allocate` which just transforms a `Inst` with virtual registers, into a `Inst` with physical registers
2. We then try to emit the instruction as a compressed instruction
    * This may fail, and that's ok
    * Since we now have the final physical registers we can check if it's possible to emit it as a compressed instruction
3. If the compressed emission fails we default to the uncompressed emission

This PR only enables 2 instructions `c.add` and `c.mv`. Both of these use the CR format which allows the full range of registers. However they are enough to get us into trouble. `c.mv` is emitted quite often, and is enough to "unalign" most of the rest of the code.

### Issues with capstone

Capstone supports decoding C instructions with a separate "Extra Mode".

Capstone currently cannot decode a number of instructions that we emit (i.e `Zca`, `Zcb`, `Zcs` or Vector Instructions). This is normally ok since it emits a `.byte ...` directive and we can still read the V-Code to figure out what is going on.

If I enable this "Extra Mode" by default it tries to decode these unknown instructions as C instructions and makes the whole thing unreadable.

My solution for this was to make C a non default extension, and only enable the Extra Mode when C is enabled. This lets us keep the normal disassembly for all current test cases. Mixing C instructions and Vector instructions still makes the whole thing unreadable, but at least its not the common case.

### Runtests

I've made pretty much all runtests run with C as well as without. Even if the runtest will never directly emits a C instruction, it can emit for example a `c.mv` and emit the rest of the instructions "unaligned" which is also a configuration worth testing.

---

This is built on top of #6988 so it's worth waiting for that to be merged before looking into this. Additionally, it's probably a good idea to review this commit by commit instead of all at once.