### PR TITLE
[wasmtime-wasi] fix logic error in `monotonic-clock/subscribe`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3077,6 +3077,7 @@ dependencies = [
  "libc",
  "once_cell",
  "wasi",
+ "wit-bindgen",
 ]
 
 [[package]]

--- a/crates/test-programs/tests/wasi-cap-std-sync.rs
+++ b/crates/test-programs/tests/wasi-cap-std-sync.rs
@@ -250,6 +250,11 @@ fn sched_yield() {
     run("sched_yield", true).unwrap()
 }
 #[test_log::test]
+#[should_panic]
+fn sleep() {
+    run("sleep", true).unwrap()
+}
+#[test_log::test]
 fn stdio() {
     run("stdio", true).unwrap()
 }

--- a/crates/test-programs/tests/wasi-preview1-host-in-preview2.rs
+++ b/crates/test-programs/tests/wasi-preview1-host-in-preview2.rs
@@ -294,6 +294,11 @@ async fn sched_yield() {
     run("sched_yield", false).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+#[should_panic]
+async fn sleep() {
+    run("sleep", false).await.unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn stdio() {
     run("stdio", false).await.unwrap()
 }

--- a/crates/test-programs/tests/wasi-preview2-components-sync.rs
+++ b/crates/test-programs/tests/wasi-preview2-components-sync.rs
@@ -272,6 +272,10 @@ fn sched_yield() {
     run("sched_yield", false).unwrap()
 }
 #[test_log::test]
+fn sleep() {
+    run("sleep", false).unwrap()
+}
+#[test_log::test]
 fn stdio() {
     run("stdio", false).unwrap()
 }

--- a/crates/test-programs/tests/wasi-preview2-components.rs
+++ b/crates/test-programs/tests/wasi-preview2-components.rs
@@ -280,6 +280,10 @@ async fn sched_yield() {
     run("sched_yield", false).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn sleep() {
+    run("sleep", false).await.unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn stdio() {
     run("stdio", false).await.unwrap()
 }

--- a/crates/test-programs/tests/wasi-tokio.rs
+++ b/crates/test-programs/tests/wasi-tokio.rs
@@ -256,6 +256,11 @@ async fn sched_yield() {
     run("sched_yield", true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+#[should_panic]
+async fn sleep() {
+    run("sleep", true).await.unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn stdio() {
     run("stdio", true).await.unwrap()
 }

--- a/crates/test-programs/wasi-tests/Cargo.toml
+++ b/crates/test-programs/wasi-tests/Cargo.toml
@@ -9,3 +9,6 @@ publish = false
 libc = "0.2.65"
 wasi = "0.11.0"
 once_cell = "1.12"
+wit-bindgen = { workspace = true, default-features = false, features = [
+    "macros",
+] }

--- a/crates/test-programs/wasi-tests/src/bin/sleep.rs
+++ b/crates/test-programs/wasi-tests/src/bin/sleep.rs
@@ -1,0 +1,16 @@
+use crate::wasi::{clocks::monotonic_clock, poll::poll};
+
+wit_bindgen::generate!({
+    path: "../../wasi/wit",
+    world: "wasmtime:wasi/command-extended",
+});
+
+fn main() {
+    // Sleep ten milliseconds.  Note that we call the relevant host functions directly rather than go through
+    // libstd, since we want to ensure we're calling `monotonic_clock::subscribe` with an `absolute` parameter of
+    // `true`, which libstd won't necessarily do (but which e.g. CPython _will_ do).
+    poll::poll_oneoff(&[monotonic_clock::subscribe(
+        monotonic_clock::now() + 10_000_000,
+        true,
+    )]);
+}

--- a/crates/wasi/src/preview2/host/clocks.rs
+++ b/crates/wasi/src/preview2/host/clocks.rs
@@ -64,7 +64,7 @@ impl<T: WasiView> monotonic_clock::Host for T {
                 })))?)
         } else {
             let duration = if absolute {
-                Duration::from_nanos(clock_now - when)
+                Duration::from_nanos(when - clock_now)
             } else {
                 Duration::from_nanos(when)
             };


### PR DESCRIPTION
When calculating the number of nanoseconds to wait, we should subtract the current time from the deadline, not vice-versa.  This was causing guests to sleep indefinitely due to integer underflow.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
