### PR TITLE
Refactor how `subscribe` works in WASI

### DIFF
--- a/crates/test-programs/wasi-tests/src/bin/poll_oneoff_files.rs
+++ b/crates/test-programs/wasi-tests/src/bin/poll_oneoff_files.rs
@@ -153,23 +153,29 @@ unsafe fn test_fd_readwrite(readable_fd: wasi::Fd, writable_fd: wasi::Fd, error_
     ];
     let out = poll_oneoff_with_retry(&r#in).unwrap();
     assert_eq!(out.len(), 2, "should return 2 events, got: {:?}", out);
+
+    let (read, write) = if out[0].userdata == 1 {
+        (&out[0], &out[1])
+    } else {
+        (&out[1], &out[0])
+    };
     assert_eq!(
-        out[0].userdata, 1,
+        read.userdata, 1,
         "the event.userdata should contain fd userdata specified by the user"
     );
-    assert_errno!(out[0].error, error_code);
+    assert_errno!(read.error, error_code);
     assert_eq!(
-        out[0].type_,
+        read.type_,
         wasi::EVENTTYPE_FD_READ,
         "the event.type_ should equal FD_READ"
     );
     assert_eq!(
-        out[1].userdata, 2,
+        write.userdata, 2,
         "the event.userdata should contain fd userdata specified by the user"
     );
-    assert_errno!(out[1].error, error_code);
+    assert_errno!(write.error, error_code);
     assert_eq!(
-        out[1].type_,
+        write.type_,
         wasi::EVENTTYPE_FD_WRITE,
         "the event.type_ should equal FD_WRITE"
     );

--- a/crates/wasi/src/preview2/host/clocks.rs
+++ b/crates/wasi/src/preview2/host/clocks.rs
@@ -5,8 +5,10 @@ use crate::preview2::bindings::{
     clocks::timezone::{self, TimezoneDisplay},
     clocks::wall_clock::{self, Datetime},
 };
+use crate::preview2::poll::{subscribe, Subscribe};
 use crate::preview2::{Pollable, WasiView};
 use cap_std::time::SystemTime;
+use std::time::Duration;
 use wasmtime::component::Resource;
 
 impl TryFrom<SystemTime> for Datetime {
@@ -51,42 +53,29 @@ impl<T: WasiView> monotonic_clock::Host for T {
     }
 
     fn subscribe(&mut self, when: Instant, absolute: bool) -> anyhow::Result<Resource<Pollable>> {
-        use std::time::Duration;
-        // Calculate time relative to clock object, which may not have the same zero
-        // point as tokio Inst::now()
         let clock_now = self.ctx().monotonic_clock.now();
-        if absolute && when < clock_now {
-            // Deadline is in the past, so pollable is always ready:
-            Ok(self
-                .table_mut()
-                .push_resource(Pollable::Closure(Box::new(|| Box::pin(async { Ok(()) }))))?)
+        let duration = if absolute {
+            Duration::from_nanos(when - clock_now)
         } else {
-            let duration = if absolute {
-                Duration::from_nanos(when - clock_now)
-            } else {
-                Duration::from_nanos(when)
-            };
-            let deadline = tokio::time::Instant::now()
-                .checked_add(duration)
-                .ok_or_else(|| anyhow::anyhow!("time overflow: duration {duration:?}"))?;
-            tracing::trace!(
-                "deadline = {:?}, now = {:?}",
-                deadline,
-                tokio::time::Instant::now()
-            );
-            Ok(self
-                .table_mut()
-                .push_resource(Pollable::Closure(Box::new(move || {
-                    Box::pin(async move {
-                        tracing::trace!(
-                            "mkf: deadline = {:?}, now = {:?}",
-                            deadline,
-                            tokio::time::Instant::now()
-                        );
-                        Ok(tokio::time::sleep_until(deadline).await)
-                    })
-                })))?)
-        }
+            Duration::from_nanos(when)
+        };
+        let deadline = tokio::time::Instant::now()
+            .checked_add(duration)
+            .ok_or_else(|| anyhow::anyhow!("time overflow: duration {duration:?}"))?;
+        // NB: this resource created here is not actually exposed to wasm, it's
+        // only an internal implementation detail used to match the signature
+        // expected by `subscribe`.
+        let sleep = self.table_mut().push_resource(Sleep(deadline))?;
+        subscribe(self.table_mut(), sleep)
+    }
+}
+
+struct Sleep(tokio::time::Instant);
+
+#[async_trait::async_trait]
+impl Subscribe for Sleep {
+    async fn ready(&mut self) {
+        tokio::time::sleep_until(self.0).await;
     }
 }
 

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -15,6 +15,10 @@
 //! `pub mod legacy` with an off-by-default feature flag, and after 2
 //! releases, retire and remove that code from our tree.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
 mod clocks;
 pub mod command;
 mod ctx;
@@ -37,7 +41,7 @@ pub use self::clocks::{HostMonotonicClock, HostWallClock};
 pub use self::ctx::{WasiCtx, WasiCtxBuilder, WasiView};
 pub use self::error::I32Exit;
 pub use self::filesystem::{DirPerms, FilePerms};
-pub use self::poll::{ClosureFuture, MakeFuture, Pollable, PollableFuture};
+pub use self::poll::{subscribe, ClosureFuture, MakeFuture, Pollable, PollableFuture, Subscribe};
 pub use self::random::{thread_rng, Deterministic};
 pub use self::stdio::{stderr, stdin, stdout, IsATTY, Stderr, Stdin, Stdout};
 pub use self::stream::{
@@ -193,14 +197,9 @@ impl<T> From<tokio::task::JoinHandle<T>> for AbortOnDropJoinHandle<T> {
         AbortOnDropJoinHandle(jh)
     }
 }
-impl<T> std::future::Future for AbortOnDropJoinHandle<T> {
+impl<T> Future for AbortOnDropJoinHandle<T> {
     type Output = T;
-    fn poll(
-        mut self: std::pin::Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        use std::pin::Pin;
-        use std::task::Poll;
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match Pin::new(&mut self.as_mut().0).poll(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(r) => Poll::Ready(r.expect("child task panicked")),
@@ -210,7 +209,7 @@ impl<T> std::future::Future for AbortOnDropJoinHandle<T> {
 
 pub fn spawn<F, G>(f: F) -> AbortOnDropJoinHandle<G>
 where
-    F: std::future::Future<Output = G> + Send + 'static,
+    F: Future<Output = G> + Send + 'static,
     G: Send + 'static,
 {
     let j = match tokio::runtime::Handle::try_current() {
@@ -223,7 +222,7 @@ where
     AbortOnDropJoinHandle(j)
 }
 
-pub fn in_tokio<F: std::future::Future>(f: F) -> F::Output {
+pub fn in_tokio<F: Future>(f: F) -> F::Output {
     match tokio::runtime::Handle::try_current() {
         Ok(h) => {
             let _enter = h.enter();
@@ -243,5 +242,16 @@ fn with_ambient_tokio_runtime<R>(f: impl FnOnce() -> R) -> R {
             let _enter = RUNTIME.enter();
             f()
         }
+    }
+}
+
+fn poll_noop<F>(future: Pin<&mut F>) -> Option<F::Output>
+where
+    F: Future,
+{
+    let mut task = Context::from_waker(futures::task::noop_waker_ref());
+    match future.poll(&mut task) {
+        Poll::Ready(result) => Some(result),
+        Poll::Pending => None,
     }
 }

--- a/crates/wasi/src/preview2/poll.rs
+++ b/crates/wasi/src/preview2/poll.rs
@@ -1,13 +1,13 @@
-use crate::preview2::{bindings::io::poll, WasiView};
+use crate::preview2::{bindings::io::poll, Table, WasiView};
 use anyhow::Result;
 use std::any::Any;
-use std::collections::{hash_map::Entry, HashMap};
+use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use wasmtime::component::Resource;
 
-pub type PollableFuture<'a> = Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
+pub type PollableFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 pub type MakeFuture = for<'a> fn(&'a mut dyn Any) -> PollableFuture<'a>;
 pub type ClosureFuture = Box<dyn Fn() -> PollableFuture<'static> + Send + Sync + 'static>;
 
@@ -17,15 +17,50 @@ pub type ClosureFuture = Box<dyn Fn() -> PollableFuture<'static> + Send + Sync +
 /// repeatedly check for readiness of a given condition, e.g. if a stream is readable
 /// or writable. So, rather than containing a Future, which can only become Ready once, a
 /// Pollable contains a way to create a Future in each call to `poll_list`.
-pub enum Pollable {
-    /// Create a Future by calling a fn on another resource in the table. This
-    /// indirection means the created Future can use a mut borrow of another
-    /// resource in the Table (e.g. a stream)
-    TableEntry { index: u32, make_future: MakeFuture },
-    /// Create a future by calling an owned, static closure. This is used for
-    /// pollables which do not share state with another resource in the Table
-    /// (e.g. a timer)
-    Closure(ClosureFuture),
+pub struct Pollable {
+    index: u32,
+    make_future: MakeFuture,
+    remove_index_on_delete: Option<fn(&mut Table, u32) -> Result<()>>,
+}
+
+#[async_trait::async_trait]
+pub trait Subscribe: Send + Sync + 'static {
+    async fn ready(&mut self);
+}
+
+/// Creates a `pollable` resource which is susbcribed to the provided
+/// `resource`.
+///
+/// If `resource` is an owned resource then it will be deleted when the returned
+/// resource is deleted. Otherwise the returned resource is considered a "child"
+/// of the given `resource` which means that the given resource cannot be
+/// deleted while the `pollable` is still alive.
+pub fn subscribe<T>(table: &mut Table, resource: Resource<T>) -> Result<Resource<Pollable>>
+where
+    T: Subscribe,
+{
+    fn make_future<'a, T>(stream: &'a mut dyn Any) -> PollableFuture<'a>
+    where
+        T: Subscribe,
+    {
+        stream.downcast_mut::<T>().unwrap().ready()
+    }
+
+    let pollable = Pollable {
+        index: resource.rep(),
+        remove_index_on_delete: if resource.owned() {
+            Some(|table, idx| {
+                let resource = Resource::<T>::new_own(idx);
+                table.delete_resource(resource)?;
+                Ok(())
+            })
+        } else {
+            None
+        },
+        make_future: make_future::<T>,
+    };
+
+    Ok(table.push_child_resource(pollable, &resource)?)
 }
 
 #[async_trait::async_trait]
@@ -36,88 +71,69 @@ impl<T: WasiView> poll::Host for T {
         let table = self.table_mut();
 
         let mut table_futures: HashMap<u32, (MakeFuture, Vec<ReadylistIndex>)> = HashMap::new();
-        let mut closure_futures: Vec<(PollableFuture<'_>, Vec<ReadylistIndex>)> = Vec::new();
 
         for (ix, p) in pollables.iter().enumerate() {
             let ix: u32 = ix.try_into()?;
-            match table.get_resource_mut(&p)? {
-                Pollable::Closure(f) => closure_futures.push((f(), vec![ix])),
-                Pollable::TableEntry { index, make_future } => match table_futures.entry(*index) {
-                    Entry::Vacant(v) => {
-                        v.insert((*make_future, vec![ix]));
-                    }
-                    Entry::Occupied(mut o) => {
-                        let (_, v) = o.get_mut();
-                        v.push(ix);
-                    }
-                },
-            }
+
+            let pollable = table.get_resource(p)?;
+            let (_, list) = table_futures
+                .entry(pollable.index)
+                .or_insert((pollable.make_future, Vec::new()));
+            list.push(ix);
         }
 
+        let mut futures: Vec<(PollableFuture<'_>, Vec<ReadylistIndex>)> = Vec::new();
         for (entry, (make_future, readylist_indices)) in table.iter_entries(table_futures) {
             let entry = entry?;
-            closure_futures.push((make_future(entry), readylist_indices));
+            futures.push((make_future(entry), readylist_indices));
         }
 
         struct PollList<'a> {
-            elems: Vec<(PollableFuture<'a>, Vec<ReadylistIndex>)>,
+            futures: Vec<(PollableFuture<'a>, Vec<ReadylistIndex>)>,
         }
         impl<'a> Future for PollList<'a> {
-            type Output = Result<Vec<u32>>;
+            type Output = Vec<u32>;
 
             fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
                 let mut any_ready = false;
                 let mut results = Vec::new();
-                for (fut, readylist_indicies) in self.elems.iter_mut() {
+                for (fut, readylist_indicies) in self.futures.iter_mut() {
                     match fut.as_mut().poll(cx) {
-                        Poll::Ready(Ok(())) => {
+                        Poll::Ready(()) => {
                             results.extend_from_slice(readylist_indicies);
                             any_ready = true;
-                        }
-                        Poll::Ready(Err(e)) => {
-                            return Poll::Ready(Err(
-                                e.context(format!("poll_list {readylist_indicies:?}"))
-                            ));
                         }
                         Poll::Pending => {}
                     }
                 }
                 if any_ready {
-                    Poll::Ready(Ok(results))
+                    Poll::Ready(results)
                 } else {
                     Poll::Pending
                 }
             }
         }
 
-        Ok(PollList {
-            elems: closure_futures,
-        }
-        .await?)
+        Ok(PollList { futures }.await)
     }
 
     async fn poll_one(&mut self, pollable: Resource<Pollable>) -> Result<()> {
-        use anyhow::Context;
-
         let table = self.table_mut();
 
-        let closure_future = match table.get_resource_mut(&pollable)? {
-            Pollable::Closure(f) => f(),
-            Pollable::TableEntry { index, make_future } => {
-                let index = *index;
-                let make_future = *make_future;
-                make_future(table.get_as_any_mut(index)?)
-            }
-        };
-
-        closure_future.await.context("poll_one")
+        let pollable = table.get_resource(&pollable)?;
+        let ready = (pollable.make_future)(table.get_as_any_mut(pollable.index)?);
+        ready.await;
+        Ok(())
     }
 }
 
 #[async_trait::async_trait]
 impl<T: WasiView> crate::preview2::bindings::io::poll::HostPollable for T {
     fn drop(&mut self, pollable: Resource<Pollable>) -> Result<()> {
-        self.table_mut().delete_resource(pollable)?;
+        let pollable = self.table_mut().delete_resource(pollable)?;
+        if let Some(delete) = pollable.remove_index_on_delete {
+            delete(self.table_mut(), pollable.index)?;
+        }
         Ok(())
     }
 }

--- a/crates/wasi/src/preview2/stdio.rs
+++ b/crates/wasi/src/preview2/stdio.rs
@@ -318,7 +318,7 @@ mod test {
                                 let mut buffer = String::new();
                                 loop {
                                     println!("child: waiting for stdin to be ready");
-                                    stdin.ready().await.unwrap();
+                                    stdin.ready().await;
 
                                     println!("child: reading input");
                                     let (bytes, status) = stdin.read(1024).unwrap();

--- a/crates/wasi/src/preview2/tcp.rs
+++ b/crates/wasi/src/preview2/tcp.rs
@@ -1,11 +1,15 @@
 use super::{HostInputStream, HostOutputStream, OutputStreamError};
+use crate::preview2::poll::Subscribe;
 use crate::preview2::stream::{InputStream, OutputStream};
 use crate::preview2::{with_ambient_tokio_runtime, AbortOnDropJoinHandle, StreamState};
+use anyhow::{Error, Result};
 use cap_net_ext::{AddressFamily, Blocking, TcpListenerExt};
 use cap_std::net::TcpListener;
 use io_lifetimes::raw::{FromRawSocketlike, IntoRawSocketlike};
 use std::io;
+use std::mem;
 use std::sync::Arc;
+use tokio::io::Interest;
 
 /// The state of a TCP socket.
 ///
@@ -102,13 +106,15 @@ impl HostInputStream for TcpReadStream {
         buf.truncate(n);
         Ok((buf.freeze(), self.stream_state()))
     }
+}
 
-    async fn ready(&mut self) -> Result<(), anyhow::Error> {
+#[async_trait::async_trait]
+impl Subscribe for TcpReadStream {
+    async fn ready(&mut self) {
         if self.closed {
-            return Ok(());
+            return;
         }
-        self.stream.readable().await?;
-        Ok(())
+        self.stream.readable().await.unwrap();
     }
 }
 
@@ -116,53 +122,60 @@ const SOCKET_READY_SIZE: usize = 1024 * 1024 * 1024;
 
 pub(crate) struct TcpWriteStream {
     stream: Arc<tokio::net::TcpStream>,
-    write_handle: Option<AbortOnDropJoinHandle<anyhow::Result<()>>>,
+    last_write: LastWrite,
+}
+
+enum LastWrite {
+    Waiting(AbortOnDropJoinHandle<Result<()>>),
+    Error(Error),
+    Done,
 }
 
 impl TcpWriteStream {
     pub(crate) fn new(stream: Arc<tokio::net::TcpStream>) -> Self {
         Self {
             stream,
-            write_handle: None,
+            last_write: LastWrite::Done,
         }
     }
 
     /// Write `bytes` in a background task, remembering the task handle for use in a future call to
     /// `write_ready`
     fn background_write(&mut self, mut bytes: bytes::Bytes) {
-        assert!(self.write_handle.is_none());
+        assert!(matches!(self.last_write, LastWrite::Done));
 
         let stream = self.stream.clone();
-        self.write_handle
-            .replace(crate::preview2::spawn(async move {
-                // Note: we are not using the AsyncWrite impl here, and instead using the TcpStream
-                // primitive try_write, which goes directly to attempt a write with mio. This has
-                // two advantages: 1. this operation takes a &TcpStream instead of a &mut TcpStream
-                // required to AsyncWrite, and 2. it eliminates any buffering in tokio we may need
-                // to flush.
-                while !bytes.is_empty() {
-                    stream.writable().await?;
-                    match stream.try_write(&bytes) {
-                        Ok(n) => {
-                            let _ = bytes.split_to(n);
-                        }
-                        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
-                        Err(e) => return Err(e.into()),
+        self.last_write = LastWrite::Waiting(crate::preview2::spawn(async move {
+            // Note: we are not using the AsyncWrite impl here, and instead using the TcpStream
+            // primitive try_write, which goes directly to attempt a write with mio. This has
+            // two advantages: 1. this operation takes a &TcpStream instead of a &mut TcpStream
+            // required to AsyncWrite, and 2. it eliminates any buffering in tokio we may need
+            // to flush.
+            while !bytes.is_empty() {
+                stream.writable().await?;
+                match stream.try_write(&bytes) {
+                    Ok(n) => {
+                        let _ = bytes.split_to(n);
                     }
+                    Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => continue,
+                    Err(e) => return Err(e.into()),
                 }
+            }
 
-                Ok(())
-            }));
+            Ok(())
+        }));
     }
 }
 
-#[async_trait::async_trait]
 impl HostOutputStream for TcpWriteStream {
     fn write(&mut self, mut bytes: bytes::Bytes) -> Result<(), OutputStreamError> {
-        if self.write_handle.is_some() {
-            return Err(OutputStreamError::Trap(anyhow::anyhow!(
-                "unpermitted: cannot write while background write ongoing"
-            )));
+        match self.last_write {
+            LastWrite::Done => {}
+            LastWrite::Waiting(_) | LastWrite::Error(_) => {
+                return Err(OutputStreamError::Trap(anyhow::anyhow!(
+                    "unpermitted: must call check_write first"
+                )));
+            }
         }
         while !bytes.is_empty() {
             match self.stream.try_write(&bytes) {
@@ -192,23 +205,37 @@ impl HostOutputStream for TcpWriteStream {
         Ok(())
     }
 
-    async fn write_ready(&mut self) -> Result<usize, OutputStreamError> {
-        if let Some(handle) = &mut self.write_handle {
-            handle
-                .await
-                .map_err(|e| OutputStreamError::LastOperationFailed(e.into()))?;
-
-            // Only clear out the write handle once the task has exited, to ensure that
-            // `write_ready` remains cancel-safe.
-            self.write_handle = None;
+    fn check_write(&mut self) -> Result<usize, OutputStreamError> {
+        match mem::replace(&mut self.last_write, LastWrite::Done) {
+            LastWrite::Waiting(task) => {
+                self.last_write = LastWrite::Waiting(task);
+                return Ok(0);
+            }
+            LastWrite::Done => {}
+            LastWrite::Error(e) => return Err(OutputStreamError::LastOperationFailed(e.into())),
         }
 
-        self.stream
-            .writable()
-            .await
-            .map_err(|e| OutputStreamError::LastOperationFailed(e.into()))?;
-
+        let writable = self.stream.writable();
+        futures::pin_mut!(writable);
+        if super::poll_noop(writable).is_none() {
+            return Ok(0);
+        }
         Ok(SOCKET_READY_SIZE)
+    }
+}
+
+#[async_trait::async_trait]
+impl Subscribe for TcpWriteStream {
+    async fn ready(&mut self) {
+        if let LastWrite::Waiting(task) = &mut self.last_write {
+            self.last_write = match task.await {
+                Ok(()) => LastWrite::Done,
+                Err(e) => LastWrite::Error(e),
+            };
+        }
+        if let LastWrite::Done = self.last_write {
+            self.stream.writable().await.unwrap();
+        }
     }
 }
 
@@ -249,5 +276,22 @@ impl TcpSocket {
         let input = Box::new(TcpReadStream::new(self.inner.clone()));
         let output = Box::new(TcpWriteStream::new(self.inner.clone()));
         (InputStream::Host(input), output)
+    }
+}
+
+#[async_trait::async_trait]
+impl Subscribe for TcpSocket {
+    async fn ready(&mut self) {
+        // Some states are ready immediately.
+        match self.tcp_state {
+            TcpState::BindStarted | TcpState::ListenStarted | TcpState::ConnectReady => return,
+            _ => {}
+        }
+
+        // FIXME: Add `Interest::ERROR` when we update to tokio 1.32.
+        self.inner
+            .ready(Interest::READABLE | Interest::WRITABLE)
+            .await
+            .unwrap();
     }
 }

--- a/crates/wasi/src/preview2/write_stream.rs
+++ b/crates/wasi/src/preview2/write_stream.rs
@@ -1,4 +1,4 @@
-use crate::preview2::{HostOutputStream, OutputStreamError};
+use crate::preview2::{HostOutputStream, OutputStreamError, Subscribe};
 use anyhow::anyhow;
 use bytes::Bytes;
 use std::sync::{Arc, Mutex};
@@ -35,11 +35,6 @@ enum Job {
     Write(Bytes),
 }
 
-enum WriteStatus<'a> {
-    Done(Result<usize, OutputStreamError>),
-    Pending(tokio::sync::futures::Notified<'a>),
-}
-
 impl Worker {
     fn new(write_budget: usize) -> Self {
         Self {
@@ -54,17 +49,31 @@ impl Worker {
             write_ready_changed: tokio::sync::Notify::new(),
         }
     }
-    fn check_write(&self) -> WriteStatus<'_> {
+    async fn ready(&self) {
+        loop {
+            {
+                let state = self.state();
+                if state.error.is_some()
+                    || !state.alive
+                    || (!state.flush_pending && state.write_budget > 0)
+                {
+                    return;
+                }
+            }
+            self.write_ready_changed.notified().await;
+        }
+    }
+    fn check_write(&self) -> Result<usize, OutputStreamError> {
         let mut state = self.state();
         if let Err(e) = state.check_error() {
-            return WriteStatus::Done(Err(e));
+            return Err(e);
         }
 
         if state.flush_pending || state.write_budget == 0 {
-            return WriteStatus::Pending(self.write_ready_changed.notified());
+            return Ok(0);
         }
 
-        WriteStatus::Done(Ok(state.write_budget))
+        Ok(state.write_budget)
     }
     fn state(&self) -> std::sync::MutexGuard<WorkerState> {
         self.state.lock().unwrap()
@@ -154,7 +163,6 @@ impl AsyncWriteStream {
     }
 }
 
-#[async_trait::async_trait]
 impl HostOutputStream for AsyncWriteStream {
     fn write(&mut self, bytes: Bytes) -> Result<(), OutputStreamError> {
         let mut state = self.worker.state();
@@ -185,12 +193,13 @@ impl HostOutputStream for AsyncWriteStream {
         Ok(())
     }
 
-    async fn write_ready(&mut self) -> Result<usize, OutputStreamError> {
-        loop {
-            match self.worker.check_write() {
-                WriteStatus::Done(r) => return r,
-                WriteStatus::Pending(notifier) => notifier.await,
-            }
-        }
+    fn check_write(&mut self) -> Result<usize, OutputStreamError> {
+        self.worker.check_write()
+    }
+}
+#[async_trait::async_trait]
+impl Subscribe for AsyncWriteStream {
+    async fn ready(&mut self) {
+        self.worker.ready().await;
     }
 }


### PR DESCRIPTION
This commit refactors how the `Pollable` resource is created in WASI. Previously this was created manually via two variants of a `Pollable` enum but this was somewhat error prone for a few reasons:

* The more common representation, `TableEntry`, had boilerplate associated with it that had dynamic downcasts and such. This is now all hidden behind a more typed API.

* Callers had to remember to use `push_child_resource` which is easy to forget.

* The previous signature of the readiness check returned a `Result<()>` which made it accidentally easy for errors to be propagated into traps rather than being returned as a "last operation failed" error.

This commit replaces the previous API with a single `subscribe` function which takes a `Resource<T>` and returns a `Resource<Pollable>`. The `T` type must implement a new trait, `Subscribe`, which indicates the asynchronous readiness check. This readiness check additionally returns `()` so it's no longer possible to accidentally return errors (or trap).

This namely required refactoring the `HostOutputStream` trait and implementations. The trait itself now has a `check_write` method corresponding to to the same WASI function. The old `write_ready` function is now a convenience helper combo between `ready` and `check_write`. Concrete implementations are refactored to store errors discovered during `ready` to get communicated through `check-write` later on.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
