### PR TITLE
fuzzgen: Enable `iabs.i128` on fuzzgen

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -513,8 +513,6 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
                 (Opcode::Udiv | Opcode::Sdiv, &[I128, I128]),
                 // https://github.com/bytecodealliance/wasmtime/issues/5474
                 (Opcode::Urem | Opcode::Srem, &[I128, I128]),
-                // https://github.com/bytecodealliance/wasmtime/issues/5466
-                (Opcode::Iabs, &[I128]),
                 // https://github.com/bytecodealliance/wasmtime/issues/3370
                 (
                     Opcode::Smin | Opcode::Umin | Opcode::Smax | Opcode::Umax,


### PR DESCRIPTION
👋 Hey,

This PR enables fuzzing the `iabs.i128` instruction on fuzzgen. It was recently added in #7166 (Thanks!).

I've fuzzed this on 6 cores for a couple of hours and nothing has come up.