### PR TITLE
Ensure exports are properly namespaced

### DIFF
--- a/crates/component-macro/tests/codegen/multiversion/root.wit
+++ b/crates/component-macro/tests/codegen/multiversion/root.wit
@@ -3,4 +3,5 @@ package foo:bar;
 world foo {
   import my:dep/a@0.1.0;
   import my:dep/a@0.2.0;
+  export my:dep/a@0.2.0;
 }

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -470,7 +470,7 @@ impl Wasmtime {
                         format!(
                             "exports::{}::{}::{snake}::{camel}",
                             pkgname.namespace.to_snake_case(),
-                            pkgname.name.to_snake_case(),
+                            self.name_package_module(resolve, iface.package.unwrap()),
                         ),
                         format!(
                             "{}_{}_{snake}",


### PR DESCRIPTION
Continuation of #7172 where imports and export _definitions_ are properly namespaced by version by the usage of exports was not.

