### PR TITLE
Remove `Table*Ext` traits for preview2

### DIFF
--- a/crates/test-programs/tests/reactor.rs
+++ b/crates/test-programs/tests/reactor.rs
@@ -102,10 +102,8 @@ async fn reactor_tests() -> Result<()> {
     // Note, this works because of the add_to_linker invocations using the
     // `host` crate for `streams`, not because of `with` in the bindgen macro.
     let writepipe = preview2::pipe::MemoryOutputPipe::new(4096);
-    let table_ix = preview2::TableStreamExt::push_output_stream(
-        store.data_mut().table_mut(),
-        Box::new(writepipe.clone()),
-    )?;
+    let stream: preview2::OutputStream = Box::new(writepipe.clone());
+    let table_ix = store.data_mut().table_mut().push_resource(stream)?;
     let r = reactor.call_write_strings_to(&mut store, table_ix).await?;
     assert_eq!(r, Ok(()));
 

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -19,7 +19,7 @@ use wasmtime::component::Resource;
 use wasmtime_wasi::preview2::{
     bindings::io::poll::Pollable,
     bindings::io::streams::{InputStream, OutputStream},
-    HostPollable, PollableFuture, TablePollableExt, TableStreamExt,
+    HostPollable, PollableFuture, TablePollableExt,
 };
 
 impl<T: WasiHttpView> crate::bindings::http::types::Host for T {
@@ -504,7 +504,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::Host for T {
         let body = self.table().get_outgoing_body(id)?;
         if let Some(stream) = body.body_output_stream.take() {
             let dummy = Resource::<u32>::new_own(id);
-            let id = self.table().push_output_stream_child(stream, dummy)?;
+            let id = self.table().push_child_resource(stream, &dummy)?;
             Ok(Ok(id))
         } else {
             Ok(Err(()))
@@ -558,7 +558,8 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostIncomingBody for T {
         let body = self.table().get_incoming_body(&id)?;
 
         if let Some(stream) = body.stream.take() {
-            let stream = self.table().push_input_stream_child(Box::new(stream), id)?;
+            let stream = InputStream::Host(Box::new(stream));
+            let stream = self.table().push_child_resource(stream, &id)?;
             return Ok(Ok(stream));
         }
 

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -17,9 +17,8 @@ use anyhow::Context;
 use std::any::Any;
 use wasmtime::component::Resource;
 use wasmtime_wasi::preview2::{
-    bindings::io::poll::Pollable,
     bindings::io::streams::{InputStream, OutputStream},
-    HostPollable, PollableFuture, TablePollableExt,
+    Pollable, PollableFuture,
 };
 
 impl<T: WasiHttpView> crate::bindings::http::types::Host for T {
@@ -360,9 +359,10 @@ impl<T: WasiHttpView> crate::bindings::http::types::Host for T {
             Box::pin(elem.downcast_mut::<HostFutureTrailers>().unwrap().ready())
         }
 
+        // FIXME: this should use `push_child_resource`
         let id = self
             .table()
-            .push_host_pollable(HostPollable::TableEntry { index, make_future })?;
+            .push_resource(Pollable::TableEntry { index, make_future })?;
 
         Ok(id)
     }
@@ -489,7 +489,8 @@ impl<T: WasiHttpView> crate::bindings::http::types::Host for T {
             )
         }
 
-        let pollable = self.table().push_host_pollable(HostPollable::TableEntry {
+        // FIXME: this should use `push_child_resource`
+        let pollable = self.table().push_resource(Pollable::TableEntry {
             index: id,
             make_future,
         })?;

--- a/crates/wasi/src/preview2/filesystem.rs
+++ b/crates/wasi/src/preview2/filesystem.rs
@@ -1,7 +1,6 @@
 use crate::preview2::bindings::filesystem::types;
 use crate::preview2::{
     AbortOnDropJoinHandle, HostOutputStream, OutputStreamError, StreamRuntimeError, StreamState,
-    TableError,
 };
 use anyhow::anyhow;
 use bytes::{Bytes, BytesMut};
@@ -14,10 +13,10 @@ pub enum Descriptor {
 }
 
 impl Descriptor {
-    pub fn file(&self) -> Result<&File, TableError> {
+    pub fn file(&self) -> Result<&File, types::ErrorCode> {
         match self {
             Descriptor::File(f) => Ok(f),
-            Descriptor::Dir(_) => Err(TableError::WrongType.into()),
+            Descriptor::Dir(_) => Err(types::ErrorCode::BadDescriptor),
         }
     }
 

--- a/crates/wasi/src/preview2/filesystem.rs
+++ b/crates/wasi/src/preview2/filesystem.rs
@@ -116,7 +116,7 @@ impl Dir {
     }
 }
 
-pub(crate) struct FileInputStream {
+pub struct FileInputStream {
     file: Arc<cap_std::fs::File>,
     position: u64,
 }

--- a/crates/wasi/src/preview2/filesystem.rs
+++ b/crates/wasi/src/preview2/filesystem.rs
@@ -1,13 +1,47 @@
-use crate::preview2::bindings::filesystem::types::{self, Descriptor};
+use crate::preview2::bindings::filesystem::types;
 use crate::preview2::{
     AbortOnDropJoinHandle, HostOutputStream, OutputStreamError, StreamRuntimeError, StreamState,
-    Table, TableError,
+    TableError,
 };
 use anyhow::anyhow;
 use bytes::{Bytes, BytesMut};
 use futures::future::{maybe_done, MaybeDone};
 use std::sync::Arc;
-use wasmtime::component::Resource;
+
+pub enum Descriptor {
+    File(File),
+    Dir(Dir),
+}
+
+impl Descriptor {
+    pub fn file(&self) -> Result<&File, TableError> {
+        match self {
+            Descriptor::File(f) => Ok(f),
+            Descriptor::Dir(_) => Err(TableError::WrongType.into()),
+        }
+    }
+
+    pub fn dir(&self) -> Result<&Dir, types::ErrorCode> {
+        match self {
+            Descriptor::Dir(d) => Ok(d),
+            Descriptor::File(_) => Err(types::ErrorCode::NotDirectory),
+        }
+    }
+
+    pub fn is_file(&self) -> bool {
+        match self {
+            Descriptor::File(_) => true,
+            Descriptor::Dir(_) => false,
+        }
+    }
+
+    pub fn is_dir(&self) -> bool {
+        match self {
+            Descriptor::File(_) => false,
+            Descriptor::Dir(_) => true,
+        }
+    }
+}
 
 bitflags::bitflags! {
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -17,7 +51,7 @@ bitflags::bitflags! {
     }
 }
 
-pub(crate) struct File {
+pub struct File {
     /// Wrapped in an Arc because the same underlying file is used for
     /// implementing the stream types. Also needed for [`spawn_blocking`].
     ///
@@ -45,45 +79,6 @@ impl File {
         tokio::task::spawn_blocking(move || body(&f)).await.unwrap()
     }
 }
-pub(crate) trait TableFsExt {
-    fn push_file(&mut self, file: File) -> Result<Resource<Descriptor>, TableError>;
-    fn delete_file(&mut self, fd: Resource<Descriptor>) -> Result<File, TableError>;
-    fn is_file(&self, fd: &Resource<Descriptor>) -> bool;
-    fn get_file(&self, fd: &Resource<Descriptor>) -> Result<&File, TableError>;
-
-    fn push_dir(&mut self, dir: Dir) -> Result<Resource<Descriptor>, TableError>;
-    fn delete_dir(&mut self, fd: Resource<Descriptor>) -> Result<Dir, TableError>;
-    fn is_dir(&self, fd: &Resource<Descriptor>) -> bool;
-    fn get_dir(&self, fd: &Resource<Descriptor>) -> Result<&Dir, TableError>;
-}
-
-impl TableFsExt for Table {
-    fn push_file(&mut self, file: File) -> Result<Resource<Descriptor>, TableError> {
-        Ok(Resource::new_own(self.push(Box::new(file))?))
-    }
-    fn delete_file(&mut self, fd: Resource<Descriptor>) -> Result<File, TableError> {
-        self.delete(fd.rep())
-    }
-    fn is_file(&self, fd: &Resource<Descriptor>) -> bool {
-        self.is::<File>(fd.rep())
-    }
-    fn get_file(&self, fd: &Resource<Descriptor>) -> Result<&File, TableError> {
-        self.get(fd.rep())
-    }
-
-    fn push_dir(&mut self, dir: Dir) -> Result<Resource<Descriptor>, TableError> {
-        Ok(Resource::new_own(self.push(Box::new(dir))?))
-    }
-    fn delete_dir(&mut self, fd: Resource<Descriptor>) -> Result<Dir, TableError> {
-        self.delete(fd.rep())
-    }
-    fn is_dir(&self, fd: &Resource<Descriptor>) -> bool {
-        self.is::<Dir>(fd.rep())
-    }
-    fn get_dir(&self, fd: &Resource<Descriptor>) -> Result<&Dir, TableError> {
-        self.get(fd.rep())
-    }
-}
 
 bitflags::bitflags! {
     #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -94,7 +89,7 @@ bitflags::bitflags! {
 }
 
 #[derive(Clone)]
-pub(crate) struct Dir {
+pub struct Dir {
     pub dir: Arc<cap_std::fs::Dir>,
     pub perms: DirPerms,
     pub file_perms: FilePerms,

--- a/crates/wasi/src/preview2/host/filesystem.rs
+++ b/crates/wasi/src/preview2/host/filesystem.rs
@@ -2,7 +2,7 @@ use crate::preview2::bindings::clocks::wall_clock;
 use crate::preview2::bindings::filesystem::types::{HostDescriptor, HostDirectoryEntryStream};
 use crate::preview2::bindings::filesystem::{preopens, types};
 use crate::preview2::bindings::io::streams;
-use crate::preview2::filesystem::{Dir, File, ReaddirIterator, TableFsExt};
+use crate::preview2::filesystem::{Descriptor, Dir, File, ReaddirIterator};
 use crate::preview2::{DirPerms, FilePerms, Table, TableError, WasiView};
 use anyhow::Context;
 use wasmtime::component::Resource;
@@ -25,7 +25,7 @@ impl<T: WasiView> preopens::Host for T {
         for (dir, name) in self.ctx().preopens.clone() {
             let fd = self
                 .table_mut()
-                .push_dir(dir)
+                .push_resource(Descriptor::Dir(dir))
                 .with_context(|| format!("failed to push preopen {name}"))?;
             results.push((fd, name));
         }
@@ -57,7 +57,7 @@ impl<T: WasiView> HostDescriptor for T {
             Advice::NoReuse => A::NoReuse,
         };
 
-        let f = self.table().get_file(&fd)?;
+        let f = self.table().get_resource(&fd)?.file()?;
         f.spawn_blocking(move |f| f.advise(offset, len, advice))
             .await?;
         Ok(())
@@ -65,28 +65,28 @@ impl<T: WasiView> HostDescriptor for T {
 
     async fn sync_data(&mut self, fd: Resource<types::Descriptor>) -> Result<(), types::Error> {
         let table = self.table();
-        if table.is_file(&fd) {
-            let f = table.get_file(&fd)?;
-            match f.spawn_blocking(|f| f.sync_data()).await {
-                Ok(()) => Ok(()),
-                // On windows, `sync_data` uses `FileFlushBuffers` which fails with
-                // `ERROR_ACCESS_DENIED` if the file is not upen for writing. Ignore
-                // this error, for POSIX compatibility.
-                #[cfg(windows)]
-                Err(e)
-                    if e.raw_os_error()
-                        == Some(windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED as _) =>
-                {
-                    Ok(())
+
+        match table.get_resource(&fd)? {
+            Descriptor::File(f) => {
+                match f.spawn_blocking(|f| f.sync_data()).await {
+                    Ok(()) => Ok(()),
+                    // On windows, `sync_data` uses `FileFlushBuffers` which fails with
+                    // `ERROR_ACCESS_DENIED` if the file is not upen for writing. Ignore
+                    // this error, for POSIX compatibility.
+                    #[cfg(windows)]
+                    Err(e)
+                        if e.raw_os_error()
+                            == Some(windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED as _) =>
+                    {
+                        Ok(())
+                    }
+                    Err(e) => Err(e.into()),
                 }
-                Err(e) => Err(e.into()),
             }
-        } else if table.is_dir(&fd) {
-            let d = table.get_dir(&fd)?;
-            d.spawn_blocking(|d| Ok(d.open(std::path::Component::CurDir)?.sync_data()?))
-                .await
-        } else {
-            Err(ErrorCode::BadDescriptor.into())
+            Descriptor::Dir(d) => {
+                d.spawn_blocking(|d| Ok(d.open(std::path::Component::CurDir)?.sync_data()?))
+                    .await
+            }
         }
     }
 
@@ -112,30 +112,29 @@ impl<T: WasiView> HostDescriptor for T {
         }
 
         let table = self.table();
-        if table.is_file(&fd) {
-            let f = table.get_file(&fd)?;
-            let flags = f.spawn_blocking(|f| f.get_fd_flags()).await?;
-            let mut flags = get_from_fdflags(flags);
-            if f.perms.contains(FilePerms::READ) {
-                flags |= DescriptorFlags::READ;
+        match table.get_resource(&fd)? {
+            Descriptor::File(f) => {
+                let flags = f.spawn_blocking(|f| f.get_fd_flags()).await?;
+                let mut flags = get_from_fdflags(flags);
+                if f.perms.contains(FilePerms::READ) {
+                    flags |= DescriptorFlags::READ;
+                }
+                if f.perms.contains(FilePerms::WRITE) {
+                    flags |= DescriptorFlags::WRITE;
+                }
+                Ok(flags)
             }
-            if f.perms.contains(FilePerms::WRITE) {
-                flags |= DescriptorFlags::WRITE;
+            Descriptor::Dir(d) => {
+                let flags = d.spawn_blocking(|d| d.get_fd_flags()).await?;
+                let mut flags = get_from_fdflags(flags);
+                if d.perms.contains(DirPerms::READ) {
+                    flags |= DescriptorFlags::READ;
+                }
+                if d.perms.contains(DirPerms::MUTATE) {
+                    flags |= DescriptorFlags::MUTATE_DIRECTORY;
+                }
+                Ok(flags)
             }
-            Ok(flags)
-        } else if table.is_dir(&fd) {
-            let d = table.get_dir(&fd)?;
-            let flags = d.spawn_blocking(|d| d.get_fd_flags()).await?;
-            let mut flags = get_from_fdflags(flags);
-            if d.perms.contains(DirPerms::READ) {
-                flags |= DescriptorFlags::READ;
-            }
-            if d.perms.contains(DirPerms::MUTATE) {
-                flags |= DescriptorFlags::MUTATE_DIRECTORY;
-            }
-            Ok(flags)
-        } else {
-            Err(ErrorCode::BadDescriptor.into())
         }
     }
 
@@ -145,14 +144,12 @@ impl<T: WasiView> HostDescriptor for T {
     ) -> Result<types::DescriptorType, types::Error> {
         let table = self.table();
 
-        if table.is_file(&fd) {
-            let f = table.get_file(&fd)?;
-            let meta = f.spawn_blocking(|f| f.metadata()).await?;
-            Ok(descriptortype_from(meta.file_type()))
-        } else if table.is_dir(&fd) {
-            Ok(types::DescriptorType::Directory)
-        } else {
-            Err(ErrorCode::BadDescriptor.into())
+        match table.get_resource(&fd)? {
+            Descriptor::File(f) => {
+                let meta = f.spawn_blocking(|f| f.metadata()).await?;
+                Ok(descriptortype_from(meta.file_type()))
+            }
+            Descriptor::Dir(_) => Ok(types::DescriptorType::Directory),
         }
     }
 
@@ -161,7 +158,7 @@ impl<T: WasiView> HostDescriptor for T {
         fd: Resource<types::Descriptor>,
         size: types::Filesize,
     ) -> Result<(), types::Error> {
-        let f = self.table().get_file(&fd)?;
+        let f = self.table().get_resource(&fd)?.file()?;
         if !f.perms.contains(FilePerms::WRITE) {
             Err(ErrorCode::NotPermitted)?;
         }
@@ -178,26 +175,25 @@ impl<T: WasiView> HostDescriptor for T {
         use fs_set_times::SetTimes;
 
         let table = self.table();
-        if table.is_file(&fd) {
-            let f = table.get_file(&fd)?;
-            if !f.perms.contains(FilePerms::WRITE) {
-                return Err(ErrorCode::NotPermitted.into());
+        match table.get_resource(&fd)? {
+            Descriptor::File(f) => {
+                if !f.perms.contains(FilePerms::WRITE) {
+                    return Err(ErrorCode::NotPermitted.into());
+                }
+                let atim = systemtimespec_from(atim)?;
+                let mtim = systemtimespec_from(mtim)?;
+                f.spawn_blocking(|f| f.set_times(atim, mtim)).await?;
+                Ok(())
             }
-            let atim = systemtimespec_from(atim)?;
-            let mtim = systemtimespec_from(mtim)?;
-            f.spawn_blocking(|f| f.set_times(atim, mtim)).await?;
-            Ok(())
-        } else if table.is_dir(&fd) {
-            let d = table.get_dir(&fd)?;
-            if !d.perms.contains(DirPerms::MUTATE) {
-                return Err(ErrorCode::NotPermitted.into());
+            Descriptor::Dir(d) => {
+                if !d.perms.contains(DirPerms::MUTATE) {
+                    return Err(ErrorCode::NotPermitted.into());
+                }
+                let atim = systemtimespec_from(atim)?;
+                let mtim = systemtimespec_from(mtim)?;
+                d.spawn_blocking(|d| d.set_times(atim, mtim)).await?;
+                Ok(())
             }
-            let atim = systemtimespec_from(atim)?;
-            let mtim = systemtimespec_from(mtim)?;
-            d.spawn_blocking(|d| d.set_times(atim, mtim)).await?;
-            Ok(())
-        } else {
-            Err(ErrorCode::BadDescriptor.into())
         }
     }
 
@@ -212,7 +208,7 @@ impl<T: WasiView> HostDescriptor for T {
 
         let table = self.table();
 
-        let f = table.get_file(&fd)?;
+        let f = table.get_resource(&fd)?.file()?;
         if !f.perms.contains(FilePerms::READ) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -249,7 +245,7 @@ impl<T: WasiView> HostDescriptor for T {
         use system_interface::fs::FileIoExt;
 
         let table = self.table();
-        let f = table.get_file(&fd)?;
+        let f = table.get_resource(&fd)?.file()?;
         if !f.perms.contains(FilePerms::WRITE) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -266,7 +262,7 @@ impl<T: WasiView> HostDescriptor for T {
         fd: Resource<types::Descriptor>,
     ) -> Result<Resource<types::DirectoryEntryStream>, types::Error> {
         let table = self.table_mut();
-        let d = table.get_dir(&fd)?;
+        let d = table.get_resource(&fd)?.dir()?;
         if !d.perms.contains(DirPerms::READ) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -328,28 +324,28 @@ impl<T: WasiView> HostDescriptor for T {
 
     async fn sync(&mut self, fd: Resource<types::Descriptor>) -> Result<(), types::Error> {
         let table = self.table();
-        if table.is_file(&fd) {
-            let f = table.get_file(&fd)?;
-            match f.spawn_blocking(|f| f.sync_all()).await {
-                Ok(()) => Ok(()),
-                // On windows, `sync_data` uses `FileFlushBuffers` which fails with
-                // `ERROR_ACCESS_DENIED` if the file is not upen for writing. Ignore
-                // this error, for POSIX compatibility.
-                #[cfg(windows)]
-                Err(e)
-                    if e.raw_os_error()
-                        == Some(windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED as _) =>
-                {
-                    Ok(())
+
+        match table.get_resource(&fd)? {
+            Descriptor::File(f) => {
+                match f.spawn_blocking(|f| f.sync_all()).await {
+                    Ok(()) => Ok(()),
+                    // On windows, `sync_data` uses `FileFlushBuffers` which fails with
+                    // `ERROR_ACCESS_DENIED` if the file is not upen for writing. Ignore
+                    // this error, for POSIX compatibility.
+                    #[cfg(windows)]
+                    Err(e)
+                        if e.raw_os_error()
+                            == Some(windows_sys::Win32::Foundation::ERROR_ACCESS_DENIED as _) =>
+                    {
+                        Ok(())
+                    }
+                    Err(e) => Err(e.into()),
                 }
-                Err(e) => Err(e.into()),
             }
-        } else if table.is_dir(&fd) {
-            let d = table.get_dir(&fd)?;
-            d.spawn_blocking(|d| Ok(d.open(std::path::Component::CurDir)?.sync_all()?))
-                .await
-        } else {
-            Err(ErrorCode::BadDescriptor.into())
+            Descriptor::Dir(d) => {
+                d.spawn_blocking(|d| Ok(d.open(std::path::Component::CurDir)?.sync_all()?))
+                    .await
+            }
         }
     }
 
@@ -359,7 +355,7 @@ impl<T: WasiView> HostDescriptor for T {
         path: String,
     ) -> Result<(), types::Error> {
         let table = self.table();
-        let d = table.get_dir(&fd)?;
+        let d = table.get_resource(&fd)?.dir()?;
         if !d.perms.contains(DirPerms::MUTATE) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -372,18 +368,17 @@ impl<T: WasiView> HostDescriptor for T {
         fd: Resource<types::Descriptor>,
     ) -> Result<types::DescriptorStat, types::Error> {
         let table = self.table();
-        if table.is_file(&fd) {
-            let f = table.get_file(&fd)?;
-            // No permissions check on stat: if opened, allowed to stat it
-            let meta = f.spawn_blocking(|f| f.metadata()).await?;
-            Ok(descriptorstat_from(meta))
-        } else if table.is_dir(&fd) {
-            let d = table.get_dir(&fd)?;
-            // No permissions check on stat: if opened, allowed to stat it
-            let meta = d.spawn_blocking(|d| d.dir_metadata()).await?;
-            Ok(descriptorstat_from(meta))
-        } else {
-            Err(ErrorCode::BadDescriptor.into())
+        match table.get_resource(&fd)? {
+            Descriptor::File(f) => {
+                // No permissions check on stat: if opened, allowed to stat it
+                let meta = f.spawn_blocking(|f| f.metadata()).await?;
+                Ok(descriptorstat_from(meta))
+            }
+            Descriptor::Dir(d) => {
+                // No permissions check on stat: if opened, allowed to stat it
+                let meta = d.spawn_blocking(|d| d.dir_metadata()).await?;
+                Ok(descriptorstat_from(meta))
+            }
         }
     }
 
@@ -394,7 +389,7 @@ impl<T: WasiView> HostDescriptor for T {
         path: String,
     ) -> Result<types::DescriptorStat, types::Error> {
         let table = self.table();
-        let d = table.get_dir(&fd)?;
+        let d = table.get_resource(&fd)?.dir()?;
         if !d.perms.contains(DirPerms::READ) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -418,7 +413,7 @@ impl<T: WasiView> HostDescriptor for T {
         use cap_fs_ext::DirExt;
 
         let table = self.table();
-        let d = table.get_dir(&fd)?;
+        let d = table.get_resource(&fd)?.dir()?;
         if !d.perms.contains(DirPerms::MUTATE) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -456,11 +451,11 @@ impl<T: WasiView> HostDescriptor for T {
         new_path: String,
     ) -> Result<(), types::Error> {
         let table = self.table();
-        let old_dir = table.get_dir(&fd)?;
+        let old_dir = table.get_resource(&fd)?.dir()?;
         if !old_dir.perms.contains(DirPerms::MUTATE) {
             return Err(ErrorCode::NotPermitted.into());
         }
-        let new_dir = table.get_dir(&new_descriptor)?;
+        let new_dir = table.get_resource(&new_descriptor)?.dir()?;
         if !new_dir.perms.contains(DirPerms::MUTATE) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -490,10 +485,7 @@ impl<T: WasiView> HostDescriptor for T {
         use types::{DescriptorFlags, OpenFlags};
 
         let table = self.table_mut();
-        if table.is_file(&fd) {
-            Err(ErrorCode::NotDirectory)?;
-        }
-        let d = table.get_dir(&fd)?;
+        let d = table.get_resource(&fd)?.dir()?;
         if !d.perms.contains(DirPerms::READ) {
             Err(ErrorCode::NotPermitted)?;
         }
@@ -582,11 +574,14 @@ impl<T: WasiView> HostDescriptor for T {
             .await?;
 
         match opened {
-            OpenResult::Dir(dir) => Ok(table.push_dir(Dir::new(dir, d.perms, d.file_perms))?),
-
-            OpenResult::File(file) => {
-                Ok(table.push_file(File::new(file, mask_file_perms(d.file_perms, flags)))?)
+            OpenResult::Dir(dir) => {
+                Ok(table.push_resource(Descriptor::Dir(Dir::new(dir, d.perms, d.file_perms)))?)
             }
+
+            OpenResult::File(file) => Ok(table.push_resource(Descriptor::File(File::new(
+                file,
+                mask_file_perms(d.file_perms, flags),
+            )))?),
 
             OpenResult::NotDir => Err(ErrorCode::NotDirectory.into()),
         }
@@ -600,9 +595,7 @@ impl<T: WasiView> HostDescriptor for T {
         // tokio::fs::File just uses std::fs::File's Drop impl to close, so
         // it doesn't appear anyone else has found this to be a problem.
         // (Not that they could solve it without async drop...)
-        if table.delete_file(Resource::new_own(fd.rep())).is_err() {
-            table.delete_dir(fd)?;
-        }
+        table.delete_resource(fd)?;
 
         Ok(())
     }
@@ -613,7 +606,7 @@ impl<T: WasiView> HostDescriptor for T {
         path: String,
     ) -> Result<String, types::Error> {
         let table = self.table();
-        let d = table.get_dir(&fd)?;
+        let d = table.get_resource(&fd)?.dir()?;
         if !d.perms.contains(DirPerms::READ) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -630,7 +623,7 @@ impl<T: WasiView> HostDescriptor for T {
         path: String,
     ) -> Result<(), types::Error> {
         let table = self.table();
-        let d = table.get_dir(&fd)?;
+        let d = table.get_resource(&fd)?.dir()?;
         if !d.perms.contains(DirPerms::MUTATE) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -645,11 +638,11 @@ impl<T: WasiView> HostDescriptor for T {
         new_path: String,
     ) -> Result<(), types::Error> {
         let table = self.table();
-        let old_dir = table.get_dir(&fd)?;
+        let old_dir = table.get_resource(&fd)?.dir()?;
         if !old_dir.perms.contains(DirPerms::MUTATE) {
             return Err(ErrorCode::NotPermitted.into());
         }
-        let new_dir = table.get_dir(&new_fd)?;
+        let new_dir = table.get_resource(&new_fd)?.dir()?;
         if !new_dir.perms.contains(DirPerms::MUTATE) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -670,7 +663,7 @@ impl<T: WasiView> HostDescriptor for T {
         use cap_fs_ext::DirExt;
 
         let table = self.table();
-        let d = table.get_dir(&fd)?;
+        let d = table.get_resource(&fd)?.dir()?;
         if !d.perms.contains(DirPerms::MUTATE) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -686,7 +679,7 @@ impl<T: WasiView> HostDescriptor for T {
         use cap_fs_ext::DirExt;
 
         let table = self.table();
-        let d = table.get_dir(&fd)?;
+        let d = table.get_resource(&fd)?.dir()?;
         if !d.perms.contains(DirPerms::MUTATE) {
             return Err(ErrorCode::NotPermitted.into());
         }
@@ -764,7 +757,7 @@ impl<T: WasiView> HostDescriptor for T {
         };
 
         // Trap if fd lookup fails:
-        let f = self.table().get_file(&fd)?;
+        let f = self.table().get_resource(&fd)?.file()?;
 
         if !f.perms.contains(FilePerms::READ) {
             Err(types::ErrorCode::BadDescriptor)?;
@@ -791,7 +784,7 @@ impl<T: WasiView> HostDescriptor for T {
         use crate::preview2::{filesystem::FileOutputStream, TableStreamExt};
 
         // Trap if fd lookup fails:
-        let f = self.table().get_file(&fd)?;
+        let f = self.table().get_resource(&fd)?.file()?;
 
         if !f.perms.contains(FilePerms::WRITE) {
             Err(types::ErrorCode::BadDescriptor)?;
@@ -816,7 +809,7 @@ impl<T: WasiView> HostDescriptor for T {
         use crate::preview2::{filesystem::FileOutputStream, TableStreamExt};
 
         // Trap if fd lookup fails:
-        let f = self.table().get_file(&fd)?;
+        let f = self.table().get_resource(&fd)?.file()?;
 
         if !f.perms.contains(FilePerms::WRITE) {
             Err(types::ErrorCode::BadDescriptor)?;
@@ -874,7 +867,7 @@ impl<T: WasiView> HostDescriptor for T {
         path: String,
     ) -> Result<types::MetadataHashValue, types::Error> {
         let table = self.table();
-        let d = table.get_dir(&fd)?;
+        let d = table.get_resource(&fd)?.dir()?;
         // No permissions check on metadata: if dir opened, allowed to stat it
         let meta = d
             .spawn_blocking(move |d| {
@@ -910,16 +903,15 @@ async fn get_descriptor_metadata(
     table: &Table,
     fd: Resource<types::Descriptor>,
 ) -> Result<cap_std::fs::Metadata, types::Error> {
-    if table.is_file(&fd) {
-        let f = table.get_file(&fd)?;
-        // No permissions check on metadata: if opened, allowed to stat it
-        Ok(f.spawn_blocking(|f| f.metadata()).await?)
-    } else if table.is_dir(&fd) {
-        let d = table.get_dir(&fd)?;
-        // No permissions check on metadata: if opened, allowed to stat it
-        Ok(d.spawn_blocking(|d| d.dir_metadata()).await?)
-    } else {
-        Err(ErrorCode::BadDescriptor.into())
+    match table.get_resource(&fd)? {
+        Descriptor::File(f) => {
+            // No permissions check on metadata: if opened, allowed to stat it
+            Ok(f.spawn_blocking(|f| f.metadata()).await?)
+        }
+        Descriptor::Dir(d) => {
+            // No permissions check on metadata: if opened, allowed to stat it
+            Ok(d.spawn_blocking(|d| d.dir_metadata()).await?)
+        }
     }
 }
 

--- a/crates/wasi/src/preview2/host/instance_network.rs
+++ b/crates/wasi/src/preview2/host/instance_network.rs
@@ -1,12 +1,12 @@
-use crate::preview2::bindings::sockets::instance_network::{self, Network};
-use crate::preview2::network::{HostNetworkState, TableNetworkExt};
+use crate::preview2::bindings::sockets::instance_network;
+use crate::preview2::network::Network;
 use crate::preview2::WasiView;
 use wasmtime::component::Resource;
 
 impl<T: WasiView> instance_network::Host for T {
     fn instance_network(&mut self) -> Result<Resource<Network>, anyhow::Error> {
-        let network = HostNetworkState::new(self.ctx().pool.clone());
-        let network = self.table_mut().push_network(network)?;
+        let network = Network::new(self.ctx().pool.clone());
+        let network = self.table_mut().push_resource(network)?;
         Ok(network)
     }
 }

--- a/crates/wasi/src/preview2/host/io.rs
+++ b/crates/wasi/src/preview2/host/io.rs
@@ -1,12 +1,8 @@
 use crate::preview2::{
     bindings::io::poll::Pollable,
     bindings::io::streams::{self, InputStream, OutputStream},
-    filesystem::FileInputStream,
     poll::PollableFuture,
-    stream::{
-        HostInputStream, HostOutputStream, InternalInputStream, InternalTableStreamExt,
-        OutputStreamError, StreamRuntimeError, StreamState, TableStreamExt,
-    },
+    stream::{OutputStreamError, StreamRuntimeError, StreamState},
     HostPollable, TableError, TablePollableExt, WasiView,
 };
 use std::any::Any;
@@ -48,12 +44,12 @@ impl<T: WasiView> streams::Host for T {}
 #[async_trait::async_trait]
 impl<T: WasiView> streams::HostOutputStream for T {
     fn drop(&mut self, stream: Resource<OutputStream>) -> anyhow::Result<()> {
-        self.table_mut().delete_output_stream(stream)?;
+        self.table_mut().delete_resource(stream)?;
         Ok(())
     }
 
     fn check_write(&mut self, stream: Resource<OutputStream>) -> Result<u64, streams::Error> {
-        let s = self.table_mut().get_output_stream_mut(&stream)?;
+        let s = self.table_mut().get_resource_mut(&stream)?;
         let mut ready = s.write_ready();
         let mut task = Context::from_waker(futures::task::noop_waker_ref());
         match Pin::new(&mut ready).poll(&mut task) {
@@ -68,19 +64,17 @@ impl<T: WasiView> streams::HostOutputStream for T {
         stream: Resource<OutputStream>,
         bytes: Vec<u8>,
     ) -> Result<(), streams::Error> {
-        let s = self.table_mut().get_output_stream_mut(&stream)?;
-        HostOutputStream::write(s, bytes.into())?;
+        self.table_mut()
+            .get_resource_mut(&stream)?
+            .write(bytes.into())?;
         Ok(())
     }
 
     fn subscribe(&mut self, stream: Resource<OutputStream>) -> anyhow::Result<Resource<Pollable>> {
-        // Ensure that table element is an output-stream:
-        let _ = self.table_mut().get_output_stream_mut(&stream)?;
-
         fn output_stream_ready<'a>(stream: &'a mut dyn Any) -> PollableFuture<'a> {
             let stream = stream
-                .downcast_mut::<Box<dyn HostOutputStream>>()
-                .expect("downcast to HostOutputStream failed");
+                .downcast_mut::<OutputStream>()
+                .expect("downcast to OutputStream failed");
             Box::pin(async move {
                 let _ = stream.write_ready().await?;
                 Ok(())
@@ -100,7 +94,7 @@ impl<T: WasiView> streams::HostOutputStream for T {
         stream: Resource<OutputStream>,
         bytes: Vec<u8>,
     ) -> Result<(), streams::Error> {
-        let s = self.table_mut().get_output_stream_mut(&stream)?;
+        let s = self.table_mut().get_resource_mut(&stream)?;
 
         if bytes.len() > 4096 {
             return Err(streams::Error::trap(anyhow::anyhow!(
@@ -113,11 +107,11 @@ impl<T: WasiView> streams::HostOutputStream for T {
             let permit = s.write_ready().await?;
             let len = bytes.len().min(permit);
             let chunk = bytes.split_to(len);
-            HostOutputStream::write(s, chunk)?;
+            s.write(chunk)?;
         }
 
-        HostOutputStream::flush(s)?;
-        let _ = s.write_ready().await?;
+        s.flush()?;
+        s.write_ready().await?;
 
         Ok(())
     }
@@ -127,7 +121,7 @@ impl<T: WasiView> streams::HostOutputStream for T {
         stream: Resource<OutputStream>,
         len: u64,
     ) -> Result<(), streams::Error> {
-        let s = self.table_mut().get_output_stream_mut(&stream)?;
+        let s = self.table_mut().get_resource_mut(&stream)?;
 
         if len > 4096 {
             return Err(streams::Error::trap(anyhow::anyhow!(
@@ -139,12 +133,12 @@ impl<T: WasiView> streams::HostOutputStream for T {
         while len > 0 {
             let permit = s.write_ready().await?;
             let this_len = len.min(permit as u64);
-            HostOutputStream::write_zeroes(s, this_len as usize)?;
+            s.write_zeroes(this_len as usize)?;
             len -= this_len;
         }
 
-        HostOutputStream::flush(s)?;
-        let _ = s.write_ready().await?;
+        s.flush()?;
+        s.write_ready().await?;
 
         Ok(())
     }
@@ -154,14 +148,14 @@ impl<T: WasiView> streams::HostOutputStream for T {
         stream: Resource<OutputStream>,
         len: u64,
     ) -> Result<(), streams::Error> {
-        let s = self.table_mut().get_output_stream_mut(&stream)?;
-        HostOutputStream::write_zeroes(s, len as usize)?;
+        self.table_mut()
+            .get_resource_mut(&stream)?
+            .write_zeroes(len as usize)?;
         Ok(())
     }
 
     fn flush(&mut self, stream: Resource<OutputStream>) -> Result<(), streams::Error> {
-        let s = self.table_mut().get_output_stream_mut(&stream)?;
-        HostOutputStream::flush(s)?;
+        self.table_mut().get_resource_mut(&stream)?.flush()?;
         Ok(())
     }
 
@@ -169,9 +163,9 @@ impl<T: WasiView> streams::HostOutputStream for T {
         &mut self,
         stream: Resource<OutputStream>,
     ) -> Result<(), streams::Error> {
-        let s = self.table_mut().get_output_stream_mut(&stream)?;
-        HostOutputStream::flush(s)?;
-        let _ = s.write_ready().await?;
+        let s = self.table_mut().get_resource_mut(&stream)?;
+        s.flush()?;
+        s.write_ready().await?;
         Ok(())
     }
 
@@ -194,7 +188,7 @@ impl<T: WasiView> streams::HostOutputStream for T {
             ?;
         let d: &mut Box<dyn crate::OutputStream> = ctx
             .table_mut()
-            .get_output_stream_mut(dst)
+            .get_resource_mut(dst)
             ?;
 
         let bytes_spliced: u64 = s.splice(&mut **d, len).await?;
@@ -233,7 +227,7 @@ impl<T: WasiView> streams::HostOutputStream for T {
             ?;
         let d: &mut Box<dyn crate::OutputStream> = ctx
             .table_mut()
-            .get_output_stream_mut(dst)
+            .get_resource_mut(dst)
             ?;
 
         let bytes_spliced: u64 = s.splice(&mut **d, len).await?;
@@ -248,7 +242,7 @@ impl<T: WasiView> streams::HostOutputStream for T {
 #[async_trait::async_trait]
 impl<T: WasiView> streams::HostInputStream for T {
     fn drop(&mut self, stream: Resource<InputStream>) -> anyhow::Result<()> {
-        self.table_mut().delete_internal_input_stream(stream)?;
+        self.table_mut().delete_resource(stream)?;
         Ok(())
     }
 
@@ -257,9 +251,9 @@ impl<T: WasiView> streams::HostInputStream for T {
         stream: Resource<InputStream>,
         len: u64,
     ) -> anyhow::Result<Result<(Vec<u8>, streams::StreamStatus), ()>> {
-        match self.table_mut().get_internal_input_stream_mut(&stream)? {
-            InternalInputStream::Host(s) => {
-                let (bytes, state) = match HostInputStream::read(s.as_mut(), len as usize) {
+        match self.table_mut().get_resource_mut(&stream)? {
+            InputStream::Host(s) => {
+                let (bytes, state) = match s.read(len as usize) {
                     Ok(a) => a,
                     Err(e) => {
                         if let Some(e) = e.downcast_ref::<StreamRuntimeError>() {
@@ -274,8 +268,8 @@ impl<T: WasiView> streams::HostInputStream for T {
 
                 Ok(Ok((bytes.into(), state.into())))
             }
-            InternalInputStream::File(s) => {
-                let (bytes, state) = match FileInputStream::read(s, len as usize).await {
+            InputStream::File(s) => {
+                let (bytes, state) = match s.read(len as usize).await {
                     Ok(a) => a,
                     Err(e) => {
                         if let Some(e) = e.downcast_ref::<StreamRuntimeError>() {
@@ -296,38 +290,10 @@ impl<T: WasiView> streams::HostInputStream for T {
         stream: Resource<InputStream>,
         len: u64,
     ) -> anyhow::Result<Result<(Vec<u8>, streams::StreamStatus), ()>> {
-        match self.table_mut().get_internal_input_stream_mut(&stream)? {
-            InternalInputStream::Host(s) => {
-                s.ready().await?;
-                let (bytes, state) = match HostInputStream::read(s.as_mut(), len as usize) {
-                    Ok(a) => a,
-                    Err(e) => {
-                        if let Some(e) = e.downcast_ref::<StreamRuntimeError>() {
-                            tracing::debug!("stream runtime error: {e:?}");
-                            return Ok(Err(()));
-                        } else {
-                            return Err(e);
-                        }
-                    }
-                };
-                debug_assert!(bytes.len() <= len as usize);
-                Ok(Ok((bytes.into(), state.into())))
-            }
-            InternalInputStream::File(s) => {
-                let (bytes, state) = match FileInputStream::read(s, len as usize).await {
-                    Ok(a) => a,
-                    Err(e) => {
-                        if let Some(e) = e.downcast_ref::<StreamRuntimeError>() {
-                            tracing::debug!("stream runtime error: {e:?}");
-                            return Ok(Err(()));
-                        } else {
-                            return Err(e);
-                        }
-                    }
-                };
-                Ok(Ok((bytes.into(), state.into())))
-            }
+        if let InputStream::Host(s) = self.table_mut().get_resource_mut(&stream)? {
+            s.ready().await?;
         }
+        self.read(stream, len).await
     }
 
     async fn skip(
@@ -335,10 +301,10 @@ impl<T: WasiView> streams::HostInputStream for T {
         stream: Resource<InputStream>,
         len: u64,
     ) -> anyhow::Result<Result<(u64, streams::StreamStatus), ()>> {
-        match self.table_mut().get_internal_input_stream_mut(&stream)? {
-            InternalInputStream::Host(s) => {
+        match self.table_mut().get_resource_mut(&stream)? {
+            InputStream::Host(s) => {
                 // TODO: the cast to usize should be fallible, use `.try_into()?`
-                let (bytes_skipped, state) = match HostInputStream::skip(s.as_mut(), len as usize) {
+                let (bytes_skipped, state) = match s.skip(len as usize) {
                     Ok(a) => a,
                     Err(e) => {
                         if let Some(e) = e.downcast_ref::<StreamRuntimeError>() {
@@ -352,8 +318,8 @@ impl<T: WasiView> streams::HostInputStream for T {
 
                 Ok(Ok((bytes_skipped as u64, state.into())))
             }
-            InternalInputStream::File(s) => {
-                let (bytes_skipped, state) = match FileInputStream::skip(s, len as usize).await {
+            InputStream::File(s) => {
+                let (bytes_skipped, state) = match s.skip(len as usize).await {
                     Ok(a) => a,
                     Err(e) => {
                         if let Some(e) = e.downcast_ref::<StreamRuntimeError>() {
@@ -374,51 +340,22 @@ impl<T: WasiView> streams::HostInputStream for T {
         stream: Resource<InputStream>,
         len: u64,
     ) -> anyhow::Result<Result<(u64, streams::StreamStatus), ()>> {
-        match self.table_mut().get_internal_input_stream_mut(&stream)? {
-            InternalInputStream::Host(s) => {
-                s.ready().await?;
-                // TODO: the cast to usize should be fallible, use `.try_into()?`
-                let (bytes_skipped, state) = match HostInputStream::skip(s.as_mut(), len as usize) {
-                    Ok(a) => a,
-                    Err(e) => {
-                        if let Some(e) = e.downcast_ref::<StreamRuntimeError>() {
-                            tracing::debug!("stream runtime error: {e:?}");
-                            return Ok(Err(()));
-                        } else {
-                            return Err(e);
-                        }
-                    }
-                };
-
-                Ok(Ok((bytes_skipped as u64, state.into())))
-            }
-            InternalInputStream::File(s) => {
-                let (bytes_skipped, state) = match FileInputStream::skip(s, len as usize).await {
-                    Ok(a) => a,
-                    Err(e) => {
-                        if let Some(e) = e.downcast_ref::<StreamRuntimeError>() {
-                            tracing::debug!("stream runtime error: {e:?}");
-                            return Ok(Err(()));
-                        } else {
-                            return Err(e);
-                        }
-                    }
-                };
-                Ok(Ok((bytes_skipped as u64, state.into())))
-            }
+        if let InputStream::Host(s) = self.table_mut().get_resource_mut(&stream)? {
+            s.ready().await?;
         }
+        self.skip(stream, len).await
     }
 
     fn subscribe(&mut self, stream: Resource<InputStream>) -> anyhow::Result<Resource<Pollable>> {
         // Ensure that table element is an input-stream:
-        let pollable = match self.table_mut().get_internal_input_stream_mut(&stream)? {
-            InternalInputStream::Host(_) => {
+        let pollable = match self.table_mut().get_resource(&stream)? {
+            InputStream::Host(_) => {
                 fn input_stream_ready<'a>(stream: &'a mut dyn Any) -> PollableFuture<'a> {
                     let stream = stream
-                        .downcast_mut::<InternalInputStream>()
-                        .expect("downcast to InternalInputStream failed");
+                        .downcast_mut::<InputStream>()
+                        .expect("downcast to InputStream failed");
                     match *stream {
-                        InternalInputStream::Host(ref mut hs) => hs.ready(),
+                        InputStream::Host(ref mut hs) => hs.ready(),
                         _ => unreachable!(),
                     }
                 }
@@ -430,7 +367,7 @@ impl<T: WasiView> streams::HostInputStream for T {
             }
             // Files are always "ready" immediately (because we have no way to actually wait on
             // readiness in epoll)
-            InternalInputStream::File(_) => {
+            InputStream::File(_) => {
                 HostPollable::Closure(Box::new(|| Box::pin(futures::future::ready(Ok(())))))
             }
         };

--- a/crates/wasi/src/preview2/host/network.rs
+++ b/crates/wasi/src/preview2/host/network.rs
@@ -2,7 +2,6 @@ use crate::preview2::bindings::sockets::network::{
     self, ErrorCode, IpAddressFamily, IpSocketAddress, Ipv4Address, Ipv4SocketAddress, Ipv6Address,
     Ipv6SocketAddress,
 };
-use crate::preview2::network::TableNetworkExt;
 use crate::preview2::{TableError, WasiView};
 use std::io;
 use wasmtime::component::Resource;
@@ -13,7 +12,7 @@ impl<T: WasiView> crate::preview2::bindings::sockets::network::HostNetwork for T
     fn drop(&mut self, this: Resource<network::Network>) -> Result<(), anyhow::Error> {
         let table = self.table_mut();
 
-        table.delete_network(this)?;
+        table.delete_resource(this)?;
 
         Ok(())
     }

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -4,7 +4,6 @@ use crate::preview2::bindings::{
     sockets::network::{self, ErrorCode, IpAddressFamily, IpSocketAddress, Network},
     sockets::tcp::{self, ShutdownType},
 };
-use crate::preview2::network::TableNetworkExt;
 use crate::preview2::poll::TablePollableExt;
 use crate::preview2::stream::TableStreamExt;
 use crate::preview2::tcp::{HostTcpSocketState, HostTcpState, TableTcpSocketExt};
@@ -35,7 +34,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
             _ => return Err(ErrorCode::NotInProgress.into()),
         }
 
-        let network = table.get_network(&network)?;
+        let network = table.get_resource(&network)?;
         let binder = network.0.tcp_binder(local_address)?;
 
         // Perform the OS bind call.
@@ -79,7 +78,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
                 _ => return Err(ErrorCode::NotInProgress.into()),
             }
 
-            let network = table.get_network(&network)?;
+            let network = table.get_resource(&network)?;
             let connecter = network.0.tcp_connecter(remote_address)?;
 
             // Do an OS `connect`. Our socket is non-blocking, so it'll either...

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -1,12 +1,10 @@
 use crate::preview2::bindings::{
-    io::poll::Pollable,
     io::streams::{InputStream, OutputStream},
     sockets::network::{self, ErrorCode, IpAddressFamily, IpSocketAddress, Network},
     sockets::tcp::{self, ShutdownType},
 };
-use crate::preview2::poll::TablePollableExt;
 use crate::preview2::tcp::{TcpSocket, TcpState};
-use crate::preview2::{HostPollable, PollableFuture, WasiView};
+use crate::preview2::{Pollable, PollableFuture, WasiView};
 use cap_net_ext::{Blocking, PoolExt, TcpListenerExt};
 use cap_std::net::TcpListener;
 use io_lifetimes::AsSocketlike;
@@ -468,12 +466,12 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
             join
         }
 
-        let pollable = HostPollable::TableEntry {
+        let pollable = Pollable::TableEntry {
             index: this.rep(),
             make_future: make_tcp_socket_future,
         };
 
-        Ok(self.table_mut().push_host_pollable(pollable)?)
+        Ok(self.table_mut().push_child_resource(pollable, &this)?)
     }
 
     fn shutdown(

--- a/crates/wasi/src/preview2/host/tcp_create_socket.rs
+++ b/crates/wasi/src/preview2/host/tcp_create_socket.rs
@@ -1,9 +1,8 @@
 use crate::preview2::bindings::{
     sockets::network::{self, IpAddressFamily},
-    sockets::tcp::TcpSocket,
     sockets::tcp_create_socket,
 };
-use crate::preview2::tcp::{HostTcpSocketState, TableTcpSocketExt};
+use crate::preview2::tcp::TcpSocket;
 use crate::preview2::WasiView;
 use wasmtime::component::Resource;
 
@@ -12,8 +11,8 @@ impl<T: WasiView> tcp_create_socket::Host for T {
         &mut self,
         address_family: IpAddressFamily,
     ) -> Result<Resource<TcpSocket>, network::Error> {
-        let socket = HostTcpSocketState::new(address_family.into())?;
-        let socket = self.table_mut().push_tcp_socket(socket)?;
+        let socket = TcpSocket::new(address_family.into())?;
+        let socket = self.table_mut().push_resource(socket)?;
         Ok(socket)
     }
 }

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -37,7 +37,7 @@ pub use self::clocks::{HostMonotonicClock, HostWallClock};
 pub use self::ctx::{WasiCtx, WasiCtxBuilder, WasiView};
 pub use self::error::I32Exit;
 pub use self::filesystem::{DirPerms, FilePerms};
-pub use self::poll::{ClosureFuture, HostPollable, MakeFuture, PollableFuture, TablePollableExt};
+pub use self::poll::{ClosureFuture, MakeFuture, Pollable, PollableFuture};
 pub use self::random::{thread_rng, Deterministic};
 pub use self::stdio::{stderr, stdin, stdout, IsATTY, Stderr, Stdin, Stdout};
 pub use self::stream::{
@@ -152,6 +152,7 @@ pub mod bindings {
             "wasi:filesystem/types/descriptor": super::filesystem::Descriptor,
             "wasi:io/streams/input-stream": super::stream::InputStream,
             "wasi:io/streams/output-stream": super::stream::OutputStream,
+            "wasi:io/poll/pollable": super::poll::Pollable,
         },
     });
 

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -42,7 +42,6 @@ pub use self::random::{thread_rng, Deterministic};
 pub use self::stdio::{stderr, stdin, stdout, IsATTY, Stderr, Stdin, Stdout};
 pub use self::stream::{
     HostInputStream, HostOutputStream, OutputStreamError, StreamRuntimeError, StreamState,
-    TableStreamExt,
 };
 pub use self::table::{OccupiedEntry, Table, TableError};
 pub use cap_fs_ext::SystemTimeSpec;
@@ -151,6 +150,8 @@ pub mod bindings {
             "wasi:sockets/tcp/tcp-socket": super::tcp::TcpSocket,
             "wasi:filesystem/types/directory-entry-stream": super::filesystem::ReaddirIterator,
             "wasi:filesystem/types/descriptor": super::filesystem::Descriptor,
+            "wasi:io/streams/input-stream": super::stream::InputStream,
+            "wasi:io/streams/output-stream": super::stream::OutputStream,
         },
     });
 

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -149,6 +149,7 @@ pub mod bindings {
         with: {
             "wasi:sockets/network/network": super::network::Network,
             "wasi:sockets/tcp/tcp-socket": super::tcp::TcpSocket,
+            "wasi:filesystem/types/directory-entry-stream": super::filesystem::ReaddirIterator,
         },
     });
 

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -150,6 +150,7 @@ pub mod bindings {
             "wasi:sockets/network/network": super::network::Network,
             "wasi:sockets/tcp/tcp-socket": super::tcp::TcpSocket,
             "wasi:filesystem/types/directory-entry-stream": super::filesystem::ReaddirIterator,
+            "wasi:filesystem/types/descriptor": super::filesystem::Descriptor,
         },
     });
 

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -146,6 +146,9 @@ pub mod bindings {
             "wasi:filesystem/types"::"error-code": Error,
             "wasi:sockets/network"::"error-code": Error,
         },
+        with: {
+            "wasi:sockets/network/network": super::network::Network,
+        },
     });
 
     pub use wasi::*;

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -154,6 +154,8 @@ pub mod bindings {
             "wasi:io/streams/input-stream": super::stream::InputStream,
             "wasi:io/streams/output-stream": super::stream::OutputStream,
             "wasi:io/poll/pollable": super::poll::Pollable,
+            "wasi:cli/terminal-input/terminal-input": super::stdio::TerminalInput,
+            "wasi:cli/terminal-output/terminal-output": super::stdio::TerminalOutput,
         },
     });
 

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -148,6 +148,7 @@ pub mod bindings {
         },
         with: {
             "wasi:sockets/network/network": super::network::Network,
+            "wasi:sockets/tcp/tcp-socket": super::tcp::TcpSocket,
         },
     });
 

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -44,7 +44,7 @@ pub use self::stream::{
     HostInputStream, HostOutputStream, InputStream, OutputStream, OutputStreamError,
     StreamRuntimeError, StreamState,
 };
-pub use self::table::{OccupiedEntry, Table, TableError};
+pub use self::table::{Table, TableError};
 pub use cap_fs_ext::SystemTimeSpec;
 pub use cap_rand::RngCore;
 

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -41,7 +41,8 @@ pub use self::poll::{ClosureFuture, MakeFuture, Pollable, PollableFuture};
 pub use self::random::{thread_rng, Deterministic};
 pub use self::stdio::{stderr, stdin, stdout, IsATTY, Stderr, Stdin, Stdout};
 pub use self::stream::{
-    HostInputStream, HostOutputStream, OutputStreamError, StreamRuntimeError, StreamState,
+    HostInputStream, HostOutputStream, InputStream, OutputStream, OutputStreamError,
+    StreamRuntimeError, StreamState,
 };
 pub use self::table::{OccupiedEntry, Table, TableError};
 pub use cap_fs_ext::SystemTimeSpec;

--- a/crates/wasi/src/preview2/network.rs
+++ b/crates/wasi/src/preview2/network.rs
@@ -1,34 +1,9 @@
-use crate::preview2::bindings::sockets::network::Network;
-use crate::preview2::{Table, TableError};
 use cap_std::net::Pool;
-use wasmtime::component::Resource;
 
-pub(crate) struct HostNetworkState(pub(crate) Pool);
+pub struct Network(pub(crate) Pool);
 
-impl HostNetworkState {
+impl Network {
     pub fn new(pool: Pool) -> Self {
         Self(pool)
-    }
-}
-
-pub(crate) trait TableNetworkExt {
-    fn push_network(&mut self, network: HostNetworkState) -> Result<Resource<Network>, TableError>;
-    fn delete_network(&mut self, fd: Resource<Network>) -> Result<HostNetworkState, TableError>;
-    fn is_network(&self, fd: &Resource<Network>) -> bool;
-    fn get_network(&self, fd: &Resource<Network>) -> Result<&HostNetworkState, TableError>;
-}
-
-impl TableNetworkExt for Table {
-    fn push_network(&mut self, network: HostNetworkState) -> Result<Resource<Network>, TableError> {
-        Ok(Resource::new_own(self.push(Box::new(network))?))
-    }
-    fn delete_network(&mut self, fd: Resource<Network>) -> Result<HostNetworkState, TableError> {
-        self.delete(fd.rep())
-    }
-    fn is_network(&self, fd: &Resource<Network>) -> bool {
-        self.is::<HostNetworkState>(fd.rep())
-    }
-    fn get_network(&self, fd: &Resource<Network>) -> Result<&HostNetworkState, TableError> {
-        self.get(fd.rep())
     }
 }

--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -2141,7 +2141,6 @@ trait ResourceExt<T> {
 
 impl<T: 'static> ResourceExt<T> for Resource<T> {
     fn borrowed(&self) -> Resource<T> {
-        assert!(self.owned());
         Resource::new_borrow(self.rep())
     }
 }

--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -7,7 +7,6 @@ use crate::preview2::bindings::filesystem::{preopens, types as filesystem};
 use crate::preview2::bindings::io::poll;
 use crate::preview2::bindings::io::streams;
 use crate::preview2::filesystem::TableFsExt;
-use crate::preview2::host::filesystem::TableReaddirExt;
 use crate::preview2::{bindings, IsATTY, TableError, WasiView};
 use anyhow::{anyhow, bail, Context};
 use std::borrow::Borrow;
@@ -1678,7 +1677,7 @@ impl<
         for (entry, d_next) in self
             .table_mut()
             // remove iterator from table and use it directly:
-            .delete_readdir(stream)?
+            .delete_resource(stream)?
             .into_iter()
             .zip(3u64..)
         {

--- a/crates/wasi/src/preview2/stdio.rs
+++ b/crates/wasi/src/preview2/stdio.rs
@@ -179,54 +179,48 @@ impl<T: WasiView> stderr::Host for T {
     }
 }
 
-pub struct HostTerminalInput;
-pub struct HostTerminalOutput;
+pub struct TerminalInput;
+pub struct TerminalOutput;
 
 impl<T: WasiView> terminal_input::Host for T {}
-impl<T: WasiView> crate::preview2::bindings::cli::terminal_input::HostTerminalInput for T {
-    fn drop(&mut self, r: Resource<terminal_input::TerminalInput>) -> anyhow::Result<()> {
-        self.table_mut().delete::<HostTerminalInput>(r.rep())?;
+impl<T: WasiView> terminal_input::HostTerminalInput for T {
+    fn drop(&mut self, r: Resource<TerminalInput>) -> anyhow::Result<()> {
+        self.table_mut().delete_resource(r)?;
         Ok(())
     }
 }
 impl<T: WasiView> terminal_output::Host for T {}
-impl<T: WasiView> crate::preview2::bindings::cli::terminal_output::HostTerminalOutput for T {
-    fn drop(&mut self, r: Resource<terminal_output::TerminalOutput>) -> anyhow::Result<()> {
-        self.table_mut().delete::<HostTerminalOutput>(r.rep())?;
+impl<T: WasiView> terminal_output::HostTerminalOutput for T {
+    fn drop(&mut self, r: Resource<TerminalOutput>) -> anyhow::Result<()> {
+        self.table_mut().delete_resource(r)?;
         Ok(())
     }
 }
 impl<T: WasiView> terminal_stdin::Host for T {
-    fn get_terminal_stdin(
-        &mut self,
-    ) -> anyhow::Result<Option<Resource<terminal_input::TerminalInput>>> {
+    fn get_terminal_stdin(&mut self) -> anyhow::Result<Option<Resource<TerminalInput>>> {
         if self.ctx().stdin.isatty() {
-            let fd = self.table_mut().push(Box::new(HostTerminalInput))?;
-            Ok(Some(Resource::new_own(fd)))
+            let fd = self.table_mut().push_resource(TerminalInput)?;
+            Ok(Some(fd))
         } else {
             Ok(None)
         }
     }
 }
 impl<T: WasiView> terminal_stdout::Host for T {
-    fn get_terminal_stdout(
-        &mut self,
-    ) -> anyhow::Result<Option<Resource<terminal_output::TerminalOutput>>> {
+    fn get_terminal_stdout(&mut self) -> anyhow::Result<Option<Resource<TerminalOutput>>> {
         if self.ctx().stdout.isatty() {
-            let fd = self.table_mut().push(Box::new(HostTerminalOutput))?;
-            Ok(Some(Resource::new_own(fd)))
+            let fd = self.table_mut().push_resource(TerminalOutput)?;
+            Ok(Some(fd))
         } else {
             Ok(None)
         }
     }
 }
 impl<T: WasiView> terminal_stderr::Host for T {
-    fn get_terminal_stderr(
-        &mut self,
-    ) -> anyhow::Result<Option<Resource<terminal_output::TerminalOutput>>> {
+    fn get_terminal_stderr(&mut self) -> anyhow::Result<Option<Resource<TerminalOutput>>> {
         if self.ctx().stderr.isatty() {
-            let fd = self.table_mut().push(Box::new(HostTerminalOutput))?;
-            Ok(Some(Resource::new_own(fd)))
+            let fd = self.table_mut().push_resource(TerminalOutput)?;
+            Ok(Some(fd))
         } else {
             Ok(None)
         }

--- a/crates/wasi/src/preview2/stdio.rs
+++ b/crates/wasi/src/preview2/stdio.rs
@@ -4,7 +4,6 @@ use crate::preview2::bindings::cli::{
 };
 use crate::preview2::bindings::io::streams;
 use crate::preview2::pipe::{self, AsyncWriteStream};
-use crate::preview2::stream::TableStreamExt;
 use crate::preview2::{HostInputStream, HostOutputStream, WasiView};
 use std::io::IsTerminal;
 use wasmtime::component::Resource;
@@ -160,21 +159,23 @@ pub enum IsATTY {
 impl<T: WasiView> stdin::Host for T {
     fn get_stdin(&mut self) -> Result<Resource<streams::InputStream>, anyhow::Error> {
         let stream = self.ctx_mut().stdin.stream();
-        Ok(self.table_mut().push_input_stream(stream)?)
+        Ok(self
+            .table_mut()
+            .push_resource(streams::InputStream::Host(stream))?)
     }
 }
 
 impl<T: WasiView> stdout::Host for T {
     fn get_stdout(&mut self) -> Result<Resource<streams::OutputStream>, anyhow::Error> {
         let stream = self.ctx_mut().stdout.stream();
-        Ok(self.table_mut().push_output_stream(stream)?)
+        Ok(self.table_mut().push_resource(stream)?)
     }
 }
 
 impl<T: WasiView> stderr::Host for T {
     fn get_stderr(&mut self) -> Result<Resource<streams::OutputStream>, anyhow::Error> {
         let stream = self.ctx_mut().stderr.stream();
-        Ok(self.table_mut().push_output_stream(stream)?)
+        Ok(self.table_mut().push_resource(stream)?)
     }
 }
 

--- a/crates/wasi/src/preview2/stream.rs
+++ b/crates/wasi/src/preview2/stream.rs
@@ -1,10 +1,7 @@
-use crate::preview2::bindings::io::streams::{InputStream, OutputStream};
 use crate::preview2::filesystem::FileInputStream;
-use crate::preview2::{Table, TableError};
 use anyhow::Error;
 use bytes::Bytes;
 use std::fmt;
-use wasmtime::component::Resource;
 
 /// An error which should be reported to Wasm as a runtime error, rather than
 /// an error which should trap Wasm execution. The definition for runtime
@@ -168,178 +165,12 @@ pub trait HostOutputStream: Send + Sync {
     }
 }
 
-pub(crate) enum InternalInputStream {
+pub enum InputStream {
     Host(Box<dyn HostInputStream>),
     File(FileInputStream),
 }
 
-pub(crate) trait InternalTableStreamExt {
-    fn push_internal_input_stream(
-        &mut self,
-        istream: InternalInputStream,
-    ) -> Result<Resource<InputStream>, TableError>;
-    fn push_internal_input_stream_child<T: 'static>(
-        &mut self,
-        istream: InternalInputStream,
-        parent: Resource<T>,
-    ) -> Result<Resource<InputStream>, TableError>;
-    fn get_internal_input_stream_mut(
-        &mut self,
-        fd: &Resource<InputStream>,
-    ) -> Result<&mut InternalInputStream, TableError>;
-    fn delete_internal_input_stream(
-        &mut self,
-        fd: Resource<InputStream>,
-    ) -> Result<InternalInputStream, TableError>;
-}
-impl InternalTableStreamExt for Table {
-    fn push_internal_input_stream(
-        &mut self,
-        istream: InternalInputStream,
-    ) -> Result<Resource<InputStream>, TableError> {
-        Ok(Resource::new_own(self.push(Box::new(istream))?))
-    }
-    fn push_internal_input_stream_child<T: 'static>(
-        &mut self,
-        istream: InternalInputStream,
-        parent: Resource<T>,
-    ) -> Result<Resource<InputStream>, TableError> {
-        Ok(Resource::new_own(
-            self.push_child(Box::new(istream), parent.rep())?,
-        ))
-    }
-    fn get_internal_input_stream_mut(
-        &mut self,
-        fd: &Resource<InputStream>,
-    ) -> Result<&mut InternalInputStream, TableError> {
-        self.get_mut(fd.rep())
-    }
-    fn delete_internal_input_stream(
-        &mut self,
-        fd: Resource<InputStream>,
-    ) -> Result<InternalInputStream, TableError> {
-        self.delete(fd.rep())
-    }
-}
-
-/// Extension trait for managing [`HostInputStream`]s and [`HostOutputStream`]s in the [`Table`].
-pub trait TableStreamExt {
-    /// Push a [`HostInputStream`] into a [`Table`], returning the table index.
-    fn push_input_stream(
-        &mut self,
-        istream: Box<dyn HostInputStream>,
-    ) -> Result<Resource<InputStream>, TableError>;
-    /// Same as [`push_input_stream`](Self::push_output_stream) except assigns a parent resource to
-    /// the input-stream created.
-    fn push_input_stream_child<T: 'static>(
-        &mut self,
-        istream: Box<dyn HostInputStream>,
-        parent: Resource<T>,
-    ) -> Result<Resource<InputStream>, TableError>;
-    /// Get a mutable reference to a [`HostInputStream`] in a [`Table`].
-    fn get_input_stream_mut(
-        &mut self,
-        fd: &Resource<InputStream>,
-    ) -> Result<&mut dyn HostInputStream, TableError>;
-    /// Remove [`HostInputStream`] from table:
-    fn delete_input_stream(
-        &mut self,
-        fd: Resource<InputStream>,
-    ) -> Result<Box<dyn HostInputStream>, TableError>;
-
-    /// Push a [`HostOutputStream`] into a [`Table`], returning the table index.
-    fn push_output_stream(
-        &mut self,
-        ostream: Box<dyn HostOutputStream>,
-    ) -> Result<Resource<OutputStream>, TableError>;
-    /// Same as [`push_output_stream`](Self::push_output_stream) except assigns a parent resource
-    /// to the output-stream created.
-    fn push_output_stream_child<T: 'static>(
-        &mut self,
-        ostream: Box<dyn HostOutputStream>,
-        parent: Resource<T>,
-    ) -> Result<Resource<OutputStream>, TableError>;
-    /// Get a mutable reference to a [`HostOutputStream`] in a [`Table`].
-    fn get_output_stream_mut(
-        &mut self,
-        fd: &Resource<OutputStream>,
-    ) -> Result<&mut dyn HostOutputStream, TableError>;
-
-    /// Remove [`HostOutputStream`] from table:
-    fn delete_output_stream(
-        &mut self,
-        fd: Resource<OutputStream>,
-    ) -> Result<Box<dyn HostOutputStream>, TableError>;
-}
-impl TableStreamExt for Table {
-    fn push_input_stream(
-        &mut self,
-        istream: Box<dyn HostInputStream>,
-    ) -> Result<Resource<InputStream>, TableError> {
-        self.push_internal_input_stream(InternalInputStream::Host(istream))
-    }
-    fn push_input_stream_child<T: 'static>(
-        &mut self,
-        istream: Box<dyn HostInputStream>,
-        parent: Resource<T>,
-    ) -> Result<Resource<InputStream>, TableError> {
-        self.push_internal_input_stream_child(InternalInputStream::Host(istream), parent)
-    }
-    fn get_input_stream_mut(
-        &mut self,
-        fd: &Resource<InputStream>,
-    ) -> Result<&mut dyn HostInputStream, TableError> {
-        match self.get_internal_input_stream_mut(fd)? {
-            InternalInputStream::Host(ref mut h) => Ok(h.as_mut()),
-            _ => Err(TableError::WrongType),
-        }
-    }
-    fn delete_input_stream(
-        &mut self,
-        fd: Resource<InputStream>,
-    ) -> Result<Box<dyn HostInputStream>, TableError> {
-        let occ = self.entry(fd.rep())?;
-        match occ.get().downcast_ref::<InternalInputStream>() {
-            Some(InternalInputStream::Host(_)) => {
-                let any = occ.remove_entry()?;
-                match *any.downcast().expect("downcast checked above") {
-                    InternalInputStream::Host(h) => Ok(h),
-                    _ => unreachable!("variant checked above"),
-                }
-            }
-            _ => Err(TableError::WrongType),
-        }
-    }
-
-    fn push_output_stream(
-        &mut self,
-        ostream: Box<dyn HostOutputStream>,
-    ) -> Result<Resource<OutputStream>, TableError> {
-        Ok(Resource::new_own(self.push(Box::new(ostream))?))
-    }
-    fn push_output_stream_child<T: 'static>(
-        &mut self,
-        ostream: Box<dyn HostOutputStream>,
-        parent: Resource<T>,
-    ) -> Result<Resource<OutputStream>, TableError> {
-        Ok(Resource::new_own(
-            self.push_child(Box::new(ostream), parent.rep())?,
-        ))
-    }
-    fn get_output_stream_mut(
-        &mut self,
-        fd: &Resource<OutputStream>,
-    ) -> Result<&mut dyn HostOutputStream, TableError> {
-        let boxed: &mut Box<dyn HostOutputStream> = self.get_mut(fd.rep())?;
-        Ok(boxed.as_mut())
-    }
-    fn delete_output_stream(
-        &mut self,
-        fd: Resource<OutputStream>,
-    ) -> Result<Box<dyn HostOutputStream>, TableError> {
-        self.delete(fd.rep())
-    }
-}
+pub type OutputStream = Box<dyn HostOutputStream>;
 
 #[cfg(test)]
 mod test {

--- a/crates/wasi/src/preview2/stream.rs
+++ b/crates/wasi/src/preview2/stream.rs
@@ -171,32 +171,3 @@ pub enum InputStream {
 }
 
 pub type OutputStream = Box<dyn HostOutputStream>;
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn input_stream_in_table() {
-        let dummy = crate::preview2::pipe::ClosedInputStream;
-        let mut table = Table::new();
-        // Put it into the table:
-        let ix = table.push_input_stream(Box::new(dummy)).unwrap();
-        // Get a mut ref to it:
-        let _ = table.get_input_stream_mut(&ix).unwrap();
-        // Delete it:
-        let _ = table.delete_input_stream(ix).unwrap();
-    }
-
-    #[test]
-    fn output_stream_in_table() {
-        let dummy = crate::preview2::pipe::SinkOutputStream;
-        let mut table = Table::new();
-        // Put it in the table:
-        let ix = table.push_output_stream(Box::new(dummy)).unwrap();
-        // Get a mut ref to it:
-        let _ = table.get_output_stream_mut(&ix).unwrap();
-        // Delete it:
-        let _ = table.delete_output_stream(ix).unwrap();
-    }
-}

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -64,32 +64,6 @@ impl TableEntry {
     }
 }
 
-/// Like [`std::collections::hash_map::OccupiedEntry`], with a subset of
-/// methods available in order to uphold [`Table`] invariants.
-pub struct OccupiedEntry<'a> {
-    table: &'a mut Table,
-    index: u32,
-}
-impl<'a> OccupiedEntry<'a> {
-    /// Get the dynamically-typed reference to the resource.
-    pub fn get(&self) -> &(dyn Any + Send + Sync + 'static) {
-        self.table.map.get(&self.index).unwrap().entry.as_ref()
-    }
-    /// Get the dynamically-typed mutable reference to the resource.
-    pub fn get_mut(&mut self) -> &mut (dyn Any + Send + Sync + 'static) {
-        self.table.map.get_mut(&self.index).unwrap().entry.as_mut()
-    }
-    /// Remove the resource from the table, returning the contents of the
-    /// resource.
-    /// May fail with [`TableError::HasChildren`] if the entry has any
-    /// children, see [`Table::push_child`].
-    /// If this method fails, the [`OccupiedEntry`] is consumed, but the
-    /// resource remains in the table.
-    pub fn remove_entry(self) -> Result<Box<dyn Any + Send + Sync>, TableError> {
-        self.table.delete_entry(self.index).map(|e| e.entry)
-    }
-}
-
 impl Table {
     /// Create an empty table
     pub fn new() -> Self {
@@ -122,8 +96,7 @@ impl Table {
     ///
     /// The parent must exist to create a child. All children resources must
     /// be destroyed before a parent can be destroyed - otherwise [`Table::delete`]
-    /// or [`OccupiedEntry::remove_entry`] will fail with
-    /// [`TableError::HasChildren`].
+    /// will fail with [`TableError::HasChildren`].
     ///
     /// Parent-child relationships are tracked inside the table to ensure that
     /// a parent resource is not deleted while it has live children. This
@@ -251,18 +224,6 @@ impl Table {
         key: &Resource<T>,
     ) -> Result<&mut T, TableError> {
         self.get_mut(key.rep())
-    }
-
-    /// Get an [`OccupiedEntry`] corresponding to a table entry, if it exists. This allows you to
-    /// remove or replace the entry based on its contents. The methods available are a subset of
-    /// [`std::collections::hash_map::OccupiedEntry`] - it does not give access to the key, it
-    /// restricts replacing the entry to items of the same type, and it does not allow for deletion.
-    pub fn entry<'a>(&'a mut self, index: u32) -> Result<OccupiedEntry<'a>, TableError> {
-        if self.map.contains_key(&index) {
-            Ok(OccupiedEntry { table: self, index })
-        } else {
-            Err(TableError::NotPresent)
-        }
     }
 
     fn delete_entry(&mut self, key: u32) -> Result<TableEntry, TableError> {

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::{BTreeSet, HashMap};
+use wasmtime::component::Resource;
 
 #[derive(thiserror::Error, Debug)]
 pub enum TableError {
@@ -105,6 +106,15 @@ impl Table {
     /// Insert a resource at the next available index.
     pub fn push(&mut self, entry: Box<dyn Any + Send + Sync>) -> Result<u32, TableError> {
         self.push_(TableEntry::new(entry, None))
+    }
+
+    /// Same as `push`, but typed.
+    pub fn push_resource<T>(&mut self, entry: T) -> Result<Resource<T>, TableError>
+    where
+        T: Send + Sync + 'static,
+    {
+        let idx = self.push(Box::new(entry))?;
+        Ok(Resource::new_own(idx))
     }
 
     /// Insert a resource at the next available index, and track that it has a
@@ -216,6 +226,19 @@ impl Table {
         }
     }
 
+    /// Same as `get`, but typed
+    pub fn get_resource<T: Any + Sized>(&self, key: &Resource<T>) -> Result<&T, TableError> {
+        self.get(key.rep())
+    }
+
+    /// Same as `get_mut`, but typed
+    pub fn get_resource_mut<T: Any + Sized>(
+        &mut self,
+        key: &Resource<T>,
+    ) -> Result<&mut T, TableError> {
+        self.get_mut(key.rep())
+    }
+
     /// Get an [`OccupiedEntry`] corresponding to a table entry, if it exists. This allows you to
     /// remove or replace the entry based on its contents. The methods available are a subset of
     /// [`std::collections::hash_map::OccupiedEntry`] - it does not give access to the key, it
@@ -281,6 +304,15 @@ impl Table {
                 Err(TableError::WrongType)
             }
         }
+    }
+
+    /// Same as `delete`, but typed
+    pub fn delete_resource<T>(&mut self, resource: Resource<T>) -> Result<T, TableError>
+    where
+        T: Any,
+    {
+        debug_assert!(resource.owned());
+        self.delete(resource.rep())
     }
 
     /// Zip the values of the map with mutable references to table entries corresponding to each

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -152,6 +152,20 @@ impl Table {
         Ok(child)
     }
 
+    /// Same as `push_child`, but typed.
+    pub fn push_child_resource<T, U>(
+        &mut self,
+        entry: T,
+        parent: &Resource<U>,
+    ) -> Result<Resource<T>, TableError>
+    where
+        T: Send + Sync + 'static,
+        U: 'static,
+    {
+        let idx = self.push_child(Box::new(entry), parent.rep())?;
+        Ok(Resource::new_own(idx))
+    }
+
     fn push_(&mut self, e: TableEntry) -> Result<u32, TableError> {
         // NOTE: The performance of this new key calculation could be very bad once keys wrap
         // around.

--- a/crates/wasi/src/preview2/tcp.rs
+++ b/crates/wasi/src/preview2/tcp.rs
@@ -1,20 +1,16 @@
 use super::{HostInputStream, HostOutputStream, OutputStreamError};
-use crate::preview2::bindings::sockets::tcp::TcpSocket;
-use crate::preview2::{
-    with_ambient_tokio_runtime, AbortOnDropJoinHandle, StreamState, Table, TableError,
-};
+use crate::preview2::{with_ambient_tokio_runtime, AbortOnDropJoinHandle, StreamState};
 use cap_net_ext::{AddressFamily, Blocking, TcpListenerExt};
 use cap_std::net::TcpListener;
 use io_lifetimes::raw::{FromRawSocketlike, IntoRawSocketlike};
 use std::io;
 use std::sync::Arc;
-use wasmtime::component::Resource;
 
 /// The state of a TCP socket.
 ///
 /// This represents the various states a socket can be in during the
 /// activities of binding, listening, accepting, and connecting.
-pub(crate) enum HostTcpState {
+pub(crate) enum TcpState {
     /// The initial state for a newly-created socket.
     Default,
 
@@ -45,13 +41,13 @@ pub(crate) enum HostTcpState {
 ///
 /// The inner state is wrapped in an Arc because the same underlying socket is
 /// used for implementing the stream types.
-pub(crate) struct HostTcpSocketState {
-    /// The part of a `HostTcpSocketState` which is reference-counted so that we
+pub struct TcpSocket {
+    /// The part of a `TcpSocket` which is reference-counted so that we
     /// can pass it to async tasks.
     pub(crate) inner: Arc<tokio::net::TcpStream>,
 
     /// The current state in the bind/listen/accept/connect progression.
-    pub(crate) tcp_state: HostTcpState,
+    pub(crate) tcp_state: TcpState,
 }
 
 pub(crate) struct TcpReadStream {
@@ -215,7 +211,7 @@ impl HostOutputStream for TcpWriteStream {
     }
 }
 
-impl HostTcpSocketState {
+impl TcpSocket {
     /// Create a new socket in the given family.
     pub fn new(family: AddressFamily) -> io::Result<Self> {
         // Create a new host socket and set it to non-blocking, which is needed
@@ -224,7 +220,7 @@ impl HostTcpSocketState {
         Self::from_tcp_listener(tcp_listener)
     }
 
-    /// Create a `HostTcpSocketState` from an existing socket.
+    /// Create a `TcpSocket` from an existing socket.
     ///
     /// The socket must be in non-blocking mode.
     pub fn from_tcp_stream(tcp_socket: cap_std::net::TcpStream) -> io::Result<Self> {
@@ -239,7 +235,7 @@ impl HostTcpSocketState {
 
         Ok(Self {
             inner: Arc::new(stream),
-            tcp_state: HostTcpState::Default,
+            tcp_state: TcpState::Default,
         })
     }
 
@@ -252,49 +248,5 @@ impl HostTcpSocketState {
         let input = Box::new(TcpReadStream::new(self.inner.clone()));
         let output = Box::new(TcpWriteStream::new(self.inner.clone()));
         (input, output)
-    }
-}
-
-pub(crate) trait TableTcpSocketExt {
-    fn push_tcp_socket(
-        &mut self,
-        tcp_socket: HostTcpSocketState,
-    ) -> Result<Resource<TcpSocket>, TableError>;
-    fn delete_tcp_socket(
-        &mut self,
-        fd: Resource<TcpSocket>,
-    ) -> Result<HostTcpSocketState, TableError>;
-    fn is_tcp_socket(&self, fd: &Resource<TcpSocket>) -> bool;
-    fn get_tcp_socket(&self, fd: &Resource<TcpSocket>) -> Result<&HostTcpSocketState, TableError>;
-    fn get_tcp_socket_mut(
-        &mut self,
-        fd: &Resource<TcpSocket>,
-    ) -> Result<&mut HostTcpSocketState, TableError>;
-}
-
-impl TableTcpSocketExt for Table {
-    fn push_tcp_socket(
-        &mut self,
-        tcp_socket: HostTcpSocketState,
-    ) -> Result<Resource<TcpSocket>, TableError> {
-        Ok(Resource::new_own(self.push(Box::new(tcp_socket))?))
-    }
-    fn delete_tcp_socket(
-        &mut self,
-        fd: Resource<TcpSocket>,
-    ) -> Result<HostTcpSocketState, TableError> {
-        self.delete(fd.rep())
-    }
-    fn is_tcp_socket(&self, fd: &Resource<TcpSocket>) -> bool {
-        self.is::<HostTcpSocketState>(fd.rep())
-    }
-    fn get_tcp_socket(&self, fd: &Resource<TcpSocket>) -> Result<&HostTcpSocketState, TableError> {
-        self.get(fd.rep())
-    }
-    fn get_tcp_socket_mut(
-        &mut self,
-        fd: &Resource<TcpSocket>,
-    ) -> Result<&mut HostTcpSocketState, TableError> {
-        self.get_mut(fd.rep())
     }
 }

--- a/crates/wasi/src/preview2/tcp.rs
+++ b/crates/wasi/src/preview2/tcp.rs
@@ -1,4 +1,5 @@
 use super::{HostInputStream, HostOutputStream, OutputStreamError};
+use crate::preview2::stream::{InputStream, OutputStream};
 use crate::preview2::{with_ambient_tokio_runtime, AbortOnDropJoinHandle, StreamState};
 use cap_net_ext::{AddressFamily, Blocking, TcpListenerExt};
 use cap_std::net::TcpListener;
@@ -244,9 +245,9 @@ impl TcpSocket {
     }
 
     /// Create the input/output stream pair for a tcp socket.
-    pub fn as_split(&self) -> (Box<impl HostInputStream>, Box<impl HostOutputStream>) {
+    pub fn as_split(&self) -> (InputStream, OutputStream) {
         let input = Box::new(TcpReadStream::new(self.inner.clone()));
         let output = Box::new(TcpWriteStream::new(self.inner.clone()));
-        (input, output)
+        (InputStream::Host(input), output)
     }
 }


### PR DESCRIPTION
With the usage of resources and some small additions to the `Table` type we can get all the benefit of type-safety here without the boilerplates of traits, yay `Resource<T>` starting to pay for itself!

I've done light refactorings here while I was at it:

* Much of preview2-to-preview1 needed restructuring as I opted to use `Resource<T>` rather than the prior `u32`.
* Blocking functions on streams now check `ready()` and then call the non-blocking version. (avoids duplication)
* All `pollable` resources are now tracked automatically as children of the resource from whence they came, causing a dynamic error if the original item is destroyed before the `pollable`