### PR TITLE
new: declare type wasi_ctx in c-api

### DIFF
--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include "wasm.h"
+#include <wasmtime/error.h>
 
 #ifndef WASI_API_EXTERN
 #ifdef _WIN32
@@ -39,6 +40,16 @@ extern "C" {
  * \brief Deletes a configuration object.
  */
 WASI_DECLARE_OWN(config)
+
+/**
+ * \typedef wasi_ctx_t
+ * \brief Convenience alias for #wasi_ctx
+ *
+ * \struct wasi_ctx_t
+ * \brief a C-API compatible type for mut wasmtime_wasi::WasiCtx
+ * 
+ */
+WASI_DECLARE_OWN(ctx)
 
 /**
  * \brief Creates a new empty configuration object.
@@ -169,6 +180,30 @@ WASI_API_EXTERN bool wasi_config_preopen_dir(wasi_config_t* config, const char* 
  * "127.0.0.1:8080") requested to listen on.
  */
 WASI_API_EXTERN bool wasi_config_preopen_socket(wasi_config_t* config, uint32_t fd_num, const char* host_port);
+
+/**
+ * \brief Insert a file descriptor into the WASI context. 
+ * 
+ * This is used to dynamically bind a file descriptor from the host to a file 
+ * descriptor in an already-built WASI context to make it available to WASI APIs.
+ * 
+ * The `guest_fd` argument is the number of the file descriptor by which it will
+ * be known in WASM and the `host_fd` is the number of the file descriptor on
+ * the host.
+ */
+WASI_API_EXTERN void wasi_ctx_insert_file(wasi_ctx_t *ctx, uint32_t guest_fd, uint32_t host_fd, uint32_t access_mode);
+
+/**
+ * \brief Push a file descriptor into the WASI context.
+ * 
+ * This is used to dynamically bind a file descriptor from the host to the next 
+ * available file descriptor in an already-built WASI context to make it available 
+ * to WASI APIs.
+ * 
+ * The `host_fd` argument is the number of the file descriptor on the host and the
+ * `access_mode` is the access mode of the file descriptor.
+ */
+WASI_API_EXTERN wasmtime_error_t *wasi_ctx_push_file(wasi_ctx_t *ctx, uint32_t host_fd, uint32_t access_mode, uint32_t *guest_fd);
 
 #undef own
 

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -218,6 +218,30 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_context_consume_fuel(wasmtime_context
 WASM_API_EXTERN wasmtime_error_t *wasmtime_context_set_wasi(wasmtime_context_t *context, wasi_config_t *wasi);
 
 /**
+ * \brief Configures default WASI state if it is not set. 
+ * 
+ * This function is required if #wasmtime_context_set_wasi is not guaranteed to 
+ * be called at an earlier time. This will configure the WASI state for instances
+ * defined within this store to the default (empty) configuration.
+ * 
+ * This function does not take ownership of `context`. It is created to be used in
+ * conjunction with #wasmtime_context_get_wasi_ctx.
+ */
+WASM_API_EXTERN bool wasmtime_context_set_default_wasi_if_not_exist(wasmtime_context_t *context);
+
+/**
+ * \brief Returns the WASI state for this store.
+ *
+ * This function returns the WASI state for this store, if it has been
+ * configured. If it has not been configured then the program will panic.
+ *
+ * The returned `context` is owned by the store, which effectively makes this 
+ * function unsafe. This function should be called only after calling 
+ * #wasmtime_context_set_wasi or #wasmtime_context_set_default_wasi_if_not_exist.
+ */
+WASM_API_EXTERN wasi_ctx_t *wasmtime_context_get_wasi_ctx(wasmtime_context_t *context);
+
+/**
  * \brief Configures the relative deadline at which point WebAssembly code will
  * trap or invoke the callback function.
  *

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -1,14 +1,17 @@
 //! The WASI embedding API definitions for Wasmtime.
 
-use crate::wasm_byte_vec_t;
-use anyhow::Result;
+use crate::{wasm_byte_vec_t, wasmtime_error_t};
+use anyhow::{anyhow, Result};
 use cap_std::ambient_authority;
 use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fs::File;
+use std::os::fd::FromRawFd;
 use std::os::raw::{c_char, c_int};
 use std::path::{Path, PathBuf};
 use std::slice;
+use wasi_cap_std_sync::file::File as WasiStdFile;
+use wasi_common::file::FileAccessMode;
 use wasi_common::pipe::ReadPipe;
 use wasmtime_wasi::{
     sync::{Dir, TcpListener, WasiCtxBuilder},
@@ -41,6 +44,8 @@ pub struct wasi_config_t {
     stderr: WasiConfigWritePipe,
     preopen_dirs: Vec<(Dir, PathBuf)>,
     preopen_sockets: HashMap<u32, TcpListener>,
+    preopen_files: HashMap<u32, (File, FileAccessMode)>,
+    next_open_fd: u32,
     inherit_args: bool,
     inherit_env: bool,
 }
@@ -136,13 +141,26 @@ impl wasi_config_t {
         for (fd_num, listener) in self.preopen_sockets {
             builder.preopened_socket(fd_num, listener)?;
         }
-        Ok(builder.build())
+
+        let ctx = builder.build();
+
+        for (fd_num, (file, access_mode)) in self.preopen_files {
+            let file = cap_std::fs::File::from_std(file);
+            let file: WasiStdFile = wasi_cap_std_sync::file::File::from_cap_std(file);
+            ctx.insert_file(fd_num, Box::new(file), access_mode);
+        }
+
+        Ok(ctx)
     }
 }
 
 #[no_mangle]
 pub extern "C" fn wasi_config_new() -> Box<wasi_config_t> {
-    Box::new(wasi_config_t::default())
+    // init next_open_fd to 3 because 0, 1 and 2 are reserved for stdio
+    Box::new(wasi_config_t {
+        next_open_fd: 3,
+        ..Default::default()
+    })
 }
 
 #[no_mangle]
@@ -315,4 +333,49 @@ pub unsafe extern "C" fn wasi_config_preopen_socket(
         .insert(fd_num, TcpListener::from_std(listener));
 
     true
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasi_ctx_insert_file(
+    ctx: &mut WasiCtx,
+    guest_fd: u32,
+    host_fd: u32,
+    access_mode: u32,
+) {
+    let access_mode = FileAccessMode::from_bits_truncate(access_mode);
+
+    // SAFETY: no other functions should call `from_raw_fd`, so there is only
+    // one owner for the file descriptor.
+    let f = unsafe { File::from_raw_fd(host_fd as i32) };
+    let f = cap_std::fs::File::from_std(f);
+    let f = wasmtime_wasi::sync::file::File::from_cap_std(f);
+    ctx.insert_file(guest_fd, Box::new(f), access_mode);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasi_ctx_push_file(
+    ctx: &mut WasiCtx,
+    host_fd: u32,
+    access_mode: u32,
+    guest_fd: &mut u32,
+) -> Option<Box<wasmtime_error_t>> {
+    let access_mode = FileAccessMode::from_bits_truncate(access_mode);
+
+    // SAFETY: no other functions should call `from_raw_fd`, so there is only
+    // one owner for the file descriptor.
+    let f = unsafe { File::from_raw_fd(host_fd as i32) };
+    let f = cap_std::fs::File::from_std(f);
+    let f = wasmtime_wasi::sync::file::File::from_cap_std(f);
+    
+    match ctx.push_file(Box::new(f), access_mode) {
+        Ok(fd) => {
+            *guest_fd = fd;
+            None
+        }
+        Err(e) => {
+            // extract the error message
+            let msg = format!("{}", e);
+            Some(Box::new(wasmtime_error_t::from(anyhow!(msg))))
+        }
+    }
 }


### PR DESCRIPTION
This pull request _incompletely_ exports `WasiCtx` in C-API: 
- Declare `wasi_ctx_t` in wasi.h.
- Add implementation for `wasi_ctx_insert_file` and `wasi_ctx_push_file` in wasi.rs. 
- Add implementation for `wasmtime_context_set_default_wasi_if_not_exist` and `wasmtime_context_get_wasi_ctx` in store.rs.

Discussed in https://github.com/bytecodealliance/wasmtime-go/issues/187 with @alexcrichton. 

The corresponding Go changes will be available in a separate pull request to wasmtime-go. 

Please let me know if there are any issues or suggested edits. 