### PR TITLE
Require semicolons in WIT files in CI

### DIFF
--- a/.github/actions/install-rust/action.yml
+++ b/.github/actions/install-rust/action.yml
@@ -61,6 +61,10 @@ runs:
         CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
         EOF
 
+    - name: Require semicolons in WIT
+      shell: bash
+      run: echo WIT_REQUIRE_SEMICOLONS=1 >> "$GITHUB_ENV"
+
     - name: Choose registry cache key
       shell: bash
       # Update the registry index cache at most once per day. actions/cache

--- a/crates/wasi-http/wit/deps/filesystem/types.wit
+++ b/crates/wasi-http/wit/deps/filesystem/types.wit
@@ -806,5 +806,5 @@ interface types {
     ///
     /// Note that this function is fallible because not all stream-related
     /// errors are filesystem-related errors.
-    filesystem-error-code: func(err: borrow<error>) -> option<error-code>
+    filesystem-error-code: func(err: borrow<error>) -> option<error-code>;
 }

--- a/crates/wasi-http/wit/deps/io/streams.wit
+++ b/crates/wasi-http/wit/deps/io/streams.wit
@@ -37,7 +37,7 @@ interface streams {
         /// The returned string will change across platforms and hosts which
         /// means that parsing it, for example, would be a
         /// platform-compatibility hazard.
-        to-debug-string: func() -> string
+        to-debug-string: func() -> string;
     }
 
     /// An input bytestream.

--- a/crates/wasi-nn/src/backend/openvino.rs
+++ b/crates/wasi-nn/src/backend/openvino.rs
@@ -163,8 +163,10 @@ fn map_tensor_type_to_precision(tensor_type: TensorType) -> openvino::Precision 
     match tensor_type {
         TensorType::Fp16 => Precision::FP16,
         TensorType::Fp32 => Precision::FP32,
+        TensorType::Fp64 => Precision::FP64,
         TensorType::U8 => Precision::U8,
         TensorType::I32 => Precision::I32,
+        TensorType::I64 => Precision::I64,
         TensorType::Bf16 => todo!("not yet supported in `openvino` bindings"),
     }
 }

--- a/crates/wasi-nn/src/witx.rs
+++ b/crates/wasi-nn/src/witx.rs
@@ -179,6 +179,8 @@ impl From<gen::types::TensorType> for crate::wit::types::TensorType {
             gen::types::TensorType::F32 => crate::wit::types::TensorType::Fp32,
             gen::types::TensorType::U8 => crate::wit::types::TensorType::U8,
             gen::types::TensorType::I32 => crate::wit::types::TensorType::I32,
+            gen::types::TensorType::I64 => crate::wit::types::TensorType::I64,
+            gen::types::TensorType::F64 => crate::wit::types::TensorType::Fp64,
         }
     }
 }

--- a/crates/wasi/wit/deps/filesystem/types.wit
+++ b/crates/wasi/wit/deps/filesystem/types.wit
@@ -806,5 +806,5 @@ interface types {
     ///
     /// Note that this function is fallible because not all stream-related
     /// errors are filesystem-related errors.
-    filesystem-error-code: func(err: borrow<error>) -> option<error-code>
+    filesystem-error-code: func(err: borrow<error>) -> option<error-code>;
 }

--- a/crates/wasi/wit/deps/io/streams.wit
+++ b/crates/wasi/wit/deps/io/streams.wit
@@ -37,7 +37,7 @@ interface streams {
         /// The returned string will change across platforms and hosts which
         /// means that parsing it, for example, would be a
         /// platform-compatibility hazard.
-        to-debug-string: func() -> string
+        to-debug-string: func() -> string;
     }
 
     /// An input bytestream.


### PR DESCRIPTION
This commit updates CI to require semicolons in all WIT files and parsed WIT documents. Some minor updates were required in existing WIT files and the wasi-nn proposal was additionally updated to its latest version with semicolons. The wasi-nn update brought some minor changes to the WIT which required some minor changes here as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
