### PR TITLE
riscv64: Add more compressed instructions

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -724,6 +724,11 @@
   (CSubw)
 ))
 
+;; Opcodes for the CJ compressed instruction format
+(type CjOp (enum
+  (CJ)
+))
+
 
 (type CsrRegOP (enum
   ;; Atomic Read/Write CSR

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -713,6 +713,7 @@
   (CMv)
   (CAdd)
   (CJr)
+  (CJalr)
 ))
 
 ;; Opcodes for the CA compressed instruction format

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -712,6 +712,7 @@
 (type CrOp (enum
   (CMv)
   (CAdd)
+  (CJr)
 ))
 
 ;; Opcodes for the CA compressed instruction format

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -708,11 +708,20 @@
   (C2)
 ))
 
-
 ;; Opcodes for the CR compressed instruction format
 (type CrOp (enum
   (CMv)
   (CAdd)
+))
+
+;; Opcodes for the CA compressed instruction format
+(type CaOp (enum
+  (CAnd)
+  (COr)
+  (CXor)
+  (CSub)
+  (CAddw)
+  (CSubw)
 ))
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1916,14 +1916,14 @@ impl CrOp {
         match self {
             // `c.jr` has the same op/funct4 as C.MV, but RS2 is 0, which is illegal for mv.
             CrOp::CMv | CrOp::CJr => 0b1000,
-            CrOp::CAdd => 0b1001,
+            CrOp::CAdd | CrOp::CJalr => 0b1001,
         }
     }
 
     pub fn op(&self) -> COpcodeSpace {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
-            CrOp::CMv | CrOp::CAdd | CrOp::CJr => COpcodeSpace::C2,
+            CrOp::CMv | CrOp::CAdd | CrOp::CJr | CrOp::CJalr => COpcodeSpace::C2,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -6,7 +6,7 @@ use super::*;
 use crate::ir::condcodes::CondCode;
 
 use crate::isa::riscv64::inst::{reg_name, reg_to_gpr_num};
-use crate::isa::riscv64::lower::isle::generated_code::{COpcodeSpace, CaOp, CrOp};
+use crate::isa::riscv64::lower::isle::generated_code::{COpcodeSpace, CaOp, CjOp, CrOp};
 use crate::machinst::isle::WritableReg;
 
 use std::fmt::{Display, Formatter, Result};
@@ -1954,6 +1954,22 @@ impl CaOp {
             CaOp::CAnd | CaOp::COr | CaOp::CXor | CaOp::CSub | CaOp::CAddw | CaOp::CSubw => {
                 COpcodeSpace::C1
             }
+        }
+    }
+}
+
+impl CjOp {
+    pub fn funct3(&self) -> u32 {
+        // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
+        match self {
+            CjOp::CJ => 0b101,
+        }
+    }
+
+    pub fn op(&self) -> COpcodeSpace {
+        // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
+        match self {
+            CjOp::CJ => COpcodeSpace::C1,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1914,7 +1914,8 @@ impl CrOp {
     pub fn funct4(&self) -> u32 {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
-            CrOp::CMv => 0b1000,
+            // `c.jr` has the same op/funct4 as C.MV, but RS2 is 0, which is illegal for mv.
+            CrOp::CMv | CrOp::CJr => 0b1000,
             CrOp::CAdd => 0b1001,
         }
     }
@@ -1922,7 +1923,7 @@ impl CrOp {
     pub fn op(&self) -> COpcodeSpace {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
-            CrOp::CMv | CrOp::CAdd => COpcodeSpace::C2,
+            CrOp::CMv | CrOp::CAdd | CrOp::CJr => COpcodeSpace::C2,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -6,7 +6,7 @@ use super::*;
 use crate::ir::condcodes::CondCode;
 
 use crate::isa::riscv64::inst::{reg_name, reg_to_gpr_num};
-use crate::isa::riscv64::lower::isle::generated_code::{COpcodeSpace, CrOp};
+use crate::isa::riscv64::lower::isle::generated_code::{COpcodeSpace, CaOp, CrOp};
 use crate::machinst::isle::WritableReg;
 
 use std::fmt::{Display, Formatter, Result};
@@ -1923,6 +1923,37 @@ impl CrOp {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
             CrOp::CMv | CrOp::CAdd => COpcodeSpace::C2,
+        }
+    }
+}
+
+impl CaOp {
+    pub fn funct2(&self) -> u32 {
+        // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
+        match self {
+            CaOp::CAnd => 0b11,
+            CaOp::COr => 0b10,
+            CaOp::CXor => 0b01,
+            CaOp::CSub => 0b00,
+            CaOp::CAddw => 0b01,
+            CaOp::CSubw => 0b00,
+        }
+    }
+
+    pub fn funct6(&self) -> u32 {
+        // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
+        match self {
+            CaOp::CAnd | CaOp::COr | CaOp::CXor | CaOp::CSub => 0b100_011,
+            CaOp::CSubw | CaOp::CAddw => 0b100_111,
+        }
+    }
+
+    pub fn op(&self) -> COpcodeSpace {
+        // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
+        match self {
+            CaOp::CAnd | CaOp::COr | CaOp::CXor | CaOp::CSub | CaOp::CAddw | CaOp::CSubw => {
+                COpcodeSpace::C1
+            }
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -731,7 +731,7 @@ impl Inst {
                             rd,
                             imm: Imm20::from_bits(0),
                         }
-                        .emit(&[], sink, emit_info, state);
+                        .emit_uncompressed(sink, emit_info, state, start_off);
 
                         // Emit a relocation for the load. This patches the offset into the instruction.
                         sink.use_label_at_offset(sink.cur_offset(), label, LabelUse::PCRelLo12I);
@@ -873,7 +873,7 @@ impl Inst {
                             0,
                         )
                         .into_iter()
-                        .for_each(|i| i.emit(&[], sink, emit_info, state));
+                        .for_each(|i| i.emit_uncompressed(sink, emit_info, state, start_off));
                     }
                     ExternalName::LibCall(..)
                     | ExternalName::TestCase { .. }
@@ -899,7 +899,7 @@ impl Inst {
                             base: spilltmp_reg2(),
                             offset: Imm12::zero(),
                         }
-                        .emit(&[], sink, emit_info, state);
+                        .emit_uncompressed(sink, emit_info, state, start_off);
                     }
                 }
 
@@ -923,7 +923,7 @@ impl Inst {
                     base: info.rn,
                     offset: Imm12::zero(),
                 }
-                .emit(&[], sink, emit_info, state);
+                .emit_uncompressed(sink, emit_info, state, start_off);
 
                 let callee_pop_size = i64::from(info.callee_pop_size);
                 state.virtual_sp_offset -= callee_pop_size;
@@ -949,7 +949,7 @@ impl Inst {
                 sink.add_reloc(Reloc::RiscvCall, &callee, 0);
                 Inst::construct_auipc_and_jalr(None, writable_spilltmp_reg(), 0)
                     .into_iter()
-                    .for_each(|i| i.emit(&[], sink, emit_info, state));
+                    .for_each(|i| i.emit_uncompressed(sink, emit_info, state, start_off));
 
                 // `emit_return_call_common_sequence` emits an island if
                 // necessary, so we can safely disable the worst-case-size check
@@ -1124,7 +1124,7 @@ impl Inst {
                 sink.use_label_at_offset(sink.cur_offset(), default_target, LabelUse::PCRel32);
                 Inst::construct_auipc_and_jalr(None, tmp2, 0)
                     .iter()
-                    .for_each(|i| i.emit(&[], sink, emit_info, state));
+                    .for_each(|i| i.emit_uncompressed(sink, emit_info, state, start_off));
 
                 // Compute the jump table offset.
                 // We need to emit a PC relative offset,
@@ -1281,7 +1281,7 @@ impl Inst {
                             rd,
                             imm: Imm20::from_bits(0),
                         };
-                        inst.emit(&[], sink, emit_info, state);
+                        inst.emit_uncompressed(sink, emit_info, state, start_off);
 
                         // Emit an add to the address with a relocation.
                         // This later gets patched up with the correct offset.
@@ -1292,7 +1292,7 @@ impl Inst {
                             rs: rd.to_reg(),
                             imm12: Imm12::zero(),
                         }
-                        .emit(&[], sink, emit_info, state);
+                        .emit_uncompressed(sink, emit_info, state, start_off);
                     }
                     (amode, _, _) => {
                         unimplemented!("LoadAddr: {:?}", amode);

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -9,8 +9,8 @@
 use super::*;
 use crate::isa::riscv64::inst::reg_to_gpr_num;
 use crate::isa::riscv64::lower::isle::generated_code::{
-    CrOp, VecAluOpRImm5, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecAluOpRRRImm5, VecAluOpRRRR,
-    VecElementWidth, VecOpCategory, VecOpMasking,
+    CaOp, CrOp, VecAluOpRImm5, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecAluOpRRRImm5,
+    VecAluOpRRRR, VecElementWidth, VecOpCategory, VecOpMasking,
 };
 use crate::machinst::isle::WritableReg;
 use crate::Reg;
@@ -335,5 +335,19 @@ pub fn encode_cr_type(op: CrOp, rd: WritableReg, rs2: Reg) -> u16 {
     bits |= reg_to_gpr_num(rs2) << 2;
     bits |= reg_to_gpr_num(rd.to_reg()) << 7;
     bits |= unsigned_field_width(op.funct4(), 4) << 12;
+    bits.try_into().unwrap()
+}
+
+// Encode a CA type instruction.
+//
+// 0--1-2-----4-5--------6-7--------9-10------15
+// |op |  rs2  |  funct2  |  rd/rs1  | funct6 |
+pub fn encode_ca_type(op: CaOp, rd: WritableReg, rs2: Reg) -> u16 {
+    let mut bits = 0;
+    bits |= unsigned_field_width(op.op().bits(), 2);
+    bits |= reg_to_compressed_gpr_num(rs2) << 2;
+    bits |= unsigned_field_width(op.funct2(), 2) << 5;
+    bits |= reg_to_compressed_gpr_num(rd.to_reg()) << 7;
+    bits |= unsigned_field_width(op.funct6(), 6) << 10;
     bits.try_into().unwrap()
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -338,6 +338,14 @@ pub fn encode_cr_type(op: CrOp, rd: WritableReg, rs2: Reg) -> u16 {
     bits.try_into().unwrap()
 }
 
+// This isn't technically a instruction format that exists. It's just a CR type
+// where the source is rs1, rs2 is zero. rs1 is never written to.
+//
+// Used for C.JR and C.JALR
+pub fn encode_cr2_type(op: CrOp, rs1: Reg) -> u16 {
+    encode_cr_type(op, WritableReg::from_reg(rs1), zero_reg())
+}
+
 // Encode a CA type instruction.
 //
 // 0--1-2-----4-5--------6-7--------9-10------15

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -334,6 +334,6 @@ pub fn encode_cr_type(op: CrOp, rd: WritableReg, rs2: Reg) -> u16 {
     bits |= unsigned_field_width(op.op().bits(), 2);
     bits |= reg_to_gpr_num(rs2) << 2;
     bits |= reg_to_gpr_num(rd.to_reg()) << 7;
-    bits |= unsigned_field_width(op.funct4(), 5) << 12;
+    bits |= unsigned_field_width(op.funct4(), 4) << 12;
     bits.try_into().unwrap()
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -1955,8 +1955,8 @@ impl MachInstLabelUse for LabelUse {
             LabelUse::PCRelLo12I | LabelUse::PCRelHi20 | LabelUse::PCRel32 => {
                 Inst::imm_max() as CodeOffset
             }
-            // RVCJump has the same range as B12 since the offset is multiplied by 2
-            LabelUse::RVCJump | LabelUse::B12 => ((1 << 11) - 1) * 2,
+            LabelUse::B12 => ((1 << 11) - 1) * 2,
+            LabelUse::RVCJump => ((1 << 10) - 1) * 2,
         }
     }
 

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -219,3 +219,36 @@ block0(v0: i32):
 ; block0: ; offset 0x0
 ;   c.jr ra
 
+
+function %call_ind(i64, i64) -> i64 {
+    sig0 = (i64) -> i64
+block0(v0: i64, v1: i64):
+    v2 = call_indirect.i64 sig0, v1(v0)
+    return v2
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   callind a1
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   c.mv s0, sp
+; block1: ; offset 0xe
+;   c.jalr a1
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   c.jr ra
+

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -51,3 +51,102 @@ block0(v0: i64, v1: i64):
 ;   c.mv a0, a1
 ;   ret
 
+function %c_and(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = band.i64 v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   and a0,a0,a1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.and a0, a1
+;   ret
+
+
+function %c_or(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = bor.i64 v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   or a0,a0,a1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.or a0, a1
+;   ret
+
+function %c_xor(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = bxor.i64 v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   xor a0,a0,a1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.xor a0, a1
+;   ret
+
+function %c_sub(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+  v2 = isub.i64 v0, v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   sub a0,a0,a1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.sub a0, a1
+;   ret
+
+function %c_add_w(i32, i32) -> i64 {
+block0(v0: i32, v1: i32):
+    v2 = iadd.i32 v0, v1
+    v3 = sextend.i64 v2
+    return v3
+}
+
+; VCode:
+; block0:
+;   addw a0,a0,a1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addw a0, a1
+;   ret
+
+function %c_sub_w(i32, i32) -> i64 {
+block0(v0: i32, v1: i32):
+    v2 = isub.i32 v0, v1
+    v3 = sextend.i64 v2
+    return v3
+}
+
+; VCode:
+; block0:
+;   subw a0,a0,a1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.subw a0, a1
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -16,8 +16,7 @@ block0(v0: i64, v1: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.add a0, a1
-;   ret
-
+;   c.jr ra
 
 function %c_mv(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -32,8 +31,7 @@ block0(v0: i64, v1: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.mv a0, a1
-;   ret
-
+;   c.jr ra
 
 function %c_mv_ori(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -49,7 +47,7 @@ block0(v0: i64, v1: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.mv a0, a1
-;   ret
+;   c.jr ra
 
 function %c_and(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -65,8 +63,7 @@ block0(v0: i64, v1: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.and a0, a1
-;   ret
-
+;   c.jr ra
 
 function %c_or(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -82,7 +79,7 @@ block0(v0: i64, v1: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.or a0, a1
-;   ret
+;   c.jr ra
 
 function %c_xor(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -98,7 +95,7 @@ block0(v0: i64, v1: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.xor a0, a1
-;   ret
+;   c.jr ra
 
 function %c_sub(i64, i64) -> i64 {
 block0(v0: i64, v1: i64):
@@ -114,7 +111,7 @@ block0(v0: i64, v1: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.sub a0, a1
-;   ret
+;   c.jr ra
 
 function %c_add_w(i32, i32) -> i64 {
 block0(v0: i32, v1: i32):
@@ -131,7 +128,7 @@ block0(v0: i32, v1: i32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.addw a0, a1
-;   ret
+;   c.jr ra
 
 function %c_sub_w(i32, i32) -> i64 {
 block0(v0: i32, v1: i32):
@@ -148,7 +145,7 @@ block0(v0: i32, v1: i32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.subw a0, a1
-;   ret
+;   c.jr ra
 
 ;; The select emits a `c.j` instruction.
 function %c_j(i8, i8, i8) -> i8 {
@@ -170,5 +167,55 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   c.mv a0, a1
 ;   c.j 4
 ;   c.mv a0, a2
+;   c.jr ra
+
+;; Tail call's use `c.jr`
+function %call_i8(i8) -> i8 tail {
+    fn0 = %callee_i8(i8) -> i8 tail
+
+block0(v0: i8):
+    return_call fn0(v0)
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   load_sym a2,%callee_i8+0
+;   return_call_ind a2 old_stack_arg_size:0 new_stack_arg_size:0 s1=s1
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   c.mv s0, sp
+; block1: ; offset 0xe
+;   auipc a2, 0
+;   ld a2, 0xa(a2)
+;   c.j 0xa
+;   c.unimp ; reloc_external Abs8 %callee_i8 0
+;   c.unimp
+;   c.unimp
+;   c.unimp
+;   ld ra, 8(s0)
+;   ld t6, 0(s0)
+;   addi sp, s0, 0x10
+;   c.mv s0, t6
+;   c.jr a2
+
+function %c_ret(i32) -> i32 {
+block0(v0: i32):
+    return v0
+}
+
+; VCode:
+; block0:
 ;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.jr ra
 

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -150,3 +150,25 @@ block0(v0: i32, v1: i32):
 ;   c.subw a0, a1
 ;   ret
 
+;; The select emits a `c.j` instruction.
+function %c_j(i8, i8, i8) -> i8 {
+block0(v0: i8, v1: i8, v2: i8):
+  v3 = select.i8 v0, v1, v2
+  return v3
+}
+
+; VCode:
+; block0:
+;   andi a4,a0,255
+;   select_i8 a0,a1,a2##condition=a4
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a4, a0, 0xff
+;   beqz a4, 8
+;   c.mv a0, a1
+;   c.j 4
+;   c.mv a0, a2
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/long-jump.clif
+++ b/cranelift/filetests/filetests/runtests/long-jump.clif
@@ -1,0 +1,19 @@
+test interpret
+test run
+set bb_padding_log2_minus_one=12
+target aarch64
+target s390x
+target x86_64
+target riscv64 has_m
+target riscv64 has_c has_zcb
+
+function %a(i16) -> i16 {
+block0(v0: i16):
+    jump block1(v0)
+
+block1(v1: i16) cold:
+    return v0
+
+}
+
+; run: %a(0) == 0


### PR DESCRIPTION
👋 Hey,

This PR adds two new compressed instruction formats. CA and CJ. These are used for some register-register arithmetic ops (CA) and jump instructions (CJ).

It also changes all instructions that use a Label, StackMap or Relocation to use `emit_uncompressed` to ensure that we don't wrongly compress a instruction when it is expecting a different type of label or relocation.

Capstone seems to not recognize `c.jr ra` as `c.ret`, but it is technically an alias as far as I understand it.
