### PR TITLE
wasi-http: Use resources in wasi-http

### DIFF
--- a/crates/test-programs/wasi-http-proxy-tests/src/lib.rs
+++ b/crates/test-programs/wasi-http-proxy-tests/src/lib.rs
@@ -16,18 +16,17 @@ struct T;
 
 impl bindings::exports::wasi::http::incoming_handler::Guest for T {
     fn handle(_request: IncomingRequest, outparam: ResponseOutparam) {
-        let hdrs = bindings::wasi::http::types::new_fields(&[]);
-        let resp = bindings::wasi::http::types::new_outgoing_response(200, hdrs);
-        let body =
-            bindings::wasi::http::types::outgoing_response_write(resp).expect("outgoing response");
+        let hdrs = bindings::wasi::http::types::Headers::new(&[]);
+        let resp = bindings::wasi::http::types::OutgoingResponse::new(200, hdrs);
+        let body = resp.write().expect("outgoing response");
 
-        bindings::wasi::http::types::set_response_outparam(outparam, Ok(resp));
+        bindings::wasi::http::types::ResponseOutparam::set(outparam, Ok(resp));
 
-        let out = bindings::wasi::http::types::outgoing_body_write(body).expect("outgoing stream");
+        let out = body.write().expect("outgoing stream");
         out.blocking_write_and_flush(b"hello, world!")
             .expect("writing response");
 
         drop(out);
-        bindings::wasi::http::types::outgoing_body_finish(body, None);
+        bindings::wasi::http::types::OutgoingBody::finish(body, None);
     }
 }

--- a/crates/test-programs/wasi-http-tests/src/lib.rs
+++ b/crates/test-programs/wasi-http-tests/src/lib.rs
@@ -53,7 +53,7 @@ pub async fn request(
     fn header_val(v: &str) -> Vec<u8> {
         v.to_string().into_bytes()
     }
-    let headers = http_types::new_fields(
+    let headers = http_types::Headers::new(
         &[
             &[
                 ("User-agent".to_string(), header_val("WASI-HTTP/0.0.1")),
@@ -64,7 +64,7 @@ pub async fn request(
         .concat(),
     );
 
-    let request = http_types::new_outgoing_request(
+    let request = http_types::OutgoingRequest::new(
         &method,
         Some(path_with_query),
         Some(&scheme),
@@ -72,11 +72,13 @@ pub async fn request(
         headers,
     );
 
-    let outgoing_body = http_types::outgoing_request_write(request)
+    let outgoing_body = request
+        .write()
         .map_err(|_| anyhow!("outgoing request write failed"))?;
 
     if let Some(mut buf) = body {
-        let request_body = http_types::outgoing_body_write(outgoing_body)
+        let request_body = outgoing_body
+            .write()
             .map_err(|_| anyhow!("outgoing request write failed"))?;
 
         let pollable = request_body.subscribe();
@@ -113,17 +115,15 @@ pub async fn request(
 
     let future_response = outgoing_handler::handle(request, None)?;
 
-    // TODO: The current implementation requires this drop after the request is sent.
-    // The ownership semantics are unclear in wasi-http we should clarify exactly what is
-    // supposed to happen here.
-    http_types::outgoing_body_finish(outgoing_body, None);
+    http_types::OutgoingBody::finish(outgoing_body, None);
 
-    let incoming_response = match http_types::future_incoming_response_get(future_response) {
+    let incoming_response = match future_response.get() {
         Some(result) => result.map_err(|_| anyhow!("incoming response errored"))?,
         None => {
-            let pollable = http_types::listen_to_future_incoming_response(future_response);
+            let pollable = future_response.subscribe();
             let _ = poll::poll_list(&[&pollable]);
-            http_types::future_incoming_response_get(future_response)
+            future_response
+                .get()
                 .expect("incoming response available")
                 .map_err(|_| anyhow!("incoming response errored"))?
         }
@@ -132,18 +132,19 @@ pub async fn request(
     // Error? anyway, just use its Debug here:
     .map_err(|e| anyhow!("{e:?}"))?;
 
-    http_types::drop_future_incoming_response(future_response);
+    drop(future_response);
 
-    let status = http_types::incoming_response_status(incoming_response);
+    let status = incoming_response.status();
 
-    let headers_handle = http_types::incoming_response_headers(incoming_response);
-    let headers = http_types::fields_entries(headers_handle);
-    http_types::drop_fields(headers_handle);
+    let headers_handle = incoming_response.headers();
+    let headers = headers_handle.entries();
+    drop(headers_handle);
 
-    let incoming_body = http_types::incoming_response_consume(incoming_response)
+    let incoming_body = incoming_response
+        .consume()
         .map_err(|()| anyhow!("incoming response has no body stream"))?;
 
-    http_types::drop_incoming_response(incoming_response);
+    drop(incoming_response);
 
     let input_stream = incoming_body.stream().unwrap();
     let input_stream_pollable = input_stream.subscribe();

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -19,6 +19,17 @@ pub mod bindings {
         with: {
             "wasi:io/streams": wasmtime_wasi::preview2::bindings::io::streams,
             "wasi:io/poll": wasmtime_wasi::preview2::bindings::io::poll,
+
+            "wasi:http/types/outgoing-body": super::body::HostOutgoingBody,
+            "wasi:http/types/future-incoming-response": super::types::HostFutureIncomingResponse,
+            "wasi:http/types/outgoing-response": super::types::HostOutgoingResponse,
+            "wasi:http/types/future-trailers": super::body::HostFutureTrailers,
+            "wasi:http/types/incoming-body": super::body::HostIncomingBody,
+            "wasi:http/types/incoming-response": super::types::HostIncomingResponse,
+            "wasi:http/types/response-outparam": super::types::HostResponseOutparam,
+            "wasi:http/types/outgoing-request": super::types::HostOutgoingRequest,
+            "wasi:http/types/incoming-request": super::types::HostIncomingRequest,
+            "wasi:http/types/fields": super::types::HostFields,
         }
     });
 

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -2,18 +2,12 @@
 //! implementation of the wasi-http API.
 
 use crate::{
-    bindings::http::types::{
-        self, FutureTrailers, IncomingBody, IncomingRequest, Method, OutgoingBody,
-        OutgoingResponse, ResponseOutparam, Scheme,
-    },
-    body::{
-        HostFutureTrailers, HostIncomingBody, HostIncomingBodyBuilder, HostOutgoingBody,
-        HyperIncomingBody, HyperOutgoingBody,
-    },
+    bindings::http::types::{self, Method, Scheme},
+    body::{HostIncomingBodyBuilder, HyperIncomingBody, HyperOutgoingBody},
 };
 use std::any::Any;
 use wasmtime::component::Resource;
-use wasmtime_wasi::preview2::{AbortOnDropJoinHandle, Subscribe, Table, TableError};
+use wasmtime_wasi::preview2::{AbortOnDropJoinHandle, Subscribe, Table};
 
 /// Capture the state necessary for use in the wasi-http API implementation.
 pub struct WasiHttpCtx;
@@ -25,21 +19,17 @@ pub trait WasiHttpView: Send {
     fn new_incoming_request(
         &mut self,
         req: hyper::Request<HyperIncomingBody>,
-    ) -> wasmtime::Result<IncomingRequest> {
+    ) -> wasmtime::Result<Resource<HostIncomingRequest>> {
         let (parts, body) = req.into_parts();
         let body = HostIncomingBodyBuilder {
             body,
             // TODO: this needs to be plumbed through
             between_bytes_timeout: std::time::Duration::from_millis(600 * 1000),
         };
-        Ok(IncomingRequestLens::push(
-            self.table(),
-            HostIncomingRequest {
-                parts,
-                body: Some(body),
-            },
-        )?
-        .id)
+        Ok(self.table().push_resource(HostIncomingRequest {
+            parts,
+            body: Some(body),
+        })?)
     }
 
     fn new_response_outparam(
@@ -47,26 +37,23 @@ pub trait WasiHttpView: Send {
         result: tokio::sync::oneshot::Sender<
             Result<hyper::Response<HyperOutgoingBody>, types::Error>,
         >,
-    ) -> wasmtime::Result<ResponseOutparam> {
-        Ok(ResponseOutparamLens::push(self.table(), HostResponseOutparam { result })?.id)
+    ) -> wasmtime::Result<Resource<HostResponseOutparam>> {
+        let id = self
+            .table()
+            .push_resource(HostResponseOutparam { result })?;
+        Ok(id)
     }
 }
-
-pub type IncomingRequestLens = TableLens<HostIncomingRequest>;
 
 pub struct HostIncomingRequest {
     pub parts: http::request::Parts,
     pub body: Option<HostIncomingBodyBuilder>,
 }
 
-pub type ResponseOutparamLens = TableLens<HostResponseOutparam>;
-
 pub struct HostResponseOutparam {
     pub result:
         tokio::sync::oneshot::Sender<Result<hyper::Response<HyperOutgoingBody>, types::Error>>,
 }
-
-pub type OutgoingRequestLens = TableLens<HostOutgoingRequest>;
 
 pub struct HostOutgoingRequest {
     pub method: Method,
@@ -83,8 +70,6 @@ pub struct HostIncomingResponse {
     pub body: Option<HostIncomingBodyBuilder>,
     pub worker: AbortOnDropJoinHandle<anyhow::Result<()>>,
 }
-
-pub type OutgoingResponseLens = TableLens<HostOutgoingResponse>;
 
 pub struct HostOutgoingResponse {
     pub status: u16,
@@ -171,261 +156,5 @@ impl Subscribe for HostFutureIncomingResponse {
         if let Self::Pending(handle) = self {
             *self = Self::Ready(handle.await);
         }
-    }
-}
-
-pub struct TableLens<T> {
-    id: u32,
-    _unused: std::marker::PhantomData<T>,
-}
-
-impl<T: Send + Sync + 'static> TableLens<T> {
-    pub fn from(id: u32) -> Self {
-        Self {
-            id,
-            _unused: std::marker::PhantomData {},
-        }
-    }
-
-    pub fn into(self) -> u32 {
-        self.id
-    }
-
-    #[inline(always)]
-    pub fn push(table: &mut Table, val: T) -> Result<Self, TableError> {
-        let id = table.push(Box::new(val))?;
-        Ok(Self::from(id))
-    }
-
-    #[inline(always)]
-    pub fn get<'t>(&self, table: &'t Table) -> Result<&'t T, TableError> {
-        table.get(self.id)
-    }
-
-    #[inline(always)]
-    pub fn get_mut<'t>(&self, table: &'t mut Table) -> Result<&'t mut T, TableError> {
-        table.get_mut(self.id)
-    }
-
-    #[inline(always)]
-    pub fn delete(&self, table: &mut Table) -> Result<T, TableError> {
-        table.delete(self.id)
-    }
-}
-
-pub trait TableHttpExt {
-    fn push_outgoing_response(
-        &mut self,
-        resp: HostOutgoingResponse,
-    ) -> Result<OutgoingResponse, TableError>;
-    fn get_outgoing_response(&mut self, id: u32) -> Result<&mut HostOutgoingResponse, TableError>;
-    fn delete_outgoing_response(&mut self, id: u32) -> Result<HostOutgoingResponse, TableError>;
-
-    fn push_incoming_response(&mut self, response: HostIncomingResponse)
-        -> Result<u32, TableError>;
-    fn get_incoming_response(&self, id: u32) -> Result<&HostIncomingResponse, TableError>;
-    fn get_incoming_response_mut(
-        &mut self,
-        id: u32,
-    ) -> Result<&mut HostIncomingResponse, TableError>;
-    fn delete_incoming_response(&mut self, id: u32) -> Result<HostIncomingResponse, TableError>;
-
-    fn push_fields(&mut self, fields: HostFields) -> Result<u32, TableError>;
-    fn get_fields(&mut self, id: u32) -> Result<&mut FieldMap, TableError>;
-    fn delete_fields(&mut self, id: u32) -> Result<HostFields, TableError>;
-
-    fn push_future_incoming_response(
-        &mut self,
-        response: HostFutureIncomingResponse,
-    ) -> Result<u32, TableError>;
-    fn get_future_incoming_response(
-        &self,
-        id: u32,
-    ) -> Result<&HostFutureIncomingResponse, TableError>;
-    fn get_future_incoming_response_mut(
-        &mut self,
-        id: u32,
-    ) -> Result<&mut HostFutureIncomingResponse, TableError>;
-    fn delete_future_incoming_response(
-        &mut self,
-        id: u32,
-    ) -> Result<HostFutureIncomingResponse, TableError>;
-
-    fn push_incoming_body(
-        &mut self,
-        body: HostIncomingBody,
-    ) -> Result<Resource<IncomingBody>, TableError>;
-    fn get_incoming_body(
-        &mut self,
-        id: &Resource<IncomingBody>,
-    ) -> Result<&mut HostIncomingBody, TableError>;
-    fn delete_incoming_body(
-        &mut self,
-        id: Resource<IncomingBody>,
-    ) -> Result<HostIncomingBody, TableError>;
-
-    fn push_outgoing_body(&mut self, body: HostOutgoingBody) -> Result<u32, TableError>;
-    fn get_outgoing_body(&mut self, id: u32) -> Result<&mut HostOutgoingBody, TableError>;
-    fn delete_outgoing_body(&mut self, id: u32) -> Result<HostOutgoingBody, TableError>;
-
-    fn push_future_trailers(
-        &mut self,
-        trailers: HostFutureTrailers,
-    ) -> Result<FutureTrailers, TableError>;
-    fn get_future_trailers(
-        &mut self,
-        id: FutureTrailers,
-    ) -> Result<&mut HostFutureTrailers, TableError>;
-    fn delete_future_trailers(
-        &mut self,
-        id: FutureTrailers,
-    ) -> Result<HostFutureTrailers, TableError>;
-}
-
-impl TableHttpExt for Table {
-    fn push_outgoing_response(
-        &mut self,
-        response: HostOutgoingResponse,
-    ) -> Result<OutgoingResponse, TableError> {
-        self.push(Box::new(response))
-    }
-
-    fn get_outgoing_response(
-        &mut self,
-        id: OutgoingResponse,
-    ) -> Result<&mut HostOutgoingResponse, TableError> {
-        self.get_mut(id)
-    }
-
-    fn delete_outgoing_response(
-        &mut self,
-        id: OutgoingResponse,
-    ) -> Result<HostOutgoingResponse, TableError> {
-        self.delete(id)
-    }
-
-    fn push_incoming_response(
-        &mut self,
-        response: HostIncomingResponse,
-    ) -> Result<u32, TableError> {
-        self.push(Box::new(response))
-    }
-    fn get_incoming_response(&self, id: u32) -> Result<&HostIncomingResponse, TableError> {
-        self.get::<HostIncomingResponse>(id)
-    }
-    fn get_incoming_response_mut(
-        &mut self,
-        id: u32,
-    ) -> Result<&mut HostIncomingResponse, TableError> {
-        self.get_mut::<HostIncomingResponse>(id)
-    }
-    fn delete_incoming_response(&mut self, id: u32) -> Result<HostIncomingResponse, TableError> {
-        let resp = self.delete::<HostIncomingResponse>(id)?;
-        Ok(resp)
-    }
-
-    fn push_fields(&mut self, fields: HostFields) -> Result<u32, TableError> {
-        match fields {
-            HostFields::Ref { parent, .. } => self.push_child(Box::new(fields), parent),
-            HostFields::Owned { .. } => self.push(Box::new(fields)),
-        }
-    }
-    fn get_fields(&mut self, id: u32) -> Result<&mut FieldMap, TableError> {
-        let fields = self.get_mut::<HostFields>(id)?;
-        if let HostFields::Ref { parent, get_fields } = *fields {
-            let entry = self.get_any_mut(parent)?;
-            return Ok(get_fields(entry));
-        }
-
-        match self.get_mut::<HostFields>(id)? {
-            HostFields::Owned { fields } => Ok(fields),
-            // NB: ideally the `if let` above would go here instead. That makes
-            // the borrow-checker unhappy. Unclear why. If you, dear reader, can
-            // refactor this to remove the `unreachable!` please do.
-            HostFields::Ref { .. } => unreachable!(),
-        }
-    }
-    fn delete_fields(&mut self, id: u32) -> Result<HostFields, TableError> {
-        let fields = self.delete::<HostFields>(id)?;
-        Ok(fields)
-    }
-
-    fn push_future_incoming_response(
-        &mut self,
-        response: HostFutureIncomingResponse,
-    ) -> Result<u32, TableError> {
-        self.push(Box::new(response))
-    }
-    fn get_future_incoming_response(
-        &self,
-        id: u32,
-    ) -> Result<&HostFutureIncomingResponse, TableError> {
-        self.get::<HostFutureIncomingResponse>(id)
-    }
-    fn get_future_incoming_response_mut(
-        &mut self,
-        id: u32,
-    ) -> Result<&mut HostFutureIncomingResponse, TableError> {
-        self.get_mut::<HostFutureIncomingResponse>(id)
-    }
-    fn delete_future_incoming_response(
-        &mut self,
-        id: u32,
-    ) -> Result<HostFutureIncomingResponse, TableError> {
-        self.delete(id)
-    }
-
-    fn push_incoming_body(
-        &mut self,
-        body: HostIncomingBody,
-    ) -> Result<Resource<IncomingBody>, TableError> {
-        Ok(Resource::new_own(self.push(Box::new(body))?))
-    }
-
-    fn get_incoming_body(
-        &mut self,
-        id: &Resource<IncomingBody>,
-    ) -> Result<&mut HostIncomingBody, TableError> {
-        self.get_mut(id.rep())
-    }
-
-    fn delete_incoming_body(
-        &mut self,
-        id: Resource<IncomingBody>,
-    ) -> Result<HostIncomingBody, TableError> {
-        self.delete(id.rep())
-    }
-
-    fn push_outgoing_body(&mut self, body: HostOutgoingBody) -> Result<OutgoingBody, TableError> {
-        Ok(self.push(Box::new(body))?)
-    }
-
-    fn get_outgoing_body(&mut self, id: u32) -> Result<&mut HostOutgoingBody, TableError> {
-        self.get_mut(id)
-    }
-
-    fn delete_outgoing_body(&mut self, id: u32) -> Result<HostOutgoingBody, TableError> {
-        self.delete(id)
-    }
-
-    fn push_future_trailers(
-        &mut self,
-        trailers: HostFutureTrailers,
-    ) -> Result<FutureTrailers, TableError> {
-        self.push(Box::new(trailers))
-    }
-
-    fn get_future_trailers(
-        &mut self,
-        id: FutureTrailers,
-    ) -> Result<&mut HostFutureTrailers, TableError> {
-        self.get_mut(id)
-    }
-
-    fn delete_future_trailers(
-        &mut self,
-        id: FutureTrailers,
-    ) -> Result<HostFutureTrailers, TableError> {
-        self.delete(id)
     }
 }

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -30,35 +30,38 @@ interface types {
   // This type enumerates the different kinds of errors that may occur when
   // initially returning a response.
   variant error {
-      invalid-url(string),
-      timeout-error(string),
-      protocol-error(string),
-      unexpected-error(string)
+    invalid-url(string),
+    timeout-error(string),
+    protocol-error(string),
+    unexpected-error(string)
   }
 
   // This following block defines the `fields` resource which corresponds to
   // HTTP standard Fields. Soon, when resource types are added, the `type
   // fields = u32` type alias can be replaced by a proper `resource fields`
   // definition containing all the functions using the method syntactic sugar.
-  type fields = u32
-  drop-fields: func(fields: /* own */ fields)
-  // Multiple values for a header are multiple entries in the list with the
-  // same key.
-  new-fields: func(entries: list<tuple<string,list<u8>>>) -> fields
-  // Values off wire are not necessarily well formed, so they are given by
-  // list<u8> instead of string.
-  fields-get: func(fields: /* borrow */ fields, name: string) -> list<list<u8>>
-  // Values off wire are not necessarily well formed, so they are given by
-  // list<u8> instead of string.
-  fields-set: func(fields: /* borrow */ fields, name: string, value: list<list<u8>>)
-  fields-delete: func(fields: /* borrow */ fields, name: string)
-  fields-append: func(fields: /* borrow */  fields, name: string, value: list<u8>)
+  resource fields {
+    // Multiple values for a header are multiple entries in the list with the
+    // same key.
+    constructor(entries: list<tuple<string,list<u8>>>)
 
-  // Values off wire are not necessarily well formed, so they are given by
-  // list<u8> instead of string.
-  fields-entries: func(fields: /* borrow */  fields) -> list<tuple<string,list<u8>>>
-  // Deep copy of all contents in a fields.
-  fields-clone: func(fields: /* borrow */ fields) -> fields
+    // Values off wire are not necessarily well formed, so they are given by
+    // list<u8> instead of string.
+    get: func(name: string) -> list<list<u8>>
+
+    // Values off wire are not necessarily well formed, so they are given by
+    // list<u8> instead of string.
+    set: func(name: string, value: list<list<u8>>)
+    delete: func(name: string)
+    append: func(name: string, value: list<u8>)
+
+    // Values off wire are not necessarily well formed, so they are given by
+    // list<u8> instead of string.
+    entries: func() -> list<tuple<string,list<u8>>>
+
+    // Deep copy of all contents in a fields.
+    clone: func() -> fields
+  }
 
   type headers = fields
   type trailers = fields
@@ -71,31 +74,35 @@ interface types {
   // a single `request` type (that uses the single `stream` type mentioned
   // above). The `consume` and `write` methods may only be called once (and
   // return failure thereafter).
-  type incoming-request = u32
-  drop-incoming-request: func(request: /* own */ incoming-request)
-  incoming-request-method: func(request: /* borrow */ incoming-request) -> method
-  incoming-request-path-with-query: func(request: /* borrow */ incoming-request) -> option<string>
-  incoming-request-scheme: func(request: /* borrow */ incoming-request) -> option<scheme>
-  incoming-request-authority: func(request: /* borrow */ incoming-request) -> option<string>
+  resource incoming-request {
+    method: func() -> method
 
-  incoming-request-headers: func(request: /* borrow */ incoming-request) -> /* child */ headers
-  // Will return the input-stream child at most once. If called more than
-  // once, subsequent calls will return error.
-  incoming-request-consume: func(request: /* borrow */ incoming-request) -> result< /* own */ incoming-body>
+    path-with-query: func() -> option<string>
 
-  type outgoing-request = u32
-  drop-outgoing-request: func(request: /* own */ outgoing-request)
-  new-outgoing-request: func(
-    method: method,
-    path-with-query: option<string>,
-    scheme: option<scheme>,
-    authority: option<string>,
-    headers: /* borrow */ headers
-  ) -> outgoing-request
+    scheme: func() -> option<scheme>
 
-  // Will return the outgoing-body child at most once. If called more than
-  // once, subsequent calls will return error.
-  outgoing-request-write: func(request: /* borrow */ outgoing-request) -> result< /* child */ outgoing-body>
+    authority: func() -> option<string>
+
+    headers: func() -> /* child */ headers
+    // Will return the input-stream child at most once. If called more than
+    // once, subsequent calls will return error.
+
+    consume: func() -> result< /* own */ incoming-body>
+  }
+
+  resource outgoing-request {
+    constructor(
+      method: method,
+      path-with-query: option<string>,
+      scheme: option<scheme>,
+      authority: option<string>,
+      headers: /* borrow */ headers
+    )
+
+    // Will return the outgoing-body child at most once. If called more than
+    // once, subsequent calls will return error.
+    write: func() -> result< /* child */ outgoing-body>
+  }
 
   // Additional optional parameters that can be set when making a request.
   record request-options {
@@ -119,9 +126,9 @@ interface types {
   // definition. Later, with Preview3, the need for an outparam goes away entirely
   // (the `wasi:http/handler` interface used for both incoming and outgoing can
   // simply return a `stream`).
-  type response-outparam = u32
-  drop-response-outparam: func(response: /* own */ response-outparam)
-  set-response-outparam: func(param: /* own */ response-outparam, response: result< /* own */ outgoing-response, error>)
+  resource response-outparam {
+    set: static func(param: /* own */ response-outparam, response: result< /* own */ outgoing-response, error>)
+  }
 
   // This type corresponds to the HTTP standard Status Code.
   type status-code = u16
@@ -133,58 +140,58 @@ interface types {
   // Preview2 will allow both types to be merged together into a single `response`
   // type (that uses the single `stream` type mentioned above). The `consume` and
   // `write` methods may only be called once (and return failure thereafter).
-  type incoming-response = u32
-  drop-incoming-response: func(response: /* own */ incoming-response)
-  incoming-response-status: func(response: /* borrow */ incoming-response) -> status-code
-  incoming-response-headers: func(response: /* borrow */ incoming-response) -> /* child */ headers
-  // May be called at most once. returns error if called additional times.
-  // TODO: make incoming-request-consume work the same way, giving a child
-  // incoming-body.
-  incoming-response-consume: func(response: /* borrow */ incoming-response) -> result</* own */ incoming-body>
+  resource incoming-response {
+    status: func() -> status-code
+
+    headers: func() -> /* child */ headers
+
+    // May be called at most once. returns error if called additional times.
+    // TODO: make incoming-request-consume work the same way, giving a child
+    // incoming-body.
+    consume: func() -> result</* own */ incoming-body>
+  }
 
   resource incoming-body {
     // returned input-stream is a child - the implementation may trap if
     // incoming-body is dropped (or consumed by call to
     // incoming-body-finish) before the input-stream is dropped.
     // May be called at most once. returns error if called additional times.
-    %stream: func() ->
-      result</* child */ input-stream>
+    %stream: func() -> result</* child */ input-stream>
+
     // takes ownership of incoming-body. this will trap if the
     // incoming-body-stream child is still alive!
-    finish: func() ->
-      /* transitive child of the incoming-response of incoming-body */ future-trailers
+    finish: static func(this: /* own */ incoming-body) ->
+    /* transitive child of the incoming-response of incoming-body */ future-trailers
   }
 
-  type future-trailers = u32
-  drop-future-trailers: func(this: /* own */ future-trailers)
-  /// Pollable that resolves when the body has been fully read, and the trailers
-  /// are ready to be consumed.
-  future-trailers-subscribe: func(this: /* borrow */ future-trailers) -> /* child */ pollable
+  resource future-trailers {
+    /// Pollable that resolves when the body has been fully read, and the trailers
+    /// are ready to be consumed.
+    subscribe: func() -> /* child */ pollable
 
-  /// Retrieve reference to trailers, if they are ready.
-  future-trailers-get: func(response: /* borrow */ future-trailers) -> option<result</* child */ trailers, error>>
+    /// Retrieve reference to trailers, if they are ready.
+    get: func() -> option<result</* child */ trailers, error>>
+  }
 
-  type outgoing-response = u32
-  drop-outgoing-response: func(response: /* own */ outgoing-response)
-  new-outgoing-response: func(
-    status-code: status-code,
-    headers: /* borrow */ headers
-  ) -> outgoing-response
+  resource outgoing-response {
+    constructor(status-code: status-code, headers: /* borrow */ headers)
 
-  /// Will give the child outgoing-response at most once. subsequent calls will
-  /// return an error.
-  outgoing-response-write: func(this: /* borrow */ outgoing-response) -> result</* own */ outgoing-body>
+    /// Will give the child outgoing-response at most once. subsequent calls will
+    /// return an error.
+    write: func() -> result</* own */ outgoing-body>
+  }
 
-  type outgoing-body = u32
-  drop-outgoing-body: func(this: /* own */ outgoing-body)
-  /// Will give the child output-stream at most once. subsequent calls will
-  /// return an error.
-  outgoing-body-write: func(this: /* borrow */ outgoing-body) -> result</* child */ output-stream>
-  /// Finalize an outgoing body, optionally providing trailers. This must be
-  /// called to signal that the response is complete. If the `outgoing-body` is
-  /// dropped without calling `outgoing-body-finalize`, the implementation
-  /// should treat the body as corrupted.
-  outgoing-body-finish: func(this: /* own */ outgoing-body, trailers: /* own */ option<trailers>)
+  resource outgoing-body {
+    /// Will give the child output-stream at most once. subsequent calls will
+    /// return an error.
+    write: func() -> result</* child */ output-stream>
+
+    /// Finalize an outgoing body, optionally providing trailers. This must be
+    /// called to signal that the response is complete. If the `outgoing-body` is
+    /// dropped without calling `outgoing-body-finalize`, the implementation
+    /// should treat the body as corrupted.
+    finish: static func(this: /* own */ outgoing-body, trailers: /* own */ option<trailers>)
+  }
 
   /// The following block defines a special resource type used by the
   /// `wasi:http/outgoing-handler` interface to emulate
@@ -193,14 +200,15 @@ interface types {
   /// method to get the result if it is available. If the result is not available,
   /// the client can call `listen` to get a `pollable` that can be passed to
   /// `wasi:io/poll.poll-list`.
-  type future-incoming-response = u32
-  drop-future-incoming-response: func(f: /* own */ future-incoming-response)
-  /// option indicates readiness.
-  /// outer result indicates you are allowed to get the
-  /// incoming-response-or-error at most once. subsequent calls after ready
-  /// will return an error here.
-  /// inner result indicates whether the incoming-response was available, or an
-  /// error occured.
-  future-incoming-response-get: func(f: /* borrow */ future-incoming-response) -> option<result<result</* NOT a child*/ incoming-response, error>>>
-  listen-to-future-incoming-response: func(f: /* borrow */ future-incoming-response) -> /* child */ pollable
+  resource future-incoming-response {
+    /// option indicates readiness.
+    /// outer result indicates you are allowed to get the
+    /// incoming-response-or-error at most once. subsequent calls after ready
+    /// will return an error here.
+    /// inner result indicates whether the incoming-response was available, or an
+    /// error occured.
+    get: func() -> option<result<result</* NOT a child*/ incoming-response, error>>>
+
+    subscribe: func() -> /* child */ pollable
+  }
 }

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -30,35 +30,38 @@ interface types {
   // This type enumerates the different kinds of errors that may occur when
   // initially returning a response.
   variant error {
-      invalid-url(string),
-      timeout-error(string),
-      protocol-error(string),
-      unexpected-error(string)
+    invalid-url(string),
+    timeout-error(string),
+    protocol-error(string),
+    unexpected-error(string)
   }
 
   // This following block defines the `fields` resource which corresponds to
   // HTTP standard Fields. Soon, when resource types are added, the `type
   // fields = u32` type alias can be replaced by a proper `resource fields`
   // definition containing all the functions using the method syntactic sugar.
-  type fields = u32
-  drop-fields: func(fields: /* own */ fields)
-  // Multiple values for a header are multiple entries in the list with the
-  // same key.
-  new-fields: func(entries: list<tuple<string,list<u8>>>) -> fields
-  // Values off wire are not necessarily well formed, so they are given by
-  // list<u8> instead of string.
-  fields-get: func(fields: /* borrow */ fields, name: string) -> list<list<u8>>
-  // Values off wire are not necessarily well formed, so they are given by
-  // list<u8> instead of string.
-  fields-set: func(fields: /* borrow */ fields, name: string, value: list<list<u8>>)
-  fields-delete: func(fields: /* borrow */ fields, name: string)
-  fields-append: func(fields: /* borrow */  fields, name: string, value: list<u8>)
+  resource fields {
+    // Multiple values for a header are multiple entries in the list with the
+    // same key.
+    constructor(entries: list<tuple<string,list<u8>>>)
 
-  // Values off wire are not necessarily well formed, so they are given by
-  // list<u8> instead of string.
-  fields-entries: func(fields: /* borrow */  fields) -> list<tuple<string,list<u8>>>
-  // Deep copy of all contents in a fields.
-  fields-clone: func(fields: /* borrow */ fields) -> fields
+    // Values off wire are not necessarily well formed, so they are given by
+    // list<u8> instead of string.
+    get: func(name: string) -> list<list<u8>>
+
+    // Values off wire are not necessarily well formed, so they are given by
+    // list<u8> instead of string.
+    set: func(name: string, value: list<list<u8>>)
+    delete: func(name: string)
+    append: func(name: string, value: list<u8>)
+
+    // Values off wire are not necessarily well formed, so they are given by
+    // list<u8> instead of string.
+    entries: func() -> list<tuple<string,list<u8>>>
+
+    // Deep copy of all contents in a fields.
+    clone: func() -> fields
+  }
 
   type headers = fields
   type trailers = fields
@@ -71,31 +74,35 @@ interface types {
   // a single `request` type (that uses the single `stream` type mentioned
   // above). The `consume` and `write` methods may only be called once (and
   // return failure thereafter).
-  type incoming-request = u32
-  drop-incoming-request: func(request: /* own */ incoming-request)
-  incoming-request-method: func(request: /* borrow */ incoming-request) -> method
-  incoming-request-path-with-query: func(request: /* borrow */ incoming-request) -> option<string>
-  incoming-request-scheme: func(request: /* borrow */ incoming-request) -> option<scheme>
-  incoming-request-authority: func(request: /* borrow */ incoming-request) -> option<string>
+  resource incoming-request {
+    method: func() -> method
 
-  incoming-request-headers: func(request: /* borrow */ incoming-request) -> /* child */ headers
-  // Will return the input-stream child at most once. If called more than
-  // once, subsequent calls will return error.
-  incoming-request-consume: func(request: /* borrow */ incoming-request) -> result< /* own */ incoming-body>
+    path-with-query: func() -> option<string>
 
-  type outgoing-request = u32
-  drop-outgoing-request: func(request: /* own */ outgoing-request)
-  new-outgoing-request: func(
-    method: method,
-    path-with-query: option<string>,
-    scheme: option<scheme>,
-    authority: option<string>,
-    headers: /* borrow */ headers
-  ) -> outgoing-request
+    scheme: func() -> option<scheme>
 
-  // Will return the outgoing-body child at most once. If called more than
-  // once, subsequent calls will return error.
-  outgoing-request-write: func(request: /* borrow */ outgoing-request) -> result< /* child */ outgoing-body>
+    authority: func() -> option<string>
+
+    headers: func() -> /* child */ headers
+    // Will return the input-stream child at most once. If called more than
+    // once, subsequent calls will return error.
+
+    consume: func() -> result< /* own */ incoming-body>
+  }
+
+  resource outgoing-request {
+    constructor(
+      method: method,
+      path-with-query: option<string>,
+      scheme: option<scheme>,
+      authority: option<string>,
+      headers: /* borrow */ headers
+    )
+
+    // Will return the outgoing-body child at most once. If called more than
+    // once, subsequent calls will return error.
+    write: func() -> result< /* child */ outgoing-body>
+  }
 
   // Additional optional parameters that can be set when making a request.
   record request-options {
@@ -119,9 +126,9 @@ interface types {
   // definition. Later, with Preview3, the need for an outparam goes away entirely
   // (the `wasi:http/handler` interface used for both incoming and outgoing can
   // simply return a `stream`).
-  type response-outparam = u32
-  drop-response-outparam: func(response: /* own */ response-outparam)
-  set-response-outparam: func(param: /* own */ response-outparam, response: result< /* own */ outgoing-response, error>)
+  resource response-outparam {
+    set: static func(param: /* own */ response-outparam, response: result< /* own */ outgoing-response, error>)
+  }
 
   // This type corresponds to the HTTP standard Status Code.
   type status-code = u16
@@ -133,58 +140,58 @@ interface types {
   // Preview2 will allow both types to be merged together into a single `response`
   // type (that uses the single `stream` type mentioned above). The `consume` and
   // `write` methods may only be called once (and return failure thereafter).
-  type incoming-response = u32
-  drop-incoming-response: func(response: /* own */ incoming-response)
-  incoming-response-status: func(response: /* borrow */ incoming-response) -> status-code
-  incoming-response-headers: func(response: /* borrow */ incoming-response) -> /* child */ headers
-  // May be called at most once. returns error if called additional times.
-  // TODO: make incoming-request-consume work the same way, giving a child
-  // incoming-body.
-  incoming-response-consume: func(response: /* borrow */ incoming-response) -> result</* own */ incoming-body>
+  resource incoming-response {
+    status: func() -> status-code
+
+    headers: func() -> /* child */ headers
+
+    // May be called at most once. returns error if called additional times.
+    // TODO: make incoming-request-consume work the same way, giving a child
+    // incoming-body.
+    consume: func() -> result</* own */ incoming-body>
+  }
 
   resource incoming-body {
     // returned input-stream is a child - the implementation may trap if
     // incoming-body is dropped (or consumed by call to
     // incoming-body-finish) before the input-stream is dropped.
     // May be called at most once. returns error if called additional times.
-    %stream: func() ->
-      result</* child */ input-stream>
+    %stream: func() -> result</* child */ input-stream>
+
     // takes ownership of incoming-body. this will trap if the
     // incoming-body-stream child is still alive!
-    finish: func() ->
-      /* transitive child of the incoming-response of incoming-body */ future-trailers
+    finish: static func(this: /* own */ incoming-body) ->
+    /* transitive child of the incoming-response of incoming-body */ future-trailers
   }
 
-  type future-trailers = u32
-  drop-future-trailers: func(this: /* own */ future-trailers)
-  /// Pollable that resolves when the body has been fully read, and the trailers
-  /// are ready to be consumed.
-  future-trailers-subscribe: func(this: /* borrow */ future-trailers) -> /* child */ pollable
+  resource future-trailers {
+    /// Pollable that resolves when the body has been fully read, and the trailers
+    /// are ready to be consumed.
+    subscribe: func() -> /* child */ pollable
 
-  /// Retrieve reference to trailers, if they are ready.
-  future-trailers-get: func(response: /* borrow */ future-trailers) -> option<result</* child */ trailers, error>>
+    /// Retrieve reference to trailers, if they are ready.
+    get: func() -> option<result</* child */ trailers, error>>
+  }
 
-  type outgoing-response = u32
-  drop-outgoing-response: func(response: /* own */ outgoing-response)
-  new-outgoing-response: func(
-    status-code: status-code,
-    headers: /* borrow */ headers
-  ) -> outgoing-response
+  resource outgoing-response {
+    constructor(status-code: status-code, headers: /* borrow */ headers)
 
-  /// Will give the child outgoing-response at most once. subsequent calls will
-  /// return an error.
-  outgoing-response-write: func(this: /* borrow */ outgoing-response) -> result</* own */ outgoing-body>
+    /// Will give the child outgoing-response at most once. subsequent calls will
+    /// return an error.
+    write: func() -> result</* own */ outgoing-body>
+  }
 
-  type outgoing-body = u32
-  drop-outgoing-body: func(this: /* own */ outgoing-body)
-  /// Will give the child output-stream at most once. subsequent calls will
-  /// return an error.
-  outgoing-body-write: func(this: /* borrow */ outgoing-body) -> result</* child */ output-stream>
-  /// Finalize an outgoing body, optionally providing trailers. This must be
-  /// called to signal that the response is complete. If the `outgoing-body` is
-  /// dropped without calling `outgoing-body-finalize`, the implementation
-  /// should treat the body as corrupted.
-  outgoing-body-finish: func(this: /* own */ outgoing-body, trailers: /* own */ option<trailers>)
+  resource outgoing-body {
+    /// Will give the child output-stream at most once. subsequent calls will
+    /// return an error.
+    write: func() -> result</* child */ output-stream>
+
+    /// Finalize an outgoing body, optionally providing trailers. This must be
+    /// called to signal that the response is complete. If the `outgoing-body` is
+    /// dropped without calling `outgoing-body-finalize`, the implementation
+    /// should treat the body as corrupted.
+    finish: static func(this: /* own */ outgoing-body, trailers: /* own */ option<trailers>)
+  }
 
   /// The following block defines a special resource type used by the
   /// `wasi:http/outgoing-handler` interface to emulate
@@ -193,14 +200,15 @@ interface types {
   /// method to get the result if it is available. If the result is not available,
   /// the client can call `listen` to get a `pollable` that can be passed to
   /// `wasi:io/poll.poll-list`.
-  type future-incoming-response = u32
-  drop-future-incoming-response: func(f: /* own */ future-incoming-response)
-  /// option indicates readiness.
-  /// outer result indicates you are allowed to get the
-  /// incoming-response-or-error at most once. subsequent calls after ready
-  /// will return an error here.
-  /// inner result indicates whether the incoming-response was available, or an
-  /// error occured.
-  future-incoming-response-get: func(f: /* borrow */ future-incoming-response) -> option<result<result</* NOT a child*/ incoming-response, error>>>
-  listen-to-future-incoming-response: func(f: /* borrow */ future-incoming-response) -> /* child */ pollable
+  resource future-incoming-response {
+    /// option indicates readiness.
+    /// outer result indicates you are allowed to get the
+    /// incoming-response-or-error at most once. subsequent calls after ready
+    /// will return an error here.
+    /// inner result indicates whether the incoming-response was available, or an
+    /// error occured.
+    get: func() -> option<result<result</* NOT a child*/ incoming-response, error>>>
+
+    subscribe: func() -> /* child */ pollable
+  }
 }


### PR DESCRIPTION
Migrate wasi-http over to resources, now that they've landed on main.

This was a pretty straight-forward refactoring: I replaced all of the `u32` alias types for the pseudo-resources in the spec with actual resources. Using resources led to the complete removal of the `TableHttpExt` trait, and also the `TableLens` machinery that I had added earlier.

One decision that I made here was to add static functions for the functions that we have that consume resources. These could have instead been functions not defined on the resource, but I liked being able to use a simple name like `finish` that was scoped to the resource rather than prefix it to make it unique.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
