### PR TITLE
winch: Use `Reg` where appropriate in the Masm

### DIFF
--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -147,9 +147,9 @@ impl Masm for MacroAssembler {
         self.asm.finalize()
     }
 
-    fn mov(&mut self, src: RegImm, dst: RegImm, size: OperandSize) {
+    fn mov(&mut self, src: RegImm, dst: Reg, size: OperandSize) {
         match (src, dst) {
-            (RegImm::Imm(v), RegImm::Reg(rd)) => {
+            (RegImm::Imm(v), rd) => {
                 let imm = match v {
                     I::I32(v) => v as u64,
                     I::I64(v) => v,
@@ -160,10 +160,9 @@ impl Masm for MacroAssembler {
                 self.asm.load_constant(imm as u64, scratch);
                 self.asm.mov_rr(scratch, rd, size);
             }
-            (RegImm::Reg(rs), RegImm::Reg(rd)) => {
+            (RegImm::Reg(rs), rd) => {
                 self.asm.mov_rr(rs, rd, size);
             }
-            _ => Self::handle_invalid_two_form_operand_combination(src, dst),
         }
     }
 
@@ -171,9 +170,9 @@ impl Masm for MacroAssembler {
         todo!()
     }
 
-    fn add(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize) {
+    fn add(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize) {
         match (rhs, lhs, dst) {
-            (RegImm::Imm(v), RegImm::Reg(rn), RegImm::Reg(rd)) => {
+            (RegImm::Imm(v), rn, rd) => {
                 let imm = match v {
                     I::I32(v) => v as u64,
                     I::I64(v) => v,
@@ -183,16 +182,15 @@ impl Masm for MacroAssembler {
                 self.asm.add_ir(imm, rn, rd, size);
             }
 
-            (RegImm::Reg(rm), RegImm::Reg(rn), RegImm::Reg(rd)) => {
+            (RegImm::Reg(rm), rn, rd) => {
                 self.asm.add_rrr(rm, rn, rd, size);
             }
-            _ => Self::handle_invalid_three_form_operand_combination(dst, lhs, rhs),
         }
     }
 
-    fn sub(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize) {
+    fn sub(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize) {
         match (rhs, lhs, dst) {
-            (RegImm::Imm(v), RegImm::Reg(rn), RegImm::Reg(rd)) => {
+            (RegImm::Imm(v), rn, rd) => {
                 let imm = match v {
                     I::I32(v) => v as u64,
                     I::I64(v) => v,
@@ -202,16 +200,15 @@ impl Masm for MacroAssembler {
                 self.asm.sub_ir(imm, rn, rd, size);
             }
 
-            (RegImm::Reg(rm), RegImm::Reg(rn), RegImm::Reg(rd)) => {
+            (RegImm::Reg(rm), rn, rd) => {
                 self.asm.sub_rrr(rm, rn, rd, size);
             }
-            _ => Self::handle_invalid_three_form_operand_combination(dst, lhs, rhs),
         }
     }
 
-    fn mul(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize) {
+    fn mul(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize) {
         match (rhs, lhs, dst) {
-            (RegImm::Imm(v), RegImm::Reg(rn), RegImm::Reg(rd)) => {
+            (RegImm::Imm(v), rn, rd) => {
                 let imm = match v {
                     I::I32(v) => v as u64,
                     I::I64(v) => v,
@@ -221,30 +218,29 @@ impl Masm for MacroAssembler {
                 self.asm.mul_ir(imm, rn, rd, size);
             }
 
-            (RegImm::Reg(rm), RegImm::Reg(rn), RegImm::Reg(rd)) => {
+            (RegImm::Reg(rm), rn, rd) => {
                 self.asm.mul_rrr(rm, rn, rd, size);
             }
-            _ => Self::handle_invalid_three_form_operand_combination(dst, lhs, rhs),
         }
     }
 
-    fn float_neg(&mut self, _dst: Reg, _src: RegImm, _size: OperandSize) {
+    fn float_neg(&mut self, _dst: Reg, _size: OperandSize) {
         todo!()
     }
 
-    fn float_abs(&mut self, _dst: Reg, _src: RegImm, _size: OperandSize) {
+    fn float_abs(&mut self, _dst: Reg, _size: OperandSize) {
         todo!()
     }
 
-    fn and(&mut self, _dst: RegImm, _lhs: RegImm, _rhs: RegImm, _size: OperandSize) {
+    fn and(&mut self, _dst: Reg, _lhs: Reg, _rhs: RegImm, _size: OperandSize) {
         todo!()
     }
 
-    fn or(&mut self, _dst: RegImm, _lhs: RegImm, _rhs: RegImm, _size: OperandSize) {
+    fn or(&mut self, _dst: Reg, _lhs: Reg, _rhs: RegImm, _size: OperandSize) {
         todo!()
     }
 
-    fn xor(&mut self, _dst: RegImm, _lhs: RegImm, _rhs: RegImm, _size: OperandSize) {
+    fn xor(&mut self, _dst: Reg, _lhs: Reg, _rhs: RegImm, _size: OperandSize) {
         todo!()
     }
 
@@ -350,16 +346,5 @@ impl MacroAssembler {
         let sp = regs::sp();
         let shadow_sp = regs::shadow_sp();
         self.asm.mov_rr(sp, shadow_sp, OperandSize::S64);
-    }
-
-    fn handle_invalid_two_form_operand_combination(src: RegImm, dst: RegImm) {
-        panic!("Invalid operand combination; src={:?}, dst={:?}", src, dst);
-    }
-
-    fn handle_invalid_three_form_operand_combination(dst: RegImm, lhs: RegImm, rhs: RegImm) {
-        panic!(
-            "Invalid operand combination; dst={:?}, lhs={:?}, rhs={:?}",
-            dst, lhs, rhs
-        );
     }
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -303,34 +303,34 @@ pub(crate) trait MacroAssembler {
     fn pop(&mut self, dst: Reg, size: OperandSize);
 
     /// Perform a move.
-    fn mov(&mut self, src: RegImm, dst: RegImm, size: OperandSize);
+    fn mov(&mut self, src: RegImm, dst: Reg, size: OperandSize);
 
     /// Perform a conditional move.
     fn cmov(&mut self, src: Reg, dst: Reg, cc: CmpKind, size: OperandSize);
 
     /// Perform add operation.
-    fn add(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
+    fn add(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform subtraction operation.
-    fn sub(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
+    fn sub(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform multiplication operation.
-    fn mul(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
+    fn mul(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform a floating point abs operation.
-    fn float_abs(&mut self, dst: Reg, src: RegImm, size: OperandSize);
+    fn float_abs(&mut self, dst: Reg, size: OperandSize);
 
     /// Perform a floating point negation operation.
-    fn float_neg(&mut self, dst: Reg, src: RegImm, size: OperandSize);
+    fn float_neg(&mut self, dst: Reg, size: OperandSize);
 
     /// Perform logical and operation.
-    fn and(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
+    fn and(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform logical or operation.
-    fn or(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
+    fn or(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform logical exclusive or operation.
-    fn xor(&mut self, dst: RegImm, lhs: RegImm, rhs: RegImm, size: OperandSize);
+    fn xor(&mut self, dst: Reg, lhs: Reg, rhs: RegImm, size: OperandSize);
 
     /// Perform a shift operation.
     /// Shift is special in that some architectures have specific expectations

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -149,28 +149,28 @@ where
     fn visit_f32_abs(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
-                masm.float_abs(reg, RegImm::Reg(reg), size);
+                masm.float_abs(reg, size);
             });
     }
 
     fn visit_f64_abs(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
-                masm.float_abs(reg, RegImm::Reg(reg), size);
+                masm.float_abs(reg, size);
             });
     }
 
     fn visit_f32_neg(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
-                masm.float_neg(reg, RegImm::Reg(reg), size);
+                masm.float_neg(reg, size);
             });
     }
 
     fn visit_f64_neg(&mut self) {
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
-                masm.float_neg(reg, RegImm::Reg(reg), size);
+                masm.float_neg(reg, size);
             });
     }
 
@@ -745,14 +745,14 @@ where
 {
     fn cmp_i32s(&mut self, kind: CmpKind) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
-            masm.cmp_with_set(src, dst.get_reg().unwrap(), kind, size);
+            masm.cmp_with_set(src, dst, kind, size);
         });
     }
 
     fn cmp_i64s(&mut self, kind: CmpKind) {
         self.context
             .i64_binop(self.masm, move |masm, dst, src, size| {
-                masm.cmp_with_set(src, dst.get_reg().unwrap(), kind, size);
+                masm.cmp_with_set(src, dst, kind, size);
             });
     }
 }


### PR DESCRIPTION
This change is a small refactoring to some of the MacroAssembler functions to use `Reg` instead of `RegImm` where appropriate (e.g. when the operand is a destination).

@elliottt pointed this out while working on https://github.com/bytecodealliance/wasmtime/pull/6982

This change also changes the signature of `float_abs` and `float_neg`, which can be simplified to take a single register.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
