### PR TITLE
PCC: add semantics for core add/shift/extend/amode ops on AArch64.

### DIFF
--- a/cranelift/codegen/src/ir/pcc.rs
+++ b/cranelift/codegen/src/ir/pcc.rs
@@ -76,6 +76,9 @@ pub enum PccError {
     /// An input to an operator that produces a fact-annotated value
     /// does not have a fact describing it, and one is needed.
     MissingFact,
+    /// A derivation of an output fact is unsupported (incorrect or
+    /// not derivable).
+    UnsupportedFact,
     /// A memory access is out of bounds.
     OutOfBounds,
     /// Proof-carrying-code checking is not implemented for a
@@ -310,7 +313,10 @@ impl FactContext {
                 if *bit_width < 64 && max > max_value_for_width(width) {
                     return Some(minimal_fact);
                 }
-                Some(minimal_fact)
+                Some(Fact::ValueMax {
+                    bit_width: *bit_width,
+                    max,
+                })
             }
             _ => None,
         }

--- a/cranelift/codegen/src/ir/pcc.rs
+++ b/cranelift/codegen/src/ir/pcc.rs
@@ -322,6 +322,15 @@ impl FactContext {
         }
     }
 
+    /// Left-shifts a value with a fact by a known constant.
+    pub fn shl(&self, fact: &Fact, width: u16, amount: u16) -> Option<Fact> {
+        if amount >= 32 {
+            return None;
+        }
+        let factor: u32 = 1 << amount;
+        self.scale(fact, width, factor)
+    }
+
     /// Offsets a value with a fact by a known amount.
     pub fn offset(&self, fact: &Fact, width: u16, offset: i64) -> Option<Fact> {
         // If we eventually support two-sided ranges, we can

--- a/cranelift/codegen/src/isa/aarch64/inst/args.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/args.rs
@@ -11,7 +11,7 @@ use std::string::String;
 // Instruction sub-components: shift and extend descriptors
 
 /// A shift operator for a register or immediate.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u8)]
 pub enum ShiftOp {
     /// Logical shift left.
@@ -578,6 +578,14 @@ impl OperandSize {
         match self {
             OperandSize::Size32 => 0,
             OperandSize::Size64 => 1,
+        }
+    }
+
+    /// The maximum unsigned value representable in a value of this size.
+    pub fn max_value(&self) -> u64 {
+        match self {
+            OperandSize::Size32 => u32::MAX as u64,
+            OperandSize::Size64 => u64::MAX,
         }
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/imms.rs
@@ -307,6 +307,16 @@ impl Imm12 {
     pub fn imm_bits(&self) -> u32 {
         self.bits as u32
     }
+
+    /// Get the actual value that this immediate corresponds to.
+    pub fn value(&self) -> u64 {
+        let base = self.bits as u64;
+        if self.shift12 {
+            base << 12
+        } else {
+            base
+        }
+    }
 }
 
 /// An immediate for logical instructions.

--- a/cranelift/codegen/src/machinst/compile.rs
+++ b/cranelift/codegen/src/machinst/compile.rs
@@ -75,8 +75,11 @@ pub fn compile<B: LowerBackend + TargetIsa>(
             .expect("register allocation")
     };
 
-    // Run the regalloc checker, if requested.
-    if b.flags().regalloc_checker() {
+    // Run the regalloc checker, if requested. Also run the checker if
+    // PCC is enabled (PCC only validates up to pre-regalloc VCode, so
+    // for a full guarantee we need to ensure that regalloc did a
+    // faithful translation to allocated machine code.)
+    if b.flags().regalloc_checker() || b.flags().enable_pcc() {
         let _tt = timing::regalloc_checker();
         let mut checker = regalloc2::checker::Checker::new(&vcode, vcode.machine_env());
         checker.prepare(&regalloc_result);

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -219,6 +219,11 @@ impl std::convert::From<Reg> for regalloc2::VReg {
         reg.0
     }
 }
+impl std::convert::From<&Reg> for regalloc2::VReg {
+    fn from(reg: &Reg) -> regalloc2::VReg {
+        reg.0
+    }
+}
 
 impl std::convert::From<VirtualReg> for regalloc2::VReg {
     fn from(reg: VirtualReg) -> regalloc2::VReg {

--- a/cranelift/filetests/filetests/pcc/fail/add.clif
+++ b/cranelift/filetests/filetests/pcc/fail/add.clif
@@ -1,0 +1,50 @@
+test compile expect-fail
+set enable_pcc=true
+target aarch64
+
+function %f0(i32, i32) -> i32 {
+block0(v0 ! max(32, 0x100): i32, v1 ! max(32, 0x80): i32):
+    v2 ! max(32, 0x17f) = iadd.i32 v0, v1
+    return v2
+}
+
+function %f1(i32) -> i32 {
+block0(v0 ! max(32, 0x100): i32):
+    v1 ! max(32, 1) = iconst.i32 1
+    v2 ! max(32, 0x100) = iadd.i32 v0, v1
+    return v2
+}
+
+function %f3(i32) -> i64 {
+block0(v0: i32):
+    v1 ! max(32, 1) = iconst.i32 1
+    v2 ! max(32, 0xffff_fffe) = iadd.i32 v0, v1
+    v3 ! max(64, 0xffff_fffe) = uextend.i64 v2
+    return v3
+}
+
+function %f3(i32) -> i64 {
+block0(v0: i32):
+    v1 ! max(32, 1) = iconst.i32 1
+    v2 ! max(32, 0xffff_ffff) = iadd.i32 v0, v1
+    v3 ! max(64, 0xffff_ffff) = uextend.i64 v2
+    v4 ! max(64, 0x1) = iconst.i64 1
+    v5 ! max(64, 0xffff_ffff) = iadd.i64 v3, v4
+    return v5
+}
+
+;; check merged ops:
+function %f4(i32, i32) -> i32 {
+block0(v0 ! max(32, 0x100): i32, v1 ! max(32, 0x200): i32):
+  v2 = iconst.i32 2
+  v3 ! max(32, 0x400) = ishl.i32 v0, v2
+  v4 ! max(32, 0x5ff) = iadd.i32 v1, v3
+  return v4
+}
+
+function %f5(i32, i64) -> i64 {
+block0(v0 ! max(32, 0x100): i32, v1 ! max(64, 0x200): i64):
+  v2 ! max(64, 0x100) = uextend.i64 v0
+  v3 ! max(64, 0x2ff) = iadd.i64 v1, v2
+  return v3
+}

--- a/cranelift/filetests/filetests/pcc/fail/extend.clif
+++ b/cranelift/filetests/filetests/pcc/fail/extend.clif
@@ -1,0 +1,20 @@
+test compile expect-fail
+set enable_pcc=true
+target aarch64
+
+function %f0(i32) -> i64 {
+block0(v0 ! max(32, 0xffff_ffff): i32):
+  v1 ! max(64, 0xffff_0000) = uextend.i64 v0
+  return v1
+}
+
+;; This one is actually true, but we don't support the reasoning it
+;; would need: one needs to assume the "don't-care" bits in the upper
+;; half of the i32 are the worst case (all ones), so `0xffff_ffff` is
+;; possible. If the `i32` were taken through another 32-bit operation
+;; and we asserted its 32-bit range at that point, it would work.
+function %f1(i32) -> i64 {
+block0(v0 ! max(16, 0xffff): i32):
+  v1 ! max(64, 0xffff_ffff) = uextend.i64 v0
+  return v1
+}

--- a/cranelift/filetests/filetests/pcc/fail/load.clif
+++ b/cranelift/filetests/filetests/pcc/fail/load.clif
@@ -1,0 +1,59 @@
+test compile expect-fail
+set enable_pcc=true
+target aarch64
+
+function %f0(i64, i32) -> i64 {
+block0(v0 ! points_to(0x1000): i64, v1 ! max(32, 0x1000): i32):
+    v2 ! max(64, 0x100) = uextend.i64 v1
+    v3 ! points_to(0x8) = iadd.i64 v0, v2
+    v4 = load.i64 checked v3
+    return v4
+}
+
+;; Insufficient guard region: the 8-byte load could go off the end.
+function %f1(i64, i32) -> i64 {
+block0(v0 ! points_to(0x1_0000_0000): i64, v1 ! max(32, 0xffff_ffff): i32):
+    v2 ! max(64, 0xffff_ffff) = uextend.i64 v1
+    ;; 8 bytes of valid range is all we actually need, so let's only claim that.
+    v3 ! points_to(0x8) = iadd.i64 v0, v2
+    v4 = load.i64 checked v3
+    return v4
+}
+
+;; RegRegExtend mode on aarch64.
+function %f2(i64, i32) -> i8 {
+block0(v0 ! points_to(0x1000): i64, v1 ! max(32, 0x1000): i32):
+    v2 ! max(64, 0x100) = uextend.i64 v1
+    v3 ! points_to(0x1) = iadd.i64 v0, v2
+    v4 = load.i8 checked v3
+    return v4
+}
+
+;; RegReg mode on aarch64.
+function %f3(i64, i64) -> i8 {
+block0(v0 ! points_to(0x100): i64, v1 ! max(64, 0xfff): i64):
+    v2 ! points_to(0x1) = iadd.i64 v0, v1
+    v3 = load.i8 checked v2
+    return v3
+}
+
+;; RegScaledExtended mode on aarch64.
+function %f4(i64, i32) -> i64 {
+block0(v0 ! points_to(0x7000): i64, v1 ! max(32, 0xfff): i32):
+    v2 ! max(64, 0xfff) = uextend.i64 v1
+    v3 = iconst.i32 3
+    v4 ! max(64, 0x7ff8) = ishl.i64 v2, v3
+    v5 ! points_to(0x8) = iadd.i64 v0, v4
+    v6 = load.i64 checked v5
+    return v6
+}
+
+;; RegScaled mode on aarch64.
+function %f5(i64, i64) -> i64 {
+block0(v0 ! points_to(0x7000): i64, v1 ! max(64, 0xfff): i64):
+    v2 = iconst.i32 3
+    v3 ! max(64, 0x7ff8) = ishl.i64 v1, v2
+    v4 ! points_to(0x8) = iadd.i64 v0, v3
+    v5 = load.i64 checked v4
+    return v5
+}

--- a/cranelift/filetests/filetests/pcc/fail/shift.clif
+++ b/cranelift/filetests/filetests/pcc/fail/shift.clif
@@ -1,0 +1,10 @@
+test compile expect-fail
+set enable_pcc=true
+target aarch64
+
+function %f0(i32) -> i32 {
+block0(v0 ! max(32, 0x100): i32):
+  v1 = iconst.i32 2
+  v2 ! max(32, 0x3ff) = ishl.i32 v0, v1
+  return v2
+}

--- a/cranelift/filetests/filetests/pcc/succeed/add.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/add.clif
@@ -1,0 +1,60 @@
+test compile
+set enable_pcc=true
+target aarch64
+
+function %f0(i32, i32) -> i32 {
+block0(v0 ! max(32, 0x100): i32, v1 ! max(32, 0x80): i32):
+    v2 ! max(32, 0x180) = iadd.i32 v0, v1
+    return v2
+}
+
+function %f1(i32) -> i32 {
+block0(v0 ! max(32, 0x100): i32):
+    v1 ! max(32, 1) = iconst.i32 1
+    v2 ! max(32, 0x101) = iadd.i32 v0, v1
+    return v2
+}
+
+;; a looser but still accurate bound should check too:
+function %f2(i32) -> i32 {
+block0(v0 ! max(32, 0x100): i32):
+    v1 ! max(32, 1) = iconst.i32 1
+    v2 ! max(32, 0x102) = iadd.i32 v0, v1
+    return v2
+}
+
+;; we should be able to verify a range based on the type alone:
+function %f3(i32) -> i64 {
+block0(v0: i32):
+    v1 ! max(32, 1) = iconst.i32 1
+    v2 ! max(32, 0xffff_ffff) = iadd.i32 v0, v1
+    v3 ! max(64, 0xffff_ffff) = uextend.i64 v2
+    return v3
+}
+
+;; we should be able to verify a range based on the type alone:
+function %f3(i32) -> i64 {
+block0(v0: i32):
+    v1 ! max(32, 1) = iconst.i32 1
+    v2 ! max(32, 0xffff_ffff) = iadd.i32 v0, v1
+    v3 ! max(64, 0xffff_ffff) = uextend.i64 v2
+    v4 ! max(64, 0x1) = iconst.i64 1
+    v5 ! max(64, 0x1_0000_0000) = iadd.i64 v3, v4
+    return v5
+}
+
+;; check merged ops:
+function %f4(i32, i32) -> i32 {
+block0(v0 ! max(32, 0x100): i32, v1 ! max(32, 0x200): i32):
+  v2 = iconst.i32 2
+  v3 ! max(32, 0x400) = ishl.i32 v0, v2
+  v4 ! max(32, 0x600) = iadd.i32 v1, v3
+  return v4
+}
+
+function %f5(i32, i64) -> i64 {
+block0(v0 ! max(32, 0x100): i32, v1 ! max(64, 0x200): i64):
+  v2 ! max(64, 0x100) = uextend.i64 v0
+  v3 ! max(64, 0x300) = iadd.i64 v1, v2
+  return v3
+}

--- a/cranelift/filetests/filetests/pcc/succeed/extend.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/extend.clif
@@ -1,0 +1,9 @@
+test compile
+set enable_pcc=true
+target aarch64
+
+function %f0(i32) -> i64 {
+block0(v0 ! max(32, 0xffff_ffff): i32):
+  v1 ! max(64, 0xffff_ffff) = uextend.i64 v0
+  return v1
+}

--- a/cranelift/filetests/filetests/pcc/succeed/load.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/load.clif
@@ -1,0 +1,60 @@
+test compile
+set enable_pcc=true
+target aarch64
+
+function %f0(i64, i32) -> i64 {
+block0(v0 ! points_to(0x1_0000_0000): i64, v1 ! max(32, 0x100): i32):
+    v2 ! max(64, 0x100) = uextend.i64 v1
+    ;; 8 bytes of valid range is all we actually need, so let's only claim that.
+    v3 ! points_to(0x8) = iadd.i64 v0, v2
+    v4 = load.i64 checked v3
+    return v4
+}
+
+;; Note the guard region of 8 bytes -- just enough for the below!
+function %f1(i64, i32) -> i64 {
+block0(v0 ! points_to(0x1_0000_0008): i64, v1 ! max(32, 0xffff_ffff): i32):
+    v2 ! max(64, 0xffff_ffff) = uextend.i64 v1
+    ;; 8 bytes of valid range is all we actually need, so let's only claim that.
+    v3 ! points_to(0x8) = iadd.i64 v0, v2
+    v4 = load.i64 checked v3
+    return v4
+}
+
+;; RegRegExtend mode on aarch64.
+function %f2(i64, i32) -> i8 {
+block0(v0 ! points_to(0x1000): i64, v1 ! max(32, 0xfff): i32):
+    v2 ! max(64, 0x100) = uextend.i64 v1
+    v3 ! points_to(0x1) = iadd.i64 v0, v2
+    v4 = load.i8 checked v3
+    return v4
+}
+
+;; RegReg mode on aarch64.
+function %f3(i64, i64) -> i8 {
+block0(v0 ! points_to(0x1000): i64, v1 ! max(64, 0xfff): i64):
+    v2 ! points_to(0x1) = iadd.i64 v0, v1
+    v3 = load.i8 checked v2
+    return v3
+}
+
+;; RegScaledExtended mode on aarch64.
+function %f4(i64, i32) -> i64 {
+block0(v0 ! points_to(0x8000): i64, v1 ! max(32, 0xfff): i32):
+    v2 ! max(64, 0xfff) = uextend.i64 v1
+    v3 = iconst.i32 3
+    v4 ! max(64, 0x7ff8) = ishl.i64 v2, v3
+    v5 ! points_to(0x8) = iadd.i64 v0, v4
+    v6 = load.i64 checked v5
+    return v6
+}
+
+;; RegScaled mode on aarch64.
+function %f5(i64, i64) -> i64 {
+block0(v0 ! points_to(0x8000): i64, v1 ! max(64, 0xfff): i64):
+    v2 = iconst.i32 3
+    v3 ! max(64, 0x7ff8) = ishl.i64 v1, v2
+    v4 ! points_to(0x8) = iadd.i64 v0, v3
+    v5 = load.i64 checked v4
+    return v5
+}

--- a/cranelift/filetests/filetests/pcc/succeed/shift.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/shift.clif
@@ -1,0 +1,17 @@
+test compile
+set enable_pcc=true
+target aarch64
+
+function %f0(i32) -> i32 {
+block0(v0 ! max(32, 0x100): i32):
+  v1 = iconst.i32 2
+  v2 ! max(32, 0x400) = ishl.i32 v0, v1
+  return v2
+}
+
+function %f0(i32) -> i32 {
+block0(v0: i32):
+  v1 = iconst.i32 2
+  v2 ! max(32, 0xffff_ffff) = ishl.i32 v0, v1
+  return v2
+}


### PR DESCRIPTION
This PR adds verification of facts on values produced by adds, shifts, and extends on AArch64, handling the various combination instructions (adds with builtin extends or shifts, for example), and also adds verification of all addressing modes, including those with builtin extends and shifts.

It also splits the test suite into"succeed" and "fail" sets, and provides cases that PCC should catch.