### PR TITLE
Add license to wasmtime-c-api-macros crate

### DIFF
--- a/crates/c-api/macros/Cargo.toml
+++ b/crates/c-api/macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "wasmtime-c-api-macros"
 version = "0.0.0"
 authors = ["The Wasmtime Project Developers"]
+license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 publish = false
 


### PR DESCRIPTION
Running cargo license on the c-api crate reports that this crate is
unlicensed.

We use cargo-license to automate our license tracking for this library
in our C++ application and it'd be nice to just have a license in here.

I used the standard license that wasmtime uses, but happy to use
another.
