### PR TITLE
Fix build of `wasmtime-wasi-bench`

### DIFF
--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -12,7 +12,6 @@ publish = false
 [lib]
 name = "wasmtime_bench_api"
 crate-type = ["cdylib"]
-test = false
 doctest = false
 
 [dependencies]


### PR DESCRIPTION
Looks like this wasn't built on CI since it wasn't tested. Flag it as testable which should build it on CI which should catch future errors like this.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
