### PR TITLE
wasi-http: Backport borrow changes to the release-14.0.0 branch

### DIFF
--- a/crates/test-programs/wasi-http-proxy-tests/src/lib.rs
+++ b/crates/test-programs/wasi-http-proxy-tests/src/lib.rs
@@ -17,7 +17,7 @@ struct T;
 impl bindings::exports::wasi::http::incoming_handler::Guest for T {
     fn handle(_request: IncomingRequest, outparam: ResponseOutparam) {
         let hdrs = bindings::wasi::http::types::Headers::new(&[]);
-        let resp = bindings::wasi::http::types::OutgoingResponse::new(200, hdrs);
+        let resp = bindings::wasi::http::types::OutgoingResponse::new(200, &hdrs);
         let body = resp.write().expect("outgoing response");
 
         bindings::wasi::http::types::ResponseOutparam::set(outparam, Ok(resp));

--- a/crates/test-programs/wasi-http-tests/src/lib.rs
+++ b/crates/test-programs/wasi-http-tests/src/lib.rs
@@ -67,7 +67,7 @@ pub fn request(
         Some(path_with_query),
         Some(&scheme),
         Some(authority),
-        headers,
+        &headers,
     );
 
     let outgoing_body = request

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -470,7 +470,6 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingResponse for T {
         headers: Resource<Headers>,
     ) -> wasmtime::Result<Resource<HostOutgoingResponse>> {
         let fields = get_fields_mut(self.table(), &headers)?.clone();
-        self.table().delete_resource(headers)?;
 
         let id = self.table().push_resource(HostOutgoingResponse {
             status,

--- a/crates/wasi-http/wit/deps/http/incoming-handler.wit
+++ b/crates/wasi-http/wit/deps/http/incoming-handler.wit
@@ -18,7 +18,7 @@ interface incoming-handler {
   // critical path, since there is no return value, there is no way to report
   // its success or failure.
   handle: func(
-    request: /* own */ incoming-request,
-    response-out: /* own */ response-outparam
+    request: incoming-request,
+    response-out: response-outparam
   )
 }

--- a/crates/wasi-http/wit/deps/http/outgoing-handler.wit
+++ b/crates/wasi-http/wit/deps/http/outgoing-handler.wit
@@ -14,7 +14,7 @@ interface outgoing-handler {
   // Consumes the outgoing-request. Gives an error if the outgoing-request
   // is invalid or cannot be satisfied by this handler.
   handle: func(
-    request: /* own */ outgoing-request,
+    request: outgoing-request,
     options: option<request-options>
   ) -> result<future-incoming-response, error>
 }

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -87,7 +87,7 @@ interface types {
     // Will return the input-stream child at most once. If called more than
     // once, subsequent calls will return error.
 
-    consume: func() -> result< /* own */ incoming-body>
+    consume: func() -> result<incoming-body>
   }
 
   resource outgoing-request {
@@ -96,7 +96,7 @@ interface types {
       path-with-query: option<string>,
       scheme: option<scheme>,
       authority: option<string>,
-      headers: /* borrow */ headers
+      headers: borrow<headers>
     )
 
     // Will return the outgoing-body child at most once. If called more than
@@ -127,7 +127,7 @@ interface types {
   // (the `wasi:http/handler` interface used for both incoming and outgoing can
   // simply return a `stream`).
   resource response-outparam {
-    set: static func(param: /* own */ response-outparam, response: result< /* own */ outgoing-response, error>)
+    set: static func(param: response-outparam, response: result<outgoing-response, error>)
   }
 
   // This type corresponds to the HTTP standard Status Code.
@@ -148,7 +148,7 @@ interface types {
     // May be called at most once. returns error if called additional times.
     // TODO: make incoming-request-consume work the same way, giving a child
     // incoming-body.
-    consume: func() -> result</* own */ incoming-body>
+    consume: func() -> result<incoming-body>
   }
 
   resource incoming-body {
@@ -160,7 +160,7 @@ interface types {
 
     // takes ownership of incoming-body. this will trap if the
     // incoming-body-stream child is still alive!
-    finish: static func(this: /* own */ incoming-body) ->
+    finish: static func(this: incoming-body) ->
     /* transitive child of the incoming-response of incoming-body */ future-trailers
   }
 
@@ -174,11 +174,11 @@ interface types {
   }
 
   resource outgoing-response {
-    constructor(status-code: status-code, headers: /* borrow */ headers)
+    constructor(status-code: status-code, headers: borrow<headers>)
 
     /// Will give the child outgoing-response at most once. subsequent calls will
     /// return an error.
-    write: func() -> result</* own */ outgoing-body>
+    write: func() -> result<outgoing-body>
   }
 
   resource outgoing-body {
@@ -190,7 +190,7 @@ interface types {
     /// called to signal that the response is complete. If the `outgoing-body` is
     /// dropped without calling `outgoing-body-finalize`, the implementation
     /// should treat the body as corrupted.
-    finish: static func(this: /* own */ outgoing-body, trailers: /* own */ option<trailers>)
+    finish: static func(this: outgoing-body, trailers: option<trailers>)
   }
 
   /// The following block defines a special resource type used by the

--- a/crates/wasi/wit/deps/http/incoming-handler.wit
+++ b/crates/wasi/wit/deps/http/incoming-handler.wit
@@ -18,7 +18,7 @@ interface incoming-handler {
   // critical path, since there is no return value, there is no way to report
   // its success or failure.
   handle: func(
-    request: /* own */ incoming-request,
-    response-out: /* own */ response-outparam
+    request: incoming-request,
+    response-out: response-outparam
   )
 }

--- a/crates/wasi/wit/deps/http/outgoing-handler.wit
+++ b/crates/wasi/wit/deps/http/outgoing-handler.wit
@@ -14,7 +14,7 @@ interface outgoing-handler {
   // Consumes the outgoing-request. Gives an error if the outgoing-request
   // is invalid or cannot be satisfied by this handler.
   handle: func(
-    request: /* own */ outgoing-request,
+    request: outgoing-request,
     options: option<request-options>
   ) -> result<future-incoming-response, error>
 }

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -87,7 +87,7 @@ interface types {
     // Will return the input-stream child at most once. If called more than
     // once, subsequent calls will return error.
 
-    consume: func() -> result< /* own */ incoming-body>
+    consume: func() -> result<incoming-body>
   }
 
   resource outgoing-request {
@@ -96,7 +96,7 @@ interface types {
       path-with-query: option<string>,
       scheme: option<scheme>,
       authority: option<string>,
-      headers: /* borrow */ headers
+      headers: borrow<headers>
     )
 
     // Will return the outgoing-body child at most once. If called more than
@@ -127,7 +127,7 @@ interface types {
   // (the `wasi:http/handler` interface used for both incoming and outgoing can
   // simply return a `stream`).
   resource response-outparam {
-    set: static func(param: /* own */ response-outparam, response: result< /* own */ outgoing-response, error>)
+    set: static func(param: response-outparam, response: result<outgoing-response, error>)
   }
 
   // This type corresponds to the HTTP standard Status Code.
@@ -148,7 +148,7 @@ interface types {
     // May be called at most once. returns error if called additional times.
     // TODO: make incoming-request-consume work the same way, giving a child
     // incoming-body.
-    consume: func() -> result</* own */ incoming-body>
+    consume: func() -> result<incoming-body>
   }
 
   resource incoming-body {
@@ -160,7 +160,7 @@ interface types {
 
     // takes ownership of incoming-body. this will trap if the
     // incoming-body-stream child is still alive!
-    finish: static func(this: /* own */ incoming-body) ->
+    finish: static func(this: incoming-body) ->
     /* transitive child of the incoming-response of incoming-body */ future-trailers
   }
 
@@ -174,11 +174,11 @@ interface types {
   }
 
   resource outgoing-response {
-    constructor(status-code: status-code, headers: /* borrow */ headers)
+    constructor(status-code: status-code, headers: borrow<headers>)
 
     /// Will give the child outgoing-response at most once. subsequent calls will
     /// return an error.
-    write: func() -> result</* own */ outgoing-body>
+    write: func() -> result<outgoing-body>
   }
 
   resource outgoing-body {
@@ -190,7 +190,7 @@ interface types {
     /// called to signal that the response is complete. If the `outgoing-body` is
     /// dropped without calling `outgoing-body-finalize`, the implementation
     /// should treat the body as corrupted.
-    finish: static func(this: /* own */ outgoing-body, trailers: /* own */ option<trailers>)
+    finish: static func(this: outgoing-body, trailers: option<trailers>)
   }
 
   /// The following block defines a special resource type used by the


### PR DESCRIPTION
Backport the changes introduced in #7161 to the release-14.0.0 branch, as the resource changes have already landed there and contained an incorrect implementation of some header-handling functions.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
