### PR TITLE
Add a whole lot of semicolons to WIT files

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -89,7 +89,7 @@ impl Parse for Config {
                         }
                         inline = Some(format!(
                             "
-                                package wasmtime:component-macro-synthesized
+                                package wasmtime:component-macro-synthesized;
 
                                 world interfaces {{
                                     {}

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -31,23 +31,23 @@ mod with_key_and_resources {
 
     wasmtime::component::bindgen!({
         inline: "
-            package demo:pkg
+            package demo:pkg;
 
             interface bar {
-                resource a
-                resource b
+                resource a;
+                resource b;
             }
 
             world foo {
-                resource a
-                resource b
+                resource a;
+                resource b;
 
                 import foo: interface {
-                    resource a
-                    resource b
+                    resource a;
+                    resource b;
                 }
 
-                import bar
+                import bar;
             }
         ",
         with: {

--- a/crates/component-macro/tests/codegen/char.wit
+++ b/crates/component-macro/tests/codegen/char.wit
@@ -1,13 +1,13 @@
-package foo:foo
+package foo:foo;
 
 interface chars {
   /// A function that accepts a character
-  take-char: func(x: char)
+  take-char: func(x: char);
   /// A function that returns a character
-  return-char: func() -> char
+  return-char: func() -> char;
 }
 
 world the-world {
-  import chars
-  export chars
+  import chars;
+  export chars;
 }

--- a/crates/component-macro/tests/codegen/conventions.wit
+++ b/crates/component-macro/tests/codegen/conventions.wit
@@ -1,22 +1,22 @@
 // hello 🐱 world
-package foo:foo
+package foo:foo;
 
 interface conventions {
-  kebab-case: func()
+  kebab-case: func();
 
   record ludicrous-speed {
     how-fast-are-you-going: u32,
     i-am-going-extremely-slow: u64,
   }
 
-  foo: func(x: ludicrous-speed)
-  %function-with-dashes: func()
-  %function-with-no-weird-characters: func()
+  foo: func(x: ludicrous-speed);
+  %function-with-dashes: func();
+  %function-with-no-weird-characters: func();
 
-  apple: func()
-  apple-pear: func()
-  apple-pear-grape: func()
-  a0: func()
+  apple: func();
+  apple-pear: func();
+  apple-pear-grape: func();
+  a0: func();
 
   // Comment out identifiers that collide when mapped to snake_case, for now; see
   // https://github.com/WebAssembly/component-model/issues/118
@@ -24,16 +24,16 @@ interface conventions {
   //APPLE-pear-GRAPE: func()
   //apple-PEAR-grape: func()
 
-  is-XML: func()
+  is-XML: func();
 
-  %explicit: func()
-  %explicit-kebab: func()
+  %explicit: func();
+  %explicit-kebab: func();
 
   // Identifiers with the same name as keywords are quoted.
-  %bool: func()
+  %bool: func();
 }
 
 world the-world {
-  import conventions
-  export conventions
+  import conventions;
+  export conventions;
 }

--- a/crates/component-macro/tests/codegen/direct-import.wit
+++ b/crates/component-macro/tests/codegen/direct-import.wit
@@ -1,5 +1,5 @@
-package foo:foo
+package foo:foo;
 
 world foo {
-  import foo: func()
+  import foo: func();
 }

--- a/crates/component-macro/tests/codegen/empty.wit
+++ b/crates/component-macro/tests/codegen/empty.wit
@@ -1,2 +1,2 @@
-package foo:foo
+package foo:foo;
 world empty {}

--- a/crates/component-macro/tests/codegen/flags.wit
+++ b/crates/component-macro/tests/codegen/flags.wit
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface flegs {
   flags flag1 {
@@ -40,16 +40,16 @@ interface flegs {
     b56, b57, b58, b59, b60, b61, b62, b63,
   }
 
-  roundtrip-flag1: func(x: flag1) -> flag1
-  roundtrip-flag2: func(x: flag2) -> flag2
-  roundtrip-flag4: func(x: flag4) -> flag4
-  roundtrip-flag8: func(x: flag8) -> flag8
-  roundtrip-flag16: func(x: flag16) -> flag16
-  roundtrip-flag32: func(x: flag32) -> flag32
-  roundtrip-flag64: func(x: flag64) -> flag64
+  roundtrip-flag1: func(x: flag1) -> flag1;
+  roundtrip-flag2: func(x: flag2) -> flag2;
+  roundtrip-flag4: func(x: flag4) -> flag4;
+  roundtrip-flag8: func(x: flag8) -> flag8;
+  roundtrip-flag16: func(x: flag16) -> flag16;
+  roundtrip-flag32: func(x: flag32) -> flag32;
+  roundtrip-flag64: func(x: flag64) -> flag64;
 }
 
 world the-flags {
-  import flegs
-  export flegs
+  import flegs;
+  export flegs;
 }

--- a/crates/component-macro/tests/codegen/floats.wit
+++ b/crates/component-macro/tests/codegen/floats.wit
@@ -1,13 +1,13 @@
-package foo:foo
+package foo:foo;
 
 interface floats {
-  float32-param: func(x: float32)
-  float64-param: func(x: float64)
-  float32-result: func() -> float32
-  float64-result: func() -> float64
+  float32-param: func(x: float32);
+  float64-param: func(x: float64);
+  float32-result: func() -> float32;
+  float64-result: func() -> float64;
 }
 
 world the-world {
-  import floats
-  export floats
+  import floats;
+  export floats;
 }

--- a/crates/component-macro/tests/codegen/function-new.wit
+++ b/crates/component-macro/tests/codegen/function-new.wit
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 world foo {
-  export new: func()
+  export new: func();
 }

--- a/crates/component-macro/tests/codegen/integers.wit
+++ b/crates/component-macro/tests/codegen/integers.wit
@@ -1,14 +1,14 @@
-package foo:foo
+package foo:foo;
 
 interface integers {
-  a1: func(x: u8)
-  a2: func(x: s8)
-  a3: func(x: u16)
-  a4: func(x: s16)
-  a5: func(x: u32)
-  a6: func(x: s32)
-  a7: func(x: u64)
-  a8: func(x: s64)
+  a1: func(x: u8);
+  a2: func(x: s8);
+  a3: func(x: u16);
+  a4: func(x: s16);
+  a5: func(x: u32);
+  a6: func(x: s32);
+  a7: func(x: u64);
+  a8: func(x: s64);
 
   a9: func(
     p1: u8,
@@ -19,22 +19,22 @@ interface integers {
     p6: s32,
     p7: u64,
     p8: s64,
-  )
+  );
 
 
-  r1: func() -> u8
-  r2: func() -> s8
-  r3: func() -> u16
-  r4: func() -> s16
-  r5: func() -> u32
-  r6: func() -> s32
-  r7: func() -> u64
-  r8: func() -> s64
+  r1: func() -> u8;
+  r2: func() -> s8;
+  r3: func() -> u16;
+  r4: func() -> s16;
+  r5: func() -> u32;
+  r6: func() -> s32;
+  r7: func() -> u64;
+  r8: func() -> s64;
 
-  pair-ret: func() -> tuple<s64, u8>
+  pair-ret: func() -> tuple<s64, u8>;
 }
 
 world the-world {
-  import integers
-  export integers
+  import integers;
+  export integers;
 }

--- a/crates/component-macro/tests/codegen/lists.wit
+++ b/crates/component-macro/tests/codegen/lists.wit
@@ -1,33 +1,33 @@
-package foo:foo
+package foo:foo;
 
 interface lists {
-  list-u8-param: func(x: list<u8>)
-  list-u16-param: func(x: list<u16>)
-  list-u32-param: func(x: list<u32>)
-  list-u64-param: func(x: list<u64>)
-  list-s8-param: func(x: list<s8>)
-  list-s16-param: func(x: list<s16>)
-  list-s32-param: func(x: list<s32>)
-  list-s64-param: func(x: list<s64>)
-  list-float32-param: func(x: list<float32>)
-  list-float64-param: func(x: list<float64>)
+  list-u8-param: func(x: list<u8>);
+  list-u16-param: func(x: list<u16>);
+  list-u32-param: func(x: list<u32>);
+  list-u64-param: func(x: list<u64>);
+  list-s8-param: func(x: list<s8>);
+  list-s16-param: func(x: list<s16>);
+  list-s32-param: func(x: list<s32>);
+  list-s64-param: func(x: list<s64>);
+  list-float32-param: func(x: list<float32>);
+  list-float64-param: func(x: list<float64>);
 
-  list-u8-ret: func() -> list<u8>
-  list-u16-ret: func() -> list<u16>
-  list-u32-ret: func() -> list<u32>
-  list-u64-ret: func() -> list<u64>
-  list-s8-ret: func() -> list<s8>
-  list-s16-ret: func() -> list<s16>
-  list-s32-ret: func() -> list<s32>
-  list-s64-ret: func() -> list<s64>
-  list-float32-ret: func() -> list<float32>
-  list-float64-ret: func() -> list<float64>
+  list-u8-ret: func() -> list<u8>;
+  list-u16-ret: func() -> list<u16>;
+  list-u32-ret: func() -> list<u32>;
+  list-u64-ret: func() -> list<u64>;
+  list-s8-ret: func() -> list<s8>;
+  list-s16-ret: func() -> list<s16>;
+  list-s32-ret: func() -> list<s32>;
+  list-s64-ret: func() -> list<s64>;
+  list-float32-ret: func() -> list<float32>;
+  list-float64-ret: func() -> list<float64>;
 
-  tuple-list: func(x: list<tuple<u8, s8>>) -> list<tuple<s64, u32>>
-  string-list-arg: func(a: list<string>)
-  string-list-ret: func() -> list<string>
-  tuple-string-list: func(x: list<tuple<u8, string>>) -> list<tuple<string, u8>>
-  string-list: func(x: list<string>) -> list<string>
+  tuple-list: func(x: list<tuple<u8, s8>>) -> list<tuple<s64, u32>>;
+  string-list-arg: func(a: list<string>);
+  string-list-ret: func() -> list<string>;
+  tuple-string-list: func(x: list<tuple<u8, string>>) -> list<tuple<string, u8>>;
+  string-list: func(x: list<string>) -> list<string>;
 
   record some-record {
     x: string,
@@ -46,8 +46,8 @@ interface lists {
     b: string,
     c: list<u8>,
   }
-  record-list: func(x: list<some-record>) -> list<other-record>
-  record-list-reverse: func(x: list<other-record>) -> list<some-record>
+  record-list: func(x: list<some-record>) -> list<other-record>;
+  record-list-reverse: func(x: list<other-record>) -> list<some-record>;
 
   variant some-variant {
     a(string),
@@ -60,7 +60,7 @@ interface lists {
     b(u32),
     c(string),
   }
-  variant-list: func(x: list<some-variant>) -> list<other-variant>
+  variant-list: func(x: list<some-variant>) -> list<other-variant>;
 
   type load-store-all-sizes = list<tuple<
     string,
@@ -75,11 +75,11 @@ interface lists {
     float32,
     float64,
     char,
-  >>
-  load-store-everything: func(a: load-store-all-sizes) -> load-store-all-sizes
+  >>;
+  load-store-everything: func(a: load-store-all-sizes) -> load-store-all-sizes;
 }
 
 world the-lists {
-  import lists
-  export lists
+  import lists;
+  export lists;
 }

--- a/crates/component-macro/tests/codegen/many-arguments.wit
+++ b/crates/component-macro/tests/codegen/many-arguments.wit
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface manyarg {
   many-args: func(
@@ -18,7 +18,7 @@ interface manyarg {
     a14: u64,
     a15: u64,
     a16: u64,
-  )
+  );
 
   record big-struct {
     a1: string,
@@ -43,10 +43,10 @@ interface manyarg {
     a20: string,
   }
 
-  big-argument: func(x: big-struct)
+  big-argument: func(x: big-struct);
 }
 
 world the-world {
-  import manyarg
-  export manyarg
+  import manyarg;
+  export manyarg;
 }

--- a/crates/component-macro/tests/codegen/multi-return.wit
+++ b/crates/component-macro/tests/codegen/multi-return.wit
@@ -1,14 +1,14 @@
-package foo:foo
+package foo:foo;
 
 interface multi-return {
-  mra: func()
-  mrb: func() -> ()
-  mrc: func() -> u32
-  mrd: func() -> (a: u32)
-  mre: func() -> (a: u32, b: float32)
+  mra: func();
+  mrb: func() -> ();
+  mrc: func() -> u32;
+  mrd: func() -> (a: u32);
+  mre: func() -> (a: u32, b: float32);
 }
 
 world the-world {
-  import multi-return
-  export multi-return
+  import multi-return;
+  export multi-return;
 }

--- a/crates/component-macro/tests/codegen/records.wit
+++ b/crates/component-macro/tests/codegen/records.wit
@@ -1,13 +1,13 @@
-package foo:foo
+package foo:foo;
 
 interface records {
-  tuple-arg: func(x: tuple<char, u32>)
-  tuple-result: func() -> tuple<char, u32>
+  tuple-arg: func(x: tuple<char, u32>);
+  tuple-result: func() -> tuple<char, u32>;
 
   record empty {}
 
-  empty-arg: func(x: empty)
-  empty-result: func() -> empty
+  empty-arg: func(x: empty);
+  empty-result: func() -> empty;
 
   /// A record containing two scalar fields
   /// that both have the same type
@@ -18,8 +18,8 @@ interface records {
       b: u32,
   }
 
-  scalar-arg: func(x: scalars)
-  scalar-result: func() -> scalars
+  scalar-arg: func(x: scalars);
+  scalar-result: func() -> scalars;
 
   /// A record that is really just flags
   /// All of the fields are bool
@@ -35,8 +35,8 @@ interface records {
       i: bool,
   }
 
-  flags-arg: func(x: really-flags)
-  flags-result: func() -> really-flags
+  flags-arg: func(x: really-flags);
+  flags-result: func() -> really-flags;
 
   record aggregates {
       a: scalars,
@@ -46,16 +46,16 @@ interface records {
       e: really-flags,
   }
 
-  aggregate-arg: func(x: aggregates)
-  aggregate-result: func() -> aggregates
+  aggregate-arg: func(x: aggregates);
+  aggregate-result: func() -> aggregates;
 
-  type tuple-typedef = tuple<s32>
-  type int-typedef = s32
-  type tuple-typedef2 = tuple<int-typedef>
-  typedef-inout: func(e: tuple-typedef2) -> s32
+  type tuple-typedef = tuple<s32>;
+  type int-typedef = s32;
+  type tuple-typedef2 = tuple<int-typedef>;
+  typedef-inout: func(e: tuple-typedef2) -> s32;
 }
 
 world the-world {
-  import records
-  export records
+  import records;
+  export records;
 }

--- a/crates/component-macro/tests/codegen/rename.wit
+++ b/crates/component-macro/tests/codegen/rename.wit
@@ -1,16 +1,16 @@
-package foo:foo
+package foo:foo;
 
 interface red {
-  use green.{thing}
+  use green.{thing};
 
-  foo: func() -> thing
+  foo: func() -> thing;
 }
 
 interface green {
-  type thing = s32
+  type thing = s32;
 }
 
 world neptune {
-  import red
-  import green
+  import red;
+  import green;
 }

--- a/crates/component-macro/tests/codegen/resources-export.wit
+++ b/crates/component-macro/tests/codegen/resources-export.wit
@@ -1,43 +1,43 @@
-package foo:foo
+package foo:foo;
 
 world w {
-  export simple-export
-  export export-using-import
+  export simple-export;
+  export export-using-import;
 
-  export export-using-export1
-  export export-using-export2
+  export export-using-export1;
+  export export-using-export2;
 }
 
 interface simple-export {
   resource a {
-    constructor()
-    static-a: static func() -> u32
-    method-a: func() -> u32
+    constructor();
+    static-a: static func() -> u32;
+    method-a: func() -> u32;
   }
 }
 
 interface export-using-import {
-  use transitive-import.{y}
+  use transitive-import.{y};
   resource a {
-    constructor(y: y)
-    static-a: static func() -> y
-    method-a: func(y: y) -> y
+    constructor(y: y);
+    static-a: static func() -> y;
+    method-a: func(y: y) -> y;
   }
 }
 
 interface transitive-import {
-  resource y
+  resource y;
 }
 
 interface export-using-export1 {
   resource a {
-    constructor()
+    constructor();
   }
 }
 
 interface export-using-export2 {
-  use export-using-export1.{a}
+  use export-using-export1.{a};
   resource b {
-    constructor(a: a)
+    constructor(a: a);
   }
 }

--- a/crates/component-macro/tests/codegen/resources-import.wit
+++ b/crates/component-macro/tests/codegen/resources-import.wit
@@ -1,31 +1,31 @@
-package foo:foo
+package foo:foo;
 
 interface resources {
   resource bar {
-    constructor()
-    static-a: static func() -> u32
-    method-a: func() -> u32
+    constructor();
+    static-a: static func() -> u32;
+    method-a: func() -> u32;
   }
 
-  bar-own-arg: func(x: own<bar>)
-  bar-borrow-arg: func(x: borrow<bar>)
-  bar-result: func() -> own<bar>
+  bar-own-arg: func(x: own<bar>);
+  bar-borrow-arg: func(x: borrow<bar>);
+  bar-result: func() -> own<bar>;
 
-  tuple-own-arg: func(x: tuple<own<bar>, u32>)
-  tuple-borrow-arg: func(x: tuple<own<bar>, u32>)
-  tuple-result: func() -> tuple<own<bar>, u32>
+  tuple-own-arg: func(x: tuple<own<bar>, u32>);
+  tuple-borrow-arg: func(x: tuple<own<bar>, u32>);
+  tuple-result: func() -> tuple<own<bar>, u32>;
 
-  option-own-arg: func(x: option<own<bar>>)
-  option-borrow-arg: func(x: option<borrow<bar>>)
-  option-result: func() -> option<own<bar>>
+  option-own-arg: func(x: option<own<bar>>);
+  option-borrow-arg: func(x: option<borrow<bar>>);
+  option-result: func() -> option<own<bar>>;
 
-  result-own-arg: func(x: result<own<bar>>)
-  result-borrow-arg: func(x: result<borrow<bar>>)
-  result-result: func() -> result<own<bar>>
+  result-own-arg: func(x: result<own<bar>>);
+  result-borrow-arg: func(x: result<borrow<bar>>);
+  result-result: func() -> result<own<bar>>;
 
-  list-own-arg: func(x: list<own<bar>>)
-  list-borrow-arg: func(x: list<borrow<bar>>)
-  list-result: func() -> list<own<bar>>
+  list-own-arg: func(x: list<own<bar>>);
+  list-borrow-arg: func(x: list<borrow<bar>>);
+  list-result: func() -> list<own<bar>>;
 
   record nested-own {
     nested-bar: own<bar>
@@ -35,53 +35,53 @@ interface resources {
     nested-bar: borrow<bar>
   }
 
-  record-own-arg: func(x: nested-own)
-  record-borrow-arg: func(x: nested-borrow)
-  record-result: func() -> nested-own
+  record-own-arg: func(x: nested-own);
+  record-borrow-arg: func(x: nested-borrow);
+  record-result: func() -> nested-own;
 
-  type some-handle = borrow<bar>
-  func-with-handle-typedef: func(x: some-handle)
+  type some-handle = borrow<bar>;
+  func-with-handle-typedef: func(x: some-handle);
 }
 
 world the-world {
-  import resources
+  import resources;
 
   resource world-resource {
-    constructor()
+    constructor();
 
-    foo: func()
-    static-foo: static func()
+    foo: func();
+    static-foo: static func();
   }
 
-  import some-world-func: func() -> world-resource
-  export some-world-func2: func() -> world-resource
+  import some-world-func: func() -> world-resource;
+  export some-world-func2: func() -> world-resource;
 
-  export uses-resource-transitively
+  export uses-resource-transitively;
 
-  import long-use-chain4
+  import long-use-chain4;
 }
 
 interface transitive-interface-with-resource {
-  resource foo
+  resource foo;
 }
 
 interface uses-resource-transitively {
-  use transitive-interface-with-resource.{foo}
+  use transitive-interface-with-resource.{foo};
 
-  handle: func(x: foo)
+  handle: func(x: foo);
 }
 
 interface long-use-chain4 {
-  use long-use-chain3.{a}
+  use long-use-chain3.{a};
 
-  foo: func() -> a
+  foo: func() -> a;
 }
 interface long-use-chain3 {
-  use long-use-chain2.{a}
+  use long-use-chain2.{a};
 }
 interface long-use-chain2 {
-  use long-use-chain1.{a}
+  use long-use-chain1.{a};
 }
 interface long-use-chain1 {
-  resource a
+  resource a;
 }

--- a/crates/component-macro/tests/codegen/share-types.wit
+++ b/crates/component-macro/tests/codegen/share-types.wit
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface http-types{
   record request {
@@ -11,11 +11,11 @@ interface http-types{
 
 world http-interface {
   export http-handler: interface {
-    use http-types.{request,response}
-    handle-request: func(request: request) -> response
+    use http-types.{request,response};
+    handle-request: func(request: request) -> response;
   }
   import http-fetch: interface {
-    use http-types.{request,response}
-    fetch-request: func(request: request) -> response
+    use http-types.{request,response};
+    fetch-request: func(request: request) -> response;
   }
 }

--- a/crates/component-macro/tests/codegen/simple-functions.wit
+++ b/crates/component-macro/tests/codegen/simple-functions.wit
@@ -1,17 +1,17 @@
-package foo:foo
+package foo:foo;
 
 interface simple {
-  f1: func()
-  f2: func(a: u32)
-  f3: func(a: u32, b: u32)
+  f1: func();
+  f2: func(a: u32);
+  f3: func(a: u32, b: u32);
 
-  f4: func() -> u32
-  f5: func() -> tuple<u32, u32>
+  f4: func() -> u32;
+  f5: func() -> tuple<u32, u32>;
 
-  f6: func(a: u32, b: u32, c: u32) -> tuple<u32, u32, u32>
+  f6: func(a: u32, b: u32, c: u32) -> tuple<u32, u32, u32>;
 }
 
 world the-world {
-  import simple
-  export simple
+  import simple;
+  export simple;
 }

--- a/crates/component-macro/tests/codegen/simple-lists.wit
+++ b/crates/component-macro/tests/codegen/simple-lists.wit
@@ -1,13 +1,13 @@
-package foo:foo
+package foo:foo;
 
 interface simple-lists {
-  simple-list1: func(l: list<u32>)
-  simple-list2: func() -> list<u32>
-  simple-list3: func(a: list<u32>, b: list<u32>) -> tuple<list<u32>, list<u32>>
-  simple-list4: func(l: list<list<u32>>) -> list<list<u32>>
+  simple-list1: func(l: list<u32>);
+  simple-list2: func() -> list<u32>;
+  simple-list3: func(a: list<u32>, b: list<u32>) -> tuple<list<u32>, list<u32>>;
+  simple-list4: func(l: list<list<u32>>) -> list<list<u32>>;
 }
 
 world my-world {
-  import simple-lists
-  export simple-lists
+  import simple-lists;
+  export simple-lists;
 }

--- a/crates/component-macro/tests/codegen/simple-wasi.wit
+++ b/crates/component-macro/tests/codegen/simple-wasi.wit
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface wasi-filesystem {
   record descriptor-stat {
@@ -7,9 +7,9 @@ interface wasi-filesystem {
   enum errno { e }
 
 
-  create-directory-at: func() -> result<_, errno>
+  create-directory-at: func() -> result<_, errno>;
 
-  stat: func() -> result<descriptor-stat, errno>
+  stat: func() -> result<descriptor-stat, errno>;
 }
 
 interface wall-clock {
@@ -18,6 +18,6 @@ interface wall-clock {
 }
 
 world wasi {
-  import wasi-filesystem
-  import wall-clock
+  import wasi-filesystem;
+  import wall-clock;
 }

--- a/crates/component-macro/tests/codegen/small-anonymous.wit
+++ b/crates/component-macro/tests/codegen/small-anonymous.wit
@@ -1,4 +1,4 @@
-package foo:foo
+package foo:foo;
 
 interface anon {
   enum error {
@@ -6,10 +6,10 @@ interface anon {
     failure,
   }
 
-  option-test: func() -> result<option<string>, error>
+  option-test: func() -> result<option<string>, error>;
 }
 
 world the-world {
-  import anon
-  export anon
+  import anon;
+  export anon;
 }

--- a/crates/component-macro/tests/codegen/smoke-default.wit
+++ b/crates/component-macro/tests/codegen/smoke-default.wit
@@ -1,5 +1,5 @@
-package foo:foo
+package foo:foo;
 
 world the-world {
-  export y: func()
+  export y: func();
 }

--- a/crates/component-macro/tests/codegen/smoke-export.wit
+++ b/crates/component-macro/tests/codegen/smoke-export.wit
@@ -1,7 +1,7 @@
-package foo:foo
+package foo:foo;
 
 world the-world {
   export the-name: interface {
-    y: func()
+    y: func();
   }
 }

--- a/crates/component-macro/tests/codegen/smoke.wit
+++ b/crates/component-macro/tests/codegen/smoke.wit
@@ -1,7 +1,7 @@
-package foo:foo
+package foo:foo;
 
 world the-world {
   import imports: interface {
-    y: func()
+    y: func();
   }
 }

--- a/crates/component-macro/tests/codegen/strings.wit
+++ b/crates/component-macro/tests/codegen/strings.wit
@@ -1,12 +1,12 @@
-package foo:foo
+package foo:foo;
 
 interface strings {
-  a: func(x: string)
-  b: func() -> string
-  c: func(a: string, b: string) -> string
+  a: func(x: string);
+  b: func() -> string;
+  c: func(a: string, b: string) -> string;
 }
 
 world the-world {
-  import strings
-  export strings
+  import strings;
+  export strings;
 }

--- a/crates/component-macro/tests/codegen/use-paths.wit
+++ b/crates/component-macro/tests/codegen/use-paths.wit
@@ -1,29 +1,29 @@
-package foo:foo
+package foo:foo;
 
 interface a {
   record foo {}
 
-  a: func() -> foo
+  a: func() -> foo;
 }
 
 interface b {
-  use a.{foo}
+  use a.{foo};
 
-  a: func() -> foo
+  a: func() -> foo;
 }
 
 interface c {
-  use b.{foo}
+  use b.{foo};
 
-  a: func() -> foo
+  a: func() -> foo;
 }
 
 world d {
-  import a
-  import b
+  import a;
+  import b;
   import d: interface {
-    use c.{foo}
+    use c.{foo};
 
-    b: func() -> foo
+    b: func() -> foo;
   }
 }

--- a/crates/component-macro/tests/codegen/variants.wit
+++ b/crates/component-macro/tests/codegen/variants.wit
@@ -1,12 +1,12 @@
-package foo:foo
+package foo:foo;
 
 interface variants {
   enum e1 {
       a,
   }
 
-  e1-arg: func(x: e1)
-  e1-result: func() -> e1
+  e1-arg: func(x: e1);
+  e1-result: func() -> e1;
 
   record empty {}
 
@@ -19,11 +19,11 @@ interface variants {
       g(u32),
   }
 
-  v1-arg: func(x: v1)
-  v1-result: func() -> v1
+  v1-arg: func(x: v1);
+  v1-result: func() -> v1;
 
-  bool-arg: func(x: bool)
-  bool-result: func() -> bool
+  bool-arg: func(x: bool);
+  bool-result: func() -> bool;
 
   option-arg: func(
     a: option<bool>,
@@ -32,7 +32,7 @@ interface variants {
     d: option<e1>,
     e: option<float32>,
     g: option<option<bool>>,
-  )
+  );
   option-result: func() -> tuple<
     option<bool>,
     option<tuple<>>,
@@ -40,7 +40,7 @@ interface variants {
     option<e1>,
     option<float32>,
     option<option<bool>>,
-  >
+  >;
 
   variant casts1 {
     a(s32),
@@ -86,7 +86,7 @@ interface variants {
     casts4,
     casts5,
     casts6,
-  >
+  >;
 
   result-arg: func(
     a: result,
@@ -95,7 +95,7 @@ interface variants {
     d: result<tuple<>, tuple<>>,
     e: result<u32, v1>,
     f: result<string, list<u8>>,
-  )
+  );
   result-result: func() -> tuple<
     result,
     result<_, e1>,
@@ -103,34 +103,34 @@ interface variants {
     result<tuple<>, tuple<>>,
     result<u32, v1>,
     result<string, list<u8>>,
-  >
+  >;
 
   enum my-errno {
     bad1,
     bad2,
   }
 
-  return-result-sugar: func() -> result<s32, my-errno>
-  return-result-sugar2: func() -> result<_, my-errno>
-  return-result-sugar3: func() -> result<my-errno, my-errno>
-  return-result-sugar4: func() -> result<tuple<s32, u32>, my-errno>
-  return-option-sugar: func() -> option<s32>
-  return-option-sugar2: func() -> option<my-errno>
+  return-result-sugar: func() -> result<s32, my-errno>;
+  return-result-sugar2: func() -> result<_, my-errno>;
+  return-result-sugar3: func() -> result<my-errno, my-errno>;
+  return-result-sugar4: func() -> result<tuple<s32, u32>, my-errno>;
+  return-option-sugar: func() -> option<s32>;
+  return-option-sugar2: func() -> option<my-errno>;
 
-  result-simple: func() -> result<u32, s32>
+  result-simple: func() -> result<u32, s32>;
 
   record is-clone {
     v1: v1,
   }
 
-  is-clone-arg: func(a: is-clone)
-  is-clone-return: func() -> is-clone
+  is-clone-arg: func(a: is-clone);
+  is-clone-return: func() -> is-clone;
 
-  return-named-option: func() -> (a: option<u8>)
-  return-named-result: func() -> (a: result<u8, my-errno>)
+  return-named-option: func() -> (a: option<u8>);
+  return-named-result: func() -> (a: result<u8, my-errno>);
 }
 
 world my-world {
-  import variants
-  export variants
+  import variants;
+  export variants;
 }

--- a/crates/component-macro/tests/codegen/worlds-with-types.wit
+++ b/crates/component-macro/tests/codegen/worlds-with-types.wit
@@ -1,16 +1,16 @@
-package foo:foo
+package foo:foo;
 
 interface i {
-  type t = u16
+  type t = u16;
 }
 
 world foo {
-  use i.{t as u}
+  use i.{t as u};
 
-  type t = u32
+  type t = u32;
 
   record r {
   }
 
-  export f: func() -> tuple<t, u, r>
+  export f: func() -> tuple<t, u, r>;
 }

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -10,10 +10,10 @@ pub mod bindings {
     wasmtime::component::bindgen!({
         path: "wit",
         interfaces: "
-                import wasi:http/incoming-handler
-                import wasi:http/outgoing-handler
-                import wasi:http/types
-            ",
+            import wasi:http/incoming-handler;
+            import wasi:http/outgoing-handler;
+            import wasi:http/types;
+        ",
         tracing: true,
         async: false,
         with: {

--- a/crates/wasi-http/wit/command-extended.wit
+++ b/crates/wasi-http/wit/command-extended.wit
@@ -1,37 +1,37 @@
 // All of the same imports and exports available in the wasi:cli/command world
 // with addition of HTTP proxy related imports:
 world command-extended {
-  import wasi:clocks/wall-clock
-  import wasi:clocks/monotonic-clock
-  import wasi:clocks/timezone
-  import wasi:filesystem/types
-  import wasi:filesystem/preopens
-  import wasi:sockets/instance-network
-  import wasi:sockets/ip-name-lookup
-  import wasi:sockets/network
-  import wasi:sockets/tcp-create-socket
-  import wasi:sockets/tcp
-  import wasi:sockets/udp-create-socket
-  import wasi:sockets/udp
-  import wasi:random/random
-  import wasi:random/insecure
-  import wasi:random/insecure-seed
-  import wasi:io/poll
-  import wasi:io/streams
-  import wasi:cli/environment
-  import wasi:cli/exit
-  import wasi:cli/stdin
-  import wasi:cli/stdout
-  import wasi:cli/stderr
-  import wasi:cli/terminal-input
-  import wasi:cli/terminal-output
-  import wasi:cli/terminal-stdin
-  import wasi:cli/terminal-stdout
-  import wasi:cli/terminal-stderr
+  import wasi:clocks/wall-clock;
+  import wasi:clocks/monotonic-clock;
+  import wasi:clocks/timezone;
+  import wasi:filesystem/types;
+  import wasi:filesystem/preopens;
+  import wasi:sockets/instance-network;
+  import wasi:sockets/ip-name-lookup;
+  import wasi:sockets/network;
+  import wasi:sockets/tcp-create-socket;
+  import wasi:sockets/tcp;
+  import wasi:sockets/udp-create-socket;
+  import wasi:sockets/udp;
+  import wasi:random/random;
+  import wasi:random/insecure;
+  import wasi:random/insecure-seed;
+  import wasi:io/poll;
+  import wasi:io/streams;
+  import wasi:cli/environment;
+  import wasi:cli/exit;
+  import wasi:cli/stdin;
+  import wasi:cli/stdout;
+  import wasi:cli/stderr;
+  import wasi:cli/terminal-input;
+  import wasi:cli/terminal-output;
+  import wasi:cli/terminal-stdin;
+  import wasi:cli/terminal-stdout;
+  import wasi:cli/terminal-stderr;
 
   // We should replace all others with `include self.command`
   // as soon as the unioning of worlds is available:
   // https://github.com/WebAssembly/component-model/issues/169
-  import wasi:logging/logging
-  import wasi:http/outgoing-handler
+  import wasi:logging/logging;
+  import wasi:http/outgoing-handler;
 }

--- a/crates/wasi-http/wit/deps/cli/command.wit
+++ b/crates/wasi-http/wit/deps/cli/command.wit
@@ -1,7 +1,7 @@
-package wasi:cli
+package wasi:cli;
 
 world command {
-  include reactor
+  include reactor;
 
-  export run
+  export run;
 }

--- a/crates/wasi-http/wit/deps/cli/environment.wit
+++ b/crates/wasi-http/wit/deps/cli/environment.wit
@@ -7,12 +7,12 @@ interface environment {
   /// Morally, these are a value import, but until value imports are available
   /// in the component model, this import function should return the same
   /// values each time it is called.
-  get-environment: func() -> list<tuple<string, string>>
+  get-environment: func() -> list<tuple<string, string>>;
 
   /// Get the POSIX-style arguments to the program.
-  get-arguments: func() -> list<string>
+  get-arguments: func() -> list<string>;
 
   /// Return a path that programs should use as their initial current working
   /// directory, interpreting `.` as shorthand for this.
-  initial-cwd: func() -> option<string>
+  initial-cwd: func() -> option<string>;
 }

--- a/crates/wasi-http/wit/deps/cli/exit.wit
+++ b/crates/wasi-http/wit/deps/cli/exit.wit
@@ -1,4 +1,4 @@
 interface exit {
   /// Exit the current instance and any linked instances.
-  exit: func(status: result)
+  exit: func(status: result);
 }

--- a/crates/wasi-http/wit/deps/cli/reactor.wit
+++ b/crates/wasi-http/wit/deps/cli/reactor.wit
@@ -1,33 +1,32 @@
-package wasi:cli
+package wasi:cli;
 
 world reactor {
-  import wasi:clocks/wall-clock
-  import wasi:clocks/monotonic-clock
-  import wasi:clocks/timezone
-  import wasi:filesystem/types
-  import wasi:filesystem/preopens
-  import wasi:sockets/instance-network
-  import wasi:sockets/ip-name-lookup
-  import wasi:sockets/network
-  import wasi:sockets/tcp-create-socket
-  import wasi:sockets/tcp
-  import wasi:sockets/udp-create-socket
-  import wasi:sockets/udp
-  import wasi:random/random
-  import wasi:random/insecure
-  import wasi:random/insecure-seed
-  import wasi:io/poll
-  import wasi:io/streams
+  import wasi:clocks/wall-clock;
+  import wasi:clocks/monotonic-clock;
+  import wasi:clocks/timezone;
+  import wasi:filesystem/types;
+  import wasi:filesystem/preopens;
+  import wasi:sockets/instance-network;
+  import wasi:sockets/ip-name-lookup;
+  import wasi:sockets/network;
+  import wasi:sockets/tcp-create-socket;
+  import wasi:sockets/tcp;
+  import wasi:sockets/udp-create-socket;
+  import wasi:sockets/udp;
+  import wasi:random/random;
+  import wasi:random/insecure;
+  import wasi:random/insecure-seed;
+  import wasi:io/poll;
+  import wasi:io/streams;
 
-  import environment
-  import exit
-  import stdin
-  import stdout
-  import stderr
-  import terminal-input
-  import terminal-output
-  import terminal-stdin
-  import terminal-stdout
-  import terminal-stderr
+  import environment;
+  import exit;
+  import stdin;
+  import stdout;
+  import stderr;
+  import terminal-input;
+  import terminal-output;
+  import terminal-stdin;
+  import terminal-stdout;
+  import terminal-stderr;
 }
-

--- a/crates/wasi-http/wit/deps/cli/run.wit
+++ b/crates/wasi-http/wit/deps/cli/run.wit
@@ -1,4 +1,4 @@
 interface run {
   /// Run the program.
-  run: func() -> result
+  run: func() -> result;
 }

--- a/crates/wasi-http/wit/deps/cli/stdio.wit
+++ b/crates/wasi-http/wit/deps/cli/stdio.wit
@@ -1,17 +1,17 @@
 interface stdin {
-  use wasi:io/streams.{input-stream}
+  use wasi:io/streams.{input-stream};
 
-  get-stdin: func() -> input-stream
+  get-stdin: func() -> input-stream;
 }
 
 interface stdout {
-  use wasi:io/streams.{output-stream}
+  use wasi:io/streams.{output-stream};
 
-  get-stdout: func() -> output-stream
+  get-stdout: func() -> output-stream;
 }
 
 interface stderr {
-  use wasi:io/streams.{output-stream}
+  use wasi:io/streams.{output-stream};
 
-  get-stderr: func() -> output-stream
+  get-stderr: func() -> output-stream;
 }

--- a/crates/wasi-http/wit/deps/cli/terminal.wit
+++ b/crates/wasi-http/wit/deps/cli/terminal.wit
@@ -1,6 +1,6 @@
 interface terminal-input {
     /// The input side of a terminal.
-    resource terminal-input
+    resource terminal-input;
 
     // In the future, this may include functions for disabling echoing,
     // disabling input buffering so that keyboard events are sent through
@@ -9,7 +9,7 @@ interface terminal-input {
 
 interface terminal-output {
     /// The output side of a terminal.
-    resource terminal-output
+    resource terminal-output;
 
     // In the future, this may include functions for querying the terminal
     // size, being notified of terminal size changes, querying supported
@@ -19,29 +19,29 @@ interface terminal-output {
 /// An interface providing an optional `terminal-input` for stdin as a
 /// link-time authority.
 interface terminal-stdin {
-    use terminal-input.{terminal-input}
+    use terminal-input.{terminal-input};
 
     /// If stdin is connected to a terminal, return a `terminal-input` handle
     /// allowing further interaction with it.
-    get-terminal-stdin: func() -> option<terminal-input>
+    get-terminal-stdin: func() -> option<terminal-input>;
 }
 
 /// An interface providing an optional `terminal-output` for stdout as a
 /// link-time authority.
 interface terminal-stdout {
-    use terminal-output.{terminal-output}
+    use terminal-output.{terminal-output};
 
     /// If stdout is connected to a terminal, return a `terminal-output` handle
     /// allowing further interaction with it.
-    get-terminal-stdout: func() -> option<terminal-output>
+    get-terminal-stdout: func() -> option<terminal-output>;
 }
 
 /// An interface providing an optional `terminal-output` for stderr as a
 /// link-time authority.
 interface terminal-stderr {
-    use terminal-output.{terminal-output}
+    use terminal-output.{terminal-output};
 
     /// If stderr is connected to a terminal, return a `terminal-output` handle
     /// allowing further interaction with it.
-    get-terminal-stderr: func() -> option<terminal-output>
+    get-terminal-stderr: func() -> option<terminal-output>;
 }

--- a/crates/wasi-http/wit/deps/clocks/monotonic-clock.wit
+++ b/crates/wasi-http/wit/deps/clocks/monotonic-clock.wit
@@ -9,24 +9,24 @@
 ///
 /// It is intended for measuring elapsed time.
 interface monotonic-clock {
-    use wasi:io/poll.{pollable}
+    use wasi:io/poll.{pollable};
 
     /// A timestamp in nanoseconds.
-    type instant = u64
+    type instant = u64;
 
     /// Read the current value of the clock.
     ///
     /// The clock is monotonic, therefore calling this function repeatedly will
     /// produce a sequence of non-decreasing values.
-    now: func() -> instant
+    now: func() -> instant;
 
     /// Query the resolution of the clock.
-    resolution: func() -> instant
+    resolution: func() -> instant;
 
     /// Create a `pollable` which will resolve once the specified time has been
     /// reached.
     subscribe: func(
         when: instant,
         absolute: bool
-    ) -> pollable
+    ) -> pollable;
 }

--- a/crates/wasi-http/wit/deps/clocks/timezone.wit
+++ b/crates/wasi-http/wit/deps/clocks/timezone.wit
@@ -1,5 +1,5 @@
 interface timezone {
-    use wall-clock.{datetime}
+    use wall-clock.{datetime};
 
     /// Return information needed to display the given `datetime`. This includes
     /// the UTC offset, the time zone name, and a flag indicating whether
@@ -8,10 +8,10 @@ interface timezone {
     /// If the timezone cannot be determined for the given `datetime`, return a
     /// `timezone-display` for `UTC` with a `utc-offset` of 0 and no daylight
     /// saving time.
-    display: func(when: datetime) -> timezone-display
+    display: func(when: datetime) -> timezone-display;
 
     /// The same as `display`, but only return the UTC offset.
-    utc-offset: func(when: datetime) -> s32
+    utc-offset: func(when: datetime) -> s32;
 
     /// Information useful for displaying the timezone of a specific `datetime`.
     ///

--- a/crates/wasi-http/wit/deps/clocks/wall-clock.wit
+++ b/crates/wasi-http/wit/deps/clocks/wall-clock.wit
@@ -32,10 +32,10 @@ interface wall-clock {
     ///
     /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
     /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
-    now: func() -> datetime
+    now: func() -> datetime;
 
     /// Query the resolution of the clock.
     ///
     /// The nanoseconds field of the output is always less than 1000000000.
-    resolution: func() -> datetime
+    resolution: func() -> datetime;
 }

--- a/crates/wasi-http/wit/deps/clocks/world.wit
+++ b/crates/wasi-http/wit/deps/clocks/world.wit
@@ -1,7 +1,7 @@
-package wasi:clocks
+package wasi:clocks;
 
 world imports {
-    import monotonic-clock
-    import wall-clock
-    import timezone
+    import monotonic-clock;
+    import wall-clock;
+    import timezone;
 }

--- a/crates/wasi-http/wit/deps/filesystem/preopens.wit
+++ b/crates/wasi-http/wit/deps/filesystem/preopens.wit
@@ -1,6 +1,6 @@
 interface preopens {
-    use types.{descriptor}
+    use types.{descriptor};
 
     /// Return the set of preopened directories, and their path.
-    get-directories: func() -> list<tuple<descriptor, string>>
+    get-directories: func() -> list<tuple<descriptor, string>>;
 }

--- a/crates/wasi-http/wit/deps/filesystem/types.wit
+++ b/crates/wasi-http/wit/deps/filesystem/types.wit
@@ -23,11 +23,11 @@
 ///
 /// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
 interface types {
-    use wasi:io/streams.{input-stream, output-stream, error}
-    use wasi:clocks/wall-clock.{datetime}
+    use wasi:io/streams.{input-stream, output-stream, error};
+    use wasi:clocks/wall-clock.{datetime};
 
     /// File size or length of a region within a file.
-    type filesize = u64
+    type filesize = u64;
 
     /// The type of a filesystem object referenced by a descriptor.
     ///
@@ -166,7 +166,7 @@ interface types {
     }
 
     /// Number of hard links to an inode.
-    type link-count = u64
+    type link-count = u64;
 
     /// When setting a timestamp, this gives the value to set it to.
     variant new-timestamp {
@@ -315,7 +315,7 @@ interface types {
         read-via-stream: func(
             /// The offset within the file at which to start reading.
             offset: filesize,
-        ) -> result<input-stream, error-code>
+        ) -> result<input-stream, error-code>;
 
         /// Return a stream for writing to a file, if available.
         ///
@@ -326,7 +326,7 @@ interface types {
         write-via-stream: func(
             /// The offset within the file at which to start writing.
             offset: filesize,
-        ) -> result<output-stream, error-code>
+        ) -> result<output-stream, error-code>;
 
         /// Return a stream for appending to a file, if available.
         ///
@@ -334,7 +334,7 @@ interface types {
         ///
         /// Note: This allows using `write-stream`, which is similar to `write` with
         /// `O_APPEND` in in POSIX.
-        append-via-stream: func() -> result<output-stream, error-code>
+        append-via-stream: func() -> result<output-stream, error-code>;
 
         /// Provide file advisory information on a descriptor.
         ///
@@ -346,7 +346,7 @@ interface types {
             length: filesize,
             /// The advice.
             advice: advice
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Synchronize the data of a file to disk.
         ///
@@ -354,7 +354,7 @@ interface types {
         /// opened for writing.
         ///
         /// Note: This is similar to `fdatasync` in POSIX.
-        sync-data: func() -> result<_, error-code>
+        sync-data: func() -> result<_, error-code>;
 
         /// Get flags associated with a descriptor.
         ///
@@ -362,7 +362,7 @@ interface types {
         ///
         /// Note: This returns the value that was the `fs_flags` value returned
         /// from `fdstat_get` in earlier versions of WASI.
-        get-flags: func() -> result<descriptor-flags, error-code>
+        get-flags: func() -> result<descriptor-flags, error-code>;
 
         /// Get the dynamic type of a descriptor.
         ///
@@ -374,13 +374,13 @@ interface types {
         ///
         /// Note: This returns the value that was the `fs_filetype` value returned
         /// from `fdstat_get` in earlier versions of WASI.
-        get-type: func() -> result<descriptor-type, error-code>
+        get-type: func() -> result<descriptor-type, error-code>;
 
         /// Adjust the size of an open file. If this increases the file's size, the
         /// extra bytes are filled with zeros.
         ///
         /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
-        set-size: func(size: filesize) -> result<_, error-code>
+        set-size: func(size: filesize) -> result<_, error-code>;
 
         /// Adjust the timestamps of an open file or directory.
         ///
@@ -392,7 +392,7 @@ interface types {
             data-access-timestamp: new-timestamp,
             /// The desired values of the data modification timestamp.
             data-modification-timestamp: new-timestamp,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Read from a descriptor, without using and updating the descriptor's offset.
         ///
@@ -410,7 +410,7 @@ interface types {
             length: filesize,
             /// The offset within the file at which to read.
             offset: filesize,
-        ) -> result<tuple<list<u8>, bool>, error-code>
+        ) -> result<tuple<list<u8>, bool>, error-code>;
 
         /// Write to a descriptor, without using and updating the descriptor's offset.
         ///
@@ -426,7 +426,7 @@ interface types {
             buffer: list<u8>,
             /// The offset within the file at which to write.
             offset: filesize,
-        ) -> result<filesize, error-code>
+        ) -> result<filesize, error-code>;
 
         /// Read directory entries from a directory.
         ///
@@ -437,7 +437,7 @@ interface types {
         /// This always returns a new stream which starts at the beginning of the
         /// directory. Multiple streams may be active on the same directory, and they
         /// do not interfere with each other.
-        read-directory: func() -> result<directory-entry-stream, error-code>
+        read-directory: func() -> result<directory-entry-stream, error-code>;
 
         /// Synchronize the data and metadata of a file to disk.
         ///
@@ -445,7 +445,7 @@ interface types {
         /// opened for writing.
         ///
         /// Note: This is similar to `fsync` in POSIX.
-        sync: func() -> result<_, error-code>
+        sync: func() -> result<_, error-code>;
 
         /// Create a directory.
         ///
@@ -453,7 +453,7 @@ interface types {
         create-directory-at: func(
             /// The relative path at which to create the directory.
             path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Return the attributes of an open file or directory.
         ///
@@ -464,7 +464,7 @@ interface types {
         /// modified, use `metadata-hash`.
         ///
         /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
-        stat: func() -> result<descriptor-stat, error-code>
+        stat: func() -> result<descriptor-stat, error-code>;
 
         /// Return the attributes of a file or directory.
         ///
@@ -478,7 +478,7 @@ interface types {
             path-flags: path-flags,
             /// The relative path of the file or directory to inspect.
             path: string,
-        ) -> result<descriptor-stat, error-code>
+        ) -> result<descriptor-stat, error-code>;
 
         /// Adjust the timestamps of a file or directory.
         ///
@@ -495,7 +495,7 @@ interface types {
             data-access-timestamp: new-timestamp,
             /// The desired values of the data modification timestamp.
             data-modification-timestamp: new-timestamp,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Create a hard link.
         ///
@@ -509,7 +509,7 @@ interface types {
             new-descriptor: borrow<descriptor>,
             /// The relative destination path at which to create the hard link.
             new-path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Open a file or directory.
         ///
@@ -540,7 +540,7 @@ interface types {
             %flags: descriptor-flags,
             /// Permissions to use when creating a new file.
             modes: modes
-        ) -> result<descriptor, error-code>
+        ) -> result<descriptor, error-code>;
 
         /// Read the contents of a symbolic link.
         ///
@@ -551,7 +551,7 @@ interface types {
         readlink-at: func(
             /// The relative path of the symbolic link from which to read.
             path: string,
-        ) -> result<string, error-code>
+        ) -> result<string, error-code>;
 
         /// Remove a directory.
         ///
@@ -561,7 +561,7 @@ interface types {
         remove-directory-at: func(
             /// The relative path to a directory to remove.
             path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Rename a filesystem object.
         ///
@@ -573,7 +573,7 @@ interface types {
             new-descriptor: borrow<descriptor>,
             /// The relative destination path to which to rename the file or directory.
             new-path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Create a symbolic link (also known as a "symlink").
         ///
@@ -586,7 +586,7 @@ interface types {
             old-path: string,
             /// The relative destination path at which to create the symbolic link.
             new-path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Check accessibility of a filesystem path.
         ///
@@ -605,7 +605,7 @@ interface types {
             path: string,
             /// The type of check to perform.
             %type: access-type
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Unlink a filesystem object that is not a directory.
         ///
@@ -614,7 +614,7 @@ interface types {
         unlink-file-at: func(
             /// The relative path to a file to unlink.
             path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Change the permissions of a filesystem object that is not a directory.
         ///
@@ -629,7 +629,7 @@ interface types {
             path: string,
             /// The new permissions for the filesystem object.
             modes: modes,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Change the permissions of a directory.
         ///
@@ -648,7 +648,7 @@ interface types {
             path: string,
             /// The new permissions for the directory.
             modes: modes,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Request a shared advisory lock for an open file.
         ///
@@ -670,7 +670,7 @@ interface types {
         /// locking, this function returns `error-code::unsupported`.
         ///
         /// Note: This is similar to `flock(fd, LOCK_SH)` in Unix.
-        lock-shared: func() -> result<_, error-code>
+        lock-shared: func() -> result<_, error-code>;
 
         /// Request an exclusive advisory lock for an open file.
         ///
@@ -694,7 +694,7 @@ interface types {
         /// locking, this function returns `error-code::unsupported`.
         ///
         /// Note: This is similar to `flock(fd, LOCK_EX)` in Unix.
-        lock-exclusive: func() -> result<_, error-code>
+        lock-exclusive: func() -> result<_, error-code>;
 
         /// Request a shared advisory lock for an open file.
         ///
@@ -717,7 +717,7 @@ interface types {
         /// locking, this function returns `error-code::unsupported`.
         ///
         /// Note: This is similar to `flock(fd, LOCK_SH | LOCK_NB)` in Unix.
-        try-lock-shared: func() -> result<_, error-code>
+        try-lock-shared: func() -> result<_, error-code>;
 
         /// Request an exclusive advisory lock for an open file.
         ///
@@ -742,12 +742,12 @@ interface types {
         /// locking, this function returns `error-code::unsupported`.
         ///
         /// Note: This is similar to `flock(fd, LOCK_EX | LOCK_NB)` in Unix.
-        try-lock-exclusive: func() -> result<_, error-code>
+        try-lock-exclusive: func() -> result<_, error-code>;
 
         /// Release a shared or exclusive lock on an open file.
         ///
         /// Note: This is similar to `flock(fd, LOCK_UN)` in Unix.
-        unlock: func() -> result<_, error-code>
+        unlock: func() -> result<_, error-code>;
 
         /// Test whether two descriptors refer to the same filesystem object.
         ///
@@ -755,7 +755,7 @@ interface types {
         /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
         /// wasi-filesystem does not expose device and inode numbers, so this function
         /// may be used instead.
-        is-same-object: func(other: borrow<descriptor>) -> bool
+        is-same-object: func(other: borrow<descriptor>) -> bool;
 
         /// Return a hash of the metadata associated with a filesystem object referred
         /// to by a descriptor.
@@ -776,7 +776,7 @@ interface types {
         ///    computed hash.
         ///
         /// However, none of these is required.
-        metadata-hash: func() -> result<metadata-hash-value, error-code>
+        metadata-hash: func() -> result<metadata-hash-value, error-code>;
 
         /// Return a hash of the metadata associated with a filesystem object referred
         /// to by a directory descriptor and a relative path.
@@ -787,13 +787,13 @@ interface types {
             path-flags: path-flags,
             /// The relative path of the file or directory to inspect.
             path: string,
-        ) -> result<metadata-hash-value, error-code>
+        ) -> result<metadata-hash-value, error-code>;
     }
 
     /// A stream of directory entries.
     resource directory-entry-stream {
         /// Read a single directory entry from a `directory-entry-stream`.
-        read-directory-entry: func() -> result<option<directory-entry>, error-code>
+        read-directory-entry: func() -> result<option<directory-entry>, error-code>;
     }
 
     /// Attempts to extract a filesystem-related `error-code` from the stream

--- a/crates/wasi-http/wit/deps/filesystem/world.wit
+++ b/crates/wasi-http/wit/deps/filesystem/world.wit
@@ -1,6 +1,6 @@
-package wasi:filesystem
+package wasi:filesystem;
 
 world imports {
-    import types
-    import preopens
+    import types;
+    import preopens;
 }

--- a/crates/wasi-http/wit/deps/http/incoming-handler.wit
+++ b/crates/wasi-http/wit/deps/http/incoming-handler.wit
@@ -7,7 +7,7 @@
 //   that takes a `request` parameter and returns a `response` result.
 //
 interface incoming-handler {
-  use types.{incoming-request, response-outparam}
+  use types.{incoming-request, response-outparam};
 
   // The `handle` function takes an outparam instead of returning its response
   // so that the component may stream its response while streaming any other
@@ -20,5 +20,5 @@ interface incoming-handler {
   handle: func(
     request: incoming-request,
     response-out: response-outparam
-  )
+  );
 }

--- a/crates/wasi-http/wit/deps/http/outgoing-handler.wit
+++ b/crates/wasi-http/wit/deps/http/outgoing-handler.wit
@@ -6,7 +6,7 @@
 //   that takes a `request` parameter and returns a `response` result.
 //
 interface outgoing-handler {
-  use types.{outgoing-request, request-options, future-incoming-response, error}
+  use types.{outgoing-request, request-options, future-incoming-response, error};
 
   // The parameter and result types of the `handle` function allow the caller
   // to concurrently stream the bodies of the outgoing request and the incoming
@@ -16,5 +16,5 @@ interface outgoing-handler {
   handle: func(
     request: outgoing-request,
     options: option<request-options>
-  ) -> result<future-incoming-response, error>
+  ) -> result<future-incoming-response, error>;
 }

--- a/crates/wasi-http/wit/deps/http/proxy.wit
+++ b/crates/wasi-http/wit/deps/http/proxy.wit
@@ -1,4 +1,4 @@
-package wasi:http
+package wasi:http;
 
 // The `wasi:http/proxy` world captures a widely-implementable intersection of
 // hosts that includes HTTP forward and reverse proxies. Components targeting
@@ -6,29 +6,29 @@ package wasi:http
 // outgoing HTTP requests.
 world proxy {
   // HTTP proxies have access to time and randomness.
-  import wasi:clocks/wall-clock
-  import wasi:clocks/monotonic-clock
-  import wasi:clocks/timezone
-  import wasi:random/random
+  import wasi:clocks/wall-clock;
+  import wasi:clocks/monotonic-clock;
+  import wasi:clocks/timezone;
+  import wasi:random/random;
 
   // Proxies have standard output and error streams which are expected to
   // terminate in a developer-facing console provided by the host.
-  import wasi:cli/stdout
-  import wasi:cli/stderr
+  import wasi:cli/stdout;
+  import wasi:cli/stderr;
 
   // TODO: this is a temporary workaround until component tooling is able to
   // gracefully handle the absence of stdin. Hosts must return an eof stream
   // for this import, which is what wasi-libc + tooling will do automatically
   // when this import is properly removed.
-  import wasi:cli/stdin
+  import wasi:cli/stdin;
 
   // This is the default handler to use when user code simply wants to make an
   // HTTP request (e.g., via `fetch()`).
-  import outgoing-handler
+  import outgoing-handler;
 
   // The host delivers incoming HTTP requests to a component by calling the
   // `handle` function of this exported interface. A host may arbitrarily reuse
   // or not reuse component instance when delivering incoming HTTP requests and
   // thus a component must be able to handle 0..N calls to `handle`.
-  export incoming-handler
+  export incoming-handler;
 }

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -2,8 +2,8 @@
 // define the HTTP resource types and operations used by the component's
 // imported and exported interfaces.
 interface types {
-  use wasi:io/streams.{input-stream, output-stream}
-  use wasi:io/poll.{pollable}
+  use wasi:io/streams.{input-stream, output-stream};
+  use wasi:io/poll.{pollable};
 
   // This type corresponds to HTTP standard Methods.
   variant method {
@@ -43,28 +43,28 @@ interface types {
   resource fields {
     // Multiple values for a header are multiple entries in the list with the
     // same key.
-    constructor(entries: list<tuple<string,list<u8>>>)
+    constructor(entries: list<tuple<string,list<u8>>>);
 
     // Values off wire are not necessarily well formed, so they are given by
     // list<u8> instead of string.
-    get: func(name: string) -> list<list<u8>>
+    get: func(name: string) -> list<list<u8>>;
 
     // Values off wire are not necessarily well formed, so they are given by
     // list<u8> instead of string.
-    set: func(name: string, value: list<list<u8>>)
-    delete: func(name: string)
-    append: func(name: string, value: list<u8>)
+    set: func(name: string, value: list<list<u8>>);
+    delete: func(name: string);
+    append: func(name: string, value: list<u8>);
 
     // Values off wire are not necessarily well formed, so they are given by
     // list<u8> instead of string.
-    entries: func() -> list<tuple<string,list<u8>>>
+    entries: func() -> list<tuple<string,list<u8>>>;
 
     // Deep copy of all contents in a fields.
-    clone: func() -> fields
+    clone: func() -> fields;
   }
 
-  type headers = fields
-  type trailers = fields
+  type headers = fields;
+  type trailers = fields;
 
   // The following block defines the `incoming-request` and `outgoing-request`
   // resource types that correspond to HTTP standard Requests. Soon, when
@@ -75,19 +75,19 @@ interface types {
   // above). The `consume` and `write` methods may only be called once (and
   // return failure thereafter).
   resource incoming-request {
-    method: func() -> method
+    method: func() -> method;
 
-    path-with-query: func() -> option<string>
+    path-with-query: func() -> option<string>;
 
-    scheme: func() -> option<scheme>
+    scheme: func() -> option<scheme>;
 
-    authority: func() -> option<string>
+    authority: func() -> option<string>;
 
-    headers: func() -> /* child */ headers
+    headers: func() -> /* child */ headers;
     // Will return the input-stream child at most once. If called more than
     // once, subsequent calls will return error.
 
-    consume: func() -> result<incoming-body>
+    consume: func() -> result<incoming-body>;
   }
 
   resource outgoing-request {
@@ -97,11 +97,11 @@ interface types {
       scheme: option<scheme>,
       authority: option<string>,
       headers: borrow<headers>
-    )
+    );
 
     // Will return the outgoing-body child at most once. If called more than
     // once, subsequent calls will return error.
-    write: func() -> result< /* child */ outgoing-body>
+    write: func() -> result< /* child */ outgoing-body>;
   }
 
   // Additional optional parameters that can be set when making a request.
@@ -127,11 +127,11 @@ interface types {
   // (the `wasi:http/handler` interface used for both incoming and outgoing can
   // simply return a `stream`).
   resource response-outparam {
-    set: static func(param: response-outparam, response: result<outgoing-response, error>)
+    set: static func(param: response-outparam, response: result<outgoing-response, error>);
   }
 
   // This type corresponds to the HTTP standard Status Code.
-  type status-code = u16
+  type status-code = u16;
 
   // The following block defines the `incoming-response` and `outgoing-response`
   // resource types that correspond to HTTP standard Responses. Soon, when
@@ -141,14 +141,14 @@ interface types {
   // type (that uses the single `stream` type mentioned above). The `consume` and
   // `write` methods may only be called once (and return failure thereafter).
   resource incoming-response {
-    status: func() -> status-code
+    status: func() -> status-code;
 
-    headers: func() -> /* child */ headers
+    headers: func() -> /* child */ headers;
 
     // May be called at most once. returns error if called additional times.
     // TODO: make incoming-request-consume work the same way, giving a child
     // incoming-body.
-    consume: func() -> result<incoming-body>
+    consume: func() -> result<incoming-body>;
   }
 
   resource incoming-body {
@@ -156,41 +156,41 @@ interface types {
     // incoming-body is dropped (or consumed by call to
     // incoming-body-finish) before the input-stream is dropped.
     // May be called at most once. returns error if called additional times.
-    %stream: func() -> result</* child */ input-stream>
+    %stream: func() -> result</* child */ input-stream>;
 
     // takes ownership of incoming-body. this will trap if the
     // incoming-body-stream child is still alive!
     finish: static func(this: incoming-body) ->
-    /* transitive child of the incoming-response of incoming-body */ future-trailers
+    /* transitive child of the incoming-response of incoming-body */ future-trailers;
   }
 
   resource future-trailers {
     /// Pollable that resolves when the body has been fully read, and the trailers
     /// are ready to be consumed.
-    subscribe: func() -> /* child */ pollable
+    subscribe: func() -> /* child */ pollable;
 
     /// Retrieve reference to trailers, if they are ready.
-    get: func() -> option<result</* child */ trailers, error>>
+    get: func() -> option<result</* child */ trailers, error>>;
   }
 
   resource outgoing-response {
-    constructor(status-code: status-code, headers: borrow<headers>)
+    constructor(status-code: status-code, headers: borrow<headers>);
 
     /// Will give the child outgoing-response at most once. subsequent calls will
     /// return an error.
-    write: func() -> result<outgoing-body>
+    write: func() -> result<outgoing-body>;
   }
 
   resource outgoing-body {
     /// Will give the child output-stream at most once. subsequent calls will
     /// return an error.
-    write: func() -> result</* child */ output-stream>
+    write: func() -> result</* child */ output-stream>;
 
     /// Finalize an outgoing body, optionally providing trailers. This must be
     /// called to signal that the response is complete. If the `outgoing-body` is
     /// dropped without calling `outgoing-body-finalize`, the implementation
     /// should treat the body as corrupted.
-    finish: static func(this: outgoing-body, trailers: option<trailers>)
+    finish: static func(this: outgoing-body, trailers: option<trailers>);
   }
 
   /// The following block defines a special resource type used by the
@@ -207,8 +207,8 @@ interface types {
     /// will return an error here.
     /// inner result indicates whether the incoming-response was available, or an
     /// error occured.
-    get: func() -> option<result<result</* NOT a child*/ incoming-response, error>>>
+    get: func() -> option<result<result</* NOT a child*/ incoming-response, error>>>;
 
-    subscribe: func() -> /* child */ pollable
+    subscribe: func() -> /* child */ pollable;
   }
 }

--- a/crates/wasi-http/wit/deps/io/poll.wit
+++ b/crates/wasi-http/wit/deps/io/poll.wit
@@ -1,10 +1,10 @@
-package wasi:io
+package wasi:io;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.
 interface poll {
     /// A "pollable" handle.
-    resource pollable
+    resource pollable;
 
     /// Poll for completion on a set of pollables.
     ///
@@ -24,11 +24,11 @@ interface poll {
     /// do any I/O so it doesn't fail. If any of the I/O sources identified by
     /// the pollables has an error, it is indicated by marking the source as
     /// being reaedy for I/O.
-    poll-list: func(in: list<borrow<pollable>>) -> list<u32>
+    poll-list: func(in: list<borrow<pollable>>) -> list<u32>;
 
     /// Poll for completion on a single pollable.
     ///
     /// This function is similar to `poll-list`, but operates on only a single
     /// pollable. When it returns, the handle is ready for I/O.
-    poll-one: func(in: borrow<pollable>)
+    poll-one: func(in: borrow<pollable>);
 }

--- a/crates/wasi-http/wit/deps/io/streams.wit
+++ b/crates/wasi-http/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io
+package wasi:io;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.
@@ -6,7 +6,7 @@ package wasi:io
 /// In the future, the component model is expected to add built-in stream types;
 /// when it does, they are expected to subsume this API.
 interface streams {
-    use poll.{pollable}
+    use poll.{pollable};
 
     /// An error for input-stream and output-stream operations.
     variant stream-error {
@@ -74,14 +74,14 @@ interface streams {
         read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<list<u8>, stream-error>
+        ) -> result<list<u8>, stream-error>;
 
         /// Read bytes from a stream, after blocking until at least one byte can
         /// be read. Except for blocking, identical to `read`.
         blocking-read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<list<u8>, stream-error>
+        ) -> result<list<u8>, stream-error>;
 
         /// Skip bytes from a stream.
         ///
@@ -98,14 +98,14 @@ interface streams {
         skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Skip bytes from a stream, after blocking until at least one byte
         /// can be skipped. Except for blocking behavior, identical to `skip`.
         blocking-skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Create a `pollable` which will resolve once either the specified stream
         /// has bytes available to read or the other end of the stream has been
@@ -113,7 +113,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `input-stream`.
         /// Implementations may trap if the `input-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
-        subscribe: func() -> pollable
+        subscribe: func() -> pollable;
     }
 
 
@@ -135,7 +135,7 @@ interface streams {
         /// When this function returns 0 bytes, the `subscribe` pollable will
         /// become ready when this function will report at least 1 byte, or an
         /// error.
-        check-write: func() -> result<u64, stream-error>
+        check-write: func() -> result<u64, stream-error>;
 
         /// Perform a write. This function never blocks.
         ///
@@ -146,7 +146,7 @@ interface streams {
         /// the last call to check-write provided a permit.
         write: func(
             contents: list<u8>
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 bytes, and then flush the stream. Block
         /// until all of these operations are complete, or an error occurs.
@@ -174,7 +174,7 @@ interface streams {
         /// ```
         blocking-write-and-flush: func(
             contents: list<u8>
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Request to flush buffered output. This function never blocks.
         ///
@@ -186,11 +186,11 @@ interface streams {
         /// writes (`check-write` will return `ok(0)`) until the flush has
         /// completed. The `subscribe` pollable will become ready when the
         /// flush has completed and the stream can accept more writes.
-        flush: func() -> result<_, stream-error>
+        flush: func() -> result<_, stream-error>;
 
         /// Request to flush buffered output, and block until flush completes
         /// and stream is ready for writing again.
-        blocking-flush: func() -> result<_, stream-error>
+        blocking-flush: func() -> result<_, stream-error>;
 
         /// Create a `pollable` which will resolve once the output-stream
         /// is ready for more writing, or an error has occured. When this
@@ -202,7 +202,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `output-stream`.
         /// Implementations may trap if the `output-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
-        subscribe: func() -> pollable
+        subscribe: func() -> pollable;
 
         /// Write zeroes to a stream.
         ///
@@ -213,7 +213,7 @@ interface streams {
         write-zeroes: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 zeroes, and then flush the stream.
         /// Block until all of these operations are complete, or an error
@@ -242,7 +242,7 @@ interface streams {
         blocking-write-zeroes-and-flush: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Read from one stream and write to another.
         ///
@@ -256,7 +256,7 @@ interface streams {
             src: input-stream,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Read from one stream and write to another, with blocking.
         ///
@@ -267,7 +267,7 @@ interface streams {
             src: input-stream,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Forward the entire contents of an input stream to an output stream.
         ///
@@ -284,6 +284,6 @@ interface streams {
         forward: func(
             /// The stream to read from
             src: input-stream
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
     }
 }

--- a/crates/wasi-http/wit/deps/io/world.wit
+++ b/crates/wasi-http/wit/deps/io/world.wit
@@ -1,6 +1,6 @@
-package wasi:io
+package wasi:io;
 
 world imports {
-    import streams
-    import poll
+    import streams;
+    import poll;
 }

--- a/crates/wasi-http/wit/deps/logging/logging.wit
+++ b/crates/wasi-http/wit/deps/logging/logging.wit
@@ -1,4 +1,4 @@
-package wasi:logging
+package wasi:logging;
 
 /// WASI Logging is a logging API intended to let users emit log messages with
 /// simple priority levels and context values.
@@ -33,5 +33,5 @@ interface logging {
     /// sent, a context, which is an uninterpreted string meant to help
     /// consumers group similar messages, and a string containing the message
     /// text.
-    log: func(level: level, context: string, message: string)
+    log: func(level: level, context: string, message: string);
 }

--- a/crates/wasi-http/wit/deps/logging/world.wit
+++ b/crates/wasi-http/wit/deps/logging/world.wit
@@ -1,5 +1,5 @@
-package wasi:logging
+package wasi:logging;
 
 world imports {
-    import logging
+    import logging;
 }

--- a/crates/wasi-http/wit/deps/random/insecure-seed.wit
+++ b/crates/wasi-http/wit/deps/random/insecure-seed.wit
@@ -20,5 +20,5 @@ interface insecure-seed {
     /// This will likely be changed to a value import, to prevent it from being
     /// called multiple times and potentially used for purposes other than DoS
     /// protection.
-    insecure-seed: func() -> tuple<u64, u64>
+    insecure-seed: func() -> tuple<u64, u64>;
 }

--- a/crates/wasi-http/wit/deps/random/insecure.wit
+++ b/crates/wasi-http/wit/deps/random/insecure.wit
@@ -11,11 +11,11 @@ interface insecure {
     /// There are no requirements on the values of the returned bytes, however
     /// implementations are encouraged to return evenly distributed values with
     /// a long period.
-    get-insecure-random-bytes: func(len: u64) -> list<u8>
+    get-insecure-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return an insecure pseudo-random `u64` value.
     ///
     /// This function returns the same type of pseudo-random data as
     /// `get-insecure-random-bytes`, represented as a `u64`.
-    get-insecure-random-u64: func() -> u64
+    get-insecure-random-u64: func() -> u64;
 }

--- a/crates/wasi-http/wit/deps/random/random.wit
+++ b/crates/wasi-http/wit/deps/random/random.wit
@@ -15,11 +15,11 @@ interface random {
     /// This function must always return fresh data. Deterministic environments
     /// must omit this function, rather than implementing it with deterministic
     /// data.
-    get-random-bytes: func(len: u64) -> list<u8>
+    get-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return a cryptographically-secure random or pseudo-random `u64` value.
     ///
     /// This function returns the same type of data as `get-random-bytes`,
     /// represented as a `u64`.
-    get-random-u64: func() -> u64
+    get-random-u64: func() -> u64;
 }

--- a/crates/wasi-http/wit/deps/random/world.wit
+++ b/crates/wasi-http/wit/deps/random/world.wit
@@ -1,7 +1,7 @@
-package wasi:random
+package wasi:random;
 
 world imports {
-    import random
-    import insecure
-    import insecure-seed
+    import random;
+    import insecure;
+    import insecure-seed;
 }

--- a/crates/wasi-http/wit/deps/sockets/instance-network.wit
+++ b/crates/wasi-http/wit/deps/sockets/instance-network.wit
@@ -1,9 +1,9 @@
 
 /// This interface provides a value-export of the default network handle..
 interface instance-network {
-	use network.{network}
+	use network.{network};
 
 	/// Get a handle to the default network.
-	instance-network: func() -> network
+	instance-network: func() -> network;
 
 }

--- a/crates/wasi-http/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi-http/wit/deps/sockets/ip-name-lookup.wit
@@ -1,13 +1,13 @@
 
 interface ip-name-lookup {
-	use wasi:io/poll.{pollable}
-	use network.{network, error-code, ip-address, ip-address-family}
+	use wasi:io/poll.{pollable};
+	use network.{network, error-code, ip-address, ip-address-family};
 
 
 	/// Resolve an internet host name to a list of IP addresses.
-	/// 
+	///
 	/// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
-	/// 
+	///
 	/// # Parameters
 	/// - `name`: The name to look up. IP addresses are not allowed. Unicode domain names are automatically converted
 	///     to ASCII using IDNA encoding.
@@ -17,45 +17,45 @@ interface ip-name-lookup {
 	///   systems without an active IPv6 interface. Notes:
 	///     - Even when no public IPv6 interfaces are present or active, names like "localhost" can still resolve to an IPv6 address.
 	///     - Whatever is "available" or "unavailable" is volatile and can change everytime a network cable is unplugged.
-	/// 
+	///
 	/// This function never blocks. It either immediately fails or immediately returns successfully with a `resolve-address-stream`
 	/// that can be used to (asynchronously) fetch the results.
-	/// 
+	///
 	/// At the moment, the stream never completes successfully with 0 items. Ie. the first call
 	/// to `resolve-next-address` never returns `ok(none)`. This may change in the future.
-	/// 
+	///
 	/// # Typical errors
 	/// - `invalid-name`:                 `name` is a syntactically invalid domain name.
 	/// - `invalid-name`:                 `name` is an IP address.
 	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAI_FAMILY)
-	/// 
+	///
 	/// # References:
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
 	/// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
-	resolve-addresses: func(network: borrow<network>, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error-code>
+	resolve-addresses: func(network: borrow<network>, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error-code>;
 
 	resource resolve-address-stream {
 		/// Returns the next address from the resolver.
-		/// 
+		///
 		/// This function should be called multiple times. On each call, it will
 		/// return the next address in connection order preference. If all
 		/// addresses have been exhausted, this function returns `none`.
-		/// 
+		///
 		/// This function never returns IPv4-mapped IPv6 addresses.
-		/// 
+		///
 		/// # Typical errors
 		/// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
 		/// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
 		/// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
 		/// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
-		resolve-next-address: func() -> result<option<ip-address>, error-code>
+		resolve-next-address: func() -> result<option<ip-address>, error-code>;
 
 		/// Create a `pollable` which will resolve once the stream is ready for I/O.
-		/// 
+		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable
+		subscribe: func() -> pollable;
 	}
 }

--- a/crates/wasi-http/wit/deps/sockets/network.wit
+++ b/crates/wasi-http/wit/deps/sockets/network.wit
@@ -3,10 +3,10 @@ interface network {
 	/// An opaque resource that represents access to (a subset of) the network.
 	/// This enables context-based security for networking.
 	/// There is no need for this to map 1:1 to a physical network interface.
-	resource network
+	resource network;
 
 	/// Error codes.
-	/// 
+	///
 	/// In theory, every API can return any error code.
 	/// In practice, API's typically only return the errors documented per API
 	/// combined with a couple of errors that are always possible:
@@ -14,7 +14,7 @@ interface network {
 	/// - `access-denied`
 	/// - `not-supported`
 	/// - `out-of-memory`
-	/// 
+	///
 	/// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
 	enum error-code {
 		// ### GENERAL ERRORS ###
@@ -23,17 +23,17 @@ interface network {
 		unknown,
 
 		/// Access denied.
-		/// 
+		///
 		/// POSIX equivalent: EACCES, EPERM
 		access-denied,
 
 		/// The operation is not supported.
-		/// 
+		///
 		/// POSIX equivalent: EOPNOTSUPP
 		not-supported,
 
 		/// Not enough memory to complete the operation.
-		/// 
+		///
 		/// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
 		out-of-memory,
 
@@ -46,12 +46,12 @@ interface network {
 		/// Trying to finish an asynchronous operation that:
 		/// - has not been started yet, or:
 		/// - was already finished by a previous `finish-*` call.
-		/// 
+		///
 		/// Note: this is scheduled to be removed when `future`s are natively supported.
 		not-in-progress,
 
 		/// The operation has been aborted because it could not be completed immediately.
-		/// 
+		///
 		/// Note: this is scheduled to be removed when `future`s are natively supported.
 		would-block,
 
@@ -79,7 +79,7 @@ interface network {
 
 		/// A new socket resource could not be created because of a system limit.
 		new-socket-limit,
-		
+
 		/// The socket is already attached to another network.
 		already-attached,
 
@@ -106,10 +106,10 @@ interface network {
 
 		/// The remote address is not reachable
 		remote-unreachable,
-		
+
 
 		// ### TCP SOCKET ERRORS ###
-		
+
 		/// The socket is already in the Listener state.
 		already-listening,
 
@@ -121,14 +121,14 @@ interface network {
 
 		/// The connection was reset.
 		connection-reset,
-		
+
 
 		// ### UDP SOCKET ERRORS ###
 		datagram-too-large,
 
 
 		// ### NAME LOOKUP ERRORS ###
-		
+
 		/// The provided name is a syntactically invalid domain name.
 		invalid-name,
 
@@ -144,14 +144,14 @@ interface network {
 
 	enum ip-address-family {
 		/// Similar to `AF_INET` in POSIX.
-		ipv4, 
+		ipv4,
 
 		/// Similar to `AF_INET6` in POSIX.
 		ipv6,
 	}
 
-	type ipv4-address = tuple<u8, u8, u8, u8>
-	type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>
+	type ipv4-address = tuple<u8, u8, u8, u8>;
+	type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
 
 	variant ip-address {
 		ipv4(ipv4-address),

--- a/crates/wasi-http/wit/deps/sockets/tcp-create-socket.wit
+++ b/crates/wasi-http/wit/deps/sockets/tcp-create-socket.wit
@@ -1,27 +1,27 @@
 
 interface tcp-create-socket {
-	use network.{network, error-code, ip-address-family}
-	use tcp.{tcp-socket}
+	use network.{network, error-code, ip-address-family};
+	use tcp.{tcp-socket};
 
 	/// Create a new TCP socket.
-	/// 
+	///
 	/// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
-	/// 
+	///
 	/// This function does not require a network capability handle. This is considered to be safe because
 	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`listen`/`connect`
 	/// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
-	/// 
+	///
 	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
-	/// 
+	///
 	/// # Typical errors
 	/// - `not-supported`:                The host does not support TCP sockets. (EOPNOTSUPP)
 	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAFNOSUPPORT)
 	/// - `new-socket-limit`:             The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-	/// 
+	///
 	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>
+	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
 }

--- a/crates/wasi-http/wit/deps/sockets/tcp.wit
+++ b/crates/wasi-http/wit/deps/sockets/tcp.wit
@@ -1,8 +1,8 @@
 
 interface tcp {
-	use wasi:io/streams.{input-stream, output-stream}
-	use wasi:io/poll.{pollable}
-	use network.{network, error-code, ip-socket-address, ip-address-family}
+	use wasi:io/streams.{input-stream, output-stream};
+	use wasi:io/poll.{pollable};
+	use network.{network, error-code, ip-socket-address, ip-address-family};
 
 	enum shutdown-type {
 		/// Similar to `SHUT_RD` in POSIX.
@@ -23,38 +23,38 @@ interface tcp {
 		/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
 		/// network interface(s) to bind to.
 		/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
-		/// 
+		///
 		/// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
 		/// implicitly bind the socket.
-		/// 
+		///
 		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		/// 
+		///
 		/// # Typical `start` errors
 		/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
 		/// - `already-bound`:             The socket is already bound. (EINVAL)
 		/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		/// 
+		///
 		/// # Typical `finish` errors
 		/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
 		/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
 		/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
 		/// - `not-in-progress`:           A `bind` operation is not in progress.
 		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
 		/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>
-		finish-bind: func() -> result<_, error-code>
+		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+		finish-bind: func() -> result<_, error-code>;
 
 		/// Connect to a remote endpoint.
-		/// 
+		///
 		/// On success:
 		/// - the socket is transitioned into the Connection state
 		/// - a pair of streams is returned that can be used to read & write to the connection
-		/// 
+		///
 		/// # Typical `start` errors
 		/// - `address-family-mismatch`:   The `remote-address` has the wrong address family. (EAFNOSUPPORT)
 		/// - `invalid-remote-address`:    The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
@@ -63,7 +63,7 @@ interface tcp {
 		/// - `already-connected`:         The socket is already in the Connection state. (EISCONN)
 		/// - `already-listening`:         The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)
 		/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		/// 
+		///
 		/// # Typical `finish` errors
 		/// - `timeout`:                   Connection timed out. (ETIMEDOUT)
 		/// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
@@ -72,23 +72,23 @@ interface tcp {
 		/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
 		/// - `not-in-progress`:           A `connect` operation is not in progress.
 		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
 		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
 		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>
-		finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>
+		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+		finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
 
 		/// Start listening for new connections.
-		/// 
+		///
 		/// Transitions the socket into the Listener state.
-		/// 
+		///
 		/// Unlike POSIX:
 		/// - this function is async. This enables interactive WASI hosts to inject permission prompts.
 		/// - the socket must already be explicitly bound.
-		/// 
+		///
 		/// # Typical `start` errors
 		/// - `not-bound`:                 The socket is not bound to any local address. (EDESTADDRREQ)
 		/// - `already-connected`:         The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
@@ -105,145 +105,145 @@ interface tcp {
 		/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
-		start-listen: func() -> result<_, error-code>
-		finish-listen: func() -> result<_, error-code>
+		start-listen: func() -> result<_, error-code>;
+		finish-listen: func() -> result<_, error-code>;
 
 		/// Accept a new client socket.
-		/// 
+		///
 		/// The returned socket is bound and in the Connection state.
-		/// 
+		///
 		/// On success, this function returns the newly accepted client socket along with
 		/// a pair of streams that can be used to read & write to the connection.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-listening`: Socket is not in the Listener state. (EINVAL)
 		/// - `would-block`:   No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// Host implementations must skip over transient errors returned by the native accept syscall.
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
 		/// - <https://man7.org/linux/man-pages/man2/accept.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-		accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>
+		accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
 
 		/// Get the bound local address.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-bound`: The socket is not bound to any local address.
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
 		/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
 		/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-		local-address: func() -> result<ip-socket-address, error-code>
+		local-address: func() -> result<ip-socket-address, error-code>;
 
 		/// Get the bound remote address.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-connected`: The socket is not connected to a remote address. (ENOTCONN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
 		/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-		remote-address: func() -> result<ip-socket-address, error-code>
+		remote-address: func() -> result<ip-socket-address, error-code>;
 
 		/// Whether this is a IPv4 or IPv6 socket.
-		/// 
+		///
 		/// Equivalent to the SO_DOMAIN socket option.
-		address-family: func() -> ip-address-family
-	
+		address-family: func() -> ip-address-family;
+
 		/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-		/// 
+		///
 		/// Equivalent to the IPV6_V6ONLY socket option.
-		/// 
+		///
 		/// # Typical errors
 		/// - `ipv6-only-operation`:  (get/set) `this` socket is an IPv4 socket.
 		/// - `already-bound`:        (set) The socket is already bound.
 		/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		ipv6-only: func() -> result<bool, error-code>
-		set-ipv6-only: func(value: bool) -> result<_, error-code>
+		ipv6-only: func() -> result<bool, error-code>;
+		set-ipv6-only: func(value: bool) -> result<_, error-code>;
 
 		/// Hints the desired listen queue size. Implementations are free to ignore this.
-		/// 
+		///
 		/// # Typical errors
 		/// - `already-connected`:    (set) The socket is already in the Connection state.
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		set-listen-backlog-size: func(value: u64) -> result<_, error-code>
+		set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
 
 		/// Equivalent to the SO_KEEPALIVE socket option.
-		/// 
+		///
 		/// # Typical errors
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		keep-alive: func() -> result<bool, error-code>
-		set-keep-alive: func(value: bool) -> result<_, error-code>
+		keep-alive: func() -> result<bool, error-code>;
+		set-keep-alive: func(value: bool) -> result<_, error-code>;
 
 		/// Equivalent to the TCP_NODELAY socket option.
-		/// 
+		///
 		/// # Typical errors
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		no-delay: func() -> result<bool, error-code>
-		set-no-delay: func(value: bool) -> result<_, error-code>
-	
+		no-delay: func() -> result<bool, error-code>;
+		set-no-delay: func(value: bool) -> result<_, error-code>;
+
 		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-		/// 
+		///
 		/// # Typical errors
 		/// - `already-connected`:    (set) The socket is already in the Connection state.
 		/// - `already-listening`:    (set) The socket is already in the Listener state.
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		unicast-hop-limit: func() -> result<u8, error-code>
-		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>
+		unicast-hop-limit: func() -> result<u8, error-code>;
+		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
 
 		/// The kernel buffer space reserved for sends/receives on this socket.
-		/// 
+		///
 		/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
 		/// 	In other words, after setting a value, reading the same setting back may return a different value.
-		/// 
+		///
 		/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
 		/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
 		/// 	for internal metadata structures.
-		/// 
+		///
 		/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-		/// 
+		///
 		/// # Typical errors
 		/// - `already-connected`:    (set) The socket is already in the Connection state.
 		/// - `already-listening`:    (set) The socket is already in the Listener state.
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		receive-buffer-size: func() -> result<u64, error-code>
-		set-receive-buffer-size: func(value: u64) -> result<_, error-code>
-		send-buffer-size: func() -> result<u64, error-code>
-		set-send-buffer-size: func(value: u64) -> result<_, error-code>
+		receive-buffer-size: func() -> result<u64, error-code>;
+		set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+		send-buffer-size: func() -> result<u64, error-code>;
+		set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
 		/// Create a `pollable` which will resolve once the socket is ready for I/O.
-		/// 
+		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable
+		subscribe: func() -> pollable;
 
 		/// Initiate a graceful shutdown.
-		/// 
+		///
 		/// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
 		///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.
 		///   Any data still in the receive queue at time of calling `shutdown` will be discarded.
 		/// - send: the socket is not expecting to send any more data to the peer. All subsequent write
 		///   operations on the `output-stream` associated with this socket will return an error.
 		/// - both: same effect as receive & send combined.
-		/// 
+		///
 		/// The shutdown function does not close (drop) the socket.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-connected`: The socket is not in the Connection state. (ENOTCONN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
 		/// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
-		shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>
+		shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
 	}
 }

--- a/crates/wasi-http/wit/deps/sockets/udp-create-socket.wit
+++ b/crates/wasi-http/wit/deps/sockets/udp-create-socket.wit
@@ -1,27 +1,27 @@
 
 interface udp-create-socket {
-	use network.{network, error-code, ip-address-family}
-	use udp.{udp-socket}
+	use network.{network, error-code, ip-address-family};
+	use udp.{udp-socket};
 
 	/// Create a new UDP socket.
-	/// 
+	///
 	/// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)` in POSIX.
-	/// 
+	///
 	/// This function does not require a network capability handle. This is considered to be safe because
 	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect` is called,
 	/// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
-	/// 
+	///
 	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
-	/// 
+	///
 	/// # Typical errors
 	/// - `not-supported`:                The host does not support UDP sockets. (EOPNOTSUPP)
 	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAFNOSUPPORT)
 	/// - `new-socket-limit`:             The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-	/// 
+	///
 	/// # References:
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>
+	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
 }

--- a/crates/wasi-http/wit/deps/sockets/udp.wit
+++ b/crates/wasi-http/wit/deps/sockets/udp.wit
@@ -1,7 +1,7 @@
 
 interface udp {
-	use wasi:io/poll.{pollable}
-	use network.{network, error-code, ip-socket-address, ip-address-family}
+	use wasi:io/poll.{pollable};
+	use network.{network, error-code, ip-socket-address, ip-address-family};
 
 
 	record datagram {
@@ -25,74 +25,74 @@ interface udp {
 		/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
 		/// network interface(s) to bind to.
 		/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
-		/// 
+		///
 		/// When a socket is not explicitly bound, the first invocation to connect will implicitly bind the socket.
-		/// 
+		///
 		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		/// 
+		///
 		/// # Typical `start` errors
 		/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
 		/// - `already-bound`:             The socket is already bound. (EINVAL)
 		/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
-		/// 
+		///
 		/// # Typical `finish` errors
 		/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
 		/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
 		/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
 		/// - `not-in-progress`:           A `bind` operation is not in progress.
 		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
 		/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>
-		finish-bind: func() -> result<_, error-code>
+		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+		finish-bind: func() -> result<_, error-code>;
 
 		/// Set the destination address.
-		/// 
+		///
 		/// The local-address is updated based on the best network path to `remote-address`.
-		/// 
+		///
 		/// When a destination address is set:
 		/// - all receive operations will only return datagrams sent from the provided `remote-address`.
 		/// - the `send` function can only be used to send to this destination.
-		/// 
+		///
 		/// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
-		/// 
+		///
 		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		/// 
+		///
 		/// # Typical `start` errors
 		/// - `address-family-mismatch`:   The `remote-address` has the wrong address family. (EAFNOSUPPORT)
 		/// - `invalid-remote-address`:    The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
 		/// - `invalid-remote-address`:    The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
 		/// - `already-attached`:          The socket is already bound to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
 		/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
-		/// 
+		///
 		/// # Typical `finish` errors
 		/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
 		/// - `not-in-progress`:           A `connect` operation is not in progress.
 		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
 		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
 		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>
-		finish-connect: func() -> result<_, error-code>
+		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+		finish-connect: func() -> result<_, error-code>;
 
 		/// Receive messages on the socket.
-		/// 
+		///
 		/// This function attempts to receive up to `max-results` datagrams on the socket without blocking.
 		/// The returned list may contain fewer elements than requested, but never more.
 		/// If `max-results` is 0, this function returns successfully with an empty list.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-bound`:          The socket is not bound to any local address. (EINVAL)
 		/// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
 		/// - `would-block`:        There is no pending data available to be read at the moment. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
@@ -102,22 +102,22 @@ interface udp {
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
 		/// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-		receive: func(max-results: u64) -> result<list<datagram>, error-code>
+		receive: func(max-results: u64) -> result<list<datagram>, error-code>;
 
 		/// Send messages on the socket.
-		/// 
+		///
 		/// This function attempts to send all provided `datagrams` on the socket without blocking and
 		/// returns how many messages were actually sent (or queued for sending).
-		/// 
+		///
 		/// This function semantically behaves the same as iterating the `datagrams` list and sequentially
 		/// sending each individual datagram until either the end of the list has been reached or the first error occurred.
 		/// If at least one datagram has been sent successfully, this function never returns an error.
-		/// 
+		///
 		/// If the input list is empty, the function returns `ok(0)`.
-		/// 
+		///
 		/// The remote address option is required. To send a message to the "connected" peer,
 		/// call `remote-address` to get their address.
-		/// 
+		///
 		/// # Typical errors
 		/// - `address-family-mismatch`: The `remote-address` has the wrong address family. (EAFNOSUPPORT)
 		/// - `invalid-remote-address`:  The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
@@ -127,7 +127,7 @@ interface udp {
 		/// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
 		/// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
 		/// - `would-block`:             The send buffer is currently full. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
@@ -137,78 +137,78 @@ interface udp {
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-		send: func(datagrams: list<datagram>) -> result<u64, error-code>
+		send: func(datagrams: list<datagram>) -> result<u64, error-code>;
 
 		/// Get the current bound address.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-bound`: The socket is not bound to any local address.
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
 		/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
 		/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-		local-address: func() -> result<ip-socket-address, error-code>
+		local-address: func() -> result<ip-socket-address, error-code>;
 
 		/// Get the address set with `connect`.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-connected`: The socket is not connected to a remote address. (ENOTCONN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
 		/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-		remote-address: func() -> result<ip-socket-address, error-code>
+		remote-address: func() -> result<ip-socket-address, error-code>;
 
 		/// Whether this is a IPv4 or IPv6 socket.
-		/// 
+		///
 		/// Equivalent to the SO_DOMAIN socket option.
-		address-family: func() -> ip-address-family
+		address-family: func() -> ip-address-family;
 
 		/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-		/// 
+		///
 		/// Equivalent to the IPV6_V6ONLY socket option.
-		/// 
+		///
 		/// # Typical errors
 		/// - `ipv6-only-operation`:  (get/set) `this` socket is an IPv4 socket.
 		/// - `already-bound`:        (set) The socket is already bound.
 		/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
 		/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
-		ipv6-only: func() -> result<bool, error-code>
-		set-ipv6-only: func(value: bool) -> result<_, error-code>
+		ipv6-only: func() -> result<bool, error-code>;
+		set-ipv6-only: func(value: bool) -> result<_, error-code>;
 
 		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-		/// 
+		///
 		/// # Typical errors
 		/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
-		unicast-hop-limit: func() -> result<u8, error-code>
-		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>
+		unicast-hop-limit: func() -> result<u8, error-code>;
+		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
 
 		/// The kernel buffer space reserved for sends/receives on this socket.
-		/// 
+		///
 		/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
 		/// 	In other words, after setting a value, reading the same setting back may return a different value.
-		/// 
+		///
 		/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
 		/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
 		/// 	for internal metadata structures.
-		/// 
+		///
 		/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-		/// 
+		///
 		/// # Typical errors
 		/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
-		receive-buffer-size: func() -> result<u64, error-code>
-		set-receive-buffer-size: func(value: u64) -> result<_, error-code>
-		send-buffer-size: func() -> result<u64, error-code>
-		set-send-buffer-size: func(value: u64) -> result<_, error-code>
+		receive-buffer-size: func() -> result<u64, error-code>;
+		set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+		send-buffer-size: func() -> result<u64, error-code>;
+		set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
 		/// Create a `pollable` which will resolve once the socket is ready for I/O.
-		/// 
+		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable
+		subscribe: func() -> pollable;
 	}
 }

--- a/crates/wasi-http/wit/deps/sockets/world.wit
+++ b/crates/wasi-http/wit/deps/sockets/world.wit
@@ -1,11 +1,11 @@
-package wasi:sockets
+package wasi:sockets;
 
 world imports {
-    import instance-network
-    import network
-    import udp
-    import udp-create-socket
-    import tcp
-    import tcp-create-socket
-    import ip-name-lookup
+    import instance-network;
+    import network;
+    import udp;
+    import udp-create-socket;
+    import tcp;
+    import tcp-create-socket;
+    import ip-name-lookup;
 }

--- a/crates/wasi-http/wit/main.wit
+++ b/crates/wasi-http/wit/main.wit
@@ -1,33 +1,33 @@
-package wasmtime:wasi
+package wasmtime:wasi;
 
 // All of the same imports available in the wasi:cli/command world, but no
 // export required:
 world preview1-adapter-reactor {
-  import wasi:clocks/wall-clock
-  import wasi:clocks/monotonic-clock
-  import wasi:clocks/timezone
-  import wasi:filesystem/types
-  import wasi:filesystem/preopens
-  import wasi:sockets/instance-network
-  import wasi:sockets/ip-name-lookup
-  import wasi:sockets/network
-  import wasi:sockets/tcp-create-socket
-  import wasi:sockets/tcp
-  import wasi:sockets/udp-create-socket
-  import wasi:sockets/udp
-  import wasi:random/random
-  import wasi:random/insecure
-  import wasi:random/insecure-seed
-  import wasi:io/poll
-  import wasi:io/streams
-  import wasi:cli/environment
-  import wasi:cli/exit
-  import wasi:cli/stdin
-  import wasi:cli/stdout
-  import wasi:cli/stderr
-  import wasi:cli/terminal-input
-  import wasi:cli/terminal-output
-  import wasi:cli/terminal-stdin
-  import wasi:cli/terminal-stdout
-  import wasi:cli/terminal-stderr
+  import wasi:clocks/wall-clock;
+  import wasi:clocks/monotonic-clock;
+  import wasi:clocks/timezone;
+  import wasi:filesystem/types;
+  import wasi:filesystem/preopens;
+  import wasi:sockets/instance-network;
+  import wasi:sockets/ip-name-lookup;
+  import wasi:sockets/network;
+  import wasi:sockets/tcp-create-socket;
+  import wasi:sockets/tcp;
+  import wasi:sockets/udp-create-socket;
+  import wasi:sockets/udp;
+  import wasi:random/random;
+  import wasi:random/insecure;
+  import wasi:random/insecure-seed;
+  import wasi:io/poll;
+  import wasi:io/streams;
+  import wasi:cli/environment;
+  import wasi:cli/exit;
+  import wasi:cli/stdin;
+  import wasi:cli/stdout;
+  import wasi:cli/stderr;
+  import wasi:cli/terminal-input;
+  import wasi:cli/terminal-output;
+  import wasi:cli/terminal-stdin;
+  import wasi:cli/terminal-stdout;
+  import wasi:cli/terminal-stderr;
 }

--- a/crates/wasi-http/wit/test.wit
+++ b/crates/wasi-http/wit/test.wit
@@ -1,44 +1,44 @@
 // only used as part of `test-programs`
 world test-reactor {
 
-  import wasi:cli/environment
-  import wasi:io/poll
-  import wasi:io/streams
-  import wasi:filesystem/types
-  import wasi:filesystem/preopens
-  import wasi:cli/exit
+  import wasi:cli/environment;
+  import wasi:io/poll;
+  import wasi:io/streams;
+  import wasi:filesystem/types;
+  import wasi:filesystem/preopens;
+  import wasi:cli/exit;
 
-  export add-strings: func(s: list<string>) -> u32
-  export get-strings: func() -> list<string>
+  export add-strings: func(s: list<string>) -> u32;
+  export get-strings: func() -> list<string>;
 
-  use wasi:io/streams.{output-stream}
+  use wasi:io/streams.{output-stream};
 
-  export write-strings-to: func(o: output-stream) -> result
+  export write-strings-to: func(o: output-stream) -> result;
 
-  use wasi:filesystem/types.{descriptor-stat}
-  export pass-an-imported-record: func(d: descriptor-stat) -> string
+  use wasi:filesystem/types.{descriptor-stat};
+  export pass-an-imported-record: func(d: descriptor-stat) -> string;
 }
 
 world test-command {
-  import wasi:io/poll
-  import wasi:io/streams
-  import wasi:cli/environment
-  import wasi:cli/stdin
-  import wasi:cli/stdout
-  import wasi:cli/stderr
+  import wasi:io/poll;
+  import wasi:io/streams;
+  import wasi:cli/environment;
+  import wasi:cli/stdin;
+  import wasi:cli/stdout;
+  import wasi:cli/stderr;
 }
 
 world test-command-with-sockets {
-  import wasi:io/poll
-  import wasi:io/streams
-  import wasi:cli/environment
-  import wasi:cli/stdin
-  import wasi:cli/stdout
-  import wasi:cli/stderr
-  import wasi:sockets/tcp
-  import wasi:sockets/tcp-create-socket
-  import wasi:sockets/network
-  import wasi:sockets/instance-network
-  import wasi:sockets/ip-name-lookup
-  import wasi:clocks/monotonic-clock
+  import wasi:io/poll;
+  import wasi:io/streams;
+  import wasi:cli/environment;
+  import wasi:cli/stdin;
+  import wasi:cli/stdout;
+  import wasi:cli/stderr;
+  import wasi:sockets/tcp;
+  import wasi:sockets/tcp-create-socket;
+  import wasi:sockets/network;
+  import wasi:sockets/instance-network;
+  import wasi:sockets/ip-name-lookup;
+  import wasi:clocks/monotonic-clock;
 }

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -65,9 +65,9 @@ pub mod bindings {
             wasmtime::component::bindgen!({
                 path: "wit",
                 interfaces: "
-                    import wasi:io/poll
-                    import wasi:io/streams
-                    import wasi:filesystem/types
+                    import wasi:io/poll;
+                    import wasi:io/streams;
+                    import wasi:filesystem/types;
                 ",
                 tracing: true,
                 trappable_error_type: {
@@ -90,7 +90,7 @@ pub mod bindings {
 
     wasmtime::component::bindgen!({
         path: "wit",
-        interfaces: "include wasi:cli/reactor",
+        interfaces: "include wasi:cli/reactor;",
         tracing: true,
         async: {
             // Only these functions are `async` and everything else is sync

--- a/crates/wasi/wit/command-extended.wit
+++ b/crates/wasi/wit/command-extended.wit
@@ -1,37 +1,37 @@
 // All of the same imports and exports available in the wasi:cli/command world
 // with addition of HTTP proxy related imports:
 world command-extended {
-  import wasi:clocks/wall-clock
-  import wasi:clocks/monotonic-clock
-  import wasi:clocks/timezone
-  import wasi:filesystem/types
-  import wasi:filesystem/preopens
-  import wasi:sockets/instance-network
-  import wasi:sockets/ip-name-lookup
-  import wasi:sockets/network
-  import wasi:sockets/tcp-create-socket
-  import wasi:sockets/tcp
-  import wasi:sockets/udp-create-socket
-  import wasi:sockets/udp
-  import wasi:random/random
-  import wasi:random/insecure
-  import wasi:random/insecure-seed
-  import wasi:io/poll
-  import wasi:io/streams
-  import wasi:cli/environment
-  import wasi:cli/exit
-  import wasi:cli/stdin
-  import wasi:cli/stdout
-  import wasi:cli/stderr
-  import wasi:cli/terminal-input
-  import wasi:cli/terminal-output
-  import wasi:cli/terminal-stdin
-  import wasi:cli/terminal-stdout
-  import wasi:cli/terminal-stderr
+  import wasi:clocks/wall-clock;
+  import wasi:clocks/monotonic-clock;
+  import wasi:clocks/timezone;
+  import wasi:filesystem/types;
+  import wasi:filesystem/preopens;
+  import wasi:sockets/instance-network;
+  import wasi:sockets/ip-name-lookup;
+  import wasi:sockets/network;
+  import wasi:sockets/tcp-create-socket;
+  import wasi:sockets/tcp;
+  import wasi:sockets/udp-create-socket;
+  import wasi:sockets/udp;
+  import wasi:random/random;
+  import wasi:random/insecure;
+  import wasi:random/insecure-seed;
+  import wasi:io/poll;
+  import wasi:io/streams;
+  import wasi:cli/environment;
+  import wasi:cli/exit;
+  import wasi:cli/stdin;
+  import wasi:cli/stdout;
+  import wasi:cli/stderr;
+  import wasi:cli/terminal-input;
+  import wasi:cli/terminal-output;
+  import wasi:cli/terminal-stdin;
+  import wasi:cli/terminal-stdout;
+  import wasi:cli/terminal-stderr;
 
   // We should replace all others with `include self.command`
   // as soon as the unioning of worlds is available:
   // https://github.com/WebAssembly/component-model/issues/169
-  import wasi:logging/logging
-  import wasi:http/outgoing-handler
+  import wasi:logging/logging;
+  import wasi:http/outgoing-handler;
 }

--- a/crates/wasi/wit/deps/cli/command.wit
+++ b/crates/wasi/wit/deps/cli/command.wit
@@ -1,7 +1,7 @@
-package wasi:cli
+package wasi:cli;
 
 world command {
-  include reactor
+  include reactor;
 
-  export run
+  export run;
 }

--- a/crates/wasi/wit/deps/cli/environment.wit
+++ b/crates/wasi/wit/deps/cli/environment.wit
@@ -7,12 +7,12 @@ interface environment {
   /// Morally, these are a value import, but until value imports are available
   /// in the component model, this import function should return the same
   /// values each time it is called.
-  get-environment: func() -> list<tuple<string, string>>
+  get-environment: func() -> list<tuple<string, string>>;
 
   /// Get the POSIX-style arguments to the program.
-  get-arguments: func() -> list<string>
+  get-arguments: func() -> list<string>;
 
   /// Return a path that programs should use as their initial current working
   /// directory, interpreting `.` as shorthand for this.
-  initial-cwd: func() -> option<string>
+  initial-cwd: func() -> option<string>;
 }

--- a/crates/wasi/wit/deps/cli/exit.wit
+++ b/crates/wasi/wit/deps/cli/exit.wit
@@ -1,4 +1,4 @@
 interface exit {
   /// Exit the current instance and any linked instances.
-  exit: func(status: result)
+  exit: func(status: result);
 }

--- a/crates/wasi/wit/deps/cli/reactor.wit
+++ b/crates/wasi/wit/deps/cli/reactor.wit
@@ -1,33 +1,32 @@
-package wasi:cli
+package wasi:cli;
 
 world reactor {
-  import wasi:clocks/wall-clock
-  import wasi:clocks/monotonic-clock
-  import wasi:clocks/timezone
-  import wasi:filesystem/types
-  import wasi:filesystem/preopens
-  import wasi:sockets/instance-network
-  import wasi:sockets/ip-name-lookup
-  import wasi:sockets/network
-  import wasi:sockets/tcp-create-socket
-  import wasi:sockets/tcp
-  import wasi:sockets/udp-create-socket
-  import wasi:sockets/udp
-  import wasi:random/random
-  import wasi:random/insecure
-  import wasi:random/insecure-seed
-  import wasi:io/poll
-  import wasi:io/streams
+  import wasi:clocks/wall-clock;
+  import wasi:clocks/monotonic-clock;
+  import wasi:clocks/timezone;
+  import wasi:filesystem/types;
+  import wasi:filesystem/preopens;
+  import wasi:sockets/instance-network;
+  import wasi:sockets/ip-name-lookup;
+  import wasi:sockets/network;
+  import wasi:sockets/tcp-create-socket;
+  import wasi:sockets/tcp;
+  import wasi:sockets/udp-create-socket;
+  import wasi:sockets/udp;
+  import wasi:random/random;
+  import wasi:random/insecure;
+  import wasi:random/insecure-seed;
+  import wasi:io/poll;
+  import wasi:io/streams;
 
-  import environment
-  import exit
-  import stdin
-  import stdout
-  import stderr
-  import terminal-input
-  import terminal-output
-  import terminal-stdin
-  import terminal-stdout
-  import terminal-stderr
+  import environment;
+  import exit;
+  import stdin;
+  import stdout;
+  import stderr;
+  import terminal-input;
+  import terminal-output;
+  import terminal-stdin;
+  import terminal-stdout;
+  import terminal-stderr;
 }
-

--- a/crates/wasi/wit/deps/cli/run.wit
+++ b/crates/wasi/wit/deps/cli/run.wit
@@ -1,4 +1,4 @@
 interface run {
   /// Run the program.
-  run: func() -> result
+  run: func() -> result;
 }

--- a/crates/wasi/wit/deps/cli/stdio.wit
+++ b/crates/wasi/wit/deps/cli/stdio.wit
@@ -1,17 +1,17 @@
 interface stdin {
-  use wasi:io/streams.{input-stream}
+  use wasi:io/streams.{input-stream};
 
-  get-stdin: func() -> input-stream
+  get-stdin: func() -> input-stream;
 }
 
 interface stdout {
-  use wasi:io/streams.{output-stream}
+  use wasi:io/streams.{output-stream};
 
-  get-stdout: func() -> output-stream
+  get-stdout: func() -> output-stream;
 }
 
 interface stderr {
-  use wasi:io/streams.{output-stream}
+  use wasi:io/streams.{output-stream};
 
-  get-stderr: func() -> output-stream
+  get-stderr: func() -> output-stream;
 }

--- a/crates/wasi/wit/deps/cli/terminal.wit
+++ b/crates/wasi/wit/deps/cli/terminal.wit
@@ -1,6 +1,6 @@
 interface terminal-input {
     /// The input side of a terminal.
-    resource terminal-input
+    resource terminal-input;
 
     // In the future, this may include functions for disabling echoing,
     // disabling input buffering so that keyboard events are sent through
@@ -9,7 +9,7 @@ interface terminal-input {
 
 interface terminal-output {
     /// The output side of a terminal.
-    resource terminal-output
+    resource terminal-output;
 
     // In the future, this may include functions for querying the terminal
     // size, being notified of terminal size changes, querying supported
@@ -19,29 +19,29 @@ interface terminal-output {
 /// An interface providing an optional `terminal-input` for stdin as a
 /// link-time authority.
 interface terminal-stdin {
-    use terminal-input.{terminal-input}
+    use terminal-input.{terminal-input};
 
     /// If stdin is connected to a terminal, return a `terminal-input` handle
     /// allowing further interaction with it.
-    get-terminal-stdin: func() -> option<terminal-input>
+    get-terminal-stdin: func() -> option<terminal-input>;
 }
 
 /// An interface providing an optional `terminal-output` for stdout as a
 /// link-time authority.
 interface terminal-stdout {
-    use terminal-output.{terminal-output}
+    use terminal-output.{terminal-output};
 
     /// If stdout is connected to a terminal, return a `terminal-output` handle
     /// allowing further interaction with it.
-    get-terminal-stdout: func() -> option<terminal-output>
+    get-terminal-stdout: func() -> option<terminal-output>;
 }
 
 /// An interface providing an optional `terminal-output` for stderr as a
 /// link-time authority.
 interface terminal-stderr {
-    use terminal-output.{terminal-output}
+    use terminal-output.{terminal-output};
 
     /// If stderr is connected to a terminal, return a `terminal-output` handle
     /// allowing further interaction with it.
-    get-terminal-stderr: func() -> option<terminal-output>
+    get-terminal-stderr: func() -> option<terminal-output>;
 }

--- a/crates/wasi/wit/deps/clocks/monotonic-clock.wit
+++ b/crates/wasi/wit/deps/clocks/monotonic-clock.wit
@@ -9,24 +9,24 @@
 ///
 /// It is intended for measuring elapsed time.
 interface monotonic-clock {
-    use wasi:io/poll.{pollable}
+    use wasi:io/poll.{pollable};
 
     /// A timestamp in nanoseconds.
-    type instant = u64
+    type instant = u64;
 
     /// Read the current value of the clock.
     ///
     /// The clock is monotonic, therefore calling this function repeatedly will
     /// produce a sequence of non-decreasing values.
-    now: func() -> instant
+    now: func() -> instant;
 
     /// Query the resolution of the clock.
-    resolution: func() -> instant
+    resolution: func() -> instant;
 
     /// Create a `pollable` which will resolve once the specified time has been
     /// reached.
     subscribe: func(
         when: instant,
         absolute: bool
-    ) -> pollable
+    ) -> pollable;
 }

--- a/crates/wasi/wit/deps/clocks/timezone.wit
+++ b/crates/wasi/wit/deps/clocks/timezone.wit
@@ -1,5 +1,5 @@
 interface timezone {
-    use wall-clock.{datetime}
+    use wall-clock.{datetime};
 
     /// Return information needed to display the given `datetime`. This includes
     /// the UTC offset, the time zone name, and a flag indicating whether
@@ -8,10 +8,10 @@ interface timezone {
     /// If the timezone cannot be determined for the given `datetime`, return a
     /// `timezone-display` for `UTC` with a `utc-offset` of 0 and no daylight
     /// saving time.
-    display: func(when: datetime) -> timezone-display
+    display: func(when: datetime) -> timezone-display;
 
     /// The same as `display`, but only return the UTC offset.
-    utc-offset: func(when: datetime) -> s32
+    utc-offset: func(when: datetime) -> s32;
 
     /// Information useful for displaying the timezone of a specific `datetime`.
     ///

--- a/crates/wasi/wit/deps/clocks/wall-clock.wit
+++ b/crates/wasi/wit/deps/clocks/wall-clock.wit
@@ -32,10 +32,10 @@ interface wall-clock {
     ///
     /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
     /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
-    now: func() -> datetime
+    now: func() -> datetime;
 
     /// Query the resolution of the clock.
     ///
     /// The nanoseconds field of the output is always less than 1000000000.
-    resolution: func() -> datetime
+    resolution: func() -> datetime;
 }

--- a/crates/wasi/wit/deps/clocks/world.wit
+++ b/crates/wasi/wit/deps/clocks/world.wit
@@ -1,7 +1,7 @@
-package wasi:clocks
+package wasi:clocks;
 
 world imports {
-    import monotonic-clock
-    import wall-clock
-    import timezone
+    import monotonic-clock;
+    import wall-clock;
+    import timezone;
 }

--- a/crates/wasi/wit/deps/filesystem/preopens.wit
+++ b/crates/wasi/wit/deps/filesystem/preopens.wit
@@ -1,6 +1,6 @@
 interface preopens {
-    use types.{descriptor}
+    use types.{descriptor};
 
     /// Return the set of preopened directories, and their path.
-    get-directories: func() -> list<tuple<descriptor, string>>
+    get-directories: func() -> list<tuple<descriptor, string>>;
 }

--- a/crates/wasi/wit/deps/filesystem/types.wit
+++ b/crates/wasi/wit/deps/filesystem/types.wit
@@ -23,11 +23,11 @@
 ///
 /// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
 interface types {
-    use wasi:io/streams.{input-stream, output-stream, error}
-    use wasi:clocks/wall-clock.{datetime}
+    use wasi:io/streams.{input-stream, output-stream, error};
+    use wasi:clocks/wall-clock.{datetime};
 
     /// File size or length of a region within a file.
-    type filesize = u64
+    type filesize = u64;
 
     /// The type of a filesystem object referenced by a descriptor.
     ///
@@ -166,7 +166,7 @@ interface types {
     }
 
     /// Number of hard links to an inode.
-    type link-count = u64
+    type link-count = u64;
 
     /// When setting a timestamp, this gives the value to set it to.
     variant new-timestamp {
@@ -315,7 +315,7 @@ interface types {
         read-via-stream: func(
             /// The offset within the file at which to start reading.
             offset: filesize,
-        ) -> result<input-stream, error-code>
+        ) -> result<input-stream, error-code>;
 
         /// Return a stream for writing to a file, if available.
         ///
@@ -326,7 +326,7 @@ interface types {
         write-via-stream: func(
             /// The offset within the file at which to start writing.
             offset: filesize,
-        ) -> result<output-stream, error-code>
+        ) -> result<output-stream, error-code>;
 
         /// Return a stream for appending to a file, if available.
         ///
@@ -334,7 +334,7 @@ interface types {
         ///
         /// Note: This allows using `write-stream`, which is similar to `write` with
         /// `O_APPEND` in in POSIX.
-        append-via-stream: func() -> result<output-stream, error-code>
+        append-via-stream: func() -> result<output-stream, error-code>;
 
         /// Provide file advisory information on a descriptor.
         ///
@@ -346,7 +346,7 @@ interface types {
             length: filesize,
             /// The advice.
             advice: advice
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Synchronize the data of a file to disk.
         ///
@@ -354,7 +354,7 @@ interface types {
         /// opened for writing.
         ///
         /// Note: This is similar to `fdatasync` in POSIX.
-        sync-data: func() -> result<_, error-code>
+        sync-data: func() -> result<_, error-code>;
 
         /// Get flags associated with a descriptor.
         ///
@@ -362,7 +362,7 @@ interface types {
         ///
         /// Note: This returns the value that was the `fs_flags` value returned
         /// from `fdstat_get` in earlier versions of WASI.
-        get-flags: func() -> result<descriptor-flags, error-code>
+        get-flags: func() -> result<descriptor-flags, error-code>;
 
         /// Get the dynamic type of a descriptor.
         ///
@@ -374,13 +374,13 @@ interface types {
         ///
         /// Note: This returns the value that was the `fs_filetype` value returned
         /// from `fdstat_get` in earlier versions of WASI.
-        get-type: func() -> result<descriptor-type, error-code>
+        get-type: func() -> result<descriptor-type, error-code>;
 
         /// Adjust the size of an open file. If this increases the file's size, the
         /// extra bytes are filled with zeros.
         ///
         /// Note: This was called `fd_filestat_set_size` in earlier versions of WASI.
-        set-size: func(size: filesize) -> result<_, error-code>
+        set-size: func(size: filesize) -> result<_, error-code>;
 
         /// Adjust the timestamps of an open file or directory.
         ///
@@ -392,7 +392,7 @@ interface types {
             data-access-timestamp: new-timestamp,
             /// The desired values of the data modification timestamp.
             data-modification-timestamp: new-timestamp,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Read from a descriptor, without using and updating the descriptor's offset.
         ///
@@ -410,7 +410,7 @@ interface types {
             length: filesize,
             /// The offset within the file at which to read.
             offset: filesize,
-        ) -> result<tuple<list<u8>, bool>, error-code>
+        ) -> result<tuple<list<u8>, bool>, error-code>;
 
         /// Write to a descriptor, without using and updating the descriptor's offset.
         ///
@@ -426,7 +426,7 @@ interface types {
             buffer: list<u8>,
             /// The offset within the file at which to write.
             offset: filesize,
-        ) -> result<filesize, error-code>
+        ) -> result<filesize, error-code>;
 
         /// Read directory entries from a directory.
         ///
@@ -437,7 +437,7 @@ interface types {
         /// This always returns a new stream which starts at the beginning of the
         /// directory. Multiple streams may be active on the same directory, and they
         /// do not interfere with each other.
-        read-directory: func() -> result<directory-entry-stream, error-code>
+        read-directory: func() -> result<directory-entry-stream, error-code>;
 
         /// Synchronize the data and metadata of a file to disk.
         ///
@@ -445,7 +445,7 @@ interface types {
         /// opened for writing.
         ///
         /// Note: This is similar to `fsync` in POSIX.
-        sync: func() -> result<_, error-code>
+        sync: func() -> result<_, error-code>;
 
         /// Create a directory.
         ///
@@ -453,7 +453,7 @@ interface types {
         create-directory-at: func(
             /// The relative path at which to create the directory.
             path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Return the attributes of an open file or directory.
         ///
@@ -464,7 +464,7 @@ interface types {
         /// modified, use `metadata-hash`.
         ///
         /// Note: This was called `fd_filestat_get` in earlier versions of WASI.
-        stat: func() -> result<descriptor-stat, error-code>
+        stat: func() -> result<descriptor-stat, error-code>;
 
         /// Return the attributes of a file or directory.
         ///
@@ -478,7 +478,7 @@ interface types {
             path-flags: path-flags,
             /// The relative path of the file or directory to inspect.
             path: string,
-        ) -> result<descriptor-stat, error-code>
+        ) -> result<descriptor-stat, error-code>;
 
         /// Adjust the timestamps of a file or directory.
         ///
@@ -495,7 +495,7 @@ interface types {
             data-access-timestamp: new-timestamp,
             /// The desired values of the data modification timestamp.
             data-modification-timestamp: new-timestamp,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Create a hard link.
         ///
@@ -509,7 +509,7 @@ interface types {
             new-descriptor: borrow<descriptor>,
             /// The relative destination path at which to create the hard link.
             new-path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Open a file or directory.
         ///
@@ -540,7 +540,7 @@ interface types {
             %flags: descriptor-flags,
             /// Permissions to use when creating a new file.
             modes: modes
-        ) -> result<descriptor, error-code>
+        ) -> result<descriptor, error-code>;
 
         /// Read the contents of a symbolic link.
         ///
@@ -551,7 +551,7 @@ interface types {
         readlink-at: func(
             /// The relative path of the symbolic link from which to read.
             path: string,
-        ) -> result<string, error-code>
+        ) -> result<string, error-code>;
 
         /// Remove a directory.
         ///
@@ -561,7 +561,7 @@ interface types {
         remove-directory-at: func(
             /// The relative path to a directory to remove.
             path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Rename a filesystem object.
         ///
@@ -573,7 +573,7 @@ interface types {
             new-descriptor: borrow<descriptor>,
             /// The relative destination path to which to rename the file or directory.
             new-path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Create a symbolic link (also known as a "symlink").
         ///
@@ -586,7 +586,7 @@ interface types {
             old-path: string,
             /// The relative destination path at which to create the symbolic link.
             new-path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Check accessibility of a filesystem path.
         ///
@@ -605,7 +605,7 @@ interface types {
             path: string,
             /// The type of check to perform.
             %type: access-type
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Unlink a filesystem object that is not a directory.
         ///
@@ -614,7 +614,7 @@ interface types {
         unlink-file-at: func(
             /// The relative path to a file to unlink.
             path: string,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Change the permissions of a filesystem object that is not a directory.
         ///
@@ -629,7 +629,7 @@ interface types {
             path: string,
             /// The new permissions for the filesystem object.
             modes: modes,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Change the permissions of a directory.
         ///
@@ -648,7 +648,7 @@ interface types {
             path: string,
             /// The new permissions for the directory.
             modes: modes,
-        ) -> result<_, error-code>
+        ) -> result<_, error-code>;
 
         /// Request a shared advisory lock for an open file.
         ///
@@ -670,7 +670,7 @@ interface types {
         /// locking, this function returns `error-code::unsupported`.
         ///
         /// Note: This is similar to `flock(fd, LOCK_SH)` in Unix.
-        lock-shared: func() -> result<_, error-code>
+        lock-shared: func() -> result<_, error-code>;
 
         /// Request an exclusive advisory lock for an open file.
         ///
@@ -694,7 +694,7 @@ interface types {
         /// locking, this function returns `error-code::unsupported`.
         ///
         /// Note: This is similar to `flock(fd, LOCK_EX)` in Unix.
-        lock-exclusive: func() -> result<_, error-code>
+        lock-exclusive: func() -> result<_, error-code>;
 
         /// Request a shared advisory lock for an open file.
         ///
@@ -717,7 +717,7 @@ interface types {
         /// locking, this function returns `error-code::unsupported`.
         ///
         /// Note: This is similar to `flock(fd, LOCK_SH | LOCK_NB)` in Unix.
-        try-lock-shared: func() -> result<_, error-code>
+        try-lock-shared: func() -> result<_, error-code>;
 
         /// Request an exclusive advisory lock for an open file.
         ///
@@ -742,12 +742,12 @@ interface types {
         /// locking, this function returns `error-code::unsupported`.
         ///
         /// Note: This is similar to `flock(fd, LOCK_EX | LOCK_NB)` in Unix.
-        try-lock-exclusive: func() -> result<_, error-code>
+        try-lock-exclusive: func() -> result<_, error-code>;
 
         /// Release a shared or exclusive lock on an open file.
         ///
         /// Note: This is similar to `flock(fd, LOCK_UN)` in Unix.
-        unlock: func() -> result<_, error-code>
+        unlock: func() -> result<_, error-code>;
 
         /// Test whether two descriptors refer to the same filesystem object.
         ///
@@ -755,7 +755,7 @@ interface types {
         /// same device (`st_dev`) and inode (`st_ino` or `d_ino`) numbers.
         /// wasi-filesystem does not expose device and inode numbers, so this function
         /// may be used instead.
-        is-same-object: func(other: borrow<descriptor>) -> bool
+        is-same-object: func(other: borrow<descriptor>) -> bool;
 
         /// Return a hash of the metadata associated with a filesystem object referred
         /// to by a descriptor.
@@ -776,7 +776,7 @@ interface types {
         ///    computed hash.
         ///
         /// However, none of these is required.
-        metadata-hash: func() -> result<metadata-hash-value, error-code>
+        metadata-hash: func() -> result<metadata-hash-value, error-code>;
 
         /// Return a hash of the metadata associated with a filesystem object referred
         /// to by a directory descriptor and a relative path.
@@ -787,13 +787,13 @@ interface types {
             path-flags: path-flags,
             /// The relative path of the file or directory to inspect.
             path: string,
-        ) -> result<metadata-hash-value, error-code>
+        ) -> result<metadata-hash-value, error-code>;
     }
 
     /// A stream of directory entries.
     resource directory-entry-stream {
         /// Read a single directory entry from a `directory-entry-stream`.
-        read-directory-entry: func() -> result<option<directory-entry>, error-code>
+        read-directory-entry: func() -> result<option<directory-entry>, error-code>;
     }
 
     /// Attempts to extract a filesystem-related `error-code` from the stream

--- a/crates/wasi/wit/deps/filesystem/world.wit
+++ b/crates/wasi/wit/deps/filesystem/world.wit
@@ -1,6 +1,6 @@
-package wasi:filesystem
+package wasi:filesystem;
 
 world imports {
-    import types
-    import preopens
+    import types;
+    import preopens;
 }

--- a/crates/wasi/wit/deps/http/incoming-handler.wit
+++ b/crates/wasi/wit/deps/http/incoming-handler.wit
@@ -7,7 +7,7 @@
 //   that takes a `request` parameter and returns a `response` result.
 //
 interface incoming-handler {
-  use types.{incoming-request, response-outparam}
+  use types.{incoming-request, response-outparam};
 
   // The `handle` function takes an outparam instead of returning its response
   // so that the component may stream its response while streaming any other
@@ -20,5 +20,5 @@ interface incoming-handler {
   handle: func(
     request: incoming-request,
     response-out: response-outparam
-  )
+  );
 }

--- a/crates/wasi/wit/deps/http/outgoing-handler.wit
+++ b/crates/wasi/wit/deps/http/outgoing-handler.wit
@@ -6,7 +6,7 @@
 //   that takes a `request` parameter and returns a `response` result.
 //
 interface outgoing-handler {
-  use types.{outgoing-request, request-options, future-incoming-response, error}
+  use types.{outgoing-request, request-options, future-incoming-response, error};
 
   // The parameter and result types of the `handle` function allow the caller
   // to concurrently stream the bodies of the outgoing request and the incoming
@@ -16,5 +16,5 @@ interface outgoing-handler {
   handle: func(
     request: outgoing-request,
     options: option<request-options>
-  ) -> result<future-incoming-response, error>
+  ) -> result<future-incoming-response, error>;
 }

--- a/crates/wasi/wit/deps/http/proxy.wit
+++ b/crates/wasi/wit/deps/http/proxy.wit
@@ -1,4 +1,4 @@
-package wasi:http
+package wasi:http;
 
 // The `wasi:http/proxy` world captures a widely-implementable intersection of
 // hosts that includes HTTP forward and reverse proxies. Components targeting
@@ -6,29 +6,29 @@ package wasi:http
 // outgoing HTTP requests.
 world proxy {
   // HTTP proxies have access to time and randomness.
-  import wasi:clocks/wall-clock
-  import wasi:clocks/monotonic-clock
-  import wasi:clocks/timezone
-  import wasi:random/random
+  import wasi:clocks/wall-clock;
+  import wasi:clocks/monotonic-clock;
+  import wasi:clocks/timezone;
+  import wasi:random/random;
 
   // Proxies have standard output and error streams which are expected to
   // terminate in a developer-facing console provided by the host.
-  import wasi:cli/stdout
-  import wasi:cli/stderr
+  import wasi:cli/stdout;
+  import wasi:cli/stderr;
 
   // TODO: this is a temporary workaround until component tooling is able to
   // gracefully handle the absence of stdin. Hosts must return an eof stream
   // for this import, which is what wasi-libc + tooling will do automatically
   // when this import is properly removed.
-  import wasi:cli/stdin
+  import wasi:cli/stdin;
 
   // This is the default handler to use when user code simply wants to make an
   // HTTP request (e.g., via `fetch()`).
-  import outgoing-handler
+  import outgoing-handler;
 
   // The host delivers incoming HTTP requests to a component by calling the
   // `handle` function of this exported interface. A host may arbitrarily reuse
   // or not reuse component instance when delivering incoming HTTP requests and
   // thus a component must be able to handle 0..N calls to `handle`.
-  export incoming-handler
+  export incoming-handler;
 }

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -2,8 +2,8 @@
 // define the HTTP resource types and operations used by the component's
 // imported and exported interfaces.
 interface types {
-  use wasi:io/streams.{input-stream, output-stream}
-  use wasi:io/poll.{pollable}
+  use wasi:io/streams.{input-stream, output-stream};
+  use wasi:io/poll.{pollable};
 
   // This type corresponds to HTTP standard Methods.
   variant method {
@@ -43,28 +43,28 @@ interface types {
   resource fields {
     // Multiple values for a header are multiple entries in the list with the
     // same key.
-    constructor(entries: list<tuple<string,list<u8>>>)
+    constructor(entries: list<tuple<string,list<u8>>>);
 
     // Values off wire are not necessarily well formed, so they are given by
     // list<u8> instead of string.
-    get: func(name: string) -> list<list<u8>>
+    get: func(name: string) -> list<list<u8>>;
 
     // Values off wire are not necessarily well formed, so they are given by
     // list<u8> instead of string.
-    set: func(name: string, value: list<list<u8>>)
-    delete: func(name: string)
-    append: func(name: string, value: list<u8>)
+    set: func(name: string, value: list<list<u8>>);
+    delete: func(name: string);
+    append: func(name: string, value: list<u8>);
 
     // Values off wire are not necessarily well formed, so they are given by
     // list<u8> instead of string.
-    entries: func() -> list<tuple<string,list<u8>>>
+    entries: func() -> list<tuple<string,list<u8>>>;
 
     // Deep copy of all contents in a fields.
-    clone: func() -> fields
+    clone: func() -> fields;
   }
 
-  type headers = fields
-  type trailers = fields
+  type headers = fields;
+  type trailers = fields;
 
   // The following block defines the `incoming-request` and `outgoing-request`
   // resource types that correspond to HTTP standard Requests. Soon, when
@@ -75,19 +75,19 @@ interface types {
   // above). The `consume` and `write` methods may only be called once (and
   // return failure thereafter).
   resource incoming-request {
-    method: func() -> method
+    method: func() -> method;
 
-    path-with-query: func() -> option<string>
+    path-with-query: func() -> option<string>;
 
-    scheme: func() -> option<scheme>
+    scheme: func() -> option<scheme>;
 
-    authority: func() -> option<string>
+    authority: func() -> option<string>;
 
-    headers: func() -> /* child */ headers
+    headers: func() -> /* child */ headers;
     // Will return the input-stream child at most once. If called more than
     // once, subsequent calls will return error.
 
-    consume: func() -> result<incoming-body>
+    consume: func() -> result<incoming-body>;
   }
 
   resource outgoing-request {
@@ -97,11 +97,11 @@ interface types {
       scheme: option<scheme>,
       authority: option<string>,
       headers: borrow<headers>
-    )
+    );
 
     // Will return the outgoing-body child at most once. If called more than
     // once, subsequent calls will return error.
-    write: func() -> result< /* child */ outgoing-body>
+    write: func() -> result< /* child */ outgoing-body>;
   }
 
   // Additional optional parameters that can be set when making a request.
@@ -127,11 +127,11 @@ interface types {
   // (the `wasi:http/handler` interface used for both incoming and outgoing can
   // simply return a `stream`).
   resource response-outparam {
-    set: static func(param: response-outparam, response: result<outgoing-response, error>)
+    set: static func(param: response-outparam, response: result<outgoing-response, error>);
   }
 
   // This type corresponds to the HTTP standard Status Code.
-  type status-code = u16
+  type status-code = u16;
 
   // The following block defines the `incoming-response` and `outgoing-response`
   // resource types that correspond to HTTP standard Responses. Soon, when
@@ -141,14 +141,14 @@ interface types {
   // type (that uses the single `stream` type mentioned above). The `consume` and
   // `write` methods may only be called once (and return failure thereafter).
   resource incoming-response {
-    status: func() -> status-code
+    status: func() -> status-code;
 
-    headers: func() -> /* child */ headers
+    headers: func() -> /* child */ headers;
 
     // May be called at most once. returns error if called additional times.
     // TODO: make incoming-request-consume work the same way, giving a child
     // incoming-body.
-    consume: func() -> result<incoming-body>
+    consume: func() -> result<incoming-body>;
   }
 
   resource incoming-body {
@@ -156,41 +156,41 @@ interface types {
     // incoming-body is dropped (or consumed by call to
     // incoming-body-finish) before the input-stream is dropped.
     // May be called at most once. returns error if called additional times.
-    %stream: func() -> result</* child */ input-stream>
+    %stream: func() -> result</* child */ input-stream>;
 
     // takes ownership of incoming-body. this will trap if the
     // incoming-body-stream child is still alive!
     finish: static func(this: incoming-body) ->
-    /* transitive child of the incoming-response of incoming-body */ future-trailers
+    /* transitive child of the incoming-response of incoming-body */ future-trailers;
   }
 
   resource future-trailers {
     /// Pollable that resolves when the body has been fully read, and the trailers
     /// are ready to be consumed.
-    subscribe: func() -> /* child */ pollable
+    subscribe: func() -> /* child */ pollable;
 
     /// Retrieve reference to trailers, if they are ready.
-    get: func() -> option<result</* child */ trailers, error>>
+    get: func() -> option<result</* child */ trailers, error>>;
   }
 
   resource outgoing-response {
-    constructor(status-code: status-code, headers: borrow<headers>)
+    constructor(status-code: status-code, headers: borrow<headers>);
 
     /// Will give the child outgoing-response at most once. subsequent calls will
     /// return an error.
-    write: func() -> result<outgoing-body>
+    write: func() -> result<outgoing-body>;
   }
 
   resource outgoing-body {
     /// Will give the child output-stream at most once. subsequent calls will
     /// return an error.
-    write: func() -> result</* child */ output-stream>
+    write: func() -> result</* child */ output-stream>;
 
     /// Finalize an outgoing body, optionally providing trailers. This must be
     /// called to signal that the response is complete. If the `outgoing-body` is
     /// dropped without calling `outgoing-body-finalize`, the implementation
     /// should treat the body as corrupted.
-    finish: static func(this: outgoing-body, trailers: option<trailers>)
+    finish: static func(this: outgoing-body, trailers: option<trailers>);
   }
 
   /// The following block defines a special resource type used by the
@@ -207,8 +207,8 @@ interface types {
     /// will return an error here.
     /// inner result indicates whether the incoming-response was available, or an
     /// error occured.
-    get: func() -> option<result<result</* NOT a child*/ incoming-response, error>>>
+    get: func() -> option<result<result</* NOT a child*/ incoming-response, error>>>;
 
-    subscribe: func() -> /* child */ pollable
+    subscribe: func() -> /* child */ pollable;
   }
 }

--- a/crates/wasi/wit/deps/io/poll.wit
+++ b/crates/wasi/wit/deps/io/poll.wit
@@ -1,10 +1,10 @@
-package wasi:io
+package wasi:io;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.
 interface poll {
     /// A "pollable" handle.
-    resource pollable
+    resource pollable;
 
     /// Poll for completion on a set of pollables.
     ///
@@ -24,11 +24,11 @@ interface poll {
     /// do any I/O so it doesn't fail. If any of the I/O sources identified by
     /// the pollables has an error, it is indicated by marking the source as
     /// being reaedy for I/O.
-    poll-list: func(in: list<borrow<pollable>>) -> list<u32>
+    poll-list: func(in: list<borrow<pollable>>) -> list<u32>;
 
     /// Poll for completion on a single pollable.
     ///
     /// This function is similar to `poll-list`, but operates on only a single
     /// pollable. When it returns, the handle is ready for I/O.
-    poll-one: func(in: borrow<pollable>)
+    poll-one: func(in: borrow<pollable>);
 }

--- a/crates/wasi/wit/deps/io/streams.wit
+++ b/crates/wasi/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io
+package wasi:io;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.
@@ -6,7 +6,7 @@ package wasi:io
 /// In the future, the component model is expected to add built-in stream types;
 /// when it does, they are expected to subsume this API.
 interface streams {
-    use poll.{pollable}
+    use poll.{pollable};
 
     /// An error for input-stream and output-stream operations.
     variant stream-error {
@@ -74,14 +74,14 @@ interface streams {
         read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<list<u8>, stream-error>
+        ) -> result<list<u8>, stream-error>;
 
         /// Read bytes from a stream, after blocking until at least one byte can
         /// be read. Except for blocking, identical to `read`.
         blocking-read: func(
             /// The maximum number of bytes to read
             len: u64
-        ) -> result<list<u8>, stream-error>
+        ) -> result<list<u8>, stream-error>;
 
         /// Skip bytes from a stream.
         ///
@@ -98,14 +98,14 @@ interface streams {
         skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Skip bytes from a stream, after blocking until at least one byte
         /// can be skipped. Except for blocking behavior, identical to `skip`.
         blocking-skip: func(
             /// The maximum number of bytes to skip.
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Create a `pollable` which will resolve once either the specified stream
         /// has bytes available to read or the other end of the stream has been
@@ -113,7 +113,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `input-stream`.
         /// Implementations may trap if the `input-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
-        subscribe: func() -> pollable
+        subscribe: func() -> pollable;
     }
 
 
@@ -135,7 +135,7 @@ interface streams {
         /// When this function returns 0 bytes, the `subscribe` pollable will
         /// become ready when this function will report at least 1 byte, or an
         /// error.
-        check-write: func() -> result<u64, stream-error>
+        check-write: func() -> result<u64, stream-error>;
 
         /// Perform a write. This function never blocks.
         ///
@@ -146,7 +146,7 @@ interface streams {
         /// the last call to check-write provided a permit.
         write: func(
             contents: list<u8>
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 bytes, and then flush the stream. Block
         /// until all of these operations are complete, or an error occurs.
@@ -174,7 +174,7 @@ interface streams {
         /// ```
         blocking-write-and-flush: func(
             contents: list<u8>
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Request to flush buffered output. This function never blocks.
         ///
@@ -186,11 +186,11 @@ interface streams {
         /// writes (`check-write` will return `ok(0)`) until the flush has
         /// completed. The `subscribe` pollable will become ready when the
         /// flush has completed and the stream can accept more writes.
-        flush: func() -> result<_, stream-error>
+        flush: func() -> result<_, stream-error>;
 
         /// Request to flush buffered output, and block until flush completes
         /// and stream is ready for writing again.
-        blocking-flush: func() -> result<_, stream-error>
+        blocking-flush: func() -> result<_, stream-error>;
 
         /// Create a `pollable` which will resolve once the output-stream
         /// is ready for more writing, or an error has occured. When this
@@ -202,7 +202,7 @@ interface streams {
         /// The created `pollable` is a child resource of the `output-stream`.
         /// Implementations may trap if the `output-stream` is dropped before
         /// all derived `pollable`s created with this function are dropped.
-        subscribe: func() -> pollable
+        subscribe: func() -> pollable;
 
         /// Write zeroes to a stream.
         ///
@@ -213,7 +213,7 @@ interface streams {
         write-zeroes: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Perform a write of up to 4096 zeroes, and then flush the stream.
         /// Block until all of these operations are complete, or an error
@@ -242,7 +242,7 @@ interface streams {
         blocking-write-zeroes-and-flush: func(
             /// The number of zero-bytes to write
             len: u64
-        ) -> result<_, stream-error>
+        ) -> result<_, stream-error>;
 
         /// Read from one stream and write to another.
         ///
@@ -256,7 +256,7 @@ interface streams {
             src: input-stream,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Read from one stream and write to another, with blocking.
         ///
@@ -267,7 +267,7 @@ interface streams {
             src: input-stream,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
 
         /// Forward the entire contents of an input stream to an output stream.
         ///
@@ -284,6 +284,6 @@ interface streams {
         forward: func(
             /// The stream to read from
             src: input-stream
-        ) -> result<u64, stream-error>
+        ) -> result<u64, stream-error>;
     }
 }

--- a/crates/wasi/wit/deps/io/world.wit
+++ b/crates/wasi/wit/deps/io/world.wit
@@ -1,6 +1,6 @@
-package wasi:io
+package wasi:io;
 
 world imports {
-    import streams
-    import poll
+    import streams;
+    import poll;
 }

--- a/crates/wasi/wit/deps/logging/logging.wit
+++ b/crates/wasi/wit/deps/logging/logging.wit
@@ -1,4 +1,4 @@
-package wasi:logging
+package wasi:logging;
 
 /// WASI Logging is a logging API intended to let users emit log messages with
 /// simple priority levels and context values.
@@ -33,5 +33,5 @@ interface logging {
     /// sent, a context, which is an uninterpreted string meant to help
     /// consumers group similar messages, and a string containing the message
     /// text.
-    log: func(level: level, context: string, message: string)
+    log: func(level: level, context: string, message: string);
 }

--- a/crates/wasi/wit/deps/logging/world.wit
+++ b/crates/wasi/wit/deps/logging/world.wit
@@ -1,5 +1,5 @@
-package wasi:logging
+package wasi:logging;
 
 world imports {
-    import logging
+    import logging;
 }

--- a/crates/wasi/wit/deps/random/insecure-seed.wit
+++ b/crates/wasi/wit/deps/random/insecure-seed.wit
@@ -20,5 +20,5 @@ interface insecure-seed {
     /// This will likely be changed to a value import, to prevent it from being
     /// called multiple times and potentially used for purposes other than DoS
     /// protection.
-    insecure-seed: func() -> tuple<u64, u64>
+    insecure-seed: func() -> tuple<u64, u64>;
 }

--- a/crates/wasi/wit/deps/random/insecure.wit
+++ b/crates/wasi/wit/deps/random/insecure.wit
@@ -11,11 +11,11 @@ interface insecure {
     /// There are no requirements on the values of the returned bytes, however
     /// implementations are encouraged to return evenly distributed values with
     /// a long period.
-    get-insecure-random-bytes: func(len: u64) -> list<u8>
+    get-insecure-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return an insecure pseudo-random `u64` value.
     ///
     /// This function returns the same type of pseudo-random data as
     /// `get-insecure-random-bytes`, represented as a `u64`.
-    get-insecure-random-u64: func() -> u64
+    get-insecure-random-u64: func() -> u64;
 }

--- a/crates/wasi/wit/deps/random/random.wit
+++ b/crates/wasi/wit/deps/random/random.wit
@@ -15,11 +15,11 @@ interface random {
     /// This function must always return fresh data. Deterministic environments
     /// must omit this function, rather than implementing it with deterministic
     /// data.
-    get-random-bytes: func(len: u64) -> list<u8>
+    get-random-bytes: func(len: u64) -> list<u8>;
 
     /// Return a cryptographically-secure random or pseudo-random `u64` value.
     ///
     /// This function returns the same type of data as `get-random-bytes`,
     /// represented as a `u64`.
-    get-random-u64: func() -> u64
+    get-random-u64: func() -> u64;
 }

--- a/crates/wasi/wit/deps/random/world.wit
+++ b/crates/wasi/wit/deps/random/world.wit
@@ -1,7 +1,7 @@
-package wasi:random
+package wasi:random;
 
 world imports {
-    import random
-    import insecure
-    import insecure-seed
+    import random;
+    import insecure;
+    import insecure-seed;
 }

--- a/crates/wasi/wit/deps/sockets/instance-network.wit
+++ b/crates/wasi/wit/deps/sockets/instance-network.wit
@@ -1,9 +1,9 @@
 
 /// This interface provides a value-export of the default network handle..
 interface instance-network {
-	use network.{network}
+	use network.{network};
 
 	/// Get a handle to the default network.
-	instance-network: func() -> network
+	instance-network: func() -> network;
 
 }

--- a/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
@@ -1,13 +1,13 @@
 
 interface ip-name-lookup {
-	use wasi:io/poll.{pollable}
-	use network.{network, error-code, ip-address, ip-address-family}
+	use wasi:io/poll.{pollable};
+	use network.{network, error-code, ip-address, ip-address-family};
 
 
 	/// Resolve an internet host name to a list of IP addresses.
-	/// 
+	///
 	/// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
-	/// 
+	///
 	/// # Parameters
 	/// - `name`: The name to look up. IP addresses are not allowed. Unicode domain names are automatically converted
 	///     to ASCII using IDNA encoding.
@@ -17,45 +17,45 @@ interface ip-name-lookup {
 	///   systems without an active IPv6 interface. Notes:
 	///     - Even when no public IPv6 interfaces are present or active, names like "localhost" can still resolve to an IPv6 address.
 	///     - Whatever is "available" or "unavailable" is volatile and can change everytime a network cable is unplugged.
-	/// 
+	///
 	/// This function never blocks. It either immediately fails or immediately returns successfully with a `resolve-address-stream`
 	/// that can be used to (asynchronously) fetch the results.
-	/// 
+	///
 	/// At the moment, the stream never completes successfully with 0 items. Ie. the first call
 	/// to `resolve-next-address` never returns `ok(none)`. This may change in the future.
-	/// 
+	///
 	/// # Typical errors
 	/// - `invalid-name`:                 `name` is a syntactically invalid domain name.
 	/// - `invalid-name`:                 `name` is an IP address.
 	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAI_FAMILY)
-	/// 
+	///
 	/// # References:
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
 	/// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
-	resolve-addresses: func(network: borrow<network>, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error-code>
+	resolve-addresses: func(network: borrow<network>, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error-code>;
 
 	resource resolve-address-stream {
 		/// Returns the next address from the resolver.
-		/// 
+		///
 		/// This function should be called multiple times. On each call, it will
 		/// return the next address in connection order preference. If all
 		/// addresses have been exhausted, this function returns `none`.
-		/// 
+		///
 		/// This function never returns IPv4-mapped IPv6 addresses.
-		/// 
+		///
 		/// # Typical errors
 		/// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
 		/// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
 		/// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
 		/// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
-		resolve-next-address: func() -> result<option<ip-address>, error-code>
+		resolve-next-address: func() -> result<option<ip-address>, error-code>;
 
 		/// Create a `pollable` which will resolve once the stream is ready for I/O.
-		/// 
+		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable
+		subscribe: func() -> pollable;
 	}
 }

--- a/crates/wasi/wit/deps/sockets/network.wit
+++ b/crates/wasi/wit/deps/sockets/network.wit
@@ -3,10 +3,10 @@ interface network {
 	/// An opaque resource that represents access to (a subset of) the network.
 	/// This enables context-based security for networking.
 	/// There is no need for this to map 1:1 to a physical network interface.
-	resource network
+	resource network;
 
 	/// Error codes.
-	/// 
+	///
 	/// In theory, every API can return any error code.
 	/// In practice, API's typically only return the errors documented per API
 	/// combined with a couple of errors that are always possible:
@@ -14,7 +14,7 @@ interface network {
 	/// - `access-denied`
 	/// - `not-supported`
 	/// - `out-of-memory`
-	/// 
+	///
 	/// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
 	enum error-code {
 		// ### GENERAL ERRORS ###
@@ -23,17 +23,17 @@ interface network {
 		unknown,
 
 		/// Access denied.
-		/// 
+		///
 		/// POSIX equivalent: EACCES, EPERM
 		access-denied,
 
 		/// The operation is not supported.
-		/// 
+		///
 		/// POSIX equivalent: EOPNOTSUPP
 		not-supported,
 
 		/// Not enough memory to complete the operation.
-		/// 
+		///
 		/// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
 		out-of-memory,
 
@@ -46,12 +46,12 @@ interface network {
 		/// Trying to finish an asynchronous operation that:
 		/// - has not been started yet, or:
 		/// - was already finished by a previous `finish-*` call.
-		/// 
+		///
 		/// Note: this is scheduled to be removed when `future`s are natively supported.
 		not-in-progress,
 
 		/// The operation has been aborted because it could not be completed immediately.
-		/// 
+		///
 		/// Note: this is scheduled to be removed when `future`s are natively supported.
 		would-block,
 
@@ -79,7 +79,7 @@ interface network {
 
 		/// A new socket resource could not be created because of a system limit.
 		new-socket-limit,
-		
+
 		/// The socket is already attached to another network.
 		already-attached,
 
@@ -106,10 +106,10 @@ interface network {
 
 		/// The remote address is not reachable
 		remote-unreachable,
-		
+
 
 		// ### TCP SOCKET ERRORS ###
-		
+
 		/// The socket is already in the Listener state.
 		already-listening,
 
@@ -121,14 +121,14 @@ interface network {
 
 		/// The connection was reset.
 		connection-reset,
-		
+
 
 		// ### UDP SOCKET ERRORS ###
 		datagram-too-large,
 
 
 		// ### NAME LOOKUP ERRORS ###
-		
+
 		/// The provided name is a syntactically invalid domain name.
 		invalid-name,
 
@@ -144,14 +144,14 @@ interface network {
 
 	enum ip-address-family {
 		/// Similar to `AF_INET` in POSIX.
-		ipv4, 
+		ipv4,
 
 		/// Similar to `AF_INET6` in POSIX.
 		ipv6,
 	}
 
-	type ipv4-address = tuple<u8, u8, u8, u8>
-	type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>
+	type ipv4-address = tuple<u8, u8, u8, u8>;
+	type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
 
 	variant ip-address {
 		ipv4(ipv4-address),

--- a/crates/wasi/wit/deps/sockets/tcp-create-socket.wit
+++ b/crates/wasi/wit/deps/sockets/tcp-create-socket.wit
@@ -1,27 +1,27 @@
 
 interface tcp-create-socket {
-	use network.{network, error-code, ip-address-family}
-	use tcp.{tcp-socket}
+	use network.{network, error-code, ip-address-family};
+	use tcp.{tcp-socket};
 
 	/// Create a new TCP socket.
-	/// 
+	///
 	/// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
-	/// 
+	///
 	/// This function does not require a network capability handle. This is considered to be safe because
 	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`listen`/`connect`
 	/// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
-	/// 
+	///
 	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
-	/// 
+	///
 	/// # Typical errors
 	/// - `not-supported`:                The host does not support TCP sockets. (EOPNOTSUPP)
 	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAFNOSUPPORT)
 	/// - `new-socket-limit`:             The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-	/// 
+	///
 	/// # References
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>
+	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
 }

--- a/crates/wasi/wit/deps/sockets/tcp.wit
+++ b/crates/wasi/wit/deps/sockets/tcp.wit
@@ -1,8 +1,8 @@
 
 interface tcp {
-	use wasi:io/streams.{input-stream, output-stream}
-	use wasi:io/poll.{pollable}
-	use network.{network, error-code, ip-socket-address, ip-address-family}
+	use wasi:io/streams.{input-stream, output-stream};
+	use wasi:io/poll.{pollable};
+	use network.{network, error-code, ip-socket-address, ip-address-family};
 
 	enum shutdown-type {
 		/// Similar to `SHUT_RD` in POSIX.
@@ -23,38 +23,38 @@ interface tcp {
 		/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
 		/// network interface(s) to bind to.
 		/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
-		/// 
+		///
 		/// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
 		/// implicitly bind the socket.
-		/// 
+		///
 		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		/// 
+		///
 		/// # Typical `start` errors
 		/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
 		/// - `already-bound`:             The socket is already bound. (EINVAL)
 		/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		/// 
+		///
 		/// # Typical `finish` errors
 		/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
 		/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
 		/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
 		/// - `not-in-progress`:           A `bind` operation is not in progress.
 		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
 		/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>
-		finish-bind: func() -> result<_, error-code>
+		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+		finish-bind: func() -> result<_, error-code>;
 
 		/// Connect to a remote endpoint.
-		/// 
+		///
 		/// On success:
 		/// - the socket is transitioned into the Connection state
 		/// - a pair of streams is returned that can be used to read & write to the connection
-		/// 
+		///
 		/// # Typical `start` errors
 		/// - `address-family-mismatch`:   The `remote-address` has the wrong address family. (EAFNOSUPPORT)
 		/// - `invalid-remote-address`:    The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
@@ -63,7 +63,7 @@ interface tcp {
 		/// - `already-connected`:         The socket is already in the Connection state. (EISCONN)
 		/// - `already-listening`:         The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)
 		/// - `concurrency-conflict`:      Another `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		/// 
+		///
 		/// # Typical `finish` errors
 		/// - `timeout`:                   Connection timed out. (ETIMEDOUT)
 		/// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
@@ -72,23 +72,23 @@ interface tcp {
 		/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
 		/// - `not-in-progress`:           A `connect` operation is not in progress.
 		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
 		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
 		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>
-		finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>
+		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+		finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
 
 		/// Start listening for new connections.
-		/// 
+		///
 		/// Transitions the socket into the Listener state.
-		/// 
+		///
 		/// Unlike POSIX:
 		/// - this function is async. This enables interactive WASI hosts to inject permission prompts.
 		/// - the socket must already be explicitly bound.
-		/// 
+		///
 		/// # Typical `start` errors
 		/// - `not-bound`:                 The socket is not bound to any local address. (EDESTADDRREQ)
 		/// - `already-connected`:         The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
@@ -105,145 +105,145 @@ interface tcp {
 		/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
-		start-listen: func() -> result<_, error-code>
-		finish-listen: func() -> result<_, error-code>
+		start-listen: func() -> result<_, error-code>;
+		finish-listen: func() -> result<_, error-code>;
 
 		/// Accept a new client socket.
-		/// 
+		///
 		/// The returned socket is bound and in the Connection state.
-		/// 
+		///
 		/// On success, this function returns the newly accepted client socket along with
 		/// a pair of streams that can be used to read & write to the connection.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-listening`: Socket is not in the Listener state. (EINVAL)
 		/// - `would-block`:   No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// Host implementations must skip over transient errors returned by the native accept syscall.
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
 		/// - <https://man7.org/linux/man-pages/man2/accept.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-		accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>
+		accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
 
 		/// Get the bound local address.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-bound`: The socket is not bound to any local address.
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
 		/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
 		/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-		local-address: func() -> result<ip-socket-address, error-code>
+		local-address: func() -> result<ip-socket-address, error-code>;
 
 		/// Get the bound remote address.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-connected`: The socket is not connected to a remote address. (ENOTCONN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
 		/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-		remote-address: func() -> result<ip-socket-address, error-code>
+		remote-address: func() -> result<ip-socket-address, error-code>;
 
 		/// Whether this is a IPv4 or IPv6 socket.
-		/// 
+		///
 		/// Equivalent to the SO_DOMAIN socket option.
-		address-family: func() -> ip-address-family
-	
+		address-family: func() -> ip-address-family;
+
 		/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-		/// 
+		///
 		/// Equivalent to the IPV6_V6ONLY socket option.
-		/// 
+		///
 		/// # Typical errors
 		/// - `ipv6-only-operation`:  (get/set) `this` socket is an IPv4 socket.
 		/// - `already-bound`:        (set) The socket is already bound.
 		/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		ipv6-only: func() -> result<bool, error-code>
-		set-ipv6-only: func(value: bool) -> result<_, error-code>
+		ipv6-only: func() -> result<bool, error-code>;
+		set-ipv6-only: func(value: bool) -> result<_, error-code>;
 
 		/// Hints the desired listen queue size. Implementations are free to ignore this.
-		/// 
+		///
 		/// # Typical errors
 		/// - `already-connected`:    (set) The socket is already in the Connection state.
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		set-listen-backlog-size: func(value: u64) -> result<_, error-code>
+		set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
 
 		/// Equivalent to the SO_KEEPALIVE socket option.
-		/// 
+		///
 		/// # Typical errors
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		keep-alive: func() -> result<bool, error-code>
-		set-keep-alive: func(value: bool) -> result<_, error-code>
+		keep-alive: func() -> result<bool, error-code>;
+		set-keep-alive: func(value: bool) -> result<_, error-code>;
 
 		/// Equivalent to the TCP_NODELAY socket option.
-		/// 
+		///
 		/// # Typical errors
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		no-delay: func() -> result<bool, error-code>
-		set-no-delay: func(value: bool) -> result<_, error-code>
-	
+		no-delay: func() -> result<bool, error-code>;
+		set-no-delay: func(value: bool) -> result<_, error-code>;
+
 		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-		/// 
+		///
 		/// # Typical errors
 		/// - `already-connected`:    (set) The socket is already in the Connection state.
 		/// - `already-listening`:    (set) The socket is already in the Listener state.
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		unicast-hop-limit: func() -> result<u8, error-code>
-		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>
+		unicast-hop-limit: func() -> result<u8, error-code>;
+		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
 
 		/// The kernel buffer space reserved for sends/receives on this socket.
-		/// 
+		///
 		/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
 		/// 	In other words, after setting a value, reading the same setting back may return a different value.
-		/// 
+		///
 		/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
 		/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
 		/// 	for internal metadata structures.
-		/// 
+		///
 		/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-		/// 
+		///
 		/// # Typical errors
 		/// - `already-connected`:    (set) The socket is already in the Connection state.
 		/// - `already-listening`:    (set) The socket is already in the Listener state.
 		/// - `concurrency-conflict`: (set) A `bind`, `connect` or `listen` operation is already in progress. (EALREADY)
-		receive-buffer-size: func() -> result<u64, error-code>
-		set-receive-buffer-size: func(value: u64) -> result<_, error-code>
-		send-buffer-size: func() -> result<u64, error-code>
-		set-send-buffer-size: func(value: u64) -> result<_, error-code>
+		receive-buffer-size: func() -> result<u64, error-code>;
+		set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+		send-buffer-size: func() -> result<u64, error-code>;
+		set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
 		/// Create a `pollable` which will resolve once the socket is ready for I/O.
-		/// 
+		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable
+		subscribe: func() -> pollable;
 
 		/// Initiate a graceful shutdown.
-		/// 
+		///
 		/// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
 		///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.
 		///   Any data still in the receive queue at time of calling `shutdown` will be discarded.
 		/// - send: the socket is not expecting to send any more data to the peer. All subsequent write
 		///   operations on the `output-stream` associated with this socket will return an error.
 		/// - both: same effect as receive & send combined.
-		/// 
+		///
 		/// The shutdown function does not close (drop) the socket.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-connected`: The socket is not in the Connection state. (ENOTCONN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
 		/// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
-		shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>
+		shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
 	}
 }

--- a/crates/wasi/wit/deps/sockets/udp-create-socket.wit
+++ b/crates/wasi/wit/deps/sockets/udp-create-socket.wit
@@ -1,27 +1,27 @@
 
 interface udp-create-socket {
-	use network.{network, error-code, ip-address-family}
-	use udp.{udp-socket}
+	use network.{network, error-code, ip-address-family};
+	use udp.{udp-socket};
 
 	/// Create a new UDP socket.
-	/// 
+	///
 	/// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)` in POSIX.
-	/// 
+	///
 	/// This function does not require a network capability handle. This is considered to be safe because
 	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect` is called,
 	/// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
-	/// 
+	///
 	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
-	/// 
+	///
 	/// # Typical errors
 	/// - `not-supported`:                The host does not support UDP sockets. (EOPNOTSUPP)
 	/// - `address-family-not-supported`: The specified `address-family` is not supported. (EAFNOSUPPORT)
 	/// - `new-socket-limit`:             The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-	/// 
+	///
 	/// # References:
 	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
 	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
 	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
 	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>
+	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
 }

--- a/crates/wasi/wit/deps/sockets/udp.wit
+++ b/crates/wasi/wit/deps/sockets/udp.wit
@@ -1,7 +1,7 @@
 
 interface udp {
-	use wasi:io/poll.{pollable}
-	use network.{network, error-code, ip-socket-address, ip-address-family}
+	use wasi:io/poll.{pollable};
+	use network.{network, error-code, ip-socket-address, ip-address-family};
 
 
 	record datagram {
@@ -25,74 +25,74 @@ interface udp {
 		/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
 		/// network interface(s) to bind to.
 		/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
-		/// 
+		///
 		/// When a socket is not explicitly bound, the first invocation to connect will implicitly bind the socket.
-		/// 
+		///
 		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		/// 
+		///
 		/// # Typical `start` errors
 		/// - `address-family-mismatch`:   The `local-address` has the wrong address family. (EINVAL)
 		/// - `already-bound`:             The socket is already bound. (EINVAL)
 		/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
-		/// 
+		///
 		/// # Typical `finish` errors
 		/// - `ephemeral-ports-exhausted`: No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
 		/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
 		/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
 		/// - `not-in-progress`:           A `bind` operation is not in progress.
 		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
 		/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>
-		finish-bind: func() -> result<_, error-code>
+		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+		finish-bind: func() -> result<_, error-code>;
 
 		/// Set the destination address.
-		/// 
+		///
 		/// The local-address is updated based on the best network path to `remote-address`.
-		/// 
+		///
 		/// When a destination address is set:
 		/// - all receive operations will only return datagrams sent from the provided `remote-address`.
 		/// - the `send` function can only be used to send to this destination.
-		/// 
+		///
 		/// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
-		/// 
+		///
 		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		/// 
+		///
 		/// # Typical `start` errors
 		/// - `address-family-mismatch`:   The `remote-address` has the wrong address family. (EAFNOSUPPORT)
 		/// - `invalid-remote-address`:    The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
 		/// - `invalid-remote-address`:    The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
 		/// - `already-attached`:          The socket is already bound to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
 		/// - `concurrency-conflict`:      Another `bind` or `connect` operation is already in progress. (EALREADY)
-		/// 
+		///
 		/// # Typical `finish` errors
 		/// - `ephemeral-ports-exhausted`: Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
 		/// - `not-in-progress`:           A `connect` operation is not in progress.
 		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
 		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
 		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>
-		finish-connect: func() -> result<_, error-code>
+		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+		finish-connect: func() -> result<_, error-code>;
 
 		/// Receive messages on the socket.
-		/// 
+		///
 		/// This function attempts to receive up to `max-results` datagrams on the socket without blocking.
 		/// The returned list may contain fewer elements than requested, but never more.
 		/// If `max-results` is 0, this function returns successfully with an empty list.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-bound`:          The socket is not bound to any local address. (EINVAL)
 		/// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
 		/// - `would-block`:        There is no pending data available to be read at the moment. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
@@ -102,22 +102,22 @@ interface udp {
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
 		/// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-		receive: func(max-results: u64) -> result<list<datagram>, error-code>
+		receive: func(max-results: u64) -> result<list<datagram>, error-code>;
 
 		/// Send messages on the socket.
-		/// 
+		///
 		/// This function attempts to send all provided `datagrams` on the socket without blocking and
 		/// returns how many messages were actually sent (or queued for sending).
-		/// 
+		///
 		/// This function semantically behaves the same as iterating the `datagrams` list and sequentially
 		/// sending each individual datagram until either the end of the list has been reached or the first error occurred.
 		/// If at least one datagram has been sent successfully, this function never returns an error.
-		/// 
+		///
 		/// If the input list is empty, the function returns `ok(0)`.
-		/// 
+		///
 		/// The remote address option is required. To send a message to the "connected" peer,
 		/// call `remote-address` to get their address.
-		/// 
+		///
 		/// # Typical errors
 		/// - `address-family-mismatch`: The `remote-address` has the wrong address family. (EAFNOSUPPORT)
 		/// - `invalid-remote-address`:  The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
@@ -127,7 +127,7 @@ interface udp {
 		/// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
 		/// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
 		/// - `would-block`:             The send buffer is currently full. (EWOULDBLOCK, EAGAIN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
@@ -137,78 +137,78 @@ interface udp {
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-		send: func(datagrams: list<datagram>) -> result<u64, error-code>
+		send: func(datagrams: list<datagram>) -> result<u64, error-code>;
 
 		/// Get the current bound address.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-bound`: The socket is not bound to any local address.
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
 		/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
 		/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-		local-address: func() -> result<ip-socket-address, error-code>
+		local-address: func() -> result<ip-socket-address, error-code>;
 
 		/// Get the address set with `connect`.
-		/// 
+		///
 		/// # Typical errors
 		/// - `not-connected`: The socket is not connected to a remote address. (ENOTCONN)
-		/// 
+		///
 		/// # References
 		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
 		/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
 		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
 		/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-		remote-address: func() -> result<ip-socket-address, error-code>
+		remote-address: func() -> result<ip-socket-address, error-code>;
 
 		/// Whether this is a IPv4 or IPv6 socket.
-		/// 
+		///
 		/// Equivalent to the SO_DOMAIN socket option.
-		address-family: func() -> ip-address-family
+		address-family: func() -> ip-address-family;
 
 		/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-		/// 
+		///
 		/// Equivalent to the IPV6_V6ONLY socket option.
-		/// 
+		///
 		/// # Typical errors
 		/// - `ipv6-only-operation`:  (get/set) `this` socket is an IPv4 socket.
 		/// - `already-bound`:        (set) The socket is already bound.
 		/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
 		/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
-		ipv6-only: func() -> result<bool, error-code>
-		set-ipv6-only: func(value: bool) -> result<_, error-code>
+		ipv6-only: func() -> result<bool, error-code>;
+		set-ipv6-only: func(value: bool) -> result<_, error-code>;
 
 		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-		/// 
+		///
 		/// # Typical errors
 		/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
-		unicast-hop-limit: func() -> result<u8, error-code>
-		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>
+		unicast-hop-limit: func() -> result<u8, error-code>;
+		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
 
 		/// The kernel buffer space reserved for sends/receives on this socket.
-		/// 
+		///
 		/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
 		/// 	In other words, after setting a value, reading the same setting back may return a different value.
-		/// 
+		///
 		/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
 		/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
 		/// 	for internal metadata structures.
-		/// 
+		///
 		/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-		/// 
+		///
 		/// # Typical errors
 		/// - `concurrency-conflict`: (set) Another `bind` or `connect` operation is already in progress. (EALREADY)
-		receive-buffer-size: func() -> result<u64, error-code>
-		set-receive-buffer-size: func(value: u64) -> result<_, error-code>
-		send-buffer-size: func() -> result<u64, error-code>
-		set-send-buffer-size: func(value: u64) -> result<_, error-code>
+		receive-buffer-size: func() -> result<u64, error-code>;
+		set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+		send-buffer-size: func() -> result<u64, error-code>;
+		set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
 		/// Create a `pollable` which will resolve once the socket is ready for I/O.
-		/// 
+		///
 		/// Note: this function is here for WASI Preview2 only.
 		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable
+		subscribe: func() -> pollable;
 	}
 }

--- a/crates/wasi/wit/deps/sockets/world.wit
+++ b/crates/wasi/wit/deps/sockets/world.wit
@@ -1,11 +1,11 @@
-package wasi:sockets
+package wasi:sockets;
 
 world imports {
-    import instance-network
-    import network
-    import udp
-    import udp-create-socket
-    import tcp
-    import tcp-create-socket
-    import ip-name-lookup
+    import instance-network;
+    import network;
+    import udp;
+    import udp-create-socket;
+    import tcp;
+    import tcp-create-socket;
+    import ip-name-lookup;
 }

--- a/crates/wasi/wit/main.wit
+++ b/crates/wasi/wit/main.wit
@@ -1,33 +1,33 @@
-package wasmtime:wasi
+package wasmtime:wasi;
 
 // All of the same imports available in the wasi:cli/command world, but no
 // export required:
 world preview1-adapter-reactor {
-  import wasi:clocks/wall-clock
-  import wasi:clocks/monotonic-clock
-  import wasi:clocks/timezone
-  import wasi:filesystem/types
-  import wasi:filesystem/preopens
-  import wasi:sockets/instance-network
-  import wasi:sockets/ip-name-lookup
-  import wasi:sockets/network
-  import wasi:sockets/tcp-create-socket
-  import wasi:sockets/tcp
-  import wasi:sockets/udp-create-socket
-  import wasi:sockets/udp
-  import wasi:random/random
-  import wasi:random/insecure
-  import wasi:random/insecure-seed
-  import wasi:io/poll
-  import wasi:io/streams
-  import wasi:cli/environment
-  import wasi:cli/exit
-  import wasi:cli/stdin
-  import wasi:cli/stdout
-  import wasi:cli/stderr
-  import wasi:cli/terminal-input
-  import wasi:cli/terminal-output
-  import wasi:cli/terminal-stdin
-  import wasi:cli/terminal-stdout
-  import wasi:cli/terminal-stderr
+  import wasi:clocks/wall-clock;
+  import wasi:clocks/monotonic-clock;
+  import wasi:clocks/timezone;
+  import wasi:filesystem/types;
+  import wasi:filesystem/preopens;
+  import wasi:sockets/instance-network;
+  import wasi:sockets/ip-name-lookup;
+  import wasi:sockets/network;
+  import wasi:sockets/tcp-create-socket;
+  import wasi:sockets/tcp;
+  import wasi:sockets/udp-create-socket;
+  import wasi:sockets/udp;
+  import wasi:random/random;
+  import wasi:random/insecure;
+  import wasi:random/insecure-seed;
+  import wasi:io/poll;
+  import wasi:io/streams;
+  import wasi:cli/environment;
+  import wasi:cli/exit;
+  import wasi:cli/stdin;
+  import wasi:cli/stdout;
+  import wasi:cli/stderr;
+  import wasi:cli/terminal-input;
+  import wasi:cli/terminal-output;
+  import wasi:cli/terminal-stdin;
+  import wasi:cli/terminal-stdout;
+  import wasi:cli/terminal-stderr;
 }

--- a/crates/wasi/wit/test.wit
+++ b/crates/wasi/wit/test.wit
@@ -1,44 +1,44 @@
 // only used as part of `test-programs`
 world test-reactor {
 
-  import wasi:cli/environment
-  import wasi:io/poll
-  import wasi:io/streams
-  import wasi:filesystem/types
-  import wasi:filesystem/preopens
-  import wasi:cli/exit
+  import wasi:cli/environment;
+  import wasi:io/poll;
+  import wasi:io/streams;
+  import wasi:filesystem/types;
+  import wasi:filesystem/preopens;
+  import wasi:cli/exit;
 
-  export add-strings: func(s: list<string>) -> u32
-  export get-strings: func() -> list<string>
+  export add-strings: func(s: list<string>) -> u32;
+  export get-strings: func() -> list<string>;
 
-  use wasi:io/streams.{output-stream}
+  use wasi:io/streams.{output-stream};
 
-  export write-strings-to: func(o: output-stream) -> result
+  export write-strings-to: func(o: output-stream) -> result;
 
-  use wasi:filesystem/types.{descriptor-stat}
-  export pass-an-imported-record: func(d: descriptor-stat) -> string
+  use wasi:filesystem/types.{descriptor-stat};
+  export pass-an-imported-record: func(d: descriptor-stat) -> string;
 }
 
 world test-command {
-  import wasi:io/poll
-  import wasi:io/streams
-  import wasi:cli/environment
-  import wasi:cli/stdin
-  import wasi:cli/stdout
-  import wasi:cli/stderr
+  import wasi:io/poll;
+  import wasi:io/streams;
+  import wasi:cli/environment;
+  import wasi:cli/stdin;
+  import wasi:cli/stdout;
+  import wasi:cli/stderr;
 }
 
 world test-command-with-sockets {
-  import wasi:io/poll
-  import wasi:io/streams
-  import wasi:cli/environment
-  import wasi:cli/stdin
-  import wasi:cli/stdout
-  import wasi:cli/stderr
-  import wasi:sockets/tcp
-  import wasi:sockets/tcp-create-socket
-  import wasi:sockets/network
-  import wasi:sockets/instance-network
-  import wasi:sockets/ip-name-lookup
-  import wasi:clocks/monotonic-clock
+  import wasi:io/poll;
+  import wasi:io/streams;
+  import wasi:cli/environment;
+  import wasi:cli/stdin;
+  import wasi:cli/stdout;
+  import wasi:cli/stderr;
+  import wasi:sockets/tcp;
+  import wasi:sockets/tcp-create-socket;
+  import wasi:sockets/network;
+  import wasi:sockets/instance-network;
+  import wasi:sockets/ip-name-lookup;
+  import wasi:clocks/monotonic-clock;
 }

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -74,11 +74,11 @@ pub(crate) use self::store::ComponentStoreData;
 /// ```text,ignore
 /// // wit/my-component.wit
 ///
-/// package my:project
+/// package my:project;
 ///
 /// world hello-world {
-///     import name: func() -> string
-///     export greet: func()
+///     import name: func() -> string;
+///     export greet: func();
 /// }
 /// ```
 ///
@@ -153,18 +153,18 @@ pub(crate) use self::store::ComponentStoreData;
 /// ```text,ignore
 /// // wit/my-component.wit
 ///
-/// package my:project
+/// package my:project;
 ///
 /// interface host {
-///     gen-random-integer: func() -> u32
-///     sha256: func(bytes: list<u8>) -> string
+///     gen-random-integer: func() -> u32;
+///     sha256: func(bytes: list<u8>) -> string;
 /// }
 ///
 /// default world hello-world {
-///     import host
+///     import host;
 ///
 ///     export demo: interface {
-///         run: func()
+///         run: func();
 ///     }
 /// }
 /// ```
@@ -258,7 +258,7 @@ pub(crate) use self::store::ComponentStoreData;
 ///     // Instead of `path` the WIT document can be provided inline if
 ///     // desired.
 ///     inline: "
-///         package my:inline
+///         package my:inline;
 ///
 ///         world foo {
 ///             // ...
@@ -326,7 +326,7 @@ pub(crate) use self::store::ComponentStoreData;
 ///     // Restrict the code generated to what's needed for the interface
 ///     // imports in the inlined WIT document fragment.
 ///     interfaces: "
-///         import wasi:cli/command
+///         import wasi:cli/command;
 ///     ",
 ///
 ///     // Remap imported interfaces or resources to types defined in Rust

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -15,14 +15,14 @@ mod no_imports {
 
     wasmtime::component::bindgen!({
         inline: "
-            package foo:foo
+            package foo:foo;
 
             world no-imports {
                 export foo: interface {
-                    foo: func()
+                    foo: func();
                 }
 
-                export bar: func()
+                export bar: func();
             }
         ",
     });
@@ -62,14 +62,14 @@ mod one_import {
 
     wasmtime::component::bindgen!({
         inline: "
-            package foo:foo
+            package foo:foo;
 
             world one-import {
                 import foo: interface {
-                    foo: func()
+                    foo: func();
                 }
 
-                export bar: func()
+                export bar: func();
             }
         ",
     });
@@ -127,14 +127,14 @@ mod resources_at_world_level {
 
     wasmtime::component::bindgen!({
         inline: "
-            package foo:foo
+            package foo:foo;
 
             world resources {
                 resource x {
-                    constructor()
+                    constructor();
                 }
 
-                export y: func(x: x)
+                export y: func(x: x);
             }
         ",
     });
@@ -216,22 +216,22 @@ mod resources_at_interface_level {
 
     wasmtime::component::bindgen!({
         inline: "
-            package foo:foo
+            package foo:foo;
 
             interface def {
                 resource x {
-                    constructor()
+                    constructor();
                 }
             }
 
             interface user {
-                use def.{x}
+                use def.{x};
 
-                y: func(x: x)
+                y: func(x: x);
             }
 
             world resources {
-                export user
+                export user;
             }
         ",
     });
@@ -322,12 +322,12 @@ mod async_config {
 
     wasmtime::component::bindgen!({
         inline: "
-            package foo:foo
+            package foo:foo;
 
             world t1 {
-                import x: func()
-                import y: func()
-                export z: func()
+                import x: func();
+                import y: func();
+                export z: func();
             }
         ",
         async: true,
@@ -352,12 +352,12 @@ mod async_config {
 
     wasmtime::component::bindgen!({
         inline: "
-            package foo:foo
+            package foo:foo;
 
             world t2 {
-                import x: func()
-                import y: func()
-                export z: func()
+                import x: func();
+                import y: func();
+                export z: func();
             }
         ",
         async: {
@@ -382,12 +382,12 @@ mod async_config {
 
     wasmtime::component::bindgen!({
         inline: "
-            package foo:foo
+            package foo:foo;
 
             world t3 {
-                import x: func()
-                import y: func()
-                export z: func()
+                import x: func();
+                import y: func();
+                export z: func();
             }
         ",
         async: {
@@ -418,27 +418,27 @@ mod exported_resources {
 
     wasmtime::component::bindgen!({
         inline: "
-            package foo:foo
+            package foo:foo;
 
             interface a {
                 resource x {
-                    constructor()
+                    constructor();
                 }
             }
 
             world resources {
                 export b: interface {
-                    use a.{x as y}
+                    use a.{x as y};
 
                     resource x {
-                        constructor(y: y)
-                        foo: func() -> u32
+                        constructor(y: y);
+                        foo: func() -> u32;
                     }
                 }
 
-                resource x
+                resource x;
 
-                export f: func(x1: x, x2: x) -> x
+                export f: func(x1: x, x2: x) -> x;
             }
         ",
     });

--- a/tests/all/component_model/bindgen/ownership.rs
+++ b/tests/all/component_model/bindgen/ownership.rs
@@ -118,10 +118,10 @@ fn component() -> String {
 fn owning() -> Result<()> {
     wasmtime::component::bindgen!({
         inline: "
-        package inline:inline
+        package inline:inline;
         world test {
             export lists: interface {
-                foo: func(a: list<list<string>>) -> list<list<string>>
+                foo: func(a: list<list<string>>) -> list<list<string>>;
             }
 
             export thing-in: interface {
@@ -130,7 +130,7 @@ fn owning() -> Result<()> {
                     value: list<string>
                 }
 
-                bar: func(a: thing)
+                bar: func(a: thing);
             }
 
             export thing-in-and-out: interface {
@@ -139,7 +139,7 @@ fn owning() -> Result<()> {
                     value: list<string>
                 }
 
-                baz: func(a: thing) -> thing
+                baz: func(a: thing) -> thing;
             }
         }",
         ownership: Owning
@@ -186,10 +186,10 @@ fn owning() -> Result<()> {
 fn borrowing_no_duplication() -> Result<()> {
     wasmtime::component::bindgen!({
         inline: "
-        package inline:inline
+        package inline:inline;
         world test {
             export lists: interface {
-                foo: func(a: list<list<string>>) -> list<list<string>>
+                foo: func(a: list<list<string>>) -> list<list<string>>;
             }
 
             export thing-in: interface {
@@ -198,7 +198,7 @@ fn borrowing_no_duplication() -> Result<()> {
                     value: list<string>
                 }
 
-                bar: func(a: thing)
+                bar: func(a: thing);
             }
 
             export thing-in-and-out: interface {
@@ -207,7 +207,7 @@ fn borrowing_no_duplication() -> Result<()> {
                     value: list<string>
                 }
 
-                baz: func(a: thing) -> thing
+                baz: func(a: thing) -> thing;
             }
         }",
         ownership: Borrowing {
@@ -256,10 +256,10 @@ fn borrowing_no_duplication() -> Result<()> {
 fn borrowing_with_duplication() -> Result<()> {
     wasmtime::component::bindgen!({
         inline: "
-        package inline:inline
+        package inline:inline;
         world test {
             export lists: interface {
-                foo: func(a: list<list<string>>) -> list<list<string>>
+                foo: func(a: list<list<string>>) -> list<list<string>>;
             }
 
             export thing-in: interface {
@@ -268,7 +268,7 @@ fn borrowing_with_duplication() -> Result<()> {
                     value: list<string>
                 }
 
-                bar: func(a: thing)
+                bar: func(a: thing);
             }
 
             export thing-in-and-out: interface {
@@ -277,7 +277,7 @@ fn borrowing_with_duplication() -> Result<()> {
                     value: list<string>
                 }
 
-                baz: func(a: thing) -> thing
+                baz: func(a: thing) -> thing;
             }
         }",
         ownership: Borrowing {

--- a/tests/all/component_model/bindgen/results.rs
+++ b/tests/all/component_model/bindgen/results.rs
@@ -9,13 +9,13 @@ mod empty_error {
     use super::*;
     wasmtime::component::bindgen!({
         inline: "
-        package inline:inline
+        package inline:inline;
         world result-playground {
             import imports: interface {
-                empty-error: func(a: float64) -> result<float64>
+                empty-error: func(a: float64) -> result<float64>;
             }
 
-            export empty-error: func(a: float64) -> result<float64>
+            export empty-error: func(a: float64) -> result<float64>;
         }",
     });
 
@@ -110,13 +110,13 @@ mod string_error {
     use super::*;
     wasmtime::component::bindgen!({
         inline: "
-        package inline:inline
+        package inline:inline;
         world result-playground {
             import imports: interface {
-                string-error: func(a: float64) -> result<float64, string>
+                string-error: func(a: float64) -> result<float64, string>;
             }
 
-            export string-error: func(a: float64) -> result<float64, string>
+            export string-error: func(a: float64) -> result<float64, string>;
         }",
     });
 
@@ -226,16 +226,16 @@ mod enum_error {
 
     wasmtime::component::bindgen!({
         inline: "
-        package inline:inline
+        package inline:inline;
         interface imports {
             enum e1 { a, b, c }
-            enum-error: func(a: float64) -> result<float64, e1>
+            enum-error: func(a: float64) -> result<float64, e1>;
         }
         world result-playground {
-            import imports
+            import imports;
             export foo: interface {
                 enum e1 { a, b, c }
-                enum-error: func(a: float64) -> result<float64, e1>
+                enum-error: func(a: float64) -> result<float64, e1>;
             }
         }",
         trappable_error_type: { "inline:inline/imports"::e1: TrappableE1 }
@@ -406,16 +406,16 @@ mod record_error {
 
     wasmtime::component::bindgen!({
         inline: "
-        package inline:inline
+        package inline:inline;
         interface imports {
             record e2 { line: u32, col: u32 }
-            record-error: func(a: float64) -> result<float64, e2>
+            record-error: func(a: float64) -> result<float64, e2>;
         }
         world result-playground {
-            import imports
+            import imports;
             export foo: interface {
                 record e2 { line: u32, col: u32 }
-                record-error: func(a: float64) -> result<float64, e2>
+                record-error: func(a: float64) -> result<float64, e2>;
             }
         }",
         // Literal strings can be used for the interface and typename fields instead of
@@ -575,20 +575,20 @@ mod variant_error {
 
     wasmtime::component::bindgen!({
         inline: "
-        package inline:inline
+        package inline:inline;
         interface imports {
             enum e1 { a, b, c }
             record e2 { line: u32, col: u32 }
             variant e3 { E1(e1), E2(e2) }
-            variant-error: func(a: float64) -> result<float64, e3>
+            variant-error: func(a: float64) -> result<float64, e3>;
         }
         world result-playground {
-            import imports
+            import imports;
             export foo: interface {
                 enum e1 { a, b, c }
                 record e2 { line: u32, col: u32 }
                 variant e3 { E1(e1), E2(e2) }
-                variant-error: func(a: float64) -> result<float64, e3>
+                variant-error: func(a: float64) -> result<float64, e3>;
             }
         }",
         trappable_error_type: { "inline:inline/imports"::e3: TrappableE3 }
@@ -770,20 +770,20 @@ mod multiple_interfaces_error {
 
     wasmtime::component::bindgen!({
         inline: "
-        package inline:inline
+        package inline:inline;
         interface types {
             enum e1 { a, b, c }
-            enum-error: func(a: float64) -> result<float64, e1>
+            enum-error: func(a: float64) -> result<float64, e1>;
         }
         interface imports {
-            use types.{e1}
-            enum-error: func(a: float64) -> result<float64, e1>
+            use types.{e1};
+            enum-error: func(a: float64) -> result<float64, e1>;
         }
         world result-playground {
-            import imports
+            import imports;
             export foo: interface {
                 enum e1 { a, b, c }
-                enum-error: func(a: float64) -> result<float64, e1>
+                enum-error: func(a: float64) -> result<float64, e1>;
             }
         }",
         trappable_error_type: { "inline:inline/types"::e1: TrappableE1 }
@@ -967,20 +967,20 @@ mod with_remapping {
         wasmtime::component::bindgen!({
             interfaces: "
             import imports: interface {
-                empty-error: func(a: float64) -> result<float64>
+                empty-error: func(a: float64) -> result<float64>;
             }",
         });
     }
 
     wasmtime::component::bindgen!({
         inline: "
-        package inline:inline
+        package inline:inline;
         world result-playground {
             import imports: interface {
-                empty-error: func(a: float64) -> result<float64>
+                empty-error: func(a: float64) -> result<float64>;
             }
 
-            export empty-error: func(a: float64) -> result<float64>
+            export empty-error: func(a: float64) -> result<float64>;
         }",
         with: {
             "imports": interfaces::imports,


### PR DESCRIPTION
To prepare this commit I've run `WIT_REQUIRE_SEMICOLONS=1 ./ci/run-tests.sh` locally which configures `wit-parser` to generate an error for missing semicolons in WIT files. This led me to add quite a few semicolons in quite a few places in what is going to be the first of a few batches of semicolons.

CI checks for this cannot be added just yet because the wasi-nn spec is a submodule which needs to be updated with semicolons before this repository can require semicolons. Nevertheless that doesn't stop us from using semicolons in the meantime (yay gradual rollout of changes!) so I figure this would be good to get in sooner rather than later.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
