### PR TITLE
cranelift: Group labels by FuncId instead of Name

### DIFF
--- a/cranelift/jit/src/backend.rs
+++ b/cranelift/jit/src/backend.rs
@@ -712,7 +712,7 @@ impl Module for JITModule {
             .buffer
             .relocs()
             .iter()
-            .map(|reloc| ModuleReloc::from_mach_reloc(reloc, &ctx.func))
+            .map(|reloc| ModuleReloc::from_mach_reloc(reloc, &ctx.func, id))
             .collect();
 
         self.record_function_for_perf(ptr, size, &decl.linkage_name(id));
@@ -797,7 +797,7 @@ impl Module for JITModule {
             size,
             relocs: relocs
                 .iter()
-                .map(|reloc| ModuleReloc::from_mach_reloc(reloc, func))
+                .map(|reloc| ModuleReloc::from_mach_reloc(reloc, func, id))
                 .collect(),
         });
 

--- a/cranelift/module/src/module.rs
+++ b/cranelift/module/src/module.rs
@@ -11,7 +11,7 @@ use core::fmt::Display;
 use cranelift_codegen::binemit::{CodeOffset, Reloc};
 use cranelift_codegen::entity::{entity_impl, PrimaryMap};
 use cranelift_codegen::ir::function::{Function, VersionMarker};
-use cranelift_codegen::ir::{ExternalName, UserFuncName};
+use cranelift_codegen::ir::ExternalName;
 use cranelift_codegen::settings::SetError;
 use cranelift_codegen::{
     ir, isa, CodegenError, CompileError, Context, FinalizedMachReloc, FinalizedRelocTarget,
@@ -36,7 +36,11 @@ pub struct ModuleReloc {
 
 impl ModuleReloc {
     /// Converts a `FinalizedMachReloc` produced from a `Function` into a `ModuleReloc`.
-    pub fn from_mach_reloc(mach_reloc: &FinalizedMachReloc, func: &Function) -> Self {
+    pub fn from_mach_reloc(
+        mach_reloc: &FinalizedMachReloc,
+        func: &Function,
+        func_id: FuncId,
+    ) -> Self {
         let name = match mach_reloc.target {
             FinalizedRelocTarget::ExternalName(ExternalName::User(reff)) => {
                 let name = &func.params.user_named_funcs()[reff];
@@ -50,7 +54,7 @@ impl ModuleReloc {
                 ModuleRelocTarget::KnownSymbol(ks)
             }
             FinalizedRelocTarget::Func(offset) => {
-                ModuleRelocTarget::FunctionOffset(func.name.clone(), offset)
+                ModuleRelocTarget::FunctionOffset(func_id, offset)
             }
         };
         Self {
@@ -430,7 +434,7 @@ pub enum ModuleRelocTarget {
     /// Symbols known to the linker.
     KnownSymbol(ir::KnownSymbol),
     /// A offset inside a function
-    FunctionOffset(UserFuncName, CodeOffset),
+    FunctionOffset(FuncId, CodeOffset),
 }
 
 impl ModuleRelocTarget {


### PR DESCRIPTION
👋 Hey,

This addresses an issue that was exposed by cg_clif when using RISC-V with GOT relocations. 

Apparently we allow multiple functions with the same name to coexist within the same module. Currently we deduplicate labels in the object backend by function name and label offset.

This caused a label confusion issue when two functions with the same name tried to emit a label at the same offset. The result was that one function referenced a label in the second one causing a very confusing relocation.

The solution here is to instead use `FuncId` which is assigned when the function is first declared and guaranteed to be unique.