### PR TITLE
Temporarily disable wasi-nn on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -483,7 +483,8 @@ jobs:
   # Build and test the wasi-nn module.
   test_wasi_nn:
     needs: determine
-    if: needs.determine.outputs.run-full
+    # FIXME(#7125) flaky at the moment
+    if: needs.determine.outputs.run-full && false
     name: Test wasi-nn module
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This appears to be failing, so temporarily disable it while the issues are worked out.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
