### PR TITLE
riscv64: Refactor implementation of `{u,s}{div,rem}`

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1090,6 +1090,9 @@
 
 ;; ISA Extension helpers
 
+(decl pure has_m () bool)
+(extern constructor has_m has_m)
+
 (decl pure has_v () bool)
 (extern constructor has_v has_v)
 
@@ -2788,25 +2791,6 @@
 (decl gen_trapz (XReg TrapCode) InstOutput)
 (rule (gen_trapz test trap_code)
   (gen_trapif (IntCC.Equal) test (zero_reg) trap_code))
-
-
-(decl shift_int_to_most_significant (XReg Type) XReg)
-(extern constructor shift_int_to_most_significant shift_int_to_most_significant)
-
-;;; generate div overflow.
-(decl gen_div_overflow (XReg XReg Type) InstOutput)
-(rule (gen_div_overflow rs1 rs2 ty)
-  (let ((r_const_neg_1 XReg (imm $I64 (i64_as_u64 -1)))
-        (r_const_min XReg (rv_slli (imm $I64 1) (imm12_const 63)))
-        (tmp_rs1 XReg (shift_int_to_most_significant rs1 ty))
-        (t1 XReg (gen_icmp (IntCC.Equal) r_const_neg_1 rs2 ty))
-        (t2 XReg (gen_icmp (IntCC.Equal) r_const_min tmp_rs1 ty))
-        (test XReg (rv_and t1 t2)))
-    (gen_trapnz test (TrapCode.IntegerOverflow))))
-
-(decl gen_div_by_zero (XReg) InstOutput)
-(rule (gen_div_by_zero r)
-  (gen_trapz r (TrapCode.IntegerDivisionByZero)))
 
 ;;;; Helpers for Emitting Calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -505,68 +505,147 @@
 (rule 4 (lower (has_type (ty_vec_fits_in_register ty) (umulhi x (splat y))))
   (rv_vmulhu_vx x y (unmasked) ty))
 
-;;;; Rules for `div` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Rules for `udiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule -1 (lower (has_type (fits_in_32 ty) (udiv x y)))
-  (let
-    ((y2 XReg (zext y))
-      (_ InstOutput (gen_div_by_zero y2)))
-    (rv_divuw (zext x) y2)))
+(rule 0 (lower (has_type (fits_in_16 ty) (udiv x y)))
+  (if-let $true (has_m))
+  (rv_divuw (zext x) (nonzero_divisor (zext y))))
 
-(rule -1 (lower (has_type (fits_in_32 ty) (sdiv x y)))
-  (let
-    ((a XReg (sext x))
-      (b XReg (sext y))
-      (_ InstOutput (gen_div_overflow a b ty))
-      (_ InstOutput (gen_div_by_zero b)))
-    (rv_divw a b)))
+(rule 1 (lower (has_type (fits_in_16 ty) (udiv x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 ty imm))
+  (rv_divuw (zext x) (zext y)))
 
-(rule (lower (has_type $I64 (sdiv x y)))
-  (let
-    ((_ InstOutput (gen_div_overflow x y $I64))
-      (_ InstOutput (gen_div_by_zero y))    )
-    (rv_div x y)))
+(rule 2 (lower (has_type $I32 (udiv x y)))
+  (if-let $true (has_m))
+  (rv_divuw x (nonzero_divisor (zext y))))
 
-(rule (lower (has_type $I64 (udiv x y)))
-  (let
-    ((_ InstOutput (gen_div_by_zero y)))
-    (rv_divu x y)))
+(rule 3 (lower (has_type $I32 (udiv x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 $I32 imm))
+  (rv_divuw x y))
 
-;;;; Rules for `rem` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+(rule 2 (lower (has_type $I64 (udiv x y)))
+  (if-let $true (has_m))
+  (rv_divu x (nonzero_divisor y)))
 
-(rule -1 (lower (has_type (fits_in_16 ty) (urem x y)))
-  (let
-    ((y2 XReg (zext y))
-      (_ InstOutput (gen_div_by_zero y2)))
-    (rv_remuw (zext x) y2)))
+(rule 3 (lower (has_type $I64 (udiv x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 $I64 imm))
+  (rv_divu x y))
 
-(rule -1 (lower (has_type (fits_in_16 ty) (srem x y)))
-  (let
-    ((y2 XReg (sext y))
-      (_ InstOutput (gen_div_by_zero y2)))
-    (rv_remw (sext x) y2)))
+;; Traps if the input register is zero, otherwise returns the same register.
+(decl nonzero_divisor (XReg) XReg)
+(rule (nonzero_divisor val)
+  (let ((_ InstOutput (gen_trapif (IntCC.Equal) val (zero_reg) (TrapCode.IntegerDivisionByZero))))
+    val))
 
-(rule (lower (has_type $I32 (srem x y)))
-  (let
-    ((y2 XReg (sext y))
-      (_ InstOutput (gen_div_by_zero y2)))
-   (rv_remw x y2)))
+;;;; Rules for `sdiv` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type $I32 (urem x y)))
-  (let
-    ((y2 XReg (zext y))
-        (_ InstOutput (gen_div_by_zero y2)))
-    (rv_remuw x y2)))
+(rule 0 (lower (has_type (fits_in_16 ty) (sdiv x y)))
+  (if-let $true (has_m))
+  (let ((x XReg (sext x)))
+    (rv_divw x (safe_sdiv_divisor ty x (sext y)))))
 
-(rule (lower (has_type $I64 (srem x y)))
-  (let
-    ((_ InstOutput (gen_div_by_zero y)))
-    (rv_rem x y)))
+(rule 1 (lower (has_type (fits_in_16 ty) (sdiv x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 ty imm))
+  (rv_divw (sext x) y))
 
-(rule (lower (has_type $I64 (urem x y)))
-  (let
-    ((_ InstOutput (gen_div_by_zero y)))
-    (rv_remu x y)))
+(rule 2 (lower (has_type $I32 (sdiv x y)))
+  (if-let $true (has_m))
+  (let ((x XReg (sext x)))
+    (rv_divw x (safe_sdiv_divisor $I32 x (sext y)))))
+
+(rule 3 (lower (has_type $I32 (sdiv x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 $I32 imm))
+  (rv_divw x y))
+
+(rule 2 (lower (has_type $I64 (sdiv x y)))
+  (if-let $true (has_m))
+  (rv_div x (safe_sdiv_divisor $I64 x y)))
+
+(rule 3 (lower (has_type $I64 (sdiv x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 $I64 imm))
+  (rv_div x y))
+
+;; Check for two trapping conditions:
+;;
+;; * the divisor is 0, or...
+;; * the divisor is -1 and the dividend is $ty::MIN
+(decl safe_sdiv_divisor (Type XReg XReg) XReg)
+(rule (safe_sdiv_divisor ty x y)
+  (let (
+      (y XReg (nonzero_divisor y))
+      (min XReg (imm $I64 (u64_shl 1 (u64_sub (ty_bits ty) 1))))
+      (x_is_not_min XReg (rv_xor x min))
+      (y_is_not_neg_one XReg (rv_not y))
+      (no_int_overflow XReg (rv_or x_is_not_min y_is_not_neg_one))
+      (_ InstOutput (gen_trapif
+                      (IntCC.Equal)
+                      no_int_overflow (zero_reg)
+                      (TrapCode.IntegerOverflow))))
+      y))
+
+;;;; Rules for `urem` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule 0 (lower (has_type (fits_in_16 ty) (urem x y)))
+  (if-let $true (has_m))
+  (rv_remuw (zext x) (nonzero_divisor (zext y))))
+
+(rule 1 (lower (has_type (fits_in_16 ty) (urem x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 ty imm))
+  (rv_remuw (zext x) y))
+
+(rule 2 (lower (has_type $I32 (urem x y)))
+  (if-let $true (has_m))
+  (rv_remuw x (nonzero_divisor (zext y))))
+
+(rule 3 (lower (has_type $I32 (urem x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 $I32 imm))
+  (rv_remuw x y))
+
+(rule 2 (lower (has_type $I64 (urem x y)))
+  (if-let $true (has_m))
+  (rv_remu x (nonzero_divisor y)))
+
+(rule 3 (lower (has_type $I64 (urem x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 $I64 imm))
+  (rv_remu x y))
+
+;;;; Rules for `srem` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(rule 0 (lower (has_type (fits_in_16 ty) (srem x y)))
+  (if-let $true (has_m))
+  (rv_remw (sext x) (nonzero_divisor (sext y))))
+
+(rule 1 (lower (has_type (fits_in_16 ty) (srem x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 ty imm))
+  (rv_remw (sext x) y))
+
+(rule 2 (lower (has_type $I32 (srem x y)))
+  (if-let $true (has_m))
+  (rv_remw x (nonzero_divisor (sext y))))
+
+(rule 3 (lower (has_type $I32 (srem x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 $I32 imm))
+  (rv_remw x y))
+
+(rule 2 (lower (has_type $I64 (srem x y)))
+  (if-let $true (has_m))
+  (rv_rem x (nonzero_divisor y)))
+
+(rule 3 (lower (has_type $I64 (srem x y @ (iconst imm))))
+  (if-let $true (has_m))
+  (if (safe_divisor_from_imm64 $I64 imm))
+  (rv_rem x y))
 
 ;;;; Rules for `and` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 0 (lower (has_type (ty_int ty) (band x y)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -579,7 +579,7 @@
 (rule (safe_sdiv_divisor ty x y)
   (let (
       (y XReg (nonzero_divisor y))
-      (min XReg (imm $I64 (u64_shl 1 (u64_sub (ty_bits ty) 1))))
+      (min XReg (imm $I64 (u64_shl 0xffffffff_ffffffff (u64_sub (ty_bits ty) 1))))
       (x_is_not_min XReg (rv_xor x min))
       (y_is_not_neg_one XReg (rv_not y))
       (no_int_overflow XReg (rv_or x_is_not_min y_is_not_neg_one))

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -392,6 +392,10 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         self.backend.isa_flags.has_v()
     }
 
+    fn has_m(&mut self) -> bool {
+        self.backend.isa_flags.has_m()
+    }
+
     fn has_zbkb(&mut self) -> bool {
         self.backend.isa_flags.has_zbkb()
     }
@@ -499,22 +503,6 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
 
     fn sp_reg(&mut self) -> PReg {
         px_reg(2)
-    }
-
-    fn shift_int_to_most_significant(&mut self, v: XReg, ty: Type) -> XReg {
-        assert!(ty.is_int() && ty.bits() <= 64);
-        if ty == I64 {
-            return v;
-        }
-        let tmp = self.temp_writable_reg(I64);
-        self.emit(&MInst::AluRRImm12 {
-            alu_op: AluOPRRI::Slli,
-            rd: tmp,
-            rs: v.to_reg(),
-            imm12: Imm12::from_i16((64 - ty.bits()) as i16),
-        });
-
-        self.xreg_new(tmp.to_reg())
     }
 
     #[inline]

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
@@ -90,35 +90,27 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   li a3,-1
-;   li a5,1
-;   slli a2,a5,63
-;   eq a3,a3,a1##ty=i64
-;   eq a5,a2,a0##ty=i64
-;   and a2,a3,a5
-;   trap_if int_ovf##(a2 ne zero)
 ;   trap_if int_divz##(a1 eq zero)
+;   li a4,-1
+;   slli a2,a4,63
+;   xor a2,a0,a2
+;   not a4,a1
+;   or a2,a2,a4
+;   trap_if int_ovf##(a2 eq zero)
 ;   div a0,a0,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a3, zero, -1
-;   addi a5, zero, 1
-;   slli a2, a5, 0x3f
-;   bne a3, a1, 0xc
-;   addi a3, zero, 1
-;   j 8
-;   mv a3, zero
-;   bne a2, a0, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   and a2, a3, a5
-;   beqz a2, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   bnez a1, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   addi a4, zero, -1
+;   slli a2, a4, 0x3f
+;   xor a2, a0, a2
+;   not a4, a1
+;   or a2, a2, a4
+;   bnez a2, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   div a0, a0, a1
 ;   ret
 
@@ -132,36 +124,12 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   li a3,2
-;   li a4,-1
-;   li a5,1
-;   slli a1,a5,63
-;   eq a4,a4,a3##ty=i64
-;   eq a5,a1,a0##ty=i64
-;   and a1,a4,a5
-;   trap_if int_ovf##(a1 ne zero)
-;   trap_if int_divz##(a3 eq zero)
 ;   div a0,a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 2
-;   addi a4, zero, -1
-;   addi a5, zero, 1
-;   slli a1, a5, 0x3f
-;   bne a4, a3, 0xc
-;   addi a4, zero, 1
-;   j 8
-;   mv a4, zero
-;   bne a1, a0, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   and a1, a4, a5
-;   beqz a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   bnez a3, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
 ;   div a0, a0, a3
 ;   ret
 
@@ -194,15 +162,12 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   li a3,2
-;   trap_if int_divz##(a3 eq zero)
 ;   divu a0,a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 2
-;   bnez a3, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
 ;   divu a0, a0, a3
 ;   ret
 
@@ -254,15 +219,13 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   sext.w a3,a0
 ;   sext.w a5,a1
-;   li a1,-1
-;   li a4,1
-;   slli a0,a4,63
-;   slli a2,a3,32
-;   eq a4,a1,a5##ty=i32
-;   eq a0,a0,a2##ty=i32
-;   and a1,a4,a0
-;   trap_if int_ovf##(a1 ne zero)
 ;   trap_if int_divz##(a5 eq zero)
+;   li a2,1
+;   slli a4,a2,31
+;   xor a0,a3,a4
+;   not a2,a5
+;   or a4,a0,a2
+;   trap_if int_ovf##(a4 eq zero)
 ;   divw a0,a3,a5
 ;   ret
 ;
@@ -270,23 +233,15 @@ block0(v0: i32, v1: i32):
 ; block0: ; offset 0x0
 ;   sext.w a3, a0
 ;   sext.w a5, a1
-;   addi a1, zero, -1
-;   addi a4, zero, 1
-;   slli a0, a4, 0x3f
-;   slli a2, a3, 0x20
-;   bne a1, a5, 0xc
-;   addi a4, zero, 1
-;   j 8
-;   mv a4, zero
-;   bne a0, a2, 0xc
-;   addi a0, zero, 1
-;   j 8
-;   mv a0, zero
-;   and a1, a4, a0
-;   beqz a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   bnez a5, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
+;   addi a2, zero, 1
+;   slli a4, a2, 0x1f
+;   xor a0, a3, a4
+;   not a2, a5
+;   or a4, a0, a2
+;   bnez a4, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   divw a0, a3, a5
 ;   ret
 
@@ -299,46 +254,14 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   mv a2,a0
-;   li a0,2
-;   sext.w a3,a2
-;   sext.w a5,a0
-;   li a1,-1
-;   li a4,1
-;   slli a0,a4,63
-;   slli a2,a3,32
-;   eq a4,a1,a5##ty=i32
-;   eq a0,a0,a2##ty=i32
-;   and a1,a4,a0
-;   trap_if int_ovf##(a1 ne zero)
-;   trap_if int_divz##(a5 eq zero)
-;   divw a0,a3,a5
+;   li a3,2
+;   divw a0,a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mv a2, a0
-;   addi a0, zero, 2
-;   sext.w a3, a2
-;   sext.w a5, a0
-;   addi a1, zero, -1
-;   addi a4, zero, 1
-;   slli a0, a4, 0x3f
-;   slli a2, a3, 0x20
-;   bne a1, a5, 0xc
-;   addi a4, zero, 1
-;   j 8
-;   mv a4, zero
-;   bne a0, a2, 0xc
-;   addi a0, zero, 1
-;   j 8
-;   mv a0, zero
-;   and a1, a4, a0
-;   beqz a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   bnez a5, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
-;   divw a0, a3, a5
+;   addi a3, zero, 2
+;   divw a0, a0, a3
 ;   ret
 
 function %f14(i32, i32) -> i32 {
@@ -352,9 +275,7 @@ block0(v0: i32, v1: i32):
 ;   slli a3,a1,32
 ;   srli a5,a3,32
 ;   trap_if int_divz##(a5 eq zero)
-;   slli a2,a0,32
-;   srli a4,a2,32
-;   divuw a0,a4,a5
+;   divuw a0,a0,a5
 ;   ret
 ;
 ; Disassembled:
@@ -363,9 +284,7 @@ block0(v0: i32, v1: i32):
 ;   srli a5, a3, 0x20
 ;   bnez a5, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
-;   slli a2, a0, 0x20
-;   srli a4, a2, 0x20
-;   divuw a0, a4, a5
+;   divuw a0, a0, a5
 ;   ret
 
 function %f15(i32) -> i32 {
@@ -377,25 +296,14 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   li a1,2
-;   slli a3,a1,32
-;   srli a5,a3,32
-;   trap_if int_divz##(a5 eq zero)
-;   slli a2,a0,32
-;   srli a4,a2,32
-;   divuw a0,a4,a5
+;   li a3,2
+;   divuw a0,a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a1, zero, 2
-;   slli a3, a1, 0x20
-;   srli a5, a3, 0x20
-;   bnez a5, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
-;   slli a2, a0, 0x20
-;   srli a4, a2, 0x20
-;   divuw a0, a4, a5
+;   addi a3, zero, 2
+;   divuw a0, a0, a3
 ;   ret
 
 function %f16(i32, i32) -> i32 {
@@ -807,15 +715,12 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   li a3,2
-;   trap_if int_divz##(a3 eq zero)
 ;   rem a0,a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 2
-;   bnez a3, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
 ;   rem a0, a0, a3
 ;   ret
 
@@ -829,15 +734,12 @@ block0(v0: i64):
 ; VCode:
 ; block0:
 ;   li a3,2
-;   trap_if int_divz##(a3 eq zero)
 ;   remu a0,a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   addi a3, zero, 2
-;   bnez a3, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
 ;   remu a0, a0, a3
 ;   ret
 
@@ -850,38 +752,30 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   li a3,-1
+;   li a2,-1
+;   trap_if int_divz##(a2 eq zero)
 ;   li a4,-1
-;   li a5,1
-;   slli a1,a5,63
-;   eq a4,a4,a3##ty=i64
-;   eq a5,a1,a0##ty=i64
-;   and a1,a4,a5
-;   trap_if int_ovf##(a1 ne zero)
-;   trap_if int_divz##(a3 eq zero)
-;   div a0,a0,a3
+;   slli a1,a4,63
+;   xor a3,a0,a1
+;   not a4,a2
+;   or a1,a3,a4
+;   trap_if int_ovf##(a1 eq zero)
+;   div a0,a0,a2
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a3, zero, -1
-;   addi a4, zero, -1
-;   addi a5, zero, 1
-;   slli a1, a5, 0x3f
-;   bne a4, a3, 0xc
-;   addi a4, zero, 1
-;   j 8
-;   mv a4, zero
-;   bne a1, a0, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   and a1, a4, a5
-;   beqz a1, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   bnez a3, 8
+;   addi a2, zero, -1
+;   bnez a2, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
-;   div a0, a0, a3
+;   addi a4, zero, -1
+;   slli a1, a4, 0x3f
+;   xor a3, a0, a1
+;   not a4, a2
+;   or a1, a3, a4
+;   bnez a1, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   div a0, a0, a2
 ;   ret
 
 function %i8_iadd_const_neg1(i8) -> i8 {

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
@@ -220,12 +220,11 @@ block0(v0: i32, v1: i32):
 ;   sext.w a3,a0
 ;   sext.w a5,a1
 ;   trap_if int_divz##(a5 eq zero)
-;   li a2,1
-;   slli a4,a2,31
-;   xor a0,a3,a4
-;   not a2,a5
-;   or a4,a0,a2
-;   trap_if int_ovf##(a4 eq zero)
+;   lui a2,-524288
+;   xor a4,a3,a2
+;   not a0,a5
+;   or a2,a4,a0
+;   trap_if int_ovf##(a2 eq zero)
 ;   divw a0,a3,a5
 ;   ret
 ;
@@ -235,12 +234,11 @@ block0(v0: i32, v1: i32):
 ;   sext.w a5, a1
 ;   bnez a5, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_divz
-;   addi a2, zero, 1
-;   slli a4, a2, 0x1f
-;   xor a0, a3, a4
-;   not a2, a5
-;   or a4, a0, a2
-;   bnez a4, 8
+;   lui a2, 0x80000
+;   xor a4, a3, a2
+;   not a0, a5
+;   or a2, a4, a0
+;   bnez a2, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   divw a0, a3, a5
 ;   ret


### PR DESCRIPTION
This commit's goal is to remove the usage of `gen_icmp` with division-related instructions in the riscv64 backend. I've opted for a slightly more verbose approach than what was present prior to make sign/zero extensions more precise and additionally enable some immediate-related optimizations.

Divison/remainder by an immediate will no longer emit checks to see if a trap needs to be emitted. Instead only the raw `div`/`rem` instructions are emitted. Additionally a few minor sign extensions are now avoided such as the dividend in 32-bit remainders/division because only the low 32-bits are inspected.

Finally, while I was here, I went ahead an added `has_m` guards to all these lowering rules. The M extension is always required with riscv64 right now and won't work if it's turned off, but I figure it's not too bad to add in terms of completeness for now.

As to the meat of the commit, the check for trapping value as part of division now happens without `gen_icmp` but instead `gen_trapif` which enables avoiding materializing the comparison's value into a register.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
