### PR TITLE
Remove usage of `is-terminal` and `atty` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2668,7 +2668,6 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
- "is-terminal",
  "lazy_static",
  "tempfile",
  "test-log",
@@ -3014,7 +3013,6 @@ dependencies = [
  "fs-set-times",
  "io-extras",
  "io-lifetimes 2.0.2",
- "is-terminal",
  "once_cell",
  "rustix 0.38.8",
  "system-interface",
@@ -3505,7 +3503,6 @@ name = "wasmtime-environ"
 version = "14.0.0"
 dependencies = [
  "anyhow",
- "atty",
  "clap",
  "cranelift-entity",
  "env_logger 0.10.0",

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -28,7 +28,6 @@ wasmprinter = { workspace = true, optional = true }
 wasmtime-component-util = { workspace = true, optional = true }
 
 [dev-dependencies]
-atty = "0.2.14"
 clap = { workspace = true }
 env_logger = { workspace = true }
 wat = { workspace = true }

--- a/crates/environ/examples/factc.rs
+++ b/crates/environ/examples/factc.rs
@@ -1,6 +1,6 @@
 use anyhow::{bail, Context, Result};
 use clap::Parser;
-use std::io::Write;
+use std::io::{IsTerminal, Write};
 use std::path::PathBuf;
 use wasmparser::{Validator, WasmFeatures};
 use wasmtime_environ::component::*;
@@ -179,7 +179,7 @@ impl Factc {
             wasmprinter::print_bytes(&wasm)
                 .context("failed to convert binary wasm to text")?
                 .into_bytes()
-        } else if self.output.is_none() && atty::is(atty::Stream::Stdout) {
+        } else if self.output.is_none() && std::io::stdout().is_terminal() {
             bail!("cannot print binary wasm output to a terminal unless `-t` flag is passed")
         } else {
             wasm.clone()

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -19,7 +19,6 @@ http = { version = "0.2.9" }
 http-body = "1.0.0-rc.2"
 http-body-util = "0.1.0-rc.2"
 hyper = { version = "1.0.0-rc.3", features = ["full"] }
-is-terminal = { workspace = true }
 tokio = { workspace = true, features = ["net", "rt-multi-thread", "macros"] }
 tracing = { workspace = true }
 

--- a/crates/test-programs/src/lib.rs
+++ b/crates/test-programs/src/lib.rs
@@ -1,5 +1,6 @@
 ///! This crate exists to build crates for wasm32-wasi in build.rs, and execute
 ///! these wasm programs in harnesses defined under tests/.
+use std::io::IsTerminal;
 
 #[cfg(all(feature = "test_programs", not(skip_wasi_http_tests)))]
 pub mod http_server;
@@ -40,8 +41,7 @@ pub fn wasi_tests_environment() -> &'static [(&'static str, &'static str)] {
 }
 
 pub fn stdio_is_terminal() -> bool {
-    use is_terminal::is_terminal;
-    is_terminal(&std::io::stdin())
-        && is_terminal(&std::io::stdout())
-        && is_terminal(&std::io::stderr())
+    std::io::stdin().is_terminal()
+        && std::io::stdout().is_terminal()
+        && std::io::stderr().is_terminal()
 }

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -23,7 +23,6 @@ fs-set-times = { workspace = true }
 system-interface = { workspace = true, features = ["cap_std_impls"] }
 tracing = { workspace = true }
 io-lifetimes = { workspace = true }
-is-terminal = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 rustix = { workspace = true, features = ["fs", "event"] }

--- a/crates/wasi-common/cap-std-sync/src/file.rs
+++ b/crates/wasi-common/cap-std-sync/src/file.rs
@@ -127,7 +127,10 @@ impl WasiFile for File {
         Ok(self.0.num_ready_bytes()?)
     }
     fn isatty(&self) -> bool {
-        self.0.as_fd().is_terminal()
+        #[cfg(unix)]
+        return self.0.as_fd().is_terminal();
+        #[cfg(windows)]
+        return self.0.as_handle().is_terminal();
     }
 }
 

--- a/crates/wasi-common/cap-std-sync/src/file.rs
+++ b/crates/wasi-common/cap-std-sync/src/file.rs
@@ -1,10 +1,9 @@
 use cap_fs_ext::MetadataExt;
 use fs_set_times::{SetTimes, SystemTimeSpec};
 use io_lifetimes::AsFilelike;
-use is_terminal::IsTerminal;
 use std::any::Any;
 use std::convert::TryInto;
-use std::io;
+use std::io::{self, IsTerminal};
 use system_interface::{
     fs::{FileIoExt, GetSetFdFlags},
     io::{IoExt, ReadReady},
@@ -128,7 +127,7 @@ impl WasiFile for File {
         Ok(self.0.num_ready_bytes()?)
     }
     fn isatty(&self) -> bool {
-        self.0.is_terminal()
+        self.0.as_fd().is_terminal()
     }
 }
 

--- a/crates/wasi-common/cap-std-sync/src/stdio.rs
+++ b/crates/wasi-common/cap-std-sync/src/stdio.rs
@@ -76,9 +76,9 @@ impl WasiFile for Stdin {
     }
     fn isatty(&self) -> bool {
         #[cfg(unix)]
-        self.0.as_fd().is_terminal()
+        return self.0.as_fd().is_terminal();
         #[cfg(windows)]
-        self.0.as_handle().is_terminal()
+        return self.0.as_handle().is_terminal();
     }
 }
 #[cfg(windows)]

--- a/crates/wasi-common/cap-std-sync/src/stdio.rs
+++ b/crates/wasi-common/cap-std-sync/src/stdio.rs
@@ -1,10 +1,8 @@
 use crate::file::convert_systimespec;
 use fs_set_times::SetTimes;
-use is_terminal::IsTerminal;
 use std::any::Any;
 use std::convert::TryInto;
-use std::io;
-use std::io::{Read, Write};
+use std::io::{self, IsTerminal, Read, Write};
 use system_interface::io::ReadReady;
 
 #[cfg(windows)]
@@ -77,7 +75,10 @@ impl WasiFile for Stdin {
         Ok(self.0.num_ready_bytes()?)
     }
     fn isatty(&self) -> bool {
-        self.0.is_terminal()
+        #[cfg(unix)]
+        self.0.as_fd().is_terminal()
+        #[cfg(windows)]
+        self.0.as_handle().is_terminal()
     }
 }
 #[cfg(windows)]


### PR DESCRIPTION
This functionality is now folded into the standard library itself.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
