### PR TITLE
Update `ittapi` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,9 +1646,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "ittapi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e648c437172ce7d3ac35ca11a068755072054826fa455a916b43524fa4a62a7"
+checksum = "41e0d0b7b3b53d92a7e8b80ede3400112a6b8b4c98d1f5b8b16bb787c780582c"
 dependencies = [
  "anyhow",
  "ittapi-sys",
@@ -1657,9 +1657,9 @@ dependencies = [
 
 [[package]]
 name = "ittapi-sys"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9b32a4d23f72548178dde54f3c12c6b6a08598e25575c0d0fa5bd861e0dc1a5"
+checksum = "f2f8763c96e54e6d6a0dccc2990d8b5e33e3313aaeae6185921a3f4c1614a77c"
 dependencies = [
  "cc",
 ]

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -12,7 +12,9 @@ edition.workspace = true
 
 [dependencies]
 wasmtime-environ = { workspace = true }
-wasmtime-jit-debug = { workspace = true, features = ["perf_jitdump"], optional = true }
+wasmtime-jit-debug = { workspace = true, features = [
+  "perf_jitdump",
+], optional = true }
 wasmtime-runtime = { workspace = true }
 target-lexicon = { workspace = true }
 anyhow = { workspace = true }
@@ -33,12 +35,10 @@ rustix = { workspace = true, features = ['thread'] }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 workspace = true
-features = [
-  "Win32_System_Diagnostics_Debug",
-]
+features = ["Win32_System_Diagnostics_Debug"]
 
 [target.'cfg(all(target_arch = "x86_64", not(target_os = "android")))'.dependencies]
-ittapi = { version = "0.3.3", optional = true  }
+ittapi = { version = "0.3.4", optional = true }
 
 [features]
 jitdump = ['wasmtime-jit-debug']

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1441,8 +1441,18 @@ notes = "The Bytecode Alliance is the author of this crate."
 [[audits.ittapi]]
 who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
+version = "0.3.4"
+
+[[audits.ittapi]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
 delta = "0.3.1 -> 0.3.3"
 notes = "I am the author of this crate."
+
+[[audits.ittapi-sys]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+version = "0.3.4"
 
 [[audits.ittapi-sys]]
 who = "Andrew Brown <andrew.brown@intel.com>"


### PR DESCRIPTION
This update gets rid of a panic that occurs when using `--profile=vtune` from the command line.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
