### PR TITLE
docs(component): Fix typo in component translator

### DIFF
--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -281,7 +281,7 @@ impl<'a, 'data> Translator<'a, 'data> {
     /// `component` does not have to be valid and it will be validated during
     /// compilation.
     ///
-    /// THe result of this function is a tuple of the final component's
+    /// The result of this function is a tuple of the final component's
     /// description plus a list of core wasm modules found within the
     /// component. The component's description actually erases internal
     /// components, instances, etc, as much as it can. Instead `Component`


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
