### PR TITLE
wasi-nn: be explicit about the error on `BackendError` variants

### DIFF
--- a/crates/wasi-nn/src/backend/mod.rs
+++ b/crates/wasi-nn/src/backend/mod.rs
@@ -52,9 +52,9 @@ pub trait BackendExecutionContext: Send + Sync {
 /// for failures interacting with the ML library.
 #[derive(Debug, Error)]
 pub enum BackendError {
-    #[error("Failed while accessing backend")]
+    #[error("Failed while accessing backend: {0}")]
     BackendAccess(#[from] anyhow::Error),
-    #[error("Failed while accessing guest module")]
+    #[error("Failed while accessing guest module: {0}")]
     GuestAccess(#[from] GuestError),
     #[error("The backend expects {0} buffers, passed {1}")]
     InvalidNumberOfBuilders(usize, usize),


### PR DESCRIPTION
`BackendAccess` and `GuestAccess` variants contain more information that might be helpful to diagnose an underlying problem. Bubble up that information to the user.

I added this in the context of an openvino installation that was missing `plugins.xml`. Adding this information helped me in finding out the issue.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
