### PR TITLE
[14.0.0] [wasmtime-wasi] make StdinStream and StdoutStream public (#7150)

### DIFF
--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -45,7 +45,9 @@ pub use self::filesystem::{DirPerms, FilePerms, FsError, FsResult};
 pub use self::network::{Network, SocketError, SocketResult};
 pub use self::poll::{subscribe, ClosureFuture, MakeFuture, Pollable, PollableFuture, Subscribe};
 pub use self::random::{thread_rng, Deterministic};
-pub use self::stdio::{stderr, stdin, stdout, IsATTY, Stderr, Stdin, Stdout};
+pub use self::stdio::{
+    stderr, stdin, stdout, IsATTY, Stderr, Stdin, StdinStream, Stdout, StdoutStream,
+};
 pub use self::stream::{
     HostInputStream, HostOutputStream, InputStream, OutputStream, StreamError, StreamResult,
 };


### PR DESCRIPTION
This allows embedders to implement those traits themselves rather than be restricted to using the built-in implementations.

Fixes https://github.com/bytecodealliance/wasmtime/issues/7149

This patch is already in `main`, and I'd like to backport it to `release-14.0.0`