### PR TITLE
Support resource maps in `component::bindgen!`

### DIFF
--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -1,26 +1,108 @@
-macro_rules! gentest {
-    ($id:ident $name:tt $path:tt) => {
-        mod $id {
-            mod sugar {
-                wasmtime::component::bindgen!(in $path);
-            }
-            mod async_ {
-                wasmtime::component::bindgen!({
-                    path: $path,
-                    async: true,
-                });
-            }
-            mod tracing {
-                wasmtime::component::bindgen!({
-                    path: $path,
-                    tracing: true,
-                    ownership: Borrowing {
-                        duplicate_if_necessary: true
-                    }
-                });
-            }
-        }
-    };
-}
+// macro_rules! gentest {
+//     ($id:ident $name:tt $path:tt) => {
+//         mod $id {
+//             mod sugar {
+//                 wasmtime::component::bindgen!(in $path);
+//             }
+//             mod async_ {
+//                 wasmtime::component::bindgen!({
+//                     path: $path,
+//                     async: true,
+//                 });
+//             }
+//             mod tracing {
+//                 wasmtime::component::bindgen!({
+//                     path: $path,
+//                     tracing: true,
+//                     ownership: Borrowing {
+//                         duplicate_if_necessary: true
+//                     }
+//                 });
+//             }
+//         }
+//     };
+// }
 
-component_macro_test_helpers::foreach!(gentest);
+// component_macro_test_helpers::foreach!(gentest);
+
+mod with_key_and_resources {
+    use anyhow::Result;
+    use wasmtime::component::Resource;
+
+    wasmtime::component::bindgen!({
+        inline: "
+            package demo:pkg
+
+            interface bar {
+                resource a
+                resource b
+            }
+
+            world foo {
+                resource a
+                resource b
+
+                import foo: interface {
+                    resource a
+                    resource b
+                }
+
+                import bar
+            }
+        ",
+        with: {
+            "a": MyA,
+            "b": MyA,
+            "foo/a": MyA,
+            "foo/b": MyA,
+            "demo:pkg/bar/a": MyA,
+            "demo:pkg/bar/b": MyA,
+        },
+    });
+
+    pub struct MyA;
+
+    struct MyComponent;
+
+    impl FooImports for MyComponent {}
+
+    impl HostA for MyComponent {
+        fn drop(&mut self, _: Resource<MyA>) -> Result<()> {
+            loop {}
+        }
+    }
+
+    impl HostB for MyComponent {
+        fn drop(&mut self, _: Resource<MyA>) -> Result<()> {
+            loop {}
+        }
+    }
+
+    impl foo::Host for MyComponent {}
+
+    impl foo::HostA for MyComponent {
+        fn drop(&mut self, _: Resource<MyA>) -> Result<()> {
+            loop {}
+        }
+    }
+
+    impl foo::HostB for MyComponent {
+        fn drop(&mut self, _: Resource<MyA>) -> Result<()> {
+            loop {}
+        }
+    }
+
+    impl demo::pkg::bar::Host for MyComponent {}
+
+    impl demo::pkg::bar::HostA for MyComponent {
+        fn drop(&mut self, _: Resource<MyA>) -> Result<()> {
+            loop {}
+        }
+    }
+
+    impl demo::pkg::bar::HostB for MyComponent {
+        fn drop(&mut self, _: Resource<MyA>) -> Result<()> {
+            loop {}
+        }
+    }
+}

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -1,29 +1,29 @@
-// macro_rules! gentest {
-//     ($id:ident $name:tt $path:tt) => {
-//         mod $id {
-//             mod sugar {
-//                 wasmtime::component::bindgen!(in $path);
-//             }
-//             mod async_ {
-//                 wasmtime::component::bindgen!({
-//                     path: $path,
-//                     async: true,
-//                 });
-//             }
-//             mod tracing {
-//                 wasmtime::component::bindgen!({
-//                     path: $path,
-//                     tracing: true,
-//                     ownership: Borrowing {
-//                         duplicate_if_necessary: true
-//                     }
-//                 });
-//             }
-//         }
-//     };
-// }
+macro_rules! gentest {
+    ($id:ident $name:tt $path:tt) => {
+        mod $id {
+            mod sugar {
+                wasmtime::component::bindgen!(in $path);
+            }
+            mod async_ {
+                wasmtime::component::bindgen!({
+                    path: $path,
+                    async: true,
+                });
+            }
+            mod tracing {
+                wasmtime::component::bindgen!({
+                    path: $path,
+                    tracing: true,
+                    ownership: Borrowing {
+                        duplicate_if_necessary: true
+                    }
+                });
+            }
+        }
+    };
+}
 
-// component_macro_test_helpers::foreach!(gentest);
+component_macro_test_helpers::foreach!(gentest);
 
 mod with_key_and_resources {
     use anyhow::Result;

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -326,16 +326,20 @@ pub(crate) use self::store::ComponentStoreData;
 ///     // Restrict the code generated to what's needed for the interface
 ///     // imports in the inlined WIT document fragment.
 ///     interfaces: "
-///         import package.foo
+///         import wasi:cli/command
 ///     ",
 ///
-///     // Remap interface names to module names, imported from elsewhere.
-///     // Using this option will prevent any code from being generated
-///     // for the names mentioned in the mapping, assuming instead that the
-///     // names mentioned come from a previous use of the `bindgen!` macro
-///     // with `only_interfaces: true`.
+///     // Remap imported interfaces or resources to types defined in Rust
+///     // elsewhere. Using this option will prevent any code from being
+///     // generated for interfaces mentioned here. Resources named here will
+///     // not have a type generated to represent the resource.
+///     //
+///     // Interfaces mapped with this option should be previously generated
+///     // with an invocation of this macro. Resources need to be mapped to a
+///     // Rust type name.
 ///     with: {
-///         "a": somewhere::else::a,
+///         "wasi:random/random": some::other::wasi::random::random,
+///         "wasi:filesystem/types/descriptor": MyDescriptorType,
 ///     },
 /// });
 /// ```


### PR DESCRIPTION
This commit adds support to `component::bindgen!` to specify resource types using the `with` key of the macro. This can be used to configure the `T` of `Resource<T>` to use a preexisting type rather than unconditionally generating a new empty enum to have a fresh type.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
