### PR TITLE
[12.0.0] Fix test expectations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -373,7 +373,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     env:
-      QEMU_BUILD_VERSION: 7.2.0
+      QEMU_BUILD_VERSION: 8.0.4
     strategy:
       fail-fast: true
       matrix: ${{ fromJson(needs.determine.outputs.test-matrix) }}

--- a/ci/qemu-cpuinfo.patch
+++ b/ci/qemu-cpuinfo.patch
@@ -1,4 +1,4 @@
-From 529c68a118055c95336f91e4d166366a23a943f4 Mon Sep 17 00:00:00 2001
+From 5d05b046efb079360d0175164ee04947f20f9e66 Mon Sep 17 00:00:00 2001
 From: Afonso Bordado <afonsobordado@az8.co>
 Date: Tue, 21 Mar 2023 18:45:20 +0000
 Subject: [PATCH] linux-user: Emulate /proc/cpuinfo output for riscv
@@ -10,17 +10,16 @@ Currently when querying this file the host's file is shown instead
 which is slightly confusing. Emulate a basic /proc/cpuinfo file
 with mmu info and an ISA string.
 ---
- linux-user/syscall.c              | 33 +++++++++++++++++++++++++++++--
- tests/tcg/riscv64/Makefile.target |  1 +
- tests/tcg/riscv64/cpuinfo.c       | 30 ++++++++++++++++++++++++++++
- 3 files changed, 62 insertions(+), 2 deletions(-)
+ linux-user/syscall.c        | 34 ++++++++++++++++++++++++++++++++--
+ tests/tcg/riscv64/cpuinfo.c | 30 ++++++++++++++++++++++++++++++
+ 2 files changed, 62 insertions(+), 2 deletions(-)
  create mode 100644 tests/tcg/riscv64/cpuinfo.c
 
 diff --git a/linux-user/syscall.c b/linux-user/syscall.c
-index 24b25759be..2b8a588be2 100644
+index 333e6b7026..e6d85e0e8a 100644
 --- a/linux-user/syscall.c
 +++ b/linux-user/syscall.c
-@@ -8206,7 +8206,8 @@ void target_exception_dump(CPUArchState *env, const char *fmt, int code)
+@@ -8231,7 +8231,8 @@ void target_exception_dump(CPUArchState *env, const char *fmt, int code)
  }
  
  #if HOST_BIG_ENDIAN != TARGET_BIG_ENDIAN || \
@@ -30,7 +29,7 @@ index 24b25759be..2b8a588be2 100644
  static int is_proc(const char *filename, const char *entry)
  {
      return strcmp(filename, entry) == 0;
-@@ -8278,6 +8279,34 @@ static int open_cpuinfo(CPUArchState *cpu_env, int fd)
+@@ -8309,6 +8310,35 @@ static int open_cpuinfo(CPUArchState *cpu_env, int fd)
  }
  #endif
  
@@ -40,10 +39,11 @@ index 24b25759be..2b8a588be2 100644
 +    int i;
 +    int num_cpus = sysconf(_SC_NPROCESSORS_ONLN);
 +    RISCVCPU *cpu = env_archcpu(cpu_env);
++    const RISCVCPUConfig *cfg = riscv_cpu_cfg((CPURISCVState *) cpu_env);
 +    char *isa_string = riscv_isa_string(cpu);
 +    const char *mmu;
 +
-+    if (cpu->cfg.mmu) {
++    if (cfg->mmu) {
 +        mmu = (cpu_env->xl == MXL_RV32) ? "sv32"  : "sv48";
 +    } else {
 +        mmu = "none";
@@ -65,7 +65,7 @@ index 24b25759be..2b8a588be2 100644
  #if defined(TARGET_M68K)
  static int open_hardware(CPUArchState *cpu_env, int fd)
  {
-@@ -8302,7 +8331,7 @@ static int do_openat(CPUArchState *cpu_env, int dirfd, const char *pathname, int
+@@ -8333,7 +8363,7 @@ static int do_openat(CPUArchState *cpu_env, int dirfd, const char *pathname, int
  #if HOST_BIG_ENDIAN != TARGET_BIG_ENDIAN
          { "/proc/net/route", open_net_route, is_proc },
  #endif
@@ -74,16 +74,6 @@ index 24b25759be..2b8a588be2 100644
          { "/proc/cpuinfo", open_cpuinfo, is_proc },
  #endif
  #if defined(TARGET_M68K)
-diff --git a/tests/tcg/riscv64/Makefile.target b/tests/tcg/riscv64/Makefile.target
-index b5b89dfb0e..f455e19a11 100644
---- a/tests/tcg/riscv64/Makefile.target
-+++ b/tests/tcg/riscv64/Makefile.target
-@@ -4,3 +4,4 @@
- VPATH += $(SRC_PATH)/tests/tcg/riscv64
- TESTS += test-div
- TESTS += noexec
-+TESTS += cpuinfo
-\ No newline at end of file
 diff --git a/tests/tcg/riscv64/cpuinfo.c b/tests/tcg/riscv64/cpuinfo.c
 new file mode 100644
 index 0000000000..296abd0a8c

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -826,7 +826,7 @@ block0(v0: i64x2):
 ;   pshufd  $237, %xmm2, %xmm4
 ;   movdqa  %xmm0, %xmm6
 ;   psrad   %xmm6, $22, %xmm6
-;   pshufd  $233, %xmm6, %xmm0
+;   pshufd  $237, %xmm6, %xmm0
 ;   punpckldq %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -842,7 +842,7 @@ block0(v0: i64x2):
 ;   pshufd $0xed, %xmm2, %xmm4
 ;   movdqa %xmm0, %xmm6
 ;   psrad $0x16, %xmm6
-;   pshufd $0xe9, %xmm6, %xmm0
+;   pshufd $0xed, %xmm6, %xmm0
 ;   punpckldq %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -864,7 +864,7 @@ block0(v0: i64x2):
 ;   pshufd  $237, %xmm2, %xmm4
 ;   movdqa  %xmm0, %xmm6
 ;   psrad   %xmm6, $4, %xmm6
-;   pshufd  $233, %xmm6, %xmm0
+;   pshufd  $237, %xmm6, %xmm0
 ;   punpckldq %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -880,7 +880,7 @@ block0(v0: i64x2):
 ;   pshufd $0xed, %xmm2, %xmm4
 ;   movdqa %xmm0, %xmm6
 ;   psrad $4, %xmm6
-;   pshufd $0xe9, %xmm6, %xmm0
+;   pshufd $0xed, %xmm6, %xmm0
 ;   punpckldq %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp


### PR DESCRIPTION
This PR fixes a mistake in the prepared fixes for the recently published [security advisory](https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-gw5p-q8mj-p7gh). I mistakenly forgot to run the full test suite locally which meant that some golden test expectations relevant to the bug in question weren't fixed.