### PR TITLE
Add support for `v128` to the typed function API

### DIFF
--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -216,7 +216,7 @@ impl wasmtime_val_t {
             Val::V128(val) => wasmtime_val_t {
                 kind: crate::WASMTIME_V128,
                 of: wasmtime_val_union {
-                    v128: val.to_le_bytes(),
+                    v128: val.as_u128().to_le_bytes(),
                 },
             },
         }
@@ -228,7 +228,7 @@ impl wasmtime_val_t {
             crate::WASMTIME_I64 => Val::I64(self.of.i64),
             crate::WASMTIME_F32 => Val::F32(self.of.f32),
             crate::WASMTIME_F64 => Val::F64(self.of.f64),
-            crate::WASMTIME_V128 => Val::V128(u128::from_le_bytes(self.of.v128)),
+            crate::WASMTIME_V128 => Val::V128(u128::from_le_bytes(self.of.v128).into()),
             crate::WASMTIME_FUNCREF => {
                 let store = self.of.funcref.store_id;
                 let index = self.of.funcref.index;

--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -196,7 +196,7 @@ impl From<&DiffValue> for Val {
             DiffValue::I64(n) => Val::I64(n),
             DiffValue::F32(n) => Val::F32(n),
             DiffValue::F64(n) => Val::F64(n),
-            DiffValue::V128(n) => Val::V128(n),
+            DiffValue::V128(n) => Val::V128(n.into()),
             DiffValue::FuncRef { null } => {
                 assert!(null);
                 Val::FuncRef(None)
@@ -216,7 +216,7 @@ impl Into<DiffValue> for Val {
             Val::I64(n) => DiffValue::I64(n),
             Val::F32(n) => DiffValue::F32(n),
             Val::F64(n) => DiffValue::F64(n),
-            Val::V128(n) => DiffValue::V128(n),
+            Val::V128(n) => DiffValue::V128(n.into()),
             Val::FuncRef(f) => DiffValue::FuncRef { null: f.is_none() },
             Val::ExternRef(e) => DiffValue::ExternRef { null: e.is_none() },
         }

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -43,7 +43,7 @@ pub fn dummy_value(val_ty: ValType) -> Val {
         ValType::I64 => Val::I64(0),
         ValType::F32 => Val::F32(0),
         ValType::F64 => Val::F64(0),
-        ValType::V128 => Val::V128(0),
+        ValType::V128 => Val::V128(0.into()),
         ValType::ExternRef => Val::ExternRef(None),
         ValType::FuncRef => Val::FuncRef(None),
     }

--- a/crates/wasmtime/src/externals.rs
+++ b/crates/wasmtime/src/externals.rs
@@ -287,7 +287,7 @@ impl Global {
                 ValType::FuncRef => {
                     Val::FuncRef(Func::from_raw(store, definition.as_func_ref().cast()))
                 }
-                ValType::V128 => Val::V128(*definition.as_u128()),
+                ValType::V128 => Val::V128((*definition.as_u128()).into()),
             }
         }
     }
@@ -332,7 +332,7 @@ impl Global {
                     let old = mem::replace(definition.as_externref_mut(), x.map(|x| x.inner));
                     drop(old);
                 }
-                Val::V128(i) => *definition.as_u128_mut() = i,
+                Val::V128(i) => *definition.as_u128_mut() = i.into(),
             }
         }
         Ok(())

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -411,6 +411,7 @@ mod store;
 mod trampoline;
 mod trap;
 mod types;
+mod v128;
 mod values;
 
 pub use crate::config::*;
@@ -433,6 +434,7 @@ pub use crate::store::{
 };
 pub use crate::trap::*;
 pub use crate::types::*;
+pub use crate::v128::V128;
 pub use crate::values::*;
 
 /// A convenience wrapper for `Result<T, anyhow::Error>`.

--- a/crates/wasmtime/src/linker.rs
+++ b/crates/wasmtime/src/linker.rs
@@ -331,7 +331,7 @@ impl<T> Linker<T> {
                                     ValType::I64 => Val::I64(0),
                                     ValType::F32 => Val::F32(0.0_f32.to_bits()),
                                     ValType::F64 => Val::F64(0.0_f64.to_bits()),
-                                    ValType::V128 => Val::V128(0),
+                                    ValType::V128 => Val::V128(0_u128.into()),
                                     ValType::FuncRef => Val::FuncRef(None),
                                     ValType::ExternRef => Val::ExternRef(None),
                                 };

--- a/crates/wasmtime/src/trampoline/global.rs
+++ b/crates/wasmtime/src/trampoline/global.rs
@@ -51,7 +51,7 @@ pub fn generate_global_export(
             Val::I64(x) => *global.as_i64_mut() = x,
             Val::F32(x) => *global.as_f32_bits_mut() = x,
             Val::F64(x) => *global.as_f64_bits_mut() = x,
-            Val::V128(x) => *global.as_u128_mut() = x,
+            Val::V128(x) => *global.as_u128_mut() = x.into(),
             Val::FuncRef(f) => {
                 *global.as_func_ref_mut() = f.map_or(ptr::null_mut(), |f| {
                     f.caller_checked_func_ref(store).as_ptr()

--- a/crates/wasmtime/src/v128.rs
+++ b/crates/wasmtime/src/v128.rs
@@ -1,3 +1,8 @@
+#![cfg_attr(
+    not(any(target_arch = "x86_64", target_arch = "aarch64")),
+    allow(unused_imports)
+)]
+
 use crate::store::StoreOpaque;
 use crate::{ValRaw, ValType, WasmTy};
 use std::cmp::Ordering;

--- a/crates/wasmtime/src/v128.rs
+++ b/crates/wasmtime/src/v128.rs
@@ -1,0 +1,145 @@
+use crate::store::StoreOpaque;
+use crate::{ValRaw, ValType, WasmTy};
+use std::cmp::Ordering;
+use std::fmt;
+
+/// Representation of a 128-bit vector type, `v128`, for WebAssembly.
+///
+/// This type corresponds to the `v128` type in WebAssembly and can be used with
+/// the [`TypedFunc`] API for example. This is additionally
+/// the payload of [`Val::V128`](crate::Val).
+///
+/// # Platform specifics
+///
+/// This type can currently only be used on x86_64 and AArch64 with the
+/// [`TypedFunc`] API. Rust does not have stable support on other platforms for
+/// this type so invoking functions with `v128` parameters requires the
+/// [`Func::call`](crate::Func::call) API (or perhaps
+/// [`Func::call_unchecked`](crate::Func::call_unchecked).
+///
+/// [`TypedFunc`]: crate::TypedFunc
+#[derive(Copy, Clone)]
+#[repr(transparent)]
+pub struct V128(Abi);
+
+// NB: this is why this type is only suitable with `TypedFunc` on some platforms
+// and no other. See the documentation for each platform for why each ABI is
+// chosen.
+cfg_if::cfg_if! {
+    if #[cfg(target_arch = "x86_64")] {
+        // x86 vectors are represented with XMM registers which are represented
+        // with the `__m128i` type. This type is considered a vector type for
+        // ABI purposes which is implemented by Cranelift.
+        type Abi = std::arch::x86_64::__m128i;
+    } else if #[cfg(target_arch = "aarch64")] {
+        // AArch64 uses vector registered which here is used with a vector type.
+        // Note that the specific type shouldn't matter too much but the choice
+        // of using a vector is the significant part.
+        type Abi = std::arch::aarch64::uint8x16_t;
+    } else if #[cfg(target_arch = "riscv64")] {
+        // RISC-V currently always passes all vector arguments indirectly in the
+        // ABI. Currently Rust has no stable means of representing this meaning
+        // that a 128-bit representation is chosen here but it can't be passed
+        // to WebAssembly for example.
+        type Abi = u128;
+    } else if #[cfg(target_arch = "s390x")] {
+        // Currently Rust has no stable means of representing vector registers
+        // so like RISC-V at this time this uses a bland 128-bit representation.
+        type Abi = u128;
+    } else {
+        compile_error!("unsupported platform");
+    }
+}
+
+union Reinterpret {
+    abi: Abi,
+    u128: u128,
+}
+
+impl V128 {
+    /// Returns the representation of this `v128` as a 128-bit integer in Rust.
+    pub fn as_u128(&self) -> u128 {
+        unsafe { Reinterpret { abi: self.0 }.u128 }
+    }
+}
+
+/// Primary constructor of a `V128` type.
+impl From<u128> for V128 {
+    fn from(val: u128) -> V128 {
+        unsafe { V128(Reinterpret { u128: val }.abi) }
+    }
+}
+
+impl From<V128> for u128 {
+    fn from(val: V128) -> u128 {
+        val.as_u128()
+    }
+}
+
+impl fmt::Debug for V128 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_u128().fmt(f)
+    }
+}
+
+impl PartialEq for V128 {
+    fn eq(&self, other: &V128) -> bool {
+        self.as_u128() == other.as_u128()
+    }
+}
+
+impl Eq for V128 {}
+
+impl PartialOrd for V128 {
+    fn partial_cmp(&self, other: &V128) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for V128 {
+    fn cmp(&self, other: &V128) -> Ordering {
+        self.as_u128().cmp(&other.as_u128())
+    }
+}
+
+// Note that this trait is conditionally implemented which is intentional. See
+// the documentation above in the `cfg_if!` for why this is conditional.
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+unsafe impl WasmTy for V128 {
+    type Abi = Abi;
+
+    #[inline]
+    fn valtype() -> ValType {
+        ValType::V128
+    }
+
+    #[inline]
+    fn compatible_with_store(&self, _: &StoreOpaque) -> bool {
+        true
+    }
+
+    #[inline]
+    fn is_externref(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    unsafe fn abi_from_raw(raw: *mut ValRaw) -> Self::Abi {
+        V128::from((*raw).get_v128()).0
+    }
+
+    #[inline]
+    unsafe fn abi_into_raw(abi: Self::Abi, raw: *mut ValRaw) {
+        *raw = ValRaw::v128(V128(abi).as_u128());
+    }
+
+    #[inline]
+    fn into_abi(self, _store: &mut StoreOpaque) -> Self::Abi {
+        self.0
+    }
+
+    #[inline]
+    unsafe fn from_abi(abi: Self::Abi, _store: &mut StoreOpaque) -> Self {
+        V128(abi)
+    }
+}

--- a/crates/wasmtime/src/v128.rs
+++ b/crates/wasmtime/src/v128.rs
@@ -40,7 +40,8 @@ cfg_if::cfg_if! {
         // RISC-V currently always passes all vector arguments indirectly in the
         // ABI. Currently Rust has no stable means of representing this meaning
         // that a 128-bit representation is chosen here but it can't be passed
-        // to WebAssembly for example.
+        // directly to WebAssembly, for example, and must instead be passed
+        // through an array-call trampoline.
         type Abi = u128;
     } else if #[cfg(target_arch = "s390x")] {
         // Currently Rust has no stable means of representing vector registers

--- a/crates/wasmtime/src/values.rs
+++ b/crates/wasmtime/src/values.rs
@@ -1,6 +1,6 @@
 use crate::r#ref::ExternRef;
 use crate::store::StoreOpaque;
-use crate::{AsContextMut, Func, ValType};
+use crate::{AsContextMut, Func, ValType, V128};
 use anyhow::{bail, Result};
 use std::ptr;
 use wasmtime_runtime::TableElement;
@@ -32,7 +32,7 @@ pub enum Val {
     F64(u64),
 
     /// A 128-bit number
-    V128(u128),
+    V128(V128),
 
     /// A first-class reference to a WebAssembly function.
     ///
@@ -107,7 +107,7 @@ impl Val {
             Val::I64(i) => ValRaw::i64(*i),
             Val::F32(u) => ValRaw::f32(*u),
             Val::F64(u) => ValRaw::f64(*u),
-            Val::V128(b) => ValRaw::v128(*b),
+            Val::V128(b) => ValRaw::v128(b.as_u128()),
             Val::ExternRef(e) => {
                 let externref = match e {
                     Some(e) => e.to_raw(store),
@@ -138,7 +138,7 @@ impl Val {
             ValType::I64 => Val::I64(raw.get_i64()),
             ValType::F32 => Val::F32(raw.get_f32()),
             ValType::F64 => Val::F64(raw.get_f64()),
-            ValType::V128 => Val::V128(raw.get_v128()),
+            ValType::V128 => Val::V128(raw.get_v128().into()),
             ValType::ExternRef => Val::ExternRef(ExternRef::from_raw(raw.get_externref())),
             ValType::FuncRef => Val::FuncRef(Func::from_raw(store, raw.get_funcref())),
         }
@@ -151,7 +151,7 @@ impl Val {
         (F32(f32) f32 unwrap_f32 f32::from_bits(*e))
         (F64(f64) f64 unwrap_f64 f64::from_bits(*e))
         (FuncRef(Option<&Func>) funcref unwrap_funcref e.as_ref())
-        (V128(u128) v128 unwrap_v128 *e)
+        (V128(V128) v128 unwrap_v128 *e)
     }
 
     /// Attempt to access the underlying `externref` value of this `Val`.
@@ -285,6 +285,13 @@ impl From<Func> for Val {
 impl From<u128> for Val {
     #[inline]
     fn from(val: u128) -> Val {
+        Val::V128(val.into())
+    }
+}
+
+impl From<V128> for Val {
+    #[inline]
+    fn from(val: V128) -> Val {
         Val::V128(val)
     }
 }

--- a/crates/wast/src/core.rs
+++ b/crates/wast/src/core.rs
@@ -13,7 +13,7 @@ pub fn val(v: &WastArgCore<'_>) -> Result<Val> {
         I64(x) => Val::I64(*x),
         F32(x) => Val::F32(x.bits),
         F64(x) => Val::F64(x.bits),
-        V128(x) => Val::V128(u128::from_le_bytes(x.to_le_bytes())),
+        V128(x) => Val::V128(u128::from_le_bytes(x.to_le_bytes()).into()),
         RefNull(HeapType::Extern) => Val::ExternRef(None),
         RefNull(HeapType::Func) => Val::FuncRef(None),
         RefExtern(x) => Val::ExternRef(Some(ExternRef::new(*x))),
@@ -53,7 +53,7 @@ pub fn match_val(actual: &Val, expected: &WastRetCore) -> Result<()> {
         // values, so we're testing for bit-for-bit equivalence
         (Val::F32(a), WastRetCore::F32(b)) => match_f32(*a, b),
         (Val::F64(a), WastRetCore::F64(b)) => match_f64(*a, b),
-        (Val::V128(a), WastRetCore::V128(b)) => match_v128(*a, b),
+        (Val::V128(a), WastRetCore::V128(b)) => match_v128(a.as_u128(), b),
         (Val::ExternRef(x), WastRetCore::RefNull(Some(HeapType::Extern))) => {
             if let Some(x) = x {
                 let x = x

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -751,7 +751,7 @@ impl RunCommand {
                 Val::F64(f) => println!("{}", f64::from_bits(f)),
                 Val::ExternRef(_) => println!("<externref>"),
                 Val::FuncRef(_) => println!("<funcref>"),
-                Val::V128(i) => println!("{}", i),
+                Val::V128(i) => println!("{}", i.as_u128()),
             }
         }
 

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -1425,6 +1425,7 @@ fn calls_with_funcref_and_externref() -> anyhow::Result<()> {
 
 #[test]
 #[cfg_attr(miri, ignore)]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn typed_v128() -> anyhow::Result<()> {
     let mut store = Store::<()>::default();
     let module = Module::new(
@@ -1493,6 +1494,7 @@ fn typed_v128() -> anyhow::Result<()> {
 
 #[test]
 #[cfg_attr(miri, ignore)]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
 fn typed_v128_imports() -> anyhow::Result<()> {
     let mut store = Store::<()>::default();
     let module = Module::new(

--- a/tests/all/globals.rs
+++ b/tests/all/globals.rs
@@ -97,8 +97,8 @@ fn v128() -> anyhow::Result<()> {
         GlobalType::new(ValType::V128, Mutability::Var),
         0u128.into(),
     )?;
-    assert_eq!(g.get(&mut store).v128(), Some(0));
+    assert_eq!(g.get(&mut store).v128(), Some(V128::from(0)));
     g.set(&mut store, 1u128.into())?;
-    assert_eq!(g.get(&mut store).v128(), Some(1));
+    assert_eq!(g.get(&mut store).v128(), Some(V128::from(1)));
     Ok(())
 }


### PR DESCRIPTION
This commit adds a Rust type `V128` which corresponds to the wasm `v128` type. This is intended to perhaps one day have accessors for lanes of various sizes but in the meantime only supports conversion back and forth between `u128`. The intention of this type is to allow platforms to perform typed between to functions that take or return `v128` wasm values.

Previously this was not implemented because it's a bit tricky ABI-wise. Typed functions work by passing arguments in registers which requires the calling convention to match in both Cranelift and in Rust. This should be the case for supported platforms and the default calling convention, especially now that the wasm calling convention is separate from the platform calling convention. This does mean, however, that this feature can only be supported on x86_64 and AArch64. Currently neither s390x nor RISC-V have a means of supporting the vector calling convention since the vector types aren't available on stable in Rust itself. This means that it's now unfortunately possible to write a Wasmtime embedding that compiles on x86_64 that doesn't compile on s390x for example, but given how niche this feature is that seems like an ok tradeoff for now and by the time it's a problem Rust might have native stable support for vector types on these platforms.

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
