### PR TITLE
Minor preview2 impl cleanups

### DIFF
--- a/crates/wasi/src/preview2/pipe.rs
+++ b/crates/wasi/src/preview2/pipe.rs
@@ -105,17 +105,6 @@ impl HostOutputStream for MemoryOutputPipe {
     }
 }
 
-/// FIXME: this needs docs
-pub fn pipe(size: usize) -> (AsyncReadStream, AsyncWriteStream) {
-    let (a, b) = tokio::io::duplex(size);
-    let (_read_half, write_half) = tokio::io::split(a);
-    let (read_half, _write_half) = tokio::io::split(b);
-    (
-        AsyncReadStream::new(read_half),
-        AsyncWriteStream::new(size, write_half),
-    )
-}
-
 /// Provides a [`HostInputStream`] impl from a [`tokio::io::AsyncRead`] impl
 pub struct AsyncReadStream {
     state: StreamState,

--- a/crates/wasi/src/preview2/stdio.rs
+++ b/crates/wasi/src/preview2/stdio.rs
@@ -334,13 +334,6 @@ mod test {
     // This test doesn't work under qemu because of the use of fork in the test helper.
     #[test]
     #[cfg_attr(not(target_arch = "x86_64"), ignore)]
-    fn test_async_fd_stdin() {
-        test_stdin_by_forking(super::stdin);
-    }
-
-    // This test doesn't work under qemu because of the use of fork in the test helper.
-    #[test]
-    #[cfg_attr(not(target_arch = "x86_64"), ignore)]
     fn test_worker_thread_stdin() {
         test_stdin_by_forking(super::worker_thread_stdin::stdin);
     }

--- a/crates/wasi/src/preview2/stdio.rs
+++ b/crates/wasi/src/preview2/stdio.rs
@@ -333,14 +333,14 @@ mod test {
 
     // This test doesn't work under qemu because of the use of fork in the test helper.
     #[test]
-    #[cfg_attr(not(target = "x86_64"), ignore)]
+    #[cfg_attr(not(target_arch = "x86_64"), ignore)]
     fn test_async_fd_stdin() {
         test_stdin_by_forking(super::stdin);
     }
 
     // This test doesn't work under qemu because of the use of fork in the test helper.
     #[test]
-    #[cfg_attr(not(target = "x86_64"), ignore)]
+    #[cfg_attr(not(target_arch = "x86_64"), ignore)]
     fn test_worker_thread_stdin() {
         test_stdin_by_forking(super::worker_thread_stdin::stdin);
     }


### PR DESCRIPTION
* delete pipe::pipe, which has no real reason for existing, no tests or docs, and the user can make their own if they really need it.
* fix cfg_attr to (approximate) ignore the forking tests when running under qemu, right now its ignored everywhere by accident
* delete duplicate stdin test that pointed to the async fd version, which no longer exists.