### PR TITLE
[s390x] Re-enable pseudo min/max test

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -242,11 +242,9 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
 
     match env::var("CARGO_CFG_TARGET_ARCH").unwrap().as_str() {
         "s390x" => {
-            // FIXME: These tests fail under qemu due to a qemu bug.
-            testname == "simd_f32x4_pmin_pmax" || testname == "simd_f64x2_pmin_pmax"
-                // TODO(#6530): These tests require tail calls, but s390x
-                // doesn't support them yet.
-                || testsuite == "function_references" || testsuite == "tail_call"
+            // TODO(#6530): These tests require tail calls, but s390x
+            // doesn't support them yet.
+            testsuite == "function_references" || testsuite == "tail_call"
         }
 
         "riscv64" => {

--- a/cranelift/filetests/filetests/runtests/fmax-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/fmax-pseudo.clif
@@ -5,7 +5,7 @@ target x86_64 has_avx
 target aarch64
 target riscv64
 target riscv64 has_c has_zcb
-; target s390x FIXME: This currently fails under qemu due to a qemu bug
+target s390x
 
 function %fmax_p_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/fmin-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/fmin-pseudo.clif
@@ -5,7 +5,7 @@ target x86_64 has_avx
 target aarch64
 target riscv64
 target riscv64 has_c has_zcb
-; target s390x FIXME: This currently fails under qemu due to a qemu bug
+target s390x
 
 function %fmin_p_f32(f32, f32) -> f32 {
 block0(v0: f32, v1: f32):

--- a/cranelift/filetests/filetests/runtests/simd-fmin-max-pseudo.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fmin-max-pseudo.clif
@@ -1,6 +1,6 @@
 test run
 target aarch64
-; target s390x FIXME: This currently fails under qemu due to a qemu bug
+target s390x
 target x86_64
 target x86_64 skylake
 target riscv64 has_v


### PR DESCRIPTION
Due to a bug in the qemu emulation of the corresponding instruction, tests for pseudo min/max support had been disabled.  After moving to qemu 8.0.4, where the bug is fixed, these can be re-enabled.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
