### PR TITLE
add i128 support for iabs on aarch64

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -2704,6 +2704,9 @@
 (rule (and_vec x y size) (vec_rrr (VecALUOp.And) x y size))
 
 ;; Helpers for generating `eor` instructions.
+(decl eor (Type Reg Reg) Reg)
+(rule (eor ty x y) (alu_rrr (ALUOp.Eor) ty x y))
+
 (decl eor_vec (Reg Reg VectorSize) Reg)
 (rule (eor_vec x y size) (vec_rrr (VecALUOp.Eor) x y size))
 

--- a/cranelift/codegen/src/isa/aarch64/lower.isle
+++ b/cranelift/codegen/src/isa/aarch64/lower.isle
@@ -339,7 +339,7 @@
 
 ;;;; Rules for `iabs` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(rule (lower (has_type ty @ (multi_lane _ _) (iabs x)))
+(rule -1 (lower (has_type ty @ (multi_lane _ _) (iabs x)))
       (vec_abs x (vector_size ty)))
 
 (rule 2 (lower (has_type $I64 (iabs x)))
@@ -347,6 +347,24 @@
 
 (rule 1 (lower (has_type (fits_in_32 ty) (iabs x)))
       (abs (OperandSize.Size32) (put_in_reg_sext32 x)))
+
+; `rustc` implementation.
+; - create a bitmask of all 1s if negative, or 0s if positive.
+; - xor all bits by bitmask. then subtract bitmask from xor'd values.
+; - if `x` is positive, the xor'd bits = x and the mask = 0, so we end up with
+;   `x - 0`.
+; - if `x` is negative, the xor'd bits = ~x and the mask = -1, so we end up with
+;   `~x - (-1) = ~x + 1`, which is exactly `abs(x)`.
+(rule (lower (has_type $I128 (iabs x)))
+      (let ((x_regs ValueRegs x)
+            (x_lo Reg (value_regs_get x_regs 0))
+            (x_hi Reg (value_regs_get x_regs 1))
+            (asr_reg Reg (asr_imm $I64 x_hi (imm_shift_from_u8 63)))
+            (eor_hi Reg (eor $I64 x_hi asr_reg))
+            (eor_lo Reg (eor $I64 x_lo asr_reg))
+            (subs_lo ProducesFlags (sub_with_flags_paired $I64 eor_lo asr_reg))
+            (sbc_hi ConsumesFlags (sbc_paired $I64 eor_hi asr_reg)))
+       (with_flags subs_lo sbc_hi)))
 
 ;;;; Rules for `avg_round` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/aarch64/iabs.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/iabs.clif
@@ -190,3 +190,27 @@ block0(v0: i64):
 ;   cneg x0, x0, le
 ;   ret
 
+function %f11(i128) -> i128 {
+block0(v0: i128):
+  v1 = iabs v0
+  return v1
+}
+
+; VCode:
+; block0:
+;   asr x3, x1, #63
+;   eor x5, x1, x3
+;   eor x7, x0, x3
+;   subs x0, x7, x3
+;   sbc x1, x5, x3
+;   ret
+; 
+; Disassembled:
+; block0: ; offset 0x0
+;   asr x3, x1, #0x3f
+;   eor x5, x1, x3
+;   eor x7, x0, x3
+;   subs x0, x7, x3
+;   sbc x1, x5, x3
+;   ret
+

--- a/cranelift/filetests/filetests/runtests/i128-iabs.clif
+++ b/cranelift/filetests/filetests/runtests/i128-iabs.clif
@@ -1,6 +1,7 @@
 test interpret
 test run
 set enable_llvm_abi_extensions=true
+target aarch64
 target s390x
 target x86_64
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

As per https://github.com/bytecodealliance/wasmtime/issues/5467, we do not yet have support for iabs on aarch64. This PR adds it, along with the instruction `csinv`.
