### PR TITLE
wasmtime: Misc optimizations

### DIFF
--- a/crates/jit/src/instantiate.rs
+++ b/crates/jit/src/instantiate.rs
@@ -509,6 +509,7 @@ impl CompiledModule {
     /// Returns the text section of the ELF image for this compiled module.
     ///
     /// This memory should have the read/execute permissions.
+    #[inline]
     pub fn text(&self) -> &[u8] {
         self.code_memory.text()
     }
@@ -575,6 +576,7 @@ impl CompiledModule {
     ///
     /// These trampolines are used for native callers (e.g. `Func::wrap`)
     /// calling Wasm callees.
+    #[inline]
     pub fn native_to_wasm_trampoline(&self, index: DefinedFuncIndex) -> Option<&[u8]> {
         let loc = self.funcs[index].native_to_wasm_trampoline?;
         Some(&self.text()[loc.start as usize..][..loc.length as usize])

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -122,6 +122,7 @@ impl Mmap {
     /// # Panics
     ///
     /// Panics of the `range` provided is outside of the limits of this mmap.
+    #[inline]
     pub unsafe fn slice(&self, range: Range<usize>) -> &[u8] {
         assert!(range.start <= range.end);
         assert!(range.end <= self.len());

--- a/crates/runtime/src/mmap_vec.rs
+++ b/crates/runtime/src/mmap_vec.rs
@@ -127,6 +127,7 @@ impl MmapVec {
 impl Deref for MmapVec {
     type Target = [u8];
 
+    #[inline]
     fn deref(&self) -> &[u8] {
         // SAFETY: this mmap owns its own range of the underlying mmap so it
         // should be all good-to-read.

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -54,7 +54,10 @@ impl WasiCtxBuilder {
     pub fn new() -> Self {
         // For the insecure random API, use `SmallRng`, which is fast. It's
         // also insecure, but that's the deal here.
-        let insecure_random = Box::new(cap_rand::rngs::SmallRng::from_entropy());
+        let insecure_random = Box::new(
+            cap_rand::rngs::SmallRng::from_rng(cap_rand::thread_rng(cap_rand::ambient_authority()))
+                .unwrap(),
+        );
 
         // For the insecure random seed, use a `u128` generated from
         // `thread_rng()`, so that it's not guessable from the insecure_random

--- a/crates/wasmtime/src/signatures.rs
+++ b/crates/wasmtime/src/signatures.rs
@@ -45,6 +45,7 @@ impl SignatureCollection {
     }
 
     /// Gets the shared signature index given a module signature index.
+    #[inline]
     pub fn shared_signature(&self, index: SignatureIndex) -> Option<VMSharedSignatureIndex> {
         self.signatures.get(index).copied()
     }


### PR DESCRIPTION
While analyzing performance of the upcoming `wasmtime serve` command with @alexcrichton, we noticed that there were a good number of hot functions that could be marked inline. Additionally we noticed that the rng in the preview2 context was being seeded with a syscall, where a use of the thread local rng would suffice.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
