### PR TITLE
riscv64: Ignore extends for `fcmp`

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2148,9 +2148,10 @@
 (rule 1 (val_already_extended (uextend _)) $true)
 (rule 1 (val_already_extended (sextend _)) $true)
 
-;; The result of `icmp` is zero or one, meaning that it's already sign extended
-;; to the full register width.
+;; The result of `icmp`/`fcmp` is zero or one, meaning that it's already sign
+;; extended to the full register width.
 (rule 1 (val_already_extended (icmp _ _ _)) $true)
+(rule 1 (val_already_extended (fcmp _ _ _)) $true)
 
 (type ExtendOp
   (enum

--- a/cranelift/filetests/filetests/isa/riscv64/extend.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/extend.clif
@@ -258,3 +258,21 @@ block0(v0: i8, v1: i64):
 ;   add a0, a0, a1
 ;   ret
 
+
+function %extend_fcmp(f64, f64) -> i64 {
+block0(v0: f64, v1: f64):
+  v3 = fcmp.f64 lt v0, v1
+  v4 = sextend.i64 v3
+  return v4
+}
+
+; VCode:
+; block0:
+;   flt.d a0,fa0,fa1
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   flt.d a0, fa0, fa1
+;   ret
+


### PR DESCRIPTION
👋 Hey,

This is a small follow up to #7121. `fcmp` only ever returns 0 or 1, so that means that we can safely ignore extends from the output of that instruction.

The other instructions that I pointed out in that [comment](https://github.com/bytecodealliance/wasmtime/pull/7121#pullrequestreview-1652537290) end up already being covered by the remaining rules. Only `fcmp` was missing.