### PR TITLE
c-api: Expose image_range for modules

### DIFF
--- a/crates/c-api/include/wasmtime/module.h
+++ b/crates/c-api/include/wasmtime/module.h
@@ -148,6 +148,21 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_module_deserialize_file(
     wasmtime_module_t **ret
 );
 
+
+/**
+ * \brief Returns the range of bytes in memory where this module’s compilation image resides.
+ *
+ * The compilation image for a module contains executable code, data, debug information, etc. 
+ * This is roughly the same as the wasmtime_module_serialize but not the exact same.
+ *
+ * For more details see: https://docs.wasmtime.dev/api/wasmtime/struct.Module.html#method.image_range
+ */
+WASM_API_EXTERN void wasmtime_module_image_range(
+    const wasm_module_t *module,
+    size_t *start,
+    size_t *end
+);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -184,6 +184,17 @@ pub extern "C" fn wasmtime_module_serialize(
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_module_image_range(
+    module: &wasmtime_module_t,
+    start: &mut usize,
+    end: &mut usize,
+) {
+    let range = module.module.image_range();
+    *start = range.start;
+    *end = range.end;
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wasmtime_module_deserialize(
     engine: &wasm_engine_t,
     bytes: *const u8,


### PR DESCRIPTION
We're using this to monitor the amount of executable memory each module
needs.

