### PR TITLE
Bump regalloc2 to 0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2196,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b4dcbd3a2ae7fb94b5813fa0e957c6ab51bf5d0a8ee1b69e0c2d0f1e6eb8485"
+checksum = "ad156d539c879b7a24a363a2016d77961786e71f48f2e2fc8302a92abd2429a6"
 dependencies = [
  "hashbrown 0.13.2",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ byte-array-literals = { path = "crates/wasi-preview1-component-adapter/byte-arra
 
 # Bytecode Alliance maintained dependencies:
 # ---------------------------
-regalloc2 = "0.9.2"
+regalloc2 = "0.9.3"
 
 # cap-std family:
 target-lexicon = { version = "0.12.3", default-features = false, features = ["std"] }

--- a/cranelift/filetests/filetests/isa/aarch64/call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call.clif
@@ -707,8 +707,8 @@ block0(v0: i128, v1: i64):
 ;   mov x5, x1
 ;   load_ext_name x10, TestCase(%f14)+0
 ;   mov x0, x4
-;   mov x2, x4
 ;   mov x1, x5
+;   mov x2, x4
 ;   mov x3, x5
 ;   blr x10
 ;   add sp, sp, #16
@@ -732,8 +732,8 @@ block0(v0: i128, v1: i64):
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f14 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   mov x0, x4
-;   mov x2, x4
 ;   mov x1, x5
+;   mov x2, x4
 ;   mov x3, x5
 ;   blr x10
 ;   add sp, sp, #0x10
@@ -785,8 +785,8 @@ block0(v0: i128, v1: i64):
 ;   mov x5, x1
 ;   load_ext_name x10, TestCase(%f15)+0
 ;   mov x0, x4
-;   mov x2, x4
 ;   mov x1, x5
+;   mov x2, x4
 ;   mov x3, x5
 ;   blr x10
 ;   add sp, sp, #16
@@ -810,8 +810,8 @@ block0(v0: i128, v1: i64):
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f15 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   mov x0, x4
-;   mov x2, x4
 ;   mov x1, x5
+;   mov x2, x4
 ;   mov x3, x5
 ;   blr x10
 ;   add sp, sp, #0x10

--- a/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/reftypes.clif
@@ -106,8 +106,8 @@ block3(v7: r64, v8: r64):
 ;   uxtb w12, w0
 ;   cbnz x12, label2 ; b label1
 ; block1:
-;   mov x1, x24
 ;   ldr x0, [sp, #16]
+;   mov x1, x24
 ;   b label3
 ; block2:
 ;   mov x0, x24
@@ -144,8 +144,8 @@ block3(v7: r64, v8: r64):
 ;   uxtb w12, w0
 ;   cbnz x12, #0x58
 ; block2: ; offset 0x4c
-;   mov x1, x24
 ;   ldur x0, [sp, #0x10]
+;   mov x1, x24
 ;   b #0x60
 ; block3: ; offset 0x58
 ;   mov x0, x24

--- a/cranelift/filetests/filetests/isa/aarch64/simd-narrow.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/simd-narrow.clif
@@ -10,16 +10,14 @@ block0(v0: i16x4, v1: i16x4):
 
 ; VCode:
 ; block0:
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v3.d[1], v1.d[0]
-;   sqxtn v0.8b, v3.8h
+;   mov v0.d[1], v0.d[1], v1.d[0]
+;   sqxtn v0.8b, v0.8h
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v1.d[0]
-;   sqxtn v0.8b, v3.8h
+;   mov v0.d[1], v1.d[0]
+;   sqxtn v0.8b, v0.8h
 ;   ret
 
 function %snarrow_i16x8(i16x8, i16x8) -> i8x16 {
@@ -48,16 +46,14 @@ block0(v0: i32x2, v1: i32x2):
 
 ; VCode:
 ; block0:
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v3.d[1], v1.d[0]
-;   sqxtn v0.4h, v3.4s
+;   mov v0.d[1], v0.d[1], v1.d[0]
+;   sqxtn v0.4h, v0.4s
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v1.d[0]
-;   sqxtn v0.4h, v3.4s
+;   mov v0.d[1], v1.d[0]
+;   sqxtn v0.4h, v0.4s
 ;   ret
 
 function %snarrow_i32x4(i32x4, i32x4) -> i16x8 {
@@ -104,16 +100,14 @@ block0(v0: i16x4, v1: i16x4):
 
 ; VCode:
 ; block0:
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v3.d[1], v1.d[0]
-;   sqxtun v0.8b, v3.8h
+;   mov v0.d[1], v0.d[1], v1.d[0]
+;   sqxtun v0.8b, v0.8h
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v1.d[0]
-;   sqxtun v0.8b, v3.8h
+;   mov v0.d[1], v1.d[0]
+;   sqxtun v0.8b, v0.8h
 ;   ret
 
 function %unarrow_i16x8(i16x8, i16x8) -> i8x16 {
@@ -142,16 +136,14 @@ block0(v0: i32x2, v1: i32x2):
 
 ; VCode:
 ; block0:
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v3.d[1], v1.d[0]
-;   sqxtun v0.4h, v3.4s
+;   mov v0.d[1], v0.d[1], v1.d[0]
+;   sqxtun v0.4h, v0.4s
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v1.d[0]
-;   sqxtun v0.4h, v3.4s
+;   mov v0.d[1], v1.d[0]
+;   sqxtun v0.4h, v0.4s
 ;   ret
 
 function %unarrow_i32x4(i32x4, i32x4) -> i16x8 {
@@ -198,16 +190,14 @@ block0(v0: i16x4, v1: i16x4):
 
 ; VCode:
 ; block0:
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v3.d[1], v1.d[0]
-;   uqxtn v0.8b, v3.8h
+;   mov v0.d[1], v0.d[1], v1.d[0]
+;   uqxtn v0.8b, v0.8h
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v1.d[0]
-;   uqxtn v0.8b, v3.8h
+;   mov v0.d[1], v1.d[0]
+;   uqxtn v0.8b, v0.8h
 ;   ret
 
 function %uunarrow_i16x8(i16x8, i16x8) -> i8x16 {
@@ -236,16 +226,14 @@ block0(v0: i32x2, v1: i32x2):
 
 ; VCode:
 ; block0:
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v3.d[1], v1.d[0]
-;   uqxtn v0.4h, v3.4s
+;   mov v0.d[1], v0.d[1], v1.d[0]
+;   uqxtn v0.4h, v0.4s
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   mov v3.16b, v0.16b
-;   mov v3.d[1], v1.d[0]
-;   uqxtn v0.4h, v3.4s
+;   mov v0.d[1], v1.d[0]
+;   uqxtn v0.4h, v0.4s
 ;   ret
 
 function %uunarrow_i32x4(i32x4, i32x4) -> i16x8 {

--- a/cranelift/filetests/filetests/isa/aarch64/stack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack.clif
@@ -479,8 +479,8 @@ block0(v0: i8):
 ;   add x14, x14, #37
 ;   ldr x15, [sp, #1144]
 ;   add x15, x15, #39
-;   ldr x3, [sp, #1128]
 ;   ldr x1, [sp, #1136]
+;   ldr x3, [sp, #1128]
 ;   add x1, x1, x3
 ;   ldr x2, [sp, #1112]
 ;   ldr x6, [sp, #1120]
@@ -500,8 +500,8 @@ block0(v0: i8):
 ;   ldr x23, [sp, #1032]
 ;   ldr x24, [sp, #1040]
 ;   add x23, x24, x23
-;   ldr x25, [sp, #1016]
 ;   ldr x24, [sp, #1024]
+;   ldr x25, [sp, #1016]
 ;   add x24, x24, x25
 ;   ldr x25, [sp, #1008]
 ;   add x25, x25, x26
@@ -657,8 +657,8 @@ block0(v0: i8):
 ;   add x14, x14, #0x25
 ;   ldr x15, [sp, #0x478]
 ;   add x15, x15, #0x27
-;   ldr x3, [sp, #0x468]
 ;   ldr x1, [sp, #0x470]
+;   ldr x3, [sp, #0x468]
 ;   add x1, x1, x3
 ;   ldr x2, [sp, #0x458]
 ;   ldr x6, [sp, #0x460]
@@ -678,8 +678,8 @@ block0(v0: i8):
 ;   ldr x23, [sp, #0x408]
 ;   ldr x24, [sp, #0x410]
 ;   add x23, x24, x23
-;   ldr x25, [sp, #0x3f8]
 ;   ldr x24, [sp, #0x400]
+;   ldr x25, [sp, #0x3f8]
 ;   add x24, x24, x25
 ;   ldr x25, [sp, #0x3f0]
 ;   add x25, x25, x26

--- a/cranelift/filetests/filetests/isa/riscv64/call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/call.clif
@@ -633,17 +633,17 @@ block0(v0: i128, v1: i64):
 ;   sd s3,-8(sp)
 ;   add sp,-16
 ; block0:
-;   mv a7,a0
 ;   mv a6,a2
+;   mv a7,a0
 ;   add sp,-16
 ;   virtual_sp_offset_adj +16
 ;   sd a1,0(sp)
 ;   mv a5,a1
 ;   load_sym s3,%f14+0
-;   mv a1,a5
-;   mv a3,a5
 ;   mv a0,a7
+;   mv a1,a5
 ;   mv a2,a7
+;   mv a3,a5
 ;   mv a4,a7
 ;   callind s3
 ;   add sp,+16
@@ -664,8 +664,8 @@ block0(v0: i128, v1: i64):
 ;   sd s3, -8(sp)
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x18
-;   mv a7, a0
 ;   mv a6, a2
+;   mv a7, a0
 ;   addi sp, sp, -0x10
 ;   sd a1, 0(sp)
 ;   mv a5, a1
@@ -674,10 +674,10 @@ block0(v0: i128, v1: i64):
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f14 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   mv a1, a5
-;   mv a3, a5
 ;   mv a0, a7
+;   mv a1, a5
 ;   mv a2, a7
+;   mv a3, a5
 ;   mv a4, a7
 ;   jalr s3
 ;   addi sp, sp, 0x10
@@ -736,17 +736,17 @@ block0(v0: i128, v1: i64):
 ;   sd s3,-8(sp)
 ;   add sp,-16
 ; block0:
-;   mv a7,a0
 ;   mv a6,a2
+;   mv a7,a0
 ;   add sp,-16
 ;   virtual_sp_offset_adj +16
 ;   sd a1,0(sp)
 ;   mv a5,a1
 ;   load_sym s3,%f15+0
-;   mv a1,a5
-;   mv a3,a5
 ;   mv a0,a7
+;   mv a1,a5
 ;   mv a2,a7
+;   mv a3,a5
 ;   mv a4,a7
 ;   callind s3
 ;   add sp,+16
@@ -767,8 +767,8 @@ block0(v0: i128, v1: i64):
 ;   sd s3, -8(sp)
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x18
-;   mv a7, a0
 ;   mv a6, a2
+;   mv a7, a0
 ;   addi sp, sp, -0x10
 ;   sd a1, 0(sp)
 ;   mv a5, a1
@@ -777,10 +777,10 @@ block0(v0: i128, v1: i64):
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %f15 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   mv a1, a5
-;   mv a3, a5
 ;   mv a0, a7
+;   mv a1, a5
 ;   mv a2, a7
+;   mv a3, a5
 ;   mv a4, a7
 ;   jalr s3
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
@@ -95,8 +95,8 @@ block3(v7: r64, v8: r64):
 ;   add sp,-48
 ; block0:
 ;   mv a3,a0
-;   sd a1,16(nominal_sp)
 ;   mv s5,a2
+;   sd a1,16(nominal_sp)
 ;   mv a3,a0
 ;   mv s9,a3
 ;   load_sym a5,%f+0
@@ -107,8 +107,8 @@ block3(v7: r64, v8: r64):
 ;   andi a5,a0,255
 ;   bne a5,zero,taken(label2),not_taken(label1)
 ; block1:
-;   mv a1,s9
 ;   ld a0,16(nominal_sp)
+;   mv a1,s9
 ;   j label3
 ; block2:
 ;   mv a0,s9
@@ -137,8 +137,8 @@ block3(v7: r64, v8: r64):
 ;   addi sp, sp, -0x30
 ; block1: ; offset 0x1c
 ;   mv a3, a0
-;   sd a1, 0x10(sp)
 ;   mv s5, a2
+;   sd a1, 0x10(sp)
 ;   mv a0, a3
 ;   mv s9, a3
 ;   auipc a5, 0
@@ -153,8 +153,8 @@ block3(v7: r64, v8: r64):
 ;   andi a5, a0, 0xff
 ;   bnez a5, 0x10
 ; block2: ; offset 0x5c
-;   mv a1, s9
 ;   ld a0, 0x10(sp)
+;   mv a1, s9
 ;   j 0xc
 ; block3: ; offset 0x68
 ;   mv a0, s9

--- a/cranelift/filetests/filetests/isa/riscv64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/return-call.clif
@@ -324,8 +324,8 @@ block0:
 ;   sd s1,24(sp)
 ;   sd a0,32(sp)
 ;   load_sym t0,%tail_callee_stack_args+0
-;   ld a0,0(nominal_sp)
 ;   ld s1,8(nominal_sp)
+;   ld a0,0(nominal_sp)
 ;   return_call_ind t0 old_stack_arg_size:0 new_stack_arg_size:48 s1=s1 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7 s2=s2 s3=s3 s4=s4 s5=s5 s6=s6 s7=s7 s8=s8 s9=s9 s10=s10 s11=s11 t3=t3 t4=t4
 ;
 ; Disassembled:
@@ -375,8 +375,8 @@ block0:
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ld a0, 0x30(sp)
 ;   ld s1, 0x38(sp)
+;   ld a0, 0x30(sp)
 ;   ld ra, 8(s0)
 ;   ld t6, 0(s0)
 ;   ld t5, 0x28(sp)
@@ -568,9 +568,9 @@ block2:
 ;   sd t0,32(sp)
 ;   sd s1,40(sp)
 ;   load_sym t0,%different_callee2+0
-;   ld a1,0(nominal_sp)
-;   ld a0,8(nominal_sp)
 ;   ld s1,16(nominal_sp)
+;   ld a0,8(nominal_sp)
+;   ld a1,0(nominal_sp)
 ;   return_call_ind t0 old_stack_arg_size:0 new_stack_arg_size:48 s1=s1 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7 s2=s2 s3=s3 s4=s4 s5=s5 s6=s6 s7=s7 s8=s8 s9=s9 s10=s10 s11=s11 t3=t3 t4=t4
 ; block2:
 ;   ld s1,16(nominal_sp)
@@ -582,8 +582,8 @@ block2:
 ;   sd t1,24(sp)
 ;   sd t0,32(sp)
 ;   load_sym t0,%different_callee1+0
-;   ld a1,0(nominal_sp)
 ;   ld a0,8(nominal_sp)
+;   ld a1,0(nominal_sp)
 ;   return_call_ind t0 old_stack_arg_size:0 new_stack_arg_size:48 s1=s1 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7 s2=s2 s3=s3 s4=s4 s5=s5 s6=s6 s7=s7 s8=s8 s9=s9 s10=s10 s11=s11 t3=t3 t4=t4
 ;
 ; Disassembled:
@@ -638,9 +638,9 @@ block2:
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %different_callee2 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ld a1, 0x30(sp)
-;   ld a0, 0x38(sp)
 ;   ld s1, 0x40(sp)
+;   ld a0, 0x38(sp)
+;   ld a1, 0x30(sp)
 ;   ld ra, 8(s0)
 ;   ld t6, 0(s0)
 ;   ld t5, 0x28(sp)
@@ -671,8 +671,8 @@ block2:
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %different_callee1 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ld a1, 0x30(sp)
 ;   ld a0, 0x38(sp)
+;   ld a1, 0x30(sp)
 ;   ld ra, 8(s0)
 ;   ld t6, 0(s0)
 ;   ld t5, 0x28(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/select.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/select.clif
@@ -629,8 +629,8 @@ block0(v0: i64, v1: i128, v2: i128):
 ;   sd s6,-16(sp)
 ;   add sp,-16
 ; block0:
-;   mv s6,a0
 ;   mv s4,a1
+;   mv s6,a0
 ;   li a5,42
 ;   select [a0,a1],[s4,a2],[a3,a4]##condition=(s6 eq a5)
 ;   add sp,+16
@@ -651,8 +651,8 @@ block0(v0: i64, v1: i128, v2: i128):
 ;   sd s6, -0x10(sp)
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x1c
-;   mv s6, a0
 ;   mv s4, a1
+;   mv s6, a0
 ;   addi a5, zero, 0x2a
 ;   bne s6, a5, 0x10
 ;   mv a0, s4

--- a/cranelift/filetests/filetests/isa/riscv64/stack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack.clif
@@ -560,11 +560,11 @@ block0(v0: i8):
 ;   ld t1,1160(nominal_sp)
 ;   ld t2,1168(nominal_sp)
 ;   add t1,t2,t1
-;   ld t4,1144(nominal_sp)
 ;   ld a7,1152(nominal_sp)
+;   ld t4,1144(nominal_sp)
 ;   add t2,a7,t4
-;   ld s5,1128(nominal_sp)
 ;   ld s3,1136(nominal_sp)
+;   ld s5,1128(nominal_sp)
 ;   add a6,s3,s5
 ;   ld a7,1112(nominal_sp)
 ;   ld t3,1120(nominal_sp)
@@ -584,8 +584,8 @@ block0(v0: i8):
 ;   ld s3,1032(nominal_sp)
 ;   ld s4,1040(nominal_sp)
 ;   add s3,s4,s3
-;   ld s5,1016(nominal_sp)
 ;   ld s4,1024(nominal_sp)
+;   ld s5,1016(nominal_sp)
 ;   add s4,s4,s5
 ;   ld s5,1008(nominal_sp)
 ;   add s5,s5,s6
@@ -766,11 +766,11 @@ block0(v0: i8):
 ;   ld t1, 0x488(sp)
 ;   ld t2, 0x490(sp)
 ;   add t1, t2, t1
-;   ld t4, 0x478(sp)
 ;   ld a7, 0x480(sp)
+;   ld t4, 0x478(sp)
 ;   add t2, a7, t4
-;   ld s5, 0x468(sp)
 ;   ld s3, 0x470(sp)
+;   ld s5, 0x468(sp)
 ;   add a6, s3, s5
 ;   ld a7, 0x458(sp)
 ;   ld t3, 0x460(sp)
@@ -790,8 +790,8 @@ block0(v0: i8):
 ;   ld s3, 0x408(sp)
 ;   ld s4, 0x410(sp)
 ;   add s3, s4, s3
-;   ld s5, 0x3f8(sp)
 ;   ld s4, 0x400(sp)
+;   ld s5, 0x3f8(sp)
 ;   add s4, s4, s5
 ;   ld s5, 0x3f0(sp)
 ;   add s5, s5, s6

--- a/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
@@ -120,8 +120,8 @@ block0:
 ;   sd s1,24(sp)
 ;   sd a0,32(sp)
 ;   load_sym t0,%tail_callee_stack_args+0
-;   ld a0,0(nominal_sp)
 ;   ld s1,8(nominal_sp)
+;   ld a0,0(nominal_sp)
 ;   callind t0
 ;   add sp,+16
 ;   ld ra,8(sp)
@@ -176,8 +176,8 @@ block0:
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ld a0, 0x30(sp)
 ;   ld s1, 0x38(sp)
+;   ld a0, 0x30(sp)
 ;   jalr t0
 ;   addi sp, sp, 0x10
 ;   ld ra, 8(sp)
@@ -259,9 +259,9 @@ block0:
 ;   sd t2,16(s1)
 ;   sd a0,24(s1)
 ;   sd a1,32(s1)
-;   ld a1,0(nominal_sp)
-;   ld a0,8(nominal_sp)
 ;   ld s1,16(nominal_sp)
+;   ld a0,8(nominal_sp)
+;   ld a1,0(nominal_sp)
 ;   add sp,+32
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
@@ -310,9 +310,9 @@ block0:
 ;   sd t2, 0x10(s1)
 ;   sd a0, 0x18(s1)
 ;   sd a1, 0x20(s1)
-;   ld a1, 0(sp)
-;   ld a0, 8(sp)
 ;   ld s1, 0x10(sp)
+;   ld a0, 8(sp)
+;   ld a1, 0(sp)
 ;   addi sp, sp, 0x20
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
@@ -526,8 +526,8 @@ block0:
 ;   load_addr a0,48(sp)
 ;   sd a0,40(sp)
 ;   load_sym t0,%tail_callee_stack_args_and_rets+0
-;   ld a0,0(nominal_sp)
 ;   ld s1,8(nominal_sp)
+;   ld a0,0(nominal_sp)
 ;   callind t0
 ;   ld a4,0(sp)
 ;   ld a0,8(sp)
@@ -591,8 +591,8 @@ block0:
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args_and_rets 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ld a0, 0x60(sp)
 ;   ld s1, 0x68(sp)
+;   ld a0, 0x60(sp)
 ;   jalr t0
 ;   ld a4, 0(sp)
 ;   ld a0, 8(sp)

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw-arch13.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw-arch13.clif
@@ -57,25 +57,23 @@ block0(v0: i64, v1: i64, v2: i16):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rnsbg %r1, %r4, 0x20, 0x30, 0x10
 ;   xilf %r1, 0xffff0000
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x12
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0xe
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -88,27 +86,25 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
 ;   xilf %r1, 0xff000000
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -170,31 +166,27 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; rnsbg %r1, %r3, 48, 64, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; rnsbg %r1, %r4, 48, 64, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
-;   rnsbg %r1, %r3, 0x30, 0x40, 0x30
+;   rnsbg %r1, %r4, 0x30, 0x40, 0x30
 ;   xilf %r1, 0xffff
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1a
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x12
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -208,27 +200,25 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
 ;   xilf %r1, 0xff000000
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw-little.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw-little.clif
@@ -59,30 +59,26 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; risbgn %r1, %r3, 48, 64, 48 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; risbgn %r1, %r4, 48, 64, 48 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
-;   risbgn %r1, %r3, 0x30, 0x40, 0x30
+;   risbgn %r1, %r4, 0x30, 0x40, 0x30
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1a
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x12
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -96,26 +92,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   risbgn %r1, %r4, 0x20, 0x28, 0x18
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -175,32 +169,28 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; ar %r1, %r3 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; ar %r1, %r4 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
 ;   lrvr %r1, %r1
-;   ar %r1, %r3
+;   ar %r1, %r4
 ;   lrvr %r1, %r1
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -214,28 +204,26 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r4 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   ar %r1, %r3
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   ar %r1, %r4
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -295,32 +283,28 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; sr %r1, %r3 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; sr %r1, %r4 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
 ;   lrvr %r1, %r1
-;   sr %r1, %r3
+;   sr %r1, %r4
 ;   lrvr %r1, %r1
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -334,28 +318,26 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r4 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   sr %r1, %r3
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   sr %r1, %r4
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -407,30 +389,26 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; rnsbg %r1, %r3, 48, 64, 48 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; rnsbg %r1, %r4, 48, 64, 48 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
-;   rnsbg %r1, %r3, 0x30, 0x40, 0x30
+;   rnsbg %r1, %r4, 0x30, 0x40, 0x30
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1a
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x12
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -444,26 +422,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -515,30 +491,26 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; rosbg %r1, %r3, 48, 64, 48 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; rosbg %r1, %r4, 48, 64, 48 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
-;   rosbg %r1, %r3, 0x30, 0x40, 0x30
+;   rosbg %r1, %r4, 0x30, 0x40, 0x30
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1a
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x12
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -552,26 +524,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rosbg %r1, %r4, 0x20, 0x28, 0x18
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -623,30 +593,26 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; rxsbg %r1, %r3, 48, 64, 48 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; rxsbg %r1, %r4, 48, 64, 48 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
-;   rxsbg %r1, %r3, 0x30, 0x40, 0x30
+;   rxsbg %r1, %r4, 0x30, 0x40, 0x30
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1a
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x12
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -660,26 +626,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rxsbg %r1, %r4, 0x20, 0x28, 0x18
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -742,31 +706,27 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; rnsbg %r1, %r3, 48, 64, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; rnsbg %r1, %r4, 48, 64, 48 ; xilf %r1, 65535 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   lrvr %r3, %r5
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   lrvr %r4, %r4
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
-;   rnsbg %r1, %r3, 0x30, 0x40, 0x30
+;   rnsbg %r1, %r4, 0x30, 0x40, 0x30
 ;   xilf %r1, 0xffff
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1a
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x12
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -780,27 +740,25 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
 ;   xilf %r1, 0xff000000
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -862,34 +820,30 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; cr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; cr %r4, %r1 ; jgnl 1f ; risbgn %r1, %r4, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
 ;   lrvr %r1, %r1
-;   cr %r3, %r1
-;   jgnl 0x48
-;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   cr %r4, %r1
+;   jgnl 0x40
+;   risbgn %r1, %r4, 0x20, 0x30, 0
 ;   lrvr %r1, %r1
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -903,30 +857,28 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; cr %r4, %r1 ; jgnl 1f ; risbgn %r1, %r4, 32, 40, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   cr %r3, %r1
-;   jgnl 0x3e
-;   risbgn %r1, %r3, 0x20, 0x28, 0
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   cr %r4, %r1
+;   jgnl 0x3a
+;   risbgn %r1, %r4, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -988,34 +940,30 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; cr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; cr %r4, %r1 ; jgnh 1f ; risbgn %r1, %r4, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
 ;   lrvr %r1, %r1
-;   cr %r3, %r1
-;   jgnh 0x48
-;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   cr %r4, %r1
+;   jgnh 0x40
+;   risbgn %r1, %r4, 0x20, 0x30, 0
 ;   lrvr %r1, %r1
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -1029,30 +977,28 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; cr %r4, %r1 ; jgnh 1f ; risbgn %r1, %r4, 32, 40, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   cr %r3, %r1
-;   jgnh 0x3e
-;   risbgn %r1, %r3, 0x20, 0x28, 0
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   cr %r4, %r1
+;   jgnh 0x3a
+;   risbgn %r1, %r4, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -1114,34 +1060,30 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; clr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; clr %r4, %r1 ; jgnl 1f ; risbgn %r1, %r4, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
 ;   lrvr %r1, %r1
-;   clr %r3, %r1
-;   jgnl 0x48
-;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   clr %r4, %r1
+;   jgnl 0x40
+;   risbgn %r1, %r4, 0x20, 0x30, 0
 ;   lrvr %r1, %r1
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -1155,30 +1097,28 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; clr %r4, %r1 ; jgnl 1f ; risbgn %r1, %r4, 32, 40, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   clr %r3, %r1
-;   jgnl 0x3e
-;   risbgn %r1, %r3, 0x20, 0x28, 0
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   clr %r4, %r1
+;   jgnl 0x3a
+;   risbgn %r1, %r4, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -1240,34 +1180,30 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; clr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 16(%r2) ; lrvr %r1, %r1 ; clr %r4, %r1 ; jgnh 1f ; risbgn %r1, %r4, 32, 48, 0 ; lrvr %r1, %r1 ; rll %r1, %r1, 16(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0x10(%r2)
 ;   lrvr %r1, %r1
-;   clr %r3, %r1
-;   jgnh 0x48
-;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   clr %r4, %r1
+;   jgnh 0x40
+;   risbgn %r1, %r4, 0x20, 0x30, 0
 ;   lrvr %r1, %r1
 ;   rll %r1, %r1, 0x10(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0(%r2)
 ;   lrvr %r2, %r2
 ;   br %r14
@@ -1281,30 +1217,28 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; clr %r4, %r1 ; jgnh 1f ; risbgn %r1, %r4, 32, 40, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   clr %r3, %r1
-;   jgnh 0x3e
-;   risbgn %r1, %r3, 0x20, 0x28, 0
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   clr %r4, %r1
+;   jgnh 0x3a
+;   risbgn %r1, %r4, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/atomic_rmw.clif
+++ b/cranelift/filetests/filetests/isa/s390x/atomic_rmw.clif
@@ -56,24 +56,22 @@ block0(v0: i64, v1: i64, v2: i16):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   risbgn %r1, %r4, 0x20, 0x30, 0x10
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x12
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0xe
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -86,26 +84,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; risbgn %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   risbgn %r1, %r4, 0x20, 0x28, 0x18
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -149,29 +145,25 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r3 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r4 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   ar %r1, %r3
+;   ar %r1, %r4
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -184,28 +176,26 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; ar %r1, %r4 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   ar %r1, %r3
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   ar %r1, %r4
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -253,29 +243,25 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r3 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r4 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   sr %r1, %r3
+;   sr %r1, %r4
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -288,28 +274,26 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r3 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; sr %r1, %r4 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   sr %r1, %r3
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   sr %r1, %r4
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -354,24 +338,22 @@ block0(v0: i64, v1: i64, v2: i16):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rnsbg %r1, %r4, 0x20, 0x30, 0x10
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x12
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0xe
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -384,26 +366,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -448,24 +428,22 @@ block0(v0: i64, v1: i64, v2: i16):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rosbg %r1, %r4, 0x20, 0x30, 0x10
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x12
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0xe
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -478,26 +456,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rosbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rosbg %r1, %r4, 0x20, 0x28, 0x18
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -542,24 +518,22 @@ block0(v0: i64, v1: i64, v2: i16):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 48, 16 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rxsbg %r1, %r4, 0x20, 0x30, 0x10
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x12
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0xe
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -572,26 +546,24 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rxsbg %r1, %r4, 32, 40, 24 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rxsbg %r1, %r4, 0x20, 0x28, 0x18
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -651,25 +623,23 @@ block0(v0: i64, v1: i64, v2: i16):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 48, 16 ; xilf %r1, 4294901760 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rnsbg %r1, %r4, 0x20, 0x30, 0x10
 ;   xilf %r1, 0xffff0000
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x12
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0xe
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -682,27 +652,25 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r3) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; rnsbg %r1, %r4, 32, 40, 24 ; xilf %r1, 4278190080 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   lcr %r3, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
 ;   rnsbg %r1, %r4, 0x20, 0x28, 0x18
 ;   xilf %r1, 0xff000000
-;   rll %r1, %r1, 0(%r3)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x14
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x10
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -760,31 +728,27 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; cr %r4, %r1 ; jgnl 1f ; risbgn %r1, %r4, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   cr %r3, %r1
-;   jgnl 0x40
-;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   cr %r4, %r1
+;   jgnl 0x38
+;   risbgn %r1, %r4, 0x20, 0x30, 0
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -797,30 +761,28 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; cr %r4, %r1 ; jgnl 1f ; risbgn %r1, %r4, 32, 40, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   cr %r3, %r1
-;   jgnl 0x3e
-;   risbgn %r1, %r3, 0x20, 0x28, 0
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   cr %r4, %r1
+;   jgnl 0x3a
+;   risbgn %r1, %r4, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -878,31 +840,27 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; cr %r4, %r1 ; jgnh 1f ; risbgn %r1, %r4, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   cr %r3, %r1
-;   jgnh 0x40
-;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   cr %r4, %r1
+;   jgnh 0x38
+;   risbgn %r1, %r4, 0x20, 0x30, 0
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -915,30 +873,28 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; cr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; cr %r4, %r1 ; jgnh 1f ; risbgn %r1, %r4, 32, 40, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   cr %r3, %r1
-;   jgnh 0x3e
-;   risbgn %r1, %r3, 0x20, 0x28, 0
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   cr %r4, %r1
+;   jgnh 0x3a
+;   risbgn %r1, %r4, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -996,31 +952,27 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; clr %r4, %r1 ; jgnl 1f ; risbgn %r1, %r4, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   clr %r3, %r1
-;   jgnl 0x40
-;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   clr %r4, %r1
+;   jgnl 0x38
+;   risbgn %r1, %r4, 0x20, 0x30, 0
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -1033,30 +985,28 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnl 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; clr %r4, %r1 ; jgnl 1f ; risbgn %r1, %r4, 32, 40, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   clr %r3, %r1
-;   jgnl 0x3e
-;   risbgn %r1, %r3, 0x20, 0x28, 0
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   clr %r4, %r1
+;   jgnl 0x3a
+;   risbgn %r1, %r4, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 
@@ -1114,31 +1064,27 @@ block0(v0: i64, v1: i64, v2: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 65532
-;   sllk %r3, %r5, 16
-;   l %r0, 0(%r4)
-;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r4) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 16
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; clr %r4, %r1 ; jgnh 1f ; risbgn %r1, %r4, 32, 48, 0 ; rll %r1, %r1, 0(%r2) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 16(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r4
 ;   sllk %r2, %r3, 3
-;   lgr %r4, %r3
-;   nill %r4, 0xfffc
-;   sllk %r3, %r5, 0x10
-;   l %r0, 0(%r4)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x10
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   clr %r3, %r1
-;   jgnh 0x40
-;   risbgn %r1, %r3, 0x20, 0x30, 0
+;   clr %r4, %r1
+;   jgnh 0x38
+;   risbgn %r1, %r4, 0x20, 0x30, 0
 ;   rll %r1, %r1, 0(%r2)
-;   cs %r0, %r1, 0(%r4)
-;   jglh 0x1c
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x14
 ;   rll %r2, %r0, 0x10(%r2)
 ;   br %r14
 
@@ -1151,30 +1097,28 @@ block0(v0: i64, v1: i64, v2: i8):
 ; VCode:
 ; block0:
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 65532
-;   sllk %r3, %r4, 24
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
-;   0: rll %r1, %r0, 0(%r2) ; clr %r3, %r1 ; jgnh 1f ; risbgn %r1, %r3, 32, 40, 0 ; rll %r1, %r1, 0(%r4) ; cs %r0, %r1, 0(%r5) ; jglh 0b ; 1:
+;   nill %r3, 65532
+;   sllk %r4, %r4, 24
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
+;   0: rll %r1, %r0, 0(%r2) ; clr %r4, %r1 ; jgnh 1f ; risbgn %r1, %r4, 32, 40, 0 ; rll %r1, %r1, 0(%r5) ; cs %r0, %r1, 0(%r3) ; jglh 0b ; 1:
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sllk %r2, %r3, 3
-;   lgr %r5, %r3
-;   nill %r5, 0xfffc
-;   sllk %r3, %r4, 0x18
-;   lcr %r4, %r2
-;   l %r0, 0(%r5)
+;   nill %r3, 0xfffc
+;   sllk %r4, %r4, 0x18
+;   lcr %r5, %r2
+;   l %r0, 0(%r3)
 ;   rll %r1, %r0, 0(%r2)
-;   clr %r3, %r1
-;   jgnh 0x3e
-;   risbgn %r1, %r3, 0x20, 0x28, 0
-;   rll %r1, %r1, 0(%r4)
-;   cs %r0, %r1, 0(%r5)
-;   jglh 0x1a
+;   clr %r4, %r1
+;   jgnh 0x3a
+;   risbgn %r1, %r4, 0x20, 0x28, 0
+;   rll %r1, %r1, 0(%r5)
+;   cs %r0, %r1, 0(%r3)
+;   jglh 0x16
 ;   rll %r2, %r0, 8(%r2)
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/bitops.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitops.clif
@@ -603,10 +603,9 @@ block0(v0: i64):
 ;   lcgr %r4, %r2
 ;   ngr %r2, %r4
 ;   flogr %r2, %r2
-;   lgr %r3, %r2
-;   locghie %r3, -1
+;   locghie %r2, -1
 ;   lghi %r5, 63
-;   sgrk %r2, %r5, %r3
+;   sgrk %r2, %r5, %r2
 ;   br %r14
 ;
 ; Disassembled:
@@ -614,10 +613,9 @@ block0(v0: i64):
 ;   lcgr %r4, %r2
 ;   ngr %r2, %r4
 ;   flogr %r2, %r2
-;   lgr %r3, %r2
-;   locghie %r3, -1
+;   locghie %r2, -1
 ;   lghi %r5, 0x3f
-;   sgrk %r2, %r5, %r3
+;   sgrk %r2, %r5, %r2
 ;   br %r14
 
 function %ctz_i32(i32) -> i32 {
@@ -628,10 +626,9 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   lgr %r4, %r2
-;   oihl %r4, 1
-;   lcgr %r2, %r4
-;   ngr %r4, %r2
+;   oihl %r2, 1
+;   lcgr %r3, %r2
+;   ngrk %r4, %r2, %r3
 ;   flogr %r2, %r4
 ;   lhi %r5, 63
 ;   srk %r2, %r5, %r2
@@ -639,10 +636,9 @@ block0(v0: i32):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r4, %r2
-;   oihl %r4, 1
-;   lcgr %r2, %r4
-;   ngr %r4, %r2
+;   oihl %r2, 1
+;   lcgr %r3, %r2
+;   ngrk %r4, %r2, %r3
 ;   flogr %r2, %r4
 ;   lhi %r5, 0x3f
 ;   srk %r2, %r5, %r2
@@ -656,10 +652,9 @@ block0(v0: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r4, %r2
-;   oilh %r4, 1
-;   lcgr %r2, %r4
-;   ngr %r4, %r2
+;   oilh %r2, 1
+;   lcgr %r3, %r2
+;   ngrk %r4, %r2, %r3
 ;   flogr %r2, %r4
 ;   lhi %r5, 63
 ;   srk %r2, %r5, %r2
@@ -667,10 +662,9 @@ block0(v0: i16):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r4, %r2
-;   oilh %r4, 1
-;   lcgr %r2, %r4
-;   ngr %r4, %r2
+;   oilh %r2, 1
+;   lcgr %r3, %r2
+;   ngrk %r4, %r2, %r3
 ;   flogr %r2, %r4
 ;   lhi %r5, 0x3f
 ;   srk %r2, %r5, %r2
@@ -684,10 +678,9 @@ block0(v0: i8):
 
 ; VCode:
 ; block0:
-;   lgr %r4, %r2
-;   oill %r4, 256
-;   lcgr %r2, %r4
-;   ngr %r4, %r2
+;   oill %r2, 256
+;   lcgr %r3, %r2
+;   ngrk %r4, %r2, %r3
 ;   flogr %r2, %r4
 ;   lhi %r5, 63
 ;   srk %r2, %r5, %r2
@@ -695,10 +688,9 @@ block0(v0: i8):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r4, %r2
-;   oill %r4, 0x100
-;   lcgr %r2, %r4
-;   ngr %r4, %r2
+;   oill %r2, 0x100
+;   lcgr %r3, %r2
+;   ngrk %r4, %r2, %r3
 ;   flogr %r2, %r4
 ;   lhi %r5, 0x3f
 ;   srk %r2, %r5, %r2

--- a/cranelift/filetests/filetests/isa/s390x/bitwise.clif
+++ b/cranelift/filetests/filetests/isa/s390x/bitwise.clif
@@ -936,20 +936,18 @@ block0(v0: i64, v1: i64, v2: i64):
 ; VCode:
 ; block0:
 ;   ngr %r3, %r2
-;   lgr %r5, %r2
-;   xilf %r5, 4294967295
-;   xihf %r5, 4294967295
-;   ngr %r4, %r5
+;   xilf %r2, 4294967295
+;   xihf %r2, 4294967295
+;   ngr %r4, %r2
 ;   ogrk %r2, %r4, %r3
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   ngr %r3, %r2
-;   lgr %r5, %r2
-;   xilf %r5, 0xffffffff
-;   xihf %r5, 0xffffffff
-;   ngr %r4, %r5
+;   xilf %r2, 0xffffffff
+;   xihf %r2, 0xffffffff
+;   ngr %r4, %r2
 ;   ogrk %r2, %r4, %r3
 ;   br %r14
 
@@ -962,18 +960,16 @@ block0(v0: i32, v1: i32, v2: i32):
 ; VCode:
 ; block0:
 ;   nr %r3, %r2
-;   lgr %r5, %r2
-;   xilf %r5, 4294967295
-;   nrk %r2, %r4, %r5
+;   xilf %r2, 4294967295
+;   nrk %r2, %r4, %r2
 ;   or %r2, %r3
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r3, %r2
-;   lgr %r5, %r2
-;   xilf %r5, 0xffffffff
-;   nrk %r2, %r4, %r5
+;   xilf %r2, 0xffffffff
+;   nrk %r2, %r4, %r2
 ;   or %r2, %r3
 ;   br %r14
 
@@ -986,18 +982,16 @@ block0(v0: i16, v1: i16, v2: i16):
 ; VCode:
 ; block0:
 ;   nr %r3, %r2
-;   lgr %r5, %r2
-;   xilf %r5, 4294967295
-;   nrk %r2, %r4, %r5
+;   xilf %r2, 4294967295
+;   nrk %r2, %r4, %r2
 ;   or %r2, %r3
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r3, %r2
-;   lgr %r5, %r2
-;   xilf %r5, 0xffffffff
-;   nrk %r2, %r4, %r5
+;   xilf %r2, 0xffffffff
+;   nrk %r2, %r4, %r2
 ;   or %r2, %r3
 ;   br %r14
 
@@ -1010,18 +1004,16 @@ block0(v0: i8, v1: i8, v2: i8):
 ; VCode:
 ; block0:
 ;   nr %r3, %r2
-;   lgr %r5, %r2
-;   xilf %r5, 4294967295
-;   nrk %r2, %r4, %r5
+;   xilf %r2, 4294967295
+;   nrk %r2, %r4, %r2
 ;   or %r2, %r3
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   nr %r3, %r2
-;   lgr %r5, %r2
-;   xilf %r5, 0xffffffff
-;   nrk %r2, %r4, %r5
+;   xilf %r2, 0xffffffff
+;   nrk %r2, %r4, %r2
 ;   or %r2, %r3
 ;   br %r14
 

--- a/cranelift/filetests/filetests/isa/s390x/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/s390x/reftypes.clif
@@ -111,8 +111,8 @@ block3(v7: r64, v8: r64):
 ;   chi %r2, 0
 ;   jglh label2 ; jg label1
 ; block1:
-;   lgr %r3, %r11
 ;   lg %r2, 176(%r15)
+;   lgr %r3, %r11
 ;   jg label3
 ; block2:
 ;   lgr %r2, %r11
@@ -148,8 +148,8 @@ block3(v7: r64, v8: r64):
 ;   chi %r2, 0
 ;   jglh 0x62
 ; block2: ; offset 0x52
-;   lgr %r3, %r11
 ;   lg %r2, 0xb0(%r15)
+;   lgr %r3, %r11
 ;   jg 0x6c
 ; block3: ; offset 0x62
 ;   lgr %r2, %r11

--- a/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
+++ b/cranelift/filetests/filetests/isa/s390x/shift-rotate.clif
@@ -915,16 +915,14 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r3
-;   nill %r5, 31
-;   srlk %r2, %r2, 0(%r5)
+;   nill %r3, 31
+;   srlk %r2, %r2, 0(%r3)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r3
-;   nill %r5, 0x1f
-;   srlk %r2, %r2, 0(%r5)
+;   nill %r3, 0x1f
+;   srlk %r2, %r2, 0(%r3)
 ;   br %r14
 
 function %ushr_i32_imm(i32) -> i32 {
@@ -1230,16 +1228,14 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r3
-;   nill %r5, 31
-;   sllk %r2, %r2, 0(%r5)
+;   nill %r3, 31
+;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r3
-;   nill %r5, 0x1f
-;   sllk %r2, %r2, 0(%r5)
+;   nill %r3, 0x1f
+;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
 
 function %ishl_i32_imm(i32) -> i32 {
@@ -1289,16 +1285,14 @@ block0(v0: i16, v1: i16):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r3
-;   nill %r5, 15
-;   sllk %r2, %r2, 0(%r5)
+;   nill %r3, 15
+;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r3
-;   nill %r5, 0xf
-;   sllk %r2, %r2, 0(%r5)
+;   nill %r3, 0xf
+;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
 
 function %ishl_i16_imm(i16) -> i16 {
@@ -1348,16 +1342,14 @@ block0(v0: i8, v1: i8):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r3
-;   nill %r5, 7
-;   sllk %r2, %r2, 0(%r5)
+;   nill %r3, 7
+;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r3
-;   nill %r5, 7
-;   sllk %r2, %r2, 0(%r5)
+;   nill %r3, 7
+;   sllk %r2, %r2, 0(%r3)
 ;   br %r14
 
 function %ishl_i8_imm(i8) -> i8 {
@@ -1537,16 +1529,14 @@ block0(v0: i32, v1: i32):
 
 ; VCode:
 ; block0:
-;   lgr %r5, %r3
-;   nill %r5, 31
-;   srak %r2, %r2, 0(%r5)
+;   nill %r3, 31
+;   srak %r2, %r2, 0(%r3)
 ;   br %r14
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   lgr %r5, %r3
-;   nill %r5, 0x1f
-;   srak %r2, %r2, 0(%r5)
+;   nill %r3, 0x1f
+;   srak %r2, %r2, 0(%r3)
 ;   br %r14
 
 function %sshr_i32_imm(i32) -> i32 {

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -48,10 +48,9 @@
 ;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
+;;   ag %r2, 0(%r4)
 ;;   lghi %r4, 4096
-;;   strv %r3, 0(%r4,%r5)
+;;   strv %r3, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14
@@ -67,10 +66,9 @@
 ;;   clgr %r2, %r4
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r4, %r2
-;;   ag %r4, 0(%r3)
+;;   ag %r2, 0(%r3)
 ;;   lghi %r3, 4096
-;;   lrv %r2, 0(%r3,%r4)
+;;   lrv %r2, 0(%r3,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -53,10 +53,9 @@
 ;;   clgr %r5, %r14
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
+;;   ag %r2, 0(%r4)
 ;;   llilh %r4, 65535
-;;   strv %r3, 0(%r4,%r5)
+;;   strv %r3, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
 ;;   lmg %r14, %r15, 112(%r15)
@@ -75,10 +74,9 @@
 ;;   clgr %r5, %r4
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r4, %r2
-;;   ag %r4, 0(%r3)
-;;   llilh %r5, 65535
-;;   lrv %r2, 0(%r5,%r4)
+;;   ag %r2, 0(%r3)
+;;   llilh %r4, 65535
+;;   lrv %r2, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -48,10 +48,9 @@
 ;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
+;;   ag %r2, 0(%r4)
 ;;   lghi %r4, 4096
-;;   stc %r3, 0(%r4,%r5)
+;;   stc %r3, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14
@@ -67,10 +66,9 @@
 ;;   clgr %r2, %r4
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r4, %r2
-;;   ag %r4, 0(%r3)
+;;   ag %r2, 0(%r3)
 ;;   lghi %r3, 4096
-;;   llc %r2, 0(%r3,%r4)
+;;   llc %r2, 0(%r3,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -53,10 +53,9 @@
 ;;   clgr %r5, %r14
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
+;;   ag %r2, 0(%r4)
 ;;   llilh %r4, 65535
-;;   stc %r3, 0(%r4,%r5)
+;;   stc %r3, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
 ;;   lmg %r14, %r15, 112(%r15)
@@ -75,10 +74,9 @@
 ;;   clgr %r5, %r4
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r4, %r2
-;;   ag %r4, 0(%r3)
-;;   llilh %r5, 65535
-;;   llc %r2, 0(%r5,%r4)
+;;   ag %r2, 0(%r3)
+;;   llilh %r4, 65535
+;;   llc %r2, 0(%r4,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -44,10 +44,9 @@
 ;;   clgfi %r2, 268431356
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
-;;   lghi %r2, 4096
-;;   strv %r3, 0(%r2,%r5)
+;;   ag %r2, 0(%r4)
+;;   lghi %r5, 4096
+;;   strv %r3, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14
@@ -61,10 +60,9 @@
 ;;   clgfi %r2, 268431356
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r3)
-;;   lghi %r2, 4096
-;;   lrv %r2, 0(%r2,%r5)
+;;   ag %r2, 0(%r3)
+;;   lghi %r5, 4096
+;;   lrv %r2, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -44,10 +44,9 @@
 ;;   clgfi %r2, 268431359
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
-;;   lghi %r2, 4096
-;;   stc %r3, 0(%r2,%r5)
+;;   ag %r2, 0(%r4)
+;;   lghi %r5, 4096
+;;   stc %r3, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14
@@ -61,10 +60,9 @@
 ;;   clgfi %r2, 268431359
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r3)
-;;   lghi %r2, 4096
-;;   llc %r2, 0(%r2,%r5)
+;;   ag %r2, 0(%r3)
+;;   lghi %r5, 4096
+;;   llc %r2, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -44,10 +44,9 @@
 ;;   clgfi %r2, 268431356
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
-;;   lghi %r2, 4096
-;;   strv %r3, 0(%r2,%r5)
+;;   ag %r2, 0(%r4)
+;;   lghi %r5, 4096
+;;   strv %r3, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14
@@ -61,10 +60,9 @@
 ;;   clgfi %r2, 268431356
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r3)
-;;   lghi %r2, 4096
-;;   lrv %r2, 0(%r2,%r5)
+;;   ag %r2, 0(%r3)
+;;   lghi %r5, 4096
+;;   lrv %r2, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -44,10 +44,9 @@
 ;;   clgfi %r2, 268431359
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r4)
-;;   lghi %r2, 4096
-;;   stc %r3, 0(%r2,%r5)
+;;   ag %r2, 0(%r4)
+;;   lghi %r5, 4096
+;;   stc %r3, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14
@@ -61,10 +60,9 @@
 ;;   clgfi %r2, 268431359
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   lgr %r5, %r2
-;;   ag %r5, 0(%r3)
-;;   lghi %r2, 4096
-;;   llc %r2, 0(%r2,%r5)
+;;   ag %r2, 0(%r3)
+;;   lghi %r5, 4096
+;;   llc %r2, 0(%r5,%r2)
 ;;   jg label2
 ;; block2:
 ;;   br %r14

--- a/cranelift/filetests/filetests/isa/x64/amode-opt.clif
+++ b/cranelift/filetests/filetests/isa/x64/amode-opt.clif
@@ -210,9 +210,8 @@ block0(v0: i64, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %rdx
-;   shll    $3, %edx, %edx
-;   movq    -1(%rdi,%rdx,1), %rax
+;   shll    $3, %esi, %esi
+;   movq    -1(%rdi,%rsi,1), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -222,9 +221,8 @@ block0(v0: i64, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, %rdx
-;   shll $3, %edx
-;   movq -1(%rdi, %rdx), %rax ; trap: heap_oob
+;   shll $3, %esi
+;   movq -1(%rdi, %rsi), %rax ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/bmask.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmask.clif
@@ -509,11 +509,11 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rdx
-;   orq     %rdx, %rsi, %rdx
-;   movq    %rdx, %r8
+;   orq     %rdi, %rsi, %rdi
+;   movq    %rdi, %r8
 ;   negq    %r8, %r8
-;   sbbq    %rdx, %rdx, %rdx
+;   movq    %rdi, %rdx
+;   sbbq    %rdx, %rdi, %rdx
 ;   movq    %rdx, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -524,11 +524,11 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rdx
-;   orq %rsi, %rdx
-;   movq %rdx, %r8
+;   orq %rsi, %rdi
+;   movq %rdi, %r8
 ;   negq %r8
-;   sbbq %rdx, %rdx
+;   movq %rdi, %rdx
+;   sbbq %rdi, %rdx
 ;   movq %rdx, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -544,11 +544,11 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   orq     %rax, %rsi, %rax
-;   movq    %rax, %r8
+;   orq     %rdi, %rsi, %rdi
+;   movq    %rdi, %r8
 ;   negq    %r8, %r8
-;   sbbq    %rax, %rax, %rax
+;   movq    %rdi, %rax
+;   sbbq    %rax, %rdi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -558,11 +558,11 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rax
-;   orq %rsi, %rax
-;   movq %rax, %r8
+;   orq %rsi, %rdi
+;   movq %rdi, %r8
 ;   negq %r8
-;   sbbq %rax, %rax
+;   movq %rdi, %rax
+;   sbbq %rdi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -577,11 +577,11 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   orq     %rax, %rsi, %rax
-;   movq    %rax, %r8
+;   orq     %rdi, %rsi, %rdi
+;   movq    %rdi, %r8
 ;   negq    %r8, %r8
-;   sbbl    %eax, %eax, %eax
+;   movq    %rdi, %rax
+;   sbbl    %eax, %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -591,11 +591,11 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rax
-;   orq %rsi, %rax
-;   movq %rax, %r8
+;   orq %rsi, %rdi
+;   movq %rdi, %r8
 ;   negq %r8
-;   sbbl %eax, %eax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -610,11 +610,11 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   orq     %rax, %rsi, %rax
-;   movq    %rax, %r8
+;   orq     %rdi, %rsi, %rdi
+;   movq    %rdi, %r8
 ;   negq    %r8, %r8
-;   sbbl    %eax, %eax, %eax
+;   movq    %rdi, %rax
+;   sbbl    %eax, %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -624,11 +624,11 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rax
-;   orq %rsi, %rax
-;   movq %rax, %r8
+;   orq %rsi, %rdi
+;   movq %rdi, %r8
 ;   negq %r8
-;   sbbl %eax, %eax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -643,11 +643,11 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rax
-;   orq     %rax, %rsi, %rax
-;   movq    %rax, %r8
+;   orq     %rdi, %rsi, %rdi
+;   movq    %rdi, %r8
 ;   negq    %r8, %r8
-;   sbbl    %eax, %eax, %eax
+;   movq    %rdi, %rax
+;   sbbl    %eax, %edi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -657,11 +657,11 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rax
-;   orq %rsi, %rax
-;   movq %rax, %r8
+;   orq %rsi, %rdi
+;   movq %rdi, %r8
 ;   negq %r8
-;   sbbl %eax, %eax
+;   movq %rdi, %rax
+;   sbbl %edi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/bmi2.clif
+++ b/cranelift/filetests/filetests/isa/x64/bmi2.clif
@@ -268,9 +268,8 @@ block0(v0: i32, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %rcx
-;   andl    %ecx, $31, %ecx
-;   bzhi    %edi, %ecx, %eax
+;   andl    %esi, $31, %esi
+;   bzhi    %edi, %esi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -280,9 +279,8 @@ block0(v0: i32, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, %rcx
-;   andl $0x1f, %ecx
-;   bzhil %ecx, %edi, %eax
+;   andl $0x1f, %esi
+;   bzhil %esi, %edi, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -300,9 +298,8 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %rcx
-;   andq    %rcx, $63, %rcx
-;   bzhi    %rdi, %rcx, %rax
+;   andq    %rsi, $63, %rsi
+;   bzhi    %rdi, %rsi, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -312,9 +309,8 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, %rcx
-;   andq $0x3f, %rcx
-;   bzhiq %rcx, %rdi, %rax
+;   andq $0x3f, %rsi
+;   bzhiq %rsi, %rdi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -333,9 +329,8 @@ block0(v0: i64, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %rcx
-;   andl    %ecx, $31, %ecx
-;   bzhi    20(%rdi), %ecx, %eax
+;   andl    %esi, $31, %esi
+;   bzhi    20(%rdi), %esi, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -345,9 +340,8 @@ block0(v0: i64, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, %rcx
-;   andl $0x1f, %ecx
-;   bzhil %ecx, 0x14(%rdi), %eax ; trap: heap_oob
+;   andl $0x1f, %esi
+;   bzhil %esi, 0x14(%rdi), %eax ; trap: heap_oob
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/call-conv.clif
@@ -425,8 +425,8 @@ block0(v0: i32, v1: i32, v2: i8x16, v3: i64, v4: i8x16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdx, %r8
 ;   movq    %rsi, %rcx
+;   movq    %rdx, %r8
 ;   subq    %rsp, $64, %rsp
 ;   virtual_sp_offset_adjust 64
 ;   lea     32(%rsp), %rdx
@@ -446,8 +446,8 @@ block0(v0: i32, v1: i32, v2: i8x16, v3: i64, v4: i8x16):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdx, %r8
 ;   movq %rsi, %rcx
+;   movq %rdx, %r8
 ;   subq $0x40, %rsp
 ;   leaq 0x20(%rsp), %rdx
 ;   movdqu %xmm0, (%rdx)

--- a/cranelift/filetests/filetests/isa/x64/conditional-values.clif
+++ b/cranelift/filetests/filetests/isa/x64/conditional-values.clif
@@ -347,8 +347,8 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
+;   notq    %rdi, %rdi
 ;   movq    %rdi, %rax
-;   notq    %rax, %rax
 ;   shrq    $63, %rax, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -359,8 +359,8 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
+;   notq %rdi
 ;   movq %rdi, %rax
-;   notq %rax
 ;   shrq $0x3f, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -377,8 +377,8 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
+;   notq    %rdi, %rdi
 ;   movq    %rdi, %rax
-;   notq    %rax, %rax
 ;   shrl    $31, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -389,8 +389,8 @@ block0(v0: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
+;   notq %rdi
 ;   movq %rdi, %rax
-;   notq %rax
 ;   shrl $0x1f, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -407,8 +407,8 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
+;   notq    %rdi, %rdi
 ;   movq    %rdi, %rax
-;   notq    %rax, %rax
 ;   shrq    $63, %rax, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -419,8 +419,8 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
+;   notq %rdi
 ;   movq %rdi, %rax
-;   notq %rax
 ;   shrq $0x3f, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -437,8 +437,8 @@ block0(v0: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
+;   notq    %rdi, %rdi
 ;   movq    %rdi, %rax
-;   notq    %rax, %rax
 ;   shrl    $31, %eax, %eax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -449,8 +449,8 @@ block0(v0: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
+;   notq %rdi
 ;   movq %rdi, %rax
-;   notq %rax
 ;   shrl $0x1f, %eax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -1066,15 +1066,14 @@ block0(v0: f32x4):
 ; block0:
 ;   uninit  %xmm6
 ;   xorps   %xmm6, %xmm6, %xmm6
-;   movdqa  %xmm0, %xmm3
-;   maxps   %xmm3, %xmm6, %xmm3
+;   maxps   %xmm0, %xmm6, %xmm0
 ;   pcmpeqd %xmm6, %xmm6, %xmm6
 ;   psrld   %xmm6, $1, %xmm6
 ;   cvtdq2ps %xmm6, %xmm7
-;   cvttps2dq %xmm3, %xmm6
-;   subps   %xmm3, %xmm7, %xmm3
-;   cmpps   $2, %xmm7, %xmm3, %xmm7
-;   cvttps2dq %xmm3, %xmm0
+;   cvttps2dq %xmm0, %xmm6
+;   subps   %xmm0, %xmm7, %xmm0
+;   cmpps   $2, %xmm7, %xmm0, %xmm7
+;   cvttps2dq %xmm0, %xmm0
 ;   pxor    %xmm0, %xmm7, %xmm0
 ;   uninit  %xmm1
 ;   pxor    %xmm1, %xmm1, %xmm1
@@ -1090,15 +1089,14 @@ block0(v0: f32x4):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   xorps %xmm6, %xmm6
-;   movdqa %xmm0, %xmm3
-;   maxps %xmm6, %xmm3
+;   maxps %xmm6, %xmm0
 ;   pcmpeqd %xmm6, %xmm6
 ;   psrld $1, %xmm6
 ;   cvtdq2ps %xmm6, %xmm7
-;   cvttps2dq %xmm3, %xmm6
-;   subps %xmm7, %xmm3
-;   cmpleps %xmm3, %xmm7
-;   cvttps2dq %xmm3, %xmm0
+;   cvttps2dq %xmm0, %xmm6
+;   subps %xmm7, %xmm0
+;   cmpleps %xmm0, %xmm7
+;   cvttps2dq %xmm0, %xmm0
 ;   pxor %xmm7, %xmm0
 ;   pxor %xmm1, %xmm1
 ;   pmaxsd %xmm1, %xmm0
@@ -1119,10 +1117,9 @@ block0(v0: f32x4):
 ; block0:
 ;   movdqa  %xmm0, %xmm4
 ;   cmpps   $0, %xmm4, %xmm0, %xmm4
-;   movdqa  %xmm0, %xmm5
-;   andps   %xmm5, %xmm4, %xmm5
-;   pxor    %xmm4, %xmm5, %xmm4
-;   cvttps2dq %xmm5, %xmm1
+;   andps   %xmm0, %xmm4, %xmm0
+;   pxor    %xmm4, %xmm0, %xmm4
+;   cvttps2dq %xmm0, %xmm1
 ;   movdqa  %xmm1, %xmm0
 ;   pand    %xmm0, %xmm4, %xmm0
 ;   psrad   %xmm0, $31, %xmm0
@@ -1138,10 +1135,9 @@ block0(v0: f32x4):
 ; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm4
 ;   cmpeqps %xmm0, %xmm4
-;   movdqa %xmm0, %xmm5
-;   andps %xmm4, %xmm5
-;   pxor %xmm5, %xmm4
-;   cvttps2dq %xmm5, %xmm1
+;   andps %xmm4, %xmm0
+;   pxor %xmm0, %xmm4
+;   cvttps2dq %xmm0, %xmm1
 ;   movdqa %xmm1, %xmm0
 ;   pand %xmm4, %xmm0
 ;   psrad $0x1f, %xmm0

--- a/cranelift/filetests/filetests/isa/x64/fma-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/fma-call.clif
@@ -74,26 +74,26 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   movdqu  rsp(16 + virtual offset), %xmm1
 ;   movdqu  rsp(32 + virtual offset), %xmm2
 ;   call    *%r8
-;   movdqu  %xmm0, rsp(48 + virtual offset)
 ;   movdqu  rsp(0 + virtual offset), %xmm4
+;   movdqu  %xmm0, rsp(80 + virtual offset)
 ;   pshufd  $1, %xmm4, %xmm0
 ;   movdqu  rsp(16 + virtual offset), %xmm2
 ;   pshufd  $1, %xmm2, %xmm1
-;   movdqu  rsp(32 + virtual offset), %xmm4
-;   pshufd  $1, %xmm4, %xmm2
+;   movdqu  rsp(32 + virtual offset), %xmm5
+;   pshufd  $1, %xmm5, %xmm2
 ;   load_ext_name %FmaF32+0, %r9
 ;   call    *%r9
-;   movdqu  %xmm0, rsp(64 + virtual offset)
 ;   movdqu  rsp(0 + virtual offset), %xmm4
+;   movdqu  %xmm0, rsp(48 + virtual offset)
 ;   pshufd  $2, %xmm4, %xmm0
-;   movdqu  rsp(16 + virtual offset), %xmm6
-;   pshufd  $2, %xmm6, %xmm1
+;   movdqu  rsp(16 + virtual offset), %xmm7
+;   pshufd  $2, %xmm7, %xmm1
 ;   movdqu  rsp(32 + virtual offset), %xmm3
 ;   pshufd  $2, %xmm3, %xmm2
 ;   load_ext_name %FmaF32+0, %r10
 ;   call    *%r10
-;   movdqu  %xmm0, rsp(80 + virtual offset)
 ;   movdqu  rsp(0 + virtual offset), %xmm4
+;   movdqu  %xmm0, rsp(64 + virtual offset)
 ;   pshufd  $3, %xmm4, %xmm0
 ;   movdqu  rsp(16 + virtual offset), %xmm1
 ;   pshufd  $3, %xmm1, %xmm1
@@ -101,12 +101,12 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   pshufd  $3, %xmm2, %xmm2
 ;   load_ext_name %FmaF32+0, %r11
 ;   call    *%r11
-;   movdqu  rsp(64 + virtual offset), %xmm4
 ;   movdqa  %xmm0, %xmm2
-;   movdqu  rsp(48 + virtual offset), %xmm0
-;   insertps $16, %xmm0, %xmm4, %xmm0
-;   movdqu  rsp(80 + virtual offset), %xmm1
-;   insertps $32, %xmm0, %xmm1, %xmm0
+;   movdqu  rsp(48 + virtual offset), %xmm1
+;   movdqu  rsp(80 + virtual offset), %xmm0
+;   insertps $16, %xmm0, %xmm1, %xmm0
+;   movdqu  rsp(64 + virtual offset), %xmm6
+;   insertps $32, %xmm0, %xmm6, %xmm0
 ;   movdqa  %xmm2, %xmm3
 ;   insertps $48, %xmm0, %xmm3, %xmm0
 ;   addq    %rsp, $96, %rsp
@@ -128,26 +128,26 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   movdqu 0x10(%rsp), %xmm1
 ;   movdqu 0x20(%rsp), %xmm2
 ;   callq *%r8
-;   movdqu %xmm0, 0x30(%rsp)
 ;   movdqu (%rsp), %xmm4
+;   movdqu %xmm0, 0x50(%rsp)
 ;   pshufd $1, %xmm4, %xmm0
 ;   movdqu 0x10(%rsp), %xmm2
 ;   pshufd $1, %xmm2, %xmm1
-;   movdqu 0x20(%rsp), %xmm4
-;   pshufd $1, %xmm4, %xmm2
+;   movdqu 0x20(%rsp), %xmm5
+;   pshufd $1, %xmm5, %xmm2
 ;   movabsq $0, %r9 ; reloc_external Abs8 %FmaF32 0
 ;   callq *%r9
-;   movdqu %xmm0, 0x40(%rsp)
 ;   movdqu (%rsp), %xmm4
+;   movdqu %xmm0, 0x30(%rsp)
 ;   pshufd $2, %xmm4, %xmm0
-;   movdqu 0x10(%rsp), %xmm6
-;   pshufd $2, %xmm6, %xmm1
+;   movdqu 0x10(%rsp), %xmm7
+;   pshufd $2, %xmm7, %xmm1
 ;   movdqu 0x20(%rsp), %xmm3
 ;   pshufd $2, %xmm3, %xmm2
 ;   movabsq $0, %r10 ; reloc_external Abs8 %FmaF32 0
 ;   callq *%r10
-;   movdqu %xmm0, 0x50(%rsp)
 ;   movdqu (%rsp), %xmm4
+;   movdqu %xmm0, 0x40(%rsp)
 ;   pshufd $3, %xmm4, %xmm0
 ;   movdqu 0x10(%rsp), %xmm1
 ;   pshufd $3, %xmm1, %xmm1
@@ -155,12 +155,12 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   pshufd $3, %xmm2, %xmm2
 ;   movabsq $0, %r11 ; reloc_external Abs8 %FmaF32 0
 ;   callq *%r11
-;   movdqu 0x40(%rsp), %xmm4
 ;   movdqa %xmm0, %xmm2
-;   movdqu 0x30(%rsp), %xmm0
-;   insertps $0x10, %xmm4, %xmm0
-;   movdqu 0x50(%rsp), %xmm1
-;   insertps $0x20, %xmm1, %xmm0
+;   movdqu 0x30(%rsp), %xmm1
+;   movdqu 0x50(%rsp), %xmm0
+;   insertps $0x10, %xmm1, %xmm0
+;   movdqu 0x40(%rsp), %xmm6
+;   insertps $0x20, %xmm6, %xmm0
 ;   movdqa %xmm2, %xmm3
 ;   insertps $0x30, %xmm3, %xmm0
 ;   addq $0x60, %rsp
@@ -196,9 +196,9 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   pshufd  $238, %xmm2, %xmm2
 ;   load_ext_name %FmaF64+0, %r9
 ;   call    *%r9
-;   movdqa  %xmm0, %xmm6
+;   movdqa  %xmm0, %xmm7
 ;   movdqu  rsp(48 + virtual offset), %xmm0
-;   movlhps %xmm0, %xmm6, %xmm0
+;   movlhps %xmm0, %xmm7, %xmm0
 ;   addq    %rsp, $64, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -227,9 +227,9 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   pshufd $0xee, %xmm2, %xmm2
 ;   movabsq $0, %r9 ; reloc_external Abs8 %FmaF64 0
 ;   callq *%r9
-;   movdqa %xmm0, %xmm6
+;   movdqa %xmm0, %xmm7
 ;   movdqu 0x30(%rsp), %xmm0
-;   movlhps %xmm6, %xmm0
+;   movlhps %xmm7, %xmm0
 ;   addq $0x40, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -203,9 +203,8 @@ block0(v0: i128, v1: i128):
 ;   imulq   %rdx, %rcx, %rdx
 ;   movq    %rax, %rcx
 ;   movq    %rdi, %rax
-;   movq    %rsi, %r10
-;   imulq   %r10, %rcx, %r10
-;   addq    %rdx, %r10, %rdx
+;   imulq   %rsi, %rcx, %rsi
+;   addq    %rdx, %rsi, %rdx
 ;   movq    %rdx, %r9
 ;   mul     %rax, %rcx, %rax, %rdx
 ;   movq    %rdx, %rcx
@@ -225,9 +224,8 @@ block0(v0: i128, v1: i128):
 ;   imulq %rcx, %rdx
 ;   movq %rax, %rcx
 ;   movq %rdi, %rax
-;   movq %rsi, %r10
-;   imulq %rcx, %r10
-;   addq %r10, %rdx
+;   imulq %rcx, %rsi
+;   addq %rsi, %rdx
 ;   movq %rdx, %r9
 ;   mulq %rcx
 ;   movq %rdx, %rcx
@@ -247,8 +245,8 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %rdx
 ;   movq    %rdi, %rax
+;   movq    %rsi, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -258,8 +256,8 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, %rdx
 ;   movq %rdi, %rax
+;   movq %rsi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -274,8 +272,8 @@ block0(v0: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rsi, %rdx
 ;   movq    %rdi, %rax
+;   movq    %rsi, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -285,8 +283,8 @@ block0(v0: i128):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rsi, %rdx
 ;   movq %rdi, %rax
+;   movq %rsi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -865,17 +863,16 @@ block0(v0: i128):
 ;   shrq    $1, %rax, %rax
 ;   movabsq $8608480567731124087, %r8
 ;   andq    %rax, %r8, %rax
-;   movq    %rdi, %r9
-;   subq    %r9, %rax, %r9
+;   subq    %rdi, %rax, %rdi
 ;   shrq    $1, %rax, %rax
 ;   andq    %rax, %r8, %rax
-;   subq    %r9, %rax, %r9
+;   subq    %rdi, %rax, %rdi
 ;   shrq    $1, %rax, %rax
 ;   andq    %rax, %r8, %rax
-;   subq    %r9, %rax, %r9
-;   movq    %r9, %rax
+;   subq    %rdi, %rax, %rdi
+;   movq    %rdi, %rax
 ;   shrq    $4, %rax, %rax
-;   addq    %rax, %r9, %rax
+;   addq    %rax, %rdi, %rax
 ;   movabsq $1085102592571150095, %rdi
 ;   andq    %rax, %rdi, %rax
 ;   movabsq $72340172838076673, %rdx
@@ -885,23 +882,22 @@ block0(v0: i128):
 ;   shrq    $1, %rdi, %rdi
 ;   movabsq $8608480567731124087, %rcx
 ;   andq    %rdi, %rcx, %rdi
-;   movq    %rsi, %rdx
-;   subq    %rdx, %rdi, %rdx
+;   subq    %rsi, %rdi, %rsi
 ;   shrq    $1, %rdi, %rdi
 ;   andq    %rdi, %rcx, %rdi
-;   subq    %rdx, %rdi, %rdx
+;   subq    %rsi, %rdi, %rsi
 ;   shrq    $1, %rdi, %rdi
 ;   andq    %rdi, %rcx, %rdi
-;   subq    %rdx, %rdi, %rdx
-;   movq    %rdx, %rsi
-;   shrq    $4, %rsi, %rsi
-;   addq    %rsi, %rdx, %rsi
+;   subq    %rsi, %rdi, %rsi
+;   movq    %rsi, %rdi
+;   shrq    $4, %rdi, %rdi
+;   addq    %rdi, %rsi, %rdi
 ;   movabsq $1085102592571150095, %r10
-;   andq    %rsi, %r10, %rsi
+;   andq    %rdi, %r10, %rdi
 ;   movabsq $72340172838076673, %rcx
-;   imulq   %rsi, %rcx, %rsi
-;   shrq    $56, %rsi, %rsi
-;   addq    %rax, %rsi, %rax
+;   imulq   %rdi, %rcx, %rdi
+;   shrq    $56, %rdi, %rdi
+;   addq    %rax, %rdi, %rax
 ;   xorq    %rdx, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -916,17 +912,16 @@ block0(v0: i128):
 ;   shrq $1, %rax
 ;   movabsq $0x7777777777777777, %r8
 ;   andq %r8, %rax
-;   movq %rdi, %r9
-;   subq %rax, %r9
+;   subq %rax, %rdi
 ;   shrq $1, %rax
 ;   andq %r8, %rax
-;   subq %rax, %r9
+;   subq %rax, %rdi
 ;   shrq $1, %rax
 ;   andq %r8, %rax
-;   subq %rax, %r9
-;   movq %r9, %rax
+;   subq %rax, %rdi
+;   movq %rdi, %rax
 ;   shrq $4, %rax
-;   addq %r9, %rax
+;   addq %rdi, %rax
 ;   movabsq $0xf0f0f0f0f0f0f0f, %rdi
 ;   andq %rdi, %rax
 ;   movabsq $0x101010101010101, %rdx
@@ -936,23 +931,22 @@ block0(v0: i128):
 ;   shrq $1, %rdi
 ;   movabsq $0x7777777777777777, %rcx
 ;   andq %rcx, %rdi
-;   movq %rsi, %rdx
-;   subq %rdi, %rdx
+;   subq %rdi, %rsi
 ;   shrq $1, %rdi
 ;   andq %rcx, %rdi
-;   subq %rdi, %rdx
+;   subq %rdi, %rsi
 ;   shrq $1, %rdi
 ;   andq %rcx, %rdi
-;   subq %rdi, %rdx
-;   movq %rdx, %rsi
-;   shrq $4, %rsi
-;   addq %rdx, %rsi
+;   subq %rdi, %rsi
+;   movq %rsi, %rdi
+;   shrq $4, %rdi
+;   addq %rsi, %rdi
 ;   movabsq $0xf0f0f0f0f0f0f0f, %r10
-;   andq %r10, %rsi
+;   andq %r10, %rdi
 ;   movabsq $0x101010101010101, %rcx
-;   imulq %rcx, %rsi
-;   shrq $0x38, %rsi
-;   addq %rsi, %rax
+;   imulq %rcx, %rdi
+;   shrq $0x38, %rdi
+;   addq %rdi, %rax
 ;   xorq %rdx, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -971,11 +965,10 @@ block0(v0: i128):
 ;   movabsq $6148914691236517205, %rcx
 ;   movq    %rsi, %rdx
 ;   andq    %rdx, %rcx, %rdx
-;   movq    %rsi, %r11
-;   shrq    $1, %r11, %r11
-;   andq    %r11, %rcx, %r11
+;   shrq    $1, %rsi, %rsi
+;   andq    %rsi, %rcx, %rsi
 ;   shlq    $1, %rdx, %rdx
-;   orq     %rdx, %r11, %rdx
+;   orq     %rdx, %rsi, %rdx
 ;   movabsq $3689348814741910323, %r9
 ;   movq    %rdx, %r10
 ;   andq    %r10, %r9, %r10
@@ -1013,11 +1006,10 @@ block0(v0: i128):
 ;   movabsq $6148914691236517205, %rdx
 ;   movq    %rdi, %rcx
 ;   andq    %rcx, %rdx, %rcx
-;   movq    %rdi, %r9
-;   shrq    $1, %r9, %r9
-;   andq    %r9, %rdx, %r9
+;   shrq    $1, %rdi, %rdi
+;   andq    %rdi, %rdx, %rdi
 ;   shlq    $1, %rcx, %rcx
-;   orq     %rcx, %r9, %rcx
+;   orq     %rcx, %rdi, %rcx
 ;   movabsq $3689348814741910323, %rdx
 ;   movq    %rcx, %r8
 ;   andq    %r8, %rdx, %r8
@@ -1064,11 +1056,10 @@ block0(v0: i128):
 ;   movabsq $0x5555555555555555, %rcx
 ;   movq %rsi, %rdx
 ;   andq %rcx, %rdx
-;   movq %rsi, %r11
-;   shrq $1, %r11
-;   andq %rcx, %r11
+;   shrq $1, %rsi
+;   andq %rcx, %rsi
 ;   shlq $1, %rdx
-;   orq %r11, %rdx
+;   orq %rsi, %rdx
 ;   movabsq $0x3333333333333333, %r9
 ;   movq %rdx, %r10
 ;   andq %r9, %r10
@@ -1106,11 +1097,10 @@ block0(v0: i128):
 ;   movabsq $0x5555555555555555, %rdx
 ;   movq %rdi, %rcx
 ;   andq %rdx, %rcx
-;   movq %rdi, %r9
-;   shrq $1, %r9
-;   andq %rdx, %r9
+;   shrq $1, %rdi
+;   andq %rdx, %rdi
 ;   shlq $1, %rcx
-;   orq %r9, %rcx
+;   orq %rdi, %rcx
 ;   movabsq $0x3333333333333333, %rdx
 ;   movq %rcx, %r8
 ;   andq %rdx, %r8
@@ -1296,36 +1286,31 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $32, %rsp
 ;   movq    %rbx, 0(%rsp)
-;   movq    %r12, 8(%rsp)
+;   movq    %r13, 8(%rsp)
 ;   movq    %r14, 16(%rsp)
 ;   movq    %r15, 24(%rsp)
 ; block0:
-;   movq    %r8, %r14
-;   movq    %rcx, %rbx
-;   movq    %rdx, %rcx
-;   movq    16(%rbp), %r15
+;   movq    %rdx, %rbx
+;   movq    %rcx, %r14
+;   movq    16(%rbp), %rcx
 ;   movq    24(%rbp), %rax
 ;   movq    32(%rbp), %rdx
 ;   movq    40(%rbp), %r11
 ;   movq    48(%rbp), %r10
-;   movq    %rdi, %r8
-;   addq    %r8, %rcx, %r8
-;   movq    %rbx, %rdi
-;   movq    %rsi, %rcx
-;   adcq    %rcx, %rdi, %rcx
-;   xorq    %rdi, %rdi, %rdi
-;   movq    %r14, %r12
-;   movq    %r9, %rsi
-;   addq    %rsi, %r12, %rsi
-;   adcq    %r15, %rdi, %r15
+;   addq    %rdi, %rbx, %rdi
+;   movq    %r14, %r15
+;   adcq    %rsi, %r15, %rsi
+;   xorq    %r13, %r13, %r13
+;   addq    %r9, %r8, %r9
+;   adcq    %rcx, %r13, %rcx
 ;   addq    %rax, %r11, %rax
 ;   adcq    %rdx, %r10, %rdx
-;   addq    %r8, %rsi, %r8
-;   adcq    %rcx, %r15, %rcx
-;   addq    %rax, %r8, %rax
-;   adcq    %rdx, %rcx, %rdx
+;   addq    %rdi, %r9, %rdi
+;   adcq    %rsi, %rcx, %rsi
+;   addq    %rax, %rdi, %rax
+;   adcq    %rdx, %rsi, %rdx
 ;   movq    0(%rsp), %rbx
-;   movq    8(%rsp), %r12
+;   movq    8(%rsp), %r13
 ;   movq    16(%rsp), %r14
 ;   movq    24(%rsp), %r15
 ;   addq    %rsp, $32, %rsp
@@ -1339,36 +1324,31 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 ;   movq %rsp, %rbp
 ;   subq $0x20, %rsp
 ;   movq %rbx, (%rsp)
-;   movq %r12, 8(%rsp)
+;   movq %r13, 8(%rsp)
 ;   movq %r14, 0x10(%rsp)
 ;   movq %r15, 0x18(%rsp)
 ; block1: ; offset 0x1b
-;   movq %r8, %r14
-;   movq %rcx, %rbx
-;   movq %rdx, %rcx
-;   movq 0x10(%rbp), %r15
+;   movq %rdx, %rbx
+;   movq %rcx, %r14
+;   movq 0x10(%rbp), %rcx
 ;   movq 0x18(%rbp), %rax
 ;   movq 0x20(%rbp), %rdx
 ;   movq 0x28(%rbp), %r11
 ;   movq 0x30(%rbp), %r10
-;   movq %rdi, %r8
-;   addq %rcx, %r8
-;   movq %rbx, %rdi
-;   movq %rsi, %rcx
-;   adcq %rdi, %rcx
-;   xorq %rdi, %rdi
-;   movq %r14, %r12
-;   movq %r9, %rsi
-;   addq %r12, %rsi
-;   adcq %rdi, %r15
+;   addq %rbx, %rdi
+;   movq %r14, %r15
+;   adcq %r15, %rsi
+;   xorq %r13, %r13
+;   addq %r8, %r9
+;   adcq %r13, %rcx
 ;   addq %r11, %rax
 ;   adcq %r10, %rdx
-;   addq %rsi, %r8
-;   adcq %r15, %rcx
-;   addq %r8, %rax
-;   adcq %rcx, %rdx
+;   addq %r9, %rdi
+;   adcq %rcx, %rsi
+;   addq %rdi, %rax
+;   adcq %rsi, %rdx
 ;   movq (%rsp), %rbx
-;   movq 8(%rsp), %r12
+;   movq 8(%rsp), %r13
 ;   movq 0x10(%rsp), %r14
 ;   movq 0x18(%rsp), %r15
 ;   addq $0x20, %rsp
@@ -1618,21 +1598,19 @@ block0(v0: i128, v1: i128):
 ;   movq    %rdx, %r10
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
-;   movq    %rsi, %r11
-;   shlq    %cl, %r11, %r11
+;   shlq    %cl, %rsi, %rsi
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
 ;   movq    %r10, %r8
 ;   subq    %rcx, %r8, %rcx
-;   movq    %rdi, %r10
-;   shrq    %cl, %r10, %r10
+;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
 ;   testq   $127, %r8
-;   cmovzq  %rax, %r10, %r10
-;   orq     %r10, %r11, %r10
+;   cmovzq  %rax, %rdi, %rdi
+;   orq     %rdi, %rsi, %rdi
 ;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %r10, %rdx, %rdx
+;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1646,21 +1624,19 @@ block0(v0: i128, v1: i128):
 ;   movq %rdx, %r10
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
-;   movq %rsi, %r11
-;   shlq %cl, %r11
+;   shlq %cl, %rsi
 ;   movq %rcx, %r10
 ;   movl $0x40, %ecx
 ;   movq %r10, %r8
 ;   subq %r8, %rcx
-;   movq %rdi, %r10
-;   shrq %cl, %r10
+;   shrq %cl, %rdi
 ;   xorq %rax, %rax
 ;   testq $0x7f, %r8
-;   cmoveq %rax, %r10
-;   orq %r11, %r10
+;   cmoveq %rax, %rdi
+;   orq %rsi, %rdi
 ;   testq $0x40, %r8
 ;   cmoveq %rdx, %rax
-;   cmoveq %r10, %rdx
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -1677,23 +1653,21 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdx, %r11
-;   movq    %rdi, %r8
-;   shrq    %cl, %r8, %r8
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r10
 ;   shrq    %cl, %r10, %r10
 ;   movq    %rcx, %r11
 ;   movl    $64, %ecx
-;   movq    %r11, %rdi
-;   subq    %rcx, %rdi, %rcx
-;   movq    %rsi, %r11
-;   shlq    %cl, %r11, %r11
+;   movq    %r11, %rax
+;   subq    %rcx, %rax, %rcx
+;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $127, %rdi
-;   cmovzq  %rdx, %r11, %r11
-;   orq     %r11, %r8, %r11
-;   testq   $64, %rdi
+;   testq   $127, %rax
+;   cmovzq  %rdx, %rsi, %rsi
+;   orq     %rsi, %rdi, %rsi
+;   testq   $64, %rax
 ;   movq    %r10, %rax
-;   cmovzq  %r11, %rax, %rax
+;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1706,23 +1680,21 @@ block0(v0: i128, v1: i128):
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdx, %r11
-;   movq %rdi, %r8
-;   shrq %cl, %r8
+;   shrq %cl, %rdi
 ;   movq %rsi, %r10
 ;   shrq %cl, %r10
 ;   movq %rcx, %r11
 ;   movl $0x40, %ecx
-;   movq %r11, %rdi
-;   subq %rdi, %rcx
-;   movq %rsi, %r11
-;   shlq %cl, %r11
+;   movq %r11, %rax
+;   subq %rax, %rcx
+;   shlq %cl, %rsi
 ;   xorq %rdx, %rdx
-;   testq $0x7f, %rdi
-;   cmoveq %rdx, %r11
-;   orq %r8, %r11
-;   testq $0x40, %rdi
+;   testq $0x7f, %rax
+;   cmoveq %rdx, %rsi
+;   orq %rdi, %rsi
+;   testq $0x40, %rax
 ;   movq %r10, %rax
-;   cmoveq %r11, %rax
+;   cmoveq %rsi, %rax
 ;   cmoveq %r10, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1740,8 +1712,7 @@ block0(v0: i128, v1: i128):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdx, %r11
-;   movq    %rdi, %r8
-;   shrq    %cl, %r8, %r8
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r10
 ;   sarq    %cl, %r10, %r10
 ;   movq    %rcx, %r11
@@ -1753,12 +1724,12 @@ block0(v0: i128, v1: i128):
 ;   xorq    %r11, %r11, %r11
 ;   testq   $127, %rax
 ;   cmovzq  %r11, %r9, %r9
-;   orq     %r8, %r9, %r8
-;   movq    %rsi, %rdx
-;   sarq    $63, %rdx, %rdx
+;   orq     %rdi, %r9, %rdi
+;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r10, %rax
-;   cmovzq  %r8, %rax, %rax
+;   cmovzq  %rdi, %rax, %rax
+;   movq    %rsi, %rdx
 ;   cmovzq  %r10, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1771,8 +1742,7 @@ block0(v0: i128, v1: i128):
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdx, %r11
-;   movq %rdi, %r8
-;   shrq %cl, %r8
+;   shrq %cl, %rdi
 ;   movq %rsi, %r10
 ;   sarq %cl, %r10
 ;   movq %rcx, %r11
@@ -1784,12 +1754,12 @@ block0(v0: i128, v1: i128):
 ;   xorq %r11, %r11
 ;   testq $0x7f, %rax
 ;   cmoveq %r11, %r9
-;   orq %r9, %r8
-;   movq %rsi, %rdx
-;   sarq $0x3f, %rdx
+;   orq %r9, %rdi
+;   sarq $0x3f, %rsi
 ;   testq $0x40, %rax
 ;   movq %r10, %rax
-;   cmoveq %r8, %rax
+;   cmoveq %rdi, %rax
+;   movq %rsi, %rdx
 ;   cmoveq %r10, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1828,26 +1798,24 @@ block0(v0: i128, v1: i128):
 ;   movl    $128, %ecx
 ;   movq    %r8, %r10
 ;   subq    %rcx, %r10, %rcx
-;   movq    %rdi, %r8
-;   shrq    %cl, %r8, %r8
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   shrq    %cl, %r9, %r9
-;   movq    %rcx, %r10
+;   movq    %rcx, %r8
 ;   movl    $64, %ecx
-;   movq    %r10, %r11
-;   subq    %rcx, %r11, %rcx
-;   movq    %rsi, %r10
-;   shlq    %cl, %r10, %r10
-;   xorq    %rsi, %rsi, %rsi
-;   testq   $127, %r11
+;   movq    %r8, %r10
+;   subq    %rcx, %r10, %rcx
+;   shlq    %cl, %rsi, %rsi
+;   xorq    %r8, %r8, %r8
+;   testq   $127, %r10
+;   cmovzq  %r8, %rsi, %rsi
+;   orq     %rsi, %rdi, %rsi
+;   testq   $64, %r10
+;   movq    %r9, %r10
 ;   cmovzq  %rsi, %r10, %r10
-;   orq     %r10, %r8, %r10
-;   testq   $64, %r11
-;   movq    %r9, %r8
-;   cmovzq  %r10, %r8, %r8
-;   cmovzq  %r9, %rsi, %rsi
-;   orq     %rax, %r8, %rax
-;   orq     %rdx, %rsi, %rdx
+;   cmovzq  %r9, %r8, %r8
+;   orq     %rax, %r10, %rax
+;   orq     %rdx, %r8, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1880,26 +1848,24 @@ block0(v0: i128, v1: i128):
 ;   movl $0x80, %ecx
 ;   movq %r8, %r10
 ;   subq %r10, %rcx
-;   movq %rdi, %r8
-;   shrq %cl, %r8
+;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   shrq %cl, %r9
-;   movq %rcx, %r10
+;   movq %rcx, %r8
 ;   movl $0x40, %ecx
-;   movq %r10, %r11
-;   subq %r11, %rcx
-;   movq %rsi, %r10
-;   shlq %cl, %r10
-;   xorq %rsi, %rsi
-;   testq $0x7f, %r11
+;   movq %r8, %r10
+;   subq %r10, %rcx
+;   shlq %cl, %rsi
+;   xorq %r8, %r8
+;   testq $0x7f, %r10
+;   cmoveq %r8, %rsi
+;   orq %rdi, %rsi
+;   testq $0x40, %r10
+;   movq %r9, %r10
 ;   cmoveq %rsi, %r10
-;   orq %r8, %r10
-;   testq $0x40, %r11
-;   movq %r9, %r8
-;   cmoveq %r10, %r8
-;   cmoveq %r9, %rsi
-;   orq %r8, %rax
-;   orq %rsi, %rdx
+;   cmoveq %r9, %r8
+;   orq %r10, %rax
+;   orq %r8, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -1940,21 +1906,18 @@ block0(v0: i128, v1: i128):
 ;   subq    %rcx, %r10, %rcx
 ;   movq    %rdi, %r8
 ;   shlq    %cl, %r8, %r8
-;   movq    %rsi, %r10
-;   shlq    %cl, %r10, %r10
+;   shlq    %cl, %rsi, %rsi
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
-;   movq    %r9, %rsi
-;   subq    %rcx, %rsi, %rcx
-;   movq    %rdi, %r9
-;   shrq    %cl, %r9, %r9
+;   subq    %rcx, %r9, %rcx
+;   shrq    %cl, %rdi, %rdi
 ;   xorq    %r11, %r11, %r11
-;   testq   $127, %rsi
-;   cmovzq  %r11, %r9, %r9
-;   orq     %r9, %r10, %r9
-;   testq   $64, %rsi
+;   testq   $127, %r9
+;   cmovzq  %r11, %rdi, %rdi
+;   orq     %rdi, %rsi, %rdi
+;   testq   $64, %r9
 ;   cmovzq  %r8, %r11, %r11
-;   cmovzq  %r9, %r8, %r8
+;   cmovzq  %rdi, %r8, %r8
 ;   orq     %rax, %r11, %rax
 ;   orq     %rdx, %r8, %rdx
 ;   movq    %rbp, %rsp
@@ -1992,21 +1955,18 @@ block0(v0: i128, v1: i128):
 ;   subq %r10, %rcx
 ;   movq %rdi, %r8
 ;   shlq %cl, %r8
-;   movq %rsi, %r10
-;   shlq %cl, %r10
+;   shlq %cl, %rsi
 ;   movq %rcx, %r9
 ;   movl $0x40, %ecx
-;   movq %r9, %rsi
-;   subq %rsi, %rcx
-;   movq %rdi, %r9
-;   shrq %cl, %r9
+;   subq %r9, %rcx
+;   shrq %cl, %rdi
 ;   xorq %r11, %r11
-;   testq $0x7f, %rsi
-;   cmoveq %r11, %r9
-;   orq %r10, %r9
-;   testq $0x40, %rsi
+;   testq $0x7f, %r9
+;   cmoveq %r11, %rdi
+;   orq %rsi, %rdi
+;   testq $0x40, %r9
 ;   cmoveq %r8, %r11
-;   cmoveq %r9, %r8
+;   cmoveq %rdi, %r8
 ;   orq %r11, %rax
 ;   orq %r8, %rdx
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/ishl.clif
+++ b/cranelift/filetests/filetests/isa/x64/ishl.clif
@@ -21,21 +21,19 @@ block0(v0: i128, v1: i8):
 ;   movzbq  %dl, %rcx
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
-;   movq    %rsi, %r11
-;   shlq    %cl, %r11, %r11
+;   shlq    %cl, %rsi, %rsi
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
 ;   movq    %r9, %r8
 ;   subq    %rcx, %r8, %rcx
-;   movq    %rdi, %r10
-;   shrq    %cl, %r10, %r10
+;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
 ;   testq   $127, %r8
-;   cmovzq  %rax, %r10, %r10
-;   orq     %r10, %r11, %r10
+;   cmovzq  %rax, %rdi, %rdi
+;   orq     %rdi, %rsi, %rdi
 ;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %r10, %rdx, %rdx
+;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -48,21 +46,19 @@ block0(v0: i128, v1: i8):
 ;   movzbq %dl, %rcx
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
-;   movq %rsi, %r11
-;   shlq %cl, %r11
+;   shlq %cl, %rsi
 ;   movq %rcx, %r9
 ;   movl $0x40, %ecx
 ;   movq %r9, %r8
 ;   subq %r8, %rcx
-;   movq %rdi, %r10
-;   shrq %cl, %r10
+;   shrq %cl, %rdi
 ;   xorq %rax, %rax
 ;   testq $0x7f, %r8
-;   cmoveq %rax, %r10
-;   orq %r11, %r10
+;   cmoveq %rax, %rdi
+;   orq %rsi, %rdi
 ;   testq $0x40, %r8
 ;   cmoveq %rdx, %rax
-;   cmoveq %r10, %rdx
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -81,21 +77,19 @@ block0(v0: i128, v1: i64):
 ;   movq    %rdx, %r9
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
-;   movq    %rsi, %r10
-;   shlq    %cl, %r10, %r10
+;   shlq    %cl, %rsi, %rsi
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
-;   movq    %r9, %rsi
-;   subq    %rcx, %rsi, %rcx
-;   movq    %rdi, %r9
-;   shrq    %cl, %r9, %r9
+;   movq    %r9, %r8
+;   subq    %rcx, %r8, %rcx
+;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
-;   testq   $127, %rsi
-;   cmovzq  %rax, %r9, %r9
-;   orq     %r9, %r10, %r9
-;   testq   $64, %rsi
+;   testq   $127, %r8
+;   cmovzq  %rax, %rdi, %rdi
+;   orq     %rdi, %rsi, %rdi
+;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %r9, %rdx, %rdx
+;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -109,21 +103,19 @@ block0(v0: i128, v1: i64):
 ;   movq %rdx, %r9
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
-;   movq %rsi, %r10
-;   shlq %cl, %r10
+;   shlq %cl, %rsi
 ;   movq %rcx, %r9
 ;   movl $0x40, %ecx
-;   movq %r9, %rsi
-;   subq %rsi, %rcx
-;   movq %rdi, %r9
-;   shrq %cl, %r9
+;   movq %r9, %r8
+;   subq %r8, %rcx
+;   shrq %cl, %rdi
 ;   xorq %rax, %rax
-;   testq $0x7f, %rsi
-;   cmoveq %rax, %r9
-;   orq %r10, %r9
-;   testq $0x40, %rsi
+;   testq $0x7f, %r8
+;   cmoveq %rax, %rdi
+;   orq %rsi, %rdi
+;   testq $0x40, %r8
 ;   cmoveq %rdx, %rax
-;   cmoveq %r9, %rdx
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -142,21 +134,19 @@ block0(v0: i128, v1: i32):
 ;   movq    %rdx, %r9
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
-;   movq    %rsi, %r10
-;   shlq    %cl, %r10, %r10
+;   shlq    %cl, %rsi, %rsi
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
-;   movq    %r9, %rsi
-;   subq    %rcx, %rsi, %rcx
-;   movq    %rdi, %r9
-;   shrq    %cl, %r9, %r9
+;   movq    %r9, %r8
+;   subq    %rcx, %r8, %rcx
+;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
-;   testq   $127, %rsi
-;   cmovzq  %rax, %r9, %r9
-;   orq     %r9, %r10, %r9
-;   testq   $64, %rsi
+;   testq   $127, %r8
+;   cmovzq  %rax, %rdi, %rdi
+;   orq     %rdi, %rsi, %rdi
+;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %r9, %rdx, %rdx
+;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -170,21 +160,19 @@ block0(v0: i128, v1: i32):
 ;   movq %rdx, %r9
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
-;   movq %rsi, %r10
-;   shlq %cl, %r10
+;   shlq %cl, %rsi
 ;   movq %rcx, %r9
 ;   movl $0x40, %ecx
-;   movq %r9, %rsi
-;   subq %rsi, %rcx
-;   movq %rdi, %r9
-;   shrq %cl, %r9
+;   movq %r9, %r8
+;   subq %r8, %rcx
+;   shrq %cl, %rdi
 ;   xorq %rax, %rax
-;   testq $0x7f, %rsi
-;   cmoveq %rax, %r9
-;   orq %r10, %r9
-;   testq $0x40, %rsi
+;   testq $0x7f, %r8
+;   cmoveq %rax, %rdi
+;   orq %rsi, %rdi
+;   testq $0x40, %r8
 ;   cmoveq %rdx, %rax
-;   cmoveq %r9, %rdx
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -203,21 +191,19 @@ block0(v0: i128, v1: i16):
 ;   movq    %rdx, %r9
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
-;   movq    %rsi, %r10
-;   shlq    %cl, %r10, %r10
+;   shlq    %cl, %rsi, %rsi
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
-;   movq    %r9, %rsi
-;   subq    %rcx, %rsi, %rcx
-;   movq    %rdi, %r9
-;   shrq    %cl, %r9, %r9
+;   movq    %r9, %r8
+;   subq    %rcx, %r8, %rcx
+;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
-;   testq   $127, %rsi
-;   cmovzq  %rax, %r9, %r9
-;   orq     %r9, %r10, %r9
-;   testq   $64, %rsi
+;   testq   $127, %r8
+;   cmovzq  %rax, %rdi, %rdi
+;   orq     %rdi, %rsi, %rdi
+;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %r9, %rdx, %rdx
+;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -231,21 +217,19 @@ block0(v0: i128, v1: i16):
 ;   movq %rdx, %r9
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
-;   movq %rsi, %r10
-;   shlq %cl, %r10
+;   shlq %cl, %rsi
 ;   movq %rcx, %r9
 ;   movl $0x40, %ecx
-;   movq %r9, %rsi
-;   subq %rsi, %rcx
-;   movq %rdi, %r9
-;   shrq %cl, %r9
+;   movq %r9, %r8
+;   subq %r8, %rcx
+;   shrq %cl, %rdi
 ;   xorq %rax, %rax
-;   testq $0x7f, %rsi
-;   cmoveq %rax, %r9
-;   orq %r10, %r9
-;   testq $0x40, %rsi
+;   testq $0x7f, %r8
+;   cmoveq %rax, %rdi
+;   orq %rsi, %rdi
+;   testq $0x40, %r8
 ;   cmoveq %rdx, %rax
-;   cmoveq %r9, %rdx
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -264,21 +248,19 @@ block0(v0: i128, v1: i8):
 ;   movq    %rdx, %r9
 ;   movq    %rdi, %rdx
 ;   shlq    %cl, %rdx, %rdx
-;   movq    %rsi, %r10
-;   shlq    %cl, %r10, %r10
+;   shlq    %cl, %rsi, %rsi
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
-;   movq    %r9, %rsi
-;   subq    %rcx, %rsi, %rcx
-;   movq    %rdi, %r9
-;   shrq    %cl, %r9, %r9
+;   movq    %r9, %r8
+;   subq    %rcx, %r8, %rcx
+;   shrq    %cl, %rdi, %rdi
 ;   xorq    %rax, %rax, %rax
-;   testq   $127, %rsi
-;   cmovzq  %rax, %r9, %r9
-;   orq     %r9, %r10, %r9
-;   testq   $64, %rsi
+;   testq   $127, %r8
+;   cmovzq  %rax, %rdi, %rdi
+;   orq     %rdi, %rsi, %rdi
+;   testq   $64, %r8
 ;   cmovzq  %rdx, %rax, %rax
-;   cmovzq  %r9, %rdx, %rdx
+;   cmovzq  %rdi, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -292,21 +274,19 @@ block0(v0: i128, v1: i8):
 ;   movq %rdx, %r9
 ;   movq %rdi, %rdx
 ;   shlq %cl, %rdx
-;   movq %rsi, %r10
-;   shlq %cl, %r10
+;   shlq %cl, %rsi
 ;   movq %rcx, %r9
 ;   movl $0x40, %ecx
-;   movq %r9, %rsi
-;   subq %rsi, %rcx
-;   movq %rdi, %r9
-;   shrq %cl, %r9
+;   movq %r9, %r8
+;   subq %r8, %rcx
+;   shrq %cl, %rdi
 ;   xorq %rax, %rax
-;   testq $0x7f, %rsi
-;   cmoveq %rax, %r9
-;   orq %r10, %r9
-;   testq $0x40, %rsi
+;   testq $0x7f, %r8
+;   cmoveq %rax, %rdi
+;   orq %rsi, %rdi
+;   testq $0x40, %r8
 ;   cmoveq %rdx, %rax
-;   cmoveq %r9, %rdx
+;   cmoveq %rdi, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/narrowing.clif
+++ b/cranelift/filetests/filetests/isa/x64/narrowing.clif
@@ -66,9 +66,8 @@ block0(v0: f64x2):
 ;   movdqa  %xmm0, %xmm3
 ;   cmppd   $0, %xmm3, %xmm0, %xmm3
 ;   andps   %xmm3, const(0), %xmm3
-;   movdqa  %xmm0, %xmm6
-;   minpd   %xmm6, %xmm3, %xmm6
-;   cvttpd2dq %xmm6, %xmm0
+;   minpd   %xmm0, %xmm3, %xmm0
+;   cvttpd2dq %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -81,12 +80,13 @@ block0(v0: f64x2):
 ;   movdqa %xmm0, %xmm3
 ;   cmpeqpd %xmm0, %xmm3
 ;   andps 0x1c(%rip), %xmm3
-;   movdqa %xmm0, %xmm6
-;   minpd %xmm3, %xmm6
-;   cvttpd2dq %xmm6, %xmm0
+;   minpd %xmm3, %xmm0
+;   cvttpd2dq %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)

--- a/cranelift/filetests/filetests/isa/x64/popcnt.clif
+++ b/cranelift/filetests/filetests/isa/x64/popcnt.clif
@@ -11,21 +11,20 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   shrq    $1, %rdi, %rdi
-;   movq    %rcx, %r8
+;   movq    %rdi, %rax
+;   shrq    $1, %rax, %rax
 ;   movabsq $8608480567731124087, %rdx
-;   andq    %rdi, %rdx, %rdi
-;   subq    %r8, %rdi, %r8
-;   shrq    $1, %rdi, %rdi
-;   andq    %rdi, %rdx, %rdi
-;   subq    %r8, %rdi, %r8
-;   shrq    $1, %rdi, %rdi
-;   andq    %rdi, %rdx, %rdi
-;   subq    %r8, %rdi, %r8
-;   movq    %r8, %rax
+;   andq    %rax, %rdx, %rax
+;   subq    %rdi, %rax, %rdi
+;   shrq    $1, %rax, %rax
+;   andq    %rax, %rdx, %rax
+;   subq    %rdi, %rax, %rdi
+;   shrq    $1, %rax, %rax
+;   andq    %rax, %rdx, %rax
+;   subq    %rdi, %rax, %rdi
+;   movq    %rdi, %rax
 ;   shrq    $4, %rax, %rax
-;   addq    %rax, %r8, %rax
+;   addq    %rax, %rdi, %rax
 ;   movabsq $1085102592571150095, %r11
 ;   andq    %rax, %r11, %rax
 ;   movabsq $72340172838076673, %rcx
@@ -40,21 +39,20 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   shrq $1, %rdi
-;   movq %rcx, %r8
+;   movq %rdi, %rax
+;   shrq $1, %rax
 ;   movabsq $0x7777777777777777, %rdx
-;   andq %rdx, %rdi
-;   subq %rdi, %r8
-;   shrq $1, %rdi
-;   andq %rdx, %rdi
-;   subq %rdi, %r8
-;   shrq $1, %rdi
-;   andq %rdx, %rdi
-;   subq %rdi, %r8
-;   movq %r8, %rax
+;   andq %rdx, %rax
+;   subq %rax, %rdi
+;   shrq $1, %rax
+;   andq %rdx, %rax
+;   subq %rax, %rdi
+;   shrq $1, %rax
+;   andq %rdx, %rax
+;   subq %rax, %rdi
+;   movq %rdi, %rax
 ;   shrq $4, %rax
-;   addq %r8, %rax
+;   addq %rdi, %rax
 ;   movabsq $0xf0f0f0f0f0f0f0f, %r11
 ;   andq %r11, %rax
 ;   movabsq $0x101010101010101, %rcx
@@ -139,20 +137,19 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movq    %rdi, %rax
-;   shrl    $1, %edi, %edi
+;   shrl    $1, %eax, %eax
 ;   movl    $2004318071, %edx
-;   andl    %edi, %edx, %edi
-;   movq    %rax, %r8
-;   subl    %r8d, %edi, %r8d
-;   shrl    $1, %edi, %edi
-;   andl    %edi, %edx, %edi
-;   subl    %r8d, %edi, %r8d
-;   shrl    $1, %edi, %edi
-;   andl    %edi, %edx, %edi
-;   subl    %r8d, %edi, %r8d
-;   movq    %r8, %rax
+;   andl    %eax, %edx, %eax
+;   subl    %edi, %eax, %edi
+;   shrl    $1, %eax, %eax
+;   andl    %eax, %edx, %eax
+;   subl    %edi, %eax, %edi
+;   shrl    $1, %eax, %eax
+;   andl    %eax, %edx, %eax
+;   subl    %edi, %eax, %edi
+;   movq    %rdi, %rax
 ;   shrl    $4, %eax, %eax
-;   addl    %eax, %r8d, %eax
+;   addl    %eax, %edi, %eax
 ;   andl    %eax, $252645135, %eax
 ;   imull   %eax, $16843009, %eax
 ;   shrl    $24, %eax, %eax
@@ -166,20 +163,19 @@ block0(v0: i32):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movq %rdi, %rax
-;   shrl $1, %edi
+;   shrl $1, %eax
 ;   movl $0x77777777, %edx
-;   andl %edx, %edi
-;   movq %rax, %r8
-;   subl %edi, %r8d
-;   shrl $1, %edi
-;   andl %edx, %edi
-;   subl %edi, %r8d
-;   shrl $1, %edi
-;   andl %edx, %edi
-;   subl %edi, %r8d
-;   movq %r8, %rax
+;   andl %edx, %eax
+;   subl %eax, %edi
+;   shrl $1, %eax
+;   andl %edx, %eax
+;   subl %eax, %edi
+;   shrl $1, %eax
+;   andl %edx, %eax
+;   subl %eax, %edi
+;   movq %rdi, %rax
 ;   shrl $4, %eax
-;   addl %r8d, %eax
+;   addl %edi, %eax
 ;   andl $0xf0f0f0f, %eax
 ;   imull $0x1010101, %eax, %eax
 ;   shrl $0x18, %eax

--- a/cranelift/filetests/filetests/isa/x64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call.clif
@@ -363,16 +363,16 @@ block0:
 ;   movq    %rbp, %r15
 ;   movq    8(%r15), %r13
 ;   load_ext_name %tail_callee_stack_args+0, %r12
-;   movq    rsp(24 + virtual offset), %r11
-;   movq    rsp(32 + virtual offset), %r10
-;   movq    rsp(40 + virtual offset), %r9
-;   movq    rsp(48 + virtual offset), %r8
-;   movq    rsp(56 + virtual offset), %rdi
-;   movq    rsp(64 + virtual offset), %rsi
-;   movq    rsp(72 + virtual offset), %rbx
-;   movq    rsp(80 + virtual offset), %rdx
-;   movq    rsp(88 + virtual offset), %rcx
 ;   movq    rsp(96 + virtual offset), %rax
+;   movq    rsp(88 + virtual offset), %rcx
+;   movq    rsp(80 + virtual offset), %rdx
+;   movq    rsp(72 + virtual offset), %rbx
+;   movq    rsp(64 + virtual offset), %rsi
+;   movq    rsp(56 + virtual offset), %rdi
+;   movq    rsp(48 + virtual offset), %r8
+;   movq    rsp(40 + virtual offset), %r9
+;   movq    rsp(32 + virtual offset), %r10
+;   movq    rsp(24 + virtual offset), %r11
 ;   return_call_unknown %r12 new_stack_arg_size:128 old_stack_arg_size:0 ret_addr:Some("%v219") fp:%v218 tmp:%v220 %rax=%rax %rcx=%rcx %rdx=%rdx %rbx=%rbx %rsi=%rsi %rdi=%rdi %r8=%r8 %r9=%r9 %r10=%r10 %r11=%r11
 ;
 ; Disassembled:
@@ -443,16 +443,16 @@ block0:
 ;   movq %rbp, %r15
 ;   movq 8(%r15), %r13
 ;   movabsq $0, %r12 ; reloc_external Abs8 %tail_callee_stack_args 0
-;   movq 0x98(%rsp), %r11
-;   movq 0xa0(%rsp), %r10
-;   movq 0xa8(%rsp), %r9
-;   movq 0xb0(%rsp), %r8
-;   movq 0xb8(%rsp), %rdi
-;   movq 0xc0(%rsp), %rsi
-;   movq 0xc8(%rsp), %rbx
-;   movq 0xd0(%rsp), %rdx
-;   movq 0xd8(%rsp), %rcx
 ;   movq 0xe0(%rsp), %rax
+;   movq 0xd8(%rsp), %rcx
+;   movq 0xd0(%rsp), %rdx
+;   movq 0xc8(%rsp), %rbx
+;   movq 0xc0(%rsp), %rsi
+;   movq 0xb8(%rsp), %rdi
+;   movq 0xb0(%rsp), %r8
+;   movq 0xa8(%rsp), %r9
+;   movq 0xa0(%rsp), %r10
+;   movq 0x98(%rsp), %r11
 ;   movq (%r15), %rbp
 ;   movq 0x78(%rsp), %r14
 ;   movq %r14, 8(%r15)

--- a/cranelift/filetests/filetests/isa/x64/select-i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/select-i128.clif
@@ -51,11 +51,11 @@ block0(v0: f32, v1: i128, v2: i128):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm0, %xmm0
+;   cmovpq  %rdx, %rdi, %rdi
 ;   movq    %rdi, %rax
-;   cmovpq  %rdx, %rax, %rax
 ;   cmovnzq %rdx, %rax, %rax
+;   cmovpq  %rcx, %rsi, %rsi
 ;   movq    %rsi, %rdx
-;   cmovpq  %rcx, %rdx, %rdx
 ;   cmovnzq %rcx, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -67,11 +67,11 @@ block0(v0: f32, v1: i128, v2: i128):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   ucomiss %xmm0, %xmm0
+;   cmovpq %rdx, %rdi
 ;   movq %rdi, %rax
-;   cmovpq %rdx, %rax
 ;   cmovneq %rdx, %rax
+;   cmovpq %rcx, %rsi
 ;   movq %rsi, %rdx
-;   cmovpq %rcx, %rdx
 ;   cmovneq %rcx, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/select.clif
+++ b/cranelift/filetests/filetests/isa/x64/select.clif
@@ -45,8 +45,8 @@ block0(v0: f32, v1: f32, v2: i64, v3: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   ucomiss %xmm1, %xmm0
+;   cmovpq  %rsi, %rdi, %rdi
 ;   movq    %rdi, %rax
-;   cmovpq  %rsi, %rax, %rax
 ;   cmovnzq %rsi, %rax, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -58,8 +58,8 @@ block0(v0: f32, v1: f32, v2: i64, v3: i64):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   ucomiss %xmm1, %xmm0
+;   cmovpq %rsi, %rdi
 ;   movq %rdi, %rax
-;   cmovpq %rsi, %rax
 ;   cmovneq %rsi, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-arith-avx.clif
@@ -914,12 +914,11 @@ block0(v0: i8x16, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %r9
-;   andq    %r9, $7, %r9
+;   andq    %rdi, $7, %rdi
 ;   vpunpcklbw %xmm0, %xmm0, %xmm5
 ;   vpunpckhbw %xmm0, %xmm0, %xmm7
-;   addl    %r9d, $8, %r9d
-;   vmovd   %r9d, %xmm3
+;   addl    %edi, $8, %edi
+;   vmovd   %edi, %xmm3
 ;   vpsraw  %xmm5, %xmm3, %xmm5
 ;   vpsraw  %xmm7, %xmm3, %xmm7
 ;   vpacksswb %xmm5, %xmm7, %xmm0
@@ -932,12 +931,11 @@ block0(v0: i8x16, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %r9
-;   andq $7, %r9
+;   andq $7, %rdi
 ;   vpunpcklbw %xmm0, %xmm0, %xmm5
 ;   vpunpckhbw %xmm0, %xmm0, %xmm7
-;   addl $8, %r9d
-;   vmovd %r9d, %xmm3
+;   addl $8, %edi
+;   vmovd %edi, %xmm3
 ;   vpsraw %xmm3, %xmm5, %xmm5
 ;   vpsraw %xmm3, %xmm7, %xmm7
 ;   vpacksswb %xmm7, %xmm5, %xmm0
@@ -989,9 +987,8 @@ block0(v0: i16x8, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   andq    %rcx, $15, %rcx
-;   vmovd   %ecx, %xmm5
+;   andq    %rdi, $15, %rdi
+;   vmovd   %edi, %xmm5
 ;   vpsraw  %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1002,9 +999,8 @@ block0(v0: i16x8, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   andq $0xf, %rcx
-;   vmovd %ecx, %xmm5
+;   andq $0xf, %rdi
+;   vmovd %edi, %xmm5
 ;   vpsraw %xmm5, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1046,9 +1042,8 @@ block0(v0: i32x4, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   andq    %rcx, $31, %rcx
-;   vmovd   %ecx, %xmm5
+;   andq    %rdi, $31, %rdi
+;   vmovd   %edi, %xmm5
 ;   vpsrad  %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1059,9 +1054,8 @@ block0(v0: i32x4, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   andq $0x1f, %rcx
-;   vmovd %ecx, %xmm5
+;   andq $0x1f, %rdi
+;   vmovd %edi, %xmm5
 ;   vpsrad %xmm5, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1387,13 +1381,12 @@ block0(v0: i8x16, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %r10
-;   andq    %r10, $7, %r10
-;   vmovd   %r10d, %xmm5
+;   andq    %rdi, $7, %rdi
+;   vmovd   %edi, %xmm5
 ;   vpsllw  %xmm0, %xmm5, %xmm7
 ;   lea     const(0), %rsi
-;   shlq    $4, %r10, %r10
-;   vmovdqu 0(%rsi,%r10,1), %xmm5
+;   shlq    $4, %rdi, %rdi
+;   vmovdqu 0(%rsi,%rdi,1), %xmm5
 ;   vpand   %xmm7, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1404,18 +1397,20 @@ block0(v0: i8x16, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %r10
-;   andq $7, %r10
-;   vmovd %r10d, %xmm5
+;   andq $7, %rdi
+;   vmovd %edi, %xmm5
 ;   vpsllw %xmm5, %xmm0, %xmm7
-;   leaq 0x15(%rip), %rsi
-;   shlq $4, %r10
-;   vmovdqu (%rsi, %r10), %xmm5
+;   leaq 0x19(%rip), %rsi
+;   shlq $4, %rdi
+;   vmovdqu (%rsi, %rdi), %xmm5
 ;   vpand %xmm5, %xmm7, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %bh, %bh
 
 function %i8x16_shl_imm(i8x16) -> i8x16 {
 block0(v0: i8x16):
@@ -1460,9 +1455,8 @@ block0(v0: i16x8, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   andq    %rcx, $15, %rcx
-;   vmovd   %ecx, %xmm5
+;   andq    %rdi, $15, %rdi
+;   vmovd   %edi, %xmm5
 ;   vpsllw  %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1473,9 +1467,8 @@ block0(v0: i16x8, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   andq $0xf, %rcx
-;   vmovd %ecx, %xmm5
+;   andq $0xf, %rdi
+;   vmovd %edi, %xmm5
 ;   vpsllw %xmm5, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1517,9 +1510,8 @@ block0(v0: i32x4, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   andq    %rcx, $31, %rcx
-;   vmovd   %ecx, %xmm5
+;   andq    %rdi, $31, %rdi
+;   vmovd   %edi, %xmm5
 ;   vpslld  %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1530,9 +1522,8 @@ block0(v0: i32x4, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   andq $0x1f, %rcx
-;   vmovd %ecx, %xmm5
+;   andq $0x1f, %rdi
+;   vmovd %edi, %xmm5
 ;   vpslld %xmm5, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1574,9 +1565,8 @@ block0(v0: i64x2, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   andq    %rcx, $63, %rcx
-;   vmovd   %ecx, %xmm5
+;   andq    %rdi, $63, %rdi
+;   vmovd   %edi, %xmm5
 ;   vpsllq  %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1587,9 +1577,8 @@ block0(v0: i64x2, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   andq $0x3f, %rcx
-;   vmovd %ecx, %xmm5
+;   andq $0x3f, %rdi
+;   vmovd %edi, %xmm5
 ;   vpsllq %xmm5, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1631,13 +1620,12 @@ block0(v0: i8x16, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %r10
-;   andq    %r10, $7, %r10
-;   vmovd   %r10d, %xmm5
+;   andq    %rdi, $7, %rdi
+;   vmovd   %edi, %xmm5
 ;   vpsrlw  %xmm0, %xmm5, %xmm7
 ;   lea     const(0), %rsi
-;   shlq    $4, %r10, %r10
-;   vpand   %xmm7, 0(%rsi,%r10,1), %xmm0
+;   shlq    $4, %rdi, %rdi
+;   vpand   %xmm7, 0(%rsi,%rdi,1), %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -1647,19 +1635,21 @@ block0(v0: i8x16, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %r10
-;   andq $7, %r10
-;   vmovd %r10d, %xmm5
+;   andq $7, %rdi
+;   vmovd %edi, %xmm5
 ;   vpsrlw %xmm5, %xmm0, %xmm7
-;   leaq 0x15(%rip), %rsi
-;   shlq $4, %r10
-;   vpand (%rsi, %r10), %xmm7, %xmm0
+;   leaq 0x19(%rip), %rsi
+;   shlq $4, %rdi
+;   vpand (%rsi, %rdi), %xmm7, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %bh, %bh
 
 function %i8x16_ushr_imm(i8x16) -> i8x16 {
 block0(v0: i8x16):
@@ -1712,9 +1702,8 @@ block0(v0: i16x8, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   andq    %rcx, $15, %rcx
-;   vmovd   %ecx, %xmm5
+;   andq    %rdi, $15, %rdi
+;   vmovd   %edi, %xmm5
 ;   vpsrlw  %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1725,9 +1714,8 @@ block0(v0: i16x8, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   andq $0xf, %rcx
-;   vmovd %ecx, %xmm5
+;   andq $0xf, %rdi
+;   vmovd %edi, %xmm5
 ;   vpsrlw %xmm5, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1769,9 +1757,8 @@ block0(v0: i32x4, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   andq    %rcx, $31, %rcx
-;   vmovd   %ecx, %xmm5
+;   andq    %rdi, $31, %rdi
+;   vmovd   %edi, %xmm5
 ;   vpsrld  %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1782,9 +1769,8 @@ block0(v0: i32x4, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   andq $0x1f, %rcx
-;   vmovd %ecx, %xmm5
+;   andq $0x1f, %rdi
+;   vmovd %edi, %xmm5
 ;   vpsrld %xmm5, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -1826,9 +1812,8 @@ block0(v0: i64x2, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   andq    %rcx, $63, %rcx
-;   vmovd   %ecx, %xmm5
+;   andq    %rdi, $63, %rdi
+;   vmovd   %edi, %xmm5
 ;   vpsrlq  %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -1839,9 +1824,8 @@ block0(v0: i64x2, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   andq $0x3f, %rcx
-;   vmovd %ecx, %xmm5
+;   andq $0x3f, %rdi
+;   vmovd %edi, %xmm5
 ;   vpsrlq %xmm5, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitselect.clif
@@ -82,11 +82,12 @@ block0(v0: i8x16, v1: i8x16, v2: i32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm0, %xmm4
-;   pand    %xmm4, %xmm2, %xmm4
+;   pand    %xmm0, %xmm2, %xmm0
+;   movdqa  %xmm0, %xmm7
+;   pandn   %xmm2, %xmm1, %xmm2
+;   movdqa  %xmm7, %xmm1
 ;   movdqa  %xmm2, %xmm0
-;   pandn   %xmm0, %xmm1, %xmm0
-;   por     %xmm0, %xmm4, %xmm0
+;   por     %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -96,11 +97,12 @@ block0(v0: i8x16, v1: i8x16, v2: i32x4):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movdqa %xmm0, %xmm4
-;   pand %xmm2, %xmm4
+;   pand %xmm2, %xmm0
+;   movdqa %xmm0, %xmm7
+;   pandn %xmm1, %xmm2
+;   movdqa %xmm7, %xmm1
 ;   movdqa %xmm2, %xmm0
-;   pandn %xmm1, %xmm0
-;   por %xmm4, %xmm0
+;   por %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -211,12 +213,12 @@ block0(v0: i8x16, v1: i8x16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm0, %xmm2
+;   movdqa  %xmm0, %xmm7
 ;   movdqu  const(0), %xmm0
-;   movdqa  %xmm2, %xmm4
-;   pand    %xmm4, %xmm0, %xmm4
+;   movdqa  %xmm7, %xmm2
+;   pand    %xmm2, %xmm0, %xmm2
 ;   pandn   %xmm0, %xmm1, %xmm0
-;   por     %xmm0, %xmm4, %xmm0
+;   por     %xmm0, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -226,12 +228,12 @@ block0(v0: i8x16, v1: i8x16):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movdqa %xmm0, %xmm2
+;   movdqa %xmm0, %xmm7
 ;   movdqu 0x20(%rip), %xmm0
-;   movdqa %xmm2, %xmm4
-;   pand %xmm0, %xmm4
+;   movdqa %xmm7, %xmm2
+;   pand %xmm0, %xmm2
 ;   pandn %xmm1, %xmm0
-;   por %xmm4, %xmm0
+;   por %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-bitwise-compile.clif
@@ -236,10 +236,9 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm1, %xmm4
-;   pand    %xmm4, %xmm0, %xmm4
+;   pand    %xmm1, %xmm0, %xmm1
 ;   pandn   %xmm0, %xmm2, %xmm0
-;   por     %xmm0, %xmm4, %xmm0
+;   por     %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -249,10 +248,9 @@ block0(v0: i16x8, v1: i16x8, v2: i16x8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movdqa %xmm1, %xmm4
-;   pand %xmm0, %xmm4
+;   pand %xmm0, %xmm1
 ;   pandn %xmm2, %xmm0
-;   por %xmm4, %xmm0
+;   por %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -267,10 +265,9 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm1, %xmm4
-;   andps   %xmm4, %xmm0, %xmm4
+;   andps   %xmm1, %xmm0, %xmm1
 ;   andnps  %xmm0, %xmm2, %xmm0
-;   orps    %xmm0, %xmm4, %xmm0
+;   orps    %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -280,10 +277,9 @@ block0(v0: f32x4, v1: f32x4, v2: f32x4):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movdqa %xmm1, %xmm4
-;   andps %xmm0, %xmm4
+;   andps %xmm0, %xmm1
 ;   andnps %xmm2, %xmm0
-;   orps %xmm4, %xmm0
+;   orps %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -298,10 +294,9 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm1, %xmm4
-;   andpd   %xmm4, %xmm0, %xmm4
+;   andpd   %xmm1, %xmm0, %xmm1
 ;   andnpd  %xmm0, %xmm2, %xmm0
-;   orpd    %xmm0, %xmm4, %xmm0
+;   orpd    %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -311,10 +306,9 @@ block0(v0: f64x2, v1: f64x2, v2: f64x2):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movdqa %xmm1, %xmm4
-;   andpd %xmm0, %xmm4
+;   andpd %xmm0, %xmm1
 ;   andnpd %xmm2, %xmm0
-;   orpd %xmm4, %xmm0
+;   orpd %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -331,13 +325,12 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(1), %xmm0
-;   movq    %rdi, %r10
-;   andq    %r10, $7, %r10
-;   movd    %r10d, %xmm5
+;   andq    %rdi, $7, %rdi
+;   movd    %edi, %xmm5
 ;   psllw   %xmm0, %xmm5, %xmm0
 ;   lea     const(0), %rsi
-;   shlq    $4, %r10, %r10
-;   movdqu  0(%rsi,%r10,1), %xmm5
+;   shlq    $4, %rdi, %rdi
+;   movdqu  0(%rsi,%rdi,1), %xmm5
 ;   pand    %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -349,13 +342,12 @@ block0(v0: i32):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movdqu 0x34(%rip), %xmm0
-;   movq %rdi, %r10
-;   andq $7, %r10
-;   movd %r10d, %xmm5
+;   andq $7, %rdi
+;   movd %edi, %xmm5
 ;   psllw %xmm5, %xmm0
-;   leaq 0x2d(%rip), %rsi
-;   shlq $4, %r10
-;   movdqu (%rsi, %r10), %xmm5
+;   leaq 0x31(%rip), %rsi
+;   shlq $4, %rdi
+;   movdqu (%rsi, %rdi), %xmm5
 ;   pand %xmm5, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -365,9 +357,13 @@ block0(v0: i32):
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
-;   addb %al, (%rcx)
-;   addb (%rbx), %al
-;   addb $5, %al
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addl %eax, (%rdx)
+;   addl 0x9080706(, %rax), %eax
+;   orb (%rbx), %cl
+;   orb $0xd, %al
 
 function %ishl_i8x16_imm(i8x16) -> i8x16 {
 block0(v0: i8x16):
@@ -605,13 +601,12 @@ block0(v0: i32):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movdqu  const(0), %xmm1
-;   movq    %rdi, %r9
-;   andq    %r9, $7, %r9
+;   andq    %rdi, $7, %rdi
 ;   movdqa  %xmm1, %xmm0
 ;   punpcklbw %xmm0, %xmm1, %xmm0
 ;   punpckhbw %xmm1, %xmm1, %xmm1
-;   addl    %r9d, $8, %r9d
-;   movd    %r9d, %xmm3
+;   addl    %edi, $8, %edi
+;   movd    %edi, %xmm3
 ;   psraw   %xmm0, %xmm3, %xmm0
 ;   psraw   %xmm1, %xmm3, %xmm1
 ;   packsswb %xmm0, %xmm1, %xmm0
@@ -625,13 +620,12 @@ block0(v0: i32):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movdqu 0x34(%rip), %xmm1
-;   movq %rdi, %r9
-;   andq $7, %r9
+;   andq $7, %rdi
 ;   movdqa %xmm1, %xmm0
 ;   punpcklbw %xmm1, %xmm0
 ;   punpckhbw %xmm1, %xmm1
-;   addl $8, %r9d
-;   movd %r9d, %xmm3
+;   addl $8, %edi
+;   movd %edi, %xmm3
 ;   psraw %xmm3, %xmm0
 ;   psraw %xmm3, %xmm1
 ;   packsswb %xmm1, %xmm0
@@ -642,10 +636,11 @@ block0(v0: i32):
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
-;   addl %eax, (%rdx)
-;   addl 0x9080706(, %rax), %eax
-;   orb (%rbx), %cl
-;   orb $0xd, %al
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rcx)
+;   addb (%rbx), %al
+;   addb $5, %al
 
 function %sshr_i8x16_imm(i8x16, i32) -> i8x16 {
 block0(v0: i8x16, v1: i32):
@@ -659,13 +654,12 @@ block0(v0: i8x16, v1: i32):
 ; block0:
 ;   movdqa  %xmm0, %xmm7
 ;   punpcklbw %xmm7, %xmm0, %xmm7
-;   movdqa  %xmm7, %xmm1
-;   movdqa  %xmm0, %xmm7
-;   punpckhbw %xmm7, %xmm0, %xmm7
-;   movdqa  %xmm1, %xmm0
+;   punpckhbw %xmm0, %xmm0, %xmm0
+;   movdqa  %xmm0, %xmm5
+;   movdqa  %xmm7, %xmm0
 ;   psraw   %xmm0, $11, %xmm0
-;   psraw   %xmm7, $11, %xmm7
-;   packsswb %xmm0, %xmm7, %xmm0
+;   psraw   %xmm5, $11, %xmm5
+;   packsswb %xmm0, %xmm5, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -677,13 +671,12 @@ block0(v0: i8x16, v1: i32):
 ; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm7
 ;   punpcklbw %xmm0, %xmm7
-;   movdqa %xmm7, %xmm1
-;   movdqa %xmm0, %xmm7
-;   punpckhbw %xmm0, %xmm7
-;   movdqa %xmm1, %xmm0
+;   punpckhbw %xmm0, %xmm0
+;   movdqa %xmm0, %xmm5
+;   movdqa %xmm7, %xmm0
 ;   psraw $0xb, %xmm0
-;   psraw $0xb, %xmm7
-;   packsswb %xmm7, %xmm0
+;   psraw $0xb, %xmm5
+;   packsswb %xmm5, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -754,9 +747,8 @@ block0(v0: i64x2):
 ;   movdqa  %xmm0, %xmm2
 ;   psrad   %xmm2, $1, %xmm2
 ;   pshufd  $237, %xmm2, %xmm4
-;   movdqa  %xmm0, %xmm6
-;   psrlq   %xmm6, $1, %xmm6
-;   pshufd  $232, %xmm6, %xmm0
+;   psrlq   %xmm0, $1, %xmm0
+;   pshufd  $232, %xmm0, %xmm0
 ;   punpckldq %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -770,9 +762,8 @@ block0(v0: i64x2):
 ;   movdqa %xmm0, %xmm2
 ;   psrad $1, %xmm2
 ;   pshufd $0xed, %xmm2, %xmm4
-;   movdqa %xmm0, %xmm6
-;   psrlq $1, %xmm6
-;   pshufd $0xe8, %xmm6, %xmm0
+;   psrlq $1, %xmm0
+;   pshufd $0xe8, %xmm0, %xmm0
 ;   punpckldq %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -790,9 +781,8 @@ block0(v0: i64x2):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   pshufd  $237, %xmm0, %xmm5
-;   movdqa  %xmm0, %xmm4
-;   psrad   %xmm4, $31, %xmm4
-;   pshufd  $237, %xmm4, %xmm6
+;   psrad   %xmm0, $31, %xmm0
+;   pshufd  $237, %xmm0, %xmm6
 ;   movdqa  %xmm5, %xmm0
 ;   punpckldq %xmm0, %xmm6, %xmm0
 ;   movq    %rbp, %rsp
@@ -805,9 +795,8 @@ block0(v0: i64x2):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   pshufd $0xed, %xmm0, %xmm5
-;   movdqa %xmm0, %xmm4
-;   psrad $0x1f, %xmm4
-;   pshufd $0xed, %xmm4, %xmm6
+;   psrad $0x1f, %xmm0
+;   pshufd $0xed, %xmm0, %xmm6
 ;   movdqa %xmm5, %xmm0
 ;   punpckldq %xmm6, %xmm0
 ;   movq %rbp, %rsp
@@ -828,9 +817,8 @@ block0(v0: i64x2):
 ;   movdqa  %xmm0, %xmm2
 ;   psrad   %xmm2, $31, %xmm2
 ;   pshufd  $237, %xmm2, %xmm4
-;   movdqa  %xmm0, %xmm6
-;   psrad   %xmm6, $22, %xmm6
-;   pshufd  $237, %xmm6, %xmm0
+;   psrad   %xmm0, $22, %xmm0
+;   pshufd  $237, %xmm0, %xmm0
 ;   punpckldq %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -844,9 +832,8 @@ block0(v0: i64x2):
 ;   movdqa %xmm0, %xmm2
 ;   psrad $0x1f, %xmm2
 ;   pshufd $0xed, %xmm2, %xmm4
-;   movdqa %xmm0, %xmm6
-;   psrad $0x16, %xmm6
-;   pshufd $0xed, %xmm6, %xmm0
+;   psrad $0x16, %xmm0
+;   pshufd $0xed, %xmm0, %xmm0
 ;   punpckldq %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -866,9 +853,8 @@ block0(v0: i64x2):
 ;   movdqa  %xmm0, %xmm2
 ;   psrad   %xmm2, $31, %xmm2
 ;   pshufd  $237, %xmm2, %xmm4
-;   movdqa  %xmm0, %xmm6
-;   psrad   %xmm6, $4, %xmm6
-;   pshufd  $237, %xmm6, %xmm0
+;   psrad   %xmm0, $4, %xmm0
+;   pshufd  $237, %xmm0, %xmm0
 ;   punpckldq %xmm0, %xmm4, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -882,9 +868,8 @@ block0(v0: i64x2):
 ;   movdqa %xmm0, %xmm2
 ;   psrad $0x1f, %xmm2
 ;   pshufd $0xed, %xmm2, %xmm4
-;   movdqa %xmm0, %xmm6
-;   psrad $4, %xmm6
-;   pshufd $0xed, %xmm6, %xmm0
+;   psrad $4, %xmm0
+;   pshufd $0xed, %xmm0, %xmm0
 ;   punpckldq %xmm4, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -900,15 +885,14 @@ block0(v0: i64x2, v1: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   andq    %rcx, $63, %rcx
-;   movq    %rcx, %xmm5
+;   andq    %rdi, $63, %rdi
+;   movq    %rdi, %xmm5
 ;   movdqu  const(0), %xmm1
 ;   psrlq   %xmm1, %xmm5, %xmm1
-;   movdqa  %xmm0, %xmm3
-;   psrlq   %xmm3, %xmm5, %xmm3
+;   psrlq   %xmm0, %xmm5, %xmm0
+;   movdqa  %xmm0, %xmm7
 ;   movdqa  %xmm1, %xmm0
-;   pxor    %xmm0, %xmm3, %xmm0
+;   pxor    %xmm0, %xmm7, %xmm0
 ;   psubq   %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -919,15 +903,14 @@ block0(v0: i64x2, v1: i32):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   andq $0x3f, %rcx
-;   movq %rcx, %xmm5
-;   movdqu 0x28(%rip), %xmm1
+;   andq $0x3f, %rdi
+;   movq %rdi, %xmm5
+;   movdqu 0x2b(%rip), %xmm1
 ;   psrlq %xmm5, %xmm1
-;   movdqa %xmm0, %xmm3
-;   psrlq %xmm5, %xmm3
+;   psrlq %xmm5, %xmm0
+;   movdqa %xmm0, %xmm7
 ;   movdqa %xmm1, %xmm0
-;   pxor %xmm3, %xmm0
+;   pxor %xmm7, %xmm0
 ;   psubq %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -941,7 +924,7 @@ block0(v0: i64x2, v1: i32):
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
-;   addb $0, (%rax)
+;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %al, (%rax)
 

--- a/cranelift/filetests/filetests/isa/x64/simd-i64x2-shift-avx512.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-i64x2-shift-avx512.clif
@@ -11,9 +11,8 @@ block0(v0: i64x2, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   andq    %rcx, $63, %rcx
-;   vmovd   %ecx, %xmm5
+;   andq    %rdi, $63, %rdi
+;   vmovd   %edi, %xmm5
 ;   vpsraq  %xmm5, %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -24,9 +23,8 @@ block0(v0: i64x2, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   andq $0x3f, %rcx
-;   vmovd %ecx, %xmm5
+;   andq $0x3f, %rdi
+;   vmovd %edi, %xmm5
 ;   vpsraq %xmm5, %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile.clif
@@ -68,9 +68,8 @@ block0(v0: i64x2):
 ; block0:
 ;   uninit  %xmm3
 ;   pxor    %xmm3, %xmm3, %xmm3
-;   movdqa  %xmm0, %xmm6
-;   pcmpeqq %xmm6, %xmm3, %xmm6
-;   ptest   %xmm6, %xmm6
+;   pcmpeqq %xmm0, %xmm3, %xmm0
+;   ptest   %xmm0, %xmm0
 ;   setz    %al
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -82,9 +81,8 @@ block0(v0: i64x2):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   pxor %xmm3, %xmm3
-;   movdqa %xmm0, %xmm6
-;   pcmpeqq %xmm3, %xmm6
-;   ptest %xmm6, %xmm6
+;   pcmpeqq %xmm3, %xmm0
+;   ptest %xmm0, %xmm0
 ;   sete %al
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-widen-mul.clif
@@ -13,12 +13,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm0, %xmm6
-;   palignr $8, %xmm6, %xmm0, %xmm6
-;   pmovsxbw %xmm6, %xmm0
-;   movdqa  %xmm1, %xmm6
-;   palignr $8, %xmm6, %xmm1, %xmm6
-;   pmovsxbw %xmm6, %xmm1
+;   palignr $8, %xmm0, %xmm0, %xmm0
+;   pmovsxbw %xmm0, %xmm0
+;   palignr $8, %xmm1, %xmm1, %xmm1
+;   pmovsxbw %xmm1, %xmm1
 ;   pmullw  %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -29,12 +27,10 @@ block0(v0: i8x16, v1: i8x16):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movdqa %xmm0, %xmm6
-;   palignr $8, %xmm0, %xmm6
-;   pmovsxbw %xmm6, %xmm0
-;   movdqa %xmm1, %xmm6
-;   palignr $8, %xmm1, %xmm6
-;   pmovsxbw %xmm6, %xmm1
+;   palignr $8, %xmm0, %xmm0
+;   pmovsxbw %xmm0, %xmm0
+;   palignr $8, %xmm1, %xmm1
+;   pmovsxbw %xmm1, %xmm1
 ;   pmullw %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -54,11 +50,10 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   pmullw  %xmm5, %xmm1, %xmm5
-;   movdqa  %xmm5, %xmm6
-;   movdqa  %xmm0, %xmm5
-;   pmulhw  %xmm5, %xmm1, %xmm5
-;   movdqa  %xmm6, %xmm0
-;   punpckhwd %xmm0, %xmm5, %xmm0
+;   pmulhw  %xmm0, %xmm1, %xmm0
+;   movdqa  %xmm0, %xmm2
+;   movdqa  %xmm5, %xmm0
+;   punpckhwd %xmm0, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -70,11 +65,10 @@ block0(v0: i16x8, v1: i16x8):
 ; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   pmullw %xmm1, %xmm5
-;   movdqa %xmm5, %xmm6
-;   movdqa %xmm0, %xmm5
-;   pmulhw %xmm1, %xmm5
-;   movdqa %xmm6, %xmm0
-;   punpckhwd %xmm5, %xmm0
+;   pmulhw %xmm1, %xmm0
+;   movdqa %xmm0, %xmm2
+;   movdqa %xmm5, %xmm0
+;   punpckhwd %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -155,11 +149,10 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   pmullw  %xmm5, %xmm1, %xmm5
-;   movdqa  %xmm5, %xmm6
-;   movdqa  %xmm0, %xmm5
-;   pmulhw  %xmm5, %xmm1, %xmm5
-;   movdqa  %xmm6, %xmm0
-;   punpcklwd %xmm0, %xmm5, %xmm0
+;   pmulhw  %xmm0, %xmm1, %xmm0
+;   movdqa  %xmm0, %xmm2
+;   movdqa  %xmm5, %xmm0
+;   punpcklwd %xmm0, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -171,11 +164,10 @@ block0(v0: i16x8, v1: i16x8):
 ; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   pmullw %xmm1, %xmm5
-;   movdqa %xmm5, %xmm6
-;   movdqa %xmm0, %xmm5
-;   pmulhw %xmm1, %xmm5
-;   movdqa %xmm6, %xmm0
-;   punpcklwd %xmm5, %xmm0
+;   pmulhw %xmm1, %xmm0
+;   movdqa %xmm0, %xmm2
+;   movdqa %xmm5, %xmm0
+;   punpcklwd %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -228,9 +220,8 @@ block0(v0: i8x16, v1: i8x16):
 ;   punpckhbw %xmm0, %xmm2, %xmm0
 ;   uninit  %xmm2
 ;   pxor    %xmm2, %xmm2, %xmm2
-;   movdqa  %xmm1, %xmm3
-;   punpckhbw %xmm3, %xmm2, %xmm3
-;   pmullw  %xmm0, %xmm3, %xmm0
+;   punpckhbw %xmm1, %xmm2, %xmm1
+;   pmullw  %xmm0, %xmm1, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -243,9 +234,8 @@ block0(v0: i8x16, v1: i8x16):
 ;   pxor %xmm2, %xmm2
 ;   punpckhbw %xmm2, %xmm0
 ;   pxor %xmm2, %xmm2
-;   movdqa %xmm1, %xmm3
-;   punpckhbw %xmm2, %xmm3
-;   pmullw %xmm3, %xmm0
+;   punpckhbw %xmm2, %xmm1
+;   pmullw %xmm1, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -264,11 +254,10 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   pmullw  %xmm5, %xmm1, %xmm5
-;   movdqa  %xmm5, %xmm6
-;   movdqa  %xmm0, %xmm5
-;   pmulhuw %xmm5, %xmm1, %xmm5
-;   movdqa  %xmm6, %xmm0
-;   punpckhwd %xmm0, %xmm5, %xmm0
+;   pmulhuw %xmm0, %xmm1, %xmm0
+;   movdqa  %xmm0, %xmm2
+;   movdqa  %xmm5, %xmm0
+;   punpckhwd %xmm0, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -280,11 +269,10 @@ block0(v0: i16x8, v1: i16x8):
 ; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   pmullw %xmm1, %xmm5
-;   movdqa %xmm5, %xmm6
-;   movdqa %xmm0, %xmm5
-;   pmulhuw %xmm1, %xmm5
-;   movdqa %xmm6, %xmm0
-;   punpckhwd %xmm5, %xmm0
+;   pmulhuw %xmm1, %xmm0
+;   movdqa %xmm0, %xmm2
+;   movdqa %xmm5, %xmm0
+;   punpckhwd %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -365,11 +353,10 @@ block0(v0: i16x8, v1: i16x8):
 ; block0:
 ;   movdqa  %xmm0, %xmm5
 ;   pmullw  %xmm5, %xmm1, %xmm5
-;   movdqa  %xmm5, %xmm6
-;   movdqa  %xmm0, %xmm5
-;   pmulhuw %xmm5, %xmm1, %xmm5
-;   movdqa  %xmm6, %xmm0
-;   punpcklwd %xmm0, %xmm5, %xmm0
+;   pmulhuw %xmm0, %xmm1, %xmm0
+;   movdqa  %xmm0, %xmm2
+;   movdqa  %xmm5, %xmm0
+;   punpcklwd %xmm0, %xmm2, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -381,11 +368,10 @@ block0(v0: i16x8, v1: i16x8):
 ; block1: ; offset 0x4
 ;   movdqa %xmm0, %xmm5
 ;   pmullw %xmm1, %xmm5
-;   movdqa %xmm5, %xmm6
-;   movdqa %xmm0, %xmm5
-;   pmulhuw %xmm1, %xmm5
-;   movdqa %xmm6, %xmm0
-;   punpcklwd %xmm5, %xmm0
+;   pmulhuw %xmm1, %xmm0
+;   movdqa %xmm0, %xmm2
+;   movdqa %xmm5, %xmm0
+;   punpcklwd %xmm2, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/sshr.clif
+++ b/cranelift/filetests/filetests/isa/x64/sshr.clif
@@ -18,8 +18,7 @@ block0(v0: i128, v1: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  %dl, %rcx
-;   movq    %rdi, %r8
-;   shrq    %cl, %r8, %r8
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r10
 ;   sarq    %cl, %r10, %r10
 ;   movq    %rcx, %r11
@@ -31,12 +30,12 @@ block0(v0: i128, v1: i8):
 ;   xorq    %r11, %r11, %r11
 ;   testq   $127, %rax
 ;   cmovzq  %r11, %r9, %r9
-;   orq     %r8, %r9, %r8
-;   movq    %rsi, %rdx
-;   sarq    $63, %rdx, %rdx
+;   orq     %rdi, %r9, %rdi
+;   sarq    $63, %rsi, %rsi
 ;   testq   $64, %rax
 ;   movq    %r10, %rax
-;   cmovzq  %r8, %rax, %rax
+;   cmovzq  %rdi, %rax, %rax
+;   movq    %rsi, %rdx
 ;   cmovzq  %r10, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -48,8 +47,7 @@ block0(v0: i128, v1: i8):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movzbq %dl, %rcx
-;   movq %rdi, %r8
-;   shrq %cl, %r8
+;   shrq %cl, %rdi
 ;   movq %rsi, %r10
 ;   sarq %cl, %r10
 ;   movq %rcx, %r11
@@ -61,12 +59,12 @@ block0(v0: i128, v1: i8):
 ;   xorq %r11, %r11
 ;   testq $0x7f, %rax
 ;   cmoveq %r11, %r9
-;   orq %r9, %r8
-;   movq %rsi, %rdx
-;   sarq $0x3f, %rdx
+;   orq %r9, %rdi
+;   sarq $0x3f, %rsi
 ;   testq $0x40, %rax
 ;   movq %r10, %rax
-;   cmoveq %r8, %rax
+;   cmoveq %rdi, %rax
+;   movq %rsi, %rdx
 ;   cmoveq %r10, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -84,25 +82,24 @@ block0(v0: i128, v1: i64):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdx, %r10
-;   movq    %rdi, %r11
-;   shrq    %cl, %r11, %r11
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   sarq    %cl, %r9, %r9
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r10, %rdi
-;   subq    %rcx, %rdi, %rcx
+;   movq    %r10, %rax
+;   subq    %rcx, %rax, %rcx
 ;   movq    %rsi, %r8
 ;   shlq    %cl, %r8, %r8
 ;   xorq    %r10, %r10, %r10
-;   testq   $127, %rdi
+;   testq   $127, %rax
 ;   cmovzq  %r10, %r8, %r8
-;   orq     %r11, %r8, %r11
-;   movq    %rsi, %rdx
-;   sarq    $63, %rdx, %rdx
-;   testq   $64, %rdi
+;   orq     %rdi, %r8, %rdi
+;   sarq    $63, %rsi, %rsi
+;   testq   $64, %rax
 ;   movq    %r9, %rax
-;   cmovzq  %r11, %rax, %rax
+;   cmovzq  %rdi, %rax, %rax
+;   movq    %rsi, %rdx
 ;   cmovzq  %r9, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -115,25 +112,24 @@ block0(v0: i128, v1: i64):
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdx, %r10
-;   movq %rdi, %r11
-;   shrq %cl, %r11
+;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   sarq %cl, %r9
 ;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r10, %rdi
-;   subq %rdi, %rcx
+;   movq %r10, %rax
+;   subq %rax, %rcx
 ;   movq %rsi, %r8
 ;   shlq %cl, %r8
 ;   xorq %r10, %r10
-;   testq $0x7f, %rdi
+;   testq $0x7f, %rax
 ;   cmoveq %r10, %r8
-;   orq %r8, %r11
-;   movq %rsi, %rdx
-;   sarq $0x3f, %rdx
-;   testq $0x40, %rdi
+;   orq %r8, %rdi
+;   sarq $0x3f, %rsi
+;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmoveq %r11, %rax
+;   cmoveq %rdi, %rax
+;   movq %rsi, %rdx
 ;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -151,25 +147,24 @@ block0(v0: i128, v1: i32):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdx, %r10
-;   movq    %rdi, %r11
-;   shrq    %cl, %r11, %r11
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   sarq    %cl, %r9, %r9
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r10, %rdi
-;   subq    %rcx, %rdi, %rcx
+;   movq    %r10, %rax
+;   subq    %rcx, %rax, %rcx
 ;   movq    %rsi, %r8
 ;   shlq    %cl, %r8, %r8
 ;   xorq    %r10, %r10, %r10
-;   testq   $127, %rdi
+;   testq   $127, %rax
 ;   cmovzq  %r10, %r8, %r8
-;   orq     %r11, %r8, %r11
-;   movq    %rsi, %rdx
-;   sarq    $63, %rdx, %rdx
-;   testq   $64, %rdi
+;   orq     %rdi, %r8, %rdi
+;   sarq    $63, %rsi, %rsi
+;   testq   $64, %rax
 ;   movq    %r9, %rax
-;   cmovzq  %r11, %rax, %rax
+;   cmovzq  %rdi, %rax, %rax
+;   movq    %rsi, %rdx
 ;   cmovzq  %r9, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -182,25 +177,24 @@ block0(v0: i128, v1: i32):
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdx, %r10
-;   movq %rdi, %r11
-;   shrq %cl, %r11
+;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   sarq %cl, %r9
 ;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r10, %rdi
-;   subq %rdi, %rcx
+;   movq %r10, %rax
+;   subq %rax, %rcx
 ;   movq %rsi, %r8
 ;   shlq %cl, %r8
 ;   xorq %r10, %r10
-;   testq $0x7f, %rdi
+;   testq $0x7f, %rax
 ;   cmoveq %r10, %r8
-;   orq %r8, %r11
-;   movq %rsi, %rdx
-;   sarq $0x3f, %rdx
-;   testq $0x40, %rdi
+;   orq %r8, %rdi
+;   sarq $0x3f, %rsi
+;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmoveq %r11, %rax
+;   cmoveq %rdi, %rax
+;   movq %rsi, %rdx
 ;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -218,25 +212,24 @@ block0(v0: i128, v1: i16):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdx, %r10
-;   movq    %rdi, %r11
-;   shrq    %cl, %r11, %r11
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   sarq    %cl, %r9, %r9
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r10, %rdi
-;   subq    %rcx, %rdi, %rcx
+;   movq    %r10, %rax
+;   subq    %rcx, %rax, %rcx
 ;   movq    %rsi, %r8
 ;   shlq    %cl, %r8, %r8
 ;   xorq    %r10, %r10, %r10
-;   testq   $127, %rdi
+;   testq   $127, %rax
 ;   cmovzq  %r10, %r8, %r8
-;   orq     %r11, %r8, %r11
-;   movq    %rsi, %rdx
-;   sarq    $63, %rdx, %rdx
-;   testq   $64, %rdi
+;   orq     %rdi, %r8, %rdi
+;   sarq    $63, %rsi, %rsi
+;   testq   $64, %rax
 ;   movq    %r9, %rax
-;   cmovzq  %r11, %rax, %rax
+;   cmovzq  %rdi, %rax, %rax
+;   movq    %rsi, %rdx
 ;   cmovzq  %r9, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -249,25 +242,24 @@ block0(v0: i128, v1: i16):
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdx, %r10
-;   movq %rdi, %r11
-;   shrq %cl, %r11
+;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   sarq %cl, %r9
 ;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r10, %rdi
-;   subq %rdi, %rcx
+;   movq %r10, %rax
+;   subq %rax, %rcx
 ;   movq %rsi, %r8
 ;   shlq %cl, %r8
 ;   xorq %r10, %r10
-;   testq $0x7f, %rdi
+;   testq $0x7f, %rax
 ;   cmoveq %r10, %r8
-;   orq %r8, %r11
-;   movq %rsi, %rdx
-;   sarq $0x3f, %rdx
-;   testq $0x40, %rdi
+;   orq %r8, %rdi
+;   sarq $0x3f, %rsi
+;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmoveq %r11, %rax
+;   cmoveq %rdi, %rax
+;   movq %rsi, %rdx
 ;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -285,25 +277,24 @@ block0(v0: i128, v1: i8):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdx, %r10
-;   movq    %rdi, %r11
-;   shrq    %cl, %r11, %r11
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   sarq    %cl, %r9, %r9
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r10, %rdi
-;   subq    %rcx, %rdi, %rcx
+;   movq    %r10, %rax
+;   subq    %rcx, %rax, %rcx
 ;   movq    %rsi, %r8
 ;   shlq    %cl, %r8, %r8
 ;   xorq    %r10, %r10, %r10
-;   testq   $127, %rdi
+;   testq   $127, %rax
 ;   cmovzq  %r10, %r8, %r8
-;   orq     %r11, %r8, %r11
-;   movq    %rsi, %rdx
-;   sarq    $63, %rdx, %rdx
-;   testq   $64, %rdi
+;   orq     %rdi, %r8, %rdi
+;   sarq    $63, %rsi, %rsi
+;   testq   $64, %rax
 ;   movq    %r9, %rax
-;   cmovzq  %r11, %rax, %rax
+;   cmovzq  %rdi, %rax, %rax
+;   movq    %rsi, %rdx
 ;   cmovzq  %r9, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -316,25 +307,24 @@ block0(v0: i128, v1: i8):
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdx, %r10
-;   movq %rdi, %r11
-;   shrq %cl, %r11
+;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   sarq %cl, %r9
 ;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r10, %rdi
-;   subq %rdi, %rcx
+;   movq %r10, %rax
+;   subq %rax, %rcx
 ;   movq %rsi, %r8
 ;   shlq %cl, %r8
 ;   xorq %r10, %r10
-;   testq $0x7f, %rdi
+;   testq $0x7f, %rax
 ;   cmoveq %r10, %r8
-;   orq %r8, %r11
-;   movq %rsi, %rdx
-;   sarq $0x3f, %rdx
-;   testq $0x40, %rdi
+;   orq %r8, %rdi
+;   sarq $0x3f, %rsi
+;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmoveq %r11, %rax
+;   cmoveq %rdi, %rax
+;   movq %rsi, %rdx
 ;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -207,8 +207,8 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   movq    %r12, 0(%rsp)
 ;   movq    %r14, 8(%rsp)
 ; block0:
-;   movq    %rdx, %r14
 ;   movq    %rdi, %r12
+;   movq    %rdx, %r14
 ;   subq    %rsp, $192, %rsp
 ;   virtual_sp_offset_adjust 192
 ;   lea     0(%rsp), %rdi
@@ -239,8 +239,8 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   movq %r12, (%rsp)
 ;   movq %r14, 8(%rsp)
 ; block1: ; offset 0x11
-;   movq %rdx, %r14
 ;   movq %rdi, %r12
+;   movq %rdx, %r14
 ;   subq $0xc0, %rsp
 ;   leaq (%rsp), %rdi
 ;   movl $0x80, %edx

--- a/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
@@ -240,19 +240,19 @@ block0:
 ;   movq    %r12, 80(%rax)
 ;   movq    %r13, 88(%rax)
 ;   movq    %r14, 96(%rax)
-;   movq    rsp(0 + virtual offset), %r14
-;   movq    rsp(8 + virtual offset), %r13
-;   movq    rsp(16 + virtual offset), %r12
-;   movq    rsp(24 + virtual offset), %r11
-;   movq    rsp(32 + virtual offset), %r10
-;   movq    rsp(40 + virtual offset), %r9
-;   movq    rsp(48 + virtual offset), %r8
-;   movq    rsp(56 + virtual offset), %rdi
-;   movq    rsp(64 + virtual offset), %rsi
-;   movq    rsp(72 + virtual offset), %rbx
-;   movq    rsp(80 + virtual offset), %rdx
-;   movq    rsp(88 + virtual offset), %rcx
 ;   movq    rsp(96 + virtual offset), %rax
+;   movq    rsp(88 + virtual offset), %rcx
+;   movq    rsp(80 + virtual offset), %rdx
+;   movq    rsp(72 + virtual offset), %rbx
+;   movq    rsp(64 + virtual offset), %rsi
+;   movq    rsp(56 + virtual offset), %rdi
+;   movq    rsp(48 + virtual offset), %r8
+;   movq    rsp(40 + virtual offset), %r9
+;   movq    rsp(32 + virtual offset), %r10
+;   movq    rsp(24 + virtual offset), %r11
+;   movq    rsp(16 + virtual offset), %r12
+;   movq    rsp(8 + virtual offset), %r13
+;   movq    rsp(0 + virtual offset), %r14
 ;   addq    %rsp, $112, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -316,19 +316,19 @@ block0:
 ;   movq %r12, 0x50(%rax)
 ;   movq %r13, 0x58(%rax)
 ;   movq %r14, 0x60(%rax)
-;   movq (%rsp), %r14
-;   movq 8(%rsp), %r13
-;   movq 0x10(%rsp), %r12
-;   movq 0x18(%rsp), %r11
-;   movq 0x20(%rsp), %r10
-;   movq 0x28(%rsp), %r9
-;   movq 0x30(%rsp), %r8
-;   movq 0x38(%rsp), %rdi
-;   movq 0x40(%rsp), %rsi
-;   movq 0x48(%rsp), %rbx
-;   movq 0x50(%rsp), %rdx
-;   movq 0x58(%rsp), %rcx
 ;   movq 0x60(%rsp), %rax
+;   movq 0x58(%rsp), %rcx
+;   movq 0x50(%rsp), %rdx
+;   movq 0x48(%rsp), %rbx
+;   movq 0x40(%rsp), %rsi
+;   movq 0x38(%rsp), %rdi
+;   movq 0x30(%rsp), %r8
+;   movq 0x28(%rsp), %r9
+;   movq 0x20(%rsp), %r10
+;   movq 0x18(%rsp), %r11
+;   movq 0x10(%rsp), %r12
+;   movq 8(%rsp), %r13
+;   movq (%rsp), %r14
 ;   addq $0x70, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -638,16 +638,16 @@ block0:
 ;   lea     144(%rsp), %r10
 ;   movq    %r10, 128(%rsp)
 ;   load_ext_name %tail_callee_stack_args_and_rets+0, %r15
-;   movq    rsp(24 + virtual offset), %r11
-;   movq    rsp(32 + virtual offset), %r10
-;   movq    rsp(40 + virtual offset), %r9
-;   movq    rsp(48 + virtual offset), %r8
-;   movq    rsp(56 + virtual offset), %rdi
-;   movq    rsp(64 + virtual offset), %rsi
-;   movq    rsp(72 + virtual offset), %rbx
-;   movq    rsp(80 + virtual offset), %rdx
-;   movq    rsp(88 + virtual offset), %rcx
 ;   movq    rsp(96 + virtual offset), %rax
+;   movq    rsp(88 + virtual offset), %rcx
+;   movq    rsp(80 + virtual offset), %rdx
+;   movq    rsp(72 + virtual offset), %rbx
+;   movq    rsp(64 + virtual offset), %rsi
+;   movq    rsp(56 + virtual offset), %rdi
+;   movq    rsp(48 + virtual offset), %r8
+;   movq    rsp(40 + virtual offset), %r9
+;   movq    rsp(32 + virtual offset), %r10
+;   movq    rsp(24 + virtual offset), %r11
 ;   call    *%r15
 ;   movq    0(%rsp), %r10
 ;   movq    8(%rsp), %rsi
@@ -737,16 +737,16 @@ block0:
 ;   leaq 0x90(%rsp), %r10
 ;   movq %r10, 0x80(%rsp)
 ;   movabsq $0, %r15 ; reloc_external Abs8 %tail_callee_stack_args_and_rets 0
-;   movq 0x118(%rsp), %r11
-;   movq 0x120(%rsp), %r10
-;   movq 0x128(%rsp), %r9
-;   movq 0x130(%rsp), %r8
-;   movq 0x138(%rsp), %rdi
-;   movq 0x140(%rsp), %rsi
-;   movq 0x148(%rsp), %rbx
-;   movq 0x150(%rsp), %rdx
-;   movq 0x158(%rsp), %rcx
 ;   movq 0x160(%rsp), %rax
+;   movq 0x158(%rsp), %rcx
+;   movq 0x150(%rsp), %rdx
+;   movq 0x148(%rsp), %rbx
+;   movq 0x140(%rsp), %rsi
+;   movq 0x138(%rsp), %rdi
+;   movq 0x130(%rsp), %r8
+;   movq 0x128(%rsp), %r9
+;   movq 0x120(%rsp), %r10
+;   movq 0x118(%rsp), %r11
 ;   callq *%r15
 ;   movq (%rsp), %r10
 ;   movq 8(%rsp), %rsi

--- a/cranelift/filetests/filetests/isa/x64/traps.clif
+++ b/cranelift/filetests/filetests/isa/x64/traps.clif
@@ -29,8 +29,7 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rdi, %rcx
-;   addq    %rcx, %rsi, %rcx
+;   addq    %rdi, %rsi, %rdi
 ;   jb #trap=user0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -41,9 +40,8 @@ block0(v0: i64, v1: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rdi, %rcx
-;   addq %rsi, %rcx
-;   jb 0x15
+;   addq %rsi, %rdi
+;   jb 0x12
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/ushr.clif
+++ b/cranelift/filetests/filetests/isa/x64/ushr.clif
@@ -17,23 +17,21 @@ block0(v0: i128, v1: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   movzbq  %dl, %rcx
-;   movq    %rdi, %r8
-;   shrq    %cl, %r8, %r8
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r10
 ;   shrq    %cl, %r10, %r10
 ;   movq    %rcx, %r9
 ;   movl    $64, %ecx
-;   movq    %r9, %rdi
-;   subq    %rcx, %rdi, %rcx
-;   movq    %rsi, %r11
-;   shlq    %cl, %r11, %r11
+;   movq    %r9, %rax
+;   subq    %rcx, %rax, %rcx
+;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $127, %rdi
-;   cmovzq  %rdx, %r11, %r11
-;   orq     %r11, %r8, %r11
-;   testq   $64, %rdi
+;   testq   $127, %rax
+;   cmovzq  %rdx, %rsi, %rsi
+;   orq     %rsi, %rdi, %rsi
+;   testq   $64, %rax
 ;   movq    %r10, %rax
-;   cmovzq  %r11, %rax, %rax
+;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r10, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -45,23 +43,21 @@ block0(v0: i128, v1: i8):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   movzbq %dl, %rcx
-;   movq %rdi, %r8
-;   shrq %cl, %r8
+;   shrq %cl, %rdi
 ;   movq %rsi, %r10
 ;   shrq %cl, %r10
 ;   movq %rcx, %r9
 ;   movl $0x40, %ecx
-;   movq %r9, %rdi
-;   subq %rdi, %rcx
-;   movq %rsi, %r11
-;   shlq %cl, %r11
+;   movq %r9, %rax
+;   subq %rax, %rcx
+;   shlq %cl, %rsi
 ;   xorq %rdx, %rdx
-;   testq $0x7f, %rdi
-;   cmoveq %rdx, %r11
-;   orq %r8, %r11
-;   testq $0x40, %rdi
+;   testq $0x7f, %rax
+;   cmoveq %rdx, %rsi
+;   orq %rdi, %rsi
+;   testq $0x40, %rax
 ;   movq %r10, %rax
-;   cmoveq %r11, %rax
+;   cmoveq %rsi, %rax
 ;   cmoveq %r10, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -79,23 +75,21 @@ block0(v0: i128, v1: i64):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdx, %r10
-;   movq    %rdi, %r8
-;   shrq    %cl, %r8, %r8
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   shrq    %cl, %r9, %r9
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r10, %rdi
-;   subq    %rcx, %rdi, %rcx
-;   movq    %rsi, %r10
-;   shlq    %cl, %r10, %r10
+;   movq    %r10, %rax
+;   subq    %rcx, %rax, %rcx
+;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $127, %rdi
-;   cmovzq  %rdx, %r10, %r10
-;   orq     %r10, %r8, %r10
-;   testq   $64, %rdi
+;   testq   $127, %rax
+;   cmovzq  %rdx, %rsi, %rsi
+;   orq     %rsi, %rdi, %rsi
+;   testq   $64, %rax
 ;   movq    %r9, %rax
-;   cmovzq  %r10, %rax, %rax
+;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -108,23 +102,21 @@ block0(v0: i128, v1: i64):
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdx, %r10
-;   movq %rdi, %r8
-;   shrq %cl, %r8
+;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   shrq %cl, %r9
 ;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r10, %rdi
-;   subq %rdi, %rcx
-;   movq %rsi, %r10
-;   shlq %cl, %r10
+;   movq %r10, %rax
+;   subq %rax, %rcx
+;   shlq %cl, %rsi
 ;   xorq %rdx, %rdx
-;   testq $0x7f, %rdi
-;   cmoveq %rdx, %r10
-;   orq %r8, %r10
-;   testq $0x40, %rdi
+;   testq $0x7f, %rax
+;   cmoveq %rdx, %rsi
+;   orq %rdi, %rsi
+;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmoveq %r10, %rax
+;   cmoveq %rsi, %rax
 ;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -142,23 +134,21 @@ block0(v0: i128, v1: i32):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdx, %r10
-;   movq    %rdi, %r8
-;   shrq    %cl, %r8, %r8
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   shrq    %cl, %r9, %r9
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r10, %rdi
-;   subq    %rcx, %rdi, %rcx
-;   movq    %rsi, %r10
-;   shlq    %cl, %r10, %r10
+;   movq    %r10, %rax
+;   subq    %rcx, %rax, %rcx
+;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $127, %rdi
-;   cmovzq  %rdx, %r10, %r10
-;   orq     %r10, %r8, %r10
-;   testq   $64, %rdi
+;   testq   $127, %rax
+;   cmovzq  %rdx, %rsi, %rsi
+;   orq     %rsi, %rdi, %rsi
+;   testq   $64, %rax
 ;   movq    %r9, %rax
-;   cmovzq  %r10, %rax, %rax
+;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -171,23 +161,21 @@ block0(v0: i128, v1: i32):
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdx, %r10
-;   movq %rdi, %r8
-;   shrq %cl, %r8
+;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   shrq %cl, %r9
 ;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r10, %rdi
-;   subq %rdi, %rcx
-;   movq %rsi, %r10
-;   shlq %cl, %r10
+;   movq %r10, %rax
+;   subq %rax, %rcx
+;   shlq %cl, %rsi
 ;   xorq %rdx, %rdx
-;   testq $0x7f, %rdi
-;   cmoveq %rdx, %r10
-;   orq %r8, %r10
-;   testq $0x40, %rdi
+;   testq $0x7f, %rax
+;   cmoveq %rdx, %rsi
+;   orq %rdi, %rsi
+;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmoveq %r10, %rax
+;   cmoveq %rsi, %rax
 ;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -205,23 +193,21 @@ block0(v0: i128, v1: i16):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdx, %r10
-;   movq    %rdi, %r8
-;   shrq    %cl, %r8, %r8
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   shrq    %cl, %r9, %r9
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r10, %rdi
-;   subq    %rcx, %rdi, %rcx
-;   movq    %rsi, %r10
-;   shlq    %cl, %r10, %r10
+;   movq    %r10, %rax
+;   subq    %rcx, %rax, %rcx
+;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $127, %rdi
-;   cmovzq  %rdx, %r10, %r10
-;   orq     %r10, %r8, %r10
-;   testq   $64, %rdi
+;   testq   $127, %rax
+;   cmovzq  %rdx, %rsi, %rsi
+;   orq     %rsi, %rdi, %rsi
+;   testq   $64, %rax
 ;   movq    %r9, %rax
-;   cmovzq  %r10, %rax, %rax
+;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -234,23 +220,21 @@ block0(v0: i128, v1: i16):
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdx, %r10
-;   movq %rdi, %r8
-;   shrq %cl, %r8
+;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   shrq %cl, %r9
 ;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r10, %rdi
-;   subq %rdi, %rcx
-;   movq %rsi, %r10
-;   shlq %cl, %r10
+;   movq %r10, %rax
+;   subq %rax, %rcx
+;   shlq %cl, %rsi
 ;   xorq %rdx, %rdx
-;   testq $0x7f, %rdi
-;   cmoveq %rdx, %r10
-;   orq %r8, %r10
-;   testq $0x40, %rdi
+;   testq $0x7f, %rax
+;   cmoveq %rdx, %rsi
+;   orq %rdi, %rsi
+;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmoveq %r10, %rax
+;   cmoveq %rsi, %rax
 ;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -268,23 +252,21 @@ block0(v0: i128, v1: i8):
 ; block0:
 ;   movq    %rdx, %rcx
 ;   movq    %rdx, %r10
-;   movq    %rdi, %r8
-;   shrq    %cl, %r8, %r8
+;   shrq    %cl, %rdi, %rdi
 ;   movq    %rsi, %r9
 ;   shrq    %cl, %r9, %r9
 ;   movq    %rcx, %r10
 ;   movl    $64, %ecx
-;   movq    %r10, %rdi
-;   subq    %rcx, %rdi, %rcx
-;   movq    %rsi, %r10
-;   shlq    %cl, %r10, %r10
+;   movq    %r10, %rax
+;   subq    %rcx, %rax, %rcx
+;   shlq    %cl, %rsi, %rsi
 ;   xorq    %rdx, %rdx, %rdx
-;   testq   $127, %rdi
-;   cmovzq  %rdx, %r10, %r10
-;   orq     %r10, %r8, %r10
-;   testq   $64, %rdi
+;   testq   $127, %rax
+;   cmovzq  %rdx, %rsi, %rsi
+;   orq     %rsi, %rdi, %rsi
+;   testq   $64, %rax
 ;   movq    %r9, %rax
-;   cmovzq  %r10, %rax, %rax
+;   cmovzq  %rsi, %rax, %rax
 ;   cmovzq  %r9, %rdx, %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -297,23 +279,21 @@ block0(v0: i128, v1: i8):
 ; block1: ; offset 0x4
 ;   movq %rdx, %rcx
 ;   movq %rdx, %r10
-;   movq %rdi, %r8
-;   shrq %cl, %r8
+;   shrq %cl, %rdi
 ;   movq %rsi, %r9
 ;   shrq %cl, %r9
 ;   movq %rcx, %r10
 ;   movl $0x40, %ecx
-;   movq %r10, %rdi
-;   subq %rdi, %rcx
-;   movq %rsi, %r10
-;   shlq %cl, %r10
+;   movq %r10, %rax
+;   subq %rax, %rcx
+;   shlq %cl, %rsi
 ;   xorq %rdx, %rdx
-;   testq $0x7f, %rdi
-;   cmoveq %rdx, %r10
-;   orq %r8, %r10
-;   testq $0x40, %rdi
+;   testq $0x7f, %rax
+;   cmoveq %rdx, %rsi
+;   orq %rdi, %rsi
+;   testq $0x40, %rax
 ;   movq %r9, %rax
-;   cmoveq %r10, %rax
+;   cmoveq %rsi, %rax
 ;   cmoveq %r9, %rdx
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/uunarrow.clif
+++ b/cranelift/filetests/filetests/isa/x64/uunarrow.clif
@@ -15,10 +15,9 @@ block0(v0: f64x2):
 ; block0:
 ;   uninit  %xmm3
 ;   xorpd   %xmm3, %xmm3, %xmm3
-;   movdqa  %xmm0, %xmm7
-;   maxpd   %xmm7, %xmm3, %xmm7
-;   minpd   %xmm7, const(0), %xmm7
-;   roundpd $3, %xmm7, %xmm0
+;   maxpd   %xmm0, %xmm3, %xmm0
+;   minpd   %xmm0, const(0), %xmm0
+;   roundpd $3, %xmm0, %xmm0
 ;   addpd   %xmm0, const(1), %xmm0
 ;   shufps  $136, %xmm0, %xmm3, %xmm0
 ;   movq    %rbp, %rsp
@@ -31,15 +30,16 @@ block0(v0: f64x2):
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
 ;   xorpd %xmm3, %xmm3
-;   movdqa %xmm0, %xmm7
-;   maxpd %xmm3, %xmm7
-;   minpd 0x18(%rip), %xmm7
-;   roundpd $3, %xmm7, %xmm0
-;   addpd 0x1a(%rip), %xmm0
+;   maxpd %xmm3, %xmm0
+;   minpd 0x1c(%rip), %xmm0
+;   roundpd $3, %xmm0, %xmm0
+;   addpd 0x1e(%rip), %xmm0
 ;   shufps $0x88, %xmm3, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
 ;   addb %al, (%rax)
 ;   addb %ah, %al
 

--- a/cranelift/filetests/filetests/isa/x64/vhigh_bits.clif
+++ b/cranelift/filetests/filetests/isa/x64/vhigh_bits.clif
@@ -61,9 +61,8 @@ block0(v0: i16x8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm0, %xmm2
-;   packsswb %xmm2, %xmm0, %xmm2
-;   pmovmskb %xmm2, %eax
+;   packsswb %xmm0, %xmm0, %xmm0
+;   pmovmskb %xmm0, %eax
 ;   shrq    $8, %rax, %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -74,9 +73,8 @@ block0(v0: i16x8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movdqa %xmm0, %xmm2
-;   packsswb %xmm0, %xmm2
-;   pmovmskb %xmm2, %eax
+;   packsswb %xmm0, %xmm0
+;   pmovmskb %xmm0, %eax
 ;   shrq $8, %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -45,18 +45,17 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r8
-;;   addq    %r8, const(0), %r8
+;;   movq    %rdi, %rax
+;;   addq    %rax, const(0), %rax
 ;;   jb #trap=heap_oob
-;;   movq    8(%rdx), %rax
-;;   movq    %rdi, %rcx
-;;   addq    %rcx, 0(%rdx), %rcx
+;;   movq    8(%rdx), %rcx
+;;   addq    %rdi, 0(%rdx), %rdi
 ;;   movl    $-65536, %edx
-;;   lea     0(%rcx,%rdx,1), %rcx
+;;   lea     0(%rdi,%rdx,1), %rdi
 ;;   xorq    %rdx, %rdx, %rdx
-;;   cmpq    %rax, %r8
-;;   cmovnbeq %rdx, %rcx, %rcx
-;;   movl    %esi, 0(%rcx)
+;;   cmpq    %rcx, %rax
+;;   cmovnbeq %rdx, %rdi, %rdi
+;;   movl    %esi, 0(%rdi)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -69,16 +68,15 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %rcx
-;;   addq    %rcx, const(0), %rcx
+;;   movq    %rdi, %rax
+;;   addq    %rax, const(0), %rax
 ;;   jb #trap=heap_oob
-;;   movq    8(%rsi), %rax
-;;   movq    %rdi, %rdx
-;;   addq    %rdx, 0(%rsi), %rdx
-;;   movl    $-65536, %r8d
-;;   lea     0(%rdx,%r8,1), %rsi
+;;   movq    8(%rsi), %rcx
+;;   addq    %rdi, 0(%rsi), %rdi
+;;   movl    $-65536, %edx
+;;   lea     0(%rdi,%rdx,1), %rsi
 ;;   xorq    %rdx, %rdx, %rdx
-;;   cmpq    %rax, %rcx
+;;   cmpq    %rcx, %rax
 ;;   cmovnbeq %rdx, %rsi, %rsi
 ;;   movl    0(%rsi), %eax
 ;;   jmp     label1

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -45,18 +45,17 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %r8
-;;   addq    %r8, const(0), %r8
+;;   movq    %rdi, %rax
+;;   addq    %rax, const(0), %rax
 ;;   jb #trap=heap_oob
-;;   movq    8(%rdx), %rax
-;;   movq    %rdi, %rcx
-;;   addq    %rcx, 0(%rdx), %rcx
+;;   movq    8(%rdx), %rcx
+;;   addq    %rdi, 0(%rdx), %rdi
 ;;   movl    $-65536, %edx
-;;   lea     0(%rcx,%rdx,1), %rcx
+;;   lea     0(%rdi,%rdx,1), %rdi
 ;;   xorq    %rdx, %rdx, %rdx
-;;   cmpq    %rax, %r8
-;;   cmovnbeq %rdx, %rcx, %rcx
-;;   movb    %sil, 0(%rcx)
+;;   cmpq    %rcx, %rax
+;;   cmovnbeq %rdx, %rdi, %rdi
+;;   movb    %sil, 0(%rdi)
 ;;   jmp     label1
 ;; block1:
 ;;   movq    %rbp, %rsp
@@ -69,16 +68,15 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rdi, %rcx
-;;   addq    %rcx, const(0), %rcx
+;;   movq    %rdi, %rax
+;;   addq    %rax, const(0), %rax
 ;;   jb #trap=heap_oob
-;;   movq    8(%rsi), %rax
-;;   movq    %rdi, %rdx
-;;   addq    %rdx, 0(%rsi), %rdx
-;;   movl    $-65536, %r8d
-;;   lea     0(%rdx,%r8,1), %rsi
+;;   movq    8(%rsi), %rcx
+;;   addq    %rdi, 0(%rsi), %rdi
+;;   movl    $-65536, %edx
+;;   lea     0(%rdi,%rdx,1), %rsi
 ;;   xorq    %rdx, %rdx, %rdx
-;;   cmpq    %rax, %rcx
+;;   cmpq    %rcx, %rax
 ;;   cmovnbeq %rdx, %rsi, %rsi
 ;;   movzbq  0(%rsi), %rax
 ;;   jmp     label1

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -49,10 +49,9 @@
 ;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    %rdi, %r11
-;;   addq    %r11, 0(%rdx), %r11
-;;   movl    $-65536, %edi
-;;   movl    %esi, 0(%r11,%rdi,1)
+;;   addq    %rdi, 0(%rdx), %rdi
+;;   movl    $-65536, %r11d
+;;   movl    %esi, 0(%rdi,%r11,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -71,10 +70,9 @@
 ;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    %rdi, %r11
-;;   addq    %r11, 0(%rsi), %r11
-;;   movl    $-65536, %esi
-;;   movl    0(%r11,%rsi,1), %eax
+;;   addq    %rdi, 0(%rsi), %rdi
+;;   movl    $-65536, %r11d
+;;   movl    0(%rdi,%r11,1), %eax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -49,10 +49,9 @@
 ;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    %rdi, %r11
-;;   addq    %r11, 0(%rdx), %r11
-;;   movl    $-65536, %edi
-;;   movb    %sil, 0(%r11,%rdi,1)
+;;   addq    %rdi, 0(%rdx), %rdi
+;;   movl    $-65536, %r11d
+;;   movb    %sil, 0(%rdi,%r11,1)
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp
@@ -71,10 +70,9 @@
 ;;   cmpq    %r9, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
-;;   movq    %rdi, %r11
-;;   addq    %r11, 0(%rsi), %r11
-;;   movl    $-65536, %esi
-;;   movzbq  0(%r11,%rsi,1), %rax
+;;   addq    %rdi, 0(%rsi), %rdi
+;;   movl    $-65536, %r11d
+;;   movzbq  0(%rdi,%r11,1), %rax
 ;;   jmp     label2
 ;; block2:
 ;;   movq    %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/widening.clif
+++ b/cranelift/filetests/filetests/isa/x64/widening.clif
@@ -86,9 +86,8 @@ block0(v0: i8x16):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm0, %xmm2
-;   palignr $8, %xmm2, %xmm0, %xmm2
-;   pmovsxbw %xmm2, %xmm0
+;   palignr $8, %xmm0, %xmm0, %xmm0
+;   pmovsxbw %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -98,9 +97,8 @@ block0(v0: i8x16):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movdqa %xmm0, %xmm2
-;   palignr $8, %xmm0, %xmm2
-;   pmovsxbw %xmm2, %xmm0
+;   palignr $8, %xmm0, %xmm0
+;   pmovsxbw %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -115,9 +113,8 @@ block0(v0: i16x8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movdqa  %xmm0, %xmm2
-;   palignr $8, %xmm2, %xmm0, %xmm2
-;   pmovsxwd %xmm2, %xmm0
+;   palignr $8, %xmm0, %xmm0, %xmm0
+;   pmovsxwd %xmm0, %xmm0
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -127,9 +124,8 @@ block0(v0: i16x8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movdqa %xmm0, %xmm2
-;   palignr $8, %xmm0, %xmm2
-;   pmovsxwd %xmm2, %xmm0
+;   palignr $8, %xmm0, %xmm0
+;   pmovsxwd %xmm0, %xmm0
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/wasm/x64-bmi2.wat
+++ b/cranelift/filetests/filetests/wasm/x64-bmi2.wat
@@ -50,9 +50,8 @@
 ;; block0:
 ;;   jmp     label1
 ;; block1:
-;;   movq    %rsi, %r8
-;;   andl    %r8d, $31, %r8d
-;;   bzhi    %edi, %r8d, %eax
+;;   andl    %esi, $31, %esi
+;;   bzhi    %edi, %esi, %eax
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret
@@ -65,9 +64,8 @@
 ;; block0:
 ;;   jmp     label1
 ;; block1:
-;;   movq    %rsi, %r8
-;;   andq    %r8, $63, %r8
-;;   bzhi    %rdi, %r8, %rax
+;;   andq    %rsi, $63, %rsi
+;;   bzhi    %rdi, %rsi, %rax
 ;;   movq    %rbp, %rsp
 ;;   popq    %rbp
 ;;   ret

--- a/cranelift/filetests/filetests/wasm/x64-relaxed-simd.wat
+++ b/cranelift/filetests/filetests/wasm/x64-relaxed-simd.wat
@@ -58,15 +58,14 @@
 ;; block0:
 ;;   uninit  %xmm7
 ;;   xorps   %xmm7, %xmm7, %xmm7
-;;   movdqa  %xmm0, %xmm4
-;;   maxps   %xmm4, %xmm7, %xmm4
+;;   maxps   %xmm0, %xmm7, %xmm0
 ;;   pcmpeqd %xmm7, %xmm7, %xmm7
 ;;   psrld   %xmm7, $1, %xmm7
 ;;   cvtdq2ps %xmm7, %xmm1
-;;   cvttps2dq %xmm4, %xmm7
-;;   subps   %xmm4, %xmm1, %xmm4
-;;   cmpps   $2, %xmm1, %xmm4, %xmm1
-;;   cvttps2dq %xmm4, %xmm0
+;;   cvttps2dq %xmm0, %xmm7
+;;   subps   %xmm0, %xmm1, %xmm0
+;;   cmpps   $2, %xmm1, %xmm0, %xmm1
+;;   cvttps2dq %xmm0, %xmm0
 ;;   pxor    %xmm0, %xmm1, %xmm0
 ;;   uninit  %xmm2
 ;;   pxor    %xmm2, %xmm2, %xmm2
@@ -131,11 +130,9 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movdqa  %xmm1, %xmm3
-;;   movdqa  %xmm0, %xmm1
-;;   movdqa  %xmm3, %xmm0
-;;   pmaddubsw %xmm0, %xmm1, %xmm0
-;;   pmaddwd %xmm0, const(0), %xmm0
+;;   pmaddubsw %xmm1, %xmm0, %xmm1
+;;   pmaddwd %xmm1, const(0), %xmm1
+;;   movdqa  %xmm1, %xmm0
 ;;   paddd   %xmm0, %xmm2, %xmm0
 ;;   jmp     label1
 ;; block1:

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1196,6 +1196,13 @@ user-id = 3726
 user-login = "cfallin"
 user-name = "Chris Fallin"
 
+[[publisher.regalloc2]]
+version = "0.9.3"
+when = "2023-10-05"
+user-id = 3726
+user-login = "cfallin"
+user-name = "Chris Fallin"
+
 [[publisher.regex]]
 version = "1.9.1"
 when = "2023-07-07"


### PR DESCRIPTION
Bump regalloc2 to version 0.9.3, which removes a pretty significant number of unnecessary moves in our filetests.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
