### PR TITLE
fuzzgen: Enable some `fcvt` instructions on AArch64

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -636,7 +636,8 @@ fn valid_for_target(triple: &Triple, op: Opcode, args: &[Type], rets: &[Type]) -
                         | Opcode::FcvtToUintSat
                         | Opcode::FcvtToSint
                         | Opcode::FcvtToSintSat,
-                    &[F32 | F64]
+                    &[F32 | F64],
+                    &[I128]
                 ),
                 // https://github.com/bytecodealliance/wasmtime/issues/4933
                 (


### PR DESCRIPTION
👋 Hey,

This PR relaxes our restriction on `fcvt_to_*int` instruction for AArch64. Currently all forms of this instruction are being rejected, however they are mostly implemented. Only versions that produce `i128`'s are unimplemented as mentioned in #4934. So lets fuzz the remaining variants of this instruction.