### PR TITLE
[wasmtime-wasi] make StdinStream and StdoutStream public

### DIFF
--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -44,7 +44,9 @@ pub use self::error::I32Exit;
 pub use self::filesystem::{DirPerms, FilePerms};
 pub use self::poll::{subscribe, ClosureFuture, MakeFuture, Pollable, PollableFuture, Subscribe};
 pub use self::random::{thread_rng, Deterministic};
-pub use self::stdio::{stderr, stdin, stdout, IsATTY, Stderr, Stdin, Stdout};
+pub use self::stdio::{
+    stderr, stdin, stdout, IsATTY, Stderr, Stdin, StdinStream, Stdout, StdoutStream,
+};
 pub use self::stream::{HostInputStream, HostOutputStream, InputStream, OutputStream, StreamError};
 pub use self::table::{Table, TableError};
 pub use cap_fs_ext::SystemTimeSpec;


### PR DESCRIPTION
This allows embedders to implement those traits themselves rather than be restricted to using the built-in implementations.

Fixes https://github.com/bytecodealliance/wasmtime/issues/7149
