### PR TITLE
riscv64: Add compressed `addi`

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -742,6 +742,11 @@
   (CSlli)
 ))
 
+;; Opcodes for the CIW compressed instruction format
+(type CiwOp (enum
+  (CAddi4spn)
+))
+
 
 (type CsrRegOP (enum
   ;; Atomic Read/Write CSR

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -734,6 +734,11 @@
   (CJ)
 ))
 
+;; Opcodes for the CI compressed instruction format
+(type CiOp (enum
+  (CAddi)
+))
+
 
 (type CsrRegOP (enum
   ;; Atomic Read/Write CSR

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -739,6 +739,7 @@
   (CAddi)
   (CAddiw)
   (CAddi16sp)
+  (CSlli)
 ))
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -714,6 +714,9 @@
   (CAdd)
   (CJr)
   (CJalr)
+  ;; c.ebreak technically isn't a CR format instruction, but it's encoding
+  ;; lines up with this format.
+  (CEbreak)
 ))
 
 ;; Opcodes for the CA compressed instruction format

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -738,6 +738,7 @@
 (type CiOp (enum
   (CAddi)
   (CAddiw)
+  (CAddi16sp)
 ))
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -737,6 +737,7 @@
 ;; Opcodes for the CI compressed instruction format
 (type CiOp (enum
   (CAddi)
+  (CAddiw)
 ))
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1980,7 +1980,7 @@ impl CiOp {
     pub fn funct3(&self) -> u32 {
         // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
         match self {
-            CiOp::CAddi => 0b000,
+            CiOp::CAddi | CiOp::CSlli => 0b000,
             CiOp::CAddiw => 0b001,
             CiOp::CAddi16sp => 0b011,
         }
@@ -1990,6 +1990,7 @@ impl CiOp {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
             CiOp::CAddi | CiOp::CAddiw | CiOp::CAddi16sp => COpcodeSpace::C1,
+            CiOp::CSlli => COpcodeSpace::C2,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -6,7 +6,8 @@ use super::*;
 use crate::ir::condcodes::CondCode;
 
 use crate::isa::riscv64::inst::{reg_name, reg_to_gpr_num};
-use crate::isa::riscv64::lower::isle::generated_code::{COpcodeSpace, CaOp, CjOp, CrOp};
+
+use crate::isa::riscv64::lower::isle::generated_code::{COpcodeSpace, CaOp, CiOp, CjOp, CrOp};
 use crate::machinst::isle::WritableReg;
 
 use std::fmt::{Display, Formatter, Result};
@@ -1971,6 +1972,22 @@ impl CjOp {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
             CjOp::CJ => COpcodeSpace::C1,
+        }
+    }
+}
+
+impl CiOp {
+    pub fn funct3(&self) -> u32 {
+        // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
+        match self {
+            CiOp::CAddi => 0b000,
+        }
+    }
+
+    pub fn op(&self) -> COpcodeSpace {
+        // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
+        match self {
+            CiOp::CAddi => COpcodeSpace::C1,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -7,7 +7,9 @@ use crate::ir::condcodes::CondCode;
 
 use crate::isa::riscv64::inst::{reg_name, reg_to_gpr_num};
 
-use crate::isa::riscv64::lower::isle::generated_code::{COpcodeSpace, CaOp, CiOp, CjOp, CrOp};
+use crate::isa::riscv64::lower::isle::generated_code::{
+    COpcodeSpace, CaOp, CiOp, CiwOp, CjOp, CrOp,
+};
 use crate::machinst::isle::WritableReg;
 
 use std::fmt::{Display, Formatter, Result};
@@ -1991,6 +1993,22 @@ impl CiOp {
         match self {
             CiOp::CAddi | CiOp::CAddiw | CiOp::CAddi16sp => COpcodeSpace::C1,
             CiOp::CSlli => COpcodeSpace::C2,
+        }
+    }
+}
+
+impl CiwOp {
+    pub fn funct3(&self) -> u32 {
+        // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
+        match self {
+            CiwOp::CAddi4spn => 0b000,
+        }
+    }
+
+    pub fn op(&self) -> COpcodeSpace {
+        // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
+        match self {
+            CiwOp::CAddi4spn => COpcodeSpace::C0,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1916,14 +1916,14 @@ impl CrOp {
         match self {
             // `c.jr` has the same op/funct4 as C.MV, but RS2 is 0, which is illegal for mv.
             CrOp::CMv | CrOp::CJr => 0b1000,
-            CrOp::CAdd | CrOp::CJalr => 0b1001,
+            CrOp::CAdd | CrOp::CJalr | CrOp::CEbreak => 0b1001,
         }
     }
 
     pub fn op(&self) -> COpcodeSpace {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
-            CrOp::CMv | CrOp::CAdd | CrOp::CJr | CrOp::CJalr => COpcodeSpace::C2,
+            CrOp::CMv | CrOp::CAdd | CrOp::CJr | CrOp::CJalr | CrOp::CEbreak => COpcodeSpace::C2,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1981,13 +1981,14 @@ impl CiOp {
         // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
         match self {
             CiOp::CAddi => 0b000,
+            CiOp::CAddiw => 0b001,
         }
     }
 
     pub fn op(&self) -> COpcodeSpace {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
-            CiOp::CAddi => COpcodeSpace::C1,
+            CiOp::CAddi | CiOp::CAddiw => COpcodeSpace::C1,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1982,13 +1982,14 @@ impl CiOp {
         match self {
             CiOp::CAddi => 0b000,
             CiOp::CAddiw => 0b001,
+            CiOp::CAddi16sp => 0b011,
         }
     }
 
     pub fn op(&self) -> COpcodeSpace {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
-            CiOp::CAddi | CiOp::CAddiw => COpcodeSpace::C1,
+            CiOp::CAddi | CiOp::CAddiw | CiOp::CAddi16sp => COpcodeSpace::C1,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -465,6 +465,12 @@ impl Inst {
     ) -> bool {
         let has_zca = emit_info.isa_flags.has_zca();
 
+        // Currently all compressed extensions (Zcb, Zcd, Zcmp, Zcmt, etc..) require Zca
+        // to be enabled, so check it early.
+        if !has_zca {
+            return false;
+        }
+
         fn reg_is_compressible(r: Reg) -> bool {
             r.to_real_reg()
                 .map(|r| r.hw_enc() >= 8 && r.hw_enc() < 16)
@@ -478,7 +484,7 @@ impl Inst {
                 rd,
                 rs1,
                 rs2,
-            } if has_zca && rd.to_reg() == rs1 && rs1 != zero_reg() && rs2 != zero_reg() => {
+            } if rd.to_reg() == rs1 && rs1 != zero_reg() && rs2 != zero_reg() => {
                 sink.put2(encode_cr_type(CrOp::CAdd, rd, rs2));
             }
 
@@ -488,8 +494,7 @@ impl Inst {
                 rd,
                 rs,
                 imm12,
-            } if has_zca
-                && rd.to_reg() != rs
+            } if rd.to_reg() != rs
                 && rd.to_reg() != zero_reg()
                 && rs != zero_reg()
                 && imm12.as_i16() == 0 =>
@@ -509,11 +514,7 @@ impl Inst {
                 rd,
                 rs1,
                 rs2,
-            } if has_zca
-                && rd.to_reg() == rs1
-                && reg_is_compressible(rs1)
-                && reg_is_compressible(rs2) =>
-            {
+            } if rd.to_reg() == rs1 && reg_is_compressible(rs1) && reg_is_compressible(rs2) => {
                 let op = match alu_op {
                     AluOPRRR::And => CaOp::CAnd,
                     AluOPRRR::Or => CaOp::COr,
@@ -530,7 +531,7 @@ impl Inst {
             // c.j
             //
             // We don't have a separate JAL as that is only availabile in RV32C
-            Inst::Jal { label } if has_zca => {
+            Inst::Jal { label } => {
                 sink.use_label_at_offset(*start_off, label, LabelUse::RVCJump);
                 sink.add_uncond_branch(*start_off, *start_off + 2, label);
                 sink.put2(encode_cj_type(CjOp::CJ, Imm12::ZERO));
@@ -538,26 +539,20 @@ impl Inst {
 
             // c.jr
             Inst::Jalr { rd, base, offset }
-                if has_zca
-                    && rd.to_reg() == zero_reg()
-                    && base != zero_reg()
-                    && offset.as_i16() == 0 =>
+                if rd.to_reg() == zero_reg() && base != zero_reg() && offset.as_i16() == 0 =>
             {
                 sink.put2(encode_cr2_type(CrOp::CJr, base));
             }
 
             // c.jalr
             Inst::Jalr { rd, base, offset }
-                if has_zca
-                    && rd.to_reg() == link_reg()
-                    && base != zero_reg()
-                    && offset.as_i16() == 0 =>
+                if rd.to_reg() == link_reg() && base != zero_reg() && offset.as_i16() == 0 =>
             {
                 sink.put2(encode_cr2_type(CrOp::CJalr, base));
             }
 
             // c.ebreak
-            Inst::EBreak if has_zca => {
+            Inst::EBreak => {
                 sink.put2(encode_cr_type(
                     CrOp::CEbreak,
                     writable_zero_reg(),
@@ -566,7 +561,7 @@ impl Inst {
             }
 
             // c.unimp
-            Inst::Udf { trap_code } if has_zca => {
+            Inst::Udf { trap_code } => {
                 sink.add_trap(trap_code);
                 if let Some(s) = state.take_stack_map() {
                     sink.add_stack_map(StackMapExtent::UpcomingBytes(2), s);
@@ -586,8 +581,7 @@ impl Inst {
                 rd,
                 rs,
                 imm12,
-            } if has_zca
-                && rd.to_reg() == rs
+            } if rd.to_reg() == rs
                 && rs == stack_reg()
                 && imm12.as_i16() != 0
                 && (imm12.as_i16() % 16) == 0
@@ -609,8 +603,7 @@ impl Inst {
                 rd,
                 rs,
                 imm12,
-            } if has_zca
-                && reg_is_compressible(rd.to_reg())
+            } if reg_is_compressible(rd.to_reg())
                 && rs == stack_reg()
                 && imm12.as_i16() != 0
                 && (imm12.as_i16() % 4) == 0
@@ -626,8 +619,7 @@ impl Inst {
                 rd,
                 rs,
                 imm12,
-            } if has_zca
-                && rd.to_reg() == rs
+            } if rd.to_reg() == rs
                 && rs != zero_reg()
                 && imm12.as_i16() != 0
                 && Imm6::maybe_from_imm12(imm12).is_some() =>
@@ -642,8 +634,7 @@ impl Inst {
                 rd,
                 rs,
                 imm12,
-            } if has_zca
-                && rd.to_reg() == rs
+            } if rd.to_reg() == rs
                 && rs != zero_reg()
                 && Imm6::maybe_from_imm12(imm12).is_some() =>
             {
@@ -657,7 +648,7 @@ impl Inst {
                 rd,
                 rs,
                 imm12,
-            } if has_zca && rd.to_reg() == rs && rs != zero_reg() && imm12.as_i16() != 0 => {
+            } if rd.to_reg() == rs && rs != zero_reg() && imm12.as_i16() != 0 => {
                 // The shift amount is unsigned, but we encode it as signed.
                 let shift = imm12.as_i16() & 0x3f;
                 let imm6 = Imm6::maybe_from_i16(shift << 10 >> 10).unwrap();

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -619,12 +619,12 @@ impl Inst {
                 rd,
                 rs,
                 imm12,
-            } if rd.to_reg() == rs
-                && rs != zero_reg()
-                && imm12.as_i16() != 0
-                && Imm6::maybe_from_imm12(imm12).is_some() =>
-            {
-                let imm6 = Imm6::maybe_from_imm12(imm12).unwrap();
+            } if rd.to_reg() == rs && rs != zero_reg() && imm12.as_i16() != 0 => {
+                let imm6 = match Imm6::maybe_from_imm12(imm12) {
+                    Some(imm6) => imm6,
+                    None => return false,
+                };
+
                 sink.put2(encode_ci_type(CiOp::CAddi, rd, imm6));
             }
 
@@ -634,11 +634,11 @@ impl Inst {
                 rd,
                 rs,
                 imm12,
-            } if rd.to_reg() == rs
-                && rs != zero_reg()
-                && Imm6::maybe_from_imm12(imm12).is_some() =>
-            {
-                let imm6 = Imm6::maybe_from_imm12(imm12).unwrap();
+            } if rd.to_reg() == rs && rs != zero_reg() => {
+                let imm6 = match Imm6::maybe_from_imm12(imm12) {
+                    Some(imm6) => imm6,
+                    None => return false,
+                };
                 sink.put2(encode_ci_type(CiOp::CAddiw, rd, imm6));
             }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -556,6 +556,15 @@ impl Inst {
                 sink.put2(encode_cr2_type(CrOp::CJalr, base));
             }
 
+            // c.ebreak
+            Inst::EBreak if has_zca => {
+                sink.put2(encode_cr_type(
+                    CrOp::CEbreak,
+                    writable_zero_reg(),
+                    zero_reg(),
+                ));
+            }
+
             _ => return false,
         }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -636,7 +636,7 @@ impl Inst {
                 sink.put2(encode_ci_type(CiOp::CAddi, rd, imm6));
             }
 
-            // c.addi / c.sext.w
+            // c.addiw
             Inst::AluRRImm12 {
                 alu_op: AluOPRRI::Addiw,
                 rd,

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -627,6 +627,19 @@ impl Inst {
                 let imm6 = Imm6::maybe_from_imm12(imm12).unwrap();
                 sink.put2(encode_ci_type(CiOp::CAddiw, rd, imm6));
             }
+
+            // c.slli
+            Inst::AluRRImm12 {
+                alu_op: AluOPRRI::Slli,
+                rd,
+                rs,
+                imm12,
+            } if has_zca && rd.to_reg() == rs && rs != zero_reg() && imm12.as_i16() != 0 => {
+                // The shift amount is unsigned, but we encode it as signed.
+                let shift = imm12.as_i16() & 0x3f;
+                let imm6 = Imm6::maybe_from_i16(shift << 10 >> 10).unwrap();
+                sink.put2(encode_ci_type(CiOp::CSlli, rd, imm6));
+            }
             _ => return false,
         }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -589,6 +589,21 @@ impl Inst {
                 let imm6 = Imm6::maybe_from_imm12(imm12).unwrap();
                 sink.put2(encode_ci_type(CiOp::CAddi, rd, imm6));
             }
+
+            // c.addi / c.sext.w
+            Inst::AluRRImm12 {
+                alu_op: AluOPRRI::Addiw,
+                rd,
+                rs,
+                imm12,
+            } if has_zca
+                && rd.to_reg() == rs
+                && rs != zero_reg()
+                && Imm6::maybe_from_imm12(imm12).is_some() =>
+            {
+                let imm6 = Imm6::maybe_from_imm12(imm12).unwrap();
+                sink.put2(encode_ci_type(CiOp::CAddiw, rd, imm6));
+            }
             _ => return false,
         }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -406,3 +406,19 @@ pub fn encode_ci_type(op: CiOp, rd: WritableReg, imm: Imm6) -> u16 {
     bits |= unsigned_field_width(op.funct3(), 3) << 13;
     bits.try_into().unwrap()
 }
+
+/// c.addi16sp is a regular CI op, but the immediate field is encoded in a weird way
+pub fn encode_c_addi16sp(imm: Imm6) -> u16 {
+    let imm = imm.bits();
+
+    // [6|1|3|5:4|2]
+    let mut enc_imm = 0;
+    enc_imm |= ((imm >> 5) & 1) << 5;
+    enc_imm |= ((imm >> 0) & 1) << 4;
+    enc_imm |= ((imm >> 2) & 1) << 3;
+    enc_imm |= ((imm >> 3) & 3) << 1;
+    enc_imm |= ((imm >> 1) & 1) << 0;
+    let enc_imm = Imm6::maybe_from_i16((enc_imm as i16) << 10 >> 10).unwrap();
+
+    encode_ci_type(CiOp::CAddi16sp, writable_stack_reg(), enc_imm)
+}

--- a/cranelift/codegen/src/isa/riscv64/inst/encode.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/encode.rs
@@ -9,7 +9,7 @@
 use super::*;
 use crate::isa::riscv64::inst::reg_to_gpr_num;
 use crate::isa::riscv64::lower::isle::generated_code::{
-    CaOp, CiOp, CjOp, CrOp, VecAluOpRImm5, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR,
+    CaOp, CiOp, CiwOp, CjOp, CrOp, VecAluOpRImm5, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR,
     VecAluOpRRRImm5, VecAluOpRRRR, VecElementWidth, VecOpCategory, VecOpMasking,
 };
 use crate::machinst::isle::WritableReg;
@@ -421,4 +421,24 @@ pub fn encode_c_addi16sp(imm: Imm6) -> u16 {
     let enc_imm = Imm6::maybe_from_i16((enc_imm as i16) << 10 >> 10).unwrap();
 
     encode_ci_type(CiOp::CAddi16sp, writable_stack_reg(), enc_imm)
+}
+
+// Encode a CIW type instruction.
+//
+// 0--1-2------4-5------12-13--------15
+// |op |   rd   |   imm   |  funct3  |
+pub fn encode_ciw_type(op: CiwOp, rd: WritableReg, imm: u8) -> u16 {
+    // [3:2|7:4|0|1]
+    let mut imm_field = 0;
+    imm_field |= ((imm >> 1) & 1) << 0;
+    imm_field |= ((imm >> 0) & 1) << 1;
+    imm_field |= ((imm >> 4) & 7) << 2;
+    imm_field |= ((imm >> 2) & 3) << 6;
+
+    let mut bits = 0;
+    bits |= unsigned_field_width(op.op().bits(), 2);
+    bits |= reg_to_compressed_gpr_num(rd.to_reg()) << 2;
+    bits |= unsigned_field_width(imm_field as u32, 8) << 5;
+    bits |= unsigned_field_width(op.funct3(), 3) << 13;
+    bits.try_into().unwrap()
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -167,6 +167,38 @@ impl Display for Imm5 {
     }
 }
 
+/// A Signed 6-bit immediate.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Imm6 {
+    value: i8,
+}
+
+impl Imm6 {
+    /// Create an signed 6-bit immediate from an i16
+    pub fn maybe_from_i16(value: i16) -> Option<Self> {
+        if value >= -32 && value <= 31 {
+            Some(Self { value: value as i8 })
+        } else {
+            None
+        }
+    }
+
+    pub fn maybe_from_imm12(value: Imm12) -> Option<Self> {
+        Imm6::maybe_from_i16(value.as_i16())
+    }
+
+    /// Bits for encoding.
+    pub fn bits(&self) -> u8 {
+        self.value as u8 & 0x3f
+    }
+}
+
+impl Display for Imm6 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.value)
+    }
+}
+
 impl Inst {
     pub(crate) fn imm_min() -> i64 {
         let imm20_max: i64 = (1 << 19) << 12;

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -400,3 +400,41 @@ block0(v0: i64):
 ;   c.slli a0, 0x3f
 ;   c.jr ra
 
+
+function %c_addi4spn() -> i64 {
+  ss0 = explicit_slot 64
+
+block0:
+  v0 = stack_addr.i64 ss0+24
+  return v0
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   add sp,-64
+; block0:
+;   load_addr a0,24(nominal_sp)
+;   add sp,+64
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi16sp sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   c.mv s0, sp
+;   c.addi16sp sp, -0x40
+; block1: ; offset 0xe
+;   c.addi4spn a0, sp, 0x18
+;   c.addi16sp sp, 0x40
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   c.addi16sp sp, 0x10
+;   c.jr ra
+

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -314,3 +314,36 @@ block0(v0: i64):
 ;   c.addi a0, -0x20
 ;   c.jr ra
 
+function %c_sext_w(i32) -> i64 {
+block0(v0: i32):
+  v1 = sextend.i64 v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   sext.w a0,a0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addiw a0, 0
+;   c.jr ra
+
+function %c_addiw(i32) -> i64 {
+block0(v0: i32):
+  v1 = iadd_imm.i32 v0, -32
+  v2 = sextend.i64 v1
+  return v2
+}
+
+; VCode:
+; block0:
+;   addiw a0,a0,-32
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addiw a0, -0x20
+;   c.jr ra
+

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -252,3 +252,19 @@ block0(v0: i64, v1: i64):
 ;   addi sp, sp, 0x10
 ;   c.jr ra
 
+function %c_ebreak() {
+block0:
+  debugtrap
+  return
+}
+
+; VCode:
+; block0:
+;   ebreak
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.ebreak
+;   c.jr ra
+

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -268,3 +268,16 @@ block0:
 ;   c.ebreak
 ;   c.jr ra
 
+function %c_unimp() {
+block0:
+  trap user0
+}
+
+; VCode:
+; block0:
+;   udf##trap_code=user0
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.unimp ; trap: user0
+

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -188,11 +188,11 @@ block0(v0: i8):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi sp, sp, -0x10
+;   c.addi sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   c.mv s0, sp
-; block1: ; offset 0xe
+; block1: ; offset 0xc
 ;   auipc a2, 0
 ;   ld a2, 0xa(a2)
 ;   c.j 0xa
@@ -241,15 +241,15 @@ block0(v0: i64, v1: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi sp, sp, -0x10
+;   c.addi sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   c.mv s0, sp
-; block1: ; offset 0xe
+; block1: ; offset 0xc
 ;   c.jalr a1
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
+;   c.addi sp, 0x10
 ;   c.jr ra
 
 function %c_ebreak() {
@@ -280,4 +280,37 @@ block0:
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.unimp ; trap: user0
+
+
+function %c_addi_max(i64) -> i64 {
+block0(v0: i64):
+  v2 = iadd_imm.i64 v0, 31
+  return v2
+}
+
+; VCode:
+; block0:
+;   addi a0,a0,31
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi a0, 0x1f
+;   c.jr ra
+
+function %c_addi_min(i64) -> i64 {
+block0(v0: i64):
+  v2 = iadd_imm.i64 v0, -32
+  return v2
+}
+
+; VCode:
+; block0:
+;   addi a0,a0,-32
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi a0, -0x20
+;   c.jr ra
 

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -384,3 +384,19 @@ block0:
 ;   c.addi16sp sp, 0x10
 ;   c.jr ra
 
+function %c_slli(i64) -> i64 {
+block0(v0: i64):
+  v1 = ishl_imm.i64 v0, 63
+  return v1
+}
+
+; VCode:
+; block0:
+;   slli a0,a0,63
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.slli a0, 0x3f
+;   c.jr ra
+

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -188,7 +188,7 @@ block0(v0: i8):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   c.addi sp, -0x10
+;   c.addi16sp sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   c.mv s0, sp
@@ -241,7 +241,7 @@ block0(v0: i64, v1: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   c.addi sp, -0x10
+;   c.addi16sp sp, -0x10
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   c.mv s0, sp
@@ -249,7 +249,7 @@ block0(v0: i64, v1: i64):
 ;   c.jalr a1
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
-;   c.addi sp, 0x10
+;   c.addi16sp sp, 0x10
 ;   c.jr ra
 
 function %c_ebreak() {
@@ -345,5 +345,42 @@ block0(v0: i32):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.addiw a0, -0x20
+;   c.jr ra
+
+function %c_addi16sp() -> i64 {
+  ss0 = explicit_slot 8
+
+block0:
+  v0 = stack_addr.i64 ss0
+  return v0
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   add sp,-16
+; block0:
+;   load_addr a0,0(nominal_sp)
+;   add sp,+16
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi16sp sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   c.mv s0, sp
+;   c.addi16sp sp, -0x10
+; block1: ; offset 0xe
+;   c.mv a0, sp
+;   c.addi16sp sp, 0x10
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   c.addi16sp sp, 0x10
 ;   c.jr ra
 


### PR DESCRIPTION
👋 Hey,

This PR introduces all of the compressed variations of the `addi` instruction (4 different adds!) as well as compressed trap, compressed `debugtrap`, and compressed shift left.

We have the following add variants:

* `c.addi` this is the normal `addi`, with a signed 6 bit immediate field.
* `c.addiw` also fairly normal, a 32 bit add with a 6 bit immediate, that sign extends the result to 64bits.
* `c.addi16sp` modifies the stack pointer with a signed 6 bit immediate scaled by 16.
* `c.addi4spn` adds a zero extended 6 bit immediate scaled by 4 to the stack pointer. Unlike `c.addi16sp` it allows saving the result in any compressible register.
