### PR TITLE
riscv64: Optimize `gen_bmask` slightly

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2902,12 +2902,22 @@
 
 ;; Generates either 0 if `Value` is zero or -1 otherwise.
 (decl gen_bmask (Value) XReg)
+
+;; Base cases: use `snez` after a sign extension to ensure that the entire
+;; register is defined. For i128 we test both the upper and lower half.
 (rule 0 (gen_bmask val @ (value_type (fits_in_64 _)))
   (let ((non_zero XReg (rv_snez (sext val))))
     (rv_neg non_zero)))
 (rule 1 (gen_bmask val @ (value_type $I128))
   (let ((non_zero XReg (rv_snez (rv_or (value_regs_get val 0) (value_regs_get val 1)))))
     (rv_neg non_zero)))
+
+;; If the input value is an `icmp` or an `fcmp` directly then the `snez` can
+;; be omitted because the result of the icmp or fcmp is a 0 or 1 directly. This
+;; means we can go straight to the `neg` instruction to produce the final
+;; result.
+(rule 2 (gen_bmask val @ (maybe_uextend (icmp _ _ _))) (rv_neg val))
+(rule 2 (gen_bmask val @ (maybe_uextend (fcmp _ _ _))) (rv_neg val))
 
 (decl lower_bmask (Value Type) ValueRegs)
 (rule 0 (lower_bmask val (fits_in_64 _))

--- a/cranelift/filetests/filetests/isa/riscv64/select_spectre_guard.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/select_spectre_guard.clif
@@ -12,33 +12,33 @@ block0(v0: i8, v1: i8, v2: i8):
 
 ; VCode:
 ; block0:
-;   li a3,42
-;   andi a5,a0,255
-;   andi a3,a3,255
-;   eq a3,a5,a3##ty=i8
-;   sltu a3,zero,a3
-;   sub a4,zero,a3
-;   and a0,a1,a4
-;   not a3,a4
-;   and a4,a2,a3
-;   or a0,a0,a4
+;   mv a3,a0
+;   li a0,42
+;   andi a4,a3,255
+;   andi a0,a0,255
+;   eq a3,a4,a0##ty=i8
+;   sub a3,zero,a3
+;   and a4,a1,a3
+;   not a0,a3
+;   and a2,a2,a0
+;   or a0,a4,a2
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   andi a5, a0, 0xff
-;   andi a3, a3, 0xff
-;   bne a5, a3, 0xc
+;   mv a3, a0
+;   addi a0, zero, 0x2a
+;   andi a4, a3, 0xff
+;   andi a0, a0, 0xff
+;   bne a4, a0, 0xc
 ;   addi a3, zero, 1
 ;   j 8
 ;   mv a3, zero
-;   snez a3, a3
-;   neg a4, a3
-;   and a0, a1, a4
-;   not a3, a4
-;   and a4, a2, a3
-;   or a0, a0, a4
+;   neg a3, a3
+;   and a4, a1, a3
+;   not a0, a3
+;   and a2, a2, a0
+;   or a0, a4, a2
 ;   ret
 
 function %f(i8, i16, i16) -> i16 {
@@ -51,33 +51,33 @@ block0(v0: i8, v1: i16, v2: i16):
 
 ; VCode:
 ; block0:
-;   li a3,42
-;   andi a5,a0,255
-;   andi a3,a3,255
-;   eq a3,a5,a3##ty=i8
-;   sltu a3,zero,a3
-;   sub a4,zero,a3
-;   and a0,a1,a4
-;   not a3,a4
-;   and a4,a2,a3
-;   or a0,a0,a4
+;   mv a3,a0
+;   li a0,42
+;   andi a4,a3,255
+;   andi a0,a0,255
+;   eq a3,a4,a0##ty=i8
+;   sub a3,zero,a3
+;   and a4,a1,a3
+;   not a0,a3
+;   and a2,a2,a0
+;   or a0,a4,a2
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   andi a5, a0, 0xff
-;   andi a3, a3, 0xff
-;   bne a5, a3, 0xc
+;   mv a3, a0
+;   addi a0, zero, 0x2a
+;   andi a4, a3, 0xff
+;   andi a0, a0, 0xff
+;   bne a4, a0, 0xc
 ;   addi a3, zero, 1
 ;   j 8
 ;   mv a3, zero
-;   snez a3, a3
-;   neg a4, a3
-;   and a0, a1, a4
-;   not a3, a4
-;   and a4, a2, a3
-;   or a0, a0, a4
+;   neg a3, a3
+;   and a4, a1, a3
+;   not a0, a3
+;   and a2, a2, a0
+;   or a0, a4, a2
 ;   ret
 
 function %f(i8, i32, i32) -> i32 {
@@ -90,33 +90,33 @@ block0(v0: i8, v1: i32, v2: i32):
 
 ; VCode:
 ; block0:
-;   li a3,42
-;   andi a5,a0,255
-;   andi a3,a3,255
-;   eq a3,a5,a3##ty=i8
-;   sltu a3,zero,a3
-;   sub a4,zero,a3
-;   and a0,a1,a4
-;   not a3,a4
-;   and a4,a2,a3
-;   or a0,a0,a4
+;   mv a3,a0
+;   li a0,42
+;   andi a4,a3,255
+;   andi a0,a0,255
+;   eq a3,a4,a0##ty=i8
+;   sub a3,zero,a3
+;   and a4,a1,a3
+;   not a0,a3
+;   and a2,a2,a0
+;   or a0,a4,a2
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   andi a5, a0, 0xff
-;   andi a3, a3, 0xff
-;   bne a5, a3, 0xc
+;   mv a3, a0
+;   addi a0, zero, 0x2a
+;   andi a4, a3, 0xff
+;   andi a0, a0, 0xff
+;   bne a4, a0, 0xc
 ;   addi a3, zero, 1
 ;   j 8
 ;   mv a3, zero
-;   snez a3, a3
-;   neg a4, a3
-;   and a0, a1, a4
-;   not a3, a4
-;   and a4, a2, a3
-;   or a0, a0, a4
+;   neg a3, a3
+;   and a4, a1, a3
+;   not a0, a3
+;   and a2, a2, a0
+;   or a0, a4, a2
 ;   ret
 
 function %f(i8, i64, i64) -> i64 {
@@ -129,33 +129,33 @@ block0(v0: i8, v1: i64, v2: i64):
 
 ; VCode:
 ; block0:
-;   li a3,42
-;   andi a5,a0,255
-;   andi a3,a3,255
-;   eq a3,a5,a3##ty=i8
-;   sltu a3,zero,a3
-;   sub a4,zero,a3
-;   and a0,a1,a4
-;   not a3,a4
-;   and a4,a2,a3
-;   or a0,a0,a4
+;   mv a3,a0
+;   li a0,42
+;   andi a4,a3,255
+;   andi a0,a0,255
+;   eq a3,a4,a0##ty=i8
+;   sub a3,zero,a3
+;   and a4,a1,a3
+;   not a0,a3
+;   and a2,a2,a0
+;   or a0,a4,a2
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   andi a5, a0, 0xff
-;   andi a3, a3, 0xff
-;   bne a5, a3, 0xc
+;   mv a3, a0
+;   addi a0, zero, 0x2a
+;   andi a4, a3, 0xff
+;   andi a0, a0, 0xff
+;   bne a4, a0, 0xc
 ;   addi a3, zero, 1
 ;   j 8
 ;   mv a3, zero
-;   snez a3, a3
-;   neg a4, a3
-;   and a0, a1, a4
-;   not a3, a4
-;   and a4, a2, a3
-;   or a0, a0, a4
+;   neg a3, a3
+;   and a4, a1, a3
+;   not a0, a3
+;   and a2, a2, a0
+;   or a0, a4, a2
 ;   ret
 
 function %f(i8, i128, i128) -> i128 {
@@ -171,714 +171,14 @@ block0(v0: i8, v1: i128, v2: i128):
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   sd s6,-8(sp)
-;   add sp,-16
-; block0:
-;   li a5,42
-;   andi a0,a0,255
-;   andi a5,a5,255
-;   eq a5,a0,a5##ty=i8
-;   sltu a5,zero,a5
-;   sub s6,zero,a5
-;   and a0,a1,s6
-;   and a5,a2,s6
-;   not a2,s6
-;   not a1,s6
-;   and a2,a3,a2
-;   and a1,a4,a1
-;   or a0,a0,a2
-;   or a1,a5,a1
-;   add sp,+16
-;   ld s6,-8(sp)
-;   ld ra,8(sp)
-;   ld fp,0(sp)
-;   add sp,+16
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi sp, sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
-;   mv s0, sp
-;   sd s6, -8(sp)
-;   addi sp, sp, -0x10
-; block1: ; offset 0x18
-;   addi a5, zero, 0x2a
-;   andi a0, a0, 0xff
-;   andi a5, a5, 0xff
-;   bne a0, a5, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   snez a5, a5
-;   neg s6, a5
-;   and a0, a1, s6
-;   and a5, a2, s6
-;   not a2, s6
-;   not a1, s6
-;   and a2, a3, a2
-;   and a1, a4, a1
-;   or a0, a0, a2
-;   or a1, a5, a1
-;   addi sp, sp, 0x10
-;   ld s6, -8(sp)
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
-;   ret
-
-function %f(i16, i8, i8) -> i8 {
-block0(v0: i16, v1: i8, v2: i8):
-  v3 = iconst.i16 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i8 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a3,42
-;   slli a5,a0,48
-;   srli a4,a5,48
-;   slli a3,a3,48
-;   srli a5,a3,48
-;   eq a3,a4,a5##ty=i16
-;   sltu a4,zero,a3
-;   sub a0,zero,a4
-;   and a3,a1,a0
-;   not a4,a0
-;   and a0,a2,a4
-;   or a0,a3,a0
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   slli a5, a0, 0x30
-;   srli a4, a5, 0x30
-;   slli a3, a3, 0x30
-;   srli a5, a3, 0x30
-;   bne a4, a5, 0xc
-;   addi a3, zero, 1
-;   j 8
-;   mv a3, zero
-;   snez a4, a3
-;   neg a0, a4
-;   and a3, a1, a0
-;   not a4, a0
-;   and a0, a2, a4
-;   or a0, a3, a0
-;   ret
-
-function %f(i16, i16, i16) -> i16 {
-block0(v0: i16, v1: i16, v2: i16):
-  v3 = iconst.i16 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i16 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a3,42
-;   slli a5,a0,48
-;   srli a4,a5,48
-;   slli a3,a3,48
-;   srli a5,a3,48
-;   eq a3,a4,a5##ty=i16
-;   sltu a4,zero,a3
-;   sub a0,zero,a4
-;   and a3,a1,a0
-;   not a4,a0
-;   and a0,a2,a4
-;   or a0,a3,a0
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   slli a5, a0, 0x30
-;   srli a4, a5, 0x30
-;   slli a3, a3, 0x30
-;   srli a5, a3, 0x30
-;   bne a4, a5, 0xc
-;   addi a3, zero, 1
-;   j 8
-;   mv a3, zero
-;   snez a4, a3
-;   neg a0, a4
-;   and a3, a1, a0
-;   not a4, a0
-;   and a0, a2, a4
-;   or a0, a3, a0
-;   ret
-
-function %f(i16, i32, i32) -> i32 {
-block0(v0: i16, v1: i32, v2: i32):
-  v3 = iconst.i16 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i32 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a3,42
-;   slli a5,a0,48
-;   srli a4,a5,48
-;   slli a3,a3,48
-;   srli a5,a3,48
-;   eq a3,a4,a5##ty=i16
-;   sltu a4,zero,a3
-;   sub a0,zero,a4
-;   and a3,a1,a0
-;   not a4,a0
-;   and a0,a2,a4
-;   or a0,a3,a0
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   slli a5, a0, 0x30
-;   srli a4, a5, 0x30
-;   slli a3, a3, 0x30
-;   srli a5, a3, 0x30
-;   bne a4, a5, 0xc
-;   addi a3, zero, 1
-;   j 8
-;   mv a3, zero
-;   snez a4, a3
-;   neg a0, a4
-;   and a3, a1, a0
-;   not a4, a0
-;   and a0, a2, a4
-;   or a0, a3, a0
-;   ret
-
-function %f(i16, i64, i64) -> i64 {
-block0(v0: i16, v1: i64, v2: i64):
-  v3 = iconst.i16 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i64 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a3,42
-;   slli a5,a0,48
-;   srli a4,a5,48
-;   slli a3,a3,48
-;   srli a5,a3,48
-;   eq a3,a4,a5##ty=i16
-;   sltu a4,zero,a3
-;   sub a0,zero,a4
-;   and a3,a1,a0
-;   not a4,a0
-;   and a0,a2,a4
-;   or a0,a3,a0
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   slli a5, a0, 0x30
-;   srli a4, a5, 0x30
-;   slli a3, a3, 0x30
-;   srli a5, a3, 0x30
-;   bne a4, a5, 0xc
-;   addi a3, zero, 1
-;   j 8
-;   mv a3, zero
-;   snez a4, a3
-;   neg a0, a4
-;   and a3, a1, a0
-;   not a4, a0
-;   and a0, a2, a4
-;   or a0, a3, a0
-;   ret
-
-function %f(i16, i128, i128) -> i128 {
-block0(v0: i16, v1: i128, v2: i128):
-  v3 = iconst.i16 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i128 v4, v1, v2
-  return v5
-}
-
-; VCode:
-;   add sp,-16
-;   sd ra,8(sp)
-;   sd fp,0(sp)
-;   mv fp,sp
-;   sd s8,-8(sp)
-;   add sp,-16
-; block0:
-;   li a5,42
-;   slli a0,a0,48
-;   srli a0,a0,48
-;   slli a5,a5,48
-;   srli a5,a5,48
-;   eq a5,a0,a5##ty=i16
-;   sltu a0,zero,a5
-;   sub s8,zero,a0
-;   and a5,a1,s8
-;   and a1,a2,s8
-;   not a0,s8
-;   not a2,s8
-;   and a0,a3,a0
-;   and a2,a4,a2
-;   or a0,a5,a0
-;   or a1,a1,a2
-;   add sp,+16
-;   ld s8,-8(sp)
-;   ld ra,8(sp)
-;   ld fp,0(sp)
-;   add sp,+16
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi sp, sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
-;   mv s0, sp
-;   sd s8, -8(sp)
-;   addi sp, sp, -0x10
-; block1: ; offset 0x18
-;   addi a5, zero, 0x2a
-;   slli a0, a0, 0x30
-;   srli a0, a0, 0x30
-;   slli a5, a5, 0x30
-;   srli a5, a5, 0x30
-;   bne a0, a5, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   snez a0, a5
-;   neg s8, a0
-;   and a5, a1, s8
-;   and a1, a2, s8
-;   not a0, s8
-;   not a2, s8
-;   and a0, a3, a0
-;   and a2, a4, a2
-;   or a0, a5, a0
-;   or a1, a1, a2
-;   addi sp, sp, 0x10
-;   ld s8, -8(sp)
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
-;   ret
-
-function %f(i32, i8, i8) -> i8 {
-block0(v0: i32, v1: i8, v2: i8):
-  v3 = iconst.i32 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i8 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a3,42
-;   slli a5,a0,32
-;   srli a4,a5,32
-;   slli a3,a3,32
-;   srli a5,a3,32
-;   eq a3,a4,a5##ty=i32
-;   sltu a4,zero,a3
-;   sub a0,zero,a4
-;   and a3,a1,a0
-;   not a4,a0
-;   and a0,a2,a4
-;   or a0,a3,a0
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   slli a5, a0, 0x20
-;   srli a4, a5, 0x20
-;   slli a3, a3, 0x20
-;   srli a5, a3, 0x20
-;   bne a4, a5, 0xc
-;   addi a3, zero, 1
-;   j 8
-;   mv a3, zero
-;   snez a4, a3
-;   neg a0, a4
-;   and a3, a1, a0
-;   not a4, a0
-;   and a0, a2, a4
-;   or a0, a3, a0
-;   ret
-
-function %f(i32, i16, i16) -> i16 {
-block0(v0: i32, v1: i16, v2: i16):
-  v3 = iconst.i32 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i16 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a3,42
-;   slli a5,a0,32
-;   srli a4,a5,32
-;   slli a3,a3,32
-;   srli a5,a3,32
-;   eq a3,a4,a5##ty=i32
-;   sltu a4,zero,a3
-;   sub a0,zero,a4
-;   and a3,a1,a0
-;   not a4,a0
-;   and a0,a2,a4
-;   or a0,a3,a0
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   slli a5, a0, 0x20
-;   srli a4, a5, 0x20
-;   slli a3, a3, 0x20
-;   srli a5, a3, 0x20
-;   bne a4, a5, 0xc
-;   addi a3, zero, 1
-;   j 8
-;   mv a3, zero
-;   snez a4, a3
-;   neg a0, a4
-;   and a3, a1, a0
-;   not a4, a0
-;   and a0, a2, a4
-;   or a0, a3, a0
-;   ret
-
-function %f(i32, i32, i32) -> i32 {
-block0(v0: i32, v1: i32, v2: i32):
-  v3 = iconst.i32 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i32 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a3,42
-;   slli a5,a0,32
-;   srli a4,a5,32
-;   slli a3,a3,32
-;   srli a5,a3,32
-;   eq a3,a4,a5##ty=i32
-;   sltu a4,zero,a3
-;   sub a0,zero,a4
-;   and a3,a1,a0
-;   not a4,a0
-;   and a0,a2,a4
-;   or a0,a3,a0
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   slli a5, a0, 0x20
-;   srli a4, a5, 0x20
-;   slli a3, a3, 0x20
-;   srli a5, a3, 0x20
-;   bne a4, a5, 0xc
-;   addi a3, zero, 1
-;   j 8
-;   mv a3, zero
-;   snez a4, a3
-;   neg a0, a4
-;   and a3, a1, a0
-;   not a4, a0
-;   and a0, a2, a4
-;   or a0, a3, a0
-;   ret
-
-function %f(i32, i64, i64) -> i64 {
-block0(v0: i32, v1: i64, v2: i64):
-  v3 = iconst.i32 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i64 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a3,42
-;   slli a5,a0,32
-;   srli a4,a5,32
-;   slli a3,a3,32
-;   srli a5,a3,32
-;   eq a3,a4,a5##ty=i32
-;   sltu a4,zero,a3
-;   sub a0,zero,a4
-;   and a3,a1,a0
-;   not a4,a0
-;   and a0,a2,a4
-;   or a0,a3,a0
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a3, zero, 0x2a
-;   slli a5, a0, 0x20
-;   srli a4, a5, 0x20
-;   slli a3, a3, 0x20
-;   srli a5, a3, 0x20
-;   bne a4, a5, 0xc
-;   addi a3, zero, 1
-;   j 8
-;   mv a3, zero
-;   snez a4, a3
-;   neg a0, a4
-;   and a3, a1, a0
-;   not a4, a0
-;   and a0, a2, a4
-;   or a0, a3, a0
-;   ret
-
-function %f(i32, i128, i128) -> i128 {
-block0(v0: i32, v1: i128, v2: i128):
-  v3 = iconst.i32 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i128 v4, v1, v2
-  return v5
-}
-
-; VCode:
-;   add sp,-16
-;   sd ra,8(sp)
-;   sd fp,0(sp)
-;   mv fp,sp
-;   sd s8,-8(sp)
-;   add sp,-16
-; block0:
-;   li a5,42
-;   slli a0,a0,32
-;   srli a0,a0,32
-;   slli a5,a5,32
-;   srli a5,a5,32
-;   eq a5,a0,a5##ty=i32
-;   sltu a0,zero,a5
-;   sub s8,zero,a0
-;   and a5,a1,s8
-;   and a1,a2,s8
-;   not a0,s8
-;   not a2,s8
-;   and a0,a3,a0
-;   and a2,a4,a2
-;   or a0,a5,a0
-;   or a1,a1,a2
-;   add sp,+16
-;   ld s8,-8(sp)
-;   ld ra,8(sp)
-;   ld fp,0(sp)
-;   add sp,+16
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi sp, sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
-;   mv s0, sp
-;   sd s8, -8(sp)
-;   addi sp, sp, -0x10
-; block1: ; offset 0x18
-;   addi a5, zero, 0x2a
-;   slli a0, a0, 0x20
-;   srli a0, a0, 0x20
-;   slli a5, a5, 0x20
-;   srli a5, a5, 0x20
-;   bne a0, a5, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   snez a0, a5
-;   neg s8, a0
-;   and a5, a1, s8
-;   and a1, a2, s8
-;   not a0, s8
-;   not a2, s8
-;   and a0, a3, a0
-;   and a2, a4, a2
-;   or a0, a5, a0
-;   or a1, a1, a2
-;   addi sp, sp, 0x10
-;   ld s8, -8(sp)
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
-;   ret
-
-function %f(i64, i8, i8) -> i8 {
-block0(v0: i64, v1: i8, v2: i8):
-  v3 = iconst.i64 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i8 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a5,42
-;   eq a5,a0,a5##ty=i64
-;   sltu a0,zero,a5
-;   sub a3,zero,a0
-;   and a4,a1,a3
-;   not a0,a3
-;   and a2,a2,a0
-;   or a0,a4,a2
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a5, zero, 0x2a
-;   bne a0, a5, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   snez a0, a5
-;   neg a3, a0
-;   and a4, a1, a3
-;   not a0, a3
-;   and a2, a2, a0
-;   or a0, a4, a2
-;   ret
-
-function %f(i64, i16, i16) -> i16 {
-block0(v0: i64, v1: i16, v2: i16):
-  v3 = iconst.i64 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i16 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a5,42
-;   eq a5,a0,a5##ty=i64
-;   sltu a0,zero,a5
-;   sub a3,zero,a0
-;   and a4,a1,a3
-;   not a0,a3
-;   and a2,a2,a0
-;   or a0,a4,a2
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a5, zero, 0x2a
-;   bne a0, a5, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   snez a0, a5
-;   neg a3, a0
-;   and a4, a1, a3
-;   not a0, a3
-;   and a2, a2, a0
-;   or a0, a4, a2
-;   ret
-
-function %f(i64, i32, i32) -> i32 {
-block0(v0: i64, v1: i32, v2: i32):
-  v3 = iconst.i64 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i32 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a5,42
-;   eq a5,a0,a5##ty=i64
-;   sltu a0,zero,a5
-;   sub a3,zero,a0
-;   and a4,a1,a3
-;   not a0,a3
-;   and a2,a2,a0
-;   or a0,a4,a2
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a5, zero, 0x2a
-;   bne a0, a5, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   snez a0, a5
-;   neg a3, a0
-;   and a4, a1, a3
-;   not a0, a3
-;   and a2, a2, a0
-;   or a0, a4, a2
-;   ret
-
-function %f(i64, i64, i64) -> i64 {
-block0(v0: i64, v1: i64, v2: i64):
-  v3 = iconst.i64 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i64 v4, v1, v2
-  return v5
-}
-
-; VCode:
-; block0:
-;   li a5,42
-;   eq a5,a0,a5##ty=i64
-;   sltu a0,zero,a5
-;   sub a3,zero,a0
-;   and a4,a1,a3
-;   not a0,a3
-;   and a2,a2,a0
-;   or a0,a4,a2
-;   ret
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   addi a5, zero, 0x2a
-;   bne a0, a5, 0xc
-;   addi a5, zero, 1
-;   j 8
-;   mv a5, zero
-;   snez a0, a5
-;   neg a3, a0
-;   and a4, a1, a3
-;   not a0, a3
-;   and a2, a2, a0
-;   or a0, a4, a2
-;   ret
-
-function %f(i64, i128, i128) -> i128 {
-block0(v0: i64, v1: i128, v2: i128):
-  v3 = iconst.i64 42
-  v4 = icmp eq v0, v3
-  v5 = select_spectre_guard.i128 v4, v1, v2
-  return v5
-}
-
-; VCode:
-;   add sp,-16
-;   sd ra,8(sp)
-;   sd fp,0(sp)
-;   mv fp,sp
 ;   sd s10,-8(sp)
 ;   add sp,-16
 ; block0:
-;   li a5,42
-;   eq a5,a0,a5##ty=i64
-;   sltu a5,zero,a5
+;   mv a5,a0
+;   li a0,42
+;   andi a5,a5,255
+;   andi a0,a0,255
+;   eq a5,a5,a0##ty=i8
 ;   sub a5,zero,a5
 ;   and a0,a1,a5
 ;   and a2,a2,a5
@@ -904,12 +204,14 @@ block0(v0: i64, v1: i128, v2: i128):
 ;   sd s10, -8(sp)
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x18
-;   addi a5, zero, 0x2a
-;   bne a0, a5, 0xc
+;   mv a5, a0
+;   addi a0, zero, 0x2a
+;   andi a5, a5, 0xff
+;   andi a0, a0, 0xff
+;   bne a5, a0, 0xc
 ;   addi a5, zero, 1
 ;   j 8
 ;   mv a5, zero
-;   snez a5, a5
 ;   neg a5, a5
 ;   and a0, a1, a5
 ;   and a2, a2, a5
@@ -921,6 +223,678 @@ block0(v0: i64, v1: i128, v2: i128):
 ;   or a1, a2, a4
 ;   addi sp, sp, 0x10
 ;   ld s10, -8(sp)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %f(i16, i8, i8) -> i8 {
+block0(v0: i16, v1: i8, v2: i8):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i8 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   slli a4,a0,48
+;   srli a0,a4,48
+;   slli a3,a3,48
+;   srli a4,a3,48
+;   eq a0,a0,a4##ty=i16
+;   sub a4,zero,a0
+;   and a0,a1,a4
+;   not a3,a4
+;   and a4,a2,a3
+;   or a0,a0,a4
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   slli a4, a0, 0x30
+;   srli a0, a4, 0x30
+;   slli a3, a3, 0x30
+;   srli a4, a3, 0x30
+;   bne a0, a4, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+;   neg a4, a0
+;   and a0, a1, a4
+;   not a3, a4
+;   and a4, a2, a3
+;   or a0, a0, a4
+;   ret
+
+function %f(i16, i16, i16) -> i16 {
+block0(v0: i16, v1: i16, v2: i16):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i16 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   slli a4,a0,48
+;   srli a0,a4,48
+;   slli a3,a3,48
+;   srli a4,a3,48
+;   eq a0,a0,a4##ty=i16
+;   sub a4,zero,a0
+;   and a0,a1,a4
+;   not a3,a4
+;   and a4,a2,a3
+;   or a0,a0,a4
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   slli a4, a0, 0x30
+;   srli a0, a4, 0x30
+;   slli a3, a3, 0x30
+;   srli a4, a3, 0x30
+;   bne a0, a4, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+;   neg a4, a0
+;   and a0, a1, a4
+;   not a3, a4
+;   and a4, a2, a3
+;   or a0, a0, a4
+;   ret
+
+function %f(i16, i32, i32) -> i32 {
+block0(v0: i16, v1: i32, v2: i32):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i32 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   slli a4,a0,48
+;   srli a0,a4,48
+;   slli a3,a3,48
+;   srli a4,a3,48
+;   eq a0,a0,a4##ty=i16
+;   sub a4,zero,a0
+;   and a0,a1,a4
+;   not a3,a4
+;   and a4,a2,a3
+;   or a0,a0,a4
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   slli a4, a0, 0x30
+;   srli a0, a4, 0x30
+;   slli a3, a3, 0x30
+;   srli a4, a3, 0x30
+;   bne a0, a4, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+;   neg a4, a0
+;   and a0, a1, a4
+;   not a3, a4
+;   and a4, a2, a3
+;   or a0, a0, a4
+;   ret
+
+function %f(i16, i64, i64) -> i64 {
+block0(v0: i16, v1: i64, v2: i64):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i64 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   slli a4,a0,48
+;   srli a0,a4,48
+;   slli a3,a3,48
+;   srli a4,a3,48
+;   eq a0,a0,a4##ty=i16
+;   sub a4,zero,a0
+;   and a0,a1,a4
+;   not a3,a4
+;   and a4,a2,a3
+;   or a0,a0,a4
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   slli a4, a0, 0x30
+;   srli a0, a4, 0x30
+;   slli a3, a3, 0x30
+;   srli a4, a3, 0x30
+;   bne a0, a4, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+;   neg a4, a0
+;   and a0, a1, a4
+;   not a3, a4
+;   and a4, a2, a3
+;   or a0, a0, a4
+;   ret
+
+function %f(i16, i128, i128) -> i128 {
+block0(v0: i16, v1: i128, v2: i128):
+  v3 = iconst.i16 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i128 v4, v1, v2
+  return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   sd s6,-8(sp)
+;   add sp,-16
+; block0:
+;   li a5,42
+;   slli a0,a0,48
+;   srli a0,a0,48
+;   slli a5,a5,48
+;   srli a5,a5,48
+;   eq a0,a0,a5##ty=i16
+;   sub s6,zero,a0
+;   and a0,a1,s6
+;   and a5,a2,s6
+;   not a2,s6
+;   not a1,s6
+;   and a2,a3,a2
+;   and a1,a4,a1
+;   or a0,a0,a2
+;   or a1,a5,a1
+;   add sp,+16
+;   ld s6,-8(sp)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+;   sd s6, -8(sp)
+;   addi sp, sp, -0x10
+; block1: ; offset 0x18
+;   addi a5, zero, 0x2a
+;   slli a0, a0, 0x30
+;   srli a0, a0, 0x30
+;   slli a5, a5, 0x30
+;   srli a5, a5, 0x30
+;   bne a0, a5, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+;   neg s6, a0
+;   and a0, a1, s6
+;   and a5, a2, s6
+;   not a2, s6
+;   not a1, s6
+;   and a2, a3, a2
+;   and a1, a4, a1
+;   or a0, a0, a2
+;   or a1, a5, a1
+;   addi sp, sp, 0x10
+;   ld s6, -8(sp)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %f(i32, i8, i8) -> i8 {
+block0(v0: i32, v1: i8, v2: i8):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i8 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   slli a4,a0,32
+;   srli a0,a4,32
+;   slli a3,a3,32
+;   srli a4,a3,32
+;   eq a0,a0,a4##ty=i32
+;   sub a4,zero,a0
+;   and a0,a1,a4
+;   not a3,a4
+;   and a4,a2,a3
+;   or a0,a0,a4
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   slli a4, a0, 0x20
+;   srli a0, a4, 0x20
+;   slli a3, a3, 0x20
+;   srli a4, a3, 0x20
+;   bne a0, a4, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+;   neg a4, a0
+;   and a0, a1, a4
+;   not a3, a4
+;   and a4, a2, a3
+;   or a0, a0, a4
+;   ret
+
+function %f(i32, i16, i16) -> i16 {
+block0(v0: i32, v1: i16, v2: i16):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i16 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   slli a4,a0,32
+;   srli a0,a4,32
+;   slli a3,a3,32
+;   srli a4,a3,32
+;   eq a0,a0,a4##ty=i32
+;   sub a4,zero,a0
+;   and a0,a1,a4
+;   not a3,a4
+;   and a4,a2,a3
+;   or a0,a0,a4
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   slli a4, a0, 0x20
+;   srli a0, a4, 0x20
+;   slli a3, a3, 0x20
+;   srli a4, a3, 0x20
+;   bne a0, a4, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+;   neg a4, a0
+;   and a0, a1, a4
+;   not a3, a4
+;   and a4, a2, a3
+;   or a0, a0, a4
+;   ret
+
+function %f(i32, i32, i32) -> i32 {
+block0(v0: i32, v1: i32, v2: i32):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i32 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   slli a4,a0,32
+;   srli a0,a4,32
+;   slli a3,a3,32
+;   srli a4,a3,32
+;   eq a0,a0,a4##ty=i32
+;   sub a4,zero,a0
+;   and a0,a1,a4
+;   not a3,a4
+;   and a4,a2,a3
+;   or a0,a0,a4
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   slli a4, a0, 0x20
+;   srli a0, a4, 0x20
+;   slli a3, a3, 0x20
+;   srli a4, a3, 0x20
+;   bne a0, a4, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+;   neg a4, a0
+;   and a0, a1, a4
+;   not a3, a4
+;   and a4, a2, a3
+;   or a0, a0, a4
+;   ret
+
+function %f(i32, i64, i64) -> i64 {
+block0(v0: i32, v1: i64, v2: i64):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i64 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a3,42
+;   slli a4,a0,32
+;   srli a0,a4,32
+;   slli a3,a3,32
+;   srli a4,a3,32
+;   eq a0,a0,a4##ty=i32
+;   sub a4,zero,a0
+;   and a0,a1,a4
+;   not a3,a4
+;   and a4,a2,a3
+;   or a0,a0,a4
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a3, zero, 0x2a
+;   slli a4, a0, 0x20
+;   srli a0, a4, 0x20
+;   slli a3, a3, 0x20
+;   srli a4, a3, 0x20
+;   bne a0, a4, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+;   neg a4, a0
+;   and a0, a1, a4
+;   not a3, a4
+;   and a4, a2, a3
+;   or a0, a0, a4
+;   ret
+
+function %f(i32, i128, i128) -> i128 {
+block0(v0: i32, v1: i128, v2: i128):
+  v3 = iconst.i32 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i128 v4, v1, v2
+  return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   sd s6,-8(sp)
+;   add sp,-16
+; block0:
+;   li a5,42
+;   slli a0,a0,32
+;   srli a0,a0,32
+;   slli a5,a5,32
+;   srli a5,a5,32
+;   eq a0,a0,a5##ty=i32
+;   sub s6,zero,a0
+;   and a0,a1,s6
+;   and a5,a2,s6
+;   not a2,s6
+;   not a1,s6
+;   and a2,a3,a2
+;   and a1,a4,a1
+;   or a0,a0,a2
+;   or a1,a5,a1
+;   add sp,+16
+;   ld s6,-8(sp)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+;   sd s6, -8(sp)
+;   addi sp, sp, -0x10
+; block1: ; offset 0x18
+;   addi a5, zero, 0x2a
+;   slli a0, a0, 0x20
+;   srli a0, a0, 0x20
+;   slli a5, a5, 0x20
+;   srli a5, a5, 0x20
+;   bne a0, a5, 0xc
+;   addi a0, zero, 1
+;   j 8
+;   mv a0, zero
+;   neg s6, a0
+;   and a0, a1, s6
+;   and a5, a2, s6
+;   not a2, s6
+;   not a1, s6
+;   and a2, a3, a2
+;   and a1, a4, a1
+;   or a0, a0, a2
+;   or a1, a5, a1
+;   addi sp, sp, 0x10
+;   ld s6, -8(sp)
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %f(i64, i8, i8) -> i8 {
+block0(v0: i64, v1: i8, v2: i8):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i8 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a4,42
+;   eq a4,a0,a4##ty=i64
+;   sub a0,zero,a4
+;   and a3,a1,a0
+;   not a4,a0
+;   and a0,a2,a4
+;   or a0,a3,a0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a4, zero, 0x2a
+;   bne a0, a4, 0xc
+;   addi a4, zero, 1
+;   j 8
+;   mv a4, zero
+;   neg a0, a4
+;   and a3, a1, a0
+;   not a4, a0
+;   and a0, a2, a4
+;   or a0, a3, a0
+;   ret
+
+function %f(i64, i16, i16) -> i16 {
+block0(v0: i64, v1: i16, v2: i16):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i16 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a4,42
+;   eq a4,a0,a4##ty=i64
+;   sub a0,zero,a4
+;   and a3,a1,a0
+;   not a4,a0
+;   and a0,a2,a4
+;   or a0,a3,a0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a4, zero, 0x2a
+;   bne a0, a4, 0xc
+;   addi a4, zero, 1
+;   j 8
+;   mv a4, zero
+;   neg a0, a4
+;   and a3, a1, a0
+;   not a4, a0
+;   and a0, a2, a4
+;   or a0, a3, a0
+;   ret
+
+function %f(i64, i32, i32) -> i32 {
+block0(v0: i64, v1: i32, v2: i32):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i32 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a4,42
+;   eq a4,a0,a4##ty=i64
+;   sub a0,zero,a4
+;   and a3,a1,a0
+;   not a4,a0
+;   and a0,a2,a4
+;   or a0,a3,a0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a4, zero, 0x2a
+;   bne a0, a4, 0xc
+;   addi a4, zero, 1
+;   j 8
+;   mv a4, zero
+;   neg a0, a4
+;   and a3, a1, a0
+;   not a4, a0
+;   and a0, a2, a4
+;   or a0, a3, a0
+;   ret
+
+function %f(i64, i64, i64) -> i64 {
+block0(v0: i64, v1: i64, v2: i64):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i64 v4, v1, v2
+  return v5
+}
+
+; VCode:
+; block0:
+;   li a4,42
+;   eq a4,a0,a4##ty=i64
+;   sub a0,zero,a4
+;   and a3,a1,a0
+;   not a4,a0
+;   and a0,a2,a4
+;   or a0,a3,a0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi a4, zero, 0x2a
+;   bne a0, a4, 0xc
+;   addi a4, zero, 1
+;   j 8
+;   mv a4, zero
+;   neg a0, a4
+;   and a3, a1, a0
+;   not a4, a0
+;   and a0, a2, a4
+;   or a0, a3, a0
+;   ret
+
+function %f(i64, i128, i128) -> i128 {
+block0(v0: i64, v1: i128, v2: i128):
+  v3 = iconst.i64 42
+  v4 = icmp eq v0, v3
+  v5 = select_spectre_guard.i128 v4, v1, v2
+  return v5
+}
+
+; VCode:
+;   add sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   sd s11,-8(sp)
+;   add sp,-16
+; block0:
+;   mv s11,a1
+;   li a5,42
+;   eq a5,a0,a5##ty=i64
+;   sub a1,zero,a5
+;   mv a5,s11
+;   and a5,a5,a1
+;   and a2,a2,a1
+;   not a0,a1
+;   not a1,a1
+;   and a0,a3,a0
+;   and a3,a4,a1
+;   or a0,a5,a0
+;   or a1,a2,a3
+;   add sp,+16
+;   ld s11,-8(sp)
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   add sp,+16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+;   sd s11, -8(sp)
+;   addi sp, sp, -0x10
+; block1: ; offset 0x18
+;   mv s11, a1
+;   addi a5, zero, 0x2a
+;   bne a0, a5, 0xc
+;   addi a5, zero, 1
+;   j 8
+;   mv a5, zero
+;   neg a1, a5
+;   mv a5, s11
+;   and a5, a5, a1
+;   and a2, a2, a1
+;   not a0, a1
+;   not a1, a1
+;   and a0, a3, a0
+;   and a3, a4, a1
+;   or a0, a5, a0
+;   or a1, a2, a3
+;   addi sp, sp, 0x10
+;   ld s11, -8(sp)
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -939,13 +913,12 @@ block0(v0: i128, v1: i8, v2: i8):
 ; block0:
 ;   li a4,42
 ;   li a5,0
-;   eq a1,[a0,a1],[a4,a5]##ty=i128
-;   sltu a4,zero,a1
-;   sub a4,zero,a4
-;   and a0,a2,a4
-;   not a2,a4
-;   and a4,a3,a2
-;   or a0,a0,a4
+;   eq a0,[a0,a1],[a4,a5]##ty=i128
+;   sub a5,zero,a0
+;   and a4,a2,a5
+;   not a0,a5
+;   and a2,a3,a0
+;   or a0,a4,a2
 ;   ret
 ;
 ; Disassembled:
@@ -954,15 +927,14 @@ block0(v0: i128, v1: i8, v2: i8):
 ;   mv a5, zero
 ;   bne a1, a5, 0x10
 ;   bne a0, a4, 0xc
-;   addi a1, zero, 1
+;   addi a0, zero, 1
 ;   j 8
-;   mv a1, zero
-;   snez a4, a1
-;   neg a4, a4
-;   and a0, a2, a4
-;   not a2, a4
-;   and a4, a3, a2
-;   or a0, a0, a4
+;   mv a0, zero
+;   neg a5, a0
+;   and a4, a2, a5
+;   not a0, a5
+;   and a2, a3, a0
+;   or a0, a4, a2
 ;   ret
 
 function %f(i128, i16, i16) -> i16 {
@@ -978,13 +950,12 @@ block0(v0: i128, v1: i16, v2: i16):
 ; block0:
 ;   li a4,42
 ;   li a5,0
-;   eq a1,[a0,a1],[a4,a5]##ty=i128
-;   sltu a4,zero,a1
-;   sub a4,zero,a4
-;   and a0,a2,a4
-;   not a2,a4
-;   and a4,a3,a2
-;   or a0,a0,a4
+;   eq a0,[a0,a1],[a4,a5]##ty=i128
+;   sub a5,zero,a0
+;   and a4,a2,a5
+;   not a0,a5
+;   and a2,a3,a0
+;   or a0,a4,a2
 ;   ret
 ;
 ; Disassembled:
@@ -993,15 +964,14 @@ block0(v0: i128, v1: i16, v2: i16):
 ;   mv a5, zero
 ;   bne a1, a5, 0x10
 ;   bne a0, a4, 0xc
-;   addi a1, zero, 1
+;   addi a0, zero, 1
 ;   j 8
-;   mv a1, zero
-;   snez a4, a1
-;   neg a4, a4
-;   and a0, a2, a4
-;   not a2, a4
-;   and a4, a3, a2
-;   or a0, a0, a4
+;   mv a0, zero
+;   neg a5, a0
+;   and a4, a2, a5
+;   not a0, a5
+;   and a2, a3, a0
+;   or a0, a4, a2
 ;   ret
 
 function %f(i128, i32, i32) -> i32 {
@@ -1017,13 +987,12 @@ block0(v0: i128, v1: i32, v2: i32):
 ; block0:
 ;   li a4,42
 ;   li a5,0
-;   eq a1,[a0,a1],[a4,a5]##ty=i128
-;   sltu a4,zero,a1
-;   sub a4,zero,a4
-;   and a0,a2,a4
-;   not a2,a4
-;   and a4,a3,a2
-;   or a0,a0,a4
+;   eq a0,[a0,a1],[a4,a5]##ty=i128
+;   sub a5,zero,a0
+;   and a4,a2,a5
+;   not a0,a5
+;   and a2,a3,a0
+;   or a0,a4,a2
 ;   ret
 ;
 ; Disassembled:
@@ -1032,15 +1001,14 @@ block0(v0: i128, v1: i32, v2: i32):
 ;   mv a5, zero
 ;   bne a1, a5, 0x10
 ;   bne a0, a4, 0xc
-;   addi a1, zero, 1
+;   addi a0, zero, 1
 ;   j 8
-;   mv a1, zero
-;   snez a4, a1
-;   neg a4, a4
-;   and a0, a2, a4
-;   not a2, a4
-;   and a4, a3, a2
-;   or a0, a0, a4
+;   mv a0, zero
+;   neg a5, a0
+;   and a4, a2, a5
+;   not a0, a5
+;   and a2, a3, a0
+;   or a0, a4, a2
 ;   ret
 
 function %f(i128, i64, i64) -> i64 {
@@ -1056,13 +1024,12 @@ block0(v0: i128, v1: i64, v2: i64):
 ; block0:
 ;   li a4,42
 ;   li a5,0
-;   eq a1,[a0,a1],[a4,a5]##ty=i128
-;   sltu a4,zero,a1
-;   sub a4,zero,a4
-;   and a0,a2,a4
-;   not a2,a4
-;   and a4,a3,a2
-;   or a0,a0,a4
+;   eq a0,[a0,a1],[a4,a5]##ty=i128
+;   sub a5,zero,a0
+;   and a4,a2,a5
+;   not a0,a5
+;   and a2,a3,a0
+;   or a0,a4,a2
 ;   ret
 ;
 ; Disassembled:
@@ -1071,15 +1038,14 @@ block0(v0: i128, v1: i64, v2: i64):
 ;   mv a5, zero
 ;   bne a1, a5, 0x10
 ;   bne a0, a4, 0xc
-;   addi a1, zero, 1
+;   addi a0, zero, 1
 ;   j 8
-;   mv a1, zero
-;   snez a4, a1
-;   neg a4, a4
-;   and a0, a2, a4
-;   not a2, a4
-;   and a4, a3, a2
-;   or a0, a0, a4
+;   mv a0, zero
+;   neg a5, a0
+;   and a4, a2, a5
+;   not a0, a5
+;   and a2, a3, a0
+;   or a0, a4, a2
 ;   ret
 
 function %f(i128, i128, i128) -> i128 {
@@ -1093,39 +1059,37 @@ block0(v0: i128, v1: i128, v2: i128):
 
 ; VCode:
 ; block0:
-;   li t1,42
-;   li t2,0
-;   eq a1,[a0,a1],[t1,t2]##ty=i128
-;   sltu a0,zero,a1
+;   li t0,42
+;   li t1,0
+;   eq a0,[a0,a1],[t0,t1]##ty=i128
 ;   sub a1,zero,a0
-;   and a2,a2,a1
-;   and a3,a3,a1
-;   not t0,a1
-;   not a0,a1
-;   and a4,a4,t0
-;   and a1,a5,a0
-;   or a0,a2,a4
-;   or a1,a3,a1
+;   and a0,a2,a1
+;   and a2,a3,a1
+;   not a3,a1
+;   not a1,a1
+;   and a3,a4,a3
+;   and a4,a5,a1
+;   or a0,a0,a3
+;   or a1,a2,a4
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi t1, zero, 0x2a
-;   mv t2, zero
-;   bne a1, t2, 0x10
-;   bne a0, t1, 0xc
-;   addi a1, zero, 1
+;   addi t0, zero, 0x2a
+;   mv t1, zero
+;   bne a1, t1, 0x10
+;   bne a0, t0, 0xc
+;   addi a0, zero, 1
 ;   j 8
-;   mv a1, zero
-;   snez a0, a1
+;   mv a0, zero
 ;   neg a1, a0
-;   and a2, a2, a1
-;   and a3, a3, a1
-;   not t0, a1
-;   not a0, a1
-;   and a4, a4, t0
-;   and a1, a5, a0
-;   or a0, a2, a4
-;   or a1, a3, a1
+;   and a0, a2, a1
+;   and a2, a3, a1
+;   not a3, a1
+;   not a1, a1
+;   and a3, a4, a3
+;   and a4, a5, a1
+;   or a0, a0, a3
+;   or a1, a2, a4
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,42 +41,40 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   ld a5,8(a2)
-;;   addi a5,a5,-4
-;;   ugt a3,a0,a5##ty=i64
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a2,zero,a3
-;;   sub a2,zero,a2
-;;   and a4,a0,a2
-;;   not a0,a2
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   ld a4,8(a2)
+;;   addi a4,a4,-4
+;;   ugt a0,a5,a4##ty=i64
+;;   ld a4,0(a2)
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a0
 ;;   and a2,a5,a0
-;;   or a4,a4,a2
-;;   sw a1,0(a4)
+;;   not a5,a0
+;;   and a0,a4,a5
+;;   or a2,a2,a0
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   ld a5,8(a1)
-;;   addi a5,a5,-4
-;;   ugt a2,a0,a5##ty=i64
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a1,zero,a2
-;;   sub a2,zero,a1
-;;   and a4,a0,a2
-;;   not a0,a2
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   ld a4,8(a1)
+;;   addi a4,a4,-4
+;;   ugt a0,a5,a4##ty=i64
+;;   ld a4,0(a1)
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a0
 ;;   and a2,a5,a0
-;;   or a4,a4,a2
-;;   lw a0,0(a4)
+;;   not a5,a0
+;;   and a0,a4,a5
+;;   or a2,a2,a0
+;;   lw a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -42,24 +42,23 @@
 ;; function u0:0:
 ;; block0:
 ;;   slli a3,a0,32
-;;   srli a4,a3,32
-;;   ld a3,8(a2)
+;;   srli a3,a3,32
+;;   ld a4,8(a2)
 ;;   lui a5,-1
 ;;   addi a5,a5,-4
-;;   add a3,a3,a5
-;;   ugt a3,a4,a3##ty=i64
-;;   ld a5,0(a2)
-;;   add a4,a5,a4
-;;   lui a5,1
 ;;   add a4,a4,a5
-;;   li a5,0
-;;   sltu a0,zero,a3
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   sw a1,0(a2)
+;;   ugt a4,a3,a4##ty=i64
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   lui a3,1
+;;   add a2,a2,a3
+;;   li a3,0
+;;   sub a4,zero,a4
+;;   and a0,a3,a4
+;;   not a3,a4
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   sw a1,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -67,24 +66,23 @@
 ;; function u0:1:
 ;; block0:
 ;;   slli a2,a0,32
-;;   srli a4,a2,32
-;;   ld a3,8(a1)
-;;   lui a2,-1
-;;   addi a5,a2,-4
-;;   add a3,a3,a5
-;;   ugt a3,a4,a3##ty=i64
-;;   ld a5,0(a1)
-;;   add a4,a5,a4
-;;   lui a5,1
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sltu a0,zero,a3
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
+;;   srli a3,a2,32
+;;   ld a2,8(a1)
+;;   lui a4,-1
+;;   addi a4,a4,-4
+;;   add a2,a2,a4
+;;   ugt a2,a3,a2##ty=i64
+;;   ld a4,0(a1)
+;;   add a3,a4,a3
+;;   lui a4,1
+;;   add a3,a3,a4
+;;   li a4,0
+;;   sub a5,zero,a2
 ;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   lw a0,0(a2)
+;;   not a2,a5
+;;   and a4,a3,a2
+;;   or a0,a0,a4
+;;   lw a0,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,56 +41,54 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
+;;   slli a3,a0,32
+;;   srli a5,a3,32
 ;;   lui a3,262140
-;;   addi a5,a3,1
-;;   slli a3,a5,2
-;;   add a5,a0,a3
-;;   trap_if heap_oob##(a5 ult a0)
-;;   ld a3,8(a2)
-;;   ugt a3,a5,a3##ty=i64
+;;   addi a4,a3,1
+;;   slli a0,a4,2
+;;   add a4,a5,a0
+;;   trap_if heap_oob##(a4 ult a5)
+;;   ld a0,8(a2)
+;;   ugt a0,a4,a0##ty=i64
 ;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a5,65535
-;;   slli a2,a5,4
-;;   add a0,a0,a2
+;;   add a5,a2,a5
+;;   lui a4,65535
+;;   slli a2,a4,4
+;;   add a5,a5,a2
 ;;   li a2,0
-;;   sltu a3,zero,a3
-;;   sub a3,zero,a3
-;;   and a5,a2,a3
-;;   not a2,a3
-;;   and a3,a0,a2
-;;   or a5,a5,a3
-;;   sw a1,0(a5)
+;;   sub a4,zero,a0
+;;   and a3,a2,a4
+;;   not a0,a4
+;;   and a2,a5,a0
+;;   or a3,a3,a2
+;;   sw a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   lui a3,262140
-;;   addi a5,a3,1
-;;   slli a2,a5,2
-;;   add a5,a0,a2
-;;   trap_if heap_oob##(a5 ult a0)
-;;   ld a2,8(a1)
-;;   ugt a2,a5,a2##ty=i64
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   lui a2,262140
+;;   addi a4,a2,1
+;;   slli a0,a4,2
+;;   add a4,a5,a0
+;;   trap_if heap_oob##(a4 ult a5)
+;;   ld a0,8(a1)
+;;   ugt a0,a4,a0##ty=i64
 ;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a5,65535
-;;   slli a1,a5,4
-;;   add a0,a0,a1
+;;   add a5,a1,a5
+;;   lui a4,65535
+;;   slli a1,a4,4
+;;   add a5,a5,a1
 ;;   li a1,0
-;;   sltu a2,zero,a2
-;;   sub a3,zero,a2
-;;   and a5,a1,a3
-;;   not a1,a3
-;;   and a3,a0,a1
-;;   or a5,a5,a3
-;;   lw a0,0(a5)
+;;   sub a2,zero,a0
+;;   and a3,a1,a2
+;;   not a0,a2
+;;   and a1,a5,a0
+;;   or a3,a3,a1
+;;   lw a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -42,39 +42,37 @@
 ;; function u0:0:
 ;; block0:
 ;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   ld a4,8(a2)
-;;   uge a0,a5,a4##ty=i64
-;;   ld a4,0(a2)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sltu a0,zero,a0
-;;   sub a2,zero,a0
-;;   and a3,a5,a2
-;;   not a5,a2
+;;   srli a4,a3,32
+;;   ld a3,8(a2)
+;;   uge a5,a4,a3##ty=i64
+;;   ld a3,0(a2)
+;;   add a3,a3,a4
+;;   li a4,0
+;;   sub a5,zero,a5
 ;;   and a2,a4,a5
-;;   or a3,a3,a2
-;;   sb a1,0(a3)
+;;   not a4,a5
+;;   and a5,a3,a4
+;;   or a2,a2,a5
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   ld a4,8(a1)
-;;   uge a0,a5,a4##ty=i64
-;;   ld a4,0(a1)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sltu a0,zero,a0
-;;   sub a1,zero,a0
-;;   and a3,a5,a1
-;;   not a5,a1
+;;   slli a2,a0,32
+;;   srli a4,a2,32
+;;   ld a3,8(a1)
+;;   uge a5,a4,a3##ty=i64
+;;   ld a3,0(a1)
+;;   add a3,a3,a4
+;;   li a4,0
+;;   sub a5,zero,a5
 ;;   and a1,a4,a5
-;;   or a3,a3,a1
-;;   lbu a0,0(a3)
+;;   not a4,a5
+;;   and a5,a3,a4
+;;   or a1,a1,a5
+;;   lbu a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -42,24 +42,23 @@
 ;; function u0:0:
 ;; block0:
 ;;   slli a3,a0,32
-;;   srli a4,a3,32
-;;   ld a3,8(a2)
+;;   srli a3,a3,32
+;;   ld a4,8(a2)
 ;;   lui a5,-1
 ;;   addi a5,a5,-1
-;;   add a3,a3,a5
-;;   ugt a3,a4,a3##ty=i64
-;;   ld a5,0(a2)
-;;   add a4,a5,a4
-;;   lui a5,1
 ;;   add a4,a4,a5
-;;   li a5,0
-;;   sltu a0,zero,a3
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   sb a1,0(a2)
+;;   ugt a4,a3,a4##ty=i64
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   lui a3,1
+;;   add a2,a2,a3
+;;   li a3,0
+;;   sub a4,zero,a4
+;;   and a0,a3,a4
+;;   not a3,a4
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   sb a1,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -67,24 +66,23 @@
 ;; function u0:1:
 ;; block0:
 ;;   slli a2,a0,32
-;;   srli a4,a2,32
-;;   ld a3,8(a1)
-;;   lui a2,-1
-;;   addi a5,a2,-1
-;;   add a3,a3,a5
-;;   ugt a3,a4,a3##ty=i64
-;;   ld a5,0(a1)
-;;   add a4,a5,a4
-;;   lui a5,1
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sltu a0,zero,a3
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
+;;   srli a3,a2,32
+;;   ld a2,8(a1)
+;;   lui a4,-1
+;;   addi a4,a4,-1
+;;   add a2,a2,a4
+;;   ugt a2,a3,a2##ty=i64
+;;   ld a4,0(a1)
+;;   add a3,a4,a3
+;;   lui a4,1
+;;   add a3,a3,a4
+;;   li a4,0
+;;   sub a5,zero,a2
 ;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   lbu a0,0(a2)
+;;   not a2,a5
+;;   and a4,a3,a2
+;;   or a0,a0,a4
+;;   lbu a0,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -42,25 +42,24 @@
 ;; function u0:0:
 ;; block0:
 ;;   slli a3,a0,32
-;;   srli a4,a3,32
-;;   ld a3,[const(0)]
-;;   add a3,a4,a3
-;;   trap_if heap_oob##(a3 ult a4)
+;;   srli a3,a3,32
+;;   ld a4,[const(0)]
+;;   add a4,a3,a4
+;;   trap_if heap_oob##(a4 ult a3)
 ;;   ld a5,8(a2)
-;;   ugt a5,a3,a5##ty=i64
-;;   ld a0,0(a2)
-;;   add a4,a0,a4
-;;   lui a3,65535
-;;   slli a0,a3,4
-;;   add a4,a4,a0
-;;   li a0,0
-;;   sltu a5,zero,a5
-;;   sub a2,zero,a5
-;;   and a3,a0,a2
-;;   not a5,a2
-;;   and a2,a4,a5
-;;   or a3,a3,a2
-;;   sb a1,0(a3)
+;;   ugt a4,a4,a5##ty=i64
+;;   ld a5,0(a2)
+;;   add a3,a5,a3
+;;   lui a2,65535
+;;   slli a5,a2,4
+;;   add a3,a3,a5
+;;   li a5,0
+;;   sub a0,zero,a4
+;;   and a2,a5,a0
+;;   not a4,a0
+;;   and a5,a3,a4
+;;   or a2,a2,a5
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -68,25 +67,24 @@
 ;; function u0:1:
 ;; block0:
 ;;   slli a2,a0,32
-;;   srli a4,a2,32
-;;   ld a3,[const(0)]
-;;   add a3,a4,a3
-;;   trap_if heap_oob##(a3 ult a4)
-;;   ld a5,8(a1)
-;;   ugt a5,a3,a5##ty=i64
-;;   ld a0,0(a1)
-;;   add a4,a0,a4
-;;   lui a3,65535
-;;   slli a0,a3,4
-;;   add a4,a4,a0
-;;   li a0,0
-;;   sltu a5,zero,a5
-;;   sub a1,zero,a5
-;;   and a3,a0,a1
-;;   not a5,a1
-;;   and a1,a4,a5
-;;   or a3,a3,a1
-;;   lbu a0,0(a3)
+;;   srli a3,a2,32
+;;   ld a2,[const(0)]
+;;   add a2,a3,a2
+;;   trap_if heap_oob##(a2 ult a3)
+;;   ld a4,8(a1)
+;;   ugt a4,a2,a4##ty=i64
+;;   ld a5,0(a1)
+;;   add a3,a5,a3
+;;   lui a2,65535
+;;   slli a5,a2,4
+;;   add a3,a3,a5
+;;   li a5,0
+;;   sub a0,zero,a4
+;;   and a1,a5,a0
+;;   not a4,a0
+;;   and a5,a3,a4
+;;   or a1,a1,a5
+;;   lbu a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -42,39 +42,37 @@
 ;; function u0:0:
 ;; block0:
 ;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   ld a4,8(a2)
-;;   ugt a0,a5,a4##ty=i64
-;;   ld a4,0(a2)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sltu a0,zero,a0
-;;   sub a2,zero,a0
-;;   and a3,a5,a2
-;;   not a5,a2
+;;   srli a4,a3,32
+;;   ld a3,8(a2)
+;;   ugt a5,a4,a3##ty=i64
+;;   ld a3,0(a2)
+;;   add a3,a3,a4
+;;   li a4,0
+;;   sub a5,zero,a5
 ;;   and a2,a4,a5
-;;   or a3,a3,a2
-;;   sw a1,0(a3)
+;;   not a4,a5
+;;   and a5,a3,a4
+;;   or a2,a2,a5
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   ld a4,8(a1)
-;;   ugt a0,a5,a4##ty=i64
-;;   ld a4,0(a1)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sltu a0,zero,a0
-;;   sub a1,zero,a0
-;;   and a3,a5,a1
-;;   not a5,a1
+;;   slli a2,a0,32
+;;   srli a4,a2,32
+;;   ld a3,8(a1)
+;;   ugt a5,a4,a3##ty=i64
+;;   ld a3,0(a1)
+;;   add a3,a3,a4
+;;   li a4,0
+;;   sub a5,zero,a5
 ;;   and a1,a4,a5
-;;   or a3,a3,a1
-;;   lw a0,0(a3)
+;;   not a4,a5
+;;   and a5,a3,a4
+;;   or a1,a1,a5
+;;   lw a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -41,44 +41,42 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a3,a5,32
-;;   ld a0,8(a2)
-;;   ugt a0,a3,a0##ty=i64
+;;   slli a4,a0,32
+;;   srli a0,a4,32
+;;   ld a5,8(a2)
+;;   ugt a5,a0,a5##ty=i64
 ;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   li a3,0
-;;   sltu a4,zero,a0
-;;   sub a4,zero,a4
-;;   and a5,a3,a4
-;;   not a3,a4
-;;   and a3,a2,a3
-;;   or a5,a5,a3
-;;   sw a1,0(a5)
+;;   add a0,a2,a0
+;;   lui a2,1
+;;   add a0,a0,a2
+;;   li a2,0
+;;   sub a4,zero,a5
+;;   and a3,a2,a4
+;;   not a5,a4
+;;   and a2,a0,a5
+;;   or a3,a3,a2
+;;   sw a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a2,a5,32
-;;   ld a0,8(a1)
-;;   ugt a0,a2,a0##ty=i64
+;;   slli a4,a0,32
+;;   srli a0,a4,32
+;;   ld a5,8(a1)
+;;   ugt a5,a0,a5##ty=i64
 ;;   ld a1,0(a1)
-;;   add a1,a1,a2
-;;   lui a2,1
-;;   add a1,a1,a2
-;;   li a2,0
-;;   sltu a3,zero,a0
-;;   sub a3,zero,a3
-;;   and a5,a2,a3
-;;   not a2,a3
+;;   add a0,a1,a0
+;;   lui a1,1
+;;   add a0,a0,a1
+;;   li a1,0
+;;   sub a2,zero,a5
 ;;   and a3,a1,a2
-;;   or a5,a5,a3
-;;   lw a0,0(a5)
+;;   not a5,a2
+;;   and a1,a0,a5
+;;   or a3,a3,a1
+;;   lw a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,46 +41,44 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a0,a0,32
-;;   srli a3,a0,32
-;;   ld a4,8(a2)
-;;   ugt a4,a3,a4##ty=i64
+;;   slli a5,a0,32
+;;   srli a3,a5,32
+;;   ld a0,8(a2)
+;;   ugt a0,a3,a0##ty=i64
 ;;   ld a2,0(a2)
 ;;   add a2,a2,a3
-;;   lui a0,65535
-;;   slli a3,a0,4
-;;   add a3,a2,a3
-;;   li a2,0
-;;   sltu a4,zero,a4
-;;   sub a4,zero,a4
-;;   and a0,a2,a4
-;;   not a2,a4
-;;   and a4,a3,a2
-;;   or a0,a0,a4
-;;   sw a1,0(a0)
+;;   lui a5,65535
+;;   slli a3,a5,4
+;;   add a2,a2,a3
+;;   li a3,0
+;;   sub a5,zero,a0
+;;   and a4,a3,a5
+;;   not a0,a5
+;;   and a2,a2,a0
+;;   or a4,a4,a2
+;;   sw a1,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a0,a0,32
-;;   srli a2,a0,32
-;;   ld a3,8(a1)
-;;   ugt a3,a2,a3##ty=i64
+;;   slli a5,a0,32
+;;   srli a2,a5,32
+;;   ld a0,8(a1)
+;;   ugt a0,a2,a0##ty=i64
 ;;   ld a1,0(a1)
 ;;   add a1,a1,a2
-;;   lui a0,65535
-;;   slli a2,a0,4
-;;   add a2,a1,a2
-;;   li a1,0
-;;   sltu a3,zero,a3
-;;   sub a4,zero,a3
-;;   and a0,a1,a4
-;;   not a3,a4
+;;   lui a5,65535
+;;   slli a2,a5,4
+;;   add a1,a1,a2
+;;   li a2,0
+;;   sub a3,zero,a0
 ;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lw a0,0(a0)
+;;   not a0,a3
+;;   and a2,a1,a0
+;;   or a4,a4,a2
+;;   lw a0,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -42,39 +42,37 @@
 ;; function u0:0:
 ;; block0:
 ;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   ld a4,8(a2)
-;;   uge a0,a5,a4##ty=i64
-;;   ld a4,0(a2)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sltu a0,zero,a0
-;;   sub a2,zero,a0
-;;   and a3,a5,a2
-;;   not a5,a2
+;;   srli a4,a3,32
+;;   ld a3,8(a2)
+;;   uge a5,a4,a3##ty=i64
+;;   ld a3,0(a2)
+;;   add a3,a3,a4
+;;   li a4,0
+;;   sub a5,zero,a5
 ;;   and a2,a4,a5
-;;   or a3,a3,a2
-;;   sb a1,0(a3)
+;;   not a4,a5
+;;   and a5,a3,a4
+;;   or a2,a2,a5
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   ld a4,8(a1)
-;;   uge a0,a5,a4##ty=i64
-;;   ld a4,0(a1)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sltu a0,zero,a0
-;;   sub a1,zero,a0
-;;   and a3,a5,a1
-;;   not a5,a1
+;;   slli a2,a0,32
+;;   srli a4,a2,32
+;;   ld a3,8(a1)
+;;   uge a5,a4,a3##ty=i64
+;;   ld a3,0(a1)
+;;   add a3,a3,a4
+;;   li a4,0
+;;   sub a5,zero,a5
 ;;   and a1,a4,a5
-;;   or a3,a3,a1
-;;   lbu a0,0(a3)
+;;   not a4,a5
+;;   and a5,a3,a4
+;;   or a1,a1,a5
+;;   lbu a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -41,44 +41,42 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a3,a5,32
-;;   ld a0,8(a2)
-;;   ugt a0,a3,a0##ty=i64
+;;   slli a4,a0,32
+;;   srli a0,a4,32
+;;   ld a5,8(a2)
+;;   ugt a5,a0,a5##ty=i64
 ;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   li a3,0
-;;   sltu a4,zero,a0
-;;   sub a4,zero,a4
-;;   and a5,a3,a4
-;;   not a3,a4
-;;   and a3,a2,a3
-;;   or a5,a5,a3
-;;   sb a1,0(a5)
+;;   add a0,a2,a0
+;;   lui a2,1
+;;   add a0,a0,a2
+;;   li a2,0
+;;   sub a4,zero,a5
+;;   and a3,a2,a4
+;;   not a5,a4
+;;   and a2,a0,a5
+;;   or a3,a3,a2
+;;   sb a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a2,a5,32
-;;   ld a0,8(a1)
-;;   ugt a0,a2,a0##ty=i64
+;;   slli a4,a0,32
+;;   srli a0,a4,32
+;;   ld a5,8(a1)
+;;   ugt a5,a0,a5##ty=i64
 ;;   ld a1,0(a1)
-;;   add a1,a1,a2
-;;   lui a2,1
-;;   add a1,a1,a2
-;;   li a2,0
-;;   sltu a3,zero,a0
-;;   sub a3,zero,a3
-;;   and a5,a2,a3
-;;   not a2,a3
+;;   add a0,a1,a0
+;;   lui a1,1
+;;   add a0,a0,a1
+;;   li a1,0
+;;   sub a2,zero,a5
 ;;   and a3,a1,a2
-;;   or a5,a5,a3
-;;   lbu a0,0(a5)
+;;   not a5,a2
+;;   and a1,a0,a5
+;;   or a3,a3,a1
+;;   lbu a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,46 +41,44 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a0,a0,32
-;;   srli a3,a0,32
-;;   ld a4,8(a2)
-;;   ugt a4,a3,a4##ty=i64
+;;   slli a5,a0,32
+;;   srli a3,a5,32
+;;   ld a0,8(a2)
+;;   ugt a0,a3,a0##ty=i64
 ;;   ld a2,0(a2)
 ;;   add a2,a2,a3
-;;   lui a0,65535
-;;   slli a3,a0,4
-;;   add a3,a2,a3
-;;   li a2,0
-;;   sltu a4,zero,a4
-;;   sub a4,zero,a4
-;;   and a0,a2,a4
-;;   not a2,a4
-;;   and a4,a3,a2
-;;   or a0,a0,a4
-;;   sb a1,0(a0)
+;;   lui a5,65535
+;;   slli a3,a5,4
+;;   add a2,a2,a3
+;;   li a3,0
+;;   sub a5,zero,a0
+;;   and a4,a3,a5
+;;   not a0,a5
+;;   and a2,a2,a0
+;;   or a4,a4,a2
+;;   sb a1,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a0,a0,32
-;;   srli a2,a0,32
-;;   ld a3,8(a1)
-;;   ugt a3,a2,a3##ty=i64
+;;   slli a5,a0,32
+;;   srli a2,a5,32
+;;   ld a0,8(a1)
+;;   ugt a0,a2,a0##ty=i64
 ;;   ld a1,0(a1)
 ;;   add a1,a1,a2
-;;   lui a0,65535
-;;   slli a2,a0,4
-;;   add a2,a1,a2
-;;   li a1,0
-;;   sltu a3,zero,a3
-;;   sub a4,zero,a3
-;;   and a0,a1,a4
-;;   not a3,a4
+;;   lui a5,65535
+;;   slli a2,a5,4
+;;   add a1,a1,a2
+;;   li a2,0
+;;   sub a3,zero,a0
 ;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lbu a0,0(a0)
+;;   not a0,a3
+;;   and a2,a1,a0
+;;   or a4,a4,a2
+;;   lbu a0,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -43,36 +43,34 @@
 ;; block0:
 ;;   ld a3,8(a2)
 ;;   addi a3,a3,-4
-;;   ugt a4,a0,a3##ty=i64
-;;   ld a3,0(a2)
-;;   add a3,a3,a0
-;;   li a5,0
-;;   sltu a4,zero,a4
-;;   sub a0,zero,a4
-;;   and a2,a5,a0
-;;   not a4,a0
-;;   and a0,a3,a4
-;;   or a2,a2,a0
-;;   sw a1,0(a2)
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   li a4,0
+;;   sub a5,zero,a3
+;;   and a0,a4,a5
+;;   not a3,a5
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   sw a1,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a3,8(a1)
-;;   addi a3,a3,-4
-;;   ugt a4,a0,a3##ty=i64
-;;   ld a3,0(a1)
-;;   add a3,a3,a0
-;;   li a5,0
-;;   sltu a4,zero,a4
-;;   sub a0,zero,a4
-;;   and a2,a5,a0
-;;   not a4,a0
-;;   and a0,a3,a4
-;;   or a2,a2,a0
-;;   lw a0,0(a2)
+;;   ld a2,8(a1)
+;;   addi a2,a2,-4
+;;   ugt a3,a0,a2##ty=i64
+;;   ld a2,0(a1)
+;;   add a2,a2,a0
+;;   li a4,0
+;;   sub a5,zero,a3
+;;   and a0,a4,a5
+;;   not a3,a5
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   lw a0,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -42,22 +42,21 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a3,8(a2)
-;;   lui a4,-1
-;;   addi a4,a4,-4
+;;   lui a5,-1
+;;   addi a4,a5,-4
 ;;   add a3,a3,a4
-;;   ugt a4,a0,a3##ty=i64
+;;   ugt a3,a0,a3##ty=i64
 ;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   lui a3,1
-;;   add a3,a2,a3
+;;   add a0,a2,a0
+;;   lui a2,1
+;;   add a0,a0,a2
 ;;   li a2,0
-;;   sltu a4,zero,a4
-;;   sub a4,zero,a4
-;;   and a0,a2,a4
-;;   not a2,a4
-;;   and a4,a3,a2
-;;   or a0,a0,a4
-;;   sw a1,0(a0)
+;;   sub a3,zero,a3
+;;   and a4,a2,a3
+;;   not a2,a3
+;;   and a2,a0,a2
+;;   or a4,a4,a2
+;;   sw a1,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -65,22 +64,21 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a2,8(a1)
-;;   lui a3,-1
-;;   addi a3,a3,-4
+;;   lui a5,-1
+;;   addi a3,a5,-4
 ;;   add a2,a2,a3
-;;   ugt a3,a0,a2##ty=i64
+;;   ugt a2,a0,a2##ty=i64
 ;;   ld a1,0(a1)
-;;   add a1,a1,a0
-;;   lui a2,1
-;;   add a2,a1,a2
+;;   add a0,a1,a0
+;;   lui a1,1
+;;   add a0,a0,a1
 ;;   li a1,0
-;;   sltu a3,zero,a3
-;;   sub a4,zero,a3
-;;   and a0,a1,a4
-;;   not a3,a4
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lw a0,0(a0)
+;;   sub a2,zero,a2
+;;   and a4,a1,a2
+;;   not a1,a2
+;;   and a2,a0,a1
+;;   or a4,a4,a2
+;;   lw a0,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -43,24 +43,23 @@
 ;; block0:
 ;;   lui a3,262140
 ;;   addi a3,a3,1
-;;   slli a5,a3,2
-;;   add a3,a0,a5
+;;   slli a4,a3,2
+;;   add a3,a0,a4
 ;;   trap_if heap_oob##(a3 ult a0)
 ;;   ld a4,8(a2)
-;;   ugt a4,a3,a4##ty=i64
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a3,65535
-;;   slli a0,a3,4
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a2,zero,a4
-;;   sub a2,zero,a2
-;;   and a3,a0,a2
-;;   not a0,a2
+;;   ugt a3,a3,a4##ty=i64
+;;   ld a4,0(a2)
+;;   add a4,a4,a0
+;;   lui a2,65535
+;;   slli a5,a2,4
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a3
 ;;   and a2,a5,a0
-;;   or a3,a3,a2
-;;   sw a1,0(a3)
+;;   not a3,a0
+;;   and a5,a4,a3
+;;   or a2,a2,a5
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -68,25 +67,24 @@
 ;; function u0:1:
 ;; block0:
 ;;   lui a2,262140
-;;   addi a3,a2,1
-;;   slli a5,a3,2
-;;   add a3,a0,a5
-;;   trap_if heap_oob##(a3 ult a0)
-;;   ld a4,8(a1)
-;;   ugt a4,a3,a4##ty=i64
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a3,65535
-;;   slli a0,a3,4
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a1,zero,a4
-;;   sub a1,zero,a1
-;;   and a3,a0,a1
-;;   not a0,a1
+;;   addi a2,a2,1
+;;   slli a4,a2,2
+;;   add a2,a0,a4
+;;   trap_if heap_oob##(a2 ult a0)
+;;   ld a3,8(a1)
+;;   ugt a3,a2,a3##ty=i64
+;;   ld a4,0(a1)
+;;   add a4,a4,a0
+;;   lui a2,65535
+;;   slli a5,a2,4
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a3
 ;;   and a1,a5,a0
-;;   or a3,a3,a1
-;;   lw a0,0(a3)
+;;   not a3,a0
+;;   and a5,a4,a3
+;;   or a1,a1,a5
+;;   lw a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -46,13 +46,12 @@
 ;;   ld a2,0(a2)
 ;;   add a2,a2,a0
 ;;   li a4,0
-;;   sltu a3,zero,a3
-;;   sub a5,zero,a3
-;;   and a3,a4,a5
-;;   not a4,a5
-;;   and a5,a2,a4
-;;   or a2,a3,a5
-;;   sb a1,0(a2)
+;;   sub a3,zero,a3
+;;   and a5,a4,a3
+;;   not a3,a3
+;;   and a3,a2,a3
+;;   or a5,a5,a3
+;;   sb a1,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -60,17 +59,16 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a2,8(a1)
-;;   uge a3,a0,a2##ty=i64
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sltu a3,zero,a3
-;;   sub a5,zero,a3
-;;   and a1,a4,a5
-;;   not a3,a5
-;;   and a5,a2,a3
-;;   or a1,a1,a5
-;;   lbu a0,0(a1)
+;;   uge a2,a0,a2##ty=i64
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   li a3,0
+;;   sub a4,zero,a2
+;;   and a5,a3,a4
+;;   not a2,a4
+;;   and a3,a1,a2
+;;   or a5,a5,a3
+;;   lbu a0,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -42,22 +42,21 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a3,8(a2)
-;;   lui a4,-1
-;;   addi a4,a4,-1
+;;   lui a5,-1
+;;   addi a4,a5,-1
 ;;   add a3,a3,a4
-;;   ugt a4,a0,a3##ty=i64
+;;   ugt a3,a0,a3##ty=i64
 ;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   lui a3,1
-;;   add a3,a2,a3
+;;   add a0,a2,a0
+;;   lui a2,1
+;;   add a0,a0,a2
 ;;   li a2,0
-;;   sltu a4,zero,a4
-;;   sub a4,zero,a4
-;;   and a0,a2,a4
-;;   not a2,a4
-;;   and a4,a3,a2
-;;   or a0,a0,a4
-;;   sb a1,0(a0)
+;;   sub a3,zero,a3
+;;   and a4,a2,a3
+;;   not a2,a3
+;;   and a2,a0,a2
+;;   or a4,a4,a2
+;;   sb a1,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -65,22 +64,21 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a2,8(a1)
-;;   lui a3,-1
-;;   addi a3,a3,-1
+;;   lui a5,-1
+;;   addi a3,a5,-1
 ;;   add a2,a2,a3
-;;   ugt a3,a0,a2##ty=i64
+;;   ugt a2,a0,a2##ty=i64
 ;;   ld a1,0(a1)
-;;   add a1,a1,a0
-;;   lui a2,1
-;;   add a2,a1,a2
+;;   add a0,a1,a0
+;;   lui a1,1
+;;   add a0,a0,a1
 ;;   li a1,0
-;;   sltu a3,zero,a3
-;;   sub a4,zero,a3
-;;   and a0,a1,a4
-;;   not a3,a4
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lbu a0,0(a0)
+;;   sub a2,zero,a2
+;;   and a4,a1,a2
+;;   not a1,a2
+;;   and a2,a0,a1
+;;   or a4,a4,a2
+;;   lbu a0,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -45,20 +45,19 @@
 ;;   add a3,a0,a3
 ;;   trap_if heap_oob##(a3 ult a0)
 ;;   ld a4,8(a2)
-;;   ugt a4,a3,a4##ty=i64
+;;   ugt a3,a3,a4##ty=i64
 ;;   ld a2,0(a2)
 ;;   add a2,a2,a0
-;;   lui a3,65535
-;;   slli a3,a3,4
-;;   add a3,a2,a3
-;;   li a2,0
-;;   sltu a4,zero,a4
-;;   sub a5,zero,a4
-;;   and a2,a2,a5
-;;   not a4,a5
-;;   and a5,a3,a4
-;;   or a2,a2,a5
-;;   sb a1,0(a2)
+;;   lui a0,65535
+;;   slli a4,a0,4
+;;   add a2,a2,a4
+;;   li a4,0
+;;   sub a3,zero,a3
+;;   and a5,a4,a3
+;;   not a3,a3
+;;   and a3,a2,a3
+;;   or a5,a5,a3
+;;   sb a1,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -70,19 +69,18 @@
 ;;   trap_if heap_oob##(a2 ult a0)
 ;;   ld a3,8(a1)
 ;;   ugt a2,a2,a3##ty=i64
-;;   ld a3,0(a1)
-;;   add a3,a3,a0
-;;   lui a1,65535
-;;   slli a4,a1,4
-;;   add a3,a3,a4
-;;   li a4,0
-;;   sltu a5,zero,a2
-;;   sub a5,zero,a5
-;;   and a1,a4,a5
-;;   not a4,a5
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   lui a0,65535
+;;   slli a3,a0,4
+;;   add a1,a1,a3
+;;   li a3,0
+;;   sub a4,zero,a2
 ;;   and a5,a3,a4
-;;   or a1,a1,a5
-;;   lbu a0,0(a1)
+;;   not a2,a4
+;;   and a3,a1,a2
+;;   or a5,a5,a3
+;;   lbu a0,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -46,13 +46,12 @@
 ;;   ld a2,0(a2)
 ;;   add a2,a2,a0
 ;;   li a4,0
-;;   sltu a3,zero,a3
-;;   sub a5,zero,a3
-;;   and a3,a4,a5
-;;   not a4,a5
-;;   and a5,a2,a4
-;;   or a2,a3,a5
-;;   sw a1,0(a2)
+;;   sub a3,zero,a3
+;;   and a5,a4,a3
+;;   not a3,a3
+;;   and a3,a2,a3
+;;   or a5,a5,a3
+;;   sw a1,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -60,17 +59,16 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a2,8(a1)
-;;   ugt a3,a0,a2##ty=i64
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sltu a3,zero,a3
-;;   sub a5,zero,a3
-;;   and a1,a4,a5
-;;   not a3,a5
-;;   and a5,a2,a3
-;;   or a1,a1,a5
-;;   lw a0,0(a1)
+;;   ugt a2,a0,a2##ty=i64
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   li a3,0
+;;   sub a4,zero,a2
+;;   and a5,a3,a4
+;;   not a2,a4
+;;   and a3,a1,a2
+;;   or a5,a5,a3
+;;   lw a0,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -41,40 +41,38 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a4,8(a2)
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a2,zero,a4
-;;   sub a2,zero,a2
-;;   and a3,a0,a2
-;;   not a0,a2
+;;   ld a3,8(a2)
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a4,0(a2)
+;;   add a4,a4,a0
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a3
 ;;   and a2,a5,a0
-;;   or a3,a3,a2
-;;   sw a1,0(a3)
+;;   not a3,a0
+;;   and a5,a4,a3
+;;   or a2,a2,a5
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a4,8(a1)
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a1,zero,a4
-;;   sub a1,zero,a1
-;;   and a3,a0,a1
-;;   not a0,a1
+;;   ld a3,8(a1)
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a4,0(a1)
+;;   add a4,a4,a0
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a3
 ;;   and a1,a5,a0
-;;   or a3,a3,a1
-;;   lw a0,0(a3)
+;;   not a3,a0
+;;   and a5,a4,a3
+;;   or a1,a1,a5
+;;   lw a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,42 +41,40 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a5,8(a2)
-;;   ugt a5,a0,a5##ty=i64
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a4,65535
-;;   slli a2,a4,4
-;;   add a0,a0,a2
-;;   li a2,0
-;;   sltu a3,zero,a5
-;;   sub a3,zero,a3
-;;   and a4,a2,a3
-;;   not a2,a3
-;;   and a2,a0,a2
-;;   or a4,a4,a2
-;;   sw a1,0(a4)
+;;   ld a4,8(a2)
+;;   ugt a4,a0,a4##ty=i64
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   lui a3,65535
+;;   slli a0,a3,4
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a3,zero,a4
+;;   and a2,a0,a3
+;;   not a4,a3
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a5,8(a1)
-;;   ugt a5,a0,a5##ty=i64
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a4,65535
-;;   slli a1,a4,4
-;;   add a0,a0,a1
-;;   li a1,0
-;;   sltu a2,zero,a5
-;;   sub a2,zero,a2
-;;   and a4,a1,a2
-;;   not a1,a2
+;;   ld a4,8(a1)
+;;   ugt a4,a0,a4##ty=i64
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lui a3,65535
+;;   slli a0,a3,4
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a1,zero,a4
 ;;   and a2,a0,a1
-;;   or a4,a4,a2
-;;   lw a0,0(a4)
+;;   not a4,a1
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   lw a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -46,13 +46,12 @@
 ;;   ld a2,0(a2)
 ;;   add a2,a2,a0
 ;;   li a4,0
-;;   sltu a3,zero,a3
-;;   sub a5,zero,a3
-;;   and a3,a4,a5
-;;   not a4,a5
-;;   and a5,a2,a4
-;;   or a2,a3,a5
-;;   sb a1,0(a2)
+;;   sub a3,zero,a3
+;;   and a5,a4,a3
+;;   not a3,a3
+;;   and a3,a2,a3
+;;   or a5,a5,a3
+;;   sb a1,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -60,17 +59,16 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a2,8(a1)
-;;   uge a3,a0,a2##ty=i64
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sltu a3,zero,a3
-;;   sub a5,zero,a3
-;;   and a1,a4,a5
-;;   not a3,a5
-;;   and a5,a2,a3
-;;   or a1,a1,a5
-;;   lbu a0,0(a1)
+;;   uge a2,a0,a2##ty=i64
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   li a3,0
+;;   sub a4,zero,a2
+;;   and a5,a3,a4
+;;   not a2,a4
+;;   and a3,a1,a2
+;;   or a5,a5,a3
+;;   lbu a0,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -41,40 +41,38 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a4,8(a2)
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a2,zero,a4
-;;   sub a2,zero,a2
-;;   and a3,a0,a2
-;;   not a0,a2
+;;   ld a3,8(a2)
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a4,0(a2)
+;;   add a4,a4,a0
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a3
 ;;   and a2,a5,a0
-;;   or a3,a3,a2
-;;   sb a1,0(a3)
+;;   not a3,a0
+;;   and a5,a4,a3
+;;   or a2,a2,a5
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a4,8(a1)
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a1,zero,a4
-;;   sub a1,zero,a1
-;;   and a3,a0,a1
-;;   not a0,a1
+;;   ld a3,8(a1)
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a4,0(a1)
+;;   add a4,a4,a0
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a3
 ;;   and a1,a5,a0
-;;   or a3,a3,a1
-;;   lbu a0,0(a3)
+;;   not a3,a0
+;;   and a5,a4,a3
+;;   or a1,a1,a5
+;;   lbu a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,42 +41,40 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a5,8(a2)
-;;   ugt a5,a0,a5##ty=i64
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a4,65535
-;;   slli a2,a4,4
-;;   add a0,a0,a2
-;;   li a2,0
-;;   sltu a3,zero,a5
-;;   sub a3,zero,a3
-;;   and a4,a2,a3
-;;   not a2,a3
-;;   and a2,a0,a2
-;;   or a4,a4,a2
-;;   sb a1,0(a4)
+;;   ld a4,8(a2)
+;;   ugt a4,a0,a4##ty=i64
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   lui a3,65535
+;;   slli a0,a3,4
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a3,zero,a4
+;;   and a2,a0,a3
+;;   not a4,a3
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a5,8(a1)
-;;   ugt a5,a0,a5##ty=i64
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a4,65535
-;;   slli a1,a4,4
-;;   add a0,a0,a1
-;;   li a1,0
-;;   sltu a2,zero,a5
-;;   sub a2,zero,a2
-;;   and a4,a1,a2
-;;   not a1,a2
+;;   ld a4,8(a1)
+;;   ugt a4,a0,a4##ty=i64
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lui a3,65535
+;;   slli a0,a3,4
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a1,zero,a4
 ;;   and a2,a0,a1
-;;   or a4,a4,a2
-;;   lbu a0,0(a4)
+;;   not a4,a1
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   lbu a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -39,42 +39,40 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   lui a4,65536
-;;   addi a3,a4,-4
-;;   ugt a3,a0,a3##ty=i64
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a2,zero,a3
-;;   sub a2,zero,a2
-;;   and a4,a0,a2
-;;   not a0,a2
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   lui a3,65536
+;;   addi a0,a3,-4
+;;   ugt a0,a5,a0##ty=i64
+;;   ld a4,0(a2)
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a0
 ;;   and a2,a5,a0
-;;   or a4,a4,a2
-;;   sw a1,0(a4)
+;;   not a5,a0
+;;   and a0,a4,a5
+;;   or a2,a2,a0
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   lui a4,65536
-;;   addi a2,a4,-4
-;;   ugt a2,a0,a2##ty=i64
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a1,zero,a2
-;;   sub a2,zero,a1
-;;   and a4,a0,a2
-;;   not a0,a2
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   lui a3,65536
+;;   addi a0,a3,-4
+;;   ugt a0,a5,a0##ty=i64
+;;   ld a4,0(a1)
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a0
 ;;   and a2,a5,a0
-;;   or a4,a4,a2
-;;   lw a0,0(a4)
+;;   not a5,a0
+;;   and a0,a4,a5
+;;   or a2,a2,a0
+;;   lw a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -39,49 +39,44 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mv a4,a2
-;;   slli a0,a0,32
-;;   srli a3,a0,32
-;;   lui a0,65535
-;;   addi a2,a0,-4
-;;   ugt a2,a3,a2##ty=i64
-;;   ld a4,0(a4)
-;;   add a3,a4,a3
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   li a4,0
-;;   sltu a2,zero,a2
-;;   sub a5,zero,a2
-;;   and a0,a4,a5
-;;   not a2,a5
-;;   and a4,a3,a2
-;;   or a0,a0,a4
-;;   sw a1,0(a0)
+;;   slli a5,a0,32
+;;   srli a3,a5,32
+;;   lui a5,65535
+;;   addi a4,a5,-4
+;;   ugt a0,a3,a4##ty=i64
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   lui a3,1
+;;   add a2,a2,a3
+;;   li a3,0
+;;   sub a5,zero,a0
+;;   and a4,a3,a5
+;;   not a0,a5
+;;   and a2,a2,a0
+;;   or a4,a4,a2
+;;   sw a1,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mv a4,a1
-;;   slli a0,a0,32
-;;   srli a2,a0,32
-;;   lui a0,65535
-;;   addi a3,a0,-4
-;;   ugt a1,a2,a3##ty=i64
-;;   mv a3,a4
-;;   ld a3,0(a3)
-;;   add a2,a3,a2
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   li a3,0
-;;   sltu a4,zero,a1
-;;   sub a4,zero,a4
-;;   and a0,a3,a4
-;;   not a3,a4
+;;   slli a5,a0,32
+;;   srli a2,a5,32
+;;   lui a5,65535
+;;   addi a3,a5,-4
+;;   ugt a0,a2,a3##ty=i64
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   lui a2,1
+;;   add a1,a1,a2
+;;   li a2,0
+;;   sub a3,zero,a0
 ;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lw a0,0(a0)
+;;   not a0,a3
+;;   and a2,a1,a0
+;;   or a4,a4,a2
+;;   lw a0,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -39,42 +39,40 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   lui a4,65536
-;;   addi a3,a4,-1
-;;   ugt a3,a0,a3##ty=i64
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a2,zero,a3
-;;   sub a2,zero,a2
-;;   and a4,a0,a2
-;;   not a0,a2
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   lui a3,65536
+;;   addi a0,a3,-1
+;;   ugt a0,a5,a0##ty=i64
+;;   ld a4,0(a2)
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a0
 ;;   and a2,a5,a0
-;;   or a4,a4,a2
-;;   sb a1,0(a4)
+;;   not a5,a0
+;;   and a0,a4,a5
+;;   or a2,a2,a0
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   lui a4,65536
-;;   addi a2,a4,-1
-;;   ugt a2,a0,a2##ty=i64
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sltu a1,zero,a2
-;;   sub a2,zero,a1
-;;   and a4,a0,a2
-;;   not a0,a2
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   lui a3,65536
+;;   addi a0,a3,-1
+;;   ugt a0,a5,a0##ty=i64
+;;   ld a4,0(a1)
+;;   add a4,a4,a5
+;;   li a5,0
+;;   sub a0,zero,a0
 ;;   and a2,a5,a0
-;;   or a4,a4,a2
-;;   lbu a0,0(a4)
+;;   not a5,a0
+;;   and a0,a4,a5
+;;   or a2,a2,a0
+;;   lbu a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -39,49 +39,44 @@
 
 ;; function u0:0:
 ;; block0:
-;;   mv a4,a2
-;;   slli a0,a0,32
-;;   srli a3,a0,32
-;;   lui a0,65535
-;;   addi a2,a0,-1
-;;   ugt a2,a3,a2##ty=i64
-;;   ld a4,0(a4)
-;;   add a3,a4,a3
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   li a4,0
-;;   sltu a2,zero,a2
-;;   sub a5,zero,a2
-;;   and a0,a4,a5
-;;   not a2,a5
-;;   and a4,a3,a2
-;;   or a0,a0,a4
-;;   sb a1,0(a0)
+;;   slli a5,a0,32
+;;   srli a3,a5,32
+;;   lui a5,65535
+;;   addi a4,a5,-1
+;;   ugt a0,a3,a4##ty=i64
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   lui a3,1
+;;   add a2,a2,a3
+;;   li a3,0
+;;   sub a5,zero,a0
+;;   and a4,a3,a5
+;;   not a0,a5
+;;   and a2,a2,a0
+;;   or a4,a4,a2
+;;   sb a1,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   mv a4,a1
-;;   slli a0,a0,32
-;;   srli a2,a0,32
-;;   lui a0,65535
-;;   addi a3,a0,-1
-;;   ugt a1,a2,a3##ty=i64
-;;   mv a3,a4
-;;   ld a3,0(a3)
-;;   add a2,a3,a2
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   li a3,0
-;;   sltu a4,zero,a1
-;;   sub a4,zero,a4
-;;   and a0,a3,a4
-;;   not a3,a4
+;;   slli a5,a0,32
+;;   srli a2,a5,32
+;;   lui a5,65535
+;;   addi a3,a5,-1
+;;   ugt a0,a2,a3##ty=i64
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   lui a2,1
+;;   add a1,a1,a2
+;;   li a2,0
+;;   sub a3,zero,a0
 ;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lbu a0,0(a0)
+;;   not a0,a3
+;;   and a2,a1,a0
+;;   or a4,a4,a2
+;;   lbu a0,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -40,18 +40,17 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65536
-;;   addi a4,a3,-4
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a3,0(a2)
-;;   add a3,a3,a0
-;;   li a5,0
-;;   sltu a4,zero,a4
-;;   sub a0,zero,a4
-;;   and a2,a5,a0
-;;   not a4,a0
-;;   and a0,a3,a4
-;;   or a2,a2,a0
-;;   sw a1,0(a2)
+;;   addi a3,a3,-4
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   li a4,0
+;;   sub a5,zero,a3
+;;   and a0,a4,a5
+;;   not a3,a5
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   sw a1,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -59,18 +58,17 @@
 ;; function u0:1:
 ;; block0:
 ;;   lui a2,65536
-;;   addi a4,a2,-4
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a3,0(a1)
-;;   add a3,a3,a0
-;;   li a5,0
-;;   sltu a4,zero,a4
-;;   sub a0,zero,a4
-;;   and a2,a5,a0
-;;   not a4,a0
-;;   and a0,a3,a4
-;;   or a2,a2,a0
-;;   lw a0,0(a2)
+;;   addi a3,a2,-4
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a2,0(a1)
+;;   add a2,a2,a0
+;;   li a4,0
+;;   sub a5,zero,a3
+;;   and a0,a4,a5
+;;   not a3,a5
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   lw a0,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -39,42 +39,40 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a4,65535
-;;   addi a3,a4,-4
-;;   ugt a5,a0,a3##ty=i64
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a2,1
-;;   add a0,a0,a2
-;;   li a2,0
-;;   sltu a3,zero,a5
-;;   sub a3,zero,a3
-;;   and a4,a2,a3
-;;   not a2,a3
-;;   and a2,a0,a2
-;;   or a4,a4,a2
-;;   sw a1,0(a4)
+;;   lui a3,65535
+;;   addi a5,a3,-4
+;;   ugt a4,a0,a5##ty=i64
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   lui a0,1
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a3,zero,a4
+;;   and a2,a0,a3
+;;   not a4,a3
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a4,65535
-;;   addi a2,a4,-4
-;;   ugt a5,a0,a2##ty=i64
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a1,1
-;;   add a0,a0,a1
-;;   li a1,0
-;;   sltu a2,zero,a5
-;;   sub a2,zero,a2
-;;   and a4,a1,a2
-;;   not a1,a2
+;;   lui a3,65535
+;;   addi a5,a3,-4
+;;   ugt a4,a0,a5##ty=i64
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lui a0,1
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a1,zero,a4
 ;;   and a2,a0,a1
-;;   or a4,a4,a2
-;;   lw a0,0(a4)
+;;   not a4,a1
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   lw a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -40,18 +40,17 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65536
-;;   addi a4,a3,-1
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a3,0(a2)
-;;   add a3,a3,a0
-;;   li a5,0
-;;   sltu a4,zero,a4
-;;   sub a0,zero,a4
-;;   and a2,a5,a0
-;;   not a4,a0
-;;   and a0,a3,a4
-;;   or a2,a2,a0
-;;   sb a1,0(a2)
+;;   addi a3,a3,-1
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   li a4,0
+;;   sub a5,zero,a3
+;;   and a0,a4,a5
+;;   not a3,a5
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   sb a1,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -59,18 +58,17 @@
 ;; function u0:1:
 ;; block0:
 ;;   lui a2,65536
-;;   addi a4,a2,-1
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a3,0(a1)
-;;   add a3,a3,a0
-;;   li a5,0
-;;   sltu a4,zero,a4
-;;   sub a0,zero,a4
-;;   and a2,a5,a0
-;;   not a4,a0
-;;   and a0,a3,a4
-;;   or a2,a2,a0
-;;   lbu a0,0(a2)
+;;   addi a3,a2,-1
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a2,0(a1)
+;;   add a2,a2,a0
+;;   li a4,0
+;;   sub a5,zero,a3
+;;   and a0,a4,a5
+;;   not a3,a5
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   lbu a0,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -39,42 +39,40 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a4,65535
-;;   addi a3,a4,-1
-;;   ugt a5,a0,a3##ty=i64
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a2,1
-;;   add a0,a0,a2
-;;   li a2,0
-;;   sltu a3,zero,a5
-;;   sub a3,zero,a3
-;;   and a4,a2,a3
-;;   not a2,a3
-;;   and a2,a0,a2
-;;   or a4,a4,a2
-;;   sb a1,0(a4)
+;;   lui a3,65535
+;;   addi a5,a3,-1
+;;   ugt a4,a0,a5##ty=i64
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   lui a0,1
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a3,zero,a4
+;;   and a2,a0,a3
+;;   not a4,a3
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a4,65535
-;;   addi a2,a4,-1
-;;   ugt a5,a0,a2##ty=i64
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a1,1
-;;   add a0,a0,a1
-;;   li a1,0
-;;   sltu a2,zero,a5
-;;   sub a2,zero,a2
-;;   and a4,a1,a2
-;;   not a1,a2
+;;   lui a3,65535
+;;   addi a5,a3,-1
+;;   ugt a4,a0,a5##ty=i64
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lui a0,1
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a1,zero,a4
 ;;   and a2,a0,a1
-;;   or a4,a4,a2
-;;   lbu a0,0(a4)
+;;   not a4,a1
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   lbu a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -40,18 +40,17 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65536
-;;   addi a4,a3,-4
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a3,0(a2)
-;;   add a3,a3,a0
-;;   li a5,0
-;;   sltu a4,zero,a4
-;;   sub a0,zero,a4
-;;   and a2,a5,a0
-;;   not a4,a0
-;;   and a0,a3,a4
-;;   or a2,a2,a0
-;;   sw a1,0(a2)
+;;   addi a3,a3,-4
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   li a4,0
+;;   sub a5,zero,a3
+;;   and a0,a4,a5
+;;   not a3,a5
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   sw a1,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -59,18 +58,17 @@
 ;; function u0:1:
 ;; block0:
 ;;   lui a2,65536
-;;   addi a4,a2,-4
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a3,0(a1)
-;;   add a3,a3,a0
-;;   li a5,0
-;;   sltu a4,zero,a4
-;;   sub a0,zero,a4
-;;   and a2,a5,a0
-;;   not a4,a0
-;;   and a0,a3,a4
-;;   or a2,a2,a0
-;;   lw a0,0(a2)
+;;   addi a3,a2,-4
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a2,0(a1)
+;;   add a2,a2,a0
+;;   li a4,0
+;;   sub a5,zero,a3
+;;   and a0,a4,a5
+;;   not a3,a5
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   lw a0,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -39,42 +39,40 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a4,65535
-;;   addi a3,a4,-4
-;;   ugt a5,a0,a3##ty=i64
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a2,1
-;;   add a0,a0,a2
-;;   li a2,0
-;;   sltu a3,zero,a5
-;;   sub a3,zero,a3
-;;   and a4,a2,a3
-;;   not a2,a3
-;;   and a2,a0,a2
-;;   or a4,a4,a2
-;;   sw a1,0(a4)
+;;   lui a3,65535
+;;   addi a5,a3,-4
+;;   ugt a4,a0,a5##ty=i64
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   lui a0,1
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a3,zero,a4
+;;   and a2,a0,a3
+;;   not a4,a3
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a4,65535
-;;   addi a2,a4,-4
-;;   ugt a5,a0,a2##ty=i64
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a1,1
-;;   add a0,a0,a1
-;;   li a1,0
-;;   sltu a2,zero,a5
-;;   sub a2,zero,a2
-;;   and a4,a1,a2
-;;   not a1,a2
+;;   lui a3,65535
+;;   addi a5,a3,-4
+;;   ugt a4,a0,a5##ty=i64
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lui a0,1
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a1,zero,a4
 ;;   and a2,a0,a1
-;;   or a4,a4,a2
-;;   lw a0,0(a4)
+;;   not a4,a1
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   lw a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -40,18 +40,17 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65536
-;;   addi a4,a3,-1
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a3,0(a2)
-;;   add a3,a3,a0
-;;   li a5,0
-;;   sltu a4,zero,a4
-;;   sub a0,zero,a4
-;;   and a2,a5,a0
-;;   not a4,a0
-;;   and a0,a3,a4
-;;   or a2,a2,a0
-;;   sb a1,0(a2)
+;;   addi a3,a3,-1
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   li a4,0
+;;   sub a5,zero,a3
+;;   and a0,a4,a5
+;;   not a3,a5
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   sb a1,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret
@@ -59,18 +58,17 @@
 ;; function u0:1:
 ;; block0:
 ;;   lui a2,65536
-;;   addi a4,a2,-1
-;;   ugt a4,a0,a4##ty=i64
-;;   ld a3,0(a1)
-;;   add a3,a3,a0
-;;   li a5,0
-;;   sltu a4,zero,a4
-;;   sub a0,zero,a4
-;;   and a2,a5,a0
-;;   not a4,a0
-;;   and a0,a3,a4
-;;   or a2,a2,a0
-;;   lbu a0,0(a2)
+;;   addi a3,a2,-1
+;;   ugt a3,a0,a3##ty=i64
+;;   ld a2,0(a1)
+;;   add a2,a2,a0
+;;   li a4,0
+;;   sub a5,zero,a3
+;;   and a0,a4,a5
+;;   not a3,a5
+;;   and a4,a2,a3
+;;   or a0,a0,a4
+;;   lbu a0,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -39,42 +39,40 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a4,65535
-;;   addi a3,a4,-1
-;;   ugt a5,a0,a3##ty=i64
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a2,1
-;;   add a0,a0,a2
-;;   li a2,0
-;;   sltu a3,zero,a5
-;;   sub a3,zero,a3
-;;   and a4,a2,a3
-;;   not a2,a3
-;;   and a2,a0,a2
-;;   or a4,a4,a2
-;;   sb a1,0(a4)
+;;   lui a3,65535
+;;   addi a5,a3,-1
+;;   ugt a4,a0,a5##ty=i64
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   lui a0,1
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a3,zero,a4
+;;   and a2,a0,a3
+;;   not a4,a3
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a4,65535
-;;   addi a2,a4,-1
-;;   ugt a5,a0,a2##ty=i64
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a1,1
-;;   add a0,a0,a1
-;;   li a1,0
-;;   sltu a2,zero,a5
-;;   sub a2,zero,a2
-;;   and a4,a1,a2
-;;   not a1,a2
+;;   lui a3,65535
+;;   addi a5,a3,-1
+;;   ugt a4,a0,a5##ty=i64
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lui a0,1
+;;   add a5,a5,a0
+;;   li a0,0
+;;   sub a1,zero,a4
 ;;   and a2,a0,a1
-;;   or a4,a4,a2
-;;   lbu a0,0(a4)
+;;   not a4,a1
+;;   and a0,a5,a4
+;;   or a2,a2,a0
+;;   lbu a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret


### PR DESCRIPTION
If the input operand is an `icmp` or an `fcmp` there's no need to use `snez` since the output value is already guaranteed to be zero or one.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
