### PR TITLE
Handle `lower_branch` consistently amongst backends

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -883,7 +883,8 @@
 
        ;; Jump-table sequence, as one compound instruction (see note in lower_inst.rs for rationale).
        (JTSequence
-        (info BoxJTSequenceInfo)
+        (default MachLabel)
+        (targets BoxVecMachLabel)
         (ridx Reg)
         (rtmp1 WritableReg)
         (rtmp2 WritableReg))
@@ -1717,17 +1718,12 @@
 (decl u64_into_imm_logic (Type u64) ImmLogic)
 (extern constructor u64_into_imm_logic u64_into_imm_logic)
 
-(decl branch_target (VecMachLabel u8) BranchTarget)
+(decl branch_target (MachLabel) BranchTarget)
 (extern constructor branch_target branch_target)
+(convert MachLabel BranchTarget branch_target)
 
-(decl targets_jt_size (VecMachLabel) u32)
-(extern constructor targets_jt_size targets_jt_size)
-
-(decl targets_jt_space (VecMachLabel) CodeOffset)
+(decl targets_jt_space (BoxVecMachLabel) CodeOffset)
 (extern constructor targets_jt_space targets_jt_space)
-
-(decl targets_jt_info (VecMachLabel) BoxJTSequenceInfo)
-(extern constructor targets_jt_info targets_jt_info)
 
 ;; Calculate the minimum floating-point bound for a conversion to floating
 ;; point from an integer type.
@@ -4076,12 +4072,12 @@
 ;; PC-rel offset to the jumptable would be incorrect.
 ;; (The alternative is to introduce a relocation pass
 ;; for inlined jumptables, which is much worse, IMHO.)
-(decl jt_sequence (Reg BoxJTSequenceInfo) ConsumesFlags)
-(rule (jt_sequence ridx info)
+(decl jt_sequence (Reg MachLabel BoxVecMachLabel) ConsumesFlags)
+(rule (jt_sequence ridx default targets)
       (let ((rtmp1 WritableReg (temp_writable_reg $I64))
             (rtmp2 WritableReg (temp_writable_reg $I64)))
        (ConsumesFlags.ConsumesFlagsSideEffect
-        (MInst.JTSequence info ridx rtmp1 rtmp2))))
+        (MInst.JTSequence default targets ridx rtmp1 rtmp2))))
 
 ;; Helper for emitting `MInst.CondBr` instructions.
 (decl cond_br (BranchTarget BranchTarget CondBrKind) ConsumesFlags)
@@ -4102,18 +4098,16 @@
        (MInst.EmitIsland needed_space)))
 
 ;; Helper for emitting `br_table` sequences.
-(decl br_table_impl (u64 Reg VecMachLabel) Unit)
-(rule (br_table_impl (imm12_from_u64 jt_size) ridx targets)
-      (let ((jt_info BoxJTSequenceInfo (targets_jt_info targets)))
-       (emit_side_effect (with_flags_side_effect
-            (cmp_imm (OperandSize.Size32) ridx jt_size)
-            (jt_sequence ridx jt_info)))))
-(rule -1 (br_table_impl jt_size ridx targets)
-      (let ((jt_size Reg (imm $I64 (ImmExtend.Zero) jt_size))
-            (jt_info BoxJTSequenceInfo (targets_jt_info targets)))
+(decl br_table_impl (u64 Reg MachLabel BoxVecMachLabel) Unit)
+(rule (br_table_impl (imm12_from_u64 jt_size) ridx default targets)
+      (emit_side_effect (with_flags_side_effect
+           (cmp_imm (OperandSize.Size32) ridx jt_size)
+           (jt_sequence ridx default targets))))
+(rule -1 (br_table_impl jt_size ridx default targets)
+      (let ((jt_size Reg (imm $I64 (ImmExtend.Zero) jt_size)))
        (emit_side_effect (with_flags_side_effect
             (cmp (OperandSize.Size32) ridx jt_size)
-            (jt_sequence ridx jt_info)))))
+            (jt_sequence ridx default targets)))))
 
 ;; Helper for emitting the `uzp1` instruction
 (decl vec_uzp1 (Reg Reg VectorSize) Reg)

--- a/cranelift/codegen/src/isa/aarch64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/mod.rs
@@ -140,16 +140,6 @@ pub struct ReturnCallInfo {
     pub key: Option<APIKey>,
 }
 
-/// Additional information for JTSequence instructions, left out of line to lower the size of the Inst
-/// enum.
-#[derive(Clone, Debug)]
-pub struct JTSequenceInfo {
-    /// Possible branch targets.
-    pub targets: Vec<BranchTarget>,
-    /// Default branch target.
-    pub default_target: BranchTarget,
-}
-
 fn count_zero_half_words(mut value: u64, num_half_words: u8) -> usize {
     let mut count = 0;
     for _ in 0..num_half_words {
@@ -2677,7 +2667,8 @@ impl Inst {
             &Inst::Word4 { data } => format!("data.i32 {}", data),
             &Inst::Word8 { data } => format!("data.i64 {}", data),
             &Inst::JTSequence {
-                ref info,
+                default,
+                ref targets,
                 ridx,
                 rtmp1,
                 rtmp2,
@@ -2686,7 +2677,7 @@ impl Inst {
                 let ridx = pretty_print_reg(ridx, allocs);
                 let rtmp1 = pretty_print_reg(rtmp1.to_reg(), allocs);
                 let rtmp2 = pretty_print_reg(rtmp2.to_reg(), allocs);
-                let default_target = info.default_target.pretty_print(0, allocs);
+                let default_target = BranchTarget::Label(default).pretty_print(0, allocs);
                 format!(
                     concat!(
                         "b.hs {} ; ",
@@ -2709,7 +2700,7 @@ impl Inst {
                     rtmp1,
                     rtmp2,
                     rtmp1,
-                    info.targets
+                    targets
                 )
             }
             &Inst::LoadExtName {

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -12,7 +12,7 @@
 ;; blocks while we lower, the fallthrough in the new order is not (necessarily)
 ;; the same as the fallthrough in CLIF. So, we use the explicitly-provided
 ;; target.
-(decl partial lower_branch (Inst VecMachLabel) Unit)
+(decl partial lower_branch (Inst MachLabelSlice) Unit)
 
 ;;;; Rules for `iconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2829,11 +2829,9 @@
 ;;; Rules for `brif` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `brif` following `icmp`
-(rule (lower_branch (brif (maybe_uextend (icmp cc x @ (value_type ty) y)) _ _) targets)
+(rule (lower_branch (brif (maybe_uextend (icmp cc x @ (value_type ty) y)) _ _) (two_targets taken not_taken))
       (let ((comparison FlagsAndCC (lower_icmp_into_flags cc x y ty))
-            (cond Cond (cond_code (flags_and_cc_cc comparison)))
-            (taken BranchTarget (branch_target targets 0))
-            (not_taken BranchTarget (branch_target targets 1)))
+            (cond Cond (cond_code (flags_and_cc_cc comparison))))
         (emit_side_effect
          (with_flags_side_effect (flags_and_cc_flags comparison)
                                  (cond_br taken
@@ -2841,49 +2839,43 @@
                                           (cond_br_cond cond))))))
 
 ;; `brif` following `fcmp`
-(rule (lower_branch (brif (maybe_uextend (fcmp cc x @ (value_type (ty_scalar_float ty)) y)) _ _) targets)
-      (let ((cond Cond (fp_cond_code cc))
-            (taken BranchTarget (branch_target targets 0))
-            (not_taken BranchTarget (branch_target targets 1)))
+(rule (lower_branch (brif (maybe_uextend (fcmp cc x @ (value_type (ty_scalar_float ty)) y)) _ _) (two_targets taken not_taken))
+      (let ((cond Cond (fp_cond_code cc)))
        (emit_side_effect
         (with_flags_side_effect (fpu_cmp (scalar_size ty) x y)
                                 (cond_br taken not_taken
                                  (cond_br_cond cond))))))
 
 ;; standard `brif`
-(rule -1 (lower_branch (brif c @ (value_type $I128) _ _) targets)
+(rule -1 (lower_branch (brif c @ (value_type $I128) _ _) (two_targets taken not_taken))
       (let ((flags ProducesFlags (flags_to_producesflags c))
             (c ValueRegs (put_in_regs c))
             (c_lo Reg (value_regs_get c 0))
             (c_hi Reg (value_regs_get c 1))
-            (rt Reg (orr $I64 c_lo c_hi))
-            (taken BranchTarget (branch_target targets 0))
-            (not_taken BranchTarget (branch_target targets 1)))
+            (rt Reg (orr $I64 c_lo c_hi)))
        (emit_side_effect
         (with_flags_side_effect flags
          (cond_br taken not_taken (cond_br_not_zero rt))))))
-(rule -2 (lower_branch (brif c @ (value_type ty) _ _) targets)
+(rule -2 (lower_branch (brif c @ (value_type ty) _ _) (two_targets taken not_taken))
       (if (ty_int_ref_scalar_64 ty))
       (let ((flags ProducesFlags (flags_to_producesflags c))
-            (rt Reg (put_in_reg_zext64 c))
-            (taken BranchTarget (branch_target targets 0))
-            (not_taken BranchTarget (branch_target targets 1)))
+            (rt Reg (put_in_reg_zext64 c)))
        (emit_side_effect
         (with_flags_side_effect flags
          (cond_br taken not_taken (cond_br_not_zero rt))))))
 
 ;;; Rules for `jump` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower_branch (jump _) targets)
-      (emit_side_effect (aarch64_jump (branch_target targets 0))))
+(rule (lower_branch (jump _) (single_target label))
+      (emit_side_effect (aarch64_jump label)))
 
 ;;; Rules for `br_table` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; `targets` contains the default target with the list of branch targets
 ;; concatenated.
-(rule (lower_branch (br_table idx _) targets)
-      (let ((jt_size u32 (targets_jt_size targets))
+(rule (lower_branch (br_table idx _) (jump_table_targets default targets))
+      (let ((jt_size u32 (jump_table_size targets))
             (_ InstOutput (side_effect
                   (emit_island (targets_jt_space targets))))
             (ridx Reg (put_in_reg_zext32 idx)))
-       (br_table_impl (u32_as_u64 jt_size) ridx targets)))
+       (br_table_impl (u32_as_u64 jt_size) ridx default targets)))

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2625,7 +2625,7 @@
 (decl int_zero_reg (Type) ValueRegs)
 (extern constructor int_zero_reg int_zero_reg)
 
-(decl lower_cond_br (IntCC ValueRegs VecMachLabel Type) Unit)
+(decl lower_cond_br (IntCC ValueRegs MachLabelSlice Type) Unit)
 (extern constructor lower_cond_br lower_cond_br)
 
 ;; Convert a truthy value, possibly of more than one register (an I128), to
@@ -2644,13 +2644,11 @@
 
 (decl label_to_br_target (MachLabel) CondBrTarget)
 (extern constructor label_to_br_target label_to_br_target)
+(convert MachLabel CondBrTarget label_to_br_target)
 
-(decl vec_label_get (VecMachLabel u8) MachLabel)
-(extern constructor vec_label_get vec_label_get)
-
-(decl partial lower_branch (Inst VecMachLabel) Unit)
-(rule (lower_branch (jump _) targets )
-      (emit_side_effect (SideEffectNoResult.Inst (MInst.Jal (vec_label_get targets 0)))))
+(decl partial lower_branch (Inst MachLabelSlice) Unit)
+(rule (lower_branch (jump _) (single_target label))
+      (emit_side_effect (SideEffectNoResult.Inst (MInst.Jal label))))
 
 ;; Default behavior for branching based on an input value.
 (rule (lower_branch (brif v @ (value_type (fits_in_64 ty)) _ _) targets)
@@ -2660,21 +2658,17 @@
 
 ;; Branching on the result of an fcmp
 (rule 1
-  (lower_branch (brif (maybe_uextend (fcmp cc a @ (value_type ty) b)) _ _) targets)
+  (lower_branch (brif (maybe_uextend (fcmp cc a @ (value_type ty) b)) _ _) (two_targets then else))
   (if-let $true (floatcc_unordered cc))
-  (let ((then CondBrTarget (label_to_br_target (vec_label_get targets 0)))
-        (else CondBrTarget (label_to_br_target (vec_label_get targets 1))))
-    (emit_side_effect (cond_br (emit_fcmp (floatcc_complement cc) ty a b) else then))))
+  (emit_side_effect (cond_br (emit_fcmp (floatcc_complement cc) ty a b) else then)))
 
 (rule 1
-  (lower_branch (brif (maybe_uextend (fcmp cc a @ (value_type ty) b)) _ _) targets)
+  (lower_branch (brif (maybe_uextend (fcmp cc a @ (value_type ty) b)) _ _) (two_targets then else))
   (if-let $false (floatcc_unordered cc))
-  (let ((then CondBrTarget (label_to_br_target (vec_label_get targets 0)))
-        (else CondBrTarget (label_to_br_target (vec_label_get targets 1))))
-    (emit_side_effect (cond_br (emit_fcmp cc ty a b) then else))))
+  (emit_side_effect (cond_br (emit_fcmp cc ty a b) then else)))
 
 
-(decl lower_br_table (Reg VecMachLabel) Unit)
+(decl lower_br_table (Reg MachLabelSlice) Unit)
 (extern constructor lower_br_table lower_br_table)
 
 (rule (lower_branch (br_table index _) targets)

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -175,13 +175,7 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         }
     }
 
-    fn lower_cond_br(
-        &mut self,
-        cc: &IntCC,
-        a: ValueRegs,
-        targets: &VecMachLabel,
-        ty: Type,
-    ) -> Unit {
+    fn lower_cond_br(&mut self, cc: &IntCC, a: ValueRegs, targets: &[MachLabel], ty: Type) -> Unit {
         MInst::lower_br_icmp(
             *cc,
             a,
@@ -214,10 +208,6 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         } else {
             ValueRegs::one(self.zero_reg())
         }
-    }
-
-    fn vec_label_get(&mut self, val: &VecMachLabel, x: u8) -> MachLabel {
-        val[x as usize]
     }
 
     fn label_to_br_target(&mut self, label: MachLabel) -> CondBrTarget {
@@ -482,14 +472,14 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         AMO::SeqCst
     }
 
-    fn lower_br_table(&mut self, index: Reg, targets: &VecMachLabel) -> Unit {
+    fn lower_br_table(&mut self, index: Reg, targets: &[MachLabel]) -> Unit {
         let tmp1 = self.temp_writable_reg(I64);
         let tmp2 = self.temp_writable_reg(I64);
         self.emit(&MInst::BrTable {
             index,
             tmp1,
             tmp2,
-            targets: targets.clone(),
+            targets: targets.to_vec(),
         });
     }
 

--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -969,7 +969,7 @@
     ;; for rationale).
     (JTSequence
       (ridx Reg)
-      (targets VecMachLabel))
+      (targets BoxVecMachLabel))
 
     ;; Load an inline symbol reference with relocation.
     (LoadSymbolReloc
@@ -1736,15 +1736,6 @@
 
 (decl unsigned () IntCC)
 (extern extractor unsigned unsigned)
-
-
-;; Helpers for machine label vectors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-
-(decl vec_length_minus1 (VecMachLabel) u32)
-(extern constructor vec_length_minus1 vec_length_minus1)
-
-(decl vec_element (VecMachLabel u8) MachLabel)
-(extern constructor vec_element vec_element)
 
 
 ;; Helpers for memory arguments ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2717,7 +2708,7 @@
       (ConsumesFlags.ConsumesFlagsSideEffect (MInst.OneWayCondBr dest cond)))
 
 ;; Helper for emitting `MInst.JTSequence` instructions.
-(decl jt_sequence (Reg VecMachLabel) SideEffectNoResult)
+(decl jt_sequence (Reg BoxVecMachLabel) SideEffectNoResult)
 (rule (jt_sequence ridx targets)
       (SideEffectNoResult.Inst (MInst.JTSequence ridx targets)))
 

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -3656,12 +3656,9 @@ impl Inst {
                 inst.emit(&[], sink, emit_info, state);
 
                 // Emit jump table (table of 32-bit offsets).
-                // The first entry is the default target, which is not emitted
-                // into the jump table, so we skip it here.  It is only in the
-                // list so MachTerminator will see the potential target.
                 sink.bind_label(table_label, &mut state.ctrl_plane);
                 let jt_off = sink.cur_offset();
-                for &target in targets.iter().skip(1) {
+                for &target in targets.iter() {
                     let word_off = sink.cur_offset();
                     let off_into_table = word_off - jt_off;
                     sink.use_label_at_offset(word_off, target, LabelUse::PCRel32);

--- a/cranelift/codegen/src/isa/s390x/lower.isle
+++ b/cranelift/codegen/src/isa/s390x/lower.isle
@@ -7,7 +7,7 @@
 ;; A variant of the main lowering constructor term, used for branches.
 ;; The only difference is that it gets an extra argument holding a vector
 ;; of branch targets to be used.
-(decl partial lower_branch (Inst VecMachLabel) Unit)
+(decl partial lower_branch (Inst MachLabelSlice) Unit)
 
 
 ;;;; Rules for `iconst` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -3734,25 +3734,24 @@
 
 ;; Unconditional branch.  The target is found as first (and only) element in
 ;; the list of the current block's branch targets passed as `targets`.
-(rule (lower_branch (jump _) targets)
-      (emit_side_effect (jump_impl (vec_element targets 0))))
+(rule (lower_branch (jump _) (single_target label))
+      (emit_side_effect (jump_impl label)))
 
 
 ;;;; Rules for `br_table` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Jump table.  `targets` contains the default target followed by the
 ;; list of branch targets per index value.
-(rule (lower_branch (br_table val_idx _) targets)
+(rule (lower_branch (br_table val_idx _) (jump_table_targets default targets))
       (let ((idx Reg (put_in_reg_zext64 val_idx))
             ;; Bounds-check the index and branch to default.
             ;; This is an internal branch that is not a terminator insn.
             ;; Instead, the default target is listed a potential target
             ;; in the final JTSequence, which is the block terminator.
             (cond ProducesBool
-              (bool (icmpu_uimm32 $I64 idx (vec_length_minus1 targets))
+              (bool (icmpu_uimm32 $I64 idx (jump_table_size targets))
                     (intcc_as_cond (IntCC.UnsignedGreaterThanOrEqual))))
-            (_ Unit (emit_side_effect (oneway_cond_br_bool cond
-                                        (vec_element targets 0)))))
+            (_ Unit (emit_side_effect (oneway_cond_br_bool cond default))))
         ;; Scale the index by the element size, and then emit the
         ;; compound instruction that does:
         ;;
@@ -3775,10 +3774,8 @@
 ;; Two-way conditional branch on nonzero.  `targets` contains:
 ;; - element 0: target if the condition is true (i.e. value is nonzero)
 ;; - element 1: target if the condition is false (i.e. value is zero)
-(rule (lower_branch (brif val_cond _ _) targets)
-      (emit_side_effect (cond_br_bool (value_nonzero val_cond)
-                                      (vec_element targets 0)
-                                      (vec_element targets 1))))
+(rule (lower_branch (brif val_cond _ _) (two_targets then else))
+      (emit_side_effect (cond_br_bool (value_nonzero val_cond) then else)))
 
 
 ;;;; Rules for `trap` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/cranelift/codegen/src/isa/s390x/lower/isle.rs
+++ b/cranelift/codegen/src/isa/s390x/lower/isle.rs
@@ -738,16 +738,6 @@ impl generated_code::Context for IsleContext<'_, '_, MInst, S390xBackend> {
     }
 
     #[inline]
-    fn vec_length_minus1(&mut self, vec: &VecMachLabel) -> u32 {
-        u32::try_from(vec.len()).unwrap() - 1
-    }
-
-    #[inline]
-    fn vec_element(&mut self, vec: &VecMachLabel, index: u8) -> MachLabel {
-        vec[usize::from(index)]
-    }
-
-    #[inline]
     fn zero_offset(&mut self) -> Offset32 {
         Offset32::new(0)
     }

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -728,26 +728,6 @@
 (type BoxCallInfo extern (enum))
 (type BoxReturnCallInfo extern (enum))
 
-(type BoxVecMachLabel extern (enum))
-
-(type MachLabelSlice extern (enum))
-
-;; The size of the jump table.
-(decl jump_table_size (BoxVecMachLabel) u32)
-(extern constructor jump_table_size jump_table_size)
-
-;; Extract a the target from a MachLabelSlice with exactly one target.
-(decl single_target (MachLabel) MachLabelSlice)
-(extern extractor single_target single_target)
-
-;; Extract a the targets from a MachLabelSlice with exactly two targets.
-(decl two_targets (MachLabel MachLabel) MachLabelSlice)
-(extern extractor two_targets two_targets)
-
-;; Extract the default target and jump table from a MachLabelSlice.
-(decl jump_table_targets (MachLabel BoxVecMachLabel) MachLabelSlice)
-(extern extractor jump_table_targets jump_table_targets)
-
 ;; Get the `OperandSize` for a given `Type`, rounding smaller types up to 32 bits.
 (decl operand_size_of_type_32_64 (Type) OperandSize)
 (extern constructor operand_size_of_type_32_64 operand_size_of_type_32_64)

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -36,14 +36,11 @@ use crate::{
 };
 use alloc::vec::Vec;
 use regalloc2::PReg;
-use smallvec::SmallVec;
 use std::boxed::Box;
 use std::convert::TryFrom;
 
 type BoxCallInfo = Box<CallInfo>;
 type BoxReturnCallInfo = Box<ReturnCallInfo>;
-type BoxVecMachLabel = Box<SmallVec<[MachLabel; 4]>>;
-type MachLabelSlice = [MachLabel];
 type VecArgPair = Vec<ArgPair>;
 
 pub struct SinkableLoad {
@@ -754,43 +751,6 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
         .expect("Failed to emit LibCall");
 
         output_reg.to_reg()
-    }
-
-    #[inline]
-    fn single_target(&mut self, targets: &MachLabelSlice) -> Option<MachLabel> {
-        if targets.len() == 1 {
-            Some(targets[0])
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    fn two_targets(&mut self, targets: &MachLabelSlice) -> Option<(MachLabel, MachLabel)> {
-        if targets.len() == 2 {
-            Some((targets[0], targets[1]))
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    fn jump_table_targets(
-        &mut self,
-        targets: &MachLabelSlice,
-    ) -> Option<(MachLabel, BoxVecMachLabel)> {
-        if targets.is_empty() {
-            return None;
-        }
-
-        let default_label = targets[0];
-        let jt_targets = Box::new(SmallVec::from(&targets[1..]));
-        Some((default_label, jt_targets))
-    }
-
-    #[inline]
-    fn jump_table_size(&mut self, targets: &BoxVecMachLabel) -> u32 {
-        targets.len() as u32
     }
 
     #[inline]

--- a/cranelift/codegen/src/prelude_lower.isle
+++ b/cranelift/codegen/src/prelude_lower.isle
@@ -181,6 +181,24 @@
 (type VecArgPair extern (enum))
 (type VecRetPair extern (enum))
 (type CallArgList extern (enum))
+(type MachLabelSlice extern (enum))
+(type BoxVecMachLabel extern (enum))
+
+;; Extract a the target from a MachLabelSlice with exactly one target.
+(decl single_target (MachLabel) MachLabelSlice)
+(extern extractor single_target single_target)
+
+;; Extract a the targets from a MachLabelSlice with exactly two targets.
+(decl two_targets (MachLabel MachLabel) MachLabelSlice)
+(extern extractor two_targets two_targets)
+
+;; Extract the default target and jump table from a MachLabelSlice.
+(decl jump_table_targets (MachLabel BoxVecMachLabel) MachLabelSlice)
+(extern extractor jump_table_targets jump_table_targets)
+
+;; The size of the jump table.
+(decl jump_table_size (BoxVecMachLabel) u32)
+(extern constructor jump_table_size jump_table_size)
 
 ;;;; Helper Clif Extractors ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/aarch64/bti.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/bti.clif
@@ -32,7 +32,7 @@ block5(v5: i32):
 ; block0:
 ;   emit_island 44
 ;   subs wzr, w0, #3
-;   b.hs label4 ; csel x11, xzr, x0, hs ; csdb ; adr x10, pc+16 ; ldrsw x11, [x10, x11, uxtw #2] ; add x10, x10, x11 ; br x10 ; jt_entries [Label(MachLabel(3)), Label(MachLabel(2)), Label(MachLabel(1))]
+;   b.hs label4 ; csel x11, xzr, x0, hs ; csdb ; adr x10, pc+16 ; ldrsw x11, [x10, x11, uxtw #2] ; add x10, x10, x11 ; br x10 ; jt_entries [MachLabel(3), MachLabel(2), MachLabel(1)]
 ; block1:
 ;   bti j
 ;   movz w5, #3
@@ -107,7 +107,7 @@ block2:
 ;   mov x8, x5
 ;   emit_island 36
 ;   subs wzr, w0, #1
-;   b.hs label2 ; csel x7, xzr, x0, hs ; csdb ; adr x6, pc+16 ; ldrsw x7, [x6, x7, uxtw #2] ; add x6, x6, x7 ; br x6 ; jt_entries [Label(MachLabel(1))]
+;   b.hs label2 ; csel x7, xzr, x0, hs ; csdb ; adr x6, pc+16 ; ldrsw x7, [x6, x7, uxtw #2] ; add x6, x6, x7 ; br x6 ; jt_entries [MachLabel(1)]
 ; block1:
 ;   bti j
 ;   mov x0, x8

--- a/cranelift/filetests/filetests/isa/aarch64/jumptable.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/jumptable.clif
@@ -31,7 +31,7 @@ block5(v5: i32):
 ; block0:
 ;   emit_island 44
 ;   subs wzr, w0, #3
-;   b.hs label4 ; csel x11, xzr, x0, hs ; csdb ; adr x10, pc+16 ; ldrsw x11, [x10, x11, uxtw #2] ; add x10, x10, x11 ; br x10 ; jt_entries [Label(MachLabel(3)), Label(MachLabel(2)), Label(MachLabel(1))]
+;   b.hs label4 ; csel x11, xzr, x0, hs ; csdb ; adr x10, pc+16 ; ldrsw x11, [x10, x11, uxtw #2] ; add x10, x10, x11 ; br x10 ; jt_entries [MachLabel(3), MachLabel(2), MachLabel(1)]
 ; block1:
 ;   movz w5, #3
 ;   b label5

--- a/cranelift/filetests/filetests/isa/s390x/jumptable.clif
+++ b/cranelift/filetests/filetests/isa/s390x/jumptable.clif
@@ -32,7 +32,7 @@ block5(v5: i32):
 ;   clgfi %r3, 3
 ;   jghe label4
 ;   sllg %r3, %r3, 2
-;   larl %r1, 14 ; agf %r1, 0(%r1, %r3) ; br %r1 ; jt_entries label3 label2 label1
+;   larl %r1, 14 ; agf %r1, 0(%r1, %r3) ; br %r1 ; jt_entries label2 label1
 ; block1:
 ;   lhi %r5, 3
 ;   jg label5

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -903,7 +903,7 @@ impl Assembler {
             tmp1: Writable::from_reg(tmp1.into()),
             tmp2: Writable::from_reg(tmp2.into()),
             default_target: default,
-            targets: Box::new(targets),
+            targets: Box::new(targets.to_vec()),
         })
     }
 


### PR DESCRIPTION
This commit is a refactoring to consistently implement `lower_branch` among Cranelift's backends. Previously each backend had its own means of extracting labels and shuffling along information, and now there's prelude methods for all backends to access and use. This changes a few display impls but the actual meat of what's emitted shouldn't change amongst the backends.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
