### PR TITLE
fuzzgen: Enable `iabs.i128` for AArch64

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -612,8 +612,6 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
                 (Opcode::Udiv | Opcode::Sdiv, &[I128, I128]),
                 // https://github.com/bytecodealliance/wasmtime/issues/5472
                 (Opcode::Urem | Opcode::Srem, &[I128, I128]),
-                // https://github.com/bytecodealliance/wasmtime/issues/5467
-                (Opcode::Iabs, &[I128]),
                 // https://github.com/bytecodealliance/wasmtime/issues/4313
                 (
                     Opcode::Smin | Opcode::Umin | Opcode::Smax | Opcode::Umax,


### PR DESCRIPTION
👋 Hey,

This PR enables `iabs.i128` for AArch64 on the fuzzgen fuzzer. It was recently implemented in https://github.com/bytecodealliance/wasmtime/pull/7185.

cc: #5467