### PR TITLE
Update syntax for `trappable_error_type` in `bindgen!`

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -318,28 +318,11 @@ impl Parse for Opt {
 }
 
 fn trappable_error_field_parse(input: ParseStream<'_>) -> Result<TrappableError> {
-    // Accept a Rust identifier or a string literal. This is required
-    // because not all wit identifiers are Rust identifiers, so we can
-    // smuggle the invalid ones inside quotes.
-    fn ident_or_str(input: ParseStream<'_>) -> Result<String> {
-        let l = input.lookahead1();
-        if l.peek(syn::LitStr) {
-            Ok(input.parse::<syn::LitStr>()?.value())
-        } else if l.peek(syn::Ident) {
-            Ok(input.parse::<syn::Ident>()?.to_string())
-        } else {
-            Err(l.error())
-        }
-    }
-
-    let wit_package_path = input.parse::<syn::LitStr>()?.value();
-    input.parse::<Token![::]>()?;
-    let wit_type_name = ident_or_str(input)?;
-    input.parse::<Token![:]>()?;
+    let wit_path = input.parse::<syn::LitStr>()?.value();
+    input.parse::<Token![=>]>()?;
     let rust_type_name = input.parse::<syn::Path>()?.to_token_stream().to_string();
     Ok(TrappableError {
-        wit_package_path,
-        wit_type_name,
+        wit_path,
         rust_type_name,
     })
 }

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -140,8 +140,8 @@ mod trappable_errors {
             }
         ",
         trappable_error_type: {
-            "demo:pkg/a"::"b": MyX,
-            "demo:pkg/c"::"b": MyX,
+            "demo:pkg/a/b" => MyX,
+            "demo:pkg/c/b" => MyX,
         },
     });
 

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -71,8 +71,8 @@ pub mod bindings {
                 ",
                 tracing: true,
                 trappable_error_type: {
-                    "wasi:io/streams"::"stream-error": StreamError,
-                    "wasi:filesystem/types"::"error-code": FsError,
+                    "wasi:io/streams/stream-error" => StreamError,
+                    "wasi:filesystem/types/error-code" => FsError,
                 },
                 with: {
                     "wasi:clocks/wall-clock": crate::preview2::bindings::clocks::wall_clock,
@@ -149,17 +149,15 @@ pub mod bindings {
                 "poll-one",
             ],
         },
-        with: {
-            "wasi:sockets/ip-name-lookup/resolve-address-stream": super::ip_name_lookup::ResolveAddressStream,
-        },
         trappable_error_type: {
-            "wasi:io/streams"::"stream-error": crate::preview2::StreamError,
-            "wasi:filesystem/types"::"error-code": crate::preview2::FsError,
-            "wasi:sockets/network"::"error-code": crate::preview2::SocketError,
+            "wasi:io/streams/stream-error" => crate::preview2::StreamError,
+            "wasi:filesystem/types/error-code" => crate::preview2::FsError,
+            "wasi:sockets/network/error-code" => crate::preview2::SocketError,
         },
         with: {
             "wasi:sockets/network/network": super::network::Network,
             "wasi:sockets/tcp/tcp-socket": super::tcp::TcpSocket,
+            "wasi:sockets/ip-name-lookup/resolve-address-stream": super::ip_name_lookup::ResolveAddressStream,
             "wasi:filesystem/types/directory-entry-stream": super::filesystem::ReaddirIterator,
             "wasi:filesystem/types/descriptor": super::filesystem::Descriptor,
             "wasi:io/streams/input-stream": super::stream::InputStream,

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -299,14 +299,15 @@ pub(crate) use self::store::ComponentStoreData;
 ///
 ///     // This can be used to translate WIT return values of the form
 ///     // `result<T, error-type>` into `Result<T, RustErrorType>` in Rust.
-///     // The `RustErrorType` structure will have an automatically generated
-///     // implementation of `From<ErrorType> for RustErrorType`. The
-///     // `RustErrorType` additionally can also represent a trap to
-///     // conveniently flatten all errors into one container.
+///     // Users must define `RustErrorType` and the `Host` trait for the
+///     // interface which defines `error-type` will have a method
+///     // called `convert_error_type` which converts `RustErrorType`
+///     // into `wasmtime::Result<ErrorType>`. This conversion can either
+///     // return the raw WIT error (`ErrorType` here) or a trap.
 ///     //
 ///     // By default this option is not specified.
 ///     trappable_error_type: {
-///         interface::ErrorType: RustErrorType,
+///         "wasi:io/streams/stream-error" => RustErrorType,
 ///     },
 ///
 ///     // All generated bindgen types are "owned" meaning types like `String`

--- a/tests/all/component_model/bindgen/results.rs
+++ b/tests/all/component_model/bindgen/results.rs
@@ -238,7 +238,7 @@ mod enum_error {
                 enum-error: func(a: float64) -> result<float64, e1>
             }
         }",
-        trappable_error_type: { "inline:inline/imports"::e1: TrappableE1 }
+        trappable_error_type: { "inline:inline/imports/e1" => TrappableE1 }
     });
 
     // You can create concrete trap types which make it all the way out to the
@@ -418,9 +418,7 @@ mod record_error {
                 record-error: func(a: float64) -> result<float64, e2>
             }
         }",
-        // Literal strings can be used for the interface and typename fields instead of
-        // identifiers, because wit identifiers arent always Rust identifiers.
-        trappable_error_type: { "inline:inline/imports"::"e2": TrappableE2 }
+        trappable_error_type: { "inline:inline/imports/e2" => TrappableE2 }
     });
 
     pub enum TrappableE2 {
@@ -591,7 +589,7 @@ mod variant_error {
                 variant-error: func(a: float64) -> result<float64, e3>
             }
         }",
-        trappable_error_type: { "inline:inline/imports"::e3: TrappableE3 }
+        trappable_error_type: { "inline:inline/imports/e3" => TrappableE3 }
     });
 
     pub enum TrappableE3 {
@@ -786,7 +784,7 @@ mod multiple_interfaces_error {
                 enum-error: func(a: float64) -> result<float64, e1>
             }
         }",
-        trappable_error_type: { "inline:inline/types"::e1: TrappableE1 }
+        trappable_error_type: { "inline:inline/types/e1" => TrappableE1 }
     });
 
     pub enum TrappableE1 {


### PR DESCRIPTION
Following through on a suggestion from #7152 this makes the syntax a bit more consistent with the rest of `bindgen!` today. This additionally updates the documentation on the `bindgen!` macro itself.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
