### PR TITLE
Optimize wasm calls ever-so-slightly

### DIFF
--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -404,6 +404,7 @@ impl Instance {
     }
 
     /// Return a pointer to the interrupts structure
+    #[inline]
     pub fn runtime_limits(&mut self) -> *mut *const VMRuntimeLimits {
         unsafe { self.vmctx_plus_offset_mut(self.offsets().vmctx_runtime_limits()) }
     }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -41,7 +41,6 @@ serde_json = { workspace = true }
 bincode = "1.2.1"
 indexmap = { workspace = true }
 paste = "1.0.3"
-psm = "0.1.11"
 once_cell = { workspace = true }
 rayon = { version = "1.0", optional = true }
 object = { workspace = true }
@@ -55,6 +54,9 @@ workspace = true
 features = [
   "Win32_System_Diagnostics_Debug",
 ]
+
+[target.'cfg(target_arch = "s390x")'.dependencies]
+psm = "0.1.11"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1447,11 +1447,15 @@ fn stack_pointer() -> usize {
                     out(reg) stack_pointer,
                     options(nostack,nomem),
                 );
-            } else if #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))] {
-                // aarch64 and riscv64 happen to have the same assembler syntax
-                // for `mov` and `sp`, so they both use this.
+            } else if #[cfg(target_arch = "aarch64")] {
                 std::arch::asm!(
                     "mov {}, sp",
+                    out(reg) stack_pointer,
+                    options(nostack,nomem),
+                );
+            } else if #[cfg(target_arch = "riscv64")] {
+                std::arch::asm!(
+                    "mv {}, sp",
                     out(reg) stack_pointer,
                     options(nostack,nomem),
                 );

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1438,31 +1438,35 @@ fn enter_wasm<T>(store: &mut StoreContextMut<'_, T>) -> Option<usize> {
 #[inline]
 fn stack_pointer() -> usize {
     let stack_pointer: usize;
-    unsafe {
-        cfg_if::cfg_if! {
-            if #[cfg(target_arch = "x86_64")] {
+    cfg_if::cfg_if! {
+        if #[cfg(target_arch = "x86_64")] {
+            unsafe {
                 std::arch::asm!(
                     "mov {}, rsp",
                     out(reg) stack_pointer,
                     options(nostack,nomem),
                 );
-            } else if #[cfg(target_arch = "aarch64")] {
+            }
+        } else if #[cfg(target_arch = "aarch64")] {
+            unsafe {
                 std::arch::asm!(
                     "mov {}, sp",
                     out(reg) stack_pointer,
                     options(nostack,nomem),
                 );
-            } else if #[cfg(target_arch = "riscv64")] {
+            }
+        } else if #[cfg(target_arch = "riscv64")] {
+            unsafe {
                 std::arch::asm!(
                     "mv {}, sp",
                     out(reg) stack_pointer,
                     options(nostack,nomem),
                 );
-            } else if #[cfg(target_arch = "s390x")] {
-                stack_pointer = psm::stack_pointer() as usize;
-            } else {
-                compile_error!("unsupported platform");
             }
+        } else if #[cfg(target_arch = "s390x")] {
+            stack_pointer = psm::stack_pointer() as usize;
+        } else {
+            compile_error!("unsupported platform");
         }
     }
     stack_pointer

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1408,7 +1408,7 @@ fn enter_wasm<T>(store: &mut StoreContextMut<'_, T>) -> Option<usize> {
         return None;
     }
 
-    let stack_pointer = psm::stack_pointer() as usize;
+    let stack_pointer = stack_pointer();
 
     // Determine the stack pointer where, after which, any wasm code will
     // immediately trap. This is checked on the entry to all wasm functions.
@@ -1433,6 +1433,36 @@ fn enter_wasm<T>(store: &mut StoreContextMut<'_, T>) -> Option<usize> {
     };
 
     Some(prev_stack)
+}
+
+#[inline]
+fn stack_pointer() -> usize {
+    // psm::stack_pointer() as usize
+    let stack_pointer: usize;
+    unsafe {
+        cfg_if::cfg_if! {
+            if #[cfg(target_arch = "x86_64")] {
+                std::arch::asm!(
+                    "mov {}, rsp",
+                    out(reg) stack_pointer,
+                    options(nostack,nomem),
+                );
+            } else if #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))] {
+                // aarch64 and riscv64 happen to have the same assembler syntax
+                // for `mov` and `sp`, so they both use this.
+                std::arch::asm!(
+                    "mov {}, sp",
+                    out(reg) stack_pointer,
+                    options(nostack,nomem),
+                );
+            } else if #[cfg(target_arch = "s390x")] {
+                stack_pointer = psm::stack_pointer() as usize;
+            } else {
+                compile_error!("unsupported platform");
+            }
+        }
+    }
+    stack_pointer
 }
 
 fn exit_wasm<T>(store: &mut StoreContextMut<'_, T>, prev_stack: Option<usize>) {

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1437,7 +1437,6 @@ fn enter_wasm<T>(store: &mut StoreContextMut<'_, T>) -> Option<usize> {
 
 #[inline]
 fn stack_pointer() -> usize {
-    // psm::stack_pointer() as usize
     let stack_pointer: usize;
     unsafe {
         cfg_if::cfg_if! {


### PR DESCRIPTION
This commit is a tiny optimization for host-to-wasm calls by inlining a few functions. One was a wasmtime-runtime function that's pretty simple and the other is the usage of the `psm` crate. Long ago `psm` was added to learn the current stack pointer and its routines are written in assembly, meaning that the calls can't be inlined. Nowadays with inline assembly it's possible to skip the external assembler entirely.