### PR TITLE
Gracefully handle failure to allocate memory during compilation

### DIFF
--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -251,7 +251,7 @@ impl CodeMemory {
             // Switch the executable portion from readonly to read/execute.
             self.mmap
                 .make_executable(self.text.clone(), self.enable_branch_protection)
-                .expect("unable to make memory executable");
+                .context("unable to make memory executable")?;
 
             // Flush any in-flight instructions from the pipeline
             icache_coherence::pipeline_flush_mt().expect("Failed pipeline flush");


### PR DESCRIPTION
We run in a unique environment with very little memory, so
it's possible if there are many modules that we run out of memory,
callers should be able to handle this gracefully.

