### PR TITLE
Support multiple versions in `bindgen!`

### DIFF
--- a/crates/component-macro/test-helpers/src/lib.rs
+++ b/crates/component-macro/test-helpers/src/lib.rs
@@ -10,7 +10,7 @@ pub fn foreach(input: TokenStream) -> TokenStream {
     let mut result = Vec::new();
     for f in cwd.read_dir().unwrap() {
         let f = f.unwrap().path();
-        if f.extension().and_then(|s| s.to_str()) == Some("wit") {
+        if f.extension().and_then(|s| s.to_str()) == Some("wit") || f.is_dir() {
             let name = f.file_stem().unwrap().to_str().unwrap();
             let ident = Ident::new(&name.replace("-", "_"), Span::call_site());
             let path = f.to_str().unwrap();

--- a/crates/component-macro/tests/codegen/multiversion/deps/v1/root.wit
+++ b/crates/component-macro/tests/codegen/multiversion/deps/v1/root.wit
@@ -1,0 +1,5 @@
+package my:dep@0.1.0;
+
+interface a {
+  x: func();
+}

--- a/crates/component-macro/tests/codegen/multiversion/deps/v2/root.wit
+++ b/crates/component-macro/tests/codegen/multiversion/deps/v2/root.wit
@@ -1,0 +1,5 @@
+package my:dep@0.2.0;
+
+interface a {
+  x: func();
+}

--- a/crates/component-macro/tests/codegen/multiversion/root.wit
+++ b/crates/component-macro/tests/codegen/multiversion/root.wit
@@ -1,0 +1,6 @@
+package foo:bar;
+
+world foo {
+  import my:dep/a@0.1.0;
+  import my:dep/a@0.2.0;
+}


### PR DESCRIPTION
This commit fixes a bug in the `bindgen!` macro where when faced with multiple packages that differ only in version number invalid bindings were generated. The fix here is to add version number information to package module names if necessary in situations such as this. This required some refactoring internally to have a single source of truth for what the name of a module should be and avoid having it implicitly calculated in two locations.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
