### PR TITLE
Cranelift: return programmatic error rather than panic when temporaries run out.

### DIFF
--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -1545,7 +1545,7 @@ impl<M: ABIMachineSpec> Callee<M> {
                 // We need to dereference the pointer.
                 let base = match &pointer {
                     &ABIArgSlot::Reg { reg, ty, .. } => {
-                        let tmp = vregs.alloc(ty).unwrap().only_reg().unwrap();
+                        let tmp = vregs.alloc_with_deferred_error(ty).only_reg().unwrap();
                         self.reg_args.push(ArgPair {
                             vreg: Writable::from_reg(tmp),
                             preg: reg.into(),
@@ -1607,9 +1607,10 @@ impl<M: ABIMachineSpec> Callee<M> {
                                     if n < word_bits =>
                                 {
                                     let signed = ext == ir::ArgumentExtension::Sext;
-                                    let dst = writable_value_regs(vregs.alloc(ty).unwrap())
-                                        .only_reg()
-                                        .unwrap();
+                                    let dst =
+                                        writable_value_regs(vregs.alloc_with_deferred_error(ty))
+                                            .only_reg()
+                                            .unwrap();
                                     ret.push(M::gen_extend(
                                         dst, from_reg, signed, from_bits,
                                         /* to_bits = */ word_bits,
@@ -1650,9 +1651,10 @@ impl<M: ABIMachineSpec> Callee<M> {
                                 {
                                     assert_eq!(M::word_reg_class(), from_reg.class());
                                     let signed = ext == ir::ArgumentExtension::Sext;
-                                    let dst = writable_value_regs(vregs.alloc(ty).unwrap())
-                                        .only_reg()
-                                        .unwrap();
+                                    let dst =
+                                        writable_value_regs(vregs.alloc_with_deferred_error(ty))
+                                            .only_reg()
+                                            .unwrap();
                                     ret.push(M::gen_extend(
                                         dst, from_reg, signed, from_bits,
                                         /* to_bits = */ word_bits,

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -18,6 +18,7 @@ use crate::machinst::{
     SigSet, VCode, VCodeBuilder, VCodeConstant, VCodeConstantData, VCodeConstants, VCodeInst,
     ValueRegs, Writable,
 };
+use crate::CodegenError;
 use crate::{trace, CodegenResult};
 use alloc::vec::Vec;
 use cranelift_control::ControlPlane;
@@ -162,6 +163,13 @@ pub struct Lower<'func, I: VCodeInst> {
 
     /// VReg allocation context, given to the vcode field at build time to finalize the vcode.
     vregs: VRegAllocator<I>,
+
+    /// A deferred error from vreg allocation, to be bubbled up to the
+    /// top level of the lowering algorithm. We take this approach
+    /// because we cannot currently propagate a `Result` upward
+    /// through ISLE code (the lowering rules), and temp allocations
+    /// typically happen as a result of particular lowering rules.
+    vreg_alloc_error: Option<CodegenError>,
 
     /// Mapping from `Value` (SSA value in IR) to virtual register.
     value_regs: SecondaryMap<Value, ValueRegs<Reg>>,
@@ -437,6 +445,7 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             allocatable: PRegSet::from(machine_env),
             vcode,
             vregs,
+            vreg_alloc_error: None,
             value_regs,
             sret_reg,
             block_end_colors,
@@ -1077,6 +1086,12 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             self.finish_bb();
         }
 
+        // Check for any deferred vreg-temp allocation errors, and
+        // bubble one up at this time if it exists.
+        if let Some(e) = self.vreg_alloc_error {
+            return Err(e);
+        }
+
         // Now that we've emitted all instructions into the
         // VCodeBuilder, let's build the VCode.
         let vcode = self.vcode.build(self.allocatable, self.vregs);
@@ -1325,7 +1340,14 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
 impl<'func, I: VCodeInst> Lower<'func, I> {
     /// Get a new temp.
     pub fn alloc_tmp(&mut self, ty: Type) -> ValueRegs<Writable<Reg>> {
-        writable_value_regs(self.vregs.alloc(ty).unwrap())
+        let allocated = match self.vregs.alloc(ty) {
+            Ok(x) => x,
+            Err(e) => {
+                self.vreg_alloc_error = Some(e);
+                self.vregs.invalid(ty)
+            }
+        };
+        writable_value_regs(allocated)
     }
 
     /// Emit a machine instruction.

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1480,7 +1480,7 @@ impl<I: VCodeInst> VRegAllocator<I> {
     /// Allocate a fresh ValueRegs.
     pub fn alloc(&mut self, ty: Type) -> CodegenResult<ValueRegs<Reg>> {
         if self.deferred_error.is_some() {
-            return Err(self.deferred_error.unwrap());
+            return Err(CodegenError::CodeTooLarge);
         }
         let v = self.next_vreg;
         let (regclasses, tys) = I::rc_for_type(ty)?;

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1493,6 +1493,18 @@ impl<I: VCodeInst> VRegAllocator<I> {
         Ok(regs)
     }
 
+    /// Produce an bogus VReg placeholder with the proper number of
+    /// registers for the given type. This is meant to be used with
+    /// deferred allocation errors (see `Lower::alloc_tmp()`).
+    pub fn invalid(&self, ty: Type) -> ValueRegs<Reg> {
+        let (regclasses, _tys) = I::rc_for_type(ty).expect("must have valid type");
+        match regclasses {
+            &[rc0] => ValueRegs::one(VReg::new(0, rc0).into()),
+            &[rc0, rc1] => ValueRegs::two(VReg::new(0, rc0).into(), VReg::new(1, rc1).into()),
+            _ => panic!("Value must reside in 1 or 2 registers"),
+        }
+    }
+
     /// Set the type of this virtual register.
     pub fn set_vreg_type(&mut self, vreg: VirtualReg, ty: Type) {
         if self.vreg_types.len() <= vreg.index() {

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1479,6 +1479,9 @@ impl<I: VCodeInst> VRegAllocator<I> {
 
     /// Allocate a fresh ValueRegs.
     pub fn alloc(&mut self, ty: Type) -> CodegenResult<ValueRegs<Reg>> {
+        if self.deferred_error.is_some() {
+            return Err(self.deferred_error.unwrap());
+        }
         let v = self.next_vreg;
         let (regclasses, tys) = I::rc_for_type(ty)?;
         self.next_vreg += regclasses.len();

--- a/tests/all/code_too_large.rs
+++ b/tests/all/code_too_large.rs
@@ -1,0 +1,36 @@
+#![cfg(not(miri))]
+
+use anyhow::Result;
+use wasmtime::*;
+
+#[test]
+fn code_too_large_without_panic() -> Result<()> {
+    const N: usize = 120000;
+
+    // Build a module with a function whose body will allocate too many
+    // temporaries for our current (Cranelift-based) compiler backend to
+    // handle. This test ensures that we propagate the failure upward
+    // and return it programmatically, rather than panic'ing. If we ever
+    // improve our compiler backend to actually handle such a large
+    // function body, we'll need to increase the limits here too!
+    let mut s = String::new();
+    s.push_str("(module\n");
+    s.push_str("(table 1 1 funcref)\n");
+    s.push_str("(func (export \"\") (result i32)\n");
+    s.push_str("i32.const 0\n");
+    for _ in 0..N {
+        s.push_str("table.get 0\n");
+        s.push_str("ref.is_null\n");
+    }
+    s.push_str("))\n");
+
+    let store = Store::<()>::default();
+    let result = Module::new(store.engine(), &s);
+    match result {
+        Err(e) => assert!(e
+            .to_string()
+            .starts_with("Compilation error: Code for function is too large")),
+        Ok(_) => panic!("Please adjust limits to make the module too large to compile!"),
+    }
+    Ok(())
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -3,6 +3,7 @@
 mod async_functions;
 mod call_hook;
 mod cli_tests;
+mod code_too_large;
 mod component_model;
 mod coredump;
 mod custom_signal_handler;


### PR DESCRIPTION
Cranelift currently has a limit of `2^21` vregs per function body in VCode. This is a consequence of (performance-motivated) bitpacking of `Operand`s into `u32`s in regalloc2.

As a result of this, it is possible to produce a function body that will fail to compile by running out of vreg temporaries during lowering. Currently, this results in a panic. Ideally, we would propagate the error upward and return it programmatically.

This PR does that, with a "deferred error" mechanism. A cleaner solution would be to properly thread the `Result` types through all layers of lowering. However, that would require supporting `Result`s in ISLE, and that is a deeper language-design and `islec`-hacking question that I think we can tackle later if we continue to see motivating cases.

The deferral works by returning a valid but bogus `ValueReg`s to the lowering rule, but storing the error and checking for it in the toplevel lowering loop. (Note that we have to return a bogus `v0` rather than `VReg::invalid()`, because the latter causes the `ValueRegs` to think there is no register provided.)

This PR also includes a test at the Wasmtime level. Note that it takes ~22s to run on my (relatively fast) laptop, because it has to run until it runs out of VRegs in a debug build of the compiler. We could remove the test if we feel we're otherwise confident.

Thanks to Venkkatesh Sekar for reporting this issue! The integration test uses one of the example inputs from the report.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
