### PR TITLE
c-api: Update reexport of wasmtime crate crate

### DIFF
--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -11,6 +11,8 @@
 
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
+pub use wasmtime;
+
 mod config;
 mod engine;
 mod error;

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -11,8 +11,6 @@
 
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
 
-pub use wasmtime::*;
-
 mod config;
 mod engine;
 mod error;


### PR DESCRIPTION
This is a follow-up to #6765 to update this reexport since it was originally added to use both the C API and the `wasmtime` crate in the same downstream crate, but this should be possible through Cargo with:

    [dependencies]
    wasmtime = "13"
    wasmtime-c-api = { version = "13", package = "wasmtime-c-api" }

and that way `wasmtime::*` is available as well as `wasmtime_c_api::*`. For convenience though the name `wasmtime` is still exported to allow depending on just this crate.

