### PR TITLE
Fix a regression with `wasmtime serve`, and enable the serve feature in tests

### DIFF
--- a/ci/run-tests.sh
+++ b/ci/run-tests.sh
@@ -5,6 +5,7 @@ cargo test \
     --features wasi-threads \
     --features wasi-http \
     --features component-model \
+    --features serve \
     --workspace \
     --exclude 'wasmtime-wasi-*' \
     --exclude wasi-tests \

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -14,14 +14,12 @@ struct Host {
 }
 
 impl Host {
-    fn new() -> Result<Self> {
-        let mut table = Table::new();
-        let ctx = WasiCtxBuilder::new().build(&mut table)?;
-        Ok(Host {
-            table,
-            ctx,
+    fn new() -> Self {
+        Host {
+            table: Table::new(),
+            ctx: WasiCtxBuilder::new().build(),
             http: WasiHttpCtx,
-        })
+        }
     }
 }
 
@@ -168,8 +166,7 @@ impl hyper::service::Service<Request> for ProxyHandler {
 
         // TODO: need to track the join handle, but don't want to block the response on it
         tokio::task::spawn(async move {
-            let host = Host::new()?;
-            let mut store = Store::new(&handler.engine, host);
+            let mut store = Store::new(&handler.engine, Host::new());
 
             let req = store.data_mut().new_incoming_request(
                 req.map(|body| body.map_err(|e| anyhow::anyhow!(e)).boxed()),


### PR DESCRIPTION
Fix a recent regression to the `wasmtime serve` command that was missed, as we hadn't enabled the `serve` command in tests.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
