### PR TITLE
riscv64: Better AMode Matching

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2433,9 +2433,6 @@
         (high Reg (gen_load p (offset32_add offset 8) (LoadOP.Ld) flags $I64)))
     (value_regs low high)))
 
-(decl default_memflags () MemFlags)
-(extern constructor default_memflags default_memflags)
-
 (decl offset32_add (Offset32 i64) Offset32)
 (extern constructor offset32_add offset32_add)
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2611,32 +2611,6 @@
 (decl store_op (Type) StoreOP)
 (extern constructor store_op store_op)
 
-;; bool is "is_signed"
-(decl int_load_op (bool u8) LoadOP)
-(rule
-  (int_load_op $false 8)
-  (LoadOP.Lbu))
-
-(rule
-  (int_load_op $true 8)
-  (LoadOP.Lb))
-
-(rule
-  (int_load_op $false 16)
-  (LoadOP.Lhu))
-(rule
-  (int_load_op $true 16)
-  (LoadOP.Lh))
-(rule
-  (int_load_op $false 32)
-  (LoadOP.Lwu))
-(rule
-  (int_load_op $true 32)
-  (LoadOP.Lw))
-
-(rule
-  (int_load_op _ 64)
-  (LoadOP.Ld))
 
 ;;;; load extern name
 (decl load_ext_name (ExternalName i64) Reg)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2403,12 +2403,48 @@
     )))
 
 ;; Generates a AMode that points to a register plus an offset.
-(decl gen_reg_offset_amode (Reg Offset32 Type) AMode)
+(decl gen_reg_offset_amode (Reg i64 Type) AMode)
 (extern constructor gen_reg_offset_amode gen_reg_offset_amode)
+
+;; Generates a AMode that an offset from the stack pointer.
+(decl gen_sp_offset_amode (i64 Type) AMode)
+(extern constructor gen_sp_offset_amode gen_sp_offset_amode)
+
+;; Generates a AMode that an offset from the frame pointer.
+(decl gen_fp_offset_amode (i64 Type) AMode)
+(extern constructor gen_fp_offset_amode gen_fp_offset_amode)
+
+;; Generates an AMode that points to a stack slot + offset.
+(decl gen_stack_slot_amode (StackSlot i64 Type) AMode)
+(extern constructor gen_stack_slot_amode gen_stack_slot_amode)
 
 ;; Generates a AMode that points to a constant in the constant pool.
 (decl gen_const_amode (VCodeConstant) AMode)
 (extern constructor gen_const_amode gen_const_amode)
+
+
+
+;; Tries to match a Value + Offset into an AMode
+(decl amode (Value i32 Type) AMode)
+
+;; The in simple case we just lower into a Reg+Offset
+(rule 0 (amode r @ (value_type (ty_addr64 _)) offset ty)
+  (gen_reg_offset_amode r offset ty))
+
+;; If the value is a `get_frame_pointer`, we can just use the offset from that.
+(rule 1 (amode (get_frame_pointer) offset ty)
+  (gen_fp_offset_amode offset ty))
+
+;; If the value is a `get_stack_pointer`, we can just use the offset from that.
+(rule 1 (amode (get_stack_pointer) offset ty)
+  (gen_sp_offset_amode offset ty))
+
+;; Similarly if the value is a `stack_addr` we can also turn that into an sp offset.
+(rule 1 (amode (stack_addr ss ss_offset) amode_offset ty)
+  (if-let combined_offset (s32_add_fallible ss_offset amode_offset))
+  (gen_stack_slot_amode ss combined_offset ty))
+
+
 
 
 ;; Returns a canonical type for a LoadOP. We only return I64 or F64.
@@ -2424,33 +2460,17 @@
         dst))
 
 ;; helper function to load from memory.
-(decl gen_load (Reg Offset32 LoadOP MemFlags Type) Reg)
-(rule (gen_load p offset op flags ty)
-  (emit_load op flags (gen_reg_offset_amode p offset $I64)))
-
-(decl gen_load_128 (Reg Offset32 MemFlags) ValueRegs)
-(rule (gen_load_128 p offset flags)
-  (let ((low Reg (gen_load p offset (LoadOP.Ld) flags $I64))
-        (high Reg (gen_load p (offset32_add offset 8) (LoadOP.Ld) flags $I64)))
-    (value_regs low high)))
-
-(decl offset32_add (Offset32 i64) Offset32)
-(extern constructor offset32_add offset32_add)
+(decl gen_load (AMode LoadOP MemFlags Type) Reg)
+(rule (gen_load amode op flags ty)
+  (emit_load op flags amode))
 
 ;; helper function to store to memory.
-(decl gen_store (Reg Offset32 StoreOP MemFlags Reg) InstOutput)
-(rule
-  (gen_store base offset op flags src)
-  (side_effect (SideEffectNoResult.Inst (MInst.Store (gen_reg_offset_amode base offset $I64) op flags src)))
-)
+(decl gen_store (AMode StoreOP MemFlags Reg) InstOutput)
+(rule (gen_store amode op flags src)
+  (side_effect (SideEffectNoResult.Inst (MInst.Store amode op flags src))))
 
-(decl gen_store_128 (Reg Offset32 MemFlags ValueRegs) InstOutput)
-(rule
-  (gen_store_128 p offset flags src)
-  (side_effect
-    (SideEffectNoResult.Inst2
-      (MInst.Store (gen_reg_offset_amode p offset $I64) (StoreOP.Sd) flags (value_regs_get src 0))
-      (MInst.Store (gen_reg_offset_amode p (offset32_add offset 8) $I64) (StoreOP.Sd) flags (value_regs_get src 1)))))
+
+
 
 (decl valid_atomic_transaction (Type) Type)
 (extern extractor valid_atomic_transaction valid_atomic_transaction)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1664,10 +1664,10 @@
 
 ;; Otherwise we fall back to loading the immediate from the constant pool.
 (rule 0 (imm (ty_int ty) c)
-  (emit_load
+  (gen_load
+    (gen_const_amode (emit_u64_le_const c))
     (LoadOP.Ld)
-    (mem_flags_trusted)
-    (gen_const_amode (emit_u64_le_const c))))
+    (mem_flags_trusted)))
 
 ;; Imm12 Rules
 
@@ -2453,16 +2453,12 @@
 (rule 1 (load_op_reg_type (LoadOP.Flw)) $F64)
 (rule 0 (load_op_reg_type _) $I64)
 
-(decl emit_load (LoadOP MemFlags AMode) Reg)
-(rule (emit_load op flags from)
-      (let ((dst WritableReg (temp_writable_reg (load_op_reg_type op)))
-            (_ Unit (emit (MInst.Load dst op flags from))))
-        dst))
-
 ;; helper function to load from memory.
-(decl gen_load (AMode LoadOP MemFlags Type) Reg)
-(rule (gen_load amode op flags ty)
-  (emit_load op flags amode))
+(decl gen_load (AMode LoadOP MemFlags) Reg)
+(rule (gen_load amode op flags)
+  (let ((dst WritableReg (temp_writable_reg (load_op_reg_type op)))
+      (_ Unit (emit (MInst.Load dst op flags amode))))
+    dst))
 
 ;; helper function to store to memory.
 (decl gen_store (AMode StoreOP MemFlags Reg) InstOutput)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2426,21 +2426,38 @@
 
 ;; Tries to match a Value + Offset into an AMode
 (decl amode (Value i32 Type) AMode)
+(rule 0 (amode addr offset ty) (amode_inner addr offset ty))
 
-;; The in simple case we just lower into a Reg+Offset
-(rule 0 (amode r @ (value_type (ty_addr64 _)) offset ty)
+;; If we are adding a constant offset with an iadd we can instead make that
+;; offset part of the amode offset.
+;;
+;; We can't recurse into `amode` again since that could cause stack overflows.
+;; See: https://github.com/bytecodealliance/wasmtime/pull/6968
+(rule 1 (amode (iadd addr (iconst (simm32 y))) offset ty)
+  (if-let new_offset (s32_add_fallible y offset))
+  (amode_inner addr new_offset ty))
+(rule 2 (amode (iadd (iconst (simm32 x)) addr) offset ty)
+  (if-let new_offset (s32_add_fallible x offset))
+  (amode_inner addr new_offset ty))
+
+
+;; These are the normal rules for generating an AMode.
+(decl amode_inner (Value i32 Type) AMode)
+
+;; In the simplest case we just lower into a Reg+Offset
+(rule 0 (amode_inner r @ (value_type (ty_addr64 _)) offset ty)
   (gen_reg_offset_amode r offset ty))
 
 ;; If the value is a `get_frame_pointer`, we can just use the offset from that.
-(rule 1 (amode (get_frame_pointer) offset ty)
+(rule 1 (amode_inner (get_frame_pointer) offset ty)
   (gen_fp_offset_amode offset ty))
 
 ;; If the value is a `get_stack_pointer`, we can just use the offset from that.
-(rule 1 (amode (get_stack_pointer) offset ty)
+(rule 1 (amode_inner (get_stack_pointer) offset ty)
   (gen_sp_offset_amode offset ty))
 
 ;; Similarly if the value is a `stack_addr` we can also turn that into an sp offset.
-(rule 1 (amode (stack_addr ss ss_offset) amode_offset ty)
+(rule 1 (amode_inner (stack_addr ss ss_offset) amode_offset ty)
   (if-let combined_offset (s32_add_fallible ss_offset amode_offset))
   (gen_stack_slot_amode ss combined_offset ty))
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2402,8 +2402,9 @@
       (gen_select_reg (IntCC.UnsignedGreaterThanOrEqual) shamt_128 const64 low high)
     )))
 
-(decl gen_amode (Reg Offset32 Type) AMode)
-(extern constructor gen_amode gen_amode)
+;; Generates a AMode that points to a register plus an offset.
+(decl gen_reg_offset_amode (Reg Offset32 Type) AMode)
+(extern constructor gen_reg_offset_amode gen_reg_offset_amode)
 
 ;; Generates a AMode that points to a constant in the constant pool.
 (decl gen_const_amode (VCodeConstant) AMode)
@@ -2425,7 +2426,7 @@
 ;; helper function to load from memory.
 (decl gen_load (Reg Offset32 LoadOP MemFlags Type) Reg)
 (rule (gen_load p offset op flags ty)
-  (emit_load op flags (gen_amode p offset $I64)))
+  (emit_load op flags (gen_reg_offset_amode p offset $I64)))
 
 (decl gen_load_128 (Reg Offset32 MemFlags) ValueRegs)
 (rule (gen_load_128 p offset flags)
@@ -2440,7 +2441,7 @@
 (decl gen_store (Reg Offset32 StoreOP MemFlags Reg) InstOutput)
 (rule
   (gen_store base offset op flags src)
-  (side_effect (SideEffectNoResult.Inst (MInst.Store (gen_amode base offset $I64) op flags src)))
+  (side_effect (SideEffectNoResult.Inst (MInst.Store (gen_reg_offset_amode base offset $I64) op flags src)))
 )
 
 (decl gen_store_128 (Reg Offset32 MemFlags ValueRegs) InstOutput)
@@ -2448,8 +2449,8 @@
   (gen_store_128 p offset flags src)
   (side_effect
     (SideEffectNoResult.Inst2
-      (MInst.Store (gen_amode p offset $I64) (StoreOP.Sd) flags (value_regs_get src 0))
-      (MInst.Store (gen_amode p (offset32_add offset 8) $I64) (StoreOP.Sd) flags (value_regs_get src 1)))))
+      (MInst.Store (gen_reg_offset_amode p offset $I64) (StoreOP.Sd) flags (value_regs_get src 0))
+      (MInst.Store (gen_reg_offset_amode p (offset32_add offset 8) $I64) (StoreOP.Sd) flags (value_regs_get src 1)))))
 
 (decl valid_atomic_transaction (Type) Type)
 (extern extractor valid_atomic_transaction valid_atomic_transaction)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1480,41 +1480,43 @@
   (udf code))
 
 ;;;;;  Rules for `uload8`;;;;;;;;;
-(rule (lower (uload8 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (LoadOP.Lbu) flags $I64))
+(rule (lower (uload8 flags p offset))
+  (gen_load (amode p offset $I8) (LoadOP.Lbu) flags $I8))
 
 ;;;;;  Rules for `sload8`;;;;;;;;;
-(rule
-  (lower (sload8 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (LoadOP.Lb) flags $I64))
+(rule (lower (sload8 flags p offset))
+  (gen_load (amode p offset $I8) (LoadOP.Lb) flags $I8))
 
 ;;;;;  Rules for `uload16`;;;;;;;;;
-(rule (lower (uload16 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (LoadOP.Lhu) flags $I64))
+(rule (lower (uload16 flags p offset))
+  (gen_load (amode p offset $I16) (LoadOP.Lhu) flags $I16))
 
 ;;;;;  Rules for `iload16`;;;;;;;;;
-(rule (lower (sload16 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (LoadOP.Lh) flags $I64))
+(rule (lower (sload16 flags p offset))
+  (gen_load (amode p offset $I16) (LoadOP.Lh) flags $I16))
 
 ;;;;;  Rules for `uload32`;;;;;;;;;
-(rule (lower (uload32 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (LoadOP.Lwu) flags $I64))
+(rule (lower (uload32 flags p offset))
+  (gen_load (amode p offset $I32) (LoadOP.Lwu) flags $I32))
 
-;;;;;  Rules for `iload16`;;;;;;;;;
-(rule (lower (sload32 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (LoadOP.Lw) flags $I64))
+;;;;;  Rules for `sload32`;;;;;;;;;
+(rule (lower (sload32 flags p offset))
+  (gen_load (amode p offset $I32) (LoadOP.Lw) flags $I32))
 
 ;;;;;  Rules for `load`;;;;;;;;;
-(rule (lower (has_type ty (load flags p @ (value_type (ty_addr64 _)) offset)))
-  (gen_load p offset (load_op ty) flags ty))
+(rule (lower (has_type ty (load flags p offset)))
+  (gen_load (amode p offset ty) (load_op ty) flags ty))
 
-;;;; for I128
-(rule 1 (lower (has_type $I128 (load flags p @ (value_type (ty_addr64 _)) offset)))
-  (gen_load_128 p offset flags))
+(rule 1 (lower (has_type $I128 (load flags p offset)))
+  (if-let offset_plus_8 (s32_add_fallible offset 8))
+  (let ((lo XReg (gen_load (amode p offset $I64) (LoadOP.Ld) flags $I64))
+        (hi XReg (gen_load (amode p offset_plus_8 $I64) (LoadOP.Ld) flags $I64)))
+    (value_regs lo hi)))
 
-(rule 2 (lower (has_type (ty_vec_fits_in_register ty) (load flags p @ (value_type (ty_addr64 _)) offset)))
-  (let ((eew VecElementWidth (element_width_from_type ty)))
-    (vec_load eew (VecAMode.UnitStride (gen_amode p offset $I64)) flags (unmasked) ty)))
+(rule 2 (lower (has_type (ty_vec_fits_in_register ty) (load flags p offset)))
+  (let ((eew VecElementWidth (element_width_from_type ty))
+        (amode AMode (amode p offset ty)))
+    (vec_load eew (VecAMode.UnitStride amode) flags (unmasked) ty)))
 
 ;;;;;  Rules for Load + Extend Combos ;;;;;;;;;
 
@@ -1523,72 +1525,72 @@
 ;; do a SEW/2 extension. This only reads half width elements from the source vector register
 ;; extends it, and writes the back the full register.
 
-(decl gen_load64_extend (Type ExtendOp MemFlags XReg Offset32) VReg)
+(decl gen_load64_extend (Type ExtendOp MemFlags AMode) VReg)
 
-(rule (gen_load64_extend ty (ExtendOp.Signed) flags addr offset)
+(rule (gen_load64_extend ty (ExtendOp.Signed) flags amode)
   (let ((eew VecElementWidth (element_width_from_type $I64))
         (load_state VState (vstate_from_type $I64))
-        (loaded VReg (vec_load eew (VecAMode.UnitStride (gen_amode addr offset $I64)) flags (unmasked) load_state)))
+        (loaded VReg (vec_load eew (VecAMode.UnitStride amode) flags (unmasked) load_state)))
     (rv_vsext_vf2 loaded (unmasked) ty)))
 
-(rule (gen_load64_extend ty (ExtendOp.Zero) flags addr offset)
+(rule (gen_load64_extend ty (ExtendOp.Zero) flags amode)
   (let ((eew VecElementWidth (element_width_from_type $I64))
         (load_state VState (vstate_from_type $I64))
-        (loaded VReg (vec_load eew (VecAMode.UnitStride (gen_amode addr offset $I64)) flags (unmasked) load_state)))
+        (loaded VReg (vec_load eew (VecAMode.UnitStride amode) flags (unmasked) load_state)))
     (rv_vzext_vf2 loaded (unmasked) ty)))
 
 ;;;;;  Rules for `uload8x8`;;;;;;;;;;
-(rule (lower (has_type (ty_vec_fits_in_register ty @ $I16X8) (uload8x8 flags addr @ (value_type (ty_addr64 _)) offset)))
-  (gen_load64_extend ty (ExtendOp.Zero) flags addr offset))
+(rule (lower (has_type (ty_vec_fits_in_register ty @ $I16X8) (uload8x8 flags addr offset)))
+  (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset ty)))
 
 ;;;;;  Rules for `uload16x4`;;;;;;;;;
-(rule (lower (has_type (ty_vec_fits_in_register ty @ $I32X4) (uload16x4 flags addr @ (value_type (ty_addr64 _)) offset)))
-  (gen_load64_extend ty (ExtendOp.Zero) flags addr offset))
+(rule (lower (has_type (ty_vec_fits_in_register ty @ $I32X4) (uload16x4 flags addr offset)))
+  (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset ty)))
 
 ;;;;;  Rules for `uload32x2`;;;;;;;;;
-(rule (lower (has_type (ty_vec_fits_in_register ty @ $I64X2) (uload32x2 flags addr @ (value_type (ty_addr64 _)) offset)))
-  (gen_load64_extend ty (ExtendOp.Zero) flags addr offset))
+(rule (lower (has_type (ty_vec_fits_in_register ty @ $I64X2) (uload32x2 flags addr offset)))
+  (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset ty)))
 
 ;;;;;  Rules for `sload8x8`;;;;;;;;;;
-(rule (lower (has_type (ty_vec_fits_in_register ty @ $I16X8) (sload8x8 flags addr @ (value_type (ty_addr64 _)) offset)))
-  (gen_load64_extend ty (ExtendOp.Signed) flags addr offset))
+(rule (lower (has_type (ty_vec_fits_in_register ty @ $I16X8) (sload8x8 flags addr offset)))
+  (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset ty)))
 
 ;;;;;  Rules for `sload16x4`;;;;;;;;;
-(rule (lower (has_type (ty_vec_fits_in_register ty @ $I32X4) (sload16x4 flags addr @ (value_type (ty_addr64 _)) offset)))
-  (gen_load64_extend ty (ExtendOp.Signed) flags addr offset))
+(rule (lower (has_type (ty_vec_fits_in_register ty @ $I32X4) (sload16x4 flags addr offset)))
+  (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset ty)))
 
 ;;;;;  Rules for `sload32x2`;;;;;;;;;
-(rule (lower (has_type (ty_vec_fits_in_register ty @ $I64X2) (sload32x2 flags addr @ (value_type (ty_addr64 _)) offset)))
-  (gen_load64_extend ty (ExtendOp.Signed) flags addr offset))
+(rule (lower (has_type (ty_vec_fits_in_register ty @ $I64X2) (sload32x2 flags addr offset)))
+  (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset ty)))
 
 ;;;;;  Rules for `istore8`;;;;;;;;;
-(rule
-  (lower (istore8 flags x p @ (value_type (ty_addr64 _)) offset))
-  (gen_store p offset (StoreOP.Sb) flags x))
+(rule (lower (istore8 flags x p offset))
+  (gen_store (amode p offset $I8) (StoreOP.Sb) flags x))
+
 ;;;;;  Rules for `istore16`;;;;;;;;;
-(rule
-  (lower (istore16 flags x p @ (value_type (ty_addr64 _)) offset))
-  (gen_store p offset (StoreOP.Sh) flags x))
+(rule (lower (istore16 flags x p offset))
+  (gen_store (amode p offset $I16) (StoreOP.Sh) flags x))
 
 ;;;;;  Rules for `istore32`;;;;;;;;;
-(rule
-  (lower (istore32 flags x p @ (value_type (ty_addr64 _)) offset))
-  (gen_store p offset (StoreOP.Sw) flags x))
+(rule (lower (istore32 flags x p offset))
+  (gen_store (amode p offset $I32) (StoreOP.Sw) flags x))
 
 ;;;;;  Rules for `store`;;;;;;;;;
-(rule
-  (lower (store flags x @ (value_type ty) p @ (value_type (ty_addr64 _)) offset))
-  (gen_store p offset (store_op ty) flags x))
+(rule (lower (store flags x @ (value_type ty) p offset))
+  (gen_store (amode p offset ty) (store_op ty) flags x))
 
-;;; special for I128
-(rule 1
-  (lower (store flags x @ (value_type $I128 ) p @ (value_type (ty_addr64 _)) offset))
-  (gen_store_128 p offset flags x))
+(rule 1 (lower (store flags x @ (value_type $I128) p offset))
+  (if-let offset_plus_8 (s32_add_fallible offset 8))
+  (let ((_ InstOutput (gen_store (amode p offset $I64) (StoreOP.Sd) flags (value_regs_get x 0))))
+    (gen_store (amode p offset_plus_8 $I64) (StoreOP.Sd) flags (value_regs_get x 1))))
 
-(rule 2
-  (lower (store flags x @ (value_type (ty_vec_fits_in_register ty)) p @ (value_type (ty_addr64 _)) offset))
-  (let ((eew VecElementWidth (element_width_from_type ty)))
-    (vec_store eew (VecAMode.UnitStride (gen_amode p offset $I64)) x flags (unmasked) ty)))
+(rule 2 (lower (store flags x @ (value_type (ty_vec_fits_in_register ty)) p offset))
+  (let ((eew VecElementWidth (element_width_from_type ty))
+        (amode AMode (amode p offset ty)))
+    (vec_store eew (VecAMode.UnitStride amode) x flags (unmasked) ty)))
+
+
+;;;;;  Rules for `icmp`;;;;;;;;;
 
 (decl gen_icmp (IntCC ValueRegs ValueRegs Type) XReg)
 (rule
@@ -1598,7 +1600,6 @@
       (_ Unit (emit (MInst.Icmp cc result x y ty))))
     result))
 
-;;;;;  Rules for `icmp`;;;;;;;;;
 (rule 0 (lower (icmp cc x @ (value_type (ty_int ty)) y))
   (lower_icmp cc x y ty))
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1480,44 +1480,39 @@
   (udf code))
 
 ;;;;;  Rules for `uload8`;;;;;;;;;
-(rule
-  (lower (uload8 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (int_load_op $false 8) flags $I64))
+(rule (lower (uload8 flags p @ (value_type (ty_addr64 _)) offset))
+  (gen_load p offset (LoadOP.Lbu) flags $I64))
+
 ;;;;;  Rules for `sload8`;;;;;;;;;
 (rule
   (lower (sload8 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (int_load_op $true 8) flags $I64))
+  (gen_load p offset (LoadOP.Lb) flags $I64))
+
 ;;;;;  Rules for `uload16`;;;;;;;;;
-(rule
-  (lower (uload16 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (int_load_op $false 16) flags $I64))
+(rule (lower (uload16 flags p @ (value_type (ty_addr64 _)) offset))
+  (gen_load p offset (LoadOP.Lhu) flags $I64))
 
 ;;;;;  Rules for `iload16`;;;;;;;;;
-(rule
-  (lower (sload16 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (int_load_op $true 16) flags $I64))
+(rule (lower (sload16 flags p @ (value_type (ty_addr64 _)) offset))
+  (gen_load p offset (LoadOP.Lh) flags $I64))
 
 ;;;;;  Rules for `uload32`;;;;;;;;;
-(rule
-  (lower (uload32 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (int_load_op $false 32) flags $I64))
+(rule (lower (uload32 flags p @ (value_type (ty_addr64 _)) offset))
+  (gen_load p offset (LoadOP.Lwu) flags $I64))
 
 ;;;;;  Rules for `iload16`;;;;;;;;;
-(rule
-  (lower (sload32 flags p @ (value_type (ty_addr64 _)) offset))
-  (gen_load p offset (int_load_op $true 32) flags $I64))
+(rule (lower (sload32 flags p @ (value_type (ty_addr64 _)) offset))
+  (gen_load p offset (LoadOP.Lw) flags $I64))
 
-(rule
-  (lower (has_type ty (load flags p @ (value_type (ty_addr64 _)) offset)))
-  (gen_load p offset (load_op ty) flags ty)
-)
+;;;;;  Rules for `load`;;;;;;;;;
+(rule (lower (has_type ty (load flags p @ (value_type (ty_addr64 _)) offset)))
+  (gen_load p offset (load_op ty) flags ty))
+
 ;;;; for I128
-(rule 1
-  (lower (has_type $I128 (load flags p @ (value_type (ty_addr64 _)) offset)))
+(rule 1 (lower (has_type $I128 (load flags p @ (value_type (ty_addr64 _)) offset)))
   (gen_load_128 p offset flags))
 
-(rule 2
-  (lower (has_type (ty_vec_fits_in_register ty) (load flags p @ (value_type (ty_addr64 _)) offset)))
+(rule 2 (lower (has_type (ty_vec_fits_in_register ty) (load flags p @ (value_type (ty_addr64 _)) offset)))
   (let ((eew VecElementWidth (element_width_from_type ty)))
     (vec_load eew (VecAMode.UnitStride (gen_amode p offset $I64)) flags (unmasked) ty)))
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1481,36 +1481,36 @@
 
 ;;;;;  Rules for `uload8`;;;;;;;;;
 (rule (lower (uload8 flags p offset))
-  (gen_load (amode p offset $I8) (LoadOP.Lbu) flags $I8))
+  (gen_load (amode p offset $I8) (LoadOP.Lbu) flags))
 
 ;;;;;  Rules for `sload8`;;;;;;;;;
 (rule (lower (sload8 flags p offset))
-  (gen_load (amode p offset $I8) (LoadOP.Lb) flags $I8))
+  (gen_load (amode p offset $I8) (LoadOP.Lb) flags))
 
 ;;;;;  Rules for `uload16`;;;;;;;;;
 (rule (lower (uload16 flags p offset))
-  (gen_load (amode p offset $I16) (LoadOP.Lhu) flags $I16))
+  (gen_load (amode p offset $I16) (LoadOP.Lhu) flags))
 
 ;;;;;  Rules for `iload16`;;;;;;;;;
 (rule (lower (sload16 flags p offset))
-  (gen_load (amode p offset $I16) (LoadOP.Lh) flags $I16))
+  (gen_load (amode p offset $I16) (LoadOP.Lh) flags))
 
 ;;;;;  Rules for `uload32`;;;;;;;;;
 (rule (lower (uload32 flags p offset))
-  (gen_load (amode p offset $I32) (LoadOP.Lwu) flags $I32))
+  (gen_load (amode p offset $I32) (LoadOP.Lwu) flags))
 
 ;;;;;  Rules for `sload32`;;;;;;;;;
 (rule (lower (sload32 flags p offset))
-  (gen_load (amode p offset $I32) (LoadOP.Lw) flags $I32))
+  (gen_load (amode p offset $I32) (LoadOP.Lw) flags))
 
 ;;;;;  Rules for `load`;;;;;;;;;
 (rule (lower (has_type ty (load flags p offset)))
-  (gen_load (amode p offset ty) (load_op ty) flags ty))
+  (gen_load (amode p offset ty) (load_op ty) flags))
 
 (rule 1 (lower (has_type $I128 (load flags p offset)))
   (if-let offset_plus_8 (s32_add_fallible offset 8))
-  (let ((lo XReg (gen_load (amode p offset $I64) (LoadOP.Ld) flags $I64))
-        (hi XReg (gen_load (amode p offset_plus_8 $I64) (LoadOP.Ld) flags $I64)))
+  (let ((lo XReg (gen_load (amode p offset $I64) (LoadOP.Ld) flags))
+        (hi XReg (gen_load (amode p offset_plus_8 $I64) (LoadOP.Ld) flags)))
     (value_regs lo hi)))
 
 (rule 2 (lower (has_type (ty_vec_fits_in_register ty) (load flags p offset)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1480,42 +1480,42 @@
   (udf code))
 
 ;;;;;  Rules for `uload8`;;;;;;;;;
-(rule (lower (uload8 flags p offset))
-  (gen_load (amode p offset $I8) (LoadOP.Lbu) flags))
+(rule (lower (uload8 flags addr offset))
+  (gen_load (amode addr offset $I8) (LoadOP.Lbu) flags))
 
 ;;;;;  Rules for `sload8`;;;;;;;;;
-(rule (lower (sload8 flags p offset))
-  (gen_load (amode p offset $I8) (LoadOP.Lb) flags))
+(rule (lower (sload8 flags addr offset))
+  (gen_load (amode addr offset $I8) (LoadOP.Lb) flags))
 
 ;;;;;  Rules for `uload16`;;;;;;;;;
-(rule (lower (uload16 flags p offset))
-  (gen_load (amode p offset $I16) (LoadOP.Lhu) flags))
+(rule (lower (uload16 flags addr offset))
+  (gen_load (amode addr offset $I16) (LoadOP.Lhu) flags))
 
 ;;;;;  Rules for `iload16`;;;;;;;;;
-(rule (lower (sload16 flags p offset))
-  (gen_load (amode p offset $I16) (LoadOP.Lh) flags))
+(rule (lower (sload16 flags addr offset))
+  (gen_load (amode addr offset $I16) (LoadOP.Lh) flags))
 
 ;;;;;  Rules for `uload32`;;;;;;;;;
-(rule (lower (uload32 flags p offset))
-  (gen_load (amode p offset $I32) (LoadOP.Lwu) flags))
+(rule (lower (uload32 flags addr offset))
+  (gen_load (amode addr offset $I32) (LoadOP.Lwu) flags))
 
 ;;;;;  Rules for `sload32`;;;;;;;;;
-(rule (lower (sload32 flags p offset))
-  (gen_load (amode p offset $I32) (LoadOP.Lw) flags))
+(rule (lower (sload32 flags addr offset))
+  (gen_load (amode addr offset $I32) (LoadOP.Lw) flags))
 
 ;;;;;  Rules for `load`;;;;;;;;;
-(rule (lower (has_type ty (load flags p offset)))
-  (gen_load (amode p offset ty) (load_op ty) flags))
+(rule (lower (has_type ty (load flags addr offset)))
+  (gen_load (amode addr offset ty) (load_op ty) flags))
 
-(rule 1 (lower (has_type $I128 (load flags p offset)))
+(rule 1 (lower (has_type $I128 (load flags addr offset)))
   (if-let offset_plus_8 (s32_add_fallible offset 8))
-  (let ((lo XReg (gen_load (amode p offset $I64) (LoadOP.Ld) flags))
-        (hi XReg (gen_load (amode p offset_plus_8 $I64) (LoadOP.Ld) flags)))
+  (let ((lo XReg (gen_load (amode addr offset $I64) (LoadOP.Ld) flags))
+        (hi XReg (gen_load (amode addr offset_plus_8 $I64) (LoadOP.Ld) flags)))
     (value_regs lo hi)))
 
-(rule 2 (lower (has_type (ty_vec_fits_in_register ty) (load flags p offset)))
+(rule 2 (lower (has_type (ty_vec_fits_in_register ty) (load flags addr offset)))
   (let ((eew VecElementWidth (element_width_from_type ty))
-        (amode AMode (amode p offset ty)))
+        (amode AMode (amode addr offset ty)))
     (vec_load eew (VecAMode.UnitStride amode) flags (unmasked) ty)))
 
 ;;;;;  Rules for Load + Extend Combos ;;;;;;;;;
@@ -1564,30 +1564,30 @@
   (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset ty)))
 
 ;;;;;  Rules for `istore8`;;;;;;;;;
-(rule (lower (istore8 flags x p offset))
-  (gen_store (amode p offset $I8) (StoreOP.Sb) flags x))
+(rule (lower (istore8 flags src addr offset))
+  (gen_store (amode addr offset $I8) (StoreOP.Sb) flags src))
 
 ;;;;;  Rules for `istore16`;;;;;;;;;
-(rule (lower (istore16 flags x p offset))
-  (gen_store (amode p offset $I16) (StoreOP.Sh) flags x))
+(rule (lower (istore16 flags src addr offset))
+  (gen_store (amode addr offset $I16) (StoreOP.Sh) flags src))
 
 ;;;;;  Rules for `istore32`;;;;;;;;;
-(rule (lower (istore32 flags x p offset))
-  (gen_store (amode p offset $I32) (StoreOP.Sw) flags x))
+(rule (lower (istore32 flags src addr offset))
+  (gen_store (amode addr offset $I32) (StoreOP.Sw) flags src))
 
 ;;;;;  Rules for `store`;;;;;;;;;
-(rule (lower (store flags x @ (value_type ty) p offset))
-  (gen_store (amode p offset ty) (store_op ty) flags x))
+(rule (lower (store flags src @ (value_type ty) addr offset))
+  (gen_store (amode addr offset ty) (store_op ty) flags src))
 
-(rule 1 (lower (store flags x @ (value_type $I128) p offset))
+(rule 1 (lower (store flags src @ (value_type $I128) addr offset))
   (if-let offset_plus_8 (s32_add_fallible offset 8))
-  (let ((_ InstOutput (gen_store (amode p offset $I64) (StoreOP.Sd) flags (value_regs_get x 0))))
-    (gen_store (amode p offset_plus_8 $I64) (StoreOP.Sd) flags (value_regs_get x 1))))
+  (let ((_ InstOutput (gen_store (amode addr offset $I64) (StoreOP.Sd) flags (value_regs_get src 0))))
+    (gen_store (amode addr offset_plus_8 $I64) (StoreOP.Sd) flags (value_regs_get src 1))))
 
-(rule 2 (lower (store flags x @ (value_type (ty_vec_fits_in_register ty)) p offset))
+(rule 2 (lower (store flags src @ (value_type (ty_vec_fits_in_register ty)) addr offset))
   (let ((eew VecElementWidth (element_width_from_type ty))
-        (amode AMode (amode p offset ty)))
-    (vec_store eew (VecAMode.UnitStride amode) x flags (unmasked) ty)))
+        (amode AMode (amode addr offset ty)))
+    (vec_store eew (VecAMode.UnitStride amode) src flags (unmasked) ty)))
 
 
 ;;;;;  Rules for `icmp`;;;;;;;;;

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -446,15 +446,11 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         self.backend.isa_flags.has_zbs()
     }
 
-    fn default_memflags(&mut self) -> MemFlags {
-        MemFlags::new()
-    }
-
     fn int_convert_2_float_op(&mut self, from: Type, is_signed: bool, to: Type) -> FpuOPRR {
         FpuOPRR::int_convert_2_float_op(from, is_signed, to)
     }
 
-    fn gen_amode(&mut self, base: Reg, offset: Offset32, ty: Type) -> AMode {
+    fn gen_reg_offset_amode(&mut self, base: Reg, offset: Offset32, ty: Type) -> AMode {
         AMode::RegOffset(base, i64::from(offset), ty)
     }
 

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -450,8 +450,24 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         FpuOPRR::int_convert_2_float_op(from, is_signed, to)
     }
 
-    fn gen_reg_offset_amode(&mut self, base: Reg, offset: Offset32, ty: Type) -> AMode {
-        AMode::RegOffset(base, i64::from(offset), ty)
+    fn gen_reg_offset_amode(&mut self, base: Reg, offset: i64, ty: Type) -> AMode {
+        AMode::RegOffset(base, offset, ty)
+    }
+
+    fn gen_sp_offset_amode(&mut self, offset: i64, ty: Type) -> AMode {
+        AMode::SPOffset(offset, ty)
+    }
+
+    fn gen_fp_offset_amode(&mut self, offset: i64, ty: Type) -> AMode {
+        AMode::FPOffset(offset, ty)
+    }
+
+    fn gen_stack_slot_amode(&mut self, ss: StackSlot, offset: i64, ty: Type) -> AMode {
+        // Offset from beginning of stackslot area, which is at nominal SP (see
+        // [MemArg::NominalSPOffset] for more details on nominal SP tracking).
+        let stack_off = self.lower_ctx.abi().sized_stackslot_offsets()[ss] as i64;
+        let sp_off: i64 = stack_off + offset;
+        AMode::NominalSPOffset(sp_off, ty)
     }
 
     fn gen_const_amode(&mut self, c: VCodeConstant) -> AMode {
@@ -489,10 +505,6 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
             offset,
         });
         tmp.to_reg()
-    }
-
-    fn offset32_add(&mut self, a: Offset32, adden: i64) -> Offset32 {
-        a.try_add_i64(adden).expect("offset exceed range.")
     }
 
     fn gen_stack_addr(&mut self, slot: StackSlot, offset: Offset32) -> Reg {

--- a/cranelift/filetests/filetests/isa/riscv64/amodes-fp.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/amodes-fp.clif
@@ -1,0 +1,37 @@
+test compile precise-output
+set unwind_info=false
+set preserve_frame_pointers=true
+target riscv64
+
+function %load_from_get_frame_pointer() -> i64 {
+block0:
+  v0 = get_frame_pointer.i64
+  v1 = load.i64 v0+24
+  return v1
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   ld a0,24(fp)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+; block1: ; offset 0x10
+;   ld a0, 0x18(s0)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/amodes.clif
@@ -581,3 +581,21 @@ block0(v0: i64, v1: i32):
 ;   sd a1, 8(a2)
 ;   ret
 
+
+function %load_from_get_stack_pointer() -> i64 {
+block0:
+  v0 = get_stack_pointer.i64
+  v1 = load.i64 v0+8
+  return v1
+}
+
+; VCode:
+; block0:
+;   ld a0,8(sp)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ld a0, 8(sp)
+;   ret
+

--- a/cranelift/filetests/filetests/isa/riscv64/amodes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/amodes.clif
@@ -116,18 +116,16 @@ block0(v0: i64, v1: i64, v2: i64):
 
 ; VCode:
 ; block0:
-;   add a1,a0,a1
-;   add a1,a1,a2
-;   addi a1,a1,48
-;   lw a0,0(a1)
+;   add a0,a0,a1
+;   add a0,a0,a2
+;   lw a0,48(a0)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   add a1, a0, a1
-;   add a1, a1, a2
-;   addi a1, a1, 0x30
-;   lw a0, 0(a1)
+;   add a0, a0, a1
+;   add a0, a0, a2
+;   lw a0, 0x30(a0)
 ;   ret
 
 function %f10(i64, i64, i64) -> i32 {
@@ -142,22 +140,19 @@ block0(v0: i64, v1: i64, v2: i64):
 
 ; VCode:
 ; block0:
-;   lui a3,1
-;   addi a4,a3,4
-;   add a3,a0,a1
-;   add a3,a3,a2
-;   add a3,a3,a4
-;   lw a0,0(a3)
+;   add a0,a0,a1
+;   add a0,a0,a2
+;   lw a0,4100(a0)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a3, 1
-;   addi a4, a3, 4
-;   add a3, a0, a1
-;   add a3, a3, a2
-;   add a3, a3, a4
-;   lw a0, 0(a3)
+;   add a0, a0, a1
+;   add a0, a0, a2
+;   lui t6, 1
+;   addi t6, t6, 4
+;   add t6, t6, a0
+;   lw a0, 0(t6)
 ;   ret
 
 function %f10() -> i32 {
@@ -189,16 +184,14 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   lui a4,2048
-;   add a4,a0,a4
-;   lw a0,0(a4)
+;   lw a0,8388608(a0)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a4, 0x800
-;   add a4, a0, a4
-;   lw a0, 0(a4)
+;   lui t6, 0x800
+;   add t6, t6, a0
+;   lw a0, 0(t6)
 ;   ret
 
 function %f12(i64) -> i32 {
@@ -211,14 +204,12 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   addi a3,a0,-4
-;   lw a0,0(a3)
+;   lw a0,-4(a0)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a3, a0, -4
-;   lw a0, 0(a3)
+;   lw a0, -4(a0)
 ;   ret
 
 function %f13(i64) -> i32 {
@@ -231,18 +222,15 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   lui a4,244141
-;   addi a1,a4,-1536
-;   add a5,a0,a1
-;   lw a0,0(a5)
+;   lw a0,1000000000(a0)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lui a4, 0x3b9ad
-;   addi a1, a4, -0x600
-;   add a5, a0, a1
-;   lw a0, 0(a5)
+;   lui t6, 0x3b9ad
+;   addi t6, t6, -0x600
+;   add t6, t6, a0
+;   lw a0, 0(t6)
 ;   ret
 
 function %f14(i32) -> i32 {
@@ -507,20 +495,22 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   addi a4,a0,32
-;   ld a0,0(a4)
-;   ld a1,8(a4)
-;   sd a0,0(a4)
-;   sd a1,8(a4)
+;   ld a2,32(a0)
+;   mv a4,a2
+;   ld a1,40(a0)
+;   sd a2,32(a0)
+;   sd a1,40(a0)
+;   mv a0,a4
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a4, a0, 0x20
-;   ld a0, 0(a4)
-;   ld a1, 8(a4)
-;   sd a0, 0(a4)
-;   sd a1, 8(a4)
+;   ld a2, 0x20(a0)
+;   mv a4, a2
+;   ld a1, 0x28(a0)
+;   sd a2, 0x20(a0)
+;   sd a1, 0x28(a0)
+;   mv a0, a4
 ;   ret
 
 function %i128_32bit_sextend_simple(i32) -> i128 {
@@ -562,25 +552,26 @@ block0(v0: i64, v1: i32):
 ; VCode:
 ; block0:
 ;   sext.w a1,a1
-;   add a1,a0,a1
-;   addi a2,a1,24
-;   ld a0,0(a2)
-;   ld a1,8(a2)
-;   sd a0,0(a2)
-;   sd a1,8(a2)
+;   add a0,a0,a1
+;   ld a5,24(a0)
+;   mv a2,a5
+;   ld a1,32(a0)
+;   sd a5,24(a0)
+;   sd a1,32(a0)
+;   mv a0,a2
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a1, a1
-;   add a1, a0, a1
-;   addi a2, a1, 0x18
-;   ld a0, 0(a2)
-;   ld a1, 8(a2)
-;   sd a0, 0(a2)
-;   sd a1, 8(a2)
+;   add a0, a0, a1
+;   ld a5, 0x18(a0)
+;   mv a2, a5
+;   ld a1, 0x20(a0)
+;   sd a5, 0x18(a0)
+;   sd a1, 0x20(a0)
+;   mv a0, a2
 ;   ret
-
 
 function %load_from_get_stack_pointer() -> i64 {
 block0:

--- a/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
@@ -123,249 +123,198 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   sd s1,-8(sp)
-;   sd s2,-16(sp)
-;   sd s3,-24(sp)
-;   sd s4,-32(sp)
-;   sd s5,-40(sp)
-;   sd s6,-48(sp)
-;   sd s7,-56(sp)
-;   sd s8,-64(sp)
-;   sd s9,-72(sp)
-;   sd s10,-80(sp)
-;   sd s11,-88(sp)
-;   add sp,-480
+;   add sp,-384
 ; block0:
 ;   vle8.v v11,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v15,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v10,48(fp) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v12,64(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   li a3,0
 ;   li a4,0
 ;   li a0,0
 ;   li a2,0
-;   li a3,0
-;   load_addr s4,0(nominal_sp)
-;   sd a2,0(s4)
-;   sd a3,8(s4)
-;   load_addr s6,16(nominal_sp)
-;   sd a2,0(s6)
-;   sd a3,8(s6)
-;   load_addr s8,32(nominal_sp)
-;   sd a2,0(s8)
-;   sd a3,8(s8)
-;   load_addr s10,48(nominal_sp)
-;   sd a2,0(s10)
-;   sd a3,8(s10)
-;   load_addr t0,64(nominal_sp)
-;   sd a2,0(t0)
-;   sd a3,8(t0)
-;   load_addr t2,80(nominal_sp)
-;   sd a2,0(t2)
-;   sd a3,8(t2)
-;   load_addr a7,96(nominal_sp)
-;   sd a2,0(a7)
-;   sd a3,8(a7)
-;   load_addr t4,112(nominal_sp)
-;   sd a2,0(t4)
-;   load_addr s1,120(nominal_sp)
-;   sw a0,0(s1)
-;   load_addr s2,124(nominal_sp)
-;   sh a4,0(s2)
-;   load_addr s3,128(nominal_sp)
-;   sd a2,0(s3)
-;   sd a3,8(s3)
-;   load_addr s5,144(nominal_sp)
-;   sd a2,0(s5)
-;   sd a3,8(s5)
-;   load_addr s7,160(nominal_sp)
-;   sd a2,0(s7)
-;   sd a3,8(s7)
-;   load_addr s9,176(nominal_sp)
-;   sd a2,0(s9)
-;   sd a3,8(s9)
-;   load_addr s11,192(nominal_sp)
-;   sd a2,0(s11)
-;   sd a3,8(s11)
-;   load_addr t1,208(nominal_sp)
-;   sd a2,0(t1)
-;   sd a3,8(t1)
-;   load_addr a7,224(nominal_sp)
-;   sd a2,0(a7)
-;   sd a3,8(a7)
-;   load_addr t3,240(nominal_sp)
-;   sd a2,0(t3)
-;   load_addr t4,248(nominal_sp)
-;   sw a0,0(t4)
-;   load_addr s1,252(nominal_sp)
-;   sh a4,0(s1)
-;   load_addr s2,256(nominal_sp)
-;   sd a2,0(s2)
-;   sd a3,8(s2)
-;   load_addr s4,272(nominal_sp)
-;   sd a2,0(s4)
-;   sd a3,8(s4)
-;   load_addr s6,288(nominal_sp)
-;   sd a2,0(s6)
-;   sd a3,8(s6)
-;   load_addr s8,304(nominal_sp)
-;   sd a2,0(s8)
-;   sd a3,8(s8)
-;   load_addr s10,320(nominal_sp)
-;   sd a2,0(s10)
-;   sd a3,8(s10)
-;   load_addr t0,336(nominal_sp)
-;   sd a2,0(t0)
-;   sd a3,8(t0)
-;   load_addr t2,352(nominal_sp)
-;   sd a2,0(t2)
-;   sd a3,8(t2)
-;   load_addr a3,368(nominal_sp)
-;   sd a2,0(a3)
-;   load_addr a2,376(nominal_sp)
-;   sw a0,0(a2)
-;   load_addr a0,380(nominal_sp)
-;   sh a4,0(a0)
+;   sd a0,0(nominal_sp)
+;   sd a2,8(nominal_sp)
+;   sd a0,16(nominal_sp)
+;   sd a2,24(nominal_sp)
+;   sd a0,32(nominal_sp)
+;   sd a2,40(nominal_sp)
+;   sd a0,48(nominal_sp)
+;   sd a2,56(nominal_sp)
+;   sd a0,64(nominal_sp)
+;   sd a2,72(nominal_sp)
+;   sd a0,80(nominal_sp)
+;   sd a2,88(nominal_sp)
+;   sd a0,96(nominal_sp)
+;   sd a2,104(nominal_sp)
+;   sd a0,112(nominal_sp)
+;   sw a4,120(nominal_sp)
+;   sh a3,124(nominal_sp)
+;   sd a0,128(nominal_sp)
+;   sd a2,136(nominal_sp)
+;   sd a0,144(nominal_sp)
+;   sd a2,152(nominal_sp)
+;   sd a0,160(nominal_sp)
+;   sd a2,168(nominal_sp)
+;   sd a0,176(nominal_sp)
+;   sd a2,184(nominal_sp)
+;   sd a0,192(nominal_sp)
+;   sd a2,200(nominal_sp)
+;   sd a0,208(nominal_sp)
+;   sd a2,216(nominal_sp)
+;   sd a0,224(nominal_sp)
+;   sd a2,232(nominal_sp)
+;   sd a0,240(nominal_sp)
+;   sw a4,248(nominal_sp)
+;   sh a3,252(nominal_sp)
+;   sd a0,256(nominal_sp)
+;   sd a2,264(nominal_sp)
+;   sd a0,272(nominal_sp)
+;   sd a2,280(nominal_sp)
+;   sd a0,288(nominal_sp)
+;   sd a2,296(nominal_sp)
+;   sd a0,304(nominal_sp)
+;   sd a2,312(nominal_sp)
+;   sd a0,320(nominal_sp)
+;   sd a2,328(nominal_sp)
+;   sd a0,336(nominal_sp)
+;   sd a2,344(nominal_sp)
+;   sd a0,352(nominal_sp)
+;   sd a2,360(nominal_sp)
+;   sd a0,368(nominal_sp)
+;   sw a4,376(nominal_sp)
+;   sh a3,380(nominal_sp)
 ;   zext.w a0,a1
-;   select_i16x8 v8,v12,v12##condition=a0
+;   select_i16x8 v9,v12,v12##condition=a0
 ;   zext.w a0,a1
-;   select_i16x8 v10,v8,v8##condition=a0
+;   select_i16x8 v12,v9,v9##condition=a0
 ;   zext.w a0,a1
-;   select_i16x8 v9,v10,v10##condition=a0
+;   select_i16x8 v10,v12,v12##condition=a0
 ;   vfsqrt.v v8,v11 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   ld a0,[const(0)]
-;   fmv.d.x fa2,a0
-;   vfmv.v.f v10,fa2 #avl=2, #vtype=(e64, m1, ta, ma)
+;   fmv.d.x fa1,a0
+;   vfmv.v.f v9,fa1 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   vmfne.vv v0,v8,v8 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vvm v11,v8,v10,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vfsqrt.v v10,v11 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vvm v11,v8,v9,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vfsqrt.v v8,v11 #avl=2, #vtype=(e64, m1, ta, ma)
 ;   ld a0,[const(0)]
-;   fmv.d.x fa2,a0
-;   vfmv.v.f v11,fa2 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmfne.vv v0,v10,v10 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vvm v8,v10,v11,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   fmv.d.x fa1,a0
+;   vfmv.v.f v11,fa1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmfne.vv v0,v8,v8 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vvm v9,v8,v11,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
 ;   zext.w a0,a1
-;   select_i16x8 v10,v9,v9##condition=a0
+;   select_i16x8 v11,v10,v10##condition=a0
 ;   zext.w a0,a1
-;   select_i16x8 v9,v10,v10##condition=a0
+;   select_i16x8 v10,v11,v11##condition=a0
 ;   zext.w a0,a1
-;   select_i16x8 v10,v9,v9##condition=a0
+;   select_i16x8 v11,v10,v10##condition=a0
 ;   zext.w a0,a1
-;   select_i16x8 v9,v10,v10##condition=a0
+;   select_i16x8 v10,v11,v11##condition=a0
 ;   zext.w a0,a1
-;   select_i16x8 v10,v9,v9##condition=a0
+;   select_i16x8 v11,v10,v10##condition=a0
 ;   zext.w a0,a1
-;   select_i16x8 v9,v10,v10##condition=a0
+;   select_i16x8 v10,v11,v11##condition=a0
 ;   zext.w a0,a1
-;   select_i16x8 v10,v9,v9##condition=a0
+;   select_i16x8 v11,v10,v10##condition=a0
 ;   zext.w a0,a1
-;   select_i16x8 v9,v10,v10##condition=a0
-;   add a1,a1,a1
-;   zext.w a0,a1
-;   select_i16x8 v10,v9,v9##condition=a0
-;   zext.w a0,a1
-;   select_i16x8 v9,v10,v10##condition=a0
-;   zext.w a0,a1
-;   select_i16x8 v10,v9,v9##condition=a0
-;   zext.w a0,a1
-;   select_i16x8 v9,v10,v10##condition=a0
-;   zext.w a0,a1
-;   select_i16x8 v10,v9,v9##condition=a0
-;   vmax.vv v15,v15,v15 #avl=2, #vtype=(e64, m1, ta, ma)
-;   zext.w a0,a1
-;   select_i16x8 v9,v10,v10##condition=a0
-;   load_addr a2,3(nominal_sp)
-;   addi a2,a2,0
-;   andi a0,a2,3
-;   slli a3,a0,3
-;   andi a4,a2,-4
-;   atomic_rmw.i8 and a0,a5,(a4)##t0=a2 offset=a3
-;   zext.w a5,a1
-;   select_i16x8 v10,v9,v9##condition=a5
-;   zext.w a5,a1
-;   select_i16x8 v9,v10,v10##condition=a5
-;   zext.w a5,a1
-;   select_i16x8 v10,v9,v9##condition=a5
-;   zext.w a5,a1
-;   select_i16x8 v9,v10,v10##condition=a5
-;   zext.w a5,a1
-;   select_i16x8 v10,v9,v9##condition=a5
-;   zext.w a5,a1
+;   select_i16x8 v10,v11,v11##condition=a0
+;   add a0,a1,a1
+;   zext.w a1,a0
+;   select_i16x8 v11,v10,v10##condition=a1
+;   zext.w a1,a0
+;   select_i16x8 v10,v11,v11##condition=a1
+;   zext.w a1,a0
+;   select_i16x8 v11,v10,v10##condition=a1
+;   zext.w a1,a0
+;   select_i16x8 v10,v11,v11##condition=a1
+;   zext.w a1,a0
+;   select_i16x8 v11,v10,v10##condition=a1
+;   vmax.vv v8,v15,v15 #avl=2, #vtype=(e64, m1, ta, ma)
+;   zext.w a1,a0
+;   select_i16x8 v10,v11,v11##condition=a1
+;   load_addr a1,3(nominal_sp)
+;   addi a1,a1,0
+;   andi a4,a1,3
+;   slli a2,a4,3
+;   andi a3,a1,-4
+;   atomic_rmw.i8 and a4,a5,(a3)##t0=a1 offset=a2
+;   mv a1,a4
+;   zext.w a4,a0
+;   select_i16x8 v11,v10,v10##condition=a4
+;   zext.w a4,a0
+;   select_i16x8 v10,v11,v11##condition=a4
+;   zext.w a4,a0
+;   select_i16x8 v11,v10,v10##condition=a4
+;   zext.w a4,a0
+;   select_i16x8 v10,v11,v11##condition=a4
+;   zext.w a4,a0
+;   select_i16x8 v11,v10,v10##condition=a4
+;   zext.w a4,a0
+;   select_i16x8 v12,v11,v11##condition=a4
+;   zext.w a4,a0
+;   select_i16x8 v10,v12,v12##condition=a4
+;   vse64.v v8,33(nominal_sp) #avl=2, #vtype=(e64, m1, ta, ma)
+;   zext.w a5,a0
 ;   select_i16x8 v11,v10,v10##condition=a5
-;   zext.w a5,a1
-;   select_i16x8 v9,v11,v11##condition=a5
-;   load_addr a2,33(nominal_sp)
-;   vse64.v v15,0(a2) #avl=2, #vtype=(e64, m1, ta, ma)
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v9,v10,v10##condition=a2
-;   zext.w a2,a1
-;   select_i16x8 v10,v9,v9##condition=a2
-;   zext.w a1,a1
-;   select_i16x8 v9,v10,v10##condition=a1
-;   vse8.v v8,0(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v9,16(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v8,32(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v9,48(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v9,64(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v9,80(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v9,96(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   add sp,+480
-;   ld s1,-8(sp)
-;   ld s2,-16(sp)
-;   ld s3,-24(sp)
-;   ld s4,-32(sp)
-;   ld s5,-40(sp)
-;   ld s6,-48(sp)
-;   ld s7,-56(sp)
-;   ld s8,-64(sp)
-;   ld s9,-72(sp)
-;   ld s10,-80(sp)
-;   ld s11,-88(sp)
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v11,v10,v10##condition=a5
+;   zext.w a5,a0
+;   select_i16x8 v10,v11,v11##condition=a5
+;   vse8.v v9,0(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v10,16(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v9,32(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v10,48(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v10,64(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v10,80(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v10,96(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   mv a0,a1
+;   add sp,+384
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -377,19 +326,8 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   sd s1, -8(sp)
-;   sd s2, -0x10(sp)
-;   sd s3, -0x18(sp)
-;   sd s4, -0x20(sp)
-;   sd s5, -0x28(sp)
-;   sd s6, -0x30(sp)
-;   sd s7, -0x38(sp)
-;   sd s8, -0x40(sp)
-;   sd s9, -0x48(sp)
-;   sd s10, -0x50(sp)
-;   sd s11, -0x58(sp)
-;   addi sp, sp, -0x1e0
-; block1: ; offset 0x40
+;   addi sp, sp, -0x180
+; block1: ; offset 0x14
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x85, 0x0f, 0x02
@@ -399,405 +337,366 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   .byte 0x07, 0x85, 0x0f, 0x02
 ;   addi t6, s0, 0x40
 ;   .byte 0x07, 0x86, 0x0f, 0x02
+;   mv a3, zero
 ;   mv a4, zero
 ;   mv a0, zero
 ;   mv a2, zero
-;   mv a3, zero
-;   mv s4, sp
-;   sd a2, 0(s4)
-;   sd a3, 8(s4)
-;   addi s6, sp, 0x10
-;   sd a2, 0(s6)
-;   sd a3, 8(s6)
-;   addi s8, sp, 0x20
-;   sd a2, 0(s8)
-;   sd a3, 8(s8)
-;   addi s10, sp, 0x30
-;   sd a2, 0(s10)
-;   sd a3, 8(s10)
-;   addi t0, sp, 0x40
-;   sd a2, 0(t0)
-;   sd a3, 8(t0)
-;   addi t2, sp, 0x50
-;   sd a2, 0(t2)
-;   sd a3, 8(t2)
-;   addi a7, sp, 0x60
-;   sd a2, 0(a7)
-;   sd a3, 8(a7)
-;   addi t4, sp, 0x70
-;   sd a2, 0(t4)
-;   addi s1, sp, 0x78
-;   sw a0, 0(s1)
-;   addi s2, sp, 0x7c
-;   sh a4, 0(s2)
-;   addi s3, sp, 0x80
-;   sd a2, 0(s3)
-;   sd a3, 8(s3)
-;   addi s5, sp, 0x90
-;   sd a2, 0(s5)
-;   sd a3, 8(s5)
-;   addi s7, sp, 0xa0
-;   sd a2, 0(s7)
-;   sd a3, 8(s7)
-;   addi s9, sp, 0xb0
-;   sd a2, 0(s9)
-;   sd a3, 8(s9)
-;   addi s11, sp, 0xc0
-;   sd a2, 0(s11)
-;   sd a3, 8(s11)
-;   addi t1, sp, 0xd0
-;   sd a2, 0(t1)
-;   sd a3, 8(t1)
-;   addi a7, sp, 0xe0
-;   sd a2, 0(a7)
-;   sd a3, 8(a7)
-;   addi t3, sp, 0xf0
-;   sd a2, 0(t3)
-;   addi t4, sp, 0xf8
-;   sw a0, 0(t4)
-;   addi s1, sp, 0xfc
-;   sh a4, 0(s1)
-;   addi s2, sp, 0x100
-;   sd a2, 0(s2)
-;   sd a3, 8(s2)
-;   addi s4, sp, 0x110
-;   sd a2, 0(s4)
-;   sd a3, 8(s4)
-;   addi s6, sp, 0x120
-;   sd a2, 0(s6)
-;   sd a3, 8(s6)
-;   addi s8, sp, 0x130
-;   sd a2, 0(s8)
-;   sd a3, 8(s8)
-;   addi s10, sp, 0x140
-;   sd a2, 0(s10)
-;   sd a3, 8(s10)
-;   addi t0, sp, 0x150
-;   sd a2, 0(t0)
-;   sd a3, 8(t0)
-;   addi t2, sp, 0x160
-;   sd a2, 0(t2)
-;   sd a3, 8(t2)
-;   addi a3, sp, 0x170
-;   sd a2, 0(a3)
-;   addi a2, sp, 0x178
-;   sw a0, 0(a2)
-;   addi a0, sp, 0x17c
-;   sh a4, 0(a0)
+;   sd a0, 0(sp)
+;   sd a2, 8(sp)
+;   sd a0, 0x10(sp)
+;   sd a2, 0x18(sp)
+;   sd a0, 0x20(sp)
+;   sd a2, 0x28(sp)
+;   sd a0, 0x30(sp)
+;   sd a2, 0x38(sp)
+;   sd a0, 0x40(sp)
+;   sd a2, 0x48(sp)
+;   sd a0, 0x50(sp)
+;   sd a2, 0x58(sp)
+;   sd a0, 0x60(sp)
+;   sd a2, 0x68(sp)
+;   sd a0, 0x70(sp)
+;   sw a4, 0x78(sp)
+;   sh a3, 0x7c(sp)
+;   sd a0, 0x80(sp)
+;   sd a2, 0x88(sp)
+;   sd a0, 0x90(sp)
+;   sd a2, 0x98(sp)
+;   sd a0, 0xa0(sp)
+;   sd a2, 0xa8(sp)
+;   sd a0, 0xb0(sp)
+;   sd a2, 0xb8(sp)
+;   sd a0, 0xc0(sp)
+;   sd a2, 0xc8(sp)
+;   sd a0, 0xd0(sp)
+;   sd a2, 0xd8(sp)
+;   sd a0, 0xe0(sp)
+;   sd a2, 0xe8(sp)
+;   sd a0, 0xf0(sp)
+;   sw a4, 0xf8(sp)
+;   sh a3, 0xfc(sp)
+;   sd a0, 0x100(sp)
+;   sd a2, 0x108(sp)
+;   sd a0, 0x110(sp)
+;   sd a2, 0x118(sp)
+;   sd a0, 0x120(sp)
+;   sd a2, 0x128(sp)
+;   sd a0, 0x130(sp)
+;   sd a2, 0x138(sp)
+;   sd a0, 0x140(sp)
+;   sd a2, 0x148(sp)
+;   sd a0, 0x150(sp)
+;   sd a2, 0x158(sp)
+;   sd a0, 0x160(sp)
+;   sd a2, 0x168(sp)
+;   sd a0, 0x170(sp)
+;   sw a4, 0x178(sp)
+;   sh a3, 0x17c(sp)
 ;   .byte 0x3b, 0x85, 0x05, 0x08
 ;   beqz a0, 0xc
-;   .byte 0x57, 0x34, 0xc0, 0x9e
+;   .byte 0xd7, 0x34, 0xc0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x34, 0xc0, 0x9e
+;   .byte 0xd7, 0x34, 0xc0, 0x9e
 ;   .byte 0x3b, 0x85, 0x05, 0x08
 ;   beqz a0, 0xc
-;   .byte 0x57, 0x35, 0x80, 0x9e
+;   .byte 0x57, 0x36, 0x90, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x80, 0x9e
+;   .byte 0x57, 0x36, 0x90, 0x9e
 ;   .byte 0x3b, 0x85, 0x05, 0x08
 ;   beqz a0, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0x57, 0x35, 0xc0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0x57, 0x35, 0xc0, 0x9e
 ;   .byte 0x57, 0x70, 0x81, 0xcd
 ;   .byte 0x57, 0x14, 0xb0, 0x4e
 ;   auipc a0, 0
-;   ld a0, 0x4b4(a0)
-;   fmv.d.x fa2, a0
-;   .byte 0x57, 0x55, 0x06, 0x5e
+;   ld a0, 0x490(a0)
+;   fmv.d.x fa1, a0
+;   .byte 0xd7, 0xd4, 0x05, 0x5e
 ;   .byte 0x57, 0x10, 0x84, 0x72
-;   .byte 0xd7, 0x05, 0x85, 0x5c
-;   .byte 0x57, 0x15, 0xb0, 0x4e
+;   .byte 0xd7, 0x85, 0x84, 0x5c
+;   .byte 0x57, 0x14, 0xb0, 0x4e
 ;   auipc a0, 0
-;   ld a0, 0x498(a0)
-;   fmv.d.x fa2, a0
-;   .byte 0xd7, 0x55, 0x06, 0x5e
-;   .byte 0x57, 0x10, 0xa5, 0x72
-;   .byte 0x57, 0x84, 0xa5, 0x5c
+;   ld a0, 0x474(a0)
+;   fmv.d.x fa1, a0
+;   .byte 0xd7, 0xd5, 0x05, 0x5e
+;   .byte 0x57, 0x10, 0x84, 0x72
+;   .byte 0xd7, 0x84, 0x85, 0x5c
 ;   .byte 0x3b, 0x85, 0x05, 0x08
 ;   beqz a0, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   .byte 0x3b, 0x85, 0x05, 0x08
 ;   beqz a0, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   .byte 0x3b, 0x85, 0x05, 0x08
 ;   beqz a0, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   .byte 0x3b, 0x85, 0x05, 0x08
 ;   beqz a0, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   .byte 0x3b, 0x85, 0x05, 0x08
 ;   beqz a0, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   .byte 0x3b, 0x85, 0x05, 0x08
 ;   beqz a0, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   .byte 0x3b, 0x85, 0x05, 0x08
 ;   beqz a0, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   .byte 0x3b, 0x85, 0x05, 0x08
 ;   beqz a0, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   add a1, a1, a1
-;   .byte 0x3b, 0x85, 0x05, 0x08
-;   beqz a0, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   add a0, a1, a1
+;   .byte 0xbb, 0x05, 0x05, 0x08
+;   beqz a1, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x85, 0x05, 0x08
-;   beqz a0, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x05, 0x05, 0x08
+;   beqz a1, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x85, 0x05, 0x08
-;   beqz a0, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x05, 0x05, 0x08
+;   beqz a1, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x85, 0x05, 0x08
-;   beqz a0, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x05, 0x05, 0x08
+;   beqz a1, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x85, 0x05, 0x08
-;   beqz a0, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x05, 0x05, 0x08
+;   beqz a1, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0xd7, 0x87, 0xf7, 0x1e
-;   .byte 0x3b, 0x85, 0x05, 0x08
-;   beqz a0, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0x57, 0x84, 0xf7, 0x1e
+;   .byte 0xbb, 0x05, 0x05, 0x08
+;   beqz a1, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   addi a2, sp, 3
-;   mv a2, a2
-;   andi a0, a2, 3
-;   slli a3, a0, 3
-;   andi a4, a2, -4
-;   lr.w.aqrl a0, (a4)
-;   srl a0, a0, a3
-;   andi a0, a0, 0xff
-;   and a2, a0, a5
-;   lr.w.aqrl t5, (a4)
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   addi a1, sp, 3
+;   mv a1, a1
+;   andi a4, a1, 3
+;   slli a2, a4, 3
+;   andi a3, a1, -4
+;   lr.w.aqrl a4, (a3)
+;   srl a4, a4, a2
+;   andi a4, a4, 0xff
+;   and a1, a4, a5
+;   lr.w.aqrl t5, (a3)
 ;   addi t6, zero, 0xff
-;   sll t6, t6, a3
+;   sll t6, t6, a2
 ;   not t6, t6
 ;   and t5, t5, t6
-;   andi t6, a2, 0xff
-;   sll t6, t6, a3
+;   andi t6, a1, 0xff
+;   sll t6, t6, a2
 ;   or t5, t5, t6
-;   sc.w.aqrl a2, t5, (a4)
-;   bnez a2, -0x34
-;   .byte 0xbb, 0x87, 0x05, 0x08
-;   beqz a5, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   sc.w.aqrl a1, t5, (a3)
+;   bnez a1, -0x34
+;   mv a1, a4
+;   .byte 0x3b, 0x07, 0x05, 0x08
+;   beqz a4, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0xbb, 0x87, 0x05, 0x08
-;   beqz a5, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0x3b, 0x07, 0x05, 0x08
+;   beqz a4, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0xbb, 0x87, 0x05, 0x08
-;   beqz a5, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0x3b, 0x07, 0x05, 0x08
+;   beqz a4, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0xbb, 0x87, 0x05, 0x08
-;   beqz a5, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0x3b, 0x07, 0x05, 0x08
+;   beqz a4, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0xbb, 0x87, 0x05, 0x08
-;   beqz a5, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0x3b, 0x07, 0x05, 0x08
+;   beqz a4, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0xbb, 0x87, 0x05, 0x08
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0x3b, 0x07, 0x05, 0x08
+;   beqz a4, 0xc
+;   .byte 0x57, 0x36, 0xb0, 0x9e
+;   j 8
+;   .byte 0x57, 0x36, 0xb0, 0x9e
+;   .byte 0x3b, 0x07, 0x05, 0x08
+;   beqz a4, 0xc
+;   .byte 0x57, 0x35, 0xc0, 0x9e
+;   j 8
+;   .byte 0x57, 0x35, 0xc0, 0x9e
+;   addi t6, sp, 0x21
+;   .byte 0x27, 0xf4, 0x0f, 0x02
+;   .byte 0xbb, 0x07, 0x05, 0x08
 ;   beqz a5, 0xc
 ;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
 ;   .byte 0xd7, 0x35, 0xa0, 0x9e
-;   .byte 0xbb, 0x87, 0x05, 0x08
+;   .byte 0xbb, 0x07, 0x05, 0x08
 ;   beqz a5, 0xc
-;   .byte 0xd7, 0x34, 0xb0, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xb0, 0x9e
-;   addi a2, sp, 0x21
-;   .byte 0xa7, 0x77, 0x06, 0x02
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   .byte 0xbb, 0x07, 0x05, 0x08
+;   beqz a5, 0xc
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   .byte 0x3b, 0x86, 0x05, 0x08
-;   beqz a2, 0xc
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   j 8
-;   .byte 0x57, 0x35, 0x90, 0x9e
-;   .byte 0xbb, 0x85, 0x05, 0x08
-;   beqz a1, 0xc
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
-;   j 8
-;   .byte 0xd7, 0x34, 0xa0, 0x9e
+;   .byte 0x57, 0x35, 0xb0, 0x9e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0x27, 0x04, 0x08, 0x02
+;   .byte 0xa7, 0x04, 0x08, 0x02
 ;   addi t6, a6, 0x10
-;   .byte 0xa7, 0x84, 0x0f, 0x02
+;   .byte 0x27, 0x85, 0x0f, 0x02
 ;   addi t6, a6, 0x20
-;   .byte 0x27, 0x84, 0x0f, 0x02
+;   .byte 0xa7, 0x84, 0x0f, 0x02
 ;   addi t6, a6, 0x30
-;   .byte 0xa7, 0x84, 0x0f, 0x02
+;   .byte 0x27, 0x85, 0x0f, 0x02
 ;   addi t6, a6, 0x40
-;   .byte 0xa7, 0x84, 0x0f, 0x02
+;   .byte 0x27, 0x85, 0x0f, 0x02
 ;   addi t6, a6, 0x50
-;   .byte 0xa7, 0x84, 0x0f, 0x02
+;   .byte 0x27, 0x85, 0x0f, 0x02
 ;   addi t6, a6, 0x60
-;   .byte 0xa7, 0x84, 0x0f, 0x02
-;   addi sp, sp, 0x1e0
-;   ld s1, -8(sp)
-;   ld s2, -0x10(sp)
-;   ld s3, -0x18(sp)
-;   ld s4, -0x20(sp)
-;   ld s5, -0x28(sp)
-;   ld s6, -0x30(sp)
-;   ld s7, -0x38(sp)
-;   ld s8, -0x40(sp)
-;   ld s9, -0x48(sp)
-;   ld s10, -0x50(sp)
-;   ld s11, -0x58(sp)
+;   .byte 0x27, 0x85, 0x0f, 0x02
+;   mv a0, a1
+;   addi sp, sp, 0x180
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
@@ -90,39 +90,37 @@ block3(v7: r64, v8: r64):
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   sd s7,-8(sp)
-;   sd s11,-16(sp)
+;   sd s5,-8(sp)
+;   sd s9,-16(sp)
 ;   add sp,-48
 ; block0:
+;   mv a3,a0
 ;   sd a1,16(nominal_sp)
-;   mv s7,a2
-;   mv a1,a0
-;   mv a1,a0
-;   mv s11,a1
-;   load_sym a1,%f+0
-;   sd s11,8(nominal_sp)
-;   callind a1
-;   load_addr a2,0(nominal_sp)
-;   mv a1,s11
-;   sd a1,0(a2)
-;   andi a1,a0,255
-;   bne a1,zero,taken(label2),not_taken(label1)
+;   mv s5,a2
+;   mv a3,a0
+;   mv s9,a3
+;   load_sym a5,%f+0
+;   sd s9,8(nominal_sp)
+;   callind a5
+;   mv a3,s9
+;   sd a3,0(nominal_sp)
+;   andi a5,a0,255
+;   bne a5,zero,taken(label2),not_taken(label1)
 ; block1:
-;   mv a1,s11
+;   mv a1,s9
 ;   ld a0,16(nominal_sp)
 ;   j label3
 ; block2:
-;   mv a0,s11
+;   mv a0,s9
 ;   ld a1,16(nominal_sp)
 ;   j label3
 ; block3:
-;   load_addr a4,0(nominal_sp)
-;   ld a4,0(a4)
-;   mv a2,s7
-;   sd a4,0(a2)
+;   ld a2,0(nominal_sp)
+;   mv a3,s5
+;   sd a2,0(a3)
 ;   add sp,+48
-;   ld s7,-8(sp)
-;   ld s11,-16(sp)
+;   ld s5,-8(sp)
+;   ld s9,-16(sp)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   add sp,+16
@@ -134,42 +132,40 @@ block3(v7: r64, v8: r64):
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   sd s7, -8(sp)
-;   sd s11, -0x10(sp)
+;   sd s5, -8(sp)
+;   sd s9, -0x10(sp)
 ;   addi sp, sp, -0x30
 ; block1: ; offset 0x1c
+;   mv a3, a0
 ;   sd a1, 0x10(sp)
-;   mv s7, a2
-;   mv a1, a0
-;   mv a0, a1
-;   mv s11, a1
-;   auipc a1, 0
-;   ld a1, 0xc(a1)
+;   mv s5, a2
+;   mv a0, a3
+;   mv s9, a3
+;   auipc a5, 0
+;   ld a5, 0xc(a5)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   sd s11, 8(sp)
-;   jalr a1
-;   mv a2, sp
-;   mv a1, s11
-;   sd a1, 0(a2)
-;   andi a1, a0, 0xff
-;   bnez a1, 0x10
-; block2: ; offset 0x60
-;   mv a1, s11
+;   sd s9, 8(sp)
+;   jalr a5
+;   mv a3, s9
+;   sd a3, 0(sp)
+;   andi a5, a0, 0xff
+;   bnez a5, 0x10
+; block2: ; offset 0x5c
+;   mv a1, s9
 ;   ld a0, 0x10(sp)
 ;   j 0xc
-; block3: ; offset 0x6c
-;   mv a0, s11
+; block3: ; offset 0x68
+;   mv a0, s9
 ;   ld a1, 0x10(sp)
-; block4: ; offset 0x74
-;   mv a4, sp
-;   ld a4, 0(a4)
-;   mv a2, s7
-;   sd a4, 0(a2)
+; block4: ; offset 0x70
+;   ld a2, 0(sp)
+;   mv a3, s5
+;   sd a2, 0(a3)
 ;   addi sp, sp, 0x30
-;   ld s7, -8(sp)
-;   ld s11, -0x10(sp)
+;   ld s5, -8(sp)
+;   ld s9, -0x10(sp)
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/stack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack.clif
@@ -108,8 +108,7 @@ block0:
 ;   mv fp,sp
 ;   add sp,-16
 ; block0:
-;   load_addr a1,0(nominal_sp)
-;   ld a0,0(a1)
+;   ld a0,0(nominal_sp)
 ;   add sp,+16
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -124,8 +123,7 @@ block0:
 ;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
-;   mv a1, sp
-;   ld a0, 0(a1)
+;   ld a0, 0(sp)
 ;   addi sp, sp, 0x10
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -151,8 +149,7 @@ block0:
 ;   call %Probestack
 ;   add sp,-100016
 ; block0:
-;   load_addr a1,0(nominal_sp)
-;   ld a0,0(a1)
+;   ld a0,0(nominal_sp)
 ;   add sp,+100016
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -177,8 +174,7 @@ block0:
 ;   addi t6, t6, -0x6b0
 ;   add sp, t6, sp
 ; block1: ; offset 0x3c
-;   mv a1, sp
-;   ld a0, 0(a1)
+;   ld a0, 0(sp)
 ;   lui t6, 0x18
 ;   addi t6, t6, 0x6b0
 ;   add sp, t6, sp
@@ -202,8 +198,7 @@ block0(v0: i64):
 ;   mv fp,sp
 ;   add sp,-16
 ; block0:
-;   load_addr a2,0(nominal_sp)
-;   sd a0,0(a2)
+;   sd a0,0(nominal_sp)
 ;   add sp,+16
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -218,8 +213,7 @@ block0(v0: i64):
 ;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
-;   mv a2, sp
-;   sd a0, 0(a2)
+;   sd a0, 0(sp)
 ;   addi sp, sp, 0x10
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -245,8 +239,7 @@ block0(v0: i64):
 ;   call %Probestack
 ;   add sp,-100016
 ; block0:
-;   load_addr a2,0(nominal_sp)
-;   sd a0,0(a2)
+;   sd a0,0(nominal_sp)
 ;   add sp,+100016
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -271,8 +264,7 @@ block0(v0: i64):
 ;   addi t6, t6, -0x6b0
 ;   add sp, t6, sp
 ; block1: ; offset 0x3c
-;   mv a2, sp
-;   sd a0, 0(a2)
+;   sd a0, 0(sp)
 ;   lui t6, 0x18
 ;   addi t6, t6, 0x6b0
 ;   add sp, t6, sp
@@ -858,9 +850,8 @@ block0(v0: i128):
 ;   mv fp,sp
 ;   add sp,-16
 ; block0:
-;   load_addr a3,0(nominal_sp)
-;   sd a0,0(a3)
-;   sd a1,8(a3)
+;   sd a0,0(nominal_sp)
+;   sd a1,8(nominal_sp)
 ;   add sp,+16
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -875,9 +866,8 @@ block0(v0: i128):
 ;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
-;   mv a3, sp
-;   sd a0, 0(a3)
-;   sd a1, 8(a3)
+;   sd a0, 0(sp)
+;   sd a1, 8(sp)
 ;   addi sp, sp, 0x10
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -900,9 +890,8 @@ block0(v0: i128):
 ;   mv fp,sp
 ;   add sp,-32
 ; block0:
-;   load_addr a3,32(nominal_sp)
-;   sd a0,0(a3)
-;   sd a1,8(a3)
+;   sd a0,32(nominal_sp)
+;   sd a1,40(nominal_sp)
 ;   add sp,+32
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -917,9 +906,8 @@ block0(v0: i128):
 ;   mv s0, sp
 ;   addi sp, sp, -0x20
 ; block1: ; offset 0x14
-;   addi a3, sp, 0x20
-;   sd a0, 0(a3)
-;   sd a1, 8(a3)
+;   sd a0, 0x20(sp)
+;   sd a1, 0x28(sp)
 ;   addi sp, sp, 0x20
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -945,9 +933,8 @@ block0(v0: i128):
 ;   call %Probestack
 ;   add sp,-100016
 ; block0:
-;   load_addr a3,0(nominal_sp)
-;   sd a0,0(a3)
-;   sd a1,8(a3)
+;   sd a0,0(nominal_sp)
+;   sd a1,8(nominal_sp)
 ;   add sp,+100016
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -972,9 +959,8 @@ block0(v0: i128):
 ;   addi t6, t6, -0x6b0
 ;   add sp, t6, sp
 ; block1: ; offset 0x3c
-;   mv a3, sp
-;   sd a0, 0(a3)
-;   sd a1, 8(a3)
+;   sd a0, 0(sp)
+;   sd a1, 8(sp)
 ;   lui t6, 0x18
 ;   addi t6, t6, 0x6b0
 ;   add sp, t6, sp
@@ -998,9 +984,8 @@ block0:
 ;   mv fp,sp
 ;   add sp,-16
 ; block0:
-;   load_addr a2,0(nominal_sp)
-;   ld a0,0(a2)
-;   ld a1,8(a2)
+;   ld a0,0(nominal_sp)
+;   ld a1,8(nominal_sp)
 ;   add sp,+16
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -1015,9 +1000,8 @@ block0:
 ;   mv s0, sp
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x14
-;   mv a2, sp
-;   ld a0, 0(a2)
-;   ld a1, 8(a2)
+;   ld a0, 0(sp)
+;   ld a1, 8(sp)
 ;   addi sp, sp, 0x10
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -1040,9 +1024,8 @@ block0:
 ;   mv fp,sp
 ;   add sp,-32
 ; block0:
-;   load_addr a2,32(nominal_sp)
-;   ld a0,0(a2)
-;   ld a1,8(a2)
+;   ld a0,32(nominal_sp)
+;   ld a1,40(nominal_sp)
 ;   add sp,+32
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -1057,9 +1040,8 @@ block0:
 ;   mv s0, sp
 ;   addi sp, sp, -0x20
 ; block1: ; offset 0x14
-;   addi a2, sp, 0x20
-;   ld a0, 0(a2)
-;   ld a1, 8(a2)
+;   ld a0, 0x20(sp)
+;   ld a1, 0x28(sp)
 ;   addi sp, sp, 0x20
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -1085,9 +1067,8 @@ block0:
 ;   call %Probestack
 ;   add sp,-100016
 ; block0:
-;   load_addr a2,0(nominal_sp)
-;   ld a0,0(a2)
-;   ld a1,8(a2)
+;   ld a0,0(nominal_sp)
+;   ld a1,8(nominal_sp)
 ;   add sp,+100016
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -1112,9 +1093,8 @@ block0:
 ;   addi t6, t6, -0x6b0
 ;   add sp, t6, sp
 ; block1: ; offset 0x3c
-;   mv a2, sp
-;   ld a0, 0(a2)
-;   ld a1, 8(a2)
+;   ld a0, 0(sp)
+;   ld a1, 8(sp)
 ;   lui t6, 0x18
 ;   addi t6, t6, 0x6b0
 ;   add sp, t6, sp

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -41,20 +41,18 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a3,a3,32
-;;   ld a4,8(a2)
+;;   slli a5,a0,32
+;;   srli a3,a5,32
+;;   ld a0,8(a2)
 ;;   lui a5,-1
-;;   addi a5,a5,-4
-;;   add a4,a4,a5
-;;   ugt a4,a3,a4##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   addi a4,a5,-4
+;;   add a0,a0,a4
+;;   ugt a0,a3,a0##ty=i64
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a4,0(a2)
-;;   add a3,a4,a3
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   sw a1,0(a3)
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sw a1,4096(a2)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -63,20 +61,18 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a3,a2,32
-;;   ld a2,8(a1)
-;;   lui a4,-1
-;;   addi a4,a4,-4
-;;   add a2,a2,a4
-;;   ugt a2,a3,a2##ty=i64
-;;   bne a2,zero,taken(label3),not_taken(label1)
+;;   slli a5,a0,32
+;;   srli a2,a5,32
+;;   ld a0,8(a1)
+;;   lui a5,-1
+;;   addi a3,a5,-4
+;;   add a0,a0,a3
+;;   ugt a0,a2,a0##ty=i64
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a4,0(a1)
-;;   add a3,a4,a3
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   lw a0,0(a3)
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   lw a0,4096(a1)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -41,20 +41,18 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a3,a3,32
-;;   ld a4,8(a2)
+;;   slli a5,a0,32
+;;   srli a3,a5,32
+;;   ld a0,8(a2)
 ;;   lui a5,-1
-;;   addi a5,a5,-1
-;;   add a4,a4,a5
-;;   ugt a4,a3,a4##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   addi a4,a5,-1
+;;   add a0,a0,a4
+;;   ugt a0,a3,a0##ty=i64
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a4,0(a2)
-;;   add a3,a4,a3
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   sb a1,0(a3)
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sb a1,4096(a2)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -63,20 +61,18 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a3,a2,32
-;;   ld a2,8(a1)
-;;   lui a4,-1
-;;   addi a4,a4,-1
-;;   add a2,a2,a4
-;;   ugt a2,a3,a2##ty=i64
-;;   bne a2,zero,taken(label3),not_taken(label1)
+;;   slli a5,a0,32
+;;   srli a2,a5,32
+;;   ld a0,8(a1)
+;;   lui a5,-1
+;;   addi a3,a5,-1
+;;   add a0,a0,a3
+;;   ugt a0,a2,a0##ty=i64
+;;   bne a0,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a4,0(a1)
-;;   add a3,a4,a3
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   lbu a0,0(a3)
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   lbu a0,4096(a1)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -41,17 +41,15 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   ld a5,8(a2)
-;;   ugt a5,a0,a5##ty=i64
-;;   bne a5,zero,taken(label3),not_taken(label1)
+;;   slli a3,a0,32
+;;   srli a4,a3,32
+;;   ld a3,8(a2)
+;;   ugt a3,a4,a3##ty=i64
+;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a2,1
-;;   add a0,a0,a2
-;;   sw a1,0(a0)
+;;   ld a5,0(a2)
+;;   add a4,a5,a4
+;;   sw a1,4096(a4)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -60,17 +58,15 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   ld a5,8(a1)
-;;   ugt a5,a0,a5##ty=i64
-;;   bne a5,zero,taken(label3),not_taken(label1)
+;;   slli a2,a0,32
+;;   srli a4,a2,32
+;;   ld a3,8(a1)
+;;   ugt a3,a4,a3##ty=i64
+;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a1,1
-;;   add a0,a0,a1
-;;   lw a0,0(a0)
+;;   ld a5,0(a1)
+;;   add a4,a5,a4
+;;   lw a0,4096(a4)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -41,17 +41,15 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   ld a5,8(a2)
-;;   ugt a5,a0,a5##ty=i64
-;;   bne a5,zero,taken(label3),not_taken(label1)
+;;   slli a3,a0,32
+;;   srli a4,a3,32
+;;   ld a3,8(a2)
+;;   ugt a3,a4,a3##ty=i64
+;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a2,1
-;;   add a0,a0,a2
-;;   sb a1,0(a0)
+;;   ld a5,0(a2)
+;;   add a4,a5,a4
+;;   sb a1,4096(a4)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -60,17 +58,15 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   ld a5,8(a1)
-;;   ugt a5,a0,a5##ty=i64
-;;   bne a5,zero,taken(label3),not_taken(label1)
+;;   slli a2,a0,32
+;;   srli a4,a2,32
+;;   ld a3,8(a1)
+;;   ugt a3,a4,a3##ty=i64
+;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a1,1
-;;   add a0,a0,a1
-;;   lbu a0,0(a0)
+;;   ld a5,0(a1)
+;;   add a4,a5,a4
+;;   lbu a0,4096(a4)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -41,18 +41,16 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a3,8(a2)
-;;   lui a5,-1
-;;   addi a4,a5,-4
-;;   add a3,a3,a4
-;;   ugt a3,a0,a3##ty=i64
-;;   bne a3,zero,taken(label3),not_taken(label1)
+;;   ld a4,8(a2)
+;;   lui a3,-1
+;;   addi a5,a3,-4
+;;   add a4,a4,a5
+;;   ugt a4,a0,a4##ty=i64
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   sw a1,0(a2)
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   sw a1,4096(a5)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -61,18 +59,16 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,8(a1)
-;;   lui a5,-1
-;;   addi a3,a5,-4
-;;   add a2,a2,a3
-;;   ugt a2,a0,a2##ty=i64
-;;   bne a2,zero,taken(label3),not_taken(label1)
+;;   ld a4,8(a1)
+;;   lui a3,-1
+;;   addi a5,a3,-4
+;;   add a4,a4,a5
+;;   ugt a4,a0,a4##ty=i64
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a1,0(a1)
-;;   add a1,a1,a0
-;;   lui a2,1
-;;   add a1,a1,a2
-;;   lw a0,0(a1)
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lw a0,4096(a5)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -41,18 +41,16 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a3,8(a2)
-;;   lui a5,-1
-;;   addi a4,a5,-1
-;;   add a3,a3,a4
-;;   ugt a3,a0,a3##ty=i64
-;;   bne a3,zero,taken(label3),not_taken(label1)
+;;   ld a4,8(a2)
+;;   lui a3,-1
+;;   addi a5,a3,-1
+;;   add a4,a4,a5
+;;   ugt a4,a0,a4##ty=i64
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   sb a1,0(a2)
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   sb a1,4096(a5)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -61,18 +59,16 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,8(a1)
-;;   lui a5,-1
-;;   addi a3,a5,-1
-;;   add a2,a2,a3
-;;   ugt a2,a0,a2##ty=i64
-;;   bne a2,zero,taken(label3),not_taken(label1)
+;;   ld a4,8(a1)
+;;   lui a3,-1
+;;   addi a5,a3,-1
+;;   add a4,a4,a5
+;;   ugt a4,a0,a4##ty=i64
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a1,0(a1)
-;;   add a1,a1,a0
-;;   lui a2,1
-;;   add a1,a1,a2
-;;   lbu a0,0(a1)
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lbu a0,4096(a5)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -45,11 +45,9 @@
 ;;   ugt a3,a0,a3##ty=i64
 ;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a4,0(a2)
-;;   add a4,a4,a0
-;;   lui a5,1
-;;   add a4,a4,a5
-;;   sw a1,0(a4)
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   sw a1,4096(a2)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -58,15 +56,13 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a3,8(a1)
-;;   ugt a3,a0,a3##ty=i64
-;;   bne a3,zero,taken(label3),not_taken(label1)
+;;   ld a2,8(a1)
+;;   ugt a2,a0,a2##ty=i64
+;;   bne a2,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a4,0(a1)
-;;   add a4,a4,a0
-;;   lui a5,1
-;;   add a4,a4,a5
-;;   lw a0,0(a4)
+;;   ld a2,0(a1)
+;;   add a2,a2,a0
+;;   lw a0,4096(a2)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -45,11 +45,9 @@
 ;;   ugt a3,a0,a3##ty=i64
 ;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a4,0(a2)
-;;   add a4,a4,a0
-;;   lui a5,1
-;;   add a4,a4,a5
-;;   sb a1,0(a4)
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   sb a1,4096(a2)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -58,15 +56,13 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a3,8(a1)
-;;   ugt a3,a0,a3##ty=i64
-;;   bne a3,zero,taken(label3),not_taken(label1)
+;;   ld a2,8(a1)
+;;   ugt a2,a0,a2##ty=i64
+;;   bne a2,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a4,0(a1)
-;;   add a4,a4,a0
-;;   lui a5,1
-;;   add a4,a4,a5
-;;   lbu a0,0(a4)
+;;   ld a2,0(a1)
+;;   add a2,a2,a0
+;;   lbu a0,4096(a2)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -39,18 +39,16 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a3,a5,32
-;;   lui a5,65535
-;;   addi a4,a5,-4
-;;   ugt a0,a3,a4##ty=i64
-;;   bne a0,zero,taken(label3),not_taken(label1)
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   lui a3,65535
+;;   addi a0,a3,-4
+;;   ugt a4,a5,a0##ty=i64
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   sw a1,0(a2)
+;;   ld a0,0(a2)
+;;   add a5,a0,a5
+;;   sw a1,4096(a5)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -59,18 +57,16 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a2,a5,32
-;;   lui a5,65535
-;;   addi a3,a5,-4
-;;   ugt a0,a2,a3##ty=i64
-;;   bne a0,zero,taken(label3),not_taken(label1)
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   lui a3,65535
+;;   addi a0,a3,-4
+;;   ugt a4,a5,a0##ty=i64
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a1,0(a1)
-;;   add a1,a1,a2
-;;   lui a2,1
-;;   add a1,a1,a2
-;;   lw a0,0(a1)
+;;   ld a0,0(a1)
+;;   add a5,a0,a5
+;;   lw a0,4096(a5)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -39,18 +39,16 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a3,a5,32
-;;   lui a5,65535
-;;   addi a4,a5,-1
-;;   ugt a0,a3,a4##ty=i64
-;;   bne a0,zero,taken(label3),not_taken(label1)
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   lui a3,65535
+;;   addi a0,a3,-1
+;;   ugt a4,a5,a0##ty=i64
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   sb a1,0(a2)
+;;   ld a0,0(a2)
+;;   add a5,a0,a5
+;;   sb a1,4096(a5)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -59,18 +57,16 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a2,a5,32
-;;   lui a5,65535
-;;   addi a3,a5,-1
-;;   ugt a0,a2,a3##ty=i64
-;;   bne a0,zero,taken(label3),not_taken(label1)
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   lui a3,65535
+;;   addi a0,a3,-1
+;;   ugt a4,a5,a0##ty=i64
+;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a1,0(a1)
-;;   add a1,a1,a2
-;;   lui a2,1
-;;   add a1,a1,a2
-;;   lbu a0,0(a1)
+;;   ld a0,0(a1)
+;;   add a5,a0,a5
+;;   lbu a0,4096(a5)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -39,26 +39,22 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a4,a3,32
-;;   ld a3,0(a2)
-;;   add a3,a3,a4
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   sw a1,0(a3)
+;;   slli a0,a0,32
+;;   srli a3,a0,32
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sw a1,4096(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a4,a2,32
-;;   ld a3,0(a1)
-;;   add a3,a3,a4
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   lw a0,0(a3)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   lw a0,4096(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -39,26 +39,22 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a4,a3,32
-;;   ld a3,0(a2)
-;;   add a3,a3,a4
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   sb a1,0(a3)
+;;   slli a0,a0,32
+;;   srli a3,a0,32
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sb a1,4096(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a4,a2,32
-;;   ld a3,0(a1)
-;;   add a3,a3,a4
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   lbu a0,0(a3)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   lbu a0,4096(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -39,26 +39,22 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a4,a3,32
-;;   ld a3,0(a2)
-;;   add a3,a3,a4
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   sw a1,0(a3)
+;;   slli a0,a0,32
+;;   srli a3,a0,32
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sw a1,4096(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a4,a2,32
-;;   ld a3,0(a1)
-;;   add a3,a3,a4
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   lw a0,0(a3)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   lw a0,4096(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -39,26 +39,22 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a4,a3,32
-;;   ld a3,0(a2)
-;;   add a3,a3,a4
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   sb a1,0(a3)
+;;   slli a0,a0,32
+;;   srli a3,a0,32
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sb a1,4096(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a4,a2,32
-;;   ld a3,0(a1)
-;;   add a3,a3,a4
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   lbu a0,0(a3)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   lbu a0,4096(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -40,15 +40,13 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65535
-;;   addi a5,a3,-4
-;;   ugt a4,a0,a5##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   addi a3,a3,-4
+;;   ugt a3,a0,a3##ty=i64
+;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   sw a1,0(a5)
+;;   ld a3,0(a2)
+;;   add a3,a3,a0
+;;   sw a1,4096(a3)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -57,16 +55,14 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a3,65535
-;;   addi a5,a3,-4
-;;   ugt a4,a0,a5##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   lui a2,65535
+;;   addi a3,a2,-4
+;;   ugt a2,a0,a3##ty=i64
+;;   bne a2,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   lw a0,0(a5)
+;;   ld a3,0(a1)
+;;   add a3,a3,a0
+;;   lw a0,4096(a3)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -40,15 +40,13 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65535
-;;   addi a5,a3,-1
-;;   ugt a4,a0,a5##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   addi a3,a3,-1
+;;   ugt a3,a0,a3##ty=i64
+;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   sb a1,0(a5)
+;;   ld a3,0(a2)
+;;   add a3,a3,a0
+;;   sb a1,4096(a3)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -57,16 +55,14 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a3,65535
-;;   addi a5,a3,-1
-;;   ugt a4,a0,a5##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   lui a2,65535
+;;   addi a3,a2,-1
+;;   ugt a2,a0,a3##ty=i64
+;;   bne a2,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   lbu a0,0(a5)
+;;   ld a3,0(a1)
+;;   add a3,a3,a0
+;;   lbu a0,4096(a3)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -40,15 +40,13 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65535
-;;   addi a5,a3,-4
-;;   ugt a4,a0,a5##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   addi a3,a3,-4
+;;   ugt a3,a0,a3##ty=i64
+;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   sw a1,0(a5)
+;;   ld a3,0(a2)
+;;   add a3,a3,a0
+;;   sw a1,4096(a3)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -57,16 +55,14 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a3,65535
-;;   addi a5,a3,-4
-;;   ugt a4,a0,a5##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   lui a2,65535
+;;   addi a3,a2,-4
+;;   ugt a2,a0,a3##ty=i64
+;;   bne a2,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   lw a0,0(a5)
+;;   ld a3,0(a1)
+;;   add a3,a3,a0
+;;   lw a0,4096(a3)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -40,15 +40,13 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65535
-;;   addi a5,a3,-1
-;;   ugt a4,a0,a5##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   addi a3,a3,-1
+;;   ugt a3,a0,a3##ty=i64
+;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   sb a1,0(a5)
+;;   ld a3,0(a2)
+;;   add a3,a3,a0
+;;   sb a1,4096(a3)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -57,16 +55,14 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a3,65535
-;;   addi a5,a3,-1
-;;   ugt a4,a0,a5##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   lui a2,65535
+;;   addi a3,a2,-1
+;;   ugt a2,a0,a3##ty=i64
+;;   bne a2,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   lbu a0,0(a5)
+;;   ld a3,0(a1)
+;;   add a3,a3,a0
+;;   lbu a0,4096(a3)
 ;;   j label2
 ;; block2:
 ;;   ret


### PR DESCRIPTION
👋 Hey,

This PR improves our AMode matching logic. In RISC-V we don't have very fancy addressing modes, it's pretty much Reg + Offset. 

One of the issues with the current lowerings is that we never feed the `sp` register into a load or store, even if it is based on a `stack_addr`. This is because the regular `stack_addr` lowering moves the address into a normal register. We now directly match the `stack_addr` as part of the amode computation so that we can perform those loads directly from the stack pointer and without an intermediary register.

Another improvement that this PR makes is that we now match an `iadd+iconst` and move that into the offset field for the load or store.

The main motivation for this is that we have some stack pointer based load and store instructions in the C extension that very rarely match because we never do loads or stores directly based on the stack pointer.