### PR TITLE
CI: switch to AArch64 macOS runners.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -668,9 +668,9 @@ jobs:
         - build: x86_64-linux
           os: ubuntu-latest
         - build: x86_64-macos
-          os: macos-latest
+          os: macos-latest-xlarge
         - build: aarch64-macos
-          os: macos-latest
+          os: macos-latest-xlarge
           target: aarch64-apple-darwin
         - build: x86_64-windows
           os: windows-latest

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -49,9 +49,16 @@ const array = [
     "rust": "msrv",
   },
   {
-    "os": "macos-latest",
-    "name": "Test macOS x86_64",
-    "filter": "macos-x64"
+    "os": "macos-latest-xlarge",
+    "name": "Test macOS aarch64",
+    "filter": "macos-aarch64",
+    "isa": "aarch64",
+  },
+  {
+    "os": "macos-latest-large",
+    "name": "Test macOS x86-64",
+    "filter": "macos-x64",
+    "isa": "x64",
   },
   {
     "os": "windows-latest",


### PR DESCRIPTION
This should result in faster builds for macOS, and additionally will let us actually run tests on aarch64-macos now (previously we only had binary builds).

Fixes #4177.

prtest:full