### PR TITLE
Simplify bindings generation for preview2 WASI

### DIFF
--- a/crates/wasi-http/src/component_impl.rs
+++ b/crates/wasi-http/src/component_impl.rs
@@ -397,7 +397,7 @@ pub fn add_component_to_linker<T: WasiHttpView>(
                     "[module='wasi:poll/poll' function='drop-pollable'] call id={:?}",
                     id
                 );
-                let result = poll::poll::Host::drop_pollable(ctx, id).await;
+                let result = poll::poll::Host::drop_pollable(ctx, id);
                 tracing::trace!(
                     "[module='wasi:poll/poll' function='drop-pollable'] return result={:?}",
                     result
@@ -465,7 +465,7 @@ pub fn add_component_to_linker<T: WasiHttpView>(
                     "[module='wasi:io/streams' function='drop-input-stream'] call id={:?}",
                     id
                 );
-                let result = io::streams::Host::drop_input_stream(ctx, id).await;
+                let result = io::streams::Host::drop_input_stream(ctx, id);
                 tracing::trace!(
                     "[module='wasi:io/streams' function='drop-input-stream'] return result={:?}",
                     result
@@ -484,7 +484,7 @@ pub fn add_component_to_linker<T: WasiHttpView>(
                     "[module='wasi:io/streams' function='drop-output-stream'] call id={:?}",
                     id
                 );
-                let result = io::streams::Host::drop_output_stream(ctx, id).await;
+                let result = io::streams::Host::drop_output_stream(ctx, id);
                 tracing::trace!(
                     "[module='wasi:io/streams' function='drop-output-stream'] return result={:?}",
                     result
@@ -581,7 +581,7 @@ pub fn add_component_to_linker<T: WasiHttpView>(
                     "[module='wasi:io/streams' function='subscribe-to-input-stream'] call stream={:?}",
                     stream
                 );
-                let result = io::streams::Host::subscribe_to_input_stream(ctx, stream).await;
+                let result = io::streams::Host::subscribe_to_input_stream(ctx, stream);
                 tracing::trace!(
                     "[module='wasi:io/streams' function='subscribe-to-input-stream'] return result={:?}",
                     result
@@ -600,7 +600,7 @@ pub fn add_component_to_linker<T: WasiHttpView>(
                     "[module='wasi:io/streams' function='subscribe-to-output-stream'] call stream={:?}",
                     stream
                 );
-                let result = io::streams::Host::subscribe_to_output_stream(ctx, stream).await;
+                let result = io::streams::Host::subscribe_to_output_stream(ctx, stream);
                 tracing::trace!(
                     "[module='wasi:io/streams' function='subscribe-to-output-stream'] return result={:?}",
                     result

--- a/crates/wasi-http/wit/deps/cli/command.wit
+++ b/crates/wasi-http/wit/deps/cli/command.wit
@@ -1,33 +1,7 @@
 package wasi:cli
 
 world command {
-  import wasi:clocks/wall-clock
-  import wasi:clocks/monotonic-clock
-  import wasi:clocks/timezone
-  import wasi:filesystem/types
-  import wasi:filesystem/preopens
-  import wasi:sockets/instance-network
-  import wasi:sockets/ip-name-lookup
-  import wasi:sockets/network
-  import wasi:sockets/tcp-create-socket
-  import wasi:sockets/tcp
-  import wasi:sockets/udp-create-socket
-  import wasi:sockets/udp
-  import wasi:random/random
-  import wasi:random/insecure
-  import wasi:random/insecure-seed
-  import wasi:poll/poll
-  import wasi:io/streams
+  include reactor
 
-  import environment
-  import exit
-  import stdin
-  import stdout
-  import stderr
-  import terminal-input
-  import terminal-output
-  import terminal-stdin
-  import terminal-stdout
-  import terminal-stderr
   export run
 }

--- a/crates/wasi-http/wit/deps/cli/reactor.wit
+++ b/crates/wasi-http/wit/deps/cli/reactor.wit
@@ -1,0 +1,33 @@
+package wasi:cli
+
+world reactor {
+  import wasi:clocks/wall-clock
+  import wasi:clocks/monotonic-clock
+  import wasi:clocks/timezone
+  import wasi:filesystem/types
+  import wasi:filesystem/preopens
+  import wasi:sockets/instance-network
+  import wasi:sockets/ip-name-lookup
+  import wasi:sockets/network
+  import wasi:sockets/tcp-create-socket
+  import wasi:sockets/tcp
+  import wasi:sockets/udp-create-socket
+  import wasi:sockets/udp
+  import wasi:random/random
+  import wasi:random/insecure
+  import wasi:random/insecure-seed
+  import wasi:poll/poll
+  import wasi:io/streams
+
+  import environment
+  import exit
+  import stdin
+  import stdout
+  import stderr
+  import terminal-input
+  import terminal-output
+  import terminal-stdin
+  import terminal-stdout
+  import terminal-stderr
+}
+

--- a/crates/wasi/src/preview2/host/filesystem.rs
+++ b/crates/wasi/src/preview2/host/filesystem.rs
@@ -319,7 +319,7 @@ impl<T: WasiView> types::Host for T {
         readdir.next()
     }
 
-    async fn drop_directory_entry_stream(
+    fn drop_directory_entry_stream(
         &mut self,
         stream: types::DirectoryEntryStream,
     ) -> anyhow::Result<()> {
@@ -590,7 +590,7 @@ impl<T: WasiView> types::Host for T {
         }
     }
 
-    async fn drop_descriptor(&mut self, fd: types::Descriptor) -> anyhow::Result<()> {
+    fn drop_descriptor(&mut self, fd: types::Descriptor) -> anyhow::Result<()> {
         let table = self.table_mut();
 
         // The Drop will close the file/dir, but if the close syscall
@@ -742,7 +742,7 @@ impl<T: WasiView> types::Host for T {
         todo!("filesystem unlock is not implemented")
     }
 
-    async fn read_via_stream(
+    fn read_via_stream(
         &mut self,
         fd: types::Descriptor,
         offset: types::Filesize,
@@ -772,7 +772,7 @@ impl<T: WasiView> types::Host for T {
         Ok(index)
     }
 
-    async fn write_via_stream(
+    fn write_via_stream(
         &mut self,
         fd: types::Descriptor,
         offset: types::Filesize,
@@ -798,7 +798,7 @@ impl<T: WasiView> types::Host for T {
         Ok(index)
     }
 
-    async fn append_via_stream(
+    fn append_via_stream(
         &mut self,
         fd: types::Descriptor,
     ) -> Result<streams::OutputStream, types::Error> {

--- a/crates/wasi/src/preview2/host/filesystem/sync.rs
+++ b/crates/wasi/src/preview2/host/filesystem/sync.rs
@@ -102,9 +102,7 @@ impl<T: async_filesystem::Host> sync_filesystem::Host for T {
         &mut self,
         stream: sync_filesystem::DirectoryEntryStream,
     ) -> anyhow::Result<()> {
-        Ok(in_tokio(async {
-            async_filesystem::Host::drop_directory_entry_stream(self, stream).await
-        })?)
+        async_filesystem::Host::drop_directory_entry_stream(self, stream)
     }
 
     fn sync(&mut self, fd: sync_filesystem::Descriptor) -> Result<(), sync_filesystem::Error> {
@@ -209,9 +207,7 @@ impl<T: async_filesystem::Host> sync_filesystem::Host for T {
     }
 
     fn drop_descriptor(&mut self, fd: sync_filesystem::Descriptor) -> anyhow::Result<()> {
-        Ok(in_tokio(async {
-            async_filesystem::Host::drop_descriptor(self, fd).await
-        })?)
+        async_filesystem::Host::drop_descriptor(self, fd)
     }
 
     fn readlink_at(
@@ -365,9 +361,7 @@ impl<T: async_filesystem::Host> sync_filesystem::Host for T {
         fd: sync_filesystem::Descriptor,
         offset: sync_filesystem::Filesize,
     ) -> Result<streams::InputStream, sync_filesystem::Error> {
-        Ok(in_tokio(async {
-            async_filesystem::Host::read_via_stream(self, fd, offset).await
-        })?)
+        Ok(async_filesystem::Host::read_via_stream(self, fd, offset)?)
     }
 
     fn write_via_stream(
@@ -375,18 +369,14 @@ impl<T: async_filesystem::Host> sync_filesystem::Host for T {
         fd: sync_filesystem::Descriptor,
         offset: sync_filesystem::Filesize,
     ) -> Result<streams::OutputStream, sync_filesystem::Error> {
-        Ok(in_tokio(async {
-            async_filesystem::Host::write_via_stream(self, fd, offset).await
-        })?)
+        Ok(async_filesystem::Host::write_via_stream(self, fd, offset)?)
     }
 
     fn append_via_stream(
         &mut self,
         fd: sync_filesystem::Descriptor,
     ) -> Result<streams::OutputStream, sync_filesystem::Error> {
-        Ok(in_tokio(async {
-            async_filesystem::Host::append_via_stream(self, fd).await
-        })?)
+        Ok(async_filesystem::Host::append_via_stream(self, fd)?)
     }
 
     fn is_same_object(

--- a/crates/wasi/src/preview2/host/io.rs
+++ b/crates/wasi/src/preview2/host/io.rs
@@ -40,12 +40,12 @@ impl From<OutputStreamError> for streams::Error {
 
 #[async_trait::async_trait]
 impl<T: WasiView> streams::Host for T {
-    async fn drop_input_stream(&mut self, stream: InputStream) -> anyhow::Result<()> {
+    fn drop_input_stream(&mut self, stream: InputStream) -> anyhow::Result<()> {
         self.table_mut().delete_internal_input_stream(stream)?;
         Ok(())
     }
 
-    async fn drop_output_stream(&mut self, stream: OutputStream) -> anyhow::Result<()> {
+    fn drop_output_stream(&mut self, stream: OutputStream) -> anyhow::Result<()> {
         self.table_mut().delete_output_stream(stream)?;
         Ok(())
     }
@@ -207,7 +207,7 @@ impl<T: WasiView> streams::Host for T {
         }
     }
 
-    async fn subscribe_to_input_stream(&mut self, stream: InputStream) -> anyhow::Result<Pollable> {
+    fn subscribe_to_input_stream(&mut self, stream: InputStream) -> anyhow::Result<Pollable> {
         // Ensure that table element is an input-stream:
         let pollable = match self.table_mut().get_internal_input_stream_mut(stream)? {
             InternalInputStream::Host(_) => {
@@ -255,10 +255,7 @@ impl<T: WasiView> streams::Host for T {
         Ok(())
     }
 
-    async fn subscribe_to_output_stream(
-        &mut self,
-        stream: OutputStream,
-    ) -> anyhow::Result<Pollable> {
+    fn subscribe_to_output_stream(&mut self, stream: OutputStream) -> anyhow::Result<Pollable> {
         // Ensure that table element is an output-stream:
         let _ = self.table_mut().get_output_stream_mut(stream)?;
 
@@ -444,11 +441,11 @@ pub mod sync {
 
     impl<T: WasiView> streams::Host for T {
         fn drop_input_stream(&mut self, stream: InputStream) -> anyhow::Result<()> {
-            in_tokio(async { AsyncHost::drop_input_stream(self, stream).await })
+            AsyncHost::drop_input_stream(self, stream)
         }
 
         fn drop_output_stream(&mut self, stream: OutputStream) -> anyhow::Result<()> {
-            in_tokio(async { AsyncHost::drop_output_stream(self, stream).await })
+            AsyncHost::drop_output_stream(self, stream)
         }
 
         fn read(
@@ -487,7 +484,7 @@ pub mod sync {
             })?)
         }
         fn subscribe_to_output_stream(&mut self, stream: OutputStream) -> anyhow::Result<Pollable> {
-            in_tokio(async { AsyncHost::subscribe_to_output_stream(self, stream).await })
+            AsyncHost::subscribe_to_output_stream(self, stream)
         }
         fn write_zeroes(&mut self, stream: OutputStream, len: u64) -> Result<(), streams::Error> {
             Ok(in_tokio(async {
@@ -547,7 +544,7 @@ pub mod sync {
         }
 
         fn subscribe_to_input_stream(&mut self, stream: InputStream) -> anyhow::Result<Pollable> {
-            in_tokio(async { AsyncHost::subscribe_to_input_stream(self, stream).await })
+            AsyncHost::subscribe_to_input_stream(self, stream)
         }
     }
 }

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -48,15 +48,19 @@ pub use cap_fs_ext::SystemTimeSpec;
 pub use cap_rand::RngCore;
 
 pub mod bindings {
+    // Generate traits for synchronous bindings.
+    //
+    // Note that this is only done for interfaces which can block, or those which
+    // have some functions in `only_imports` below for being async.
     pub mod sync_io {
         pub(crate) mod _internal {
             wasmtime::component::bindgen!({
                 path: "wit",
                 interfaces: "
-              import wasi:poll/poll
-              import wasi:io/streams
-              import wasi:filesystem/types
-            ",
+                    import wasi:poll/poll
+                    import wasi:io/streams
+                    import wasi:filesystem/types
+                ",
                 tracing: true,
                 trappable_error_type: {
                     "wasi:io/streams"::"write-error": Error,
@@ -70,82 +74,75 @@ pub mod bindings {
         pub use self::_internal::wasi::{filesystem, io, poll};
     }
 
-    pub(crate) mod _internal_clocks {
-        wasmtime::component::bindgen!({
+    wasmtime::component::bindgen!({
         path: "wit",
-        interfaces: "
-              import wasi:clocks/wall-clock
-              import wasi:clocks/monotonic-clock
-              import wasi:clocks/timezone
-            ",
+        interfaces: "include wasi:cli/reactor",
         tracing: true,
-        });
-    }
-    pub use self::_internal_clocks::wasi::clocks;
-
-    pub(crate) mod _internal_io {
-        wasmtime::component::bindgen!({
-            path: "wit",
-            interfaces: "
-              import wasi:poll/poll
-              import wasi:io/streams
-              import wasi:filesystem/types
-            ",
-            tracing: true,
-            async: true,
-            trappable_error_type: {
-                "wasi:io/streams"::"write-error": Error,
-                "wasi:filesystem/types"::"error-code": Error,
-            },
-            with: {
-                "wasi:clocks/wall-clock": crate::preview2::bindings::clocks::wall_clock,
-            }
-        });
-    }
-    pub use self::_internal_io::wasi::{io, poll};
-
-    pub(crate) mod _internal_rest {
-        wasmtime::component::bindgen!({
-        path: "wit",
-        interfaces: "
-              import wasi:filesystem/preopens
-              import wasi:random/random
-              import wasi:random/insecure
-              import wasi:random/insecure-seed
-              import wasi:cli/environment
-              import wasi:cli/exit
-              import wasi:cli/stdin
-              import wasi:cli/stdout
-              import wasi:cli/stderr
-              import wasi:cli/terminal-input
-              import wasi:cli/terminal-output
-              import wasi:cli/terminal-stdin
-              import wasi:cli/terminal-stdout
-              import wasi:cli/terminal-stderr
-              import wasi:sockets/tcp
-              import wasi:sockets/tcp-create-socket
-              import wasi:sockets/instance-network
-            ",
-        tracing: true,
+        async: {
+            // Only these functions are `async` and everything else is sync
+            // meaning that it basically doesn't need to block. These functions
+            // are the only ones that need to block.
+            //
+            // Note that at this time `only_imports` works on function names
+            // which in theory can be shared across interfaces, so this may
+            // need fancier syntax in the future.
+            only_imports: [
+                "access-at",
+                "advise",
+                "blocking-flush",
+                "blocking-read",
+                "blocking-skip",
+                "blocking-splice",
+                "blocking-write",
+                "blocking-write-and-flush",
+                "change-directory-permissions-at",
+                "change-file-permissions-at",
+                "check-write",
+                "create-directory-at",
+                "flush",
+                "forward",
+                "get-flags",
+                "get-type",
+                "is-same-object",
+                "link-at",
+                "lock-exclusive",
+                "lock-shared",
+                "metadata-hash",
+                "metadata-hash-at",
+                "open-at",
+                "poll-oneoff",
+                "read",
+                "read-directory",
+                "read-directory-entry",
+                "readlink-at",
+                "remove-directory-at",
+                "rename-at",
+                "set-size",
+                "set-times",
+                "set-times-at",
+                "skip",
+                "splice",
+                "stat",
+                "stat-at",
+                "symlink-at",
+                "sync",
+                "sync-data",
+                "try-lock-exclusive",
+                "try-lock-shared",
+                "unlink-file-at",
+                "unlock",
+                "write",
+                "write-zeroes",
+            ],
+        },
         trappable_error_type: {
             "wasi:io/streams"::"write-error": Error,
             "wasi:filesystem/types"::"error-code": Error,
             "wasi:sockets/network"::"error-code": Error,
         },
-        with: {
-            "wasi:clocks/wall-clock": crate::preview2::bindings::clocks::wall_clock,
-            "wasi:poll/poll": crate::preview2::bindings::poll::poll,
-            "wasi:io/streams": crate::preview2::bindings::io::streams,
-            "wasi:filesystem/types": crate::preview2::bindings::filesystem::types,
-        }
-        });
-    }
+    });
 
-    pub use self::_internal_rest::wasi::{cli, random, sockets};
-    pub mod filesystem {
-        pub use super::_internal_io::wasi::filesystem::types;
-        pub use super::_internal_rest::wasi::filesystem::preopens;
-    }
+    pub use wasi::*;
 }
 
 pub(crate) static RUNTIME: once_cell::sync::Lazy<tokio::runtime::Runtime> =

--- a/crates/wasi/src/preview2/poll.rs
+++ b/crates/wasi/src/preview2/poll.rs
@@ -53,7 +53,7 @@ impl TablePollableExt for Table {
 
 #[async_trait::async_trait]
 impl<T: WasiView> poll::Host for T {
-    async fn drop_pollable(&mut self, pollable: Pollable) -> Result<()> {
+    fn drop_pollable(&mut self, pollable: Pollable) -> Result<()> {
         self.table_mut().delete_host_pollable(pollable)?;
         Ok(())
     }
@@ -138,7 +138,7 @@ pub mod sync {
 
     impl<T: WasiView> poll::Host for T {
         fn drop_pollable(&mut self, pollable: Pollable) -> Result<()> {
-            in_tokio(async { AsyncHost::drop_pollable(self, pollable).await })
+            AsyncHost::drop_pollable(self, pollable)
         }
 
         fn poll_oneoff(&mut self, pollables: Vec<Pollable>) -> Result<Vec<bool>> {

--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -1019,17 +1019,14 @@ impl<
         match desc {
             Descriptor::Stdin { input_stream, .. } => {
                 streams::Host::drop_input_stream(self, input_stream)
-                    .await
                     .context("failed to call `drop-input-stream`")
             }
             Descriptor::Stdout { output_stream, .. } | Descriptor::Stderr { output_stream, .. } => {
                 streams::Host::drop_output_stream(self, output_stream)
-                    .await
                     .context("failed to call `drop-output-stream`")
             }
             Descriptor::File(File { fd, .. }) | Descriptor::PreopenDirectory((fd, _)) => self
                 .drop_descriptor(fd)
-                .await
                 .context("failed to call `drop-descriptor`"),
         }
         .map_err(types::Error::trap)
@@ -1322,7 +1319,7 @@ impl<
                 };
 
                 let pos = position.load(Ordering::Relaxed);
-                let stream = self.read_via_stream(fd, pos).await.map_err(|e| {
+                let stream = self.read_via_stream(fd, pos).map_err(|e| {
                     e.try_into()
                         .context("failed to call `read-via-stream`")
                         .unwrap_or_else(types::Error::trap)
@@ -1380,7 +1377,7 @@ impl<
                     return Ok(0);
                 };
 
-                let stream = self.read_via_stream(fd, offset).await.map_err(|e| {
+                let stream = self.read_via_stream(fd, offset).map_err(|e| {
                     e.try_into()
                         .context("failed to call `read-via-stream`")
                         .unwrap_or_else(types::Error::trap)
@@ -1426,7 +1423,7 @@ impl<
                     return Ok(0);
                 };
                 let (stream, pos) = if append {
-                    let stream = self.append_via_stream(fd).await.map_err(|e| {
+                    let stream = self.append_via_stream(fd).map_err(|e| {
                         e.try_into()
                             .context("failed to call `append-via-stream`")
                             .unwrap_or_else(types::Error::trap)
@@ -1434,7 +1431,7 @@ impl<
                     (stream, 0)
                 } else {
                     let position = position.load(Ordering::Relaxed);
-                    let stream = self.write_via_stream(fd, position).await.map_err(|e| {
+                    let stream = self.write_via_stream(fd, position).map_err(|e| {
                         e.try_into()
                             .context("failed to call `write-via-stream`")
                             .unwrap_or_else(types::Error::trap)
@@ -1478,7 +1475,7 @@ impl<
                 let Some(buf) = first_non_empty_ciovec(ciovs)? else {
                     return Ok(0);
                 };
-                let stream = self.write_via_stream(fd, offset).await.map_err(|e| {
+                let stream = self.write_via_stream(fd, offset).map_err(|e| {
                     e.try_into()
                         .context("failed to call `write-via-stream`")
                         .unwrap_or_else(types::Error::trap)

--- a/crates/wasi/wit/deps/cli/command.wit
+++ b/crates/wasi/wit/deps/cli/command.wit
@@ -1,33 +1,7 @@
 package wasi:cli
 
 world command {
-  import wasi:clocks/wall-clock
-  import wasi:clocks/monotonic-clock
-  import wasi:clocks/timezone
-  import wasi:filesystem/types
-  import wasi:filesystem/preopens
-  import wasi:sockets/instance-network
-  import wasi:sockets/ip-name-lookup
-  import wasi:sockets/network
-  import wasi:sockets/tcp-create-socket
-  import wasi:sockets/tcp
-  import wasi:sockets/udp-create-socket
-  import wasi:sockets/udp
-  import wasi:random/random
-  import wasi:random/insecure
-  import wasi:random/insecure-seed
-  import wasi:poll/poll
-  import wasi:io/streams
+  include reactor
 
-  import environment
-  import exit
-  import stdin
-  import stdout
-  import stderr
-  import terminal-input
-  import terminal-output
-  import terminal-stdin
-  import terminal-stdout
-  import terminal-stderr
   export run
 }

--- a/crates/wasi/wit/deps/cli/reactor.wit
+++ b/crates/wasi/wit/deps/cli/reactor.wit
@@ -1,0 +1,33 @@
+package wasi:cli
+
+world reactor {
+  import wasi:clocks/wall-clock
+  import wasi:clocks/monotonic-clock
+  import wasi:clocks/timezone
+  import wasi:filesystem/types
+  import wasi:filesystem/preopens
+  import wasi:sockets/instance-network
+  import wasi:sockets/ip-name-lookup
+  import wasi:sockets/network
+  import wasi:sockets/tcp-create-socket
+  import wasi:sockets/tcp
+  import wasi:sockets/udp-create-socket
+  import wasi:sockets/udp
+  import wasi:random/random
+  import wasi:random/insecure
+  import wasi:random/insecure-seed
+  import wasi:poll/poll
+  import wasi:io/streams
+
+  import environment
+  import exit
+  import stdin
+  import stdout
+  import stderr
+  import terminal-input
+  import terminal-output
+  import terminal-stdin
+  import terminal-stdout
+  import terminal-stderr
+}
+


### PR DESCRIPTION
This commit attempts to simplify the `preview2::bindings` module by consolidating everything into a single invocation of `bindgen!`. Previously this was separated out (I think) to handle some methods being `async` and not others, but the `bindgen!` macro has since grown the capability to have some functions async and not all.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
