### PR TITLE
riscv64: Refactor and simplify some branches/fcmp 

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2641,9 +2641,6 @@
 (decl int_zero_reg (Type) ValueRegs)
 (extern constructor int_zero_reg int_zero_reg)
 
-(decl lower_cond_br (IntCC ValueRegs MachLabelSlice Type) Unit)
-(extern constructor lower_cond_br lower_cond_br)
-
 ;; Convert a truthy value, possibly of more than one register (an I128), to
 ;; one register.
 ;;
@@ -2658,30 +2655,43 @@
             (hi XReg (value_regs_get regs 1)))
         (rv_or lo hi)))
 
+;; Consume a CmpResult, producing a branch on its result.
+(decl cond_br (IntegerCompare CondBrTarget CondBrTarget) SideEffectNoResult)
+(rule (cond_br cmp then else)
+      (SideEffectNoResult.Inst
+        (MInst.CondBr then else cmp)))
+
+;; Helper for emitting the `j` mnemonic, an unconditional jump to label.
+(decl rv_j (MachLabel) SideEffectNoResult)
+(rule (rv_j label)
+  (SideEffectNoResult.Inst (MInst.Jal label)))
+
+;; Construct an IntegerCompare value.
+(decl int_compare (IntCC XReg XReg) IntegerCompare)
+(extern constructor int_compare int_compare)
+
 (decl label_to_br_target (MachLabel) CondBrTarget)
 (extern constructor label_to_br_target label_to_br_target)
 (convert MachLabel CondBrTarget label_to_br_target)
 
 (decl partial lower_branch (Inst MachLabelSlice) Unit)
 (rule (lower_branch (jump _) (single_target label))
-      (emit_side_effect (SideEffectNoResult.Inst (MInst.Jal label))))
+      (emit_side_effect (rv_j label)))
 
 ;; Default behavior for branching based on an input value.
-(rule (lower_branch (brif v @ (value_type (fits_in_64 ty)) _ _) targets)
-  (lower_cond_br (IntCC.NotEqual) (zext v) targets ty))
-(rule 2 (lower_branch (brif v @ (value_type $I128)_ _) targets)
-    (lower_cond_br (IntCC.NotEqual) (truthy_to_reg v) targets $I64))
+(rule (lower_branch (brif v @ (value_type (fits_in_64 ty)) _ _) (two_targets then else))
+  (emit_side_effect (cond_br (int_compare (IntCC.NotEqual) (zext v) (zero_reg)) then else)))
+(rule 2 (lower_branch (brif v @ (value_type $I128)_ _) (two_targets then else))
+  (emit_side_effect (cond_br (int_compare (IntCC.NotEqual) (truthy_to_reg v) (zero_reg)) then else)))
 
-;; Branching on the result of an fcmp
-(rule 1
-  (lower_branch (brif (maybe_uextend (fcmp cc a @ (value_type ty) b)) _ _) (two_targets then else))
-  (if-let $true (floatcc_unordered cc))
-  (emit_side_effect (cond_br (emit_fcmp (floatcc_complement cc) ty a b) else then)))
-
-(rule 1
-  (lower_branch (brif (maybe_uextend (fcmp cc a @ (value_type ty) b)) _ _) (two_targets then else))
-  (if-let $false (floatcc_unordered cc))
+;; Branching on the result of an fcmp.
+(rule 1 (lower_branch (brif (maybe_uextend (fcmp cc a @ (value_type ty) b)) _ _) (two_targets then else))
   (emit_side_effect (cond_br (emit_fcmp cc ty a b) then else)))
+
+(decl fcmp_to_compare (FCmp) IntegerCompare)
+(rule (fcmp_to_compare (FCmp.One r)) (int_compare (IntCC.NotEqual) r (zero_reg)))
+(rule (fcmp_to_compare (FCmp.Zero r)) (int_compare (IntCC.Equal) r (zero_reg)))
+(convert FCmp IntegerCompare fcmp_to_compare)
 
 
 (decl lower_br_table (Reg MachLabelSlice) Unit)
@@ -2847,131 +2857,62 @@
 
 ;;;; Helpers for floating point comparisons ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(decl not (XReg) XReg)
-(rule (not x) (rv_xori x (imm_from_bits 1)))
-
 (decl is_not_nan (Type FReg) XReg)
 (rule (is_not_nan ty a) (rv_feq ty a a))
 
 (decl ordered (Type FReg FReg) XReg)
 (rule (ordered ty a b) (rv_and (is_not_nan ty a) (is_not_nan ty b)))
 
-(type CmpResult (enum
-                  (Result
-                    (result XReg)
-                    (invert bool))))
+(type FCmp (enum
+  ;; The comparison succeeded if `r` is one
+  (One (r XReg))
+  ;; The comparison succeeded if `r` is zero
+  (Zero (r XReg))
+))
 
-;; Wrapper for the common case when constructing comparison results. It assumes
-;; that the result isn't negated.
-(decl cmp_result (XReg) CmpResult)
-(rule (cmp_result result) (CmpResult.Result result $false))
-
-;; Wrapper for the case where it's more convenient to construct the negated
-;; version of the comparison.
-(decl cmp_result_invert (XReg) CmpResult)
-(rule (cmp_result_invert result) (CmpResult.Result result $true))
-
-;; Consume a CmpResult, producing a branch on its result.
-(decl cond_br (CmpResult CondBrTarget CondBrTarget) SideEffectNoResult)
-(rule (cond_br cmp then else)
-      (SideEffectNoResult.Inst
-        (MInst.CondBr then else (cmp_integer_compare cmp))))
-
-;; Construct an IntegerCompare value.
-(decl int_compare (IntCC XReg XReg) IntegerCompare)
-(extern constructor int_compare int_compare)
-
-;; Convert a comparison into a branch test.
-(decl cmp_integer_compare (CmpResult) IntegerCompare)
-
-(rule
-  (cmp_integer_compare (CmpResult.Result res $false))
-  (int_compare (IntCC.NotEqual) res (zero_reg)))
-
-(rule
-  (cmp_integer_compare (CmpResult.Result res $true))
-  (int_compare (IntCC.Equal) res (zero_reg)))
-
-;; Convert a comparison into a boolean value.
-(decl cmp_value (CmpResult) XReg)
-(rule (cmp_value (CmpResult.Result res $false)) res)
-(rule (cmp_value (CmpResult.Result res $true)) (not res))
+(decl fcmp_invert (FCmp) FCmp)
+(rule (fcmp_invert (FCmp.One r)) (FCmp.Zero r))
+(rule (fcmp_invert (FCmp.Zero r)) (FCmp.One r))
 
 ;; Compare two floating point numbers and return a zero/non-zero result.
-(decl emit_fcmp (FloatCC Type FReg FReg) CmpResult)
+(decl emit_fcmp (FloatCC Type FReg FReg) FCmp)
+
+;; Direct codegen for unordered comparisons is not that efficient, so invert
+;; the comparison to get an ordered comparison and generate that. Then invert
+;; the result to produce the final fcmp result.
+(rule 0 (emit_fcmp cc ty a b)
+  (if-let $true (floatcc_unordered cc))
+  (fcmp_invert (emit_fcmp (floatcc_complement cc) ty a b)))
 
 ;; a is not nan && b is not nan
-(rule
-  (emit_fcmp (FloatCC.Ordered) ty a b)
-  (cmp_result (ordered ty a b)))
-
-;; a is nan || b is nan
-;; == !(a is not nan && b is not nan)
-(rule
-  (emit_fcmp (FloatCC.Unordered) ty a b)
-  (cmp_result_invert (ordered ty a b)))
+(rule 1 (emit_fcmp (FloatCC.Ordered) ty a b)
+  (FCmp.One (ordered ty a b)))
 
 ;; a == b
-(rule
-  (emit_fcmp (FloatCC.Equal) ty a b)
-  (cmp_result (rv_feq ty a b)))
+(rule 1 (emit_fcmp (FloatCC.Equal) ty a b)
+  (FCmp.One (rv_feq ty a b)))
 
 ;; a != b
 ;; == !(a == b)
-(rule
-  (emit_fcmp (FloatCC.NotEqual) ty a b)
-  (cmp_result_invert (rv_feq ty a b)))
+(rule 1 (emit_fcmp (FloatCC.NotEqual) ty a b)
+  (FCmp.Zero (rv_feq ty a b)))
 
 ;; a < b || a > b
-(rule
-  (emit_fcmp (FloatCC.OrderedNotEqual) ty a b)
-  (cmp_result (rv_or (rv_flt ty a b) (rv_fgt ty a b))))
-
-;; !(ordered a b) || a == b
-(rule
-  (emit_fcmp (FloatCC.UnorderedOrEqual) ty a b)
-  (cmp_result (rv_or (not (ordered ty a b)) (rv_feq ty a b))))
+(rule 1 (emit_fcmp (FloatCC.OrderedNotEqual) ty a b)
+  (FCmp.One (rv_or (rv_flt ty a b) (rv_fgt ty a b))))
 
 ;; a < b
-(rule
-  (emit_fcmp (FloatCC.LessThan) ty a b)
-  (cmp_result (rv_flt ty a b)))
+(rule 1 (emit_fcmp (FloatCC.LessThan) ty a b)
+  (FCmp.One (rv_flt ty a b)))
 
 ;; a <= b
-(rule
-  (emit_fcmp (FloatCC.LessThanOrEqual) ty a b)
-  (cmp_result (rv_fle ty a b)))
+(rule 1 (emit_fcmp (FloatCC.LessThanOrEqual) ty a b)
+  (FCmp.One (rv_fle ty a b)))
 
 ;; a > b
-(rule
-  (emit_fcmp (FloatCC.GreaterThan) ty a b)
-  (cmp_result (rv_fgt ty a b)))
+(rule 1 (emit_fcmp (FloatCC.GreaterThan) ty a b)
+  (FCmp.One (rv_fgt ty a b)))
 
 ;; a >= b
-(rule
-  (emit_fcmp (FloatCC.GreaterThanOrEqual) ty a b)
-  (cmp_result (rv_fge ty a b)))
-
-;; !(ordered a b) || a < b
-;; == !(ordered a b && a >= b)
-(rule
-  (emit_fcmp (FloatCC.UnorderedOrLessThan) ty a b)
-  (cmp_result_invert (rv_and (ordered ty a b) (rv_fge ty a b))))
-
-;; !(ordered a b) || a <= b
-;; == !(ordered a b && a > b)
-(rule
-  (emit_fcmp (FloatCC.UnorderedOrLessThanOrEqual) ty a b)
-  (cmp_result_invert (rv_and (ordered ty a b) (rv_fgt ty a b))))
-
-;; !(ordered a b) || a > b
-;; == !(ordered a b && a <= b)
-(rule
-  (emit_fcmp (FloatCC.UnorderedOrGreaterThan) ty a b)
-  (cmp_result_invert (rv_and (ordered ty a b) (rv_fle ty a b))))
-
-;; !(ordered a b) || a >= b
-;; == !(ordered a b && a < b)
-(rule
-  (emit_fcmp (FloatCC.UnorderedOrGreaterThanOrEqual) ty a b)
-  (cmp_result_invert (rv_and (ordered ty a b) (rv_flt ty a b))))
+(rule 1 (emit_fcmp (FloatCC.GreaterThanOrEqual) ty a b)
+  (FCmp.One (rv_fge ty a b)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1846,7 +1846,11 @@
 
 ;;;;;  Rules for `fcmp`;;;;;;;;;
 (rule 0 (lower (fcmp cc x @ (value_type (ty_scalar_float ty)) y))
-  (cmp_value (emit_fcmp cc ty x y)))
+  (lower_fcmp (emit_fcmp cc ty x y)))
+
+(decl lower_fcmp (FCmp) XReg)
+(rule (lower_fcmp (FCmp.One r)) r)
+(rule (lower_fcmp (FCmp.Zero r)) (rv_seqz r))
 
 (rule 1 (lower (fcmp cc x @ (value_type (ty_vec_fits_in_register ty)) y))
   (gen_expand_mask ty (gen_fcmp_mask ty cc x y)))

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -175,18 +175,6 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         }
     }
 
-    fn lower_cond_br(&mut self, cc: &IntCC, a: ValueRegs, targets: &[MachLabel], ty: Type) -> Unit {
-        MInst::lower_br_icmp(
-            *cc,
-            a,
-            self.int_zero_reg(ty),
-            CondBrTarget::Label(targets[0]),
-            CondBrTarget::Label(targets[1]),
-            ty,
-        )
-        .iter()
-        .for_each(|i| self.emit(i));
-    }
     fn load_ra(&mut self) -> Reg {
         if self.backend.flags.preserve_frame_pointers() {
             let tmp = self.temp_writable_reg(I64);

--- a/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
@@ -17,7 +17,7 @@ block1:
 ;   li a1,0
 ;   fmv.d.x fa3,a1
 ;   fle.d a2,fa3,fa3
-;   bne a2,zero,taken(label2),not_taken(label1)
+;   beq a2,zero,taken(label1),not_taken(label2)
 ; block1:
 ;   j label3
 ; block2:
@@ -48,7 +48,7 @@ block1:
 ;   li a1,0
 ;   fmv.d.x fa3,a1
 ;   fle.d a2,fa3,fa3
-;   bne a2,zero,taken(label2),not_taken(label1)
+;   beq a2,zero,taken(label1),not_taken(label2)
 ; block1:
 ;   j label3
 ; block2:
@@ -95,7 +95,7 @@ block0(v0: f32, v1: f32):
 ;   feq.s a3,fa0,fa0
 ;   feq.s a5,fa1,fa1
 ;   and a1,a3,a5
-;   xori a0,a1,1
+;   seqz a0,a1
 ;   ret
 ;
 ; Disassembled:
@@ -103,7 +103,7 @@ block0(v0: f32, v1: f32):
 ;   feq.s a3, fa0, fa0
 ;   feq.s a5, fa1, fa1
 ;   and a1, a3, a5
-;   xori a0, a1, 1
+;   seqz a0, a1
 ;   ret
 
 function %eq(f32, f32) -> i8 {
@@ -131,13 +131,13 @@ block0(v0: f32, v1: f32):
 ; VCode:
 ; block0:
 ;   feq.s a3,fa0,fa1
-;   xori a0,a3,1
+;   seqz a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   feq.s a3, fa0, fa1
-;   xori a0, a3, 1
+;   seqz a0, a3
 ;   ret
 
 function %one(f32, f32) -> i8 {
@@ -168,22 +168,18 @@ block0(v0: f32, v1: f32):
 
 ; VCode:
 ; block0:
-;   feq.s a3,fa0,fa0
-;   feq.s a5,fa1,fa1
-;   and a1,a3,a5
-;   xori a3,a1,1
-;   feq.s a5,fa0,fa1
-;   or a0,a3,a5
+;   flt.s a3,fa0,fa1
+;   flt.s a5,fa1,fa0
+;   or a1,a3,a5
+;   seqz a0,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   feq.s a3, fa0, fa0
-;   feq.s a5, fa1, fa1
-;   and a1, a3, a5
-;   xori a3, a1, 1
-;   feq.s a5, fa0, fa1
-;   or a0, a3, a5
+;   flt.s a3, fa0, fa1
+;   flt.s a5, fa1, fa0
+;   or a1, a3, a5
+;   seqz a0, a1
 ;   ret
 
 function %lt(f64, f64) -> i8 {
@@ -258,22 +254,14 @@ block0(v0: f64, v1: f64):
 
 ; VCode:
 ; block0:
-;   feq.d a3,fa0,fa0
-;   feq.d a5,fa1,fa1
-;   and a1,a3,a5
 ;   fle.d a3,fa1,fa0
-;   and a5,a1,a3
-;   xori a0,a5,1
+;   seqz a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   feq.d a3, fa0, fa0
-;   feq.d a5, fa1, fa1
-;   and a1, a3, a5
 ;   fle.d a3, fa1, fa0
-;   and a5, a1, a3
-;   xori a0, a5, 1
+;   seqz a0, a3
 ;   ret
 
 function %ule(f64, f64) -> i8 {
@@ -284,22 +272,14 @@ block0(v0: f64, v1: f64):
 
 ; VCode:
 ; block0:
-;   feq.d a3,fa0,fa0
-;   feq.d a5,fa1,fa1
-;   and a1,a3,a5
 ;   flt.d a3,fa1,fa0
-;   and a5,a1,a3
-;   xori a0,a5,1
+;   seqz a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   feq.d a3, fa0, fa0
-;   feq.d a5, fa1, fa1
-;   and a1, a3, a5
 ;   flt.d a3, fa1, fa0
-;   and a5, a1, a3
-;   xori a0, a5, 1
+;   seqz a0, a3
 ;   ret
 
 function %ugt(f64, f64) -> i8 {
@@ -310,22 +290,14 @@ block0(v0: f64, v1: f64):
 
 ; VCode:
 ; block0:
-;   feq.d a3,fa0,fa0
-;   feq.d a5,fa1,fa1
-;   and a1,a3,a5
 ;   fle.d a3,fa0,fa1
-;   and a5,a1,a3
-;   xori a0,a5,1
+;   seqz a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   feq.d a3, fa0, fa0
-;   feq.d a5, fa1, fa1
-;   and a1, a3, a5
 ;   fle.d a3, fa0, fa1
-;   and a5, a1, a3
-;   xori a0, a5, 1
+;   seqz a0, a3
 ;   ret
 
 function %uge(f64, f64) -> i8 {
@@ -336,22 +308,14 @@ block0(v0: f64, v1: f64):
 
 ; VCode:
 ; block0:
-;   feq.d a3,fa0,fa0
-;   feq.d a5,fa1,fa1
-;   and a1,a3,a5
 ;   flt.d a3,fa0,fa1
-;   and a5,a1,a3
-;   xori a0,a5,1
+;   seqz a0,a3
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   feq.d a3, fa0, fa0
-;   feq.d a5, fa1, fa1
-;   and a1, a3, a5
 ;   flt.d a3, fa0, fa1
-;   and a5, a1, a3
-;   xori a0, a5, 1
+;   seqz a0, a3
 ;   ret
 
 function %br_ord(f32, f32) -> i8 {
@@ -409,7 +373,7 @@ block2:
 ;   feq.s a5,fa0,fa0
 ;   feq.s a1,fa1,fa1
 ;   and a3,a5,a1
-;   bne a3,zero,taken(label1),not_taken(label2)
+;   beq a3,zero,taken(label2),not_taken(label1)
 ; block1:
 ;   li a0,0
 ;   ret
@@ -553,7 +517,7 @@ block2:
 ;   flt.s a5,fa0,fa1
 ;   flt.s a1,fa1,fa0
 ;   or a3,a5,a1
-;   bne a3,zero,taken(label1),not_taken(label2)
+;   beq a3,zero,taken(label2),not_taken(label1)
 ; block1:
 ;   li a0,0
 ;   ret
@@ -725,7 +689,7 @@ block2:
 ; VCode:
 ; block0:
 ;   fle.s a5,fa1,fa0
-;   bne a5,zero,taken(label1),not_taken(label2)
+;   beq a5,zero,taken(label2),not_taken(label1)
 ; block1:
 ;   li a0,0
 ;   ret
@@ -759,7 +723,7 @@ block2:
 ; VCode:
 ; block0:
 ;   fle.s a5,fa0,fa1
-;   bne a5,zero,taken(label1),not_taken(label2)
+;   beq a5,zero,taken(label2),not_taken(label1)
 ; block1:
 ;   li a0,0
 ;   ret
@@ -793,7 +757,7 @@ block2:
 ; VCode:
 ; block0:
 ;   flt.s a5,fa1,fa0
-;   bne a5,zero,taken(label1),not_taken(label2)
+;   beq a5,zero,taken(label2),not_taken(label1)
 ; block1:
 ;   li a0,0
 ;   ret
@@ -827,7 +791,7 @@ block2:
 ; VCode:
 ; block0:
 ;   flt.s a5,fa0,fa1
-;   bne a5,zero,taken(label1),not_taken(label2)
+;   beq a5,zero,taken(label2),not_taken(label1)
 ; block1:
 ;   li a0,0
 ;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fcmp.clif
@@ -64,3 +64,785 @@ block1:
 ; block1: ; offset 0xc
 ;   ret
 
+function %ord(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp ord v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   feq.s a3,fa0,fa0
+;   feq.s a5,fa1,fa1
+;   and a0,a3,a5
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a3, fa0, fa0
+;   feq.s a5, fa1, fa1
+;   and a0, a3, a5
+;   ret
+
+function %uno(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp uno v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   feq.s a3,fa0,fa0
+;   feq.s a5,fa1,fa1
+;   and a1,a3,a5
+;   xori a0,a1,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a3, fa0, fa0
+;   feq.s a5, fa1, fa1
+;   and a1, a3, a5
+;   xori a0, a1, 1
+;   ret
+
+function %eq(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp eq v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   feq.s a0,fa0,fa1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a0, fa0, fa1
+;   ret
+
+function %ne(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp ne v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   feq.s a3,fa0,fa1
+;   xori a0,a3,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a3, fa0, fa1
+;   xori a0, a3, 1
+;   ret
+
+function %one(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp one v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   flt.s a3,fa0,fa1
+;   flt.s a5,fa1,fa0
+;   or a0,a3,a5
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   flt.s a3, fa0, fa1
+;   flt.s a5, fa1, fa0
+;   or a0, a3, a5
+;   ret
+
+function %ueq(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp ueq v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   feq.s a3,fa0,fa0
+;   feq.s a5,fa1,fa1
+;   and a1,a3,a5
+;   xori a3,a1,1
+;   feq.s a5,fa0,fa1
+;   or a0,a3,a5
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a3, fa0, fa0
+;   feq.s a5, fa1, fa1
+;   and a1, a3, a5
+;   xori a3, a1, 1
+;   feq.s a5, fa0, fa1
+;   or a0, a3, a5
+;   ret
+
+function %lt(f64, f64) -> i8 {
+block0(v0: f64, v1: f64):
+    v2 = fcmp lt v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   flt.d a0,fa0,fa1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   flt.d a0, fa0, fa1
+;   ret
+
+function %le(f64, f64) -> i8 {
+block0(v0: f64, v1: f64):
+    v2 = fcmp le v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   fle.d a0,fa0,fa1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fle.d a0, fa0, fa1
+;   ret
+
+function %gt(f64, f64) -> i8 {
+block0(v0: f64, v1: f64):
+    v2 = fcmp gt v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   flt.d a0,fa1,fa0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   flt.d a0, fa1, fa0
+;   ret
+
+function %ge(f64, f64) -> i8 {
+block0(v0: f64, v1: f64):
+    v2 = fcmp ge v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   fle.d a0,fa1,fa0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fle.d a0, fa1, fa0
+;   ret
+
+function %ult(f64, f64) -> i8 {
+block0(v0: f64, v1: f64):
+    v2 = fcmp ult v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   feq.d a3,fa0,fa0
+;   feq.d a5,fa1,fa1
+;   and a1,a3,a5
+;   fle.d a3,fa1,fa0
+;   and a5,a1,a3
+;   xori a0,a5,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a3, fa0, fa0
+;   feq.d a5, fa1, fa1
+;   and a1, a3, a5
+;   fle.d a3, fa1, fa0
+;   and a5, a1, a3
+;   xori a0, a5, 1
+;   ret
+
+function %ule(f64, f64) -> i8 {
+block0(v0: f64, v1: f64):
+    v2 = fcmp ule v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   feq.d a3,fa0,fa0
+;   feq.d a5,fa1,fa1
+;   and a1,a3,a5
+;   flt.d a3,fa1,fa0
+;   and a5,a1,a3
+;   xori a0,a5,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a3, fa0, fa0
+;   feq.d a5, fa1, fa1
+;   and a1, a3, a5
+;   flt.d a3, fa1, fa0
+;   and a5, a1, a3
+;   xori a0, a5, 1
+;   ret
+
+function %ugt(f64, f64) -> i8 {
+block0(v0: f64, v1: f64):
+    v2 = fcmp ugt v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   feq.d a3,fa0,fa0
+;   feq.d a5,fa1,fa1
+;   and a1,a3,a5
+;   fle.d a3,fa0,fa1
+;   and a5,a1,a3
+;   xori a0,a5,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a3, fa0, fa0
+;   feq.d a5, fa1, fa1
+;   and a1, a3, a5
+;   fle.d a3, fa0, fa1
+;   and a5, a1, a3
+;   xori a0, a5, 1
+;   ret
+
+function %uge(f64, f64) -> i8 {
+block0(v0: f64, v1: f64):
+    v2 = fcmp uge v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   feq.d a3,fa0,fa0
+;   feq.d a5,fa1,fa1
+;   and a1,a3,a5
+;   flt.d a3,fa0,fa1
+;   and a5,a1,a3
+;   xori a0,a5,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.d a3, fa0, fa0
+;   feq.d a5, fa1, fa1
+;   and a1, a3, a5
+;   flt.d a3, fa0, fa1
+;   and a5, a1, a3
+;   xori a0, a5, 1
+;   ret
+
+function %br_ord(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp ord v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   feq.s a5,fa0,fa0
+;   feq.s a1,fa1,fa1
+;   and a3,a5,a1
+;   bne a3,zero,taken(label2),not_taken(label1)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a5, fa0, fa0
+;   feq.s a1, fa1, fa1
+;   and a3, a5, a1
+;   bnez a3, 0xc
+; block1: ; offset 0x10
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x18
+;   addi a0, zero, 1
+;   ret
+
+function %br_uno(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp uno v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   feq.s a5,fa0,fa0
+;   feq.s a1,fa1,fa1
+;   and a3,a5,a1
+;   bne a3,zero,taken(label1),not_taken(label2)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a5, fa0, fa0
+;   feq.s a1, fa1, fa1
+;   and a3, a5, a1
+;   beqz a3, 0xc
+; block1: ; offset 0x10
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x18
+;   addi a0, zero, 1
+;   ret
+
+function %br_eq(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp eq v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   feq.s a5,fa0,fa1
+;   bne a5,zero,taken(label2),not_taken(label1)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a5, fa0, fa1
+;   bnez a5, 0xc
+; block1: ; offset 0x8
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x10
+;   addi a0, zero, 1
+;   ret
+
+function %br_ne(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp ne v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   feq.s a5,fa0,fa1
+;   beq a5,zero,taken(label2),not_taken(label1)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   feq.s a5, fa0, fa1
+;   beqz a5, 0xc
+; block1: ; offset 0x8
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x10
+;   addi a0, zero, 1
+;   ret
+
+function %br_one(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp one v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   flt.s a5,fa0,fa1
+;   flt.s a1,fa1,fa0
+;   or a3,a5,a1
+;   bne a3,zero,taken(label2),not_taken(label1)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   flt.s a5, fa0, fa1
+;   flt.s a1, fa1, fa0
+;   or a3, a5, a1
+;   bnez a3, 0xc
+; block1: ; offset 0x10
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x18
+;   addi a0, zero, 1
+;   ret
+
+function %br_ueq(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp ueq v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   flt.s a5,fa0,fa1
+;   flt.s a1,fa1,fa0
+;   or a3,a5,a1
+;   bne a3,zero,taken(label1),not_taken(label2)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   flt.s a5, fa0, fa1
+;   flt.s a1, fa1, fa0
+;   or a3, a5, a1
+;   beqz a3, 0xc
+; block1: ; offset 0x10
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x18
+;   addi a0, zero, 1
+;   ret
+
+function %br_lt(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp lt v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   flt.s a5,fa0,fa1
+;   bne a5,zero,taken(label2),not_taken(label1)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   flt.s a5, fa0, fa1
+;   bnez a5, 0xc
+; block1: ; offset 0x8
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x10
+;   addi a0, zero, 1
+;   ret
+
+function %br_gt(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp gt v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   flt.s a5,fa1,fa0
+;   bne a5,zero,taken(label2),not_taken(label1)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   flt.s a5, fa1, fa0
+;   bnez a5, 0xc
+; block1: ; offset 0x8
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x10
+;   addi a0, zero, 1
+;   ret
+
+function %br_le(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp le v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   fle.s a5,fa0,fa1
+;   bne a5,zero,taken(label2),not_taken(label1)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fle.s a5, fa0, fa1
+;   bnez a5, 0xc
+; block1: ; offset 0x8
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x10
+;   addi a0, zero, 1
+;   ret
+
+function %br_ge(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp ge v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   fle.s a5,fa1,fa0
+;   bne a5,zero,taken(label2),not_taken(label1)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fle.s a5, fa1, fa0
+;   bnez a5, 0xc
+; block1: ; offset 0x8
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x10
+;   addi a0, zero, 1
+;   ret
+
+function %br_ult(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp ult v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   fle.s a5,fa1,fa0
+;   bne a5,zero,taken(label1),not_taken(label2)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fle.s a5, fa1, fa0
+;   beqz a5, 0xc
+; block1: ; offset 0x8
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x10
+;   addi a0, zero, 1
+;   ret
+
+function %br_ugt(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp ugt v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   fle.s a5,fa0,fa1
+;   bne a5,zero,taken(label1),not_taken(label2)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fle.s a5, fa0, fa1
+;   beqz a5, 0xc
+; block1: ; offset 0x8
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x10
+;   addi a0, zero, 1
+;   ret
+
+function %br_ule(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp ule v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   flt.s a5,fa1,fa0
+;   bne a5,zero,taken(label1),not_taken(label2)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   flt.s a5, fa1, fa0
+;   beqz a5, 0xc
+; block1: ; offset 0x8
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x10
+;   addi a0, zero, 1
+;   ret
+
+function %br_uge(f32, f32) -> i8 {
+block0(v0: f32, v1: f32):
+    v2 = fcmp uge v0, v1
+    brif v2, block1, block2
+block1:
+    v3 = iconst.i8 1
+    return v3
+block2:
+    v4 = iconst.i8 0
+    return v4
+}
+
+; VCode:
+; block0:
+;   flt.s a5,fa0,fa1
+;   bne a5,zero,taken(label1),not_taken(label2)
+; block1:
+;   li a0,0
+;   ret
+; block2:
+;   li a0,1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   flt.s a5, fa0, fa1
+;   beqz a5, 0xc
+; block1: ; offset 0x8
+;   mv a0, zero
+;   ret
+; block2: ; offset 0x10
+;   addi a0, zero, 1
+;   ret
+


### PR DESCRIPTION
This commit is aimed at simplifying the layers necessary to generate a
branch for a `brif` statement. Previously this involved a
`lower_cond_br` helper which bottomed out in emitting a `CondBr`
instruction. The intention here was to cut all that out and emit a
`CondBr` directly.

Along the way I've additionally taken the liberty of simplifying `fcmp`
as well. This moves the "prefer ordered compares" logic into `emit_fcmp`
so it can benefit the `fcmp` instruction as well. This additionally
trimmed some abstractions around branches which shouldn't be necessary
any longer.