### PR TITLE
Refactor HTTP tests to be less flaky and more robust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3063,7 +3063,6 @@ name = "wasi-http-tests"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "tokio",
  "wit-bindgen",
 ]
 

--- a/crates/test-programs/tests/wasi-http-components-sync.rs
+++ b/crates/test-programs/tests/wasi-http-components-sync.rs
@@ -1,4 +1,7 @@
 #![cfg(all(feature = "test_programs", not(skip_wasi_http_tests)))]
+
+use anyhow::Result;
+use test_programs::http_server::Server;
 use wasmtime::{
     component::{Component, Linker},
     Config, Engine, Store,
@@ -7,8 +10,6 @@ use wasmtime_wasi::preview2::{
     command::sync::Command, pipe::MemoryOutputPipe, Table, WasiCtx, WasiCtxBuilder, WasiView,
 };
 use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
-
-use test_programs::http_server::{setup_http1_sync, setup_http2_sync};
 
 lazy_static::lazy_static! {
     static ref ENGINE: Engine = {
@@ -66,7 +67,7 @@ fn instantiate_component(
     Ok((store, command))
 }
 
-fn run(name: &str) -> anyhow::Result<()> {
+fn run(name: &str, server: &Server) -> Result<()> {
     let stdout = MemoryOutputPipe::new(4096);
     let stderr = MemoryOutputPipe::new(4096);
     let r = {
@@ -81,6 +82,7 @@ fn run(name: &str) -> anyhow::Result<()> {
         for (var, val) in test_programs::wasi_tests_environment() {
             builder.env(var, val);
         }
+        builder.env("HTTP_SERVER", server.addr().to_string());
         let wasi = builder.build();
         let http = WasiHttpCtx {};
 
@@ -109,70 +111,55 @@ fn run(name: &str) -> anyhow::Result<()> {
 }
 
 #[test_log::test]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
-fn outbound_request_get() {
-    setup_http1_sync(|| run("outbound_request_get")).unwrap();
+fn outbound_request_get() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_get", &server)
 }
 
 #[test_log::test]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
-fn outbound_request_post() {
-    setup_http1_sync(|| run("outbound_request_post")).unwrap();
+fn outbound_request_post() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_post", &server)
 }
 
 #[test_log::test]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
-fn outbound_request_large_post() {
-    setup_http1_sync(|| run("outbound_request_large_post")).unwrap();
+fn outbound_request_large_post() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_large_post", &server)
 }
 
 #[test_log::test]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
-fn outbound_request_put() {
-    setup_http1_sync(|| run("outbound_request_put")).unwrap();
+fn outbound_request_put() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_put", &server)
 }
 
 #[test_log::test]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
-fn outbound_request_invalid_version() {
-    setup_http2_sync(|| run("outbound_request_invalid_version")).unwrap();
+fn outbound_request_invalid_version() -> Result<()> {
+    let server = Server::http2()?;
+    run("outbound_request_invalid_version", &server)
 }
 
 #[test_log::test]
-fn outbound_request_unknown_method() {
-    run("outbound_request_unknown_method").unwrap();
+fn outbound_request_unknown_method() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_unknown_method", &server)
 }
 
 #[test_log::test]
-fn outbound_request_unsupported_scheme() {
-    run("outbound_request_unsupported_scheme").unwrap();
+fn outbound_request_unsupported_scheme() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_unsupported_scheme", &server)
 }
 
 #[test_log::test]
-fn outbound_request_invalid_port() {
-    run("outbound_request_invalid_port").unwrap();
+fn outbound_request_invalid_port() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_invalid_port", &server)
 }
 
 #[test_log::test]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
-fn outbound_request_invalid_dnsname() {
-    run("outbound_request_invalid_dnsname").unwrap();
+fn outbound_request_invalid_dnsname() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_invalid_dnsname", &server)
 }

--- a/crates/test-programs/tests/wasi-http-components.rs
+++ b/crates/test-programs/tests/wasi-http-components.rs
@@ -82,7 +82,7 @@ async fn run(name: &str, server: &Server) -> Result<()> {
         for (var, val) in test_programs::wasi_tests_environment() {
             builder.env(var, val);
         }
-        builder.env("HTTP_SERVER", &server.addr().to_string());
+        builder.env("HTTP_SERVER", server.addr());
         let wasi = builder.build();
         let http = WasiHttpCtx;
 
@@ -109,10 +109,6 @@ async fn run(name: &str, server: &Server) -> Result<()> {
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
 async fn outbound_request_get() -> Result<()> {
     let server = Server::http1()?;
     run("outbound_request_get", &server).await

--- a/crates/test-programs/tests/wasi-http-components.rs
+++ b/crates/test-programs/tests/wasi-http-components.rs
@@ -1,4 +1,7 @@
 #![cfg(all(feature = "test_programs", not(skip_wasi_http_tests)))]
+
+use anyhow::Result;
+use test_programs::http_server::Server;
 use wasmtime::{
     component::{Component, Linker},
     Config, Engine, Store,
@@ -7,8 +10,6 @@ use wasmtime_wasi::preview2::{
     command::Command, pipe::MemoryOutputPipe, Table, WasiCtx, WasiCtxBuilder, WasiView,
 };
 use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
-
-use test_programs::http_server::{setup_http1, setup_http2};
 
 lazy_static::lazy_static! {
     static ref ENGINE: Engine = {
@@ -66,7 +67,7 @@ async fn instantiate_component(
     Ok((store, command))
 }
 
-async fn run(name: &str) -> anyhow::Result<()> {
+async fn run(name: &str, server: &Server) -> Result<()> {
     let stdout = MemoryOutputPipe::new(4096);
     let stderr = MemoryOutputPipe::new(4096);
     let r = {
@@ -81,6 +82,7 @@ async fn run(name: &str) -> anyhow::Result<()> {
         for (var, val) in test_programs::wasi_tests_environment() {
             builder.env(var, val);
         }
+        builder.env("HTTP_SERVER", &server.addr().to_string());
         let wasi = builder.build();
         let http = WasiHttpCtx;
 
@@ -111,70 +113,55 @@ async fn run(name: &str) -> anyhow::Result<()> {
     windows,
     ignore = "test is currently flaky in ci and needs to be debugged"
 )]
-async fn outbound_request_get() {
-    setup_http1(run("outbound_request_get")).await.unwrap();
+async fn outbound_request_get() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_get", &server).await
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
-async fn outbound_request_post() {
-    setup_http1(run("outbound_request_post")).await.unwrap();
+async fn outbound_request_post() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_post", &server).await
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
-async fn outbound_request_large_post() {
-    setup_http1(run("outbound_request_large_post"))
-        .await
-        .unwrap();
+async fn outbound_request_large_post() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_large_post", &server).await
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
-async fn outbound_request_put() {
-    setup_http1(run("outbound_request_put")).await.unwrap();
+async fn outbound_request_put() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_put", &server).await
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
-async fn outbound_request_invalid_version() {
-    setup_http2(run("outbound_request_invalid_version"))
-        .await
-        .unwrap();
+async fn outbound_request_invalid_version() -> Result<()> {
+    let server = Server::http2()?;
+    run("outbound_request_invalid_version", &server).await
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn outbound_request_unknown_method() {
-    run("outbound_request_unknown_method").await.unwrap();
+async fn outbound_request_unknown_method() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_unknown_method", &server).await
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn outbound_request_unsupported_scheme() {
-    run("outbound_request_unsupported_scheme").await.unwrap();
+async fn outbound_request_unsupported_scheme() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_unsupported_scheme", &server).await
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn outbound_request_invalid_port() {
-    run("outbound_request_invalid_port").await.unwrap();
+async fn outbound_request_invalid_port() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_invalid_port", &server).await
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-#[cfg_attr(
-    windows,
-    ignore = "test is currently flaky in ci and needs to be debugged"
-)]
-async fn outbound_request_invalid_dnsname() {
-    run("outbound_request_invalid_dnsname").await.unwrap();
+async fn outbound_request_invalid_dnsname() -> Result<()> {
+    let server = Server::http1()?;
+    run("outbound_request_invalid_dnsname", &server).await
 }

--- a/crates/test-programs/wasi-http-tests/Cargo.toml
+++ b/crates/test-programs/wasi-http-tests/Cargo.toml
@@ -7,7 +7,6 @@ publish = false
 
 [dependencies]
 anyhow = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt"] }
 wit-bindgen = { workspace = true, default-features = false, features = [
     "macros",
 ] }

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_get.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_get.rs
@@ -2,30 +2,26 @@ use anyhow::Context;
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
 fn main() {
-    wasi_http_tests::in_tokio(async { run().await })
-}
-
-async fn run() {
+    let addr = std::env::var("HTTP_SERVER").unwrap();
     let res = wasi_http_tests::request(
         Method::Get,
         Scheme::Http,
-        "localhost:3000",
+        &addr,
         "/get?some=arg&goes=here",
         None,
         None,
     )
-    .await
-    .context("localhost:3000 /get")
+    .context("/get")
     .unwrap();
 
-    println!("localhost:3000 /get: {res:?}");
+    println!("{addr} /get: {res:?}");
     assert_eq!(res.status, 200);
     let method = res.header("x-wasmtime-test-method").unwrap();
     assert_eq!(std::str::from_utf8(method).unwrap(), "GET");
     let uri = res.header("x-wasmtime-test-uri").unwrap();
     assert_eq!(
         std::str::from_utf8(uri).unwrap(),
-        "http://localhost:3000/get?some=arg&goes=here"
+        format!("http://{addr}/get?some=arg&goes=here")
     );
     assert_eq!(res.body, b"");
 }

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_dnsname.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_dnsname.rs
@@ -11,5 +11,8 @@ fn main() {
     );
 
     let error = res.unwrap_err().to_string();
-    assert!(error.starts_with("Error::InvalidUrl(\"failed to lookup address information:"));
+    assert!(
+        error.starts_with("Error::InvalidUrl(\"failed to lookup address information:"),
+        "bad error: {error}"
+    );
 }

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_dnsname.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_dnsname.rs
@@ -1,10 +1,6 @@
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
 fn main() {
-    wasi_http_tests::in_tokio(async { run().await })
-}
-
-async fn run() {
     let res = wasi_http_tests::request(
         Method::Get,
         Scheme::Http,
@@ -12,8 +8,7 @@ async fn run() {
         "/",
         None,
         None,
-    )
-    .await;
+    );
 
     let error = res.unwrap_err().to_string();
     assert!(error.starts_with("Error::InvalidUrl(\"failed to lookup address information:"));

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_dnsname.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_dnsname.rs
@@ -12,7 +12,7 @@ fn main() {
 
     let error = res.unwrap_err().to_string();
     assert!(
-        error.starts_with("Error::InvalidUrl(\"failed to lookup address information:"),
+        error.starts_with("Error::InvalidUrl(\""),
         "bad error: {error}"
     );
 }

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_port.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_port.rs
@@ -1,10 +1,6 @@
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
 fn main() {
-    wasi_http_tests::in_tokio(async { run().await })
-}
-
-async fn run() {
     let res = wasi_http_tests::request(
         Method::Get,
         Scheme::Http,
@@ -12,8 +8,7 @@ async fn run() {
         "/",
         None,
         None,
-    )
-    .await;
+    );
 
     let error = res.unwrap_err();
     assert_eq!(

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_version.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_version.rs
@@ -1,19 +1,8 @@
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
 fn main() {
-    wasi_http_tests::in_tokio(async { run().await })
-}
-
-async fn run() {
-    let res = wasi_http_tests::request(
-        Method::Connect,
-        Scheme::Http,
-        "localhost:3001",
-        "/",
-        None,
-        Some(&[]),
-    )
-    .await;
+    let addr = std::env::var("HTTP_SERVER").unwrap();
+    let res = wasi_http_tests::request(Method::Connect, Scheme::Http, &addr, "/", None, Some(&[]));
 
     let error = res.unwrap_err().to_string();
     if error.ne("Error::ProtocolError(\"invalid HTTP version parsed\")")

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_version.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_invalid_version.rs
@@ -5,9 +5,7 @@ fn main() {
     let res = wasi_http_tests::request(Method::Connect, Scheme::Http, &addr, "/", None, Some(&[]));
 
     let error = res.unwrap_err().to_string();
-    if error.ne("Error::ProtocolError(\"invalid HTTP version parsed\")")
-        && !error.starts_with("Error::ProtocolError(\"operation was canceled")
-    {
+    if !error.starts_with("Error::ProtocolError(\"") {
         panic!(
             r#"assertion failed: `(left == right)`
       left: `"{error}"`,

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_large_post.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_large_post.rs
@@ -3,27 +3,23 @@ use std::io::{self, Read};
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
 fn main() {
-    wasi_http_tests::in_tokio(async { run().await })
-}
-
-async fn run() {
     // TODO: ensure more than 700 bytes is allowed without error
     const LEN: usize = 700;
     let mut buffer = [0; LEN];
+    let addr = std::env::var("HTTP_SERVER").unwrap();
     io::repeat(0b001).read_exact(&mut buffer).unwrap();
     let res = wasi_http_tests::request(
         Method::Post,
         Scheme::Http,
-        "localhost:3000",
+        &addr,
         "/post",
         Some(&buffer),
         None,
     )
-    .await
-    .context("localhost:3000 /post large")
+    .context("/post large")
     .unwrap();
 
-    println!("localhost:3000 /post large: {}", res.status);
+    println!("/post large: {}", res.status);
     assert_eq!(res.status, 200);
     let method = res.header("x-wasmtime-test-method").unwrap();
     assert_eq!(std::str::from_utf8(method).unwrap(), "POST");

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_post.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_post.rs
@@ -2,23 +2,19 @@ use anyhow::Context;
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
 fn main() {
-    wasi_http_tests::in_tokio(async { run().await })
-}
-
-async fn run() {
+    let addr = std::env::var("HTTP_SERVER").unwrap();
     let res = wasi_http_tests::request(
         Method::Post,
         Scheme::Http,
-        "localhost:3000",
+        &addr,
         "/post",
         Some(b"{\"foo\": \"bar\"}"),
         None,
     )
-    .await
-    .context("localhost:3000 /post")
+    .context("/post")
     .unwrap();
 
-    println!("localhost:3000 /post: {res:?}");
+    println!("/post: {res:?}");
     assert_eq!(res.status, 200);
     let method = res.header("x-wasmtime-test-method").unwrap();
     assert_eq!(std::str::from_utf8(method).unwrap(), "POST");

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_put.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_put.rs
@@ -2,23 +2,12 @@ use anyhow::Context;
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
 fn main() {
-    wasi_http_tests::in_tokio(async { run().await })
-}
+    let addr = std::env::var("HTTP_SERVER").unwrap();
+    let res = wasi_http_tests::request(Method::Put, Scheme::Http, &addr, "/put", Some(&[]), None)
+        .context("/put")
+        .unwrap();
 
-async fn run() {
-    let res = wasi_http_tests::request(
-        Method::Put,
-        Scheme::Http,
-        "localhost:3000",
-        "/put",
-        Some(&[]),
-        None,
-    )
-    .await
-    .context("localhost:3000 /put")
-    .unwrap();
-
-    println!("localhost:3000 /put: {res:?}");
+    println!("/put: {res:?}");
     assert_eq!(res.status, 200);
     let method = res.header("x-wasmtime-test-method").unwrap();
     assert_eq!(std::str::from_utf8(method).unwrap(), "PUT");

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_unknown_method.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_unknown_method.rs
@@ -1,10 +1,6 @@
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
 fn main() {
-    wasi_http_tests::in_tokio(async { run().await })
-}
-
-async fn run() {
     let res = wasi_http_tests::request(
         Method::Other("OTHER".to_owned()),
         Scheme::Http,
@@ -12,8 +8,7 @@ async fn run() {
         "/",
         None,
         None,
-    )
-    .await;
+    );
 
     let error = res.unwrap_err();
     assert_eq!(

--- a/crates/test-programs/wasi-http-tests/src/bin/outbound_request_unsupported_scheme.rs
+++ b/crates/test-programs/wasi-http-tests/src/bin/outbound_request_unsupported_scheme.rs
@@ -1,10 +1,6 @@
 use wasi_http_tests::bindings::wasi::http::types::{Method, Scheme};
 
 fn main() {
-    wasi_http_tests::in_tokio(async { run().await })
-}
-
-async fn run() {
     let res = wasi_http_tests::request(
         Method::Get,
         Scheme::Other("WS".to_owned()),
@@ -12,8 +8,7 @@ async fn run() {
         "/",
         None,
         None,
-    )
-    .await;
+    );
 
     let error = res.unwrap_err();
     assert_eq!(

--- a/crates/test-programs/wasi-http-tests/src/lib.rs
+++ b/crates/test-programs/wasi-http-tests/src/lib.rs
@@ -8,12 +8,10 @@ pub mod bindings {
 }
 
 use anyhow::{anyhow, Result};
-use std::fmt;
-use std::sync::OnceLock;
-
 use bindings::wasi::http::{outgoing_handler, types as http_types};
 use bindings::wasi::io::poll;
 use bindings::wasi::io::streams;
+use std::fmt;
 
 pub struct Response {
     pub status: http_types::StatusCode,

--- a/crates/test-programs/wasi-http-tests/src/lib.rs
+++ b/crates/test-programs/wasi-http-tests/src/lib.rs
@@ -42,7 +42,7 @@ impl Response {
     }
 }
 
-pub async fn request(
+pub fn request(
     method: http_types::Method,
     scheme: http_types::Scheme,
     authority: &str,
@@ -169,25 +169,4 @@ pub async fn request(
         headers,
         body,
     })
-}
-
-static RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
-
-pub fn in_tokio<F: std::future::Future>(f: F) -> F::Output {
-    match tokio::runtime::Handle::try_current() {
-        Ok(h) => {
-            let _enter = h.enter();
-            h.block_on(f)
-        }
-        Err(_) => {
-            let runtime = RUNTIME.get_or_init(|| {
-                tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .unwrap()
-            });
-            let _enter = runtime.enter();
-            runtime.block_on(f)
-        }
-    }
 }


### PR DESCRIPTION
This commit refactors the wasi-http tests we have in this repository with a few changes:

* Each test now uses a dedicated port for the test. The port 0 is bound and whatever the OS gives is used for the duration of the test. This prevents tests from possibly interfering with each other.

* Server spawning is abstracted behind a single `Server` type now which internally has http1/2 constructors.

* Timeouts for server shutdown are removed since they were failing in CI and are likely best handled for each test individually if necessary.

As a minor cleanup the `tokio` usage in guest programs was removed as it was boilerplate in this case. This shouldn't affect the runtimes of tests, however.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
