### PR TITLE
Fix printing error information in sync http tests

### DIFF
--- a/crates/test-programs/tests/wasi-http-components-sync.rs
+++ b/crates/test-programs/tests/wasi-http-components-sync.rs
@@ -87,11 +87,7 @@ fn run(name: &str, server: &Server) -> Result<()> {
         let http = WasiHttpCtx {};
 
         let (mut store, command) = instantiate_component(component, Ctx { table, wasi, http })?;
-        command
-            .wasi_cli_run()
-            .call_run(&mut store)?
-            .map_err(|()| anyhow::anyhow!("run returned a failure"))?;
-        Ok(())
+        command.wasi_cli_run().call_run(&mut store)
     };
     r.map_err(move |trap: anyhow::Error| {
         let stdout = stdout.try_into_inner().expect("single ref to stdout");
@@ -106,7 +102,8 @@ fn run(name: &str, server: &Server) -> Result<()> {
             "error while testing wasi-tests {} with http-components-sync",
             name
         ))
-    })?;
+    })?
+    .map_err(|()| anyhow::anyhow!("run returned an error"))?;
     Ok(())
 }
 


### PR DESCRIPTION
The usage of `?` accidentally caused the extra information to not get printed, so avoid the use of `?` until the extra error info has been attached.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
