### PR TITLE
Flag more WASI methods as not-async

### DIFF
--- a/crates/wasi-http/src/component_impl.rs
+++ b/crates/wasi-http/src/component_impl.rs
@@ -617,7 +617,7 @@ pub fn add_component_to_linker<T: WasiHttpView>(
                 let memory: Memory = memory_get(&mut caller)?;
                 let ctx = get_cx(caller.data_mut());
 
-                let result = match io::streams::Host::check_write(ctx, stream).await {
+                let result = match io::streams::Host::check_write(ctx, stream) {
                     // 0 == outer result tag (success)
                     // 1 == result value (u64 lower 32 bits)
                     // 2 == result value (u64 upper 32 bits)
@@ -643,7 +643,7 @@ pub fn add_component_to_linker<T: WasiHttpView>(
             Box::new(async move {
                 let ctx = get_cx(caller.data_mut());
 
-                let result: [u32; 2] = match io::streams::Host::flush(ctx, stream).await {
+                let result: [u32; 2] = match io::streams::Host::flush(ctx, stream) {
                     // 0 == outer result tag
                     // 1 == unused
                     Ok(_) => [0, 0],

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -97,9 +97,7 @@ pub mod bindings {
                 "blocking-write-and-flush",
                 "change-directory-permissions-at",
                 "change-file-permissions-at",
-                "check-write",
                 "create-directory-at",
-                "flush",
                 "forward",
                 "get-flags",
                 "get-type",
@@ -132,7 +130,6 @@ pub mod bindings {
                 "unlink-file-at",
                 "unlock",
                 "write",
-                "write-zeroes",
             ],
         },
         trappable_error_type: {

--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -90,7 +90,7 @@ impl BlockingMode {
                 Ok(total)
             }
             BlockingMode::NonBlocking => {
-                let n = match Streams::check_write(host, output_stream).await {
+                let n = match Streams::check_write(host, output_stream) {
                     Ok(n) => n,
                     Err(e) if matches!(e.downcast_ref(), Some(streams::WriteError::Closed)) => 0,
                     Err(e) => Err(e)?,


### PR DESCRIPTION
All of `check-write`, `write`, and `write-zeros` can be represented as synchronous functions and don't need `async` treatment.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
