### PR TITLE
Refactor preview2's `Table` representation

### DIFF
--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -40,7 +40,7 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
                 .unwrap_or(600 * 1000) as u64,
         );
 
-        let req = self.table().delete_resource(request_id)?;
+        let req = self.table().delete(request_id)?;
 
         let method = match req.method {
             crate::bindings::http::types::Method::Get => Method::GET,
@@ -176,9 +176,7 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
             })
         });
 
-        let fut = self
-            .table()
-            .push_resource(HostFutureIncomingResponse::new(handle))?;
+        let fut = self.table().push(HostFutureIncomingResponse::new(handle))?;
 
         Ok(Ok(fut))
     }

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -26,7 +26,7 @@ pub trait WasiHttpView: Send {
             // TODO: this needs to be plumbed through
             between_bytes_timeout: std::time::Duration::from_millis(600 * 1000),
         };
-        Ok(self.table().push_resource(HostIncomingRequest {
+        Ok(self.table().push(HostIncomingRequest {
             parts,
             body: Some(body),
         })?)
@@ -38,9 +38,7 @@ pub trait WasiHttpView: Send {
             Result<hyper::Response<HyperOutgoingBody>, types::Error>,
         >,
     ) -> wasmtime::Result<Resource<HostResponseOutparam>> {
-        let id = self
-            .table()
-            .push_resource(HostResponseOutparam { result })?;
+        let id = self.table().push(HostResponseOutparam { result })?;
         Ok(id)
     }
 }

--- a/crates/wasi/src/preview2/host/clocks.rs
+++ b/crates/wasi/src/preview2/host/clocks.rs
@@ -65,7 +65,7 @@ impl<T: WasiView> monotonic_clock::Host for T {
         // NB: this resource created here is not actually exposed to wasm, it's
         // only an internal implementation detail used to match the signature
         // expected by `subscribe`.
-        let sleep = self.table_mut().push_resource(Sleep(deadline))?;
+        let sleep = self.table_mut().push(Sleep(deadline))?;
         subscribe(self.table_mut(), sleep)
     }
 }

--- a/crates/wasi/src/preview2/host/instance_network.rs
+++ b/crates/wasi/src/preview2/host/instance_network.rs
@@ -9,7 +9,7 @@ impl<T: WasiView> instance_network::Host for T {
             pool: self.ctx().pool.clone(),
             allow_ip_name_lookup: self.ctx().allow_ip_name_lookup,
         };
-        let network = self.table_mut().push_resource(network)?;
+        let network = self.table_mut().push(network)?;
         Ok(network)
     }
 }

--- a/crates/wasi/src/preview2/host/network.rs
+++ b/crates/wasi/src/preview2/host/network.rs
@@ -17,7 +17,7 @@ impl<T: WasiView> crate::preview2::bindings::sockets::network::HostNetwork for T
     fn drop(&mut self, this: Resource<network::Network>) -> Result<(), anyhow::Error> {
         let table = self.table_mut();
 
-        table.delete_resource(this)?;
+        table.delete(this)?;
 
         Ok(())
     }

--- a/crates/wasi/src/preview2/host/tcp_create_socket.rs
+++ b/crates/wasi/src/preview2/host/tcp_create_socket.rs
@@ -9,7 +9,7 @@ impl<T: WasiView> tcp_create_socket::Host for T {
         address_family: IpAddressFamily,
     ) -> SocketResult<Resource<TcpSocket>> {
         let socket = TcpSocket::new(address_family.into())?;
-        let socket = self.table_mut().push_resource(socket)?;
+        let socket = self.table_mut().push(socket)?;
         Ok(socket)
     }
 }

--- a/crates/wasi/src/preview2/host/udp_create_socket.rs
+++ b/crates/wasi/src/preview2/host/udp_create_socket.rs
@@ -9,7 +9,7 @@ impl<T: WasiView> udp_create_socket::Host for T {
         address_family: IpAddressFamily,
     ) -> SocketResult<Resource<UdpSocket>> {
         let socket = UdpSocket::new(address_family.into())?;
-        let socket = self.table_mut().push_resource(socket)?;
+        let socket = self.table_mut().push(socket)?;
         Ok(socket)
     }
 }

--- a/crates/wasi/src/preview2/ip_name_lookup.rs
+++ b/crates/wasi/src/preview2/ip_name_lookup.rs
@@ -23,7 +23,7 @@ impl<T: WasiView> Host for T {
         family: Option<IpAddressFamily>,
         include_unavailable: bool,
     ) -> Result<Resource<ResolveAddressStream>, SocketError> {
-        let network = self.table().get_resource(&network)?;
+        let network = self.table().get(&network)?;
 
         // `Host::parse` serves us two functions:
         // 1. validate the input is not an IP address,
@@ -74,9 +74,7 @@ impl<T: WasiView> Host for T {
                 })
                 .collect())
         });
-        let resource = self
-            .table_mut()
-            .push_resource(ResolveAddressStream::Waiting(task))?;
+        let resource = self.table_mut().push(ResolveAddressStream::Waiting(task))?;
         Ok(resource)
     }
 }
@@ -87,7 +85,7 @@ impl<T: WasiView> HostResolveAddressStream for T {
         &mut self,
         resource: Resource<ResolveAddressStream>,
     ) -> Result<Option<IpAddress>, SocketError> {
-        let stream = self.table_mut().get_resource_mut(&resource)?;
+        let stream = self.table_mut().get_mut(&resource)?;
         loop {
             match stream {
                 ResolveAddressStream::Waiting(future) => {
@@ -115,7 +113,7 @@ impl<T: WasiView> HostResolveAddressStream for T {
     }
 
     fn drop(&mut self, resource: Resource<ResolveAddressStream>) -> Result<()> {
-        self.table_mut().delete_resource(resource)?;
+        self.table_mut().delete(resource)?;
         Ok(())
     }
 }

--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -357,7 +357,7 @@ impl<T: WasiPreview1View + ?Sized> Transaction<'_, T> {
         let fd = fd.into();
         match self.descriptors.get(&fd) {
             Some(Descriptor::File(file @ File { fd, .. })) => {
-                self.view.table().get_resource(fd)?.file()?;
+                self.view.table().get(fd)?.file()?;
                 Ok(file)
             }
             _ => Err(types::Errno::Badf.into()),
@@ -370,7 +370,7 @@ impl<T: WasiPreview1View + ?Sized> Transaction<'_, T> {
         let fd = fd.into();
         match self.descriptors.get_mut(&fd) {
             Some(Descriptor::File(file)) => {
-                self.view.table().get_resource(&file.fd)?.file()?;
+                self.view.table().get(&file.fd)?.file()?;
                 Ok(file)
             }
             _ => Err(types::Errno::Badf.into()),
@@ -387,7 +387,7 @@ impl<T: WasiPreview1View + ?Sized> Transaction<'_, T> {
         let fd = fd.into();
         match self.descriptors.get(&fd) {
             Some(Descriptor::File(file @ File { fd, .. }))
-                if self.view.table().get_resource(fd)?.is_file() =>
+                if self.view.table().get(fd)?.is_file() =>
             {
                 Ok(file)
             }
@@ -424,9 +424,7 @@ impl<T: WasiPreview1View + ?Sized> Transaction<'_, T> {
     fn get_dir_fd(&self, fd: types::Fd) -> Result<Resource<filesystem::Descriptor>> {
         let fd = fd.into();
         match self.descriptors.get(&fd) {
-            Some(Descriptor::File(File { fd, .. }))
-                if self.view.table().get_resource(fd)?.is_dir() =>
-            {
+            Some(Descriptor::File(File { fd, .. })) if self.view.table().get(fd)?.is_dir() => {
                 Ok(fd.borrowed())
             }
             Some(Descriptor::PreopenDirectory((fd, _))) => Ok(fd.borrowed()),
@@ -1322,7 +1320,7 @@ impl<
                 blocking_mode,
                 position,
                 ..
-            }) if t.view.table().get_resource(fd)?.is_file() => {
+            }) if t.view.table().get(fd)?.is_file() => {
                 let fd = fd.borrowed();
                 let blocking_mode = *blocking_mode;
                 let position = position.clone();
@@ -1378,7 +1376,7 @@ impl<
         let (mut buf, read) = match desc {
             Descriptor::File(File {
                 fd, blocking_mode, ..
-            }) if t.view.table().get_resource(fd)?.is_file() => {
+            }) if t.view.table().get(fd)?.is_file() => {
                 let fd = fd.borrowed();
                 let blocking_mode = *blocking_mode;
                 drop(t);
@@ -1425,7 +1423,7 @@ impl<
                 blocking_mode,
                 append,
                 position,
-            }) if t.view.table().get_resource(fd)?.is_file() => {
+            }) if t.view.table().get(fd)?.is_file() => {
                 let fd = fd.borrowed();
                 let blocking_mode = *blocking_mode;
                 let position = position.clone();
@@ -1488,7 +1486,7 @@ impl<
         let n = match desc {
             Descriptor::File(File {
                 fd, blocking_mode, ..
-            }) if t.view.table().get_resource(fd)?.is_file() => {
+            }) if t.view.table().get(fd)?.is_file() => {
                 let fd = fd.borrowed();
                 let blocking_mode = *blocking_mode;
                 drop(t);
@@ -1652,7 +1650,7 @@ impl<
         for (entry, d_next) in self
             .table_mut()
             // remove iterator from table and use it directly:
-            .delete_resource(stream)?
+            .delete(stream)?
             .into_iter()
             .zip(3u64..)
         {
@@ -1885,7 +1883,7 @@ impl<
         let dirfd = match t.get_descriptor(dirfd)? {
             Descriptor::PreopenDirectory((fd, _)) => fd.borrowed(),
             Descriptor::File(File { fd, .. }) => {
-                t.view.table().get_resource(fd)?.dir()?;
+                t.view.table().get(fd)?.dir()?;
                 fd.borrowed()
             }
             _ => return Err(types::Errno::Badf.into()),
@@ -2084,7 +2082,7 @@ impl<
                         match desc {
                             Descriptor::Stdin { stream, .. } => stream.borrowed(),
                             Descriptor::File(File { fd, position, .. })
-                                if t.view.table().get_resource(fd)?.is_file() =>
+                                if t.view.table().get(fd)?.is_file() =>
                             {
                                 let pos = position.load(Ordering::Relaxed);
                                 let fd = fd.borrowed();
@@ -2117,7 +2115,7 @@ impl<
                                 position,
                                 append,
                                 ..
-                            }) if t.view.table().get_resource(fd)?.is_file() => {
+                            }) if t.view.table().get(fd)?.is_file() => {
                                 let fd = fd.borrowed();
                                 let position = position.clone();
                                 let append = *append;
@@ -2190,7 +2188,7 @@ impl<
                             },
                         },
                         Descriptor::File(File { fd, position, .. })
-                            if t.view.table().get_resource(fd)?.is_file() =>
+                            if t.view.table().get(fd)?.is_file() =>
                         {
                             let fd = fd.borrowed();
                             let position = position.clone();
@@ -2234,9 +2232,7 @@ impl<
                                 nbytes: 1,
                             },
                         },
-                        Descriptor::File(File { fd, .. })
-                            if t.view.table().get_resource(fd)?.is_file() =>
-                        {
+                        Descriptor::File(File { fd, .. }) if t.view.table().get(fd)?.is_file() => {
                             types::Event {
                                 userdata: sub.userdata,
                                 error: types::Errno::Success,

--- a/crates/wasi/src/preview2/stdio.rs
+++ b/crates/wasi/src/preview2/stdio.rs
@@ -159,23 +159,21 @@ pub enum IsATTY {
 impl<T: WasiView> stdin::Host for T {
     fn get_stdin(&mut self) -> Result<Resource<streams::InputStream>, anyhow::Error> {
         let stream = self.ctx_mut().stdin.stream();
-        Ok(self
-            .table_mut()
-            .push_resource(streams::InputStream::Host(stream))?)
+        Ok(self.table_mut().push(streams::InputStream::Host(stream))?)
     }
 }
 
 impl<T: WasiView> stdout::Host for T {
     fn get_stdout(&mut self) -> Result<Resource<streams::OutputStream>, anyhow::Error> {
         let stream = self.ctx_mut().stdout.stream();
-        Ok(self.table_mut().push_resource(stream)?)
+        Ok(self.table_mut().push(stream)?)
     }
 }
 
 impl<T: WasiView> stderr::Host for T {
     fn get_stderr(&mut self) -> Result<Resource<streams::OutputStream>, anyhow::Error> {
         let stream = self.ctx_mut().stderr.stream();
-        Ok(self.table_mut().push_resource(stream)?)
+        Ok(self.table_mut().push(stream)?)
     }
 }
 
@@ -185,21 +183,21 @@ pub struct TerminalOutput;
 impl<T: WasiView> terminal_input::Host for T {}
 impl<T: WasiView> terminal_input::HostTerminalInput for T {
     fn drop(&mut self, r: Resource<TerminalInput>) -> anyhow::Result<()> {
-        self.table_mut().delete_resource(r)?;
+        self.table_mut().delete(r)?;
         Ok(())
     }
 }
 impl<T: WasiView> terminal_output::Host for T {}
 impl<T: WasiView> terminal_output::HostTerminalOutput for T {
     fn drop(&mut self, r: Resource<TerminalOutput>) -> anyhow::Result<()> {
-        self.table_mut().delete_resource(r)?;
+        self.table_mut().delete(r)?;
         Ok(())
     }
 }
 impl<T: WasiView> terminal_stdin::Host for T {
     fn get_terminal_stdin(&mut self) -> anyhow::Result<Option<Resource<TerminalInput>>> {
         if self.ctx().stdin.isatty() {
-            let fd = self.table_mut().push_resource(TerminalInput)?;
+            let fd = self.table_mut().push(TerminalInput)?;
             Ok(Some(fd))
         } else {
             Ok(None)
@@ -209,7 +207,7 @@ impl<T: WasiView> terminal_stdin::Host for T {
 impl<T: WasiView> terminal_stdout::Host for T {
     fn get_terminal_stdout(&mut self) -> anyhow::Result<Option<Resource<TerminalOutput>>> {
         if self.ctx().stdout.isatty() {
-            let fd = self.table_mut().push_resource(TerminalOutput)?;
+            let fd = self.table_mut().push(TerminalOutput)?;
             Ok(Some(fd))
         } else {
             Ok(None)
@@ -219,7 +217,7 @@ impl<T: WasiView> terminal_stdout::Host for T {
 impl<T: WasiView> terminal_stderr::Host for T {
     fn get_terminal_stderr(&mut self) -> anyhow::Result<Option<Resource<TerminalOutput>>> {
         if self.ctx().stderr.isatty() {
-            let fd = self.table_mut().push_resource(TerminalOutput)?;
+            let fd = self.table_mut().push(TerminalOutput)?;
             Ok(Some(fd))
         } else {
             Ok(None)

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -77,65 +77,13 @@ impl Table {
         }
     }
 
-    /// Insert a resource at the next available index.
-    pub fn push(&mut self, entry: Box<dyn Any + Send + Sync>) -> Result<u32, TableError> {
-        self.push_(TableEntry::new(entry, None))
-    }
-
-    /// Same as `push`, but typed.
-    pub fn push_resource<T>(&mut self, entry: T) -> Result<Resource<T>, TableError>
+    /// Inserts a new value `T` into this table, returning a corresponding
+    /// `Resource<T>` which can be used to refer to it after it was inserted.
+    pub fn push<T>(&mut self, entry: T) -> Result<Resource<T>, TableError>
     where
         T: Send + Sync + 'static,
     {
-        let idx = self.push(Box::new(entry))?;
-        Ok(Resource::new_own(idx))
-    }
-
-    /// Insert a resource at the next available index, and track that it has a
-    /// parent resource.
-    ///
-    /// The parent must exist to create a child. All children resources must
-    /// be destroyed before a parent can be destroyed - otherwise [`Table::delete`]
-    /// will fail with [`TableError::HasChildren`].
-    ///
-    /// Parent-child relationships are tracked inside the table to ensure that
-    /// a parent resource is not deleted while it has live children. This
-    /// allows child resources to hold "references" to a parent by table
-    /// index, to avoid needing e.g. an `Arc<Mutex<parent>>` and the associated
-    /// locking overhead and design issues, such as child existence extending
-    /// lifetime of parent referent even after parent resource is destroyed,
-    /// possibility for deadlocks.
-    ///
-    /// Parent-child relationships may not be modified once created. There
-    /// is no way to observe these relationships through the [`Table`] methods
-    /// except for erroring on deletion, or the [`std::fmt::Debug`] impl.
-    pub fn push_child(
-        &mut self,
-        entry: Box<dyn Any + Send + Sync>,
-        parent: u32,
-    ) -> Result<u32, TableError> {
-        if !self.contains_key(parent) {
-            return Err(TableError::NotPresent);
-        }
-        let child = self.push_(TableEntry::new(entry, Some(parent)))?;
-        self.map
-            .get_mut(&parent)
-            .expect("parent existence assured above")
-            .add_child(child);
-        Ok(child)
-    }
-
-    /// Same as `push_child`, but typed.
-    pub fn push_child_resource<T, U>(
-        &mut self,
-        entry: T,
-        parent: &Resource<U>,
-    ) -> Result<Resource<T>, TableError>
-    where
-        T: Send + Sync + 'static,
-        U: 'static,
-    {
-        let idx = self.push_child(Box::new(entry), parent.rep())?;
+        let idx = self.push_(TableEntry::new(Box::new(entry), None))?;
         Ok(Resource::new_own(idx))
     }
 
@@ -156,74 +104,93 @@ impl Table {
         }
     }
 
-    /// Check if the table has a resource at the given index.
-    pub fn contains_key(&self, key: u32) -> bool {
-        self.map.contains_key(&key)
-    }
-
-    /// Check if the resource at a given index can be downcast to a given type.
-    /// Note: this will always fail if the resource is already borrowed.
-    pub fn is<T: Any + Sized>(&self, key: u32) -> bool {
-        if let Some(r) = self.map.get(&key) {
-            r.entry.is::<T>()
-        } else {
-            false
-        }
-    }
-
-    /// Get a mutable reference to the underlying untyped cell for an entry in the table.
-    pub fn get_any_mut(&mut self, key: u32) -> Result<&mut dyn Any, TableError> {
-        if let Some(r) = self.map.get_mut(&key) {
-            Ok(&mut *r.entry)
-        } else {
-            Err(TableError::NotPresent)
-        }
-    }
-
-    /// Get an immutable reference to a resource of a given type at a given index. Multiple
-    /// immutable references can be borrowed at any given time. Borrow failure
-    /// results in a trapping error.
-    pub fn get<T: Any + Sized>(&self, key: u32) -> Result<&T, TableError> {
-        if let Some(r) = self.map.get(&key) {
-            r.entry
-                .downcast_ref::<T>()
-                .ok_or_else(|| TableError::WrongType)
-        } else {
-            Err(TableError::NotPresent)
-        }
-    }
-
-    /// Get a mutable reference to a resource of a given type at a given index.
-    pub fn get_mut<T: Any + Sized>(&mut self, key: u32) -> Result<&mut T, TableError> {
-        if let Some(r) = self.map.get_mut(&key) {
-            r.entry
-                .downcast_mut::<T>()
-                .ok_or_else(|| TableError::WrongType)
-        } else {
-            Err(TableError::NotPresent)
-        }
-    }
-
-    /// Get a mutable reference to a resource a a `&mut dyn Any`.
-    pub fn get_as_any_mut(&mut self, key: u32) -> Result<&mut dyn Any, TableError> {
-        if let Some(r) = self.map.get_mut(&key) {
-            Ok(&mut *r.entry)
-        } else {
-            Err(TableError::NotPresent)
-        }
-    }
-
-    /// Same as `get`, but typed
-    pub fn get_resource<T: Any + Sized>(&self, key: &Resource<T>) -> Result<&T, TableError> {
-        self.get(key.rep())
-    }
-
-    /// Same as `get_mut`, but typed
-    pub fn get_resource_mut<T: Any + Sized>(
+    /// Insert a resource at the next available index, and track that it has a
+    /// parent resource.
+    ///
+    /// The parent must exist to create a child. All children resources must
+    /// be destroyed before a parent can be destroyed - otherwise [`Table::delete`]
+    /// will fail with [`TableError::HasChildren`].
+    ///
+    /// Parent-child relationships are tracked inside the table to ensure that
+    /// a parent resource is not deleted while it has live children. This
+    /// allows child resources to hold "references" to a parent by table
+    /// index, to avoid needing e.g. an `Arc<Mutex<parent>>` and the associated
+    /// locking overhead and design issues, such as child existence extending
+    /// lifetime of parent referent even after parent resource is destroyed,
+    /// possibility for deadlocks.
+    ///
+    /// Parent-child relationships may not be modified once created. There
+    /// is no way to observe these relationships through the [`Table`] methods
+    /// except for erroring on deletion, or the [`std::fmt::Debug`] impl.
+    pub fn push_child<T, U>(
         &mut self,
-        key: &Resource<T>,
-    ) -> Result<&mut T, TableError> {
-        self.get_mut(key.rep())
+        entry: T,
+        parent: &Resource<U>,
+    ) -> Result<Resource<T>, TableError>
+    where
+        T: Send + Sync + 'static,
+        U: 'static,
+    {
+        let idx = self.push_child_(Box::new(entry), parent.rep())?;
+        Ok(Resource::new_own(idx))
+    }
+
+    fn push_child_(
+        &mut self,
+        entry: Box<dyn Any + Send + Sync>,
+        parent: u32,
+    ) -> Result<u32, TableError> {
+        if !self.map.contains_key(&parent) {
+            return Err(TableError::NotPresent);
+        }
+        let child = self.push_(TableEntry::new(entry, Some(parent)))?;
+        self.map
+            .get_mut(&parent)
+            .expect("parent existence assured above")
+            .add_child(child);
+        Ok(child)
+    }
+
+    /// Get an immutable reference to a resource of a given type at a given
+    /// index.
+    ///
+    /// Multiple shared references can be borrowed at any given time.
+    pub fn get<T: Any + Sized>(&self, key: &Resource<T>) -> Result<&T, TableError> {
+        self.get_(key.rep())?
+            .downcast_ref()
+            .ok_or(TableError::WrongType)
+    }
+
+    fn get_(&self, key: u32) -> Result<&dyn Any, TableError> {
+        let r = self.map.get(&key).ok_or(TableError::NotPresent)?;
+        Ok(&*r.entry)
+    }
+
+    /// Get an mutable reference to a resource of a given type at a given
+    /// index.
+    pub fn get_mut<T: Any + Sized>(&mut self, key: &Resource<T>) -> Result<&mut T, TableError> {
+        self.get_any_mut(key.rep())?
+            .downcast_mut()
+            .ok_or(TableError::WrongType)
+    }
+
+    /// Returns the raw `Any` at the `key` index provided.
+    pub fn get_any_mut(&mut self, key: u32) -> Result<&mut dyn Any, TableError> {
+        let r = self.map.get_mut(&key).ok_or(TableError::NotPresent)?;
+        Ok(&mut *r.entry)
+    }
+
+    /// Same as `delete`, but typed
+    pub fn delete<T>(&mut self, resource: Resource<T>) -> Result<T, TableError>
+    where
+        T: Any,
+    {
+        debug_assert!(resource.owned());
+        let entry = self.delete_entry(resource.rep())?;
+        match entry.entry.downcast() {
+            Ok(t) => Ok(*t),
+            Err(_e) => Err(TableError::WrongType),
+        }
     }
 
     fn delete_entry(&mut self, key: u32) -> Result<TableEntry, TableError> {
@@ -247,47 +214,6 @@ impl Table {
                 .remove_child(key);
         }
         Ok(e)
-    }
-
-    /// Remove a resource at a given index from the table.
-    ///
-    /// If this method fails, the resource remains in the table.
-    ///
-    /// May fail with [`TableError::HasChildren`] if the resource has any live
-    /// children.
-    pub fn delete<T: Any + Sized>(&mut self, key: u32) -> Result<T, TableError> {
-        let e = self.delete_entry(key)?;
-        match e.entry.downcast::<T>() {
-            Ok(v) => Ok(*v),
-            Err(entry) => {
-                // Re-insert into parent list
-                if let Some(parent) = e.parent {
-                    self.map
-                        .get_mut(&parent)
-                        .expect("already checked parent exists")
-                        .add_child(key);
-                }
-                // Insert the value back
-                self.map.insert(
-                    key,
-                    TableEntry {
-                        entry,
-                        children: e.children,
-                        parent: e.parent,
-                    },
-                );
-                Err(TableError::WrongType)
-            }
-        }
-    }
-
-    /// Same as `delete`, but typed
-    pub fn delete_resource<T>(&mut self, resource: Resource<T>) -> Result<T, TableError>
-    where
-        T: Any,
-    {
-        debug_assert!(resource.owned());
-        self.delete(resource.rep())
     }
 
     /// Zip the values of the map with mutable references to table entries corresponding to each

--- a/crates/wasi/tests/all/api.rs
+++ b/crates/wasi/tests/all/api.rs
@@ -180,7 +180,7 @@ async fn api_reactor() -> Result<()> {
     // `host` crate for `streams`, not because of `with` in the bindgen macro.
     let writepipe = preview2::pipe::MemoryOutputPipe::new(4096);
     let stream: preview2::OutputStream = Box::new(writepipe.clone());
-    let table_ix = store.data_mut().table_mut().push_resource(stream)?;
+    let table_ix = store.data_mut().table_mut().push(stream)?;
     let r = reactor.call_write_strings_to(&mut store, table_ix).await?;
     assert_eq!(r, Ok(()));
 


### PR DESCRIPTION
* Move around some internal methods and internalize what we can.
* Rename all `*_resource` methods to drop the suffix.
* Lean more into "wrong table usage is a trap" and remove the `delete` logic which re-inserted a parent link, if needed, on downcast errors.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
