### PR TITLE
riscv64: Add the remainder of Zca and Zcd instructions

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -741,6 +741,8 @@
   (CAddiw)
   (CAddi16sp)
   (CSlli)
+  (CLi)
+  (CLui)
 ))
 
 ;; Opcodes for the CIW compressed instruction format

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -750,6 +750,13 @@
   (CAddi4spn)
 ))
 
+;; Opcodes for the CB compressed instruction format
+(type CbOp (enum
+  (CSrli)
+  (CSrai)
+  (CAndi)
+))
+
 
 (type CsrRegOP (enum
   ;; Atomic Read/Write CSR

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -767,6 +767,12 @@
   (CFsdsp)
 ))
 
+;; Opcodes for the CS compressed instruction format
+(type CsOp (enum
+  (CSw)
+  (CSd)
+  (CFsd)
+))
 
 (type CsrRegOP (enum
   ;; Atomic Read/Write CSR

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -743,6 +743,9 @@
   (CSlli)
   (CLi)
   (CLui)
+  (CLwsp)
+  (CLdsp)
+  (CFldsp)
 ))
 
 ;; Opcodes for the CIW compressed instruction format

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -774,6 +774,13 @@
   (CFsd)
 ))
 
+;; Opcodes for the CL compressed instruction format
+(type ClOp (enum
+  (CLw)
+  (CLd)
+  (CFld)
+))
+
 (type CsrRegOP (enum
   ;; Atomic Read/Write CSR
   (CsrRW)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -760,6 +760,13 @@
   (CAndi)
 ))
 
+;; Opcodes for the CSS compressed instruction format
+(type CssOp (enum
+  (CSwsp)
+  (CSdsp)
+  (CFsdsp)
+))
+
 
 (type CsrRegOP (enum
   ;; Atomic Read/Write CSR

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1983,15 +1983,18 @@ impl CiOp {
         // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
         match self {
             CiOp::CAddi | CiOp::CSlli => 0b000,
+            CiOp::CLi => 0b010,
             CiOp::CAddiw => 0b001,
-            CiOp::CAddi16sp => 0b011,
+            CiOp::CAddi16sp | CiOp::CLui => 0b011,
         }
     }
 
     pub fn op(&self) -> COpcodeSpace {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
-            CiOp::CAddi | CiOp::CAddiw | CiOp::CAddi16sp => COpcodeSpace::C1,
+            CiOp::CAddi | CiOp::CAddiw | CiOp::CAddi16sp | CiOp::CLi | CiOp::CLui => {
+                COpcodeSpace::C1
+            }
             CiOp::CSlli => COpcodeSpace::C2,
         }
     }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1317,6 +1317,15 @@ impl LoadOP {
         }
     }
 
+    pub(crate) fn size(&self) -> i64 {
+        match self {
+            Self::Lb | Self::Lbu => 1,
+            Self::Lh | Self::Lhu => 2,
+            Self::Lw | Self::Lwu | Self::Flw => 4,
+            Self::Ld | Self::Fld => 8,
+        }
+    }
+
     pub(crate) fn op_code(self) -> u32 {
         match self {
             Self::Lb | Self::Lh | Self::Lw | Self::Lbu | Self::Lhu | Self::Lwu | Self::Ld => {
@@ -1983,9 +1992,9 @@ impl CiOp {
         // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
         match self {
             CiOp::CAddi | CiOp::CSlli => 0b000,
-            CiOp::CLi => 0b010,
-            CiOp::CAddiw => 0b001,
-            CiOp::CAddi16sp | CiOp::CLui => 0b011,
+            CiOp::CAddiw | CiOp::CFldsp => 0b001,
+            CiOp::CLi | CiOp::CLwsp => 0b010,
+            CiOp::CAddi16sp | CiOp::CLui | CiOp::CLdsp => 0b011,
         }
     }
 
@@ -1995,7 +2004,7 @@ impl CiOp {
             CiOp::CAddi | CiOp::CAddiw | CiOp::CAddi16sp | CiOp::CLi | CiOp::CLui => {
                 COpcodeSpace::C1
             }
-            CiOp::CSlli => COpcodeSpace::C2,
+            CiOp::CSlli | CiOp::CLwsp | CiOp::CLdsp | CiOp::CFldsp => COpcodeSpace::C2,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -8,7 +8,7 @@ use crate::ir::condcodes::CondCode;
 use crate::isa::riscv64::inst::{reg_name, reg_to_gpr_num};
 
 use crate::isa::riscv64::lower::isle::generated_code::{
-    COpcodeSpace, CaOp, CiOp, CiwOp, CjOp, CrOp,
+    COpcodeSpace, CaOp, CbOp, CiOp, CiwOp, CjOp, CrOp,
 };
 use crate::machinst::isle::WritableReg;
 
@@ -2012,6 +2012,31 @@ impl CiwOp {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
             CiwOp::CAddi4spn => COpcodeSpace::C0,
+        }
+    }
+}
+
+impl CbOp {
+    pub fn funct3(&self) -> u32 {
+        // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
+        match self {
+            CbOp::CSrli | CbOp::CSrai | CbOp::CAndi => 0b100,
+        }
+    }
+
+    pub fn funct2(&self) -> u32 {
+        // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
+        match self {
+            CbOp::CSrli => 0b00,
+            CbOp::CSrai => 0b01,
+            CbOp::CAndi => 0b10,
+        }
+    }
+
+    pub fn op(&self) -> COpcodeSpace {
+        // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
+        match self {
+            CbOp::CSrli | CbOp::CSrai | CbOp::CAndi => COpcodeSpace::C1,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -8,7 +8,7 @@ use crate::ir::condcodes::CondCode;
 use crate::isa::riscv64::inst::{reg_name, reg_to_gpr_num};
 
 use crate::isa::riscv64::lower::isle::generated_code::{
-    COpcodeSpace, CaOp, CbOp, CiOp, CiwOp, CjOp, CrOp,
+    COpcodeSpace, CaOp, CbOp, CiOp, CiwOp, CjOp, CrOp, CssOp,
 };
 use crate::machinst::isle::WritableReg;
 
@@ -1372,6 +1372,16 @@ impl StoreOP {
             _ => unreachable!(),
         }
     }
+
+    pub(crate) fn size(&self) -> i64 {
+        match self {
+            Self::Sb => 1,
+            Self::Sh => 2,
+            Self::Sw | Self::Fsw => 4,
+            Self::Sd | Self::Fsd => 8,
+        }
+    }
+
     pub(crate) fn op_code(self) -> u32 {
         match self {
             Self::Sb | Self::Sh | Self::Sw | Self::Sd => 0b0100011,
@@ -2046,6 +2056,24 @@ impl CbOp {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
             CbOp::CSrli | CbOp::CSrai | CbOp::CAndi => COpcodeSpace::C1,
+        }
+    }
+}
+
+impl CssOp {
+    pub fn funct3(&self) -> u32 {
+        // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
+        match self {
+            CssOp::CFsdsp => 0b101,
+            CssOp::CSwsp => 0b110,
+            CssOp::CSdsp => 0b111,
+        }
+    }
+
+    pub fn op(&self) -> COpcodeSpace {
+        // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
+        match self {
+            CssOp::CSwsp | CssOp::CSdsp | CssOp::CFsdsp => COpcodeSpace::C2,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -8,7 +8,7 @@ use crate::ir::condcodes::CondCode;
 use crate::isa::riscv64::inst::{reg_name, reg_to_gpr_num};
 
 use crate::isa::riscv64::lower::isle::generated_code::{
-    COpcodeSpace, CaOp, CbOp, CiOp, CiwOp, CjOp, CrOp, CssOp,
+    COpcodeSpace, CaOp, CbOp, CiOp, CiwOp, CjOp, CrOp, CsOp, CssOp,
 };
 use crate::machinst::isle::WritableReg;
 
@@ -2074,6 +2074,24 @@ impl CssOp {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
             CssOp::CSwsp | CssOp::CSdsp | CssOp::CFsdsp => COpcodeSpace::C2,
+        }
+    }
+}
+
+impl CsOp {
+    pub fn funct3(&self) -> u32 {
+        // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
+        match self {
+            CsOp::CFsd => 0b101,
+            CsOp::CSw => 0b110,
+            CsOp::CSd => 0b111,
+        }
+    }
+
+    pub fn op(&self) -> COpcodeSpace {
+        // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
+        match self {
+            CsOp::CSw | CsOp::CSd | CsOp::CFsd => COpcodeSpace::C0,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -8,7 +8,7 @@ use crate::ir::condcodes::CondCode;
 use crate::isa::riscv64::inst::{reg_name, reg_to_gpr_num};
 
 use crate::isa::riscv64::lower::isle::generated_code::{
-    COpcodeSpace, CaOp, CbOp, CiOp, CiwOp, CjOp, CrOp, CsOp, CssOp,
+    COpcodeSpace, CaOp, CbOp, CiOp, CiwOp, CjOp, ClOp, CrOp, CsOp, CssOp,
 };
 use crate::machinst::isle::WritableReg;
 
@@ -2092,6 +2092,24 @@ impl CsOp {
         // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
         match self {
             CsOp::CSw | CsOp::CSd | CsOp::CFsd => COpcodeSpace::C0,
+        }
+    }
+}
+
+impl ClOp {
+    pub fn funct3(&self) -> u32 {
+        // https://github.com/michaeljclark/riscv-meta/blob/master/opcodes
+        match self {
+            ClOp::CFld => 0b001,
+            ClOp::CLw => 0b010,
+            ClOp::CLd => 0b011,
+        }
+    }
+
+    pub fn op(&self) -> COpcodeSpace {
+        // https://five-embeddev.com/riscv-isa-manual/latest/rvc-opcode-map.html#rvcopcodemap
+        match self {
+            ClOp::CLw | ClOp::CLd | ClOp::CFld => COpcodeSpace::C0,
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -201,6 +201,12 @@ impl Imm6 {
     }
 }
 
+impl Display for Imm6 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.value)
+    }
+}
+
 /// A unsigned 6-bit immediate.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Uimm6 {
@@ -223,7 +229,35 @@ impl Uimm6 {
     }
 }
 
-impl Display for Imm6 {
+impl Display for Uimm6 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        write!(f, "{}", self.value)
+    }
+}
+
+/// A unsigned 5-bit immediate.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Uimm5 {
+    value: u8,
+}
+
+impl Uimm5 {
+    /// Create an unsigned 5-bit immediate from an u8
+    pub fn maybe_from_u8(value: u8) -> Option<Self> {
+        if value <= 31 {
+            Some(Self { value })
+        } else {
+            None
+        }
+    }
+
+    /// Bits for encoding.
+    pub fn bits(&self) -> u8 {
+        self.value & 0x1f
+    }
+}
+
+impl Display for Uimm5 {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}", self.value)
     }

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -183,6 +183,10 @@ impl Imm6 {
         }
     }
 
+    pub fn maybe_from_i32(value: i32) -> Option<Self> {
+        value.try_into().ok().and_then(Imm6::maybe_from_i16)
+    }
+
     pub fn maybe_from_imm12(value: Imm12) -> Option<Self> {
         Imm6::maybe_from_i16(value.as_i16())
     }

--- a/cranelift/codegen/src/isa/riscv64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/imms.rs
@@ -187,6 +187,10 @@ impl Imm6 {
         value.try_into().ok().and_then(Imm6::maybe_from_i16)
     }
 
+    pub fn maybe_from_i64(value: i64) -> Option<Self> {
+        value.try_into().ok().and_then(Imm6::maybe_from_i16)
+    }
+
     pub fn maybe_from_imm12(value: Imm12) -> Option<Self> {
         Imm6::maybe_from_i16(value.as_i16())
     }
@@ -194,6 +198,28 @@ impl Imm6 {
     /// Bits for encoding.
     pub fn bits(&self) -> u8 {
         self.value as u8 & 0x3f
+    }
+}
+
+/// A unsigned 6-bit immediate.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Uimm6 {
+    value: u8,
+}
+
+impl Uimm6 {
+    /// Create an unsigned 6-bit immediate from an u8
+    pub fn maybe_from_u8(value: u8) -> Option<Self> {
+        if value <= 63 {
+            Some(Self { value })
+        } else {
+            None
+        }
+    }
+
+    /// Bits for encoding.
+    pub fn bits(&self) -> u8 {
+        self.value & 0x3f
     }
 }
 

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -438,3 +438,98 @@ block0:
 ;   c.addi16sp sp, 0x10
 ;   c.jr ra
 
+
+function %c_li() -> i64 {
+block0:
+  v0 = iconst.i64 1
+  return v0
+}
+
+; VCode:
+; block0:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.li a0, 1
+;   c.jr ra
+
+
+function %c_lui() -> i64, i64, i64 {
+block0:
+  v0 = iconst.i64 0x4000
+  v1 = iconst.i64 0xffffffff_fffff000
+  v2 = iconst.i64 0xffffffff_fffe0000
+  return v0, v1, v2
+}
+
+; VCode:
+; block0:
+;   mv a2,a0
+;   lui a0,4
+;   lui a1,-1
+;   lui a4,-32
+;   sd a4,0(a2)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.mv a2, a0
+;   c.lui a0, 4
+;   c.lui a1, 0xfffff
+;   c.lui a4, 0xfffe0
+;   sd a4, 0(a2)
+;   c.jr ra
+
+<<<<<<< Updated upstream
+=======
+function %c_andi_f(i64) -> i64 {
+block0(v0: i64):
+  v1 = band_imm.i64 v0, 0xf
+  return v1
+}
+
+; VCode:
+; block0:
+;   andi a0,a0,15
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.andi a0, 0xf
+;   c.jr ra
+
+function %c_andi_neg_16(i64) -> i64 {
+block0(v0: i64):
+  v1 = band_imm.i64 v0, -16
+  return v1
+}
+
+; VCode:
+; block0:
+;   andi a0,a0,-16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.andi a0, -0x10
+;   c.jr ra
+
+function %c_andi_zero(i64) -> i64 {
+block0(v0: i64):
+  v1 = band_imm.i64 v0, 0
+  return v1
+}
+
+; VCode:
+; block0:
+;   andi a0,a0,0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.andi a0, 0
+;   c.jr ra
+
+>>>>>>> Stashed changes

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -400,6 +400,37 @@ block0(v0: i64):
 ;   c.slli a0, 0x3f
 ;   c.jr ra
 
+function %c_srai(i64) -> i64 {
+block0(v0: i64):
+  v1 = sshr_imm.i64 v0, 63
+  return v1
+}
+
+; VCode:
+; block0:
+;   srai a0,a0,63
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.srai a0, 0x3f
+;   c.jr ra
+
+function %c_srli(i64) -> i64 {
+block0(v0: i64):
+  v1 = ushr_imm.i64 v0, 20
+  return v1
+}
+
+; VCode:
+; block0:
+;   srli a0,a0,20
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.srli a0, 0x14
+;   c.jr ra
 
 function %c_addi4spn() -> i64 {
   ss0 = explicit_slot 64
@@ -482,8 +513,6 @@ block0:
 ;   sd a4, 0(a2)
 ;   c.jr ra
 
-<<<<<<< Updated upstream
-=======
 function %c_andi_f(i64) -> i64 {
 block0(v0: i64):
   v1 = band_imm.i64 v0, 0xf
@@ -531,5 +560,3 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   c.andi a0, 0
 ;   c.jr ra
-
->>>>>>> Stashed changes

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -247,8 +247,8 @@ block0(v0: i64, v1: i64):
 ;   c.mv s0, sp
 ; block1: ; offset 0xc
 ;   c.jalr a1
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
 ;   c.addi16sp sp, 0x10
 ;   c.jr ra
 
@@ -379,8 +379,8 @@ block0:
 ; block1: ; offset 0xe
 ;   c.mv a0, sp
 ;   c.addi16sp sp, 0x10
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
 ;   c.addi16sp sp, 0x10
 ;   c.jr ra
 
@@ -464,11 +464,10 @@ block0:
 ; block1: ; offset 0xe
 ;   c.addi4spn a0, sp, 0x18
 ;   c.addi16sp sp, 0x40
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
 ;   c.addi16sp sp, 0x10
 ;   c.jr ra
-
 
 function %c_li() -> i64 {
 block0:
@@ -560,3 +559,78 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   c.andi a0, 0
 ;   c.jr ra
+
+function %c_lwsp() -> i32 {
+  ss0 = explicit_slot 16
+
+block0:
+  v0 = stack_load.i32 ss0+12
+  return v0
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   add sp,-16
+; block0:
+;   lw a0,12(nominal_sp)
+;   add sp,+16
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi16sp sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   c.mv s0, sp
+;   c.addi16sp sp, -0x10
+; block1: ; offset 0xe
+;   c.lwsp a0, 0xc(sp)
+;   c.addi16sp sp, 0x10
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
+;   c.addi16sp sp, 0x10
+;   c.jr ra
+
+function %c_ldsp() -> i64 {
+  ss0 = explicit_slot 128
+
+block0:
+  v0 = stack_load.i64 ss0+64
+  return v0
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   add sp,-128
+; block0:
+;   ld a0,64(nominal_sp)
+;   add sp,+128
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi16sp sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   c.mv s0, sp
+;   c.addi16sp sp, -0x80
+; block1: ; offset 0xe
+;   c.ldsp a0, 0x40(sp)
+;   c.addi16sp sp, 0x80
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
+;   c.addi16sp sp, 0x10
+;   c.jr ra
+

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -743,7 +743,39 @@ block0(v0: i64, v1: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   c.sd a1, 8(a0)
+;   c.sd a1, 0x10(a0)
 ;   sd a1, -0x10(a0)
+;   c.jr ra
+
+function %c_lw(i64) -> i32 {
+block0(v0: i64):
+  v1 = load.i32 v0+64
+  return v1
+}
+
+; VCode:
+; block0:
+;   lw a0,64(a0)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.lw a0, 0x40(a0)
+;   c.jr ra
+
+function %c_ld(i64) -> i64 {
+block0(v0: i64):
+  v1 = load.i64 v0+64
+  return v1
+}
+
+; VCode:
+; block0:
+;   ld a0,64(a0)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.ld a0, 0x40(a0)
 ;   c.jr ra
 

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -509,7 +509,7 @@ block0:
 ;   c.lui a0, 4
 ;   c.lui a1, 0xfffff
 ;   c.lui a4, 0xfffe0
-;   sd a4, 0(a2)
+;   c.sd a4, 0(a2)
 ;   c.jr ra
 
 function %c_andi_f(i64) -> i64 {
@@ -706,5 +706,44 @@ block0(v0: i64):
 ;   c.ldsp ra, 8(sp)
 ;   c.ldsp s0, 0(sp)
 ;   c.addi16sp sp, 0x10
+;   c.jr ra
+
+
+function %c_sw(i64, i32) {
+block0(v0: i64, v1: i32):
+  store.i32 v1, v0+12
+  store.i32 v1, v0-12
+  return
+}
+
+; VCode:
+; block0:
+;   sw a1,12(a0)
+;   sw a1,-12(a0)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.sw a1, 0xc(a0)
+;   sw a1, -0xc(a0)
+;   c.jr ra
+
+function %c_sd(i64, i64) {
+block0(v0: i64, v1: i64):
+  store.i32 v1, v0+16
+  store.i32 v1, v0-16
+  return
+}
+
+; VCode:
+; block0:
+;   sd a1,16(a0)
+;   sd a1,-16(a0)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.sd a1, 8(a0)
+;   sd a1, -0x10(a0)
 ;   c.jr ra
 

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -189,10 +189,10 @@ block0(v0: i8):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.addi16sp sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
 ;   c.mv s0, sp
-; block1: ; offset 0xc
+; block1: ; offset 0x8
 ;   auipc a2, 0
 ;   ld a2, 0xa(a2)
 ;   c.j 0xa
@@ -242,10 +242,10 @@ block0(v0: i64, v1: i64):
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.addi16sp sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
 ;   c.mv s0, sp
-; block1: ; offset 0xc
+; block1: ; offset 0x8
 ;   c.jalr a1
 ;   c.ldsp ra, 8(sp)
 ;   c.ldsp s0, 0(sp)
@@ -372,11 +372,11 @@ block0:
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.addi16sp sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
 ;   c.mv s0, sp
 ;   c.addi16sp sp, -0x10
-; block1: ; offset 0xe
+; block1: ; offset 0xa
 ;   c.mv a0, sp
 ;   c.addi16sp sp, 0x10
 ;   c.ldsp ra, 8(sp)
@@ -457,11 +457,11 @@ block0:
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.addi16sp sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
 ;   c.mv s0, sp
 ;   c.addi16sp sp, -0x40
-; block1: ; offset 0xe
+; block1: ; offset 0xa
 ;   c.addi4spn a0, sp, 0x18
 ;   c.addi16sp sp, 0x40
 ;   c.ldsp ra, 8(sp)
@@ -585,11 +585,11 @@ block0:
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.addi16sp sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
 ;   c.mv s0, sp
 ;   c.addi16sp sp, -0x10
-; block1: ; offset 0xe
+; block1: ; offset 0xa
 ;   c.lwsp a0, 0xc(sp)
 ;   c.addi16sp sp, 0x10
 ;   c.ldsp ra, 8(sp)
@@ -622,12 +622,86 @@ block0:
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.addi16sp sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
 ;   c.mv s0, sp
 ;   c.addi16sp sp, -0x80
-; block1: ; offset 0xe
+; block1: ; offset 0xa
 ;   c.ldsp a0, 0x40(sp)
+;   c.addi16sp sp, 0x80
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
+;   c.addi16sp sp, 0x10
+;   c.jr ra
+
+function %c_swsp(i32) {
+  ss0 = explicit_slot 16
+
+block0(v0: i32):
+  stack_store.i32 v0, ss0+12
+  return
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   add sp,-16
+; block0:
+;   sw a0,12(nominal_sp)
+;   add sp,+16
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi16sp sp, -0x10
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
+;   c.mv s0, sp
+;   c.addi16sp sp, -0x10
+; block1: ; offset 0xa
+;   c.swsp a0, 0xc(sp)
+;   c.addi16sp sp, 0x10
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
+;   c.addi16sp sp, 0x10
+;   c.jr ra
+
+function %c_sdsp(i64) {
+  ss0 = explicit_slot 128
+
+block0(v0: i64):
+  stack_store.i64 v0, ss0+64
+  return
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   add sp,-128
+; block0:
+;   sd a0,64(nominal_sp)
+;   add sp,+128
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi16sp sp, -0x10
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
+;   c.mv s0, sp
+;   c.addi16sp sp, -0x80
+; block1: ; offset 0xa
+;   c.sdsp a0, 0x40(sp)
 ;   c.addi16sp sp, 0x80
 ;   c.ldsp ra, 8(sp)
 ;   c.ldsp s0, 0(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/zcd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zcd.clif
@@ -92,7 +92,23 @@ block0(v0: i64, v1: f64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   c.fsd fa0, 8(a0)
+;   c.fsd fa0, 0x10(a0)
 ;   fsd fa0, -0x10(a0)
+;   c.jr ra
+
+function %c_fld(i64) -> f64 {
+block0(v0: i64):
+  v1 = load.f64 v0+64
+  return v1
+}
+
+; VCode:
+; block0:
+;   fld fa0,64(a0)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.fld fa0, 0x40(a0)
 ;   c.jr ra
 

--- a/cranelift/filetests/filetests/isa/riscv64/zcd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zcd.clif
@@ -1,0 +1,41 @@
+test compile precise-output
+set unwind_info=false
+target riscv64 has_zca has_zcd
+
+function %c_fldsp() -> f64 {
+  ss0 = explicit_slot 16
+
+block0:
+  v0 = stack_load.f64 ss0+8
+  return v0
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   add sp,-16
+; block0:
+;   fld fa0,8(nominal_sp)
+;   add sp,+16
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi16sp sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   c.mv s0, sp
+;   c.addi16sp sp, -0x10
+; block1: ; offset 0xe
+;   c.fldsp fa0, 8(sp)
+;   c.addi16sp sp, 0x10
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
+;   c.addi16sp sp, 0x10
+;   c.jr ra
+

--- a/cranelift/filetests/filetests/isa/riscv64/zcd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zcd.clif
@@ -76,3 +76,23 @@ block0(v0: f64):
 ;   c.addi16sp sp, 0x10
 ;   c.jr ra
 
+
+function %c_fsd(i64, f64) {
+block0(v0: i64, v1: f64):
+  store.i32 v1, v0+16
+  store.i32 v1, v0-16
+  return
+}
+
+; VCode:
+; block0:
+;   fsd fa0,16(a0)
+;   fsd fa0,-16(a0)
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.fsd fa0, 8(a0)
+;   fsd fa0, -0x10(a0)
+;   c.jr ra
+

--- a/cranelift/filetests/filetests/isa/riscv64/zcd.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zcd.clif
@@ -27,13 +27,50 @@ block0:
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   c.addi16sp sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
 ;   c.mv s0, sp
 ;   c.addi16sp sp, -0x10
-; block1: ; offset 0xe
+; block1: ; offset 0xa
 ;   c.fldsp fa0, 8(sp)
 ;   c.addi16sp sp, 0x10
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
+;   c.addi16sp sp, 0x10
+;   c.jr ra
+
+function %c_fsdsp(f64) {
+  ss0 = explicit_slot 128
+
+block0(v0: f64):
+  stack_store.f64 v0, ss0+64
+  return
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   add sp,-128
+; block0:
+;   fsd fa0,64(nominal_sp)
+;   add sp,+128
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi16sp sp, -0x10
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
+;   c.mv s0, sp
+;   c.addi16sp sp, -0x80
+; block1: ; offset 0xa
+;   c.fsdsp fa0, 0x40(sp)
+;   c.addi16sp sp, 0x80
 ;   c.ldsp ra, 8(sp)
 ;   c.ldsp s0, 0(sp)
 ;   c.addi16sp sp, 0x10


### PR DESCRIPTION
👋 Hey,

This PR completes the Zca and Zcd compressed instruction extensions.

Here's an overview of the new instructions:

* `c.srli` / `c.srai` / `c.andi` / `c.li` / `c.lui` these are all fairly regular instruction using the existing CI format or the new CB format. CB encodes a 6bit signed immediate and one compressed register.
* `c.*sp` these instructions encode loads or stores from the stack pointer. The immediate is a zero extended 6 bit field so they only encode positive offsets.
* `c.fsd` / `c.fld` / `c.ld` / `c.sd` / `c.lw` / `c.sw` these are the regular compressed loads, the immediate is also zero extended but only 5 bits. And they only support compressible registers.

This PR also includes all of the Zcd instructions. Which are essentially the floating point loads and stores, they are not part of Zca, but are on a separate extension.

We now have complete support for the base C extension (except compressed branches, see https://github.com/bytecodealliance/wasmtime/pull/7047#issuecomment-1723618095). We are still missing `Zcb`, which I'm planning on adding fairly soon.