### PR TITLE
riscv64: Update `replicated_{u,}imm5` to match `vconst`

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -3312,17 +3312,6 @@
 (rule (splat_const n size)
       (vec_dup (imm $I64 (ImmExtend.Zero) n) size))
 
-;; Each of these extractors tests whether the upper half of the input equals the
-;; lower half of the input
-(decl u128_replicated_u64 (u64) u128)
-(extern extractor u128_replicated_u64 u128_replicated_u64)
-(decl u64_replicated_u32 (u64) u64)
-(extern extractor u64_replicated_u32 u64_replicated_u32)
-(decl u32_replicated_u16 (u64) u64)
-(extern extractor u32_replicated_u16 u32_replicated_u16)
-(decl u16_replicated_u8 (u64) u64)
-(extern extractor u16_replicated_u8 u16_replicated_u8)
-
 ;; Lower a FloatCC to a Cond.
 (decl fp_cond_code (FloatCC) Cond)
 ;; TODO: Port lower_fp_condcode() to ISLE.

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -815,44 +815,6 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
         }
     }
 
-    fn u128_replicated_u64(&mut self, val: u128) -> Option<u64> {
-        let low64 = val as u64 as u128;
-        if (low64 | (low64 << 64)) == val {
-            Some(low64 as u64)
-        } else {
-            None
-        }
-    }
-
-    fn u64_replicated_u32(&mut self, val: u64) -> Option<u64> {
-        let low32 = val as u32 as u64;
-        if (low32 | (low32 << 32)) == val {
-            Some(low32)
-        } else {
-            None
-        }
-    }
-
-    fn u32_replicated_u16(&mut self, val: u64) -> Option<u64> {
-        let val = val as u32;
-        let low16 = val as u16 as u32;
-        if (low16 | (low16 << 16)) == val {
-            Some(low16.into())
-        } else {
-            None
-        }
-    }
-
-    fn u16_replicated_u8(&mut self, val: u64) -> Option<u64> {
-        let val = val as u16;
-        let low8 = val as u8 as u16;
-        if (low8 | (low8 << 8)) == val {
-            Some(low8.into())
-        } else {
-            None
-        }
-    }
-
     fn shift_masked_imm(&mut self, ty: Type, imm: u64) -> u8 {
         (imm as u8) & ((ty.lane_bits() - 1) as u8)
     }

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1839,19 +1839,29 @@
 (decl pure partial i8_to_imm5 (i8) Imm5)
 (extern constructor i8_to_imm5 i8_to_imm5)
 
-;; Extractor that matches a `Value` equivalent to a replicated Imm5 on all lanes.
-;; TODO(#6527): Try matching vconst here as well
-(decl replicated_imm5 (Imm5) Value)
-(extractor (replicated_imm5 n)
-  (def_inst (splat (i64_from_iconst (imm5_from_i64 n)))))
+;; Constructor that matches a `Value` equivalent to a replicated Imm5 on all lanes.
+(decl pure partial replicated_imm5 (Value) Imm5)
+(rule (replicated_imm5 (splat (i64_from_iconst (imm5_from_i64 n)))) n)
+(rule (replicated_imm5 (vconst (u128_from_constant n128)))
+  (if-let (u128_replicated_u64 n64) n128)
+  (if-let (u64_replicated_u32 n32) n64)
+  (if-let (u32_replicated_u16 n16) n32)
+  (if-let (u16_replicated_u8 n8) n16)
+  (if-let n (i8_to_imm5 (u8_as_i8 n8)))
+  n)
 
 ;; UImm5 Helpers
 
-;; Extractor that matches a `Value` equivalent to a replicated UImm5 on all lanes.
-;; TODO(#6527): Try matching vconst here as well
-(decl replicated_uimm5 (UImm5) Value)
-(extractor (replicated_uimm5 n)
-  (def_inst (splat (uimm5_from_value n))))
+;; Constructor that matches a `Value` equivalent to a replicated UImm5 on all lanes.
+(decl pure partial replicated_uimm5 (Value) UImm5)
+(rule (replicated_uimm5 (splat (uimm5_from_value n))) n)
+(rule 1 (replicated_uimm5 (vconst (u128_from_constant n128)))
+  (if-let (u128_replicated_u64 n64) n128)
+  (if-let (u64_replicated_u32 n32) n64)
+  (if-let (u32_replicated_u16 n16) n32)
+  (if-let (u16_replicated_u8 n8) n16)
+  (if-let (uimm5_from_u8 n) n8)
+  n)
 
 ;; Helper to go directly from a `Value`, when it's an `iconst`, to an `UImm5`.
 (decl uimm5_from_value (UImm5) Value)

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -1585,11 +1585,13 @@
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.Equal) (splat x) y)
   (rv_vmseq_vx y x (unmasked) ty))
 
-(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.Equal) x (replicated_imm5 y))
-  (rv_vmseq_vi x y (unmasked) ty))
+(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.Equal) x y)
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vmseq_vi x y_imm (unmasked) ty))
 
-(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.Equal) (replicated_imm5 x) y)
-  (rv_vmseq_vi y x (unmasked) ty))
+(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.Equal) x y)
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vmseq_vi y x_imm (unmasked) ty))
 
 ;; IntCC.NotEqual
 
@@ -1602,11 +1604,13 @@
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.NotEqual) (splat x) y)
   (rv_vmsne_vx y x (unmasked) ty))
 
-(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.NotEqual) x (replicated_imm5 y))
-  (rv_vmsne_vi x y (unmasked) ty))
+(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.NotEqual) x y)
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vmsne_vi x y_imm (unmasked) ty))
 
-(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.NotEqual) (replicated_imm5 x) y)
-  (rv_vmsne_vi y x (unmasked) ty))
+(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.NotEqual) x y)
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vmsne_vi y x_imm (unmasked) ty))
 
 ;; IntCC.UnsignedLessThan
 
@@ -1619,8 +1623,9 @@
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedLessThan) (splat x) y)
   (rv_vmsgtu_vx y x (unmasked) ty))
 
-(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedLessThan) (replicated_imm5 x) y)
-  (rv_vmsgtu_vi y x (unmasked) ty))
+(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedLessThan) x y)
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vmsgtu_vi y x_imm (unmasked) ty))
 
 ;; IntCC.SignedLessThan
 
@@ -1633,8 +1638,9 @@
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedLessThan) (splat x) y)
   (rv_vmsgt_vx y x (unmasked) ty))
 
-(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedLessThan) (replicated_imm5 x) y)
-  (rv_vmsgt_vi y x (unmasked) ty))
+(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedLessThan) x y)
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vmsgt_vi y x_imm (unmasked) ty))
 
 ;; IntCC.UnsignedLessThanOrEqual
 
@@ -1644,8 +1650,9 @@
 (rule 1 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedLessThanOrEqual) x (splat y))
   (rv_vmsleu_vx x y (unmasked) ty))
 
-(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedLessThanOrEqual) x (replicated_imm5 y))
-  (rv_vmsleu_vi x y (unmasked) ty))
+(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedLessThanOrEqual) x y)
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vmsleu_vi x y_imm (unmasked) ty))
 
 ;; IntCC.SignedLessThanOrEqual
 
@@ -1655,8 +1662,9 @@
 (rule 1 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedLessThanOrEqual) x (splat y))
   (rv_vmsle_vx x y (unmasked) ty))
 
-(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedLessThanOrEqual) x (replicated_imm5 y))
-  (rv_vmsle_vi x y (unmasked) ty))
+(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedLessThanOrEqual) x y)
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vmsle_vi x y_imm (unmasked) ty))
 
 ;; IntCC.UnsignedGreaterThan
 
@@ -1669,8 +1677,9 @@
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThan) (splat x) y)
   (rv_vmsltu_vx y x (unmasked) ty))
 
-(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThan) x (replicated_imm5 y))
-  (rv_vmsgtu_vi x y (unmasked) ty))
+(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThan) x y)
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vmsgtu_vi x y_imm (unmasked) ty))
 
 ;; IntCC.SignedGreaterThan
 
@@ -1683,8 +1692,9 @@
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThan) (splat x) y)
   (rv_vmslt_vx y x (unmasked) ty))
 
-(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThan) x (replicated_imm5 y))
-  (rv_vmsgt_vi x y (unmasked) ty))
+(rule 3 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThan) x y)
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vmsgt_vi x y_imm (unmasked) ty))
 
 ;; IntCC.UnsignedGreaterThanOrEqual
 
@@ -1694,8 +1704,9 @@
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThanOrEqual) (splat x) y)
   (rv_vmsleu_vx y x (unmasked) ty))
 
-(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThanOrEqual) (replicated_imm5 x) y)
-  (rv_vmsleu_vi y x (unmasked) ty))
+(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.UnsignedGreaterThanOrEqual) x y)
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vmsleu_vi y x_imm (unmasked) ty))
 
 ;; IntCC.SignedGreaterThanOrEqual
 
@@ -1705,8 +1716,9 @@
 (rule 2 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThanOrEqual) (splat x) y)
   (rv_vmsle_vx y x (unmasked) ty))
 
-(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThanOrEqual) (replicated_imm5 x) y)
-  (rv_vmsle_vi y x (unmasked) ty))
+(rule 4 (gen_icmp_mask (ty_vec_fits_in_register ty) (IntCC.SignedGreaterThanOrEqual) x y)
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vmsle_vi y x_imm (unmasked) ty))
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -119,8 +119,9 @@
   (if-let $true (ty_equal (lane_type half_ty) uext_ty))
   (rv_vwaddu_wx x y (unmasked) (vstate_mf2 half_ty)))
 
-(rule 11 (lower (has_type (ty_vec_fits_in_register ty) (iadd x (replicated_imm5 y))))
-  (rv_vadd_vi x y (unmasked) ty))
+(rule 20 (lower (has_type (ty_vec_fits_in_register ty) (iadd x y)))
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vadd_vi x y_imm (unmasked) ty))
 
 
 (rule 12 (lower (has_type (ty_vec_fits_in_register ty) (iadd (splat x) y)))
@@ -136,8 +137,9 @@
   (if-let $true (ty_equal (lane_type half_ty) uext_ty))
   (rv_vwaddu_wx y x (unmasked) (vstate_mf2 half_ty)))
 
-(rule 14 (lower (has_type (ty_vec_fits_in_register ty) (iadd (replicated_imm5 x) y)))
-  (rv_vadd_vi y x (unmasked) ty))
+(rule 21 (lower (has_type (ty_vec_fits_in_register ty) (iadd x y)))
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vadd_vi y x_imm (unmasked) ty))
 
 ;; Signed Widening Low Additions
 
@@ -339,8 +341,9 @@
 (rule 6 (lower (has_type (ty_vec_fits_in_register ty) (isub (splat x) y)))
   (rv_vrsub_vx y x (unmasked) ty))
 
-(rule 7 (lower (has_type (ty_vec_fits_in_register ty) (isub (replicated_imm5 x) y)))
-  (rv_vrsub_vi y x (unmasked) ty))
+(rule 7 (lower (has_type (ty_vec_fits_in_register ty) (isub x y)))
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vrsub_vi y x_imm (unmasked) ty))
 
 
 ;; Signed Widening Low Subtractions
@@ -696,11 +699,13 @@
   (if (ty_vector_not_float ty))
   (rv_vand_vx y x (unmasked) ty))
 
-(rule 11 (lower (has_type (ty_vec_fits_in_register ty) (band x (replicated_imm5 y))))
-  (rv_vand_vi x y (unmasked) ty))
+(rule 11 (lower (has_type (ty_vec_fits_in_register ty) (band x y)))
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vand_vi x y_imm (unmasked) ty))
 
-(rule 12 (lower (has_type (ty_vec_fits_in_register ty) (band (replicated_imm5 x) y)))
-  (rv_vand_vi y x (unmasked) ty))
+(rule 12 (lower (has_type (ty_vec_fits_in_register ty) (band x y)))
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vand_vi y x_imm (unmasked) ty))
 
 
 ;;;; Rules for `or` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -752,11 +757,13 @@
   (if (ty_vector_not_float ty))
   (rv_vor_vx y x (unmasked) ty))
 
-(rule 11 (lower (has_type (ty_vec_fits_in_register ty) (bor x (replicated_imm5 y))))
-  (rv_vor_vi x y (unmasked) ty))
+(rule 11 (lower (has_type (ty_vec_fits_in_register ty) (bor x y)))
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vor_vi x y_imm (unmasked) ty))
 
-(rule 12 (lower (has_type (ty_vec_fits_in_register ty) (bor (replicated_imm5 x) y)))
-  (rv_vor_vi y x (unmasked) ty))
+(rule 12 (lower (has_type (ty_vec_fits_in_register ty) (bor x y)))
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vor_vi y x_imm (unmasked) ty))
 
 
 ;;;; Rules for `xor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -787,11 +794,13 @@
   (if (ty_vector_not_float ty))
   (rv_vxor_vx y x (unmasked) ty))
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register ty) (bxor x (replicated_imm5 y))))
-  (rv_vxor_vi x y (unmasked) ty))
+(rule 8 (lower (has_type (ty_vec_fits_in_register ty) (bxor x y)))
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vxor_vi x y_imm (unmasked) ty))
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register ty) (bxor (replicated_imm5 x) y)))
-  (rv_vxor_vi y x (unmasked) ty))
+(rule 9 (lower (has_type (ty_vec_fits_in_register ty) (bxor x y)))
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vxor_vi y x_imm (unmasked) ty))
 
 
 ;;;; Rules for `bnot` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -2107,11 +2116,13 @@
 (rule 2 (lower (has_type (ty_vec_fits_in_register ty) (uadd_sat (splat x) y)))
   (rv_vsaddu_vx y x (unmasked) ty))
 
-(rule 3 (lower (has_type (ty_vec_fits_in_register ty) (uadd_sat x (replicated_imm5 y))))
-  (rv_vsaddu_vi x y (unmasked) ty))
+(rule 3 (lower (has_type (ty_vec_fits_in_register ty) (uadd_sat x y)))
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vsaddu_vi x y_imm (unmasked) ty))
 
-(rule 4 (lower (has_type (ty_vec_fits_in_register ty) (uadd_sat (replicated_imm5 x) y)))
-  (rv_vsaddu_vi y x (unmasked) ty))
+(rule 4 (lower (has_type (ty_vec_fits_in_register ty) (uadd_sat x y)))
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vsaddu_vi y x_imm (unmasked) ty))
 
 ;;;; Rules for `sadd_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2124,11 +2135,13 @@
 (rule 2 (lower (has_type (ty_vec_fits_in_register ty) (sadd_sat (splat x) y)))
   (rv_vsadd_vx y x (unmasked) ty))
 
-(rule 3 (lower (has_type (ty_vec_fits_in_register ty) (sadd_sat x (replicated_imm5 y))))
-  (rv_vsadd_vi x y (unmasked) ty))
+(rule 3 (lower (has_type (ty_vec_fits_in_register ty) (sadd_sat x y)))
+  (if-let y_imm (replicated_imm5 y))
+  (rv_vsadd_vi x y_imm (unmasked) ty))
 
-(rule 4 (lower (has_type (ty_vec_fits_in_register ty) (sadd_sat (replicated_imm5 x) y)))
-  (rv_vsadd_vi y x (unmasked) ty))
+(rule 4 (lower (has_type (ty_vec_fits_in_register ty) (sadd_sat x y)))
+  (if-let x_imm (replicated_imm5 x))
+  (rv_vsadd_vi y x_imm (unmasked) ty))
 
 ;;;; Rules for `usub_sat` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -2202,8 +2215,9 @@
 (rule 1 (lower (has_type (ty_vec_fits_in_register ty) (swizzle x (splat y))))
   (rv_vrgather_vx x y (unmasked) ty))
 
-(rule 2 (lower (has_type (ty_vec_fits_in_register ty) (swizzle x (replicated_uimm5 y))))
-  (rv_vrgather_vi x y (unmasked) ty))
+(rule 2 (lower (has_type (ty_vec_fits_in_register ty) (swizzle x y)))
+  (if-let y_imm (replicated_uimm5 y))
+  (rv_vrgather_vi x y_imm (unmasked) ty))
 
 ;;;; Rules for `shuffle` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -908,5 +908,47 @@ macro_rules! isle_common_prelude_methods {
         fn u64_as_u32(&mut self, val: u64) -> Option<u32> {
             u32::try_from(val).ok()
         }
+
+        fn u8_as_i8(&mut self, val: u8) -> i8 {
+            val as i8
+        }
+
+        fn u128_replicated_u64(&mut self, val: u128) -> Option<u64> {
+            let low64 = val as u64 as u128;
+            if (low64 | (low64 << 64)) == val {
+                Some(low64 as u64)
+            } else {
+                None
+            }
+        }
+
+        fn u64_replicated_u32(&mut self, val: u64) -> Option<u64> {
+            let low32 = val as u32 as u64;
+            if (low32 | (low32 << 32)) == val {
+                Some(low32)
+            } else {
+                None
+            }
+        }
+
+        fn u32_replicated_u16(&mut self, val: u64) -> Option<u64> {
+            let val = val as u32;
+            let low16 = val as u16 as u32;
+            if (low16 | (low16 << 16)) == val {
+                Some(low16.into())
+            } else {
+                None
+            }
+        }
+
+        fn u16_replicated_u8(&mut self, val: u64) -> Option<u8> {
+            let val = val as u16;
+            let low8 = val as u8 as u16;
+            if (low8 | (low8 << 8)) == val {
+                Some(low8 as u8)
+            } else {
+                None
+            }
+        }
     };
 }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -77,6 +77,9 @@
 
 ;;;; Primitive Type Conversions ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(decl pure u8_as_i8 (u8) i8)
+(extern constructor u8_as_i8 u8_as_i8)
+
 (decl pure u8_as_u32 (u8) u32)
 (extern constructor u8_as_u32 u8_as_u32)
 (convert u8 u32 u8_as_u32)
@@ -218,6 +221,17 @@
 
 (decl pure u64_is_odd (u64) bool)
 (extern constructor u64_is_odd u64_is_odd)
+
+;; Each of these extractors tests whether the upper half of the input equals the
+;; lower half of the input
+(decl u128_replicated_u64 (u64) u128)
+(extern extractor u128_replicated_u64 u128_replicated_u64)
+(decl u64_replicated_u32 (u64) u64)
+(extern extractor u64_replicated_u32 u64_replicated_u32)
+(decl u32_replicated_u16 (u64) u64)
+(extern extractor u32_replicated_u16 u32_replicated_u16)
+(decl u16_replicated_u8 (u8) u64)
+(extern extractor u16_replicated_u8 u16_replicated_u8)
 
 ;;;; `cranelift_codegen::ir::Type` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-bor.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-bor.clif
@@ -579,3 +579,41 @@ block0(v0: f64x2, v1: i64):
 ;   addi sp, sp, 0x10
 ;   ret
 
+function %vi_format_with_vconst1(i8x16) -> i8x16 {
+block0(v0: i8x16):
+    v1 = vconst.i8x16 0x05050505050505050505050505050505
+    v2 = bor v0, v1
+    return v2
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   vle8.v v9,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vor.vi v12,v9,5 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+; block1: ; offset 0x10
+;   .byte 0x57, 0x70, 0x08, 0xcc
+;   addi t6, s0, 0x10
+;   .byte 0x87, 0x84, 0x0f, 0x02
+;   .byte 0x57, 0xb6, 0x92, 0x2a
+;   .byte 0x27, 0x06, 0x05, 0x02
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+


### PR DESCRIPTION
This switches the `extractor` to a `pure partial` constructor to be used in `if-let` instead of the extraction position, which while not quite as ergonomic does enable matching more constant values in more locations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
