### PR TITLE
Allow building for x86_64-linux-android

### DIFF
--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -37,7 +37,7 @@ features = [
   "Win32_System_Diagnostics_Debug",
 ]
 
-[target.'cfg(target_arch = "x86_64")'.dependencies]
+[target.'cfg(all(target_arch = "x86_64", not(target_os = "android")))'.dependencies]
 ittapi = { version = "0.3.3", optional = true  }
 
 [features]

--- a/crates/jit/src/profiling.rs
+++ b/crates/jit/src/profiling.rs
@@ -33,7 +33,7 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     // Note: VTune support is disabled on windows mingw because the ittapi crate doesn't compile
     // there; see also https://github.com/bytecodealliance/wasmtime/pull/4003 for rationale.
-    if #[cfg(all(feature = "vtune", target_arch = "x86_64", not(all(target_os = "windows", target_env = "gnu"))))] {
+    if #[cfg(all(feature = "vtune", target_arch = "x86_64", not(any(target_os = "android", all(target_os = "windows", target_env = "gnu")))))] {
         mod vtune;
         pub use vtune::new as new_vtune;
     } else {

--- a/crates/runtime/src/traphandlers/unix.rs
+++ b/crates/runtime/src/traphandlers/unix.rs
@@ -190,7 +190,7 @@ struct ucontext_t {
 
 unsafe fn get_pc_and_fp(cx: *mut libc::c_void, _signum: libc::c_int) -> (*const u8, usize) {
     cfg_if::cfg_if! {
-        if #[cfg(all(target_os = "linux", target_arch = "x86_64"))] {
+        if #[cfg(all(any(target_os = "linux", target_os = "android"), target_arch = "x86_64"))] {
             let cx = &*(cx as *const libc::ucontext_t);
             (
                 cx.uc_mcontext.gregs[libc::REG_RIP as usize] as *const u8,


### PR DESCRIPTION
Hi, these set of patches allow building for target x86_64-linux-android.

armv7-linux-androideabi and i686-linux-android are blocked by https://github.com/mitsuhiko/listenfd/issues/16.
There maybe other roadblocks ahead but I wont investigate further for now.