### PR TITLE
Implement support for exported resources in `bindgen!`

### DIFF
--- a/crates/component-macro/tests/codegen/resources-export.wit
+++ b/crates/component-macro/tests/codegen/resources-export.wit
@@ -1,0 +1,43 @@
+package foo:foo
+
+world w {
+  export simple-export
+  export export-using-import
+
+  export export-using-export1
+  export export-using-export2
+}
+
+interface simple-export {
+  resource a {
+    constructor()
+    static-a: static func() -> u32
+    method-a: func() -> u32
+  }
+}
+
+interface export-using-import {
+  use transitive-import.{y}
+  resource a {
+    constructor(y: y)
+    static-a: static func() -> y
+    method-a: func(y: y) -> y
+  }
+}
+
+interface transitive-import {
+  resource y
+}
+
+interface export-using-export1 {
+  resource a {
+    constructor()
+  }
+}
+
+interface export-using-export2 {
+  use export-using-export1.{a}
+  resource b {
+    constructor(a: a)
+  }
+}

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -410,3 +410,231 @@ mod async_config {
         let _ = t3.call_z(&mut *store).await;
     }
 }
+
+mod exported_resources {
+    use super::*;
+    use std::mem;
+    use wasmtime::component::Resource;
+
+    wasmtime::component::bindgen!({
+        inline: "
+            package foo:foo
+
+            interface a {
+                resource x {
+                    constructor()
+                }
+            }
+
+            world resources {
+                export b: interface {
+                    use a.{x as y}
+
+                    resource x {
+                        constructor(y: y)
+                        foo: func() -> u32
+                    }
+                }
+
+                resource x
+
+                export f: func(x1: x, x2: x) -> x
+            }
+        ",
+    });
+
+    #[derive(Default)]
+    struct MyImports {
+        hostcalls: Vec<Hostcall>,
+        next_a_x: u32,
+    }
+
+    #[derive(PartialEq, Debug)]
+    enum Hostcall {
+        DropRootX(u32),
+        DropAX(u32),
+        NewA,
+    }
+
+    use foo::foo::a;
+
+    impl ResourcesImports for MyImports {}
+
+    impl HostX for MyImports {
+        fn drop(&mut self, val: Resource<X>) -> Result<()> {
+            self.hostcalls.push(Hostcall::DropRootX(val.rep()));
+            Ok(())
+        }
+    }
+
+    impl a::HostX for MyImports {
+        fn new(&mut self) -> Result<Resource<a::X>> {
+            let rep = self.next_a_x;
+            self.next_a_x += 1;
+            self.hostcalls.push(Hostcall::NewA);
+            Ok(Resource::new_own(rep))
+        }
+
+        fn drop(&mut self, val: Resource<a::X>) -> Result<()> {
+            self.hostcalls.push(Hostcall::DropAX(val.rep()));
+            Ok(())
+        }
+    }
+
+    impl foo::foo::a::Host for MyImports {}
+
+    #[test]
+    fn run() -> Result<()> {
+        let engine = engine();
+
+        let component = Component::new(
+            &engine,
+            r#"
+(component
+  ;; setup the `foo:foo/a` import
+  (import (interface "foo:foo/a") (instance $a
+    (export $x "x" (type (sub resource)))
+    (export "[constructor]x" (func (result (own $x))))
+  ))
+  (alias export $a "x" (type $a-x))
+  (core func $a-x-drop (canon resource.drop $a-x))
+  (core func $a-x-ctor (canon lower (func $a "[constructor]x")))
+
+  ;; setup the root import of the `x` resource
+  (import "x" (type $x (sub resource)))
+  (core func $root-x-dtor (canon resource.drop $x))
+
+  ;; setup and declare the `x` resource for the `b` export.
+  (core module $indirect-dtor
+    (func (export "b-x-dtor") (param i32)
+      local.get 0
+      i32.const 0
+      call_indirect (param i32)
+    )
+    (table (export "$imports") 1 1 funcref)
+  )
+  (core instance $indirect-dtor (instantiate $indirect-dtor))
+  (type $b-x (resource (rep i32) (dtor (func $indirect-dtor "b-x-dtor"))))
+  (core func $b-x-drop (canon resource.drop $b-x))
+  (core func $b-x-rep (canon resource.rep $b-x))
+  (core func $b-x-new (canon resource.new $b-x))
+
+  ;; main module implementation
+  (core module $main
+    (import "foo:foo/a" "[constructor]x" (func $a-x-ctor (result i32)))
+    (import "foo:foo/a" "[resource-drop]x" (func $a-x-dtor (param i32)))
+    (import "$root" "[resource-drop]x" (func $x-dtor (param i32)))
+    (import "[export]b" "[resource-drop]x" (func $b-x-dtor (param i32)))
+    (import "[export]b" "[resource-new]x" (func $b-x-new (param i32) (result i32)))
+    (import "[export]b" "[resource-rep]x" (func $b-x-rep (param i32) (result i32)))
+    (func (export "b#[constructor]x") (param i32) (result i32)
+      (call $a-x-dtor (local.get 0))
+      (call $b-x-new (call $a-x-ctor))
+    )
+    (func (export "b#[method]x.foo") (param i32) (result i32)
+      local.get 0)
+    (func (export "b#[dtor]x") (param i32)
+      (call $a-x-dtor (local.get 0))
+    )
+    (func (export "f") (param i32 i32) (result i32)
+      (call $x-dtor (local.get 0))
+      local.get 1
+    )
+  )
+  (core instance $main (instantiate $main
+    (with "foo:foo/a" (instance
+      (export "[resource-drop]x" (func $a-x-drop))
+      (export "[constructor]x" (func $a-x-ctor))
+    ))
+    (with "$root" (instance
+      (export "[resource-drop]x" (func $root-x-dtor))
+    ))
+    (with "[export]b" (instance
+      (export "[resource-drop]x" (func $b-x-drop))
+      (export "[resource-rep]x" (func $b-x-rep))
+      (export "[resource-new]x" (func $b-x-new))
+    ))
+  ))
+
+  ;; fill in `$indirect-dtor`'s table with the actual destructor definition
+  ;; now that it's available.
+  (core module $fixup
+    (import "" "b-x-dtor" (func $b-x-dtor (param i32)))
+    (import "" "$imports" (table 1 1 funcref))
+    (elem (i32.const 0) func $b-x-dtor)
+  )
+  (core instance (instantiate $fixup
+    (with "" (instance
+      (export "$imports" (table 0 "$imports"))
+      (export "b-x-dtor" (func $main "b#[dtor]x"))
+    ))
+  ))
+
+  ;; Create the `b` export through a subcomponent instantiation.
+  (func $b-x-ctor (param "y" (own $a-x)) (result (own $b-x))
+    (canon lift (core func $main "b#[constructor]x")))
+  (func $b-x-foo (param "self" (borrow $b-x)) (result u32)
+    (canon lift (core func $main "b#[method]x.foo")))
+  (component $b
+    (import "a-x" (type $y (sub resource)))
+    (import "b-x" (type $x' (sub resource)))
+    (import "ctor" (func $ctor (param "y" (own $y)) (result (own $x'))))
+    (import "foo" (func $foo (param "self" (borrow $x')) (result u32)))
+    (export $x "x" (type $x'))
+    (export "[constructor]x"
+      (func $ctor)
+      (func (param "y" (own $y)) (result (own $x))))
+    (export "[method]x.foo"
+      (func $foo)
+      (func (param "self" (borrow $x)) (result u32)))
+  )
+  (instance (export "b") (instantiate $b
+    (with "ctor" (func $b-x-ctor))
+    (with "foo" (func $b-x-foo))
+    (with "a-x" (type 0 "x"))
+    (with "b-x" (type $b-x))
+  ))
+
+  ;; Create the `f` export which is a bare function
+  (func (export "f") (param "x1" (own $x)) (param "x2" (own $x)) (result (own $x))
+    (canon lift (core func $main "f")))
+)
+            "#,
+        )?;
+
+        let mut linker = Linker::new(&engine);
+        Resources::add_to_linker(&mut linker, |f: &mut MyImports| f)?;
+        let mut store = Store::new(&engine, MyImports::default());
+        let (i, _) = Resources::instantiate(&mut store, &component, &linker)?;
+
+        // call the root export `f` twice
+        let ret = i.call_f(&mut store, Resource::new_own(1), Resource::new_own(2))?;
+        assert_eq!(ret.rep(), 2);
+        assert_eq!(
+            mem::take(&mut store.data_mut().hostcalls),
+            [Hostcall::DropRootX(1)]
+        );
+        let ret = i.call_f(&mut store, Resource::new_own(3), Resource::new_own(4))?;
+        assert_eq!(ret.rep(), 4);
+        assert_eq!(
+            mem::take(&mut store.data_mut().hostcalls),
+            [Hostcall::DropRootX(3)]
+        );
+
+        // interact with the `b` export
+        let b = i.b();
+        let b_x = b.x().call_constructor(&mut store, Resource::new_own(5))?;
+        assert_eq!(
+            mem::take(&mut store.data_mut().hostcalls),
+            [Hostcall::DropAX(5), Hostcall::NewA]
+        );
+        b.x().call_foo(&mut store, b_x.clone())?;
+        assert_eq!(mem::take(&mut store.data_mut().hostcalls), []);
+        b_x.resource_drop(&mut store)?;
+        assert_eq!(
+            mem::take(&mut store.data_mut().hostcalls),
+            [Hostcall::DropAX(0)],
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
This commit updates the `wasmtime::component::bindgen!` to support exported resources. Exported resources are themselves always modeled as `ResourceAny` at runtime and are required to perform dynamic type checks to ensure that the right type of resource is passed in. Exported resources have their own `GuestXXX` structure exported to namespace all of their methods. Otherwise, like imports, there's not a whole lot of special treatment of exported resources.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
