### PR TITLE
wasi-nn: reenable CI task

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -483,8 +483,7 @@ jobs:
   # Build and test the wasi-nn module.
   test_wasi_nn:
     needs: determine
-    # FIXME(#7125) flaky at the moment
-    if: needs.determine.outputs.run-full && false
+    if: needs.determine.outputs.run-full
     name: Test wasi-nn module
     runs-on: ubuntu-latest
     steps:
@@ -493,7 +492,7 @@ jobs:
           submodules: true
       - uses: ./.github/actions/install-rust
       - run: rustup target add wasm32-wasi
-      - uses: abrown/install-openvino-action@v6
+      - uses: abrown/install-openvino-action@v7
         with:
           version: 2022.3.0
           apt: true


### PR DESCRIPTION
The task was disabled due to a failing checksum. Since then, the `install-openvino-action` has improved and now _almost_ has cross-platform support. This change just restores the status quo in expectation that #6895 will significantly improve the testing story.

prtest:full

Closes https://github.com/bytecodealliance/wasmtime/issues/7125

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
