### PR TITLE
 Implement the `wasi:sockets/ip-name-lookup` interface 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3761,6 +3761,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
  "wasi-cap-std-sync",
  "wasi-common",
  "wasi-tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3752,6 +3752,7 @@ dependencies = [
  "io-extras",
  "io-lifetimes 2.0.2",
  "libc",
+ "log",
  "once_cell",
  "rustix 0.38.8",
  "system-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -270,6 +270,7 @@ pretty_env_logger = "0.5.0"
 syn = "2.0.25"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ['fmt', 'env-filter'] }
+url = "2.3.1"
 
 [features]
 default = [

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -242,6 +242,8 @@ wasmtime_option_group! {
         /// Flag for WASI preview2 to inherit the host's network within the
         /// guest so it has full access to all addresses/ports/etc.
         pub inherit_network: Option<bool>,
+        /// Indicates whether `wasi:sockets/ip-name-lookup` is enabled or not.
+        pub allow_ip_name_lookup: Option<bool>,
 
     }
 

--- a/crates/test-programs/tests/wasi-sockets.rs
+++ b/crates/test-programs/tests/wasi-sockets.rs
@@ -52,6 +52,7 @@ async fn run(name: &str) -> anyhow::Result<()> {
     let wasi = WasiCtxBuilder::new()
         .inherit_stdio()
         .inherit_network(ambient_authority())
+        .allow_ip_name_lookup(true)
         .arg(name)
         .build();
 
@@ -73,4 +74,9 @@ async fn tcp_v4() {
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn tcp_v6() {
     run("tcp_v6").await.unwrap();
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn ip_name_lookup() {
+    run("ip_name_lookup").await.unwrap();
 }

--- a/crates/test-programs/wasi-sockets-tests/src/bin/ip_name_lookup.rs
+++ b/crates/test-programs/wasi-sockets-tests/src/bin/ip_name_lookup.rs
@@ -11,10 +11,8 @@ fn main() {
     poll::poll_one(&pollable);
     assert!(addresses.resolve_next_address().is_ok());
 
-    let addresses = ip_name_lookup::resolve_addresses(&network, "a.b<&>", None, false).unwrap();
-    let pollable = addresses.subscribe();
-    poll::poll_one(&pollable);
-    assert!(addresses.resolve_next_address().is_err());
+    let result = ip_name_lookup::resolve_addresses(&network, "a.b<&>", None, false);
+    assert!(matches!(result, Err(network::ErrorCode::InvalidName)));
 
     // Try resolving a valid address and ensure that it eventually terminates.
     // To help prevent this test from being flaky this additionally times out

--- a/crates/test-programs/wasi-sockets-tests/src/bin/ip_name_lookup.rs
+++ b/crates/test-programs/wasi-sockets-tests/src/bin/ip_name_lookup.rs
@@ -1,0 +1,38 @@
+use wasi_sockets_tests::wasi::clocks::*;
+use wasi_sockets_tests::wasi::io::*;
+use wasi_sockets_tests::wasi::sockets::*;
+
+fn main() {
+    let network = instance_network::instance_network();
+
+    let addresses =
+        ip_name_lookup::resolve_addresses(&network, "example.com", None, false).unwrap();
+    let pollable = addresses.subscribe();
+    poll::poll_one(&pollable);
+    assert!(addresses.resolve_next_address().is_ok());
+
+    let addresses = ip_name_lookup::resolve_addresses(&network, "a.b<&>", None, false).unwrap();
+    let pollable = addresses.subscribe();
+    poll::poll_one(&pollable);
+    assert!(addresses.resolve_next_address().is_err());
+
+    // Try resolving a valid address and ensure that it eventually terminates.
+    // To help prevent this test from being flaky this additionally times out
+    // the resolution and allows errors.
+    let addresses = ip_name_lookup::resolve_addresses(&network, "github.com", None, false).unwrap();
+    let lookup = addresses.subscribe();
+    let timeout = monotonic_clock::subscribe(1_000_000_000, false);
+    let ready = poll::poll_list(&[&lookup, &timeout]);
+    assert!(ready.len() > 0);
+    match ready[0] {
+        0 => loop {
+            match addresses.resolve_next_address() {
+                Ok(Some(_)) => {}
+                Ok(None) => break,
+                Err(_) => break,
+            }
+        },
+        1 => {}
+        _ => unreachable!(),
+    }
+}

--- a/crates/wasi-http/wit/test.wit
+++ b/crates/wasi-http/wit/test.wit
@@ -39,4 +39,6 @@ world test-command-with-sockets {
   import wasi:sockets/tcp-create-socket
   import wasi:sockets/network
   import wasi:sockets/instance-network
+  import wasi:sockets/ip-name-lookup
+  import wasi:clocks/monotonic-clock
 }

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -22,6 +22,7 @@ wiggle = { workspace = true, optional = true }
 libc = { workspace = true }
 once_cell = { workspace = true }
 log = { workspace = true }
+url = { workspace = true }
 
 tokio = { workspace = true, optional = true, features = ["time", "sync", "io-std", "io-util", "rt", "rt-multi-thread", "net"] }
 bytes = { workspace = true }

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -21,6 +21,7 @@ wasi-tokio = { workspace = true, optional = true }
 wiggle = { workspace = true, optional = true }
 libc = { workspace = true }
 once_cell = { workspace = true }
+log = { workspace = true }
 
 tokio = { workspace = true, optional = true, features = ["time", "sync", "io-std", "io-util", "rt", "rt-multi-thread", "net"] }
 bytes = { workspace = true }

--- a/crates/wasi/src/preview2/command.rs
+++ b/crates/wasi/src/preview2/command.rs
@@ -54,6 +54,7 @@ pub fn add_to_linker<T: WasiView>(l: &mut wasmtime::component::Linker<T>) -> any
     crate::preview2::bindings::sockets::tcp_create_socket::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::sockets::instance_network::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::sockets::network::add_to_linker(l, |t| t)?;
+    crate::preview2::bindings::sockets::ip_name_lookup::add_to_linker(l, |t| t)?;
     Ok(())
 }
 
@@ -116,6 +117,7 @@ pub mod sync {
         crate::preview2::bindings::sockets::tcp_create_socket::add_to_linker(l, |t| t)?;
         crate::preview2::bindings::sockets::instance_network::add_to_linker(l, |t| t)?;
         crate::preview2::bindings::sockets::network::add_to_linker(l, |t| t)?;
+        crate::preview2::bindings::sockets::ip_name_lookup::add_to_linker(l, |t| t)?;
         Ok(())
     }
 }

--- a/crates/wasi/src/preview2/host/instance_network.rs
+++ b/crates/wasi/src/preview2/host/instance_network.rs
@@ -5,7 +5,10 @@ use wasmtime::component::Resource;
 
 impl<T: WasiView> instance_network::Host for T {
     fn instance_network(&mut self) -> Result<Resource<Network>, anyhow::Error> {
-        let network = Network::new(self.ctx().pool.clone());
+        let network = Network {
+            pool: self.ctx().pool.clone(),
+            allow_ip_name_lookup: self.ctx().allow_ip_name_lookup,
+        };
         let network = self.table_mut().push_resource(network)?;
         Ok(network)
     }

--- a/crates/wasi/src/preview2/host/network.rs
+++ b/crates/wasi/src/preview2/host/network.rs
@@ -67,7 +67,11 @@ impl From<io::Error> for network::Error {
                 Some(libc::EADDRINUSE) => ErrorCode::AddressInUse,
                 Some(_) => return Self::trap(error.into()),
             },
-            _ => return Self::trap(error.into()),
+
+            _ => {
+                log::debug!("unknown I/O error: {error}");
+                ErrorCode::Unknown
+            }
         }
         .into()
     }

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -31,7 +31,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         }
 
         let network = table.get_resource(&network)?;
-        let binder = network.0.tcp_binder(local_address)?;
+        let binder = network.pool.tcp_binder(local_address)?;
 
         // Perform the OS bind call.
         binder.bind_existing_tcp_listener(
@@ -75,7 +75,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
             }
 
             let network = table.get_resource(&network)?;
-            let connecter = network.0.tcp_connecter(remote_address)?;
+            let connecter = network.pool.tcp_connecter(remote_address)?;
 
             // Do an OS `connect`. Our socket is non-blocking, so it'll either...
             {

--- a/crates/wasi/src/preview2/ip_name_lookup.rs
+++ b/crates/wasi/src/preview2/ip_name_lookup.rs
@@ -1,0 +1,127 @@
+use crate::preview2::bindings::sockets::ip_name_lookup::{Host, HostResolveAddressStream};
+use crate::preview2::bindings::sockets::network::{
+    Error, ErrorCode, IpAddress, IpAddressFamily, Network,
+};
+use crate::preview2::poll::{subscribe, Pollable, Subscribe};
+use crate::preview2::{AbortOnDropJoinHandle, WasiView};
+use anyhow::Result;
+use std::io;
+use std::mem;
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::pin::Pin;
+use std::vec;
+use wasmtime::component::Resource;
+
+pub enum ResolveAddressStream {
+    Waiting(AbortOnDropJoinHandle<io::Result<Vec<IpAddress>>>),
+    Done(io::Result<vec::IntoIter<IpAddress>>),
+}
+
+#[async_trait::async_trait]
+impl<T: WasiView> Host for T {
+    fn resolve_addresses(
+        &mut self,
+        network: Resource<Network>,
+        name: String,
+        family: Option<IpAddressFamily>,
+        include_unavailable: bool,
+    ) -> Result<Resource<ResolveAddressStream>, Error> {
+        if !self.table().get_resource(&network)?.allow_ip_name_lookup {
+            return Err(ErrorCode::PermanentResolverFailure.into());
+        }
+
+        // ignored for now, should probably have a future PR to actually take
+        // this into account. This would require invoking `getaddrinfo` directly
+        // rather than using the standard library to do it for us.
+        let _ = include_unavailable;
+
+        // For now use the standard library to perform actual resolution through
+        // the usage of the `ToSocketAddrs` trait. This blocks the current
+        // thread, so use `spawn_blocking`. Finally note that this is only
+        // resolving names, not ports, so force the port to be 0.
+        let task = tokio::task::spawn_blocking(move || -> io::Result<Vec<_>> {
+            let result = (name.as_str(), 0).to_socket_addrs()?;
+            Ok(result
+                .filter_map(|addr| {
+                    // In lieu of preventing these addresses from being resolved
+                    // in the first place, filter them out here.
+                    match addr {
+                        SocketAddr::V4(addr) => match family {
+                            None | Some(IpAddressFamily::Ipv4) => {
+                                let [a, b, c, d] = addr.ip().octets();
+                                Some(IpAddress::Ipv4((a, b, c, d)))
+                            }
+                            Some(IpAddressFamily::Ipv6) => None,
+                        },
+                        SocketAddr::V6(addr) => match family {
+                            None | Some(IpAddressFamily::Ipv6) => {
+                                let [a, b, c, d, e, f, g, h] = addr.ip().segments();
+                                Some(IpAddress::Ipv6((a, b, c, d, e, f, g, h)))
+                            }
+                            Some(IpAddressFamily::Ipv4) => None,
+                        },
+                    }
+                })
+                .collect())
+        });
+        let task = AbortOnDropJoinHandle(task);
+        let resource = self
+            .table_mut()
+            .push_resource(ResolveAddressStream::Waiting(task))?;
+        Ok(resource)
+    }
+}
+
+#[async_trait::async_trait]
+impl<T: WasiView> HostResolveAddressStream for T {
+    fn resolve_next_address(
+        &mut self,
+        resource: Resource<ResolveAddressStream>,
+    ) -> Result<Option<IpAddress>, Error> {
+        let stream = self.table_mut().get_resource_mut(&resource)?;
+        loop {
+            match stream {
+                ResolveAddressStream::Waiting(future) => {
+                    match crate::preview2::poll_noop(Pin::new(future)) {
+                        Some(result) => {
+                            *stream = ResolveAddressStream::Done(result.map(|v| v.into_iter()));
+                        }
+                        None => return Err(ErrorCode::WouldBlock.into()),
+                    }
+                }
+                ResolveAddressStream::Done(slot @ Err(_)) => {
+                    // TODO: this `?` is what converts `io::Error` into `Error`
+                    // and the conversion is not great right now. The standard
+                    // library doesn't expose a ton of information through the
+                    // return value of `getaddrinfo` right now so supporting a
+                    // richer conversion here will probably require calling
+                    // `getaddrinfo` directly.
+                    mem::replace(slot, Ok(Vec::new().into_iter()))?;
+                    unreachable!();
+                }
+                ResolveAddressStream::Done(Ok(iter)) => return Ok(iter.next()),
+            }
+        }
+    }
+
+    fn subscribe(
+        &mut self,
+        resource: Resource<ResolveAddressStream>,
+    ) -> Result<Resource<Pollable>> {
+        subscribe(self.table_mut(), resource)
+    }
+
+    fn drop(&mut self, resource: Resource<ResolveAddressStream>) -> Result<()> {
+        self.table_mut().delete_resource(resource)?;
+        Ok(())
+    }
+}
+
+#[async_trait::async_trait]
+impl Subscribe for ResolveAddressStream {
+    async fn ready(&mut self) {
+        if let ResolveAddressStream::Waiting(future) = self {
+            *self = ResolveAddressStream::Done(future.await.map(|v| v.into_iter()));
+        }
+    }
+}

--- a/crates/wasi/src/preview2/network.rs
+++ b/crates/wasi/src/preview2/network.rs
@@ -1,9 +1,6 @@
 use cap_std::net::Pool;
 
-pub struct Network(pub(crate) Pool);
-
-impl Network {
-    pub fn new(pool: Pool) -> Self {
-        Self(pool)
-    }
+pub struct Network {
+    pub pool: Pool,
+    pub allow_ip_name_lookup: bool,
 }

--- a/crates/wasi/wit/test.wit
+++ b/crates/wasi/wit/test.wit
@@ -39,4 +39,6 @@ world test-command-with-sockets {
   import wasi:sockets/tcp-create-socket
   import wasi:sockets/network
   import wasi:sockets/instance-network
+  import wasi:sockets/ip-name-lookup
+  import wasi:clocks/monotonic-clock
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -936,6 +936,9 @@ impl RunCommand {
         if self.common.wasi.inherit_network == Some(true) {
             builder.inherit_network(ambient_authority());
         }
+        if let Some(enable) = self.common.wasi.allow_ip_name_lookup {
+            builder.allow_ip_name_lookup(enable);
+        }
 
         store.data_mut().preview2_ctx = Some(Arc::new(builder.build()));
         Ok(())


### PR DESCRIPTION
This commit is an initial implementation of the new `ip-name-lookup`
interface from the `wasi-sockets` proposal. The intention is to get a
sketch of what an implementation would look like for the preview2
release later this year. Notable features of this implementation are:

* Name lookups are disabled by default and must be explicitly enabled in
  `WasiCtx`. This seems like a reasonable default for now while the full
  set of configuration around this is settled.

* I've added new "typed" methods to `preview2::Table` to avoid the need
  for extra helpers when using resources.

* A new `-Sallow-ip-name-lookup` option is added to control this on the
  CLI.

* Implementation-wise this uses the blocking resolution in the Rust
  standard library, built on `getaddrinfo`. This doesn't invoke
  `getaddrinfo` "raw", however, so information such as error details can
  be lost in translation. This will probably need to change in the
  future.

Closes https://github.com/bytecodealliance/wasmtime/issues/7070