### PR TITLE
Fix compatibility with Rust 1.70.0

### DIFF
--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -513,7 +513,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
                 | TcpState::ConnectReady => {}
 
                 TcpState::Listening | TcpState::Connecting | TcpState::Connected => {
-                    match rustix::net::shutdown(&dropped.inner, rustix::net::Shutdown::ReadWrite) {
+                    match rustix::net::shutdown(&*dropped.inner, rustix::net::Shutdown::ReadWrite) {
                         Ok(()) | Err(Errno::NOTCONN) => {}
                         Err(err) => Err(err).unwrap(),
                     }


### PR DESCRIPTION
This commit fixes a compatibility issue with Rust 1.70.0 on Windows targets. Rust 1.71.0 stabilized `AsSocket for Arc<T>` which is used here implicitly, so to compile successfully on 1.70.0, our current MSRV, a slight code change is required.

Closes #7127

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
