### PR TITLE
Reapply #7150

### DIFF
--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -45,7 +45,9 @@ pub use self::filesystem::{DirPerms, FilePerms, FsError, FsResult};
 pub use self::network::{Network, SocketError, SocketResult};
 pub use self::poll::{subscribe, ClosureFuture, MakeFuture, Pollable, PollableFuture, Subscribe};
 pub use self::random::{thread_rng, Deterministic};
-pub use self::stdio::{stderr, stdin, stdout, IsATTY, Stderr, Stdin, Stdout};
+pub use self::stdio::{
+    stderr, stdin, stdout, IsATTY, Stderr, Stdin, StdinStream, Stdout, StdoutStream,
+};
 pub use self::stream::{
     HostInputStream, HostOutputStream, InputStream, OutputStream, StreamError, StreamResult,
 };


### PR DESCRIPTION
#7150 seems to [have been lost in #7152](https://github.com/bytecodealliance/wasmtime/commit/722310a2d9ae352192e1c5052866aca74f3f1f94#diff-30b8d431d2d3c97efe5fcaeb3ebdd5860b9f5a3699b2051f12dd0a1b0b2bd7ffL48) (perhaps a bad rebase?).

cc @alexcrichton 