### PR TITLE
Remove submodule re-added by accident

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,10 +1,10 @@
-[submodule "spec_testsuite"]
+[submodule "tests/spec_testsuite"]
 	path = tests/spec_testsuite
 	url = https://github.com/WebAssembly/testsuite
-[submodule "crates/c-api/examples/wasm-c-api"]
+[submodule "crates/c-api/wasm-c-api"]
 	path = crates/c-api/wasm-c-api
 	url = https://github.com/WebAssembly/wasm-c-api
-[submodule "WASI"]
+[submodule "crates/wasi-common/WASI"]
 	path = crates/wasi-common/WASI
 	url = https://github.com/WebAssembly/WASI
 [submodule "crates/wasi-nn/spec"]
@@ -13,10 +13,7 @@
 [submodule "tests/wasi_testsuite/wasi-threads"]
 	path = tests/wasi_testsuite/wasi-threads
 	url = https://github.com/WebAssembly/wasi-threads
-[submodule "crates/wasi-http/wasi-http"]
-	path = crates/wasi-http/wasi-http
-	url = https://github.com/WebAssembly/wasi-http
-[submodule "tests/wasi_testsuite/wasi"]
+[submodule "tests/wasi_testsuite/wasi-common"]
 	path = tests/wasi_testsuite/wasi-common
 	url = https://github.com/WebAssembly/wasi-testsuite.git
 	branch = prod/testsuite-base


### PR DESCRIPTION
This was removed in #6195 but re-added in #6877, I believe by accident, so this re-deletes it. I've also edited `.gitmodules` a bit while I was here to remove it and additionally keep other entries up-to-date with matching paths.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
