### PR TITLE
Fix a typo in an error message.

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -878,7 +878,7 @@ impl RunCommand {
             let value = match value {
                 Some(value) => value.clone(),
                 None => std::env::var(key)
-                    .map_err(|_| anyhow!("environment varialbe `{key}` not found"))?,
+                    .map_err(|_| anyhow!("environment variable `{key}` not found"))?,
             };
             builder.env(key, &value)?;
         }
@@ -910,7 +910,7 @@ impl RunCommand {
             let value = match value {
                 Some(value) => value.clone(),
                 None => std::env::var(key)
-                    .map_err(|_| anyhow!("environment varialbe `{key}` not found"))?,
+                    .map_err(|_| anyhow!("environment variable `{key}` not found"))?,
             };
             builder.env(key, &value);
         }


### PR DESCRIPTION
I didn't open a discussion for this issue since it's seems straightforward. While looking through the source I noticed there was a typo in a couple of error messages. This PR simply updates the error message strings. Since it was the same typo in two places we could extract a common string, but I wanted to keep this diff as small as possible. I don't think we need a new test case for this, but if you'd like one I can look into it.