### PR TITLE
riscv64: Optimize `uadd_overflow_trap` lowering

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -304,8 +304,7 @@
 
 (rule 1 (lower (has_type $I64 (uadd_overflow_trap x y tc)))
   (let ((tmp XReg (rv_add x y))
-        (test XReg (gen_icmp (IntCC.UnsignedLessThan) tmp x $I64))
-        (_ InstOutput (gen_trapnz test tc)))
+        (_ InstOutput (gen_trapif (IntCC.UnsignedLessThan) tmp x tc)))
     tmp))
 
 ;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/filetests/filetests/isa/riscv64/uadd_overflow_trap.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/uadd_overflow_trap.clif
@@ -104,22 +104,17 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   mv a1,a0
-;   li a4,127
-;   add a0,a1,a4
-;   ult a5,a0,a1##ty=i64
-;   trap_if user0##(a5 ne zero)
+;   li a3,127
+;   add a0,a1,a3
+;   trap_if user0##(a0 ult a1)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mv a1, a0
-;   addi a4, zero, 0x7f
-;   add a0, a1, a4
-;   bgeu a0, a1, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   beqz a5, 8
+;   addi a3, zero, 0x7f
+;   add a0, a1, a3
+;   bgeu a0, a1, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
 ;   ret
 
@@ -132,21 +127,16 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   li a4,127
-;   add a0,a4,a0
-;   ult a5,a0,a4##ty=i64
-;   trap_if user0##(a5 ne zero)
+;   li a3,127
+;   add a0,a3,a0
+;   trap_if user0##(a0 ult a3)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a4, zero, 0x7f
-;   add a0, a4, a0
-;   bgeu a0, a4, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   beqz a5, 8
+;   addi a3, zero, 0x7f
+;   add a0, a3, a0
+;   bgeu a0, a3, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
 ;   ret
 
@@ -158,23 +148,16 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   add a3,a0,a1
-;   mv a1,a3
-;   ult a5,a1,a0##ty=i64
-;   mv a0,a1
-;   trap_if user0##(a5 ne zero)
+;   mv a5,a0
+;   add a0,a5,a1
+;   trap_if user0##(a0 ult a5)
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   add a3, a0, a1
-;   mv a1, a3
-;   bgeu a1, a0, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   mv a0, a1
-;   beqz a5, 8
+;   mv a5, a0
+;   add a0, a5, a1
+;   bgeu a0, a5, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: user0
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,21 +41,20 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a3,a3,32
+;;   slli a0,a0,32
+;;   srli a3,a0,32
 ;;   ld a4,[const(1)]
 ;;   add a4,a3,a4
-;;   ult a5,a4,a3##ty=i64
-;;   trap_if heap_oob##(a5 ne zero)
+;;   trap_if heap_oob##(a4 ult a3)
 ;;   ld a5,8(a2)
 ;;   ugt a4,a4,a5##ty=i64
 ;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a4,0(a2)
-;;   add a4,a4,a3
-;;   ld a5,[const(0)]
-;;   add a4,a4,a5
-;;   sw a1,0(a4)
+;;   add a3,a4,a3
+;;   ld a4,[const(0)]
+;;   add a3,a3,a4
+;;   sw a1,0(a3)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -64,21 +63,20 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a3,a2,32
-;;   ld a2,[const(1)]
-;;   add a2,a3,a2
-;;   ult a4,a2,a3##ty=i64
-;;   trap_if heap_oob##(a4 ne zero)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   ld a3,[const(1)]
+;;   add a3,a2,a3
+;;   trap_if heap_oob##(a3 ult a2)
 ;;   ld a4,8(a1)
-;;   ugt a4,a2,a4##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   ugt a3,a3,a4##ty=i64
+;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a4,0(a1)
-;;   add a4,a4,a3
-;;   ld a5,[const(0)]
-;;   add a4,a4,a5
-;;   lw a0,0(a4)
+;;   ld a3,0(a1)
+;;   add a3,a3,a2
+;;   ld a4,[const(0)]
+;;   add a3,a3,a4
+;;   lw a0,0(a3)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,21 +41,20 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a3,a3,32
+;;   slli a0,a0,32
+;;   srli a3,a0,32
 ;;   ld a4,[const(1)]
 ;;   add a4,a3,a4
-;;   ult a5,a4,a3##ty=i64
-;;   trap_if heap_oob##(a5 ne zero)
+;;   trap_if heap_oob##(a4 ult a3)
 ;;   ld a5,8(a2)
 ;;   ugt a4,a4,a5##ty=i64
 ;;   bne a4,zero,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a4,0(a2)
-;;   add a4,a4,a3
-;;   ld a5,[const(0)]
-;;   add a4,a4,a5
-;;   sb a1,0(a4)
+;;   add a3,a4,a3
+;;   ld a4,[const(0)]
+;;   add a3,a3,a4
+;;   sb a1,0(a3)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -64,21 +63,20 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a3,a2,32
-;;   ld a2,[const(1)]
-;;   add a2,a3,a2
-;;   ult a4,a2,a3##ty=i64
-;;   trap_if heap_oob##(a4 ne zero)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   ld a3,[const(1)]
+;;   add a3,a2,a3
+;;   trap_if heap_oob##(a3 ult a2)
 ;;   ld a4,8(a1)
-;;   ugt a4,a2,a4##ty=i64
-;;   bne a4,zero,taken(label3),not_taken(label1)
+;;   ugt a3,a3,a4##ty=i64
+;;   bne a3,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a4,0(a1)
-;;   add a4,a4,a3
-;;   ld a5,[const(0)]
-;;   add a4,a4,a5
-;;   lbu a0,0(a4)
+;;   ld a3,0(a1)
+;;   add a3,a3,a2
+;;   ld a4,[const(0)]
+;;   add a3,a3,a4
+;;   lbu a0,0(a3)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -42,25 +42,24 @@
 ;; function u0:0:
 ;; block0:
 ;;   slli a3,a0,32
-;;   srli a4,a3,32
-;;   ld a3,[const(1)]
-;;   add a3,a4,a3
-;;   ult a5,a3,a4##ty=i64
-;;   trap_if heap_oob##(a5 ne zero)
+;;   srli a3,a3,32
+;;   ld a4,[const(1)]
+;;   add a4,a3,a4
+;;   trap_if heap_oob##(a4 ult a3)
 ;;   ld a5,8(a2)
-;;   ugt a5,a3,a5##ty=i64
-;;   ld a0,0(a2)
-;;   add a4,a0,a4
-;;   ld a0,[const(0)]
-;;   add a4,a4,a0
-;;   li a0,0
-;;   sltu a5,zero,a5
-;;   sub a2,zero,a5
-;;   and a3,a0,a2
-;;   not a5,a2
-;;   and a2,a4,a5
-;;   or a3,a3,a2
-;;   sw a1,0(a3)
+;;   ugt a4,a4,a5##ty=i64
+;;   ld a5,0(a2)
+;;   add a3,a5,a3
+;;   ld a5,[const(0)]
+;;   add a3,a3,a5
+;;   li a5,0
+;;   sltu a4,zero,a4
+;;   sub a0,zero,a4
+;;   and a2,a5,a0
+;;   not a4,a0
+;;   and a0,a3,a4
+;;   or a2,a2,a0
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -68,25 +67,24 @@
 ;; function u0:1:
 ;; block0:
 ;;   slli a2,a0,32
-;;   srli a4,a2,32
-;;   ld a3,[const(1)]
-;;   add a2,a4,a3
-;;   ult a5,a2,a4##ty=i64
-;;   trap_if heap_oob##(a5 ne zero)
-;;   ld a5,8(a1)
-;;   ugt a5,a2,a5##ty=i64
-;;   ld a0,0(a1)
-;;   add a4,a0,a4
-;;   ld a0,[const(0)]
-;;   add a4,a4,a0
-;;   li a0,0
-;;   sltu a5,zero,a5
-;;   sub a1,zero,a5
-;;   and a3,a0,a1
-;;   not a5,a1
-;;   and a1,a4,a5
-;;   or a3,a3,a1
-;;   lw a0,0(a3)
+;;   srli a3,a2,32
+;;   ld a2,[const(1)]
+;;   add a2,a3,a2
+;;   trap_if heap_oob##(a2 ult a3)
+;;   ld a4,8(a1)
+;;   ugt a4,a2,a4##ty=i64
+;;   ld a5,0(a1)
+;;   add a3,a5,a3
+;;   ld a5,[const(0)]
+;;   add a3,a3,a5
+;;   li a5,0
+;;   sltu a4,zero,a4
+;;   sub a0,zero,a4
+;;   and a2,a5,a0
+;;   not a4,a0
+;;   and a0,a3,a4
+;;   or a2,a2,a0
+;;   lw a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -42,25 +42,24 @@
 ;; function u0:0:
 ;; block0:
 ;;   slli a3,a0,32
-;;   srli a4,a3,32
-;;   ld a3,[const(1)]
-;;   add a3,a4,a3
-;;   ult a5,a3,a4##ty=i64
-;;   trap_if heap_oob##(a5 ne zero)
+;;   srli a3,a3,32
+;;   ld a4,[const(1)]
+;;   add a4,a3,a4
+;;   trap_if heap_oob##(a4 ult a3)
 ;;   ld a5,8(a2)
-;;   ugt a5,a3,a5##ty=i64
-;;   ld a0,0(a2)
-;;   add a4,a0,a4
-;;   ld a0,[const(0)]
-;;   add a4,a4,a0
-;;   li a0,0
-;;   sltu a5,zero,a5
-;;   sub a2,zero,a5
-;;   and a3,a0,a2
-;;   not a5,a2
-;;   and a2,a4,a5
-;;   or a3,a3,a2
-;;   sb a1,0(a3)
+;;   ugt a4,a4,a5##ty=i64
+;;   ld a5,0(a2)
+;;   add a3,a5,a3
+;;   ld a5,[const(0)]
+;;   add a3,a3,a5
+;;   li a5,0
+;;   sltu a4,zero,a4
+;;   sub a0,zero,a4
+;;   and a2,a5,a0
+;;   not a4,a0
+;;   and a0,a3,a4
+;;   or a2,a2,a0
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -68,25 +67,24 @@
 ;; function u0:1:
 ;; block0:
 ;;   slli a2,a0,32
-;;   srli a4,a2,32
-;;   ld a3,[const(1)]
-;;   add a2,a4,a3
-;;   ult a5,a2,a4##ty=i64
-;;   trap_if heap_oob##(a5 ne zero)
-;;   ld a5,8(a1)
-;;   ugt a5,a2,a5##ty=i64
-;;   ld a0,0(a1)
-;;   add a4,a0,a4
-;;   ld a0,[const(0)]
-;;   add a4,a4,a0
-;;   li a0,0
-;;   sltu a5,zero,a5
-;;   sub a1,zero,a5
-;;   and a3,a0,a1
-;;   not a5,a1
-;;   and a1,a4,a5
-;;   or a3,a3,a1
-;;   lbu a0,0(a3)
+;;   srli a3,a2,32
+;;   ld a2,[const(1)]
+;;   add a2,a3,a2
+;;   trap_if heap_oob##(a2 ult a3)
+;;   ld a4,8(a1)
+;;   ugt a4,a2,a4##ty=i64
+;;   ld a5,0(a1)
+;;   add a3,a5,a3
+;;   ld a5,[const(0)]
+;;   add a3,a3,a5
+;;   li a5,0
+;;   sltu a4,zero,a4
+;;   sub a0,zero,a4
+;;   and a2,a5,a0
+;;   not a4,a0
+;;   and a0,a3,a4
+;;   or a2,a2,a0
+;;   lbu a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -41,10 +41,9 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a3,[const(1)]
-;;   add a5,a0,a3
-;;   ult a3,a5,a0##ty=i64
-;;   trap_if heap_oob##(a3 ne zero)
+;;   ld a5,[const(1)]
+;;   add a5,a0,a5
+;;   trap_if heap_oob##(a5 ult a0)
 ;;   ld a3,8(a2)
 ;;   ugt a3,a5,a3##ty=i64
 ;;   bne a3,zero,taken(label3),not_taken(label1)
@@ -62,19 +61,18 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,[const(1)]
-;;   add a5,a0,a2
-;;   ult a2,a5,a0##ty=i64
-;;   trap_if heap_oob##(a2 ne zero)
+;;   ld a5,[const(1)]
+;;   add a5,a0,a5
+;;   trap_if heap_oob##(a5 ult a0)
 ;;   ld a2,8(a1)
 ;;   ugt a2,a5,a2##ty=i64
 ;;   bne a2,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   ld a3,[const(0)]
-;;   add a2,a2,a3
-;;   lw a0,0(a2)
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   ld a2,[const(0)]
+;;   add a1,a1,a2
+;;   lw a0,0(a1)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -41,10 +41,9 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a3,[const(1)]
-;;   add a5,a0,a3
-;;   ult a3,a5,a0##ty=i64
-;;   trap_if heap_oob##(a3 ne zero)
+;;   ld a5,[const(1)]
+;;   add a5,a0,a5
+;;   trap_if heap_oob##(a5 ult a0)
 ;;   ld a3,8(a2)
 ;;   ugt a3,a5,a3##ty=i64
 ;;   bne a3,zero,taken(label3),not_taken(label1)
@@ -62,19 +61,18 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,[const(1)]
-;;   add a5,a0,a2
-;;   ult a2,a5,a0##ty=i64
-;;   trap_if heap_oob##(a2 ne zero)
+;;   ld a5,[const(1)]
+;;   add a5,a0,a5
+;;   trap_if heap_oob##(a5 ult a0)
 ;;   ld a2,8(a1)
 ;;   ugt a2,a5,a2##ty=i64
 ;;   bne a2,zero,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   ld a3,[const(0)]
-;;   add a2,a2,a3
-;;   lbu a0,0(a2)
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   ld a2,[const(0)]
+;;   add a1,a1,a2
+;;   lbu a0,0(a1)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -43,22 +43,21 @@
 ;; block0:
 ;;   ld a3,[const(1)]
 ;;   add a3,a0,a3
-;;   ult a4,a3,a0##ty=i64
-;;   trap_if heap_oob##(a4 ne zero)
+;;   trap_if heap_oob##(a3 ult a0)
 ;;   ld a4,8(a2)
-;;   ugt a3,a3,a4##ty=i64
+;;   ugt a4,a3,a4##ty=i64
 ;;   ld a2,0(a2)
 ;;   add a2,a2,a0
-;;   ld a4,[const(0)]
-;;   add a2,a2,a4
-;;   li a4,0
-;;   sltu a3,zero,a3
-;;   sub a5,zero,a3
-;;   and a3,a4,a5
-;;   not a4,a5
-;;   and a5,a2,a4
-;;   or a2,a3,a5
-;;   sw a1,0(a2)
+;;   ld a3,[const(0)]
+;;   add a3,a2,a3
+;;   li a2,0
+;;   sltu a4,zero,a4
+;;   sub a4,zero,a4
+;;   and a0,a2,a4
+;;   not a2,a4
+;;   and a4,a3,a2
+;;   or a0,a0,a4
+;;   sw a1,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -67,22 +66,21 @@
 ;; block0:
 ;;   ld a2,[const(1)]
 ;;   add a2,a0,a2
-;;   ult a3,a2,a0##ty=i64
-;;   trap_if heap_oob##(a3 ne zero)
+;;   trap_if heap_oob##(a2 ult a0)
 ;;   ld a3,8(a1)
-;;   ugt a2,a2,a3##ty=i64
-;;   ld a3,0(a1)
-;;   add a3,a3,a0
-;;   ld a4,[const(0)]
-;;   add a3,a3,a4
-;;   li a4,0
-;;   sltu a5,zero,a2
-;;   sub a5,zero,a5
-;;   and a1,a4,a5
-;;   not a4,a5
-;;   and a5,a3,a4
-;;   or a1,a1,a5
-;;   lw a0,0(a1)
+;;   ugt a3,a2,a3##ty=i64
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   ld a2,[const(0)]
+;;   add a2,a1,a2
+;;   li a1,0
+;;   sltu a3,zero,a3
+;;   sub a4,zero,a3
+;;   and a0,a1,a4
+;;   not a3,a4
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   lw a0,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -43,22 +43,21 @@
 ;; block0:
 ;;   ld a3,[const(1)]
 ;;   add a3,a0,a3
-;;   ult a4,a3,a0##ty=i64
-;;   trap_if heap_oob##(a4 ne zero)
+;;   trap_if heap_oob##(a3 ult a0)
 ;;   ld a4,8(a2)
-;;   ugt a3,a3,a4##ty=i64
+;;   ugt a4,a3,a4##ty=i64
 ;;   ld a2,0(a2)
 ;;   add a2,a2,a0
-;;   ld a4,[const(0)]
-;;   add a2,a2,a4
-;;   li a4,0
-;;   sltu a3,zero,a3
-;;   sub a5,zero,a3
-;;   and a3,a4,a5
-;;   not a4,a5
-;;   and a5,a2,a4
-;;   or a2,a3,a5
-;;   sb a1,0(a2)
+;;   ld a3,[const(0)]
+;;   add a3,a2,a3
+;;   li a2,0
+;;   sltu a4,zero,a4
+;;   sub a4,zero,a4
+;;   and a0,a2,a4
+;;   not a2,a4
+;;   and a4,a3,a2
+;;   or a0,a0,a4
+;;   sb a1,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -67,22 +66,21 @@
 ;; block0:
 ;;   ld a2,[const(1)]
 ;;   add a2,a0,a2
-;;   ult a3,a2,a0##ty=i64
-;;   trap_if heap_oob##(a3 ne zero)
+;;   trap_if heap_oob##(a2 ult a0)
 ;;   ld a3,8(a1)
-;;   ugt a2,a2,a3##ty=i64
-;;   ld a3,0(a1)
-;;   add a3,a3,a0
-;;   ld a4,[const(0)]
-;;   add a3,a3,a4
-;;   li a4,0
-;;   sltu a5,zero,a2
-;;   sub a5,zero,a5
-;;   and a1,a4,a5
-;;   not a4,a5
-;;   and a5,a3,a4
-;;   or a1,a1,a5
-;;   lbu a0,0(a1)
+;;   ugt a3,a2,a3##ty=i64
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   ld a2,[const(0)]
+;;   add a2,a1,a2
+;;   li a1,0
+;;   sltu a3,zero,a3
+;;   sub a4,zero,a3
+;;   and a0,a1,a4
+;;   not a3,a4
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   lbu a0,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret


### PR DESCRIPTION
This commit removes the usage of `gen_icmp` in `uadd_overflow_trap`. The comparison previously done with an explicit comparison is now bundled directly into the conditional branch to go to the trap itself.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
