### PR TITLE
riscv64: Move `sextend` optimizations into `sext`

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2110,7 +2110,7 @@
 ;; Ignore sign extensions for values whose representation is already the full
 ;; register width.
 (rule 3 (zext val)
-  (if (val_already_extended val))
+  (if (val_already_extended (ExtendOp.Zero) val))
   val)
 
 ;; Performs a signed extension of the given value
@@ -2139,25 +2139,36 @@
 ;; Ignore sign extensions for values whose representation is already the full
 ;; register width.
 (rule 2 (sext val)
-  (if (val_already_extended val))
+  (if (val_already_extended (ExtendOp.Signed) val))
   val)
 
 ;; Helper matcher for when a value's representation is already sign or zero
 ;; extended to the full 64-bit register representation. This is used by `zext`
 ;; and `sext` above to skip the extension instruction entirely in some
 ;; circumstances.
-(decl pure partial val_already_extended (Value) bool)
-(rule 0 (val_already_extended v @ (value_type $I64)) $true)
+(decl pure partial val_already_extended (ExtendOp Value) bool)
+(rule 0 (val_already_extended _ v @ (value_type $I64)) $true)
 
 ;; When extending our backend always extends to the full register width, so
 ;; there's no need to extend-an-extend.
-(rule 1 (val_already_extended (uextend _)) $true)
-(rule 1 (val_already_extended (sextend _)) $true)
+(rule 1 (val_already_extended (ExtendOp.Zero) (uextend _)) $true)
+(rule 1 (val_already_extended (ExtendOp.Signed) (sextend _)) $true)
 
 ;; The result of `icmp`/`fcmp` is zero or one, meaning that it's already sign
 ;; extended to the full register width.
-(rule 1 (val_already_extended (icmp _ _ _)) $true)
-(rule 1 (val_already_extended (fcmp _ _ _)) $true)
+(rule 1 (val_already_extended _ (icmp _ _ _)) $true)
+(rule 1 (val_already_extended _ (fcmp _ _ _)) $true)
+
+;; The lowering for these operations always sign-extend their results due to the
+;; use of the `*w` instructions in RV64I. Note that this requires that the
+;; extension is from 32 to 64, 16/8-bit operations are explicitly excluded here.
+;; There are no native instructions for the 16/8 bit operations so they must
+;; fall through to actual sign extension above.
+(rule 1 (val_already_extended (ExtendOp.Signed) (has_type $I32 (ishl _ _))) $true)
+(rule 1 (val_already_extended (ExtendOp.Signed) (has_type $I32 (ushr _ _))) $true)
+(rule 1 (val_already_extended (ExtendOp.Signed) (has_type $I32 (sshr _ _))) $true)
+(rule 1 (val_already_extended (ExtendOp.Signed) (has_type $I32 (iadd _ _))) $true)
+(rule 1 (val_already_extended (ExtendOp.Signed) (has_type $I32 (isub _ _))) $true)
 
 (type ExtendOp
   (enum

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -33,7 +33,10 @@
 ;;;; Rules for `iadd` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 ;; Base case, simply adding things in registers.
-(rule 0 (lower (has_type (ty_int_ref_scalar_64 ty) (iadd x y)))
+(rule -1 (lower (has_type (fits_in_32 (ty_int ty)) (iadd x y)))
+  (rv_addw x y))
+
+(rule 0 (lower (has_type $I64 (iadd x y)))
   (rv_add x y))
 
 ;; Special cases for when one operand is an immediate that fits in 12 bits.
@@ -312,11 +315,11 @@
 ;;;; Rules for `isub` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Base case, simply subtracting things in registers.
 
-(rule (lower (has_type (ty_int_ref_scalar_64 ty) (isub x y)))
-  (rv_sub x y))
-
-(rule 1 (lower (has_type (fits_in_32 (ty_int ty)) (isub x y)))
+(rule 0 (lower (has_type (fits_in_32 (ty_int ty)) (isub x y)))
   (rv_subw x y))
+
+(rule 1 (lower (has_type $I64 (isub x y)))
+  (rv_sub x y))
 
 (rule 2 (lower (has_type $I128 (isub x y)))
   (i128_sub x y))
@@ -961,39 +964,6 @@
 (rule 1 (lower (has_type $I128 (sextend val @ (value_type in_ty))))
   (let ((lo XReg (sext val)))
     (value_regs lo (rv_srai lo (imm12_const 63)))))
-
-;; The instructions below are present in RV64I and sign-extend the result to 64 bits.
-
-(rule 1 (lower (has_type $I64 (sextend (has_type $I32 (iadd x y)))))
-  (rv_addw x y))
-
-(rule 1 (lower (has_type $I64 (sextend (has_type $I32 (isub x y)))))
-  (rv_subw x y))
-
-(rule 1 (lower (has_type $I64 (sextend (has_type $I32 (ishl x y)))))
-  (rv_sllw x (value_regs_get y 0)))
-
-(rule 1 (lower (has_type $I64 (sextend (has_type $I32 (ushr x y)))))
-  (rv_srlw x (value_regs_get y 0)))
-
-(rule 1 (lower (has_type $I64 (sextend (has_type $I32 (sshr x y)))))
-  (rv_sraw x (value_regs_get y 0)))
-
-
-(rule 2 (lower (has_type $I64 (sextend (has_type $I32 (iadd x (imm12_from_value y))))))
-  (rv_addiw x y))
-
-(rule 3 (lower (has_type $I64 (sextend (has_type $I32 (iadd (imm12_from_value x) y)))))
-  (rv_addiw y x))
-
-(rule 2 (lower (has_type $I64 (sextend (has_type $I32 (ishl x (imm12_from_value y))))))
-  (rv_slliw x y))
-
-(rule 2 (lower (has_type $I64 (sextend (has_type $I32 (ushr x (imm12_from_value y))))))
-  (rv_srliw x y))
-
-(rule 2 (lower (has_type $I64 (sextend (has_type $I32 (sshr x (imm12_from_value y))))))
-  (rv_sraiw x y))
 
 ;;;; Rules for `popcnt` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
@@ -618,13 +618,13 @@ block0(v0: i32, v1: i32, v2: i32):
 ; VCode:
 ; block0:
 ;   mulw a5,a1,a2
-;   add a0,a5,a0
+;   addw a0,a5,a0
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   mulw a5, a1, a2
-;   add a0, a5, a0
+;   addw a0, a5, a0
 ;   ret
 
 function %msub_i32(i32, i32, i32) -> i32 {

--- a/cranelift/filetests/filetests/isa/riscv64/br_table.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/br_table.clif
@@ -47,7 +47,7 @@ block5(v5: i32):
 ;   li a5,4
 ;   j label7
 ; block7:
-;   add a0,a0,a5
+;   addw a0,a0,a5
 ;   ret
 ;
 ; Disassembled:
@@ -84,6 +84,6 @@ block5(v5: i32):
 ; block5: ; offset 0x64
 ;   addi a5, zero, 4
 ; block6: ; offset 0x68
-;   add a0, a0, a5
+;   addw a0, a0, a5
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/issue-6954.clif
@@ -129,191 +129,154 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   vle8.v v15,32(fp) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v10,48(fp) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   vle8.v v12,64(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   li a0,0
 ;   li a2,0
 ;   li a3,0
 ;   li a4,0
-;   sd a3,0(nominal_sp)
-;   sd a4,8(nominal_sp)
-;   sd a3,16(nominal_sp)
-;   sd a4,24(nominal_sp)
-;   sd a3,32(nominal_sp)
-;   sd a4,40(nominal_sp)
-;   sd a3,48(nominal_sp)
-;   sd a4,56(nominal_sp)
-;   sd a3,64(nominal_sp)
-;   sd a4,72(nominal_sp)
-;   sd a3,80(nominal_sp)
-;   sd a4,88(nominal_sp)
-;   sd a3,96(nominal_sp)
-;   sd a4,104(nominal_sp)
-;   sd a3,112(nominal_sp)
-;   sw a2,120(nominal_sp)
-;   sh a0,124(nominal_sp)
-;   sd a3,128(nominal_sp)
-;   sd a4,136(nominal_sp)
-;   sd a3,144(nominal_sp)
-;   sd a4,152(nominal_sp)
-;   sd a3,160(nominal_sp)
-;   sd a4,168(nominal_sp)
-;   sd a3,176(nominal_sp)
-;   sd a4,184(nominal_sp)
-;   sd a3,192(nominal_sp)
-;   sd a4,200(nominal_sp)
-;   sd a3,208(nominal_sp)
-;   sd a4,216(nominal_sp)
-;   sd a3,224(nominal_sp)
-;   sd a4,232(nominal_sp)
-;   sd a3,240(nominal_sp)
-;   sw a2,248(nominal_sp)
-;   sh a0,252(nominal_sp)
-;   sd a3,256(nominal_sp)
-;   sd a4,264(nominal_sp)
-;   sd a3,272(nominal_sp)
-;   sd a4,280(nominal_sp)
-;   sd a3,288(nominal_sp)
-;   sd a4,296(nominal_sp)
-;   sd a3,304(nominal_sp)
-;   sd a4,312(nominal_sp)
-;   sd a3,320(nominal_sp)
-;   sd a4,328(nominal_sp)
-;   sd a3,336(nominal_sp)
-;   sd a4,344(nominal_sp)
-;   sd a3,352(nominal_sp)
-;   sd a4,360(nominal_sp)
-;   sd a3,368(nominal_sp)
-;   sw a2,376(nominal_sp)
-;   sh a0,380(nominal_sp)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   vfsqrt.v v10,v11 #avl=2, #vtype=(e64, m1, ta, ma)
-;   lui a0,4095
-;   slli a2,a0,39
-;   fmv.d.x fa4,a2
-;   vfmv.v.f v11,fa4 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmfne.vv v0,v10,v10 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vvm v13,v10,v11,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   vfsqrt.v v10,v13 #avl=2, #vtype=(e64, m1, ta, ma)
-;   lui a0,4095
-;   slli a2,a0,39
-;   fmv.d.x fa4,a2
-;   vfmv.v.f v13,fa4 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmfne.vv v0,v10,v10 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vmerge.vvm v11,v10,v13,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   sext.w a2,a1
-;   select v12,v12,v12##condition=(a2 ne zero)
-;   add a2,a1,a1
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   vmax.vv v10,v15,v15 #avl=2, #vtype=(e64, m1, ta, ma)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   load_addr a3,3(nominal_sp)
-;   addi a3,a3,0
-;   andi a0,a3,3
-;   slli a4,a0,3
-;   andi a1,a3,-4
-;   atomic_rmw.i8 and a0,a5,(a1)##t0=a3 offset=a4
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   vse64.v v10,33(nominal_sp) #avl=2, #vtype=(e64, m1, ta, ma)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   sext.w a1,a2
-;   select v12,v12,v12##condition=(a1 ne zero)
-;   vse8.v v11,0(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v12,16(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v11,32(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v12,48(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v12,64(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v12,80(a6) #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v12,96(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   li a0,0
+;   sd a4,0(nominal_sp)
+;   sd a0,8(nominal_sp)
+;   sd a4,16(nominal_sp)
+;   sd a0,24(nominal_sp)
+;   sd a4,32(nominal_sp)
+;   sd a0,40(nominal_sp)
+;   sd a4,48(nominal_sp)
+;   sd a0,56(nominal_sp)
+;   sd a4,64(nominal_sp)
+;   sd a0,72(nominal_sp)
+;   sd a4,80(nominal_sp)
+;   sd a0,88(nominal_sp)
+;   sd a4,96(nominal_sp)
+;   sd a0,104(nominal_sp)
+;   sd a4,112(nominal_sp)
+;   sw a3,120(nominal_sp)
+;   sh a2,124(nominal_sp)
+;   sd a4,128(nominal_sp)
+;   sd a0,136(nominal_sp)
+;   sd a4,144(nominal_sp)
+;   sd a0,152(nominal_sp)
+;   sd a4,160(nominal_sp)
+;   sd a0,168(nominal_sp)
+;   sd a4,176(nominal_sp)
+;   sd a0,184(nominal_sp)
+;   sd a4,192(nominal_sp)
+;   sd a0,200(nominal_sp)
+;   sd a4,208(nominal_sp)
+;   sd a0,216(nominal_sp)
+;   sd a4,224(nominal_sp)
+;   sd a0,232(nominal_sp)
+;   sd a4,240(nominal_sp)
+;   sw a3,248(nominal_sp)
+;   sh a2,252(nominal_sp)
+;   sd a4,256(nominal_sp)
+;   sd a0,264(nominal_sp)
+;   sd a4,272(nominal_sp)
+;   sd a0,280(nominal_sp)
+;   sd a4,288(nominal_sp)
+;   sd a0,296(nominal_sp)
+;   sd a4,304(nominal_sp)
+;   sd a0,312(nominal_sp)
+;   sd a4,320(nominal_sp)
+;   sd a0,328(nominal_sp)
+;   sd a4,336(nominal_sp)
+;   sd a0,344(nominal_sp)
+;   sd a4,352(nominal_sp)
+;   sd a0,360(nominal_sp)
+;   sd a4,368(nominal_sp)
+;   sw a3,376(nominal_sp)
+;   sh a2,380(nominal_sp)
+;   sext.w a4,a1
+;   select v12,v12,v12##condition=(a4 ne zero)
+;   sext.w a4,a1
+;   select v12,v12,v12##condition=(a4 ne zero)
+;   sext.w a4,a1
+;   select v13,v12,v12##condition=(a4 ne zero)
+;   vfsqrt.v v11,v11 #avl=2, #vtype=(e64, m1, ta, ma)
+;   lui a3,4095
+;   slli a0,a3,39
+;   fmv.d.x fa1,a0
+;   vfmv.v.f v12,fa1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmfne.vv v0,v11,v11 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vvm v14,v11,v12,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   vfsqrt.v v11,v14 #avl=2, #vtype=(e64, m1, ta, ma)
+;   lui a3,4095
+;   slli a0,a3,39
+;   fmv.d.x fa1,a0
+;   vfmv.v.f v14,fa1 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmfne.vv v0,v11,v11 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vmerge.vvm v12,v11,v14,v0.t #avl=2, #vtype=(e64, m1, ta, ma)
+;   sext.w a4,a1
+;   select v13,v13,v13##condition=(a4 ne zero)
+;   sext.w a4,a1
+;   select v13,v13,v13##condition=(a4 ne zero)
+;   sext.w a4,a1
+;   select v13,v13,v13##condition=(a4 ne zero)
+;   sext.w a4,a1
+;   select v13,v13,v13##condition=(a4 ne zero)
+;   sext.w a4,a1
+;   select v13,v13,v13##condition=(a4 ne zero)
+;   sext.w a4,a1
+;   select v13,v13,v13##condition=(a4 ne zero)
+;   sext.w a4,a1
+;   select v13,v13,v13##condition=(a4 ne zero)
+;   sext.w a4,a1
+;   select v13,v13,v13##condition=(a4 ne zero)
+;   addw a0,a1,a1
+;   select v11,v13,v13##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v13,v11,v11##condition=(a0 ne zero)
+;   vmax.vv v11,v15,v15 #avl=2, #vtype=(e64, m1, ta, ma)
+;   select v13,v13,v13##condition=(a0 ne zero)
+;   load_addr a1,3(nominal_sp)
+;   addi a1,a1,0
+;   andi a3,a1,3
+;   slli a2,a3,3
+;   andi a1,a1,-4
+;   atomic_rmw.i8 and a4,a5,(a1)##t0=a3 offset=a2
+;   mv a5,a4
+;   select v10,v13,v13##condition=(a0 ne zero)
+;   select v10,v10,v10##condition=(a0 ne zero)
+;   select v10,v10,v10##condition=(a0 ne zero)
+;   select v10,v10,v10##condition=(a0 ne zero)
+;   select v10,v10,v10##condition=(a0 ne zero)
+;   select v10,v10,v10##condition=(a0 ne zero)
+;   select v10,v10,v10##condition=(a0 ne zero)
+;   vse64.v v11,33(nominal_sp) #avl=2, #vtype=(e64, m1, ta, ma)
+;   select v11,v10,v10##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   select v11,v11,v11##condition=(a0 ne zero)
+;   vse8.v v12,0(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,16(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,32(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,48(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,64(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,80(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v11,96(a6) #avl=16, #vtype=(e8, m1, ta, ma)
+;   mv a0,a5
 ;   add sp,+384
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -337,163 +300,146 @@ block0(v0: i16, v1: f32, v2: f64x2, v3: i32, v4: i8, v5: i64x2, v6: i8, v7: f32x
 ;   .byte 0x07, 0x85, 0x0f, 0x02
 ;   addi t6, s0, 0x40
 ;   .byte 0x07, 0x86, 0x0f, 0x02
-;   mv a0, zero
 ;   mv a2, zero
 ;   mv a3, zero
 ;   mv a4, zero
-;   sd a3, 0(sp)
-;   sd a4, 8(sp)
-;   sd a3, 0x10(sp)
-;   sd a4, 0x18(sp)
-;   sd a3, 0x20(sp)
-;   sd a4, 0x28(sp)
-;   sd a3, 0x30(sp)
-;   sd a4, 0x38(sp)
-;   sd a3, 0x40(sp)
-;   sd a4, 0x48(sp)
-;   sd a3, 0x50(sp)
-;   sd a4, 0x58(sp)
-;   sd a3, 0x60(sp)
-;   sd a4, 0x68(sp)
-;   sd a3, 0x70(sp)
-;   sw a2, 0x78(sp)
-;   sh a0, 0x7c(sp)
-;   sd a3, 0x80(sp)
-;   sd a4, 0x88(sp)
-;   sd a3, 0x90(sp)
-;   sd a4, 0x98(sp)
-;   sd a3, 0xa0(sp)
-;   sd a4, 0xa8(sp)
-;   sd a3, 0xb0(sp)
-;   sd a4, 0xb8(sp)
-;   sd a3, 0xc0(sp)
-;   sd a4, 0xc8(sp)
-;   sd a3, 0xd0(sp)
-;   sd a4, 0xd8(sp)
-;   sd a3, 0xe0(sp)
-;   sd a4, 0xe8(sp)
-;   sd a3, 0xf0(sp)
-;   sw a2, 0xf8(sp)
-;   sh a0, 0xfc(sp)
-;   sd a3, 0x100(sp)
-;   sd a4, 0x108(sp)
-;   sd a3, 0x110(sp)
-;   sd a4, 0x118(sp)
-;   sd a3, 0x120(sp)
-;   sd a4, 0x128(sp)
-;   sd a3, 0x130(sp)
-;   sd a4, 0x138(sp)
-;   sd a3, 0x140(sp)
-;   sd a4, 0x148(sp)
-;   sd a3, 0x150(sp)
-;   sd a4, 0x158(sp)
-;   sd a3, 0x160(sp)
-;   sd a4, 0x168(sp)
-;   sd a3, 0x170(sp)
-;   sw a2, 0x178(sp)
-;   sh a0, 0x17c(sp)
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
+;   mv a0, zero
+;   sd a4, 0(sp)
+;   sd a0, 8(sp)
+;   sd a4, 0x10(sp)
+;   sd a0, 0x18(sp)
+;   sd a4, 0x20(sp)
+;   sd a0, 0x28(sp)
+;   sd a4, 0x30(sp)
+;   sd a0, 0x38(sp)
+;   sd a4, 0x40(sp)
+;   sd a0, 0x48(sp)
+;   sd a4, 0x50(sp)
+;   sd a0, 0x58(sp)
+;   sd a4, 0x60(sp)
+;   sd a0, 0x68(sp)
+;   sd a4, 0x70(sp)
+;   sw a3, 0x78(sp)
+;   sh a2, 0x7c(sp)
+;   sd a4, 0x80(sp)
+;   sd a0, 0x88(sp)
+;   sd a4, 0x90(sp)
+;   sd a0, 0x98(sp)
+;   sd a4, 0xa0(sp)
+;   sd a0, 0xa8(sp)
+;   sd a4, 0xb0(sp)
+;   sd a0, 0xb8(sp)
+;   sd a4, 0xc0(sp)
+;   sd a0, 0xc8(sp)
+;   sd a4, 0xd0(sp)
+;   sd a0, 0xd8(sp)
+;   sd a4, 0xe0(sp)
+;   sd a0, 0xe8(sp)
+;   sd a4, 0xf0(sp)
+;   sw a3, 0xf8(sp)
+;   sh a2, 0xfc(sp)
+;   sd a4, 0x100(sp)
+;   sd a0, 0x108(sp)
+;   sd a4, 0x110(sp)
+;   sd a0, 0x118(sp)
+;   sd a4, 0x120(sp)
+;   sd a0, 0x128(sp)
+;   sd a4, 0x130(sp)
+;   sd a0, 0x138(sp)
+;   sd a4, 0x140(sp)
+;   sd a0, 0x148(sp)
+;   sd a4, 0x150(sp)
+;   sd a0, 0x158(sp)
+;   sd a4, 0x160(sp)
+;   sd a0, 0x168(sp)
+;   sd a4, 0x170(sp)
+;   sw a3, 0x178(sp)
+;   sh a2, 0x17c(sp)
+;   sext.w a4, a1
+;   sext.w a4, a1
+;   sext.w a4, a1
+;   beqz a4, 0xc
+;   .byte 0xd7, 0x36, 0xc0, 0x9e
+;   j 8
+;   .byte 0xd7, 0x36, 0xc0, 0x9e
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0x57, 0x15, 0xb0, 0x4e
-;   lui a0, 0xfff
-;   slli a2, a0, 0x27
-;   fmv.d.x fa4, a2
-;   .byte 0xd7, 0x55, 0x07, 0x5e
-;   .byte 0x57, 0x10, 0xa5, 0x72
-;   .byte 0xd7, 0x86, 0xa5, 0x5c
-;   .byte 0x57, 0x15, 0xd0, 0x4e
-;   lui a0, 0xfff
-;   slli a2, a0, 0x27
-;   fmv.d.x fa4, a2
-;   .byte 0xd7, 0x56, 0x07, 0x5e
-;   .byte 0x57, 0x10, 0xa5, 0x72
-;   .byte 0xd7, 0x85, 0xa6, 0x5c
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   sext.w a2, a1
-;   add a2, a1, a1
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   .byte 0x57, 0x85, 0xf7, 0x1e
-;   sext.w a1, a2
-;   addi a3, sp, 3
-;   mv a3, a3
-;   andi a0, a3, 3
-;   slli a4, a0, 3
-;   andi a1, a3, -4
-;   lr.w.aqrl a0, (a1)
-;   srl a0, a0, a4
-;   andi a0, a0, 0xff
-;   and a3, a0, a5
+;   .byte 0xd7, 0x15, 0xb0, 0x4e
+;   lui a3, 0xfff
+;   slli a0, a3, 0x27
+;   fmv.d.x fa1, a0
+;   .byte 0x57, 0xd6, 0x05, 0x5e
+;   .byte 0x57, 0x90, 0xb5, 0x72
+;   .byte 0x57, 0x07, 0xb6, 0x5c
+;   .byte 0xd7, 0x15, 0xe0, 0x4e
+;   lui a3, 0xfff
+;   slli a0, a3, 0x27
+;   fmv.d.x fa1, a0
+;   .byte 0x57, 0xd7, 0x05, 0x5e
+;   .byte 0x57, 0x90, 0xb5, 0x72
+;   .byte 0x57, 0x06, 0xb7, 0x5c
+;   sext.w a4, a1
+;   sext.w a4, a1
+;   sext.w a4, a1
+;   sext.w a4, a1
+;   sext.w a4, a1
+;   sext.w a4, a1
+;   sext.w a4, a1
+;   sext.w a4, a1
+;   addw a0, a1, a1
+;   beqz a0, 0xc
+;   .byte 0xd7, 0x35, 0xd0, 0x9e
+;   j 8
+;   .byte 0xd7, 0x35, 0xd0, 0x9e
+;   beqz a0, 0xc
+;   .byte 0xd7, 0x36, 0xb0, 0x9e
+;   j 8
+;   .byte 0xd7, 0x36, 0xb0, 0x9e
+;   .byte 0xd7, 0x85, 0xf7, 0x1e
+;   addi a1, sp, 3
+;   mv a1, a1
+;   andi a3, a1, 3
+;   slli a2, a3, 3
+;   andi a1, a1, -4
+;   lr.w.aqrl a4, (a1)
+;   srl a4, a4, a2
+;   andi a4, a4, 0xff
+;   and a3, a4, a5
 ;   lr.w.aqrl t5, (a1)
 ;   addi t6, zero, 0xff
-;   sll t6, t6, a4
+;   sll t6, t6, a2
 ;   not t6, t6
 ;   and t5, t5, t6
 ;   andi t6, a3, 0xff
-;   sll t6, t6, a4
+;   sll t6, t6, a2
 ;   or t5, t5, t6
 ;   sc.w.aqrl a3, t5, (a1)
 ;   bnez a3, -0x34
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
+;   mv a5, a4
+;   beqz a0, 0xc
+;   .byte 0x57, 0x35, 0xd0, 0x9e
+;   j 8
+;   .byte 0x57, 0x35, 0xd0, 0x9e
 ;   addi t6, sp, 0x21
-;   .byte 0x27, 0xf5, 0x0f, 0x02
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
-;   sext.w a1, a2
+;   .byte 0xa7, 0xf5, 0x0f, 0x02
+;   beqz a0, 0xc
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
+;   j 8
+;   .byte 0xd7, 0x35, 0xa0, 0x9e
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x05, 0x08, 0x02
+;   .byte 0x27, 0x06, 0x08, 0x02
 ;   addi t6, a6, 0x10
-;   .byte 0x27, 0x86, 0x0f, 0x02
-;   addi t6, a6, 0x20
 ;   .byte 0xa7, 0x85, 0x0f, 0x02
+;   addi t6, a6, 0x20
+;   .byte 0x27, 0x86, 0x0f, 0x02
 ;   addi t6, a6, 0x30
-;   .byte 0x27, 0x86, 0x0f, 0x02
+;   .byte 0xa7, 0x85, 0x0f, 0x02
 ;   addi t6, a6, 0x40
-;   .byte 0x27, 0x86, 0x0f, 0x02
+;   .byte 0xa7, 0x85, 0x0f, 0x02
 ;   addi t6, a6, 0x50
-;   .byte 0x27, 0x86, 0x0f, 0x02
+;   .byte 0xa7, 0x85, 0x0f, 0x02
 ;   addi t6, a6, 0x60
-;   .byte 0x27, 0x86, 0x0f, 0x02
+;   .byte 0xa7, 0x85, 0x0f, 0x02
+;   mv a0, a5
 ;   addi sp, sp, 0x180
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/narrow-arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/narrow-arithmetic.clif
@@ -10,12 +10,12 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   add a0,a0,a1
+;   addw a0,a0,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   add a0, a0, a1
+;   addw a0, a0, a1
 ;   ret
 
 function %add16(i16, i16) -> i16 {
@@ -26,12 +26,12 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   add a0,a0,a1
+;   addw a0,a0,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   add a0, a0, a1
+;   addw a0, a0, a1
 ;   ret
 
 function %add32(i32, i32) -> i32 {
@@ -42,12 +42,12 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   add a0,a0,a1
+;   addw a0,a0,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   add a0, a0, a1
+;   addw a0, a0, a1
 ;   ret
 
 function %add32_8(i32, i8) -> i32 {
@@ -61,14 +61,14 @@ block0(v0: i32, v1: i8):
 ; block0:
 ;   slli a4,a1,56
 ;   srai a1,a4,56
-;   add a0,a0,a1
+;   addw a0,a0,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   slli a4, a1, 0x38
 ;   srai a1, a4, 0x38
-;   add a0, a0, a1
+;   addw a0, a0, a1
 ;   ret
 
 function %add64_32(i64, i32) -> i64 {

--- a/cranelift/filetests/filetests/runtests/extend.clif
+++ b/cranelift/filetests/filetests/runtests/extend.clif
@@ -216,3 +216,21 @@ block0(v0: i32, v1: i32):
 }
 ; run: %add_sextend32_64(0xffff_ee00, 0x1000_0001) == 0x0000_0000_0fff_ee01
 ; run: %add_sextend32_64(0xffff_ee00, 0x9000_0001) == 0xffff_ffff_8fff_ee01
+
+function %sext16_zext32(i8) -> i32 {
+block0(v0: i8):
+    v1 = sextend.i16 v0
+    v2 = uextend.i32 v1
+    return v2
+}
+; run: %sext16_zext32(0xff) == 0xffff
+; run: %sext16_zext32(0x7f) == 0x7f
+
+function %zext16_sext32(i8) -> i32 {
+block0(v0: i8):
+    v1 = uextend.i16 v0
+    v2 = sextend.i32 v1
+    return v2
+}
+; run: %zext16_sext32(0xff) == 0xff
+; run: %zext16_sext32(0x7f) == 0x7f


### PR DESCRIPTION
This commit moves the optimizations from `sextend` for various shapes of instructions into the `sext` helper. This enables these optimizations to kick in when generating other instructions which require sign-extensions such as `icmp` and `brif`.

This additionally fixes an issue introduced in #7121 where uextend-of-sextend wasn't translated correctly and the outer `uextend` was mistakenly omitted.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
