### PR TITLE
riscv64: Implement ELF TLS GD Relocations 

### DIFF
--- a/cranelift/codegen/src/binemit/mod.rs
+++ b/cranelift/codegen/src/binemit/mod.rs
@@ -92,6 +92,18 @@ pub enum Reloc {
     /// jalr ra, ra, 0
     RiscvCall,
 
+    /// RISC-V TLS GD: High 20 bits of 32-bit PC-relative TLS GD GOT reference,
+    ///
+    /// This is the `R_RISCV_TLS_GD_HI20` relocation from the RISC-V ELF psABI document.
+    /// https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#global-dynamic
+    RiscvTlsGdHi20,
+
+    /// Low 12 bits of a 32-bit PC-relative relocation (I-Type instruction)
+    ///
+    /// This is the `R_RISCV_PCREL_LO12_I` relocation from the RISC-V ELF psABI document.
+    /// https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#pc-relative-symbol-addresses
+    RiscvPCRelLo12I,
+
     /// s390x TLS GD64 - 64-bit offset of tls_index for GD symbol in GOT
     S390xTlsGd64,
     /// s390x TLS GDCall - marker to enable optimization of TLS calls
@@ -114,7 +126,8 @@ impl fmt::Display for Reloc {
             Self::X86SecRel => write!(f, "SecRel"),
             Self::Arm32Call | Self::Arm64Call => write!(f, "Call"),
             Self::RiscvCall => write!(f, "RiscvCall"),
-
+            Self::RiscvTlsGdHi20 => write!(f, "RiscvTlsGdHi20"),
+            Self::RiscvPCRelLo12I => write!(f, "RiscvPCRelLo12I"),
             Self::ElfX86_64TlsGd => write!(f, "ElfX86_64TlsGd"),
             Self::MachOX86_64Tlv => write!(f, "MachOX86_64Tlv"),
             Self::MachOAarch64TlsAdrPage21 => write!(f, "MachOAarch64TlsAdrPage21"),

--- a/cranelift/codegen/src/isa/aarch64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit.rs
@@ -3174,7 +3174,7 @@ impl MachInstEmit for Inst {
                 // Note: this is not `Inst::Jump { .. }.emit(..)` because we
                 // have different metadata in this case: we don't have a label
                 // for the target, but rather a function relocation.
-                sink.add_reloc(Reloc::Arm64Call, callee, 0);
+                sink.add_reloc(Reloc::Arm64Call, &**callee, 0);
                 sink.put4(enc_jump26(0b000101, 0));
                 sink.add_call_site(ir::Opcode::ReturnCall);
 
@@ -3382,12 +3382,12 @@ impl MachInstEmit for Inst {
                     //   ldr     rd, [rd, :got_lo12:X]
 
                     // adrp rd, symbol
-                    sink.add_reloc(Reloc::Aarch64AdrGotPage21, name, 0);
+                    sink.add_reloc(Reloc::Aarch64AdrGotPage21, &**name, 0);
                     let inst = Inst::Adrp { rd, off: 0 };
                     inst.emit(&[], sink, emit_info, state);
 
                     // ldr rd, [rd, :got_lo12:X]
-                    sink.add_reloc(Reloc::Aarch64Ld64GotLo12Nc, name, 0);
+                    sink.add_reloc(Reloc::Aarch64Ld64GotLo12Nc, &**name, 0);
                     let inst = Inst::ULoad64 {
                         rd,
                         mem: AMode::reg(rd.to_reg()),
@@ -3415,7 +3415,7 @@ impl MachInstEmit for Inst {
                         dest: BranchTarget::ResolvedOffset(12),
                     };
                     inst.emit(&[], sink, emit_info, state);
-                    sink.add_reloc(Reloc::Abs8, name, offset);
+                    sink.add_reloc(Reloc::Abs8, &**name, offset);
                     sink.put8(0);
                 }
             }

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -148,6 +148,11 @@
       (name BoxExternalName)
       (offset i64))
 
+    ;; Load a TLS symbol address
+    (ElfTlsGetAddr
+      (rd WritableReg)
+      (name BoxExternalName))
+
     ;; Load address referenced by `mem` into `rd`.
     (LoadAddr
       (rd WritableReg)
@@ -2624,6 +2629,12 @@
 ;;;; load extern name
 (decl load_ext_name (ExternalName i64) Reg)
 (extern constructor load_ext_name load_ext_name)
+
+(decl elf_tls_get_addr (ExternalName) Reg)
+(rule (elf_tls_get_addr name)
+      (let ((dst WritableReg (temp_writable_reg $I64))
+            (_ Unit (emit (MInst.ElfTlsGetAddr dst name))))
+        dst))
 
 (decl int_convert_2_float_op (Type bool Type) FpuOPRR)
 (extern constructor int_convert_2_float_op int_convert_2_float_op)

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1976,16 +1976,15 @@ impl Inst {
                 //
                 // https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#global-dynamic
 
-                // Create a lable that is going to be published to the final binary object.
+                // Create the lable that is going to be published to the final binary object.
                 let auipc_label = sink.get_label();
                 sink.bind_label(auipc_label, &mut state.ctrl_plane);
-                sink.set_label_visiblity(auipc_label, LabelVisibility::Public);
 
                 // Get the current PC.
                 sink.add_reloc(Reloc::RiscvTlsGdHi20, &**name, 0);
                 Inst::Auipc {
                     rd: rd,
-                    imm: Imm20::from_bits(0),
+                    imm: Imm20::from_i32(0),
                 }
                 .emit_uncompressed(sink, emit_info, state, start_off);
 
@@ -1995,7 +1994,7 @@ impl Inst {
                     alu_op: AluOPRRI::Addi,
                     rd: rd,
                     rs: rd.to_reg(),
-                    imm12: Imm12::from_bits(0),
+                    imm12: Imm12::from_i16(0),
                 }
                 .emit_uncompressed(sink, emit_info, state, start_off);
 

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -978,7 +978,7 @@ impl Inst {
                 );
 
                 sink.add_call_site(ir::Opcode::ReturnCall);
-                sink.add_reloc(Reloc::RiscvCall, &callee, 0);
+                sink.add_reloc(Reloc::RiscvCall, &**callee, 0);
                 Inst::construct_auipc_and_jalr(None, writable_spilltmp_reg(), 0)
                     .into_iter()
                     .for_each(|i| i.emit_uncompressed(sink, emit_info, state, start_off));

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1675,6 +1675,11 @@
    (lower (symbol_value (symbol_value_data name _ offset)))
    (load_ext_name name offset))
 
+;;;;;  Rules for `tls_value` ;;;;;;;;;;;;;;
+
+(rule (lower (has_type (tls_model (TlsModel.ElfGd)) (tls_value (symbol_value_data name _ _))))
+      (elf_tls_get_addr name))
+
 ;;;;;  Rules for `bitcast`;;;;;;;;;
 (rule
    (lower (has_type out_ty (bitcast _ v @ (value_type in_ty))))

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -56,7 +56,8 @@ pub mod write;
 
 pub use crate::entity::packed_option;
 pub use crate::machinst::buffer::{
-    MachCallSite, MachReloc, MachSrcLoc, MachStackMap, MachTextSectionBuilder, MachTrap,
+    MachCallSite, MachLabelSite, MachReloc, MachSrcLoc, MachStackMap, MachTextSectionBuilder,
+    MachTrap,
 };
 pub use crate::machinst::{
     CompiledCode, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit,

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -56,8 +56,8 @@ pub mod write;
 
 pub use crate::entity::packed_option;
 pub use crate::machinst::buffer::{
-    MachCallSite, MachLabelSite, MachReloc, MachSrcLoc, MachStackMap, MachTextSectionBuilder,
-    MachTrap, RelocTarget,
+    FinalizedMachReloc, FinalizedRelocTarget, MachCallSite, MachSrcLoc, MachStackMap,
+    MachTextSectionBuilder, MachTrap,
 };
 pub use crate::machinst::{
     CompiledCode, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit,

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -57,7 +57,7 @@ pub mod write;
 pub use crate::entity::packed_option;
 pub use crate::machinst::buffer::{
     MachCallSite, MachLabelSite, MachReloc, MachSrcLoc, MachStackMap, MachTextSectionBuilder,
-    MachTrap,
+    MachTrap, RelocTarget,
 };
 pub use crate::machinst::{
     CompiledCode, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit,

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1492,10 +1492,10 @@ impl<I: VCodeInst> MachBuffer<I> {
         let labels = self
             .label_is_public
             .iter()
-            .enumerate()
-            .map(|(id, label)| MachLabelSite {
-                offset: self.resolve_label_offset(*label),
-                id: id as u32,
+            .copied()
+            .map(|label| MachLabelSite {
+                offset: self.resolve_label_offset(label),
+                label,
             })
             .collect();
 
@@ -1838,9 +1838,8 @@ pub struct MachLabelSite {
     /// The offset at which the relocation applies, *relative to the
     /// containing section*.
     pub offset: CodeOffset,
-    /// The id of the label. This is unrelated to the id assigned during
-    /// compilation.
-    pub id: u32,
+    /// The label.
+    pub label: MachLabel,
 }
 
 /// A trap record resulting from a compilation.

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -281,7 +281,7 @@ pub struct MachBuffer<I: VCodeInst> {
     ///
     /// Public labels are the exception, so we only keep track of them and assume
     /// all others are private.
-    label_is_public: SmallVec<[MachLabel; 4]>,
+    public_labels: SmallVec<[MachLabel; 4]>,
     /// Constants that must be emitted at some point.
     pending_constants: SmallVec<[VCodeConstant; 16]>,
     /// Byte size of all constants in `pending_constants`.
@@ -448,7 +448,7 @@ impl<I: VCodeInst> MachBuffer<I> {
             cur_srcloc: None,
             label_offsets: SmallVec::new(),
             label_aliases: SmallVec::new(),
-            label_is_public: SmallVec::new(),
+            public_labels: SmallVec::new(),
             pending_constants: SmallVec::new(),
             pending_constants_size: 0,
             pending_traps: SmallVec::new(),
@@ -664,8 +664,8 @@ impl<I: VCodeInst> MachBuffer<I> {
         );
         debug_assert_ne!(self.resolve_label_offset(label), UNKNOWN_LABEL_OFFSET);
         match visibility {
-            LabelVisibility::Public => self.label_is_public.push(label),
-            LabelVisibility::Private => self.label_is_public.retain(|l| *l != label),
+            LabelVisibility::Public => self.public_labels.push(label),
+            LabelVisibility::Private => self.public_labels.retain(|l| *l != label),
         }
     }
 
@@ -1490,7 +1490,7 @@ impl<I: VCodeInst> MachBuffer<I> {
         let alignment = self.finish_constants(constants);
 
         let labels = self
-            .label_is_public
+            .public_labels
             .iter()
             .copied()
             .map(|label| MachLabelSite {

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -430,7 +430,7 @@ impl<T: CompilePhase> CompiledCodeBase<T> {
                         buf,
                         " ; reloc_external {} {} {}",
                         reloc.kind,
-                        reloc.name.display(params),
+                        reloc.target.display(params),
                         reloc.addend,
                     )?;
                 }

--- a/cranelift/filetests/filetests/isa/riscv64/tls-elf.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/tls-elf.clif
@@ -40,7 +40,7 @@ block0(v0: i32):
 ; block1: ; offset 0x18
 ;   mv s1, a0
 ;   auipc a0, 0 ; reloc_external RiscvTlsGdHi20 u1:0 0
-;   mv a0, a0 ; reloc_external RiscvPCRelLo12I .L1 0
+;   mv a0, a0 ; reloc_external RiscvPCRelLo12I func+28 0
 ;   auipc t5, 0
 ;   ld t5, 0xc(t5)
 ;   j 0xc

--- a/cranelift/filetests/filetests/isa/riscv64/tls-elf.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/tls-elf.clif
@@ -1,0 +1,58 @@
+test compile precise-output
+set tls_model=elf_gd
+target riscv64
+
+function u0:0(i32) -> i32, i64 {
+gv0 = symbol colocated tls u1:0
+
+block0(v0: i32):
+    v1 = global_value.i64 gv0
+    return v0, v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   sd s1,-8(sp)
+;   add sp,-16
+; block0:
+;   mv s1,a0
+;   elf_tls_get_addr a0,userextname0
+;   mv a1,a0
+;   mv a0,s1
+;   add sp,+16
+;   ld s1,-8(sp)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+;   sd s1, -8(sp)
+;   addi sp, sp, -0x10
+; block1: ; offset 0x18
+;   mv s1, a0
+;   auipc a0, 0 ; reloc_external RiscvTlsGdHi20 u1:0 0
+;   mv a0, a0 ; reloc_external RiscvPCRelLo12I .L1 0
+;   auipc t5, 0
+;   ld t5, 0xc(t5)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %ElfTlsGetAddr 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   jalr t5
+;   mv a1, a0
+;   mv a0, s1
+;   addi sp, sp, 0x10
+;   ld s1, -8(sp)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -4,7 +4,7 @@ use crate::{compiled_blob::CompiledBlob, memory::BranchProtection, memory::Memor
 use cranelift_codegen::binemit::Reloc;
 use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
 use cranelift_codegen::settings::Configurable;
-use cranelift_codegen::{self, ir, settings, MachReloc};
+use cranelift_codegen::{self, ir, settings, MachLabelSite, MachReloc};
 use cranelift_control::ControlPlane;
 use cranelift_entity::SecondaryMap;
 use cranelift_module::{
@@ -759,6 +759,7 @@ impl Module for JITModule {
         alignment: u64,
         bytes: &[u8],
         relocs: &[MachReloc],
+        _labels: &[MachLabelSite],
     ) -> ModuleResult<()> {
         info!("defining function {} with bytes", id);
         let decl = self.declarations.get_function_decl(id);

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -9,7 +9,7 @@ use cranelift_control::ControlPlane;
 use cranelift_entity::SecondaryMap;
 use cranelift_module::{
     DataDescription, DataId, FuncId, Init, Linkage, Module, ModuleDeclarations, ModuleError,
-    ModuleExtName, ModuleReloc, ModuleResult,
+    ModuleReloc, ModuleRelocTarget, ModuleResult,
 };
 use log::info;
 use std::cell::RefCell;
@@ -300,9 +300,9 @@ impl JITModule {
         std::ptr::write(plt_ptr, plt_val);
     }
 
-    fn get_address(&self, name: &ModuleExtName) -> *const u8 {
+    fn get_address(&self, name: &ModuleRelocTarget) -> *const u8 {
         match *name {
-            ModuleExtName::User { .. } => {
+            ModuleRelocTarget::User { .. } => {
                 let (name, linkage) = if ModuleDeclarations::is_function(name) {
                     if self.hotswap_enabled {
                         return self.get_plt_address(name);
@@ -337,7 +337,7 @@ impl JITModule {
                     panic!("can't resolve symbol {}", name);
                 }
             }
-            ModuleExtName::LibCall(ref libcall) => {
+            ModuleRelocTarget::LibCall(ref libcall) => {
                 let sym = (self.libcall_names)(*libcall);
                 self.lookup_symbol(&sym)
                     .unwrap_or_else(|| panic!("can't resolve libcall {}", sym))
@@ -354,9 +354,9 @@ impl JITModule {
         unsafe { got_entry.as_ref() }.load(Ordering::SeqCst)
     }
 
-    fn get_got_address(&self, name: &ModuleExtName) -> NonNull<AtomicPtr<u8>> {
+    fn get_got_address(&self, name: &ModuleRelocTarget) -> NonNull<AtomicPtr<u8>> {
         match *name {
-            ModuleExtName::User { .. } => {
+            ModuleRelocTarget::User { .. } => {
                 if ModuleDeclarations::is_function(name) {
                     let func_id = FuncId::from_name(name);
                     self.function_got_entries[func_id].unwrap()
@@ -365,7 +365,7 @@ impl JITModule {
                     self.data_object_got_entries[data_id].unwrap()
                 }
             }
-            ModuleExtName::LibCall(ref libcall) => *self
+            ModuleRelocTarget::LibCall(ref libcall) => *self
                 .libcall_got_entries
                 .get(libcall)
                 .unwrap_or_else(|| panic!("can't resolve libcall {}", libcall)),
@@ -373,9 +373,9 @@ impl JITModule {
         }
     }
 
-    fn get_plt_address(&self, name: &ModuleExtName) -> *const u8 {
+    fn get_plt_address(&self, name: &ModuleRelocTarget) -> *const u8 {
         match *name {
-            ModuleExtName::User { .. } => {
+            ModuleRelocTarget::User { .. } => {
                 if ModuleDeclarations::is_function(name) {
                     let func_id = FuncId::from_name(name);
                     self.function_plt_entries[func_id]
@@ -386,7 +386,7 @@ impl JITModule {
                     unreachable!("PLT relocations can only have functions as target");
                 }
             }
-            ModuleExtName::LibCall(ref libcall) => self
+            ModuleRelocTarget::LibCall(ref libcall) => self
                 .libcall_plt_entries
                 .get(libcall)
                 .unwrap_or_else(|| panic!("can't resolve libcall {}", libcall))
@@ -731,10 +731,10 @@ impl Module for JITModule {
                 .unwrap()
                 .perform_relocations(
                     |name| match *name {
-                        ModuleExtName::User { .. } => {
+                        ModuleRelocTarget::User { .. } => {
                             unreachable!("non GOT or PLT relocation in function {} to {}", id, name)
                         }
-                        ModuleExtName::LibCall(ref libcall) => self
+                        ModuleRelocTarget::LibCall(ref libcall) => self
                             .libcall_plt_entries
                             .get(libcall)
                             .unwrap_or_else(|| panic!("can't resolve libcall {}", libcall))

--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -4,7 +4,7 @@ use crate::{compiled_blob::CompiledBlob, memory::BranchProtection, memory::Memor
 use cranelift_codegen::binemit::Reloc;
 use cranelift_codegen::isa::{OwnedTargetIsa, TargetIsa};
 use cranelift_codegen::settings::Configurable;
-use cranelift_codegen::{self, ir, settings, MachLabelSite, MachReloc};
+use cranelift_codegen::{self, ir, settings, FinalizedMachReloc};
 use cranelift_control::ControlPlane;
 use cranelift_entity::SecondaryMap;
 use cranelift_module::{
@@ -758,8 +758,7 @@ impl Module for JITModule {
         func: &ir::Function,
         alignment: u64,
         bytes: &[u8],
-        relocs: &[MachReloc],
-        _labels: &[MachLabelSite],
+        relocs: &[FinalizedMachReloc],
     ) -> ModuleResult<()> {
         info!("defining function {} with bytes", id);
         let decl = self.declarations.get_function_decl(id);

--- a/cranelift/jit/src/compiled_blob.rs
+++ b/cranelift/jit/src/compiled_blob.rs
@@ -1,6 +1,6 @@
 use cranelift_codegen::binemit::Reloc;
-use cranelift_module::ModuleExtName;
 use cranelift_module::ModuleReloc;
+use cranelift_module::ModuleRelocTarget;
 use std::convert::TryFrom;
 
 /// Reads a 32bit instruction at `iptr`, and writes it again after
@@ -21,9 +21,9 @@ pub(crate) struct CompiledBlob {
 impl CompiledBlob {
     pub(crate) fn perform_relocations(
         &self,
-        get_address: impl Fn(&ModuleExtName) -> *const u8,
-        get_got_entry: impl Fn(&ModuleExtName) -> *const u8,
-        get_plt_entry: impl Fn(&ModuleExtName) -> *const u8,
+        get_address: impl Fn(&ModuleRelocTarget) -> *const u8,
+        get_got_entry: impl Fn(&ModuleRelocTarget) -> *const u8,
+        get_plt_entry: impl Fn(&ModuleRelocTarget) -> *const u8,
     ) {
         use std::ptr::write_unaligned;
 

--- a/cranelift/module/src/data_context.rs
+++ b/cranelift/module/src/data_context.rs
@@ -9,7 +9,7 @@ use std::string::String;
 use std::vec::Vec;
 
 use crate::module::ModuleReloc;
-use crate::ModuleExtName;
+use crate::ModuleRelocTarget;
 
 /// This specifies how data is to be initialized.
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -53,9 +53,9 @@ pub struct DataDescription {
     /// How the data should be initialized.
     pub init: Init,
     /// External function declarations.
-    pub function_decls: PrimaryMap<ir::FuncRef, ModuleExtName>,
+    pub function_decls: PrimaryMap<ir::FuncRef, ModuleRelocTarget>,
     /// External data object declarations.
-    pub data_decls: PrimaryMap<ir::GlobalValue, ModuleExtName>,
+    pub data_decls: PrimaryMap<ir::GlobalValue, ModuleRelocTarget>,
     /// Function addresses to write at specified offsets.
     pub function_relocs: Vec<(CodeOffset, ir::FuncRef)>,
     /// Data addresses to write at specified offsets.
@@ -122,7 +122,7 @@ impl DataDescription {
     /// Users of the `Module` API generally should call
     /// `Module::declare_func_in_data` instead, as it takes care of generating
     /// the appropriate `ExternalName`.
-    pub fn import_function(&mut self, name: ModuleExtName) -> ir::FuncRef {
+    pub fn import_function(&mut self, name: ModuleRelocTarget) -> ir::FuncRef {
         self.function_decls.push(name)
     }
 
@@ -133,7 +133,7 @@ impl DataDescription {
     /// Users of the `Module` API generally should call
     /// `Module::declare_data_in_data` instead, as it takes care of generating
     /// the appropriate `ExternalName`.
-    pub fn import_global_value(&mut self, name: ModuleExtName) -> ir::GlobalValue {
+    pub fn import_global_value(&mut self, name: ModuleRelocTarget) -> ir::GlobalValue {
         self.data_decls.push(name)
     }
 
@@ -176,7 +176,7 @@ impl DataDescription {
 
 #[cfg(test)]
 mod tests {
-    use crate::ModuleExtName;
+    use crate::ModuleRelocTarget;
 
     use super::{DataDescription, Init};
 
@@ -191,11 +191,11 @@ mod tests {
 
         data.define_zeroinit(256);
 
-        let _func_a = data.import_function(ModuleExtName::user(0, 0));
-        let func_b = data.import_function(ModuleExtName::user(0, 1));
-        let func_c = data.import_function(ModuleExtName::user(0, 2));
-        let _data_a = data.import_global_value(ModuleExtName::user(0, 3));
-        let data_b = data.import_global_value(ModuleExtName::user(0, 4));
+        let _func_a = data.import_function(ModuleRelocTarget::user(0, 0));
+        let func_b = data.import_function(ModuleRelocTarget::user(0, 1));
+        let func_c = data.import_function(ModuleRelocTarget::user(0, 2));
+        let _data_a = data.import_global_value(ModuleRelocTarget::user(0, 3));
+        let data_b = data.import_global_value(ModuleRelocTarget::user(0, 4));
 
         data.write_function_addr(8, func_b);
         data.write_function_addr(16, func_c);

--- a/cranelift/module/src/lib.rs
+++ b/cranelift/module/src/lib.rs
@@ -29,7 +29,7 @@ mod traps;
 pub use crate::data_context::{DataDescription, Init};
 pub use crate::module::{
     DataDeclaration, DataId, FuncId, FuncOrDataId, FunctionDeclaration, Linkage, Module,
-    ModuleDeclarations, ModuleError, ModuleExtName, ModuleReloc, ModuleResult,
+    ModuleDeclarations, ModuleError, ModuleReloc, ModuleRelocTarget, ModuleResult,
 };
 pub use crate::traps::TrapSite;
 

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -11,9 +11,9 @@ use core::fmt::Display;
 use cranelift_codegen::binemit::{CodeOffset, Reloc};
 use cranelift_codegen::entity::{entity_impl, PrimaryMap};
 use cranelift_codegen::ir::function::{Function, VersionMarker};
-use cranelift_codegen::ir::ExternalName;
+use cranelift_codegen::ir::{ExternalName, UserFuncName};
 use cranelift_codegen::settings::SetError;
-use cranelift_codegen::{ir, isa, CodegenError, CompileError, Context, RelocTarget};
+use cranelift_codegen::{ir, isa, CodegenError, CompileError, Context, MachLabel, RelocTarget};
 use cranelift_codegen::{MachLabelSite, MachReloc};
 use cranelift_control::ControlPlane;
 use std::borrow::{Cow, ToOwned};
@@ -28,7 +28,7 @@ pub struct ModuleReloc {
     /// The kind of relocation.
     pub kind: Reloc,
     /// The external symbol / name to which this relocation refers.
-    pub name: ModuleExtName,
+    pub name: ModuleRelocTarget,
     /// The addend to add to the symbol value.
     pub addend: i64,
 }
@@ -39,16 +39,16 @@ impl ModuleReloc {
         let name = match mach_reloc.target {
             RelocTarget::ExternalName(ExternalName::User(reff)) => {
                 let name = &func.params.user_named_funcs()[reff];
-                ModuleExtName::user(name.namespace, name.index)
+                ModuleRelocTarget::user(name.namespace, name.index)
             }
             RelocTarget::ExternalName(ExternalName::TestCase(_)) => unimplemented!(),
             RelocTarget::ExternalName(ExternalName::LibCall(libcall)) => {
-                ModuleExtName::LibCall(libcall)
+                ModuleRelocTarget::LibCall(libcall)
             }
             RelocTarget::ExternalName(ExternalName::KnownSymbol(ks)) => {
-                ModuleExtName::KnownSymbol(ks)
+                ModuleRelocTarget::KnownSymbol(ks)
             }
-            RelocTarget::Label(_) => unimplemented!(),
+            RelocTarget::Label(label) => ModuleRelocTarget::FunctionLabel(func.name.clone(), label),
         };
         Self {
             offset: mach_reloc.offset,
@@ -69,7 +69,7 @@ pub struct FuncId(u32);
 entity_impl!(FuncId, "funcid");
 
 /// Function identifiers are namespace 0 in `ir::ExternalName`
-impl From<FuncId> for ModuleExtName {
+impl From<FuncId> for ModuleRelocTarget {
     fn from(id: FuncId) -> Self {
         Self::User {
             namespace: 0,
@@ -80,8 +80,8 @@ impl From<FuncId> for ModuleExtName {
 
 impl FuncId {
     /// Get the `FuncId` for the function named by `name`.
-    pub fn from_name(name: &ModuleExtName) -> FuncId {
-        if let ModuleExtName::User { namespace, index } = name {
+    pub fn from_name(name: &ModuleRelocTarget) -> FuncId {
+        if let ModuleRelocTarget::User { namespace, index } = name {
             debug_assert_eq!(*namespace, 0);
             FuncId::from_u32(*index)
         } else {
@@ -100,7 +100,7 @@ pub struct DataId(u32);
 entity_impl!(DataId, "dataid");
 
 /// Data identifiers are namespace 1 in `ir::ExternalName`
-impl From<DataId> for ModuleExtName {
+impl From<DataId> for ModuleRelocTarget {
     fn from(id: DataId) -> Self {
         Self::User {
             namespace: 1,
@@ -111,8 +111,8 @@ impl From<DataId> for ModuleExtName {
 
 impl DataId {
     /// Get the `DataId` for the data object named by `name`.
-    pub fn from_name(name: &ModuleExtName) -> DataId {
-        if let ModuleExtName::User { namespace, index } = name {
+    pub fn from_name(name: &ModuleRelocTarget) -> DataId {
+        if let ModuleRelocTarget::User { namespace, index } = name {
             debug_assert_eq!(*namespace, 1);
             DataId::from_u32(*index)
         } else {
@@ -197,7 +197,7 @@ pub enum FuncOrDataId {
 }
 
 /// Mapping to `ModuleExtName` is trivial based on the `FuncId` and `DataId` mapping.
-impl From<FuncOrDataId> for ModuleExtName {
+impl From<FuncOrDataId> for ModuleRelocTarget {
     fn from(id: FuncOrDataId) -> Self {
         match id {
             FuncOrDataId::Func(funcid) => Self::from(funcid),
@@ -414,7 +414,7 @@ impl DataDeclaration {
     feature = "enable-serde",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
 )]
-pub enum ModuleExtName {
+pub enum ModuleRelocTarget {
     /// User defined function, converted from `ExternalName::User`.
     User {
         /// Arbitrary.
@@ -426,21 +426,24 @@ pub enum ModuleExtName {
     LibCall(ir::LibCall),
     /// Symbols known to the linker.
     KnownSymbol(ir::KnownSymbol),
+    /// A label inside a function
+    FunctionLabel(UserFuncName, MachLabel),
 }
 
-impl ModuleExtName {
+impl ModuleRelocTarget {
     /// Creates a user-defined external name.
     pub fn user(namespace: u32, index: u32) -> Self {
         Self::User { namespace, index }
     }
 }
 
-impl Display for ModuleExtName {
+impl Display for ModuleRelocTarget {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::User { namespace, index } => write!(f, "u{}:{}", namespace, index),
             Self::LibCall(lc) => write!(f, "%{}", lc),
             Self::KnownSymbol(ks) => write!(f, "{}", ks),
+            Self::FunctionLabel(fname, label) => write!(f, ".L{}_{}", fname, label.as_u32()),
         }
     }
 }
@@ -692,10 +695,12 @@ impl ModuleDeclarations {
     }
 
     /// Return whether `name` names a function, rather than a data object.
-    pub fn is_function(name: &ModuleExtName) -> bool {
+    pub fn is_function(name: &ModuleRelocTarget) -> bool {
         match name {
-            ModuleExtName::User { namespace, .. } => *namespace == 0,
-            ModuleExtName::LibCall(_) | ModuleExtName::KnownSymbol(_) => {
+            ModuleRelocTarget::User { namespace, .. } => *namespace == 0,
+            ModuleRelocTarget::LibCall(_)
+            | ModuleRelocTarget::KnownSymbol(_)
+            | ModuleRelocTarget::FunctionLabel(..) => {
                 panic!("unexpected module ext name")
             }
         }
@@ -924,12 +929,12 @@ pub trait Module {
 
     /// TODO: Same as above.
     fn declare_func_in_data(&self, func_id: FuncId, data: &mut DataDescription) -> ir::FuncRef {
-        data.import_function(ModuleExtName::user(0, func_id.as_u32()))
+        data.import_function(ModuleRelocTarget::user(0, func_id.as_u32()))
     }
 
     /// TODO: Same as above.
     fn declare_data_in_data(&self, data_id: DataId, data: &mut DataDescription) -> ir::GlobalValue {
-        data.import_global_value(ModuleExtName::user(1, data_id.as_u32()))
+        data.import_global_value(ModuleRelocTarget::user(1, data_id.as_u32()))
     }
 
     /// Define a function, producing the function body from the given `Context`.

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -12,8 +12,8 @@ use cranelift_codegen::binemit::{CodeOffset, Reloc};
 use cranelift_codegen::entity::{entity_impl, PrimaryMap};
 use cranelift_codegen::ir::function::{Function, VersionMarker};
 use cranelift_codegen::settings::SetError;
-use cranelift_codegen::MachReloc;
 use cranelift_codegen::{ir, isa, CodegenError, CompileError, Context};
+use cranelift_codegen::{MachLabelSite, MachReloc};
 use cranelift_control::ControlPlane;
 use std::borrow::{Cow, ToOwned};
 use std::string::String;
@@ -966,6 +966,7 @@ pub trait Module {
         alignment: u64,
         bytes: &[u8],
         relocs: &[MachReloc],
+        labels: &[MachLabelSite],
     ) -> ModuleResult<()>;
 
     /// Define a data object, producing the data contents from the given `DataContext`.
@@ -1068,8 +1069,9 @@ impl<M: Module> Module for &mut M {
         alignment: u64,
         bytes: &[u8],
         relocs: &[MachReloc],
+        labels: &[MachLabelSite],
     ) -> ModuleResult<()> {
-        (**self).define_function_bytes(func_id, func, alignment, bytes, relocs)
+        (**self).define_function_bytes(func_id, func, alignment, bytes, relocs, labels)
     }
 
     fn define_data(&mut self, data_id: DataId, data: &DataDescription) -> ModuleResult<()> {

--- a/cranelift/object/src/backend.rs
+++ b/cranelift/object/src/backend.rs
@@ -803,6 +803,30 @@ impl ObjectModule {
                     0,
                 )
             }
+            Reloc::RiscvTlsGdHi20 => {
+                assert_eq!(
+                    self.object.format(),
+                    object::BinaryFormat::Elf,
+                    "RiscvTlsGdHi20 is not supported for this file format"
+                );
+                (
+                    RelocationKind::Elf(object::elf::R_RISCV_TLS_GD_HI20),
+                    RelocationEncoding::Generic,
+                    0,
+                )
+            }
+            Reloc::RiscvPCRelLo12I => {
+                assert_eq!(
+                    self.object.format(),
+                    object::BinaryFormat::Elf,
+                    "RiscvPCRelLo12I is not supported for this file format"
+                );
+                (
+                    RelocationKind::Elf(object::elf::R_RISCV_PCREL_LO12_I),
+                    RelocationEncoding::Generic,
+                    0,
+                )
+            }
             // FIXME
             reloc => unimplemented!("{:?}", reloc),
         };

--- a/cranelift/src/disasm.rs
+++ b/cranelift/src/disasm.rs
@@ -2,12 +2,12 @@ use anyhow::Result;
 use cfg_if::cfg_if;
 use cranelift_codegen::ir::function::FunctionParameters;
 use cranelift_codegen::isa::TargetIsa;
-use cranelift_codegen::{MachReloc, MachStackMap, MachTrap};
+use cranelift_codegen::{FinalizedMachReloc, MachStackMap, MachTrap};
 use std::fmt::Write;
 
-fn print_relocs(func_params: &FunctionParameters, relocs: &[MachReloc]) -> String {
+fn print_relocs(func_params: &FunctionParameters, relocs: &[FinalizedMachReloc]) -> String {
     let mut text = String::new();
-    for &MachReloc {
+    for &FinalizedMachReloc {
         kind,
         offset,
         ref target,
@@ -121,7 +121,7 @@ pub fn print_all(
     mem: &[u8],
     code_size: u32,
     print: bool,
-    relocs: &[MachReloc],
+    relocs: &[FinalizedMachReloc],
     traps: &[MachTrap],
     stack_maps: &[MachStackMap],
 ) -> Result<()> {

--- a/cranelift/src/disasm.rs
+++ b/cranelift/src/disasm.rs
@@ -10,7 +10,7 @@ fn print_relocs(func_params: &FunctionParameters, relocs: &[MachReloc]) -> Strin
     for &MachReloc {
         kind,
         offset,
-        ref name,
+        ref target,
         addend,
     } in relocs
     {
@@ -18,7 +18,7 @@ fn print_relocs(func_params: &FunctionParameters, relocs: &[MachReloc]) -> Strin
             text,
             "reloc_external: {} {} {} at {}",
             kind,
-            name.display(Some(func_params)),
+            target.display(Some(func_params)),
             addend,
             offset
         )


### PR DESCRIPTION
👋 Hey,

This PR implements ELF TLS GD relocations in the RISC-V backend. This is required to get the `rustc_codegen_cranelift`'s testsuite passing on this architecture.

The [TLS GD model for RISC-V](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-elf.adoc#global-dynamic) works slightly differently from the rest of the existing architectures. Usually you have 2 or 3 relocations pointing to a symbol and then a call to `__tls_get_addr`. RISC-V however has one relocation pointing to the symbol in a `auipc` instruction, and then a relocation pointing to a label in that `auipc` instruction, not the final symbol itself.

```asm
label:
    auipc a0,0                    # R_RISCV_TLS_GD_HI20 (symbol)
    addi  a0,a0,0                 # R_RISCV_PCREL_LO12_I (label)
    call __tls_get_addr@plt
```

This presents a problem as we currently don't have a way to export labels into the final binary, or a way to target labels with relocations.

Most of this PR is dealing with that issue. In the first commit I've introduced a notion of label visibility that allows a label to be marked as public, and if so, be carried all the way through to binary object emission.

Secondly is altering our allowed relocation targets. Currently we only allow external names, such as libcalls or other functions. I've altered this to allow targeting other labels within the function.

Only the final commit deals with implementing the TLS GD relocations in the RISC-V backend.


---

I also considered implementing TLS descriptors, but their spec isn't finalized yet (https://github.com/riscv-non-isa/riscv-elf-psabi-doc/issues/94)

This doesn't have a great deal of tests as its quite difficult to test these kinds of binary emissions. But I've manually tested this by running `cg_clif`'s testsuite.

CC: @bjorn3 