### PR TITLE
add i128 support for iabs on x86_64

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -1265,6 +1265,27 @@
             (cmove ConsumesFlags (cmove ty (CC.S) src neg_result)))
         (with_flags_reg (produces_flags_ignore neg) cmove)))
 
+;; `i128`. Negate the low bits, `adc` to the higher bits, then negate high bits.
+(rule (lower (has_type $I128 (iabs x)))
+      ;; Get the high/low registers for `x`.
+      (let ((x_regs ValueRegs x)
+            (x_lo Gpr (value_regs_get_gpr x_regs 0))
+            (x_hi Gpr (value_regs_get_gpr x_regs 1))
+            ; negate low bits, then add 0 with carry to high bits.
+            (neg_lo ProducesFlags (x64_neg_paired $I64 x_lo))
+            (adc_hi ConsumesFlags (x64_adc_paired $I64 x_hi (imm $I64 0)))
+            (neg_adc_vals ValueRegs (with_flags neg_lo adc_hi))
+            ; negate high bits.
+            (neg_hi ProducesFlags (x64_neg_paired $I64 (value_regs_get neg_adc_vals 1)))
+            (neg_hi_flag_only ProducesFlags (produces_flags_ignore neg_hi))
+            ; cmove based on sign flag from hi negation.
+            (cmove_lo ConsumesFlags (cmove $I64 (CC.S) x_lo
+                                     (value_regs_get neg_adc_vals 0)))
+            (cmove_hi ConsumesFlags (cmove $I64 (CC.S) x_hi
+                                     (produces_flags_get_reg neg_hi)))
+            (cmoves ConsumesFlags (consumes_flags_concat cmove_lo cmove_hi)))
+        (with_flags neg_hi_flag_only cmoves)))
+
 ;;;; Rules for `fabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (rule (lower (has_type $F32 (fabs x)))

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1973,3 +1973,41 @@ block0(v0: i128, v1: i128):
 ;   popq %rbp
 ;   retq
 
+function %iabs_i128(i128) -> i128 {
+block0(v0: i128):
+    v1 = iabs.i128 v0
+    return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   xorq    %r8, %r8, %r8
+;   movq    %rdi, %rax
+;   negq    %rax, %rax
+;   movq    %rsi, %rdx
+;   adcq    %rdx, %r8, %rdx
+;   negq    %rdx, %rdx
+;   cmovsq  %rdi, %rax, %rax
+;   cmovsq  %rsi, %rdx, %rdx
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   xorq %r8, %r8
+;   movq %rdi, %rax
+;   negq %rax
+;   movq %rsi, %rdx
+;   adcq %r8, %rdx
+;   negq %rdx
+;   cmovsq %rdi, %rax
+;   cmovsq %rsi, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq

--- a/cranelift/filetests/filetests/runtests/i128-iabs.clif
+++ b/cranelift/filetests/filetests/runtests/i128-iabs.clif
@@ -1,6 +1,8 @@
 test interpret
 test run
+set enable_llvm_abi_extensions=true
 target s390x
+target x86_64
 
 function %iabs_i128(i128) -> i128 {
 block0(v0: i128):
@@ -10,4 +12,6 @@ block0(v0: i128):
 ; run: %iabs_i128(0) == 0
 ; run: %iabs_i128(-1) == 1
 ; run: %iabs_i128(1) == 1
+; run: %iabs_i128(0x40000000_00000000_80000000_00000000) == 0x40000000_00000000_80000000_00000000
+; run: %iabs_i128(0x80000000_00000000_80000000_00000000) == 0x7fffffff_ffffffff_80000000_00000000
 ; run: %iabs_i128(0x80000000_00000000_00000000_00000000) == 0x80000000_00000000_00000000_00000000


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Per https://github.com/bytecodealliance/wasmtime/issues/5466, we do not have i128 support for iabs on either aarch64 or x86_64. This PR adds support for x86.
