### PR TITLE
[10.0.0] Fix test expectations

### DIFF
--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -827,7 +827,7 @@ block0(v0: i64x2):
 ;   pshufd  $237, %xmm2, %xmm4
 ;   movdqa  %xmm0, %xmm6
 ;   psrad   %xmm6, $22, %xmm6
-;   pshufd  $233, %xmm6, %xmm0
+;   pshufd  $237, %xmm6, %xmm0
 ;   punpckldq %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -843,7 +843,7 @@ block0(v0: i64x2):
 ;   pshufd $0xed, %xmm2, %xmm4
 ;   movdqa %xmm0, %xmm6
 ;   psrad $0x16, %xmm6
-;   pshufd $0xe9, %xmm6, %xmm0
+;   pshufd $0xed, %xmm6, %xmm0
 ;   punpckldq %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -865,7 +865,7 @@ block0(v0: i64x2):
 ;   pshufd  $237, %xmm2, %xmm4
 ;   movdqa  %xmm0, %xmm6
 ;   psrad   %xmm6, $4, %xmm6
-;   pshufd  $233, %xmm6, %xmm0
+;   pshufd  $237, %xmm6, %xmm0
 ;   punpckldq %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -881,7 +881,7 @@ block0(v0: i64x2):
 ;   pshufd $0xed, %xmm2, %xmm4
 ;   movdqa %xmm0, %xmm6
 ;   psrad $4, %xmm6
-;   pshufd $0xe9, %xmm6, %xmm0
+;   pshufd $0xed, %xmm6, %xmm0
 ;   punpckldq %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp


### PR DESCRIPTION
Same as https://github.com/bytecodealliance/wasmtime/pull/7038, but for 10.0.x