### PR TITLE
Release Wasmtime 11.0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -354,7 +354,7 @@ jobs:
     - uses: ./.github/actions/install-rust
       with:
         toolchain: nightly-2023-03-20
-    - run: cargo install cargo-fuzz --vers "^0.11"
+    - run: cargo install cargo-fuzz --vers "^0.11" --locked
     # Install the OCaml packages necessary for fuzz targets that use the
     # `wasm-spec-interpreter`.
     - run: sudo apt-get update && sudo apt install -y ocaml-nox ocamlbuild ocaml-findlib libzarith-ocaml-dev

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,7 +236,7 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-array-literals"
-version = "11.0.1"
+version = "11.0.2"
 
 [[package]]
 name = "byteorder"
@@ -596,7 +596,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -604,14 +604,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -638,25 +638,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.98.1"
+version = "0.98.2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "serde",
 ]
@@ -692,7 +692,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.13.2",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -760,7 +760,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -771,7 +771,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -795,7 +795,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -805,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -852,7 +852,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.98.1"
+version = "0.98.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -3442,7 +3442,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "wasmparser 0.92.0",
@@ -3498,7 +3498,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "bitflags 1.3.2",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "byte-array-literals",
  "object",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3841,14 +3841,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3890,7 +3890,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3974,7 +3974,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3990,11 +3990,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "11.0.1"
+version = "11.0.2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4015,7 +4015,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4029,7 +4029,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "atty",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "capstone",
@@ -4080,7 +4080,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "backtrace",
  "cc",
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "object",
  "once_cell",
@@ -4180,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "cc",
@@ -4215,7 +4215,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -4225,7 +4225,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4251,7 +4251,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-crypto"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "wasi-crypto",
@@ -4261,7 +4261,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "openvino",
@@ -4290,7 +4290,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -4302,7 +4302,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -4396,7 +4396,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "11.0.1"
+version = "11.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4481,7 +4481,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,63 +117,63 @@ exclude = [
 ]
 
 [workspace.package]
-version = "11.0.1"
+version = "11.0.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 rust-version = "1.66.0"
 
 [workspace.dependencies]
-wasmtime = { path = "crates/wasmtime", version = "11.0.1", default-features = false }
-wasmtime-cache = { path = "crates/cache", version = "=11.0.1" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=11.0.1" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=11.0.1" }
-wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=11.0.1" }
-wasmtime-winch = { path = "crates/winch", version = "=11.0.1" }
-wasmtime-environ = { path = "crates/environ", version = "=11.0.1" }
-wasmtime-explorer = { path = "crates/explorer", version = "=11.0.1" }
-wasmtime-fiber = { path = "crates/fiber", version = "=11.0.1" }
-wasmtime-types = { path = "crates/types", version = "11.0.1" }
-wasmtime-jit = { path = "crates/jit", version = "=11.0.1" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=11.0.1" }
-wasmtime-runtime = { path = "crates/runtime", version = "=11.0.1" }
-wasmtime-wast = { path = "crates/wast", version = "=11.0.1" }
-wasmtime-wasi = { path = "crates/wasi", version = "11.0.1" }
-wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "11.0.1" }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=11.0.1" }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "11.0.1" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "11.0.1" }
-wasmtime-component-util = { path = "crates/component-util", version = "=11.0.1" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=11.0.1" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=11.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "11.0.2", default-features = false }
+wasmtime-cache = { path = "crates/cache", version = "=11.0.2" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=11.0.2" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=11.0.2" }
+wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=11.0.2" }
+wasmtime-winch = { path = "crates/winch", version = "=11.0.2" }
+wasmtime-environ = { path = "crates/environ", version = "=11.0.2" }
+wasmtime-explorer = { path = "crates/explorer", version = "=11.0.2" }
+wasmtime-fiber = { path = "crates/fiber", version = "=11.0.2" }
+wasmtime-types = { path = "crates/types", version = "11.0.2" }
+wasmtime-jit = { path = "crates/jit", version = "=11.0.2" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=11.0.2" }
+wasmtime-runtime = { path = "crates/runtime", version = "=11.0.2" }
+wasmtime-wast = { path = "crates/wast", version = "=11.0.2" }
+wasmtime-wasi = { path = "crates/wasi", version = "11.0.2" }
+wasmtime-wasi-crypto = { path = "crates/wasi-crypto", version = "11.0.2" }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=11.0.2" }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "11.0.2" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "11.0.2" }
+wasmtime-component-util = { path = "crates/component-util", version = "=11.0.2" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=11.0.2" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=11.0.2" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=11.0.1", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=11.0.1" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=11.0.1" }
-wasi-common = { path = "crates/wasi-common", version = "=11.0.1" }
-wasi-tokio = { path = "crates/wasi-common/tokio", version = "=11.0.1" }
-wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=11.0.1" }
+wiggle = { path = "crates/wiggle", version = "=11.0.2", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=11.0.2" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=11.0.2" }
+wasi-common = { path = "crates/wasi-common", version = "=11.0.2" }
+wasi-tokio = { path = "crates/wasi-common/tokio", version = "=11.0.2" }
+wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=11.0.2" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=11.0.1" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=11.0.1" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=11.0.2" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=11.0.2" }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.98.1" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.98.1" }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.98.1" }
-cranelift-entity = { path = "cranelift/entity", version = "0.98.1" }
-cranelift-native = { path = "cranelift/native", version = "0.98.1" }
-cranelift-module = { path = "cranelift/module", version = "0.98.1" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.98.1" }
-cranelift-reader = { path = "cranelift/reader", version = "0.98.1" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.98.2" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.98.2" }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.98.2" }
+cranelift-entity = { path = "cranelift/entity", version = "0.98.2" }
+cranelift-native = { path = "cranelift/native", version = "0.98.2" }
+cranelift-module = { path = "cranelift/module", version = "0.98.2" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.98.2" }
+cranelift-reader = { path = "cranelift/reader", version = "0.98.2" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.98.1" }
-cranelift-jit = { path = "cranelift/jit", version = "0.98.1" }
+cranelift-object = { path = "cranelift/object", version = "0.98.2" }
+cranelift-jit = { path = "cranelift/jit", version = "0.98.2" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.98.1" }
-cranelift-control = { path = "cranelift/control", version = "0.98.1" }
-cranelift = { path = "cranelift/umbrella", version = "0.98.1" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.98.2" }
+cranelift-control = { path = "cranelift/control", version = "0.98.2" }
+cranelift = { path = "cranelift/umbrella", version = "0.98.2" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.9.1" }
+winch-codegen = { path = "winch/codegen", version = "=0.9.2" }
 winch-filetests = { path = "winch/filetests" }
 winch-test-macros = { path = "winch/test-macros" }
 

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.98.1"
+version = "0.98.2"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.98.1"
+version = "0.98.2"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -16,7 +16,7 @@ edition.workspace = true
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.98.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.98.2" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -40,8 +40,8 @@ criterion = { version = "0.4.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.98.1" }
-cranelift-isle = { path = "../isle/isle", version = "=0.98.1" }
+cranelift-codegen-meta = { path = "meta", version = "0.98.2" }
+cranelift-isle = { path = "../isle/isle", version = "=0.98.2" }
 
 [features]
 default = ["std", "unwind", "host-arch"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.98.1"
+version = "0.98.2"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -13,4 +13,4 @@ edition.workspace = true
 # rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.98.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.98.2" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.98.1"
+version = "0.98.2"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.98.1"
+version = "0.98.2"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.98.1"
+version = "0.98.2"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.98.1"
+version = "0.98.2"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.98.1"
+version = "0.98.2"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.98.1"
+version = "0.98.2"
 
 [dependencies]
 codespan-reporting = { version = "0.11.1", optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.98.1"
+version = "0.98.2"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.98.1"
+version = "0.98.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.98.1"
+version = "0.98.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.98.1"
+version = "0.98.2"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.98.1"
+version = "0.98.2"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.98.1"
+version = "0.98.2"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.98.1"
+version = "0.98.2"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.98.1"
+version = "0.98.2"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -199,7 +199,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "11.0.1"
+#define WASMTIME_VERSION "11.0.2"
 /**
  * \brief Wasmtime major version number.
  */
@@ -211,7 +211,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 1
+#define WASMTIME_VERSION_PATCH 2
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.97.1"
 version = "0.98.1"
 audited_as = "0.98.0"
 
+[[unpublished.cranelift]]
+version = "0.98.2"
+audited_as = "0.98.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.98.0"
 audited_as = "0.97.1"
@@ -16,6 +20,10 @@ audited_as = "0.97.1"
 [[unpublished.cranelift-bforest]]
 version = "0.98.1"
 audited_as = "0.98.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.98.2"
+audited_as = "0.98.1"
 
 [[unpublished.cranelift-codegen]]
 version = "0.98.0"
@@ -25,6 +33,10 @@ audited_as = "0.97.1"
 version = "0.98.1"
 audited_as = "0.98.0"
 
+[[unpublished.cranelift-codegen]]
+version = "0.98.2"
+audited_as = "0.98.1"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.98.0"
 audited_as = "0.97.1"
@@ -32,6 +44,10 @@ audited_as = "0.97.1"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.98.1"
 audited_as = "0.98.0"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.98.2"
+audited_as = "0.98.1"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.98.0"
@@ -41,6 +57,10 @@ audited_as = "0.97.1"
 version = "0.98.1"
 audited_as = "0.98.0"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.98.2"
+audited_as = "0.98.1"
+
 [[unpublished.cranelift-control]]
 version = "0.98.0"
 audited_as = "0.97.1"
@@ -48,6 +68,10 @@ audited_as = "0.97.1"
 [[unpublished.cranelift-control]]
 version = "0.98.1"
 audited_as = "0.98.0"
+
+[[unpublished.cranelift-control]]
+version = "0.98.2"
+audited_as = "0.98.1"
 
 [[unpublished.cranelift-entity]]
 version = "0.98.0"
@@ -57,6 +81,10 @@ audited_as = "0.97.1"
 version = "0.98.1"
 audited_as = "0.98.0"
 
+[[unpublished.cranelift-entity]]
+version = "0.98.2"
+audited_as = "0.98.1"
+
 [[unpublished.cranelift-frontend]]
 version = "0.98.0"
 audited_as = "0.97.1"
@@ -64,6 +92,10 @@ audited_as = "0.97.1"
 [[unpublished.cranelift-frontend]]
 version = "0.98.1"
 audited_as = "0.98.0"
+
+[[unpublished.cranelift-frontend]]
+version = "0.98.2"
+audited_as = "0.98.1"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.98.0"
@@ -73,6 +105,10 @@ audited_as = "0.97.1"
 version = "0.98.1"
 audited_as = "0.98.0"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.98.2"
+audited_as = "0.98.1"
+
 [[unpublished.cranelift-isle]]
 version = "0.98.0"
 audited_as = "0.97.1"
@@ -80,6 +116,10 @@ audited_as = "0.97.1"
 [[unpublished.cranelift-isle]]
 version = "0.98.1"
 audited_as = "0.98.0"
+
+[[unpublished.cranelift-isle]]
+version = "0.98.2"
+audited_as = "0.98.1"
 
 [[unpublished.cranelift-jit]]
 version = "0.98.0"
@@ -89,6 +129,10 @@ audited_as = "0.97.1"
 version = "0.98.1"
 audited_as = "0.98.0"
 
+[[unpublished.cranelift-jit]]
+version = "0.98.2"
+audited_as = "0.98.1"
+
 [[unpublished.cranelift-module]]
 version = "0.98.0"
 audited_as = "0.97.1"
@@ -96,6 +140,10 @@ audited_as = "0.97.1"
 [[unpublished.cranelift-module]]
 version = "0.98.1"
 audited_as = "0.98.0"
+
+[[unpublished.cranelift-module]]
+version = "0.98.2"
+audited_as = "0.98.1"
 
 [[unpublished.cranelift-native]]
 version = "0.98.0"
@@ -105,6 +153,10 @@ audited_as = "0.97.1"
 version = "0.98.1"
 audited_as = "0.98.0"
 
+[[unpublished.cranelift-native]]
+version = "0.98.2"
+audited_as = "0.98.1"
+
 [[unpublished.cranelift-object]]
 version = "0.98.0"
 audited_as = "0.97.1"
@@ -112,6 +164,10 @@ audited_as = "0.97.1"
 [[unpublished.cranelift-object]]
 version = "0.98.1"
 audited_as = "0.98.0"
+
+[[unpublished.cranelift-object]]
+version = "0.98.2"
+audited_as = "0.98.1"
 
 [[unpublished.cranelift-reader]]
 version = "0.98.0"
@@ -121,6 +177,10 @@ audited_as = "0.97.1"
 version = "0.98.1"
 audited_as = "0.98.0"
 
+[[unpublished.cranelift-reader]]
+version = "0.98.2"
+audited_as = "0.98.1"
+
 [[unpublished.cranelift-serde]]
 version = "0.98.0"
 audited_as = "0.97.1"
@@ -128,6 +188,10 @@ audited_as = "0.97.1"
 [[unpublished.cranelift-serde]]
 version = "0.98.1"
 audited_as = "0.98.0"
+
+[[unpublished.cranelift-serde]]
+version = "0.98.2"
+audited_as = "0.98.1"
 
 [[unpublished.cranelift-wasm]]
 version = "0.98.0"
@@ -137,6 +201,10 @@ audited_as = "0.97.1"
 version = "0.98.1"
 audited_as = "0.98.0"
 
+[[unpublished.cranelift-wasm]]
+version = "0.98.2"
+audited_as = "0.98.1"
+
 [[unpublished.wasi-cap-std-sync]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -144,6 +212,10 @@ audited_as = "10.0.1"
 [[unpublished.wasi-cap-std-sync]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasi-cap-std-sync]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasi-common]]
 version = "11.0.0"
@@ -153,6 +225,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasi-common]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasi-tokio]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -160,6 +236,10 @@ audited_as = "10.0.1"
 [[unpublished.wasi-tokio]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasi-tokio]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime]]
 version = "11.0.0"
@@ -169,6 +249,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -176,6 +260,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-asm-macros]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-cache]]
 version = "11.0.0"
@@ -185,6 +273,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-cache]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -192,6 +284,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-cli]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "11.0.0"
@@ -201,6 +297,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-component-macro]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -208,6 +308,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-component-macro]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-component-macro]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-component-util]]
 version = "11.0.0"
@@ -217,6 +321,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-component-util]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-cranelift]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -224,6 +332,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-cranelift]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "11.0.0"
@@ -233,6 +345,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-cranelift-shared]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-environ]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -240,6 +356,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-environ]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-environ]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-explorer]]
 version = "11.0.0"
@@ -249,6 +369,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-explorer]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-fiber]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -256,6 +380,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-fiber]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-fiber]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-jit]]
 version = "11.0.0"
@@ -265,6 +393,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-jit]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -272,6 +404,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-jit-debug]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "11.0.0"
@@ -281,6 +417,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-runtime]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -288,6 +428,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-runtime]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-runtime]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-types]]
 version = "11.0.0"
@@ -297,6 +441,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-types]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-wasi]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -304,6 +452,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-wasi]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-wasi]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-wasi-crypto]]
 version = "11.0.0"
@@ -313,6 +465,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-wasi-crypto]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -320,6 +476,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-wasi-http]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "11.0.0"
@@ -329,6 +489,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -336,6 +500,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-wasi-threads]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "11.0.0"
@@ -345,6 +513,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-wast]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wasmtime-winch]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -352,6 +524,10 @@ audited_as = "10.0.1"
 [[unpublished.wasmtime-winch]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wasmtime-winch]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "11.0.0"
@@ -361,6 +537,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wiggle]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -368,6 +548,10 @@ audited_as = "10.0.1"
 [[unpublished.wiggle]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wiggle]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wiggle-generate]]
 version = "11.0.0"
@@ -377,6 +561,10 @@ audited_as = "10.0.1"
 version = "11.0.1"
 audited_as = "11.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "11.0.2"
+audited_as = "11.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "11.0.0"
 audited_as = "10.0.1"
@@ -384,6 +572,10 @@ audited_as = "10.0.1"
 [[unpublished.wiggle-macro]]
 version = "11.0.1"
 audited_as = "11.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "11.0.2"
+audited_as = "11.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -396,6 +588,10 @@ audited_as = "0.8.1"
 [[unpublished.winch-codegen]]
 version = "0.9.1"
 audited_as = "0.9.0"
+
+[[unpublished.winch-codegen]]
+version = "0.9.2"
+audited_as = "0.9.1"
 
 [[publisher.arbitrary]]
 version = "1.3.0"
@@ -423,6 +619,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.98.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.97.1"
 when = "2023-06-21"
@@ -432,6 +634,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.98.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.98.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -447,6 +655,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.98.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.97.1"
 when = "2023-06-21"
@@ -456,6 +670,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-meta]]
 version = "0.98.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.98.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -471,6 +691,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.98.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.97.1"
 when = "2023-06-21"
@@ -480,6 +706,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-control]]
 version = "0.98.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.98.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -495,6 +727,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.98.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.97.1"
 when = "2023-06-21"
@@ -504,6 +742,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-frontend]]
 version = "0.98.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.98.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -519,6 +763,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.98.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.97.1"
 when = "2023-06-21"
@@ -528,6 +778,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-isle]]
 version = "0.98.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.98.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -543,6 +799,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.98.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.97.1"
 when = "2023-06-21"
@@ -552,6 +814,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-module]]
 version = "0.98.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.98.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -567,6 +835,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.98.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.97.1"
 when = "2023-06-21"
@@ -576,6 +850,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-object]]
 version = "0.98.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.98.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -591,6 +871,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.98.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.97.1"
 when = "2023-06-21"
@@ -603,6 +889,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.98.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.97.1"
 when = "2023-06-21"
@@ -612,6 +904,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.98.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.98.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -669,6 +967,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-cap-std-sync]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-common]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -681,6 +985,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-tokio]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -690,6 +1000,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasi-tokio]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasi-tokio]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -747,6 +1063,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -756,6 +1078,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -771,6 +1099,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -780,6 +1114,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -795,6 +1135,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -804,6 +1150,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -819,6 +1171,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -828,6 +1186,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -843,6 +1207,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cranelift-shared]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-environ]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -852,6 +1222,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-environ]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-environ]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -867,6 +1243,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-explorer]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-fiber]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -876,6 +1258,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-fiber]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-fiber]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -891,6 +1279,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -900,6 +1294,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-debug]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -915,6 +1315,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-runtime]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -924,6 +1330,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-runtime]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-runtime]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -939,6 +1351,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-types]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -948,6 +1366,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -963,6 +1387,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-crypto]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -972,6 +1402,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -987,6 +1423,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-nn]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -996,6 +1438,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1011,6 +1459,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -1023,6 +1477,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-winch]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wit-bindgen]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -1032,6 +1492,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wit-bindgen]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wit-bindgen]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1061,6 +1527,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -1073,6 +1545,12 @@ when = "2023-07-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "11.0.1"
+when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "10.0.1"
 when = "2023-06-21"
@@ -1082,6 +1560,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "11.0.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "11.0.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1101,6 +1585,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.9.0"
 when = "2023-07-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.9.1"
+when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.9.1"
+version = "0.9.2"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 11.0.2, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
