### PR TITLE
Introduce API for custom stack memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3523,6 +3523,7 @@ dependencies = [
 name = "wasmtime-fiber"
 version = "15.0.0"
 dependencies = [
+ "anyhow",
  "backtrace",
  "cc",
  "cfg-if",

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true
 
 [dependencies]
+anyhow = { workspace = true }
 cfg-if = { workspace = true }
 wasmtime-versioned-export-macros = { workspace = true }
 

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -31,21 +31,28 @@
 
 #![allow(unused_macros)]
 
-use crate::RunResult;
+use crate::{RunResult, RuntimeFiberStack};
 use std::cell::Cell;
 use std::io;
 use std::ops::Range;
 use std::ptr;
 
-#[derive(Debug)]
-pub struct FiberStack {
-    // The top of the stack; for stacks allocated by the fiber implementation itself,
-    // the base address of the allocation will be `top.sub(len.unwrap())`
-    top: *mut u8,
-    // The length of the stack
-    len: usize,
-    // whether or not this stack was mmap'd
-    mmap: bool,
+pub enum FiberStack {
+    Mmap {
+        // The top of the stack; for stacks allocated by the fiber implementation itself,
+        // the base address of the allocation will be `top.sub(len.unwrap())`
+        top: *mut u8,
+        // The length of the stack
+        len: usize,
+    },
+    Manual {
+        // The top of the stack; for stacks allocated by the fiber implementation itself,
+        // the base address of the allocation will be `top.sub(len.unwrap())`
+        top: *mut u8,
+        // The length of the stack
+        len: usize,
+    },
+    Custom(Box<dyn RuntimeFiberStack>),
 }
 
 impl FiberStack {
@@ -75,37 +82,52 @@ impl FiberStack {
                 rustix::mm::MprotectFlags::READ | rustix::mm::MprotectFlags::WRITE,
             )?;
 
-            Ok(Self {
+            Ok(Self::Mmap {
                 top: mmap.cast::<u8>().add(mmap_len),
                 len: mmap_len,
-                mmap: true,
             })
         }
     }
 
     pub unsafe fn from_raw_parts(base: *mut u8, len: usize) -> io::Result<Self> {
-        Ok(Self {
+        Ok(Self::Manual {
             top: base.add(len),
             len,
-            mmap: false,
         })
     }
 
+    pub fn from_custom(custom: Box<dyn RuntimeFiberStack>) -> io::Result<Self> {
+        Ok(Self::Custom(custom))
+    }
+
     pub fn top(&self) -> Option<*mut u8> {
-        Some(self.top)
+        Some(match self {
+            FiberStack::Mmap { top, len: _ } => *top,
+            FiberStack::Manual { top, len: _ } => *top,
+            FiberStack::Custom(r) => r.top(),
+        })
     }
 
     pub fn range(&self) -> Option<Range<usize>> {
-        let base = unsafe { self.top.sub(self.len) as usize };
-        Some(base..base + self.len)
+        Some(match self {
+            FiberStack::Mmap { top, len } => {
+                let base = unsafe { top.sub(*len) as usize };
+                base..base + len
+            }
+            FiberStack::Manual { top, len } => {
+                let base = unsafe { top.sub(*len) as usize };
+                base..base + len
+            }
+            FiberStack::Custom(r) => r.range(),
+        })
     }
 }
 
 impl Drop for FiberStack {
     fn drop(&mut self) {
         unsafe {
-            if self.mmap {
-                let ret = rustix::mm::munmap(self.top.sub(self.len) as _, self.len);
+            if let FiberStack::Mmap { top, len } = self {
+                let ret = rustix::mm::munmap(top.sub(*len) as _, *len);
                 debug_assert!(ret.is_ok());
             }
         }
@@ -148,7 +170,7 @@ impl Fiber {
     {
         unsafe {
             let data = Box::into_raw(Box::new(func)).cast();
-            wasmtime_fiber_init(stack.top, fiber_start::<F, A, B, C>, data);
+            wasmtime_fiber_init(stack.top().unwrap(), fiber_start::<F, A, B, C>, data);
         }
 
         Ok(Self)
@@ -160,10 +182,10 @@ impl Fiber {
             // stack, otherwise known as our reserved slot for this information.
             //
             // In the diagram above this is updating address 0xAff8
-            let addr = stack.top.cast::<usize>().offset(-1);
+            let addr = stack.top().unwrap().cast::<usize>().offset(-1);
             addr.write(result as *const _ as usize);
 
-            wasmtime_fiber_switch(stack.top);
+            wasmtime_fiber_switch(stack.top().unwrap());
 
             // null this out to help catch use-after-free
             addr.write(0);

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -1,4 +1,4 @@
-use crate::RunResult;
+use crate::{RunResult, RuntimeFiberStack};
 use std::cell::Cell;
 use std::ffi::c_void;
 use std::io;
@@ -16,6 +16,10 @@ impl FiberStack {
     }
 
     pub unsafe fn from_raw_parts(_base: *mut u8, _len: usize) -> io::Result<Self> {
+        Err(io::Error::from_raw_os_error(ERROR_NOT_SUPPORTED as i32))
+    }
+
+    pub fn from_custom(custom: Box<dyn RuntimeFiberStack>) -> io::Result<Self> {
         Err(io::Error::from_raw_os_error(ERROR_NOT_SUPPORTED as i32))
     }
 

--- a/crates/fiber/src/windows.rs
+++ b/crates/fiber/src/windows.rs
@@ -19,7 +19,7 @@ impl FiberStack {
         Err(io::Error::from_raw_os_error(ERROR_NOT_SUPPORTED as i32))
     }
 
-    pub fn from_custom(custom: Box<dyn RuntimeFiberStack>) -> io::Result<Self> {
+    pub fn from_custom(_custom: Box<dyn RuntimeFiberStack>) -> io::Result<Self> {
         Err(io::Error::from_raw_os_error(ERROR_NOT_SUPPORTED as i32))
     }
 

--- a/crates/runtime/src/instance/allocator/on_demand.rs
+++ b/crates/runtime/src/instance/allocator/on_demand.rs
@@ -33,22 +33,20 @@ pub struct OnDemandInstanceAllocator {
 
 impl OnDemandInstanceAllocator {
     /// Creates a new on-demand instance allocator.
-    #[cfg(feature = "async")]
-    pub fn new(
-        mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>,
-        stack_creator: Option<Arc<dyn RuntimeFiberStackCreator>>,
-        stack_size: usize,
-    ) -> Self {
+    pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>, stack_size: usize) -> Self {
         Self {
             mem_creator,
-            stack_creator,
+            #[cfg(feature = "async")]
+            stack_creator: None,
             #[cfg(feature = "async")]
             stack_size,
         }
     }
-    #[cfg(not(feature = "async"))]
-    pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>) -> Self {
-        Self { mem_creator }
+
+    /// Set the stack creator.
+    #[cfg(feature = "async")]
+    pub fn set_stack_creator(&mut self, stack_creator: Arc<dyn RuntimeFiberStackCreator>) {
+        self.stack_creator = Some(stack_creator);
     }
 }
 

--- a/crates/runtime/src/instance/allocator/on_demand.rs
+++ b/crates/runtime/src/instance/allocator/on_demand.rs
@@ -12,6 +12,9 @@ use wasmtime_environ::{
     DefinedMemoryIndex, DefinedTableIndex, HostPtr, MemoryPlan, Module, TablePlan, VMOffsets,
 };
 
+#[cfg(feature = "async")]
+use wasmtime_fiber::RuntimeFiberStackCreator;
+
 #[cfg(feature = "component-model")]
 use wasmtime_environ::{
     component::{Component, VMComponentOffsets},
@@ -23,18 +26,29 @@ use wasmtime_environ::{
 pub struct OnDemandInstanceAllocator {
     mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>,
     #[cfg(feature = "async")]
+    stack_creator: Option<Arc<dyn RuntimeFiberStackCreator>>,
+    #[cfg(feature = "async")]
     stack_size: usize,
 }
 
 impl OnDemandInstanceAllocator {
     /// Creates a new on-demand instance allocator.
-    pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>, stack_size: usize) -> Self {
-        let _ = stack_size; // suppress unused warnings w/o async feature
+    #[cfg(feature = "async")]
+    pub fn new(
+        mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>,
+        stack_creator: Option<Arc<dyn RuntimeFiberStackCreator>>,
+        stack_size: usize,
+    ) -> Self {
         Self {
             mem_creator,
+            stack_creator,
             #[cfg(feature = "async")]
             stack_size,
         }
+    }
+    #[cfg(not(feature = "async"))]
+    pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>) -> Self {
+        Self { mem_creator }
     }
 }
 
@@ -42,6 +56,8 @@ impl Default for OnDemandInstanceAllocator {
     fn default() -> Self {
         Self {
             mem_creator: None,
+            #[cfg(feature = "async")]
+            stack_creator: None,
             #[cfg(feature = "async")]
             stack_size: 0,
         }
@@ -141,8 +157,13 @@ unsafe impl InstanceAllocatorImpl for OnDemandInstanceAllocator {
         if self.stack_size == 0 {
             anyhow::bail!("fiber stacks are not supported by the allocator")
         }
-
-        let stack = wasmtime_fiber::FiberStack::new(self.stack_size)?;
+        let stack = match &self.stack_creator {
+            Some(stack_creator) => {
+                let stack = stack_creator.new_stack(self.stack_size)?;
+                wasmtime_fiber::FiberStack::from_custom(stack)
+            }
+            None => wasmtime_fiber::FiberStack::new(self.stack_size),
+        }?;
         Ok(stack)
     }
 

--- a/crates/runtime/src/instance/allocator/on_demand.rs
+++ b/crates/runtime/src/instance/allocator/on_demand.rs
@@ -34,6 +34,7 @@ pub struct OnDemandInstanceAllocator {
 impl OnDemandInstanceAllocator {
     /// Creates a new on-demand instance allocator.
     pub fn new(mem_creator: Option<Arc<dyn RuntimeMemoryCreator>>, stack_size: usize) -> Self {
+        let _ = stack_size; // suppress warnings when async feature is disabled.
         Self {
             mem_creator,
             #[cfg(feature = "async")]

--- a/crates/runtime/src/instance/allocator/pooling/stack_pool.rs
+++ b/crates/runtime/src/instance/allocator/pooling/stack_pool.rs
@@ -213,7 +213,7 @@ mod tests {
 
         assert_eq!(pool.index_allocator.testing_freelist(), []);
 
-        pool.allocate().unwrap_err();
+        assert!(pool.allocate().is_err(), "allocation should fail");
 
         for stack in stacks {
             unsafe {

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -16,6 +16,11 @@ use wasmtime_environ::Tunables;
 use wasmtime_jit::profiling::{self, ProfilingAgent};
 use wasmtime_runtime::{mpk, InstanceAllocator, OnDemandInstanceAllocator, RuntimeMemoryCreator};
 
+#[cfg(feature = "async")]
+use crate::stack::{StackCreator, StackCreatorProxy};
+#[cfg(feature = "async")]
+use wasmtime_fiber::RuntimeFiberStackCreator;
+
 pub use wasmtime_environ::CacheStore;
 pub use wasmtime_runtime::MpkEnabled;
 
@@ -105,6 +110,8 @@ pub struct Config {
     pub(crate) native_unwind_info: Option<bool>,
     #[cfg(feature = "async")]
     pub(crate) async_stack_size: usize,
+    #[cfg(feature = "async")]
+    pub(crate) stack_creator: Option<Arc<dyn RuntimeFiberStackCreator>>,
     pub(crate) async_support: bool,
     pub(crate) module_version: ModuleVersionStrategy,
     pub(crate) parallel_compilation: bool,
@@ -199,6 +206,8 @@ impl Config {
             features: WasmFeatures::default(),
             #[cfg(feature = "async")]
             async_stack_size: 2 << 20,
+            #[cfg(feature = "async")]
+            stack_creator: None,
             async_support: false,
             module_version: ModuleVersionStrategy::default(),
             parallel_compilation: !cfg!(miri),
@@ -1084,6 +1093,17 @@ impl Config {
         self
     }
 
+    /// Sets a custom stack creator.
+    ///
+    /// Custom memory creators are used when creating creating async instance stacks for
+    /// the on-demand instance allocation strategy.
+    #[cfg(feature = "async")]
+    #[cfg_attr(nightlydoc, doc(cfg(feature = "async")))]
+    pub fn with_host_stack(&mut self, stack_creator: Arc<dyn StackCreator>) -> &mut Self {
+        self.stack_creator = Some(Arc::new(StackCreatorProxy(stack_creator)));
+        self
+    }
+
     /// Sets the instance allocation strategy to use.
     ///
     /// When using the pooling instance allocation strategy, all linear memories
@@ -1566,19 +1586,25 @@ impl Config {
     }
 
     pub(crate) fn build_allocator(&self) -> Result<Box<dyn InstanceAllocator + Send + Sync>> {
-        #[cfg(feature = "async")]
-        let stack_size = self.async_stack_size;
-
-        #[cfg(not(feature = "async"))]
-        let stack_size = 0;
-
         match &self.allocation_strategy {
+            #[cfg(feature = "async")]
             InstanceAllocationStrategy::OnDemand => Ok(Box::new(OnDemandInstanceAllocator::new(
                 self.mem_creator.clone(),
-                stack_size,
+                self.stack_creator.clone(),
+                self.async_stack_size,
+            ))),
+            #[cfg(not(feature = "async"))]
+            InstanceAllocationStrategy::OnDemand => Ok(Box::new(OnDemandInstanceAllocator::new(
+                self.mem_creator.clone(),
             ))),
             #[cfg(feature = "pooling-allocator")]
             InstanceAllocationStrategy::Pooling(config) => {
+                #[cfg(feature = "async")]
+                let stack_size = self.async_stack_size;
+
+                #[cfg(not(feature = "async"))]
+                let stack_size = 0;
+
                 let mut config = config.config;
                 config.stack_size = stack_size;
                 Ok(Box::new(wasmtime_runtime::PoolingInstanceAllocator::new(

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -414,6 +414,9 @@ mod types;
 mod v128;
 mod values;
 
+#[cfg(feature = "async")]
+mod stack;
+
 pub use crate::config::*;
 pub use crate::coredump::*;
 pub use crate::engine::*;
@@ -436,6 +439,9 @@ pub use crate::trap::*;
 pub use crate::types::*;
 pub use crate::v128::V128;
 pub use crate::values::*;
+
+#[cfg(feature = "async")]
+pub use crate::stack::*;
 
 /// A convenience wrapper for `Result<T, anyhow::Error>`.
 ///

--- a/crates/wasmtime/src/stack.rs
+++ b/crates/wasmtime/src/stack.rs
@@ -1,0 +1,73 @@
+use std::{ops::Range, sync::Arc};
+
+use anyhow::Error;
+use wasmtime_fiber::{RuntimeFiberStack, RuntimeFiberStackCreator};
+
+/// A stack creator. Can be used to provide a stack creator to wasmtime
+/// which supplies stacks for async support.
+///
+/// # Safety
+///
+/// This trait is unsafe, as memory safety depends on a proper implemenation
+/// of memory management. Stacks created by the StackCreator should always be
+/// treated as owned by an wasmtime instance, and any modification of them
+/// outside of wasmtime invoked routines is unsafe and may lead to corruption.
+///
+/// Note that this is a relatively new and experimental feature and it is
+/// recommended to be familiar with wasmtime runtime code to use it.
+pub unsafe trait StackCreator: Send + Sync {
+    /// Create a new `StackMemory` object with the specified size.
+    ///
+    /// The `size` parameter is the expected size of the stack without any guard pages.
+    ///
+    /// Note there should be at least one guard page of protected memory at the bottom
+    /// of the stack to catch potential stack overflow scenarios. Additionally, stacks should be
+    /// page aligned.
+    fn new_stack(&self, size: usize) -> Result<Box<dyn StackMemory>, Error>;
+}
+
+#[derive(Clone)]
+pub(crate) struct StackCreatorProxy(pub Arc<dyn StackCreator>);
+
+unsafe impl RuntimeFiberStackCreator for StackCreatorProxy {
+    fn new_stack(&self, size: usize) -> Result<Box<dyn RuntimeFiberStack>, Error> {
+        let stack = self.0.new_stack(size)?;
+        Ok(Box::new(FiberStackProxy(stack)) as Box<dyn RuntimeFiberStack>)
+    }
+}
+
+/// A stack memory. This trait provides an interface for raw memory buffers
+/// which are used by wasmtime inside of stacks which wasmtime executes
+/// WebAssembly in for async support. By implementing this trait together
+/// with StackCreator, one can supply wasmtime with custom allocated host
+/// managed stacks.
+///
+/// # Safety
+///
+/// The memory should be page aligned and a multiple of page size.
+/// To prevent possible silent overflows, the memory should be protected by a
+/// guard page. Additionally the safety concerns explained in ['Memory'], for
+/// accessing the memory apply here as well.
+///
+/// Note that this is a relatively new and experimental feature and it is
+/// recommended to be familiar with wasmtime runtime code to use it.
+pub unsafe trait StackMemory: Send + Sync {
+    /// The top of the allocated stack.
+    ///
+    /// This address should be page aligned.
+    fn top(&self) -> *mut u8;
+    /// The range of where this stack resides in memory, excluding guard pages.
+    fn range(&self) -> Range<usize>;
+}
+
+pub(crate) struct FiberStackProxy(pub Box<dyn StackMemory>);
+
+unsafe impl RuntimeFiberStack for FiberStackProxy {
+    fn top(&self) -> *mut u8 {
+        self.0.top()
+    }
+
+    fn range(&self) -> Range<usize> {
+        self.0.range()
+    }
+}

--- a/crates/wasmtime/src/stack.rs
+++ b/crates/wasmtime/src/stack.rs
@@ -8,7 +8,7 @@ use wasmtime_fiber::{RuntimeFiberStack, RuntimeFiberStackCreator};
 ///
 /// # Safety
 ///
-/// This trait is unsafe, as memory safety depends on a proper implemenation
+/// This trait is unsafe, as memory safety depends on a proper implementation
 /// of memory management. Stacks created by the StackCreator should always be
 /// treated as owned by an wasmtime instance, and any modification of them
 /// outside of wasmtime invoked routines is unsafe and may lead to corruption.

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -41,10 +41,7 @@ fn create_handle(
         let module = Arc::new(module);
         let runtime_info =
             &BareModuleInfo::maybe_imported_func(module, one_signature).into_traitobj();
-        #[cfg(feature = "async")]
-        let allocator = OnDemandInstanceAllocator::new(config.mem_creator.clone(), None, 0);
-        #[cfg(not(feature = "async"))]
-        let allocator = OnDemandInstanceAllocator::new(config.mem_creator.clone());
+        let allocator = OnDemandInstanceAllocator::new(config.mem_creator.clone(), 0);
         let handle = allocator.allocate_module(InstanceAllocationRequest {
             imports,
             host_state,

--- a/crates/wasmtime/src/trampoline.rs
+++ b/crates/wasmtime/src/trampoline.rs
@@ -41,15 +41,18 @@ fn create_handle(
         let module = Arc::new(module);
         let runtime_info =
             &BareModuleInfo::maybe_imported_func(module, one_signature).into_traitobj();
-        let handle = OnDemandInstanceAllocator::new(config.mem_creator.clone(), 0)
-            .allocate_module(InstanceAllocationRequest {
-                imports,
-                host_state,
-                store: StorePtr::new(store.traitobj()),
-                runtime_info,
-                wmemcheck: false,
-                pkey: None,
-            })?;
+        #[cfg(feature = "async")]
+        let allocator = OnDemandInstanceAllocator::new(config.mem_creator.clone(), None, 0);
+        #[cfg(not(feature = "async"))]
+        let allocator = OnDemandInstanceAllocator::new(config.mem_creator.clone());
+        let handle = allocator.allocate_module(InstanceAllocationRequest {
+            imports,
+            host_state,
+            store: StorePtr::new(store.traitobj()),
+            runtime_info,
+            wmemcheck: false,
+            pkey: None,
+        })?;
 
         Ok(store.add_dummy_instance(handle))
     }

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -30,6 +30,7 @@ mod module_serialize;
 mod name;
 mod pooling_allocator;
 mod relocs;
+mod stack_creator;
 mod stack_overflow;
 mod store;
 mod table;

--- a/tests/all/stack_creator.rs
+++ b/tests/all/stack_creator.rs
@@ -1,157 +1,155 @@
-#[cfg(all(not(target_os = "windows"), not(miri)))]
-mod not_for_windows {
-    use anyhow::{bail, Context};
-    use std::{
-        alloc::{GlobalAlloc, Layout, System},
-        ops::Range,
-        ptr::NonNull,
-        sync::Arc,
-    };
-    use wasmtime::*;
+#![cfg(all(not(target_os = "windows"), not(miri)))]
+use anyhow::{bail, Context};
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    ops::Range,
+    ptr::NonNull,
+    sync::Arc,
+};
+use wasmtime::*;
 
-    fn align_up(v: usize, align: usize) -> usize {
-        return (v + (align - 1)) & (!(align - 1));
-    }
+fn align_up(v: usize, align: usize) -> usize {
+    return (v + (align - 1)) & (!(align - 1));
+}
 
-    struct CustomStack {
-        base: NonNull<u8>,
-        len: usize,
+struct CustomStack {
+    base: NonNull<u8>,
+    len: usize,
+}
+unsafe impl Send for CustomStack {}
+unsafe impl Sync for CustomStack {}
+impl CustomStack {
+    fn new(base: NonNull<u8>, len: usize) -> Self {
+        CustomStack { base, len }
     }
-    unsafe impl Send for CustomStack {}
-    unsafe impl Sync for CustomStack {}
-    impl CustomStack {
-        fn new(base: NonNull<u8>, len: usize) -> Self {
-            CustomStack { base, len }
-        }
+}
+unsafe impl StackMemory for CustomStack {
+    fn top(&self) -> *mut u8 {
+        unsafe { self.base.as_ptr().add(self.len) }
     }
-    unsafe impl StackMemory for CustomStack {
-        fn top(&self) -> *mut u8 {
-            unsafe { self.base.as_ptr().add(self.len) }
-        }
-        fn range(&self) -> Range<usize> {
-            let base = self.base.as_ptr() as usize;
-            base..base + self.len
-        }
+    fn range(&self) -> Range<usize> {
+        let base = self.base.as_ptr() as usize;
+        base..base + self.len
     }
+}
 
-    // A creator that allocates stacks on the heap instead of mmap'ing.
-    struct CustomStackCreator {
-        memory: NonNull<u8>,
-        size: usize,
-        layout: Layout,
-    }
+// A creator that allocates stacks on the heap instead of mmap'ing.
+struct CustomStackCreator {
+    memory: NonNull<u8>,
+    size: usize,
+    layout: Layout,
+}
 
-    unsafe impl Send for CustomStackCreator {}
-    unsafe impl Sync for CustomStackCreator {}
-    impl CustomStackCreator {
-        fn new() -> Result<Self> {
-            // 1MB
-            const MINIMUM_STACK_SIZE: usize = 1 * 1_024 * 1_024;
-            let page_size = rustix::param::page_size();
-            let size = align_up(MINIMUM_STACK_SIZE, page_size);
-            // Add an extra page for the guard page
-            let layout = Layout::from_size_align(size + page_size, page_size)
-                .context("unable to compute stack layout")?;
-            let memory = unsafe {
-                let mem = System.alloc(layout);
-                let notnull = NonNull::new(mem);
-                if let Some(mem) = notnull {
-                    // Mark guard page as protected
-                    rustix::mm::mprotect(
-                        mem.as_ptr().cast(),
-                        page_size,
-                        rustix::mm::MprotectFlags::empty(),
-                    )?;
-                }
-                notnull
-            }
-            .context("unable to allocate stack memory")?;
-            Ok(CustomStackCreator {
-                memory,
-                size,
-                layout,
-            })
-        }
-        fn range(&self) -> Range<usize> {
-            let page_size = rustix::param::page_size();
-            let base = unsafe { self.memory.as_ptr().add(page_size) as usize };
-            base..base + self.size
-        }
-    }
-    impl Drop for CustomStackCreator {
-        fn drop(&mut self) {
-            let page_size = rustix::param::page_size();
-            unsafe {
-                // Unprotect the guard page as the allocator could reuse it.
+unsafe impl Send for CustomStackCreator {}
+unsafe impl Sync for CustomStackCreator {}
+impl CustomStackCreator {
+    fn new() -> Result<Self> {
+        // 1MB
+        const MINIMUM_STACK_SIZE: usize = 1 * 1_024 * 1_024;
+        let page_size = rustix::param::page_size();
+        let size = align_up(MINIMUM_STACK_SIZE, page_size);
+        // Add an extra page for the guard page
+        let layout = Layout::from_size_align(size + page_size, page_size)
+            .context("unable to compute stack layout")?;
+        let memory = unsafe {
+            let mem = System.alloc(layout);
+            let notnull = NonNull::new(mem);
+            if let Some(mem) = notnull {
+                // Mark guard page as protected
                 rustix::mm::mprotect(
-                    self.memory.as_ptr().cast(),
+                    mem.as_ptr().cast(),
                     page_size,
-                    rustix::mm::MprotectFlags::READ | rustix::mm::MprotectFlags::WRITE,
-                )
-                .unwrap();
-                System.dealloc(self.memory.as_ptr(), self.layout);
+                    rustix::mm::MprotectFlags::empty(),
+                )?;
             }
+            notnull
+        }
+        .context("unable to allocate stack memory")?;
+        Ok(CustomStackCreator {
+            memory,
+            size,
+            layout,
+        })
+    }
+    fn range(&self) -> Range<usize> {
+        let page_size = rustix::param::page_size();
+        let base = unsafe { self.memory.as_ptr().add(page_size) as usize };
+        base..base + self.size
+    }
+}
+impl Drop for CustomStackCreator {
+    fn drop(&mut self) {
+        let page_size = rustix::param::page_size();
+        unsafe {
+            // Unprotect the guard page as the allocator could reuse it.
+            rustix::mm::mprotect(
+                self.memory.as_ptr().cast(),
+                page_size,
+                rustix::mm::MprotectFlags::READ | rustix::mm::MprotectFlags::WRITE,
+            )
+            .unwrap();
+            System.dealloc(self.memory.as_ptr(), self.layout);
         }
     }
-    unsafe impl StackCreator for CustomStackCreator {
-        fn new_stack(&self, size: usize) -> Result<Box<dyn StackMemory>> {
-            if size != self.size {
-                bail!("must use the size we allocated for this stack memory creator");
-            }
-            let page_size = rustix::param::page_size();
-            // skip over the page size
-            let base_ptr = unsafe { self.memory.as_ptr().add(page_size) };
-            let base = NonNull::new(base_ptr).context("unable to compute stack base")?;
-            Ok(Box::new(CustomStack::new(base, self.size)))
+}
+unsafe impl StackCreator for CustomStackCreator {
+    fn new_stack(&self, size: usize) -> Result<Box<dyn StackMemory>> {
+        if size != self.size {
+            bail!("must use the size we allocated for this stack memory creator");
         }
+        let page_size = rustix::param::page_size();
+        // skip over the page size
+        let base_ptr = unsafe { self.memory.as_ptr().add(page_size) };
+        let base = NonNull::new(base_ptr).context("unable to compute stack base")?;
+        Ok(Box::new(CustomStack::new(base, self.size)))
     }
+}
 
-    fn config() -> (Store<()>, Arc<CustomStackCreator>) {
-        let stack_creator = Arc::new(CustomStackCreator::new().unwrap());
-        let mut config = Config::new();
-        config
-            .async_support(true)
-            .max_wasm_stack(stack_creator.size / 2)
-            .async_stack_size(stack_creator.size)
-            .with_host_stack(stack_creator.clone());
-        (
-            Store::new(&Engine::new(&config).unwrap(), ()),
-            stack_creator,
-        )
-    }
+fn config() -> (Store<()>, Arc<CustomStackCreator>) {
+    let stack_creator = Arc::new(CustomStackCreator::new().unwrap());
+    let mut config = Config::new();
+    config
+        .async_support(true)
+        .max_wasm_stack(stack_creator.size / 2)
+        .async_stack_size(stack_creator.size)
+        .with_host_stack(stack_creator.clone());
+    (
+        Store::new(&Engine::new(&config).unwrap(), ()),
+        stack_creator,
+    )
+}
 
-    #[tokio::test]
-    async fn called_on_custom_heap_stack() -> Result<()> {
-        let (mut store, stack_creator) = config();
-        let module = Module::new(
-            store.engine(),
-            r#"
+#[tokio::test]
+async fn called_on_custom_heap_stack() -> Result<()> {
+    let (mut store, stack_creator) = config();
+    let module = Module::new(
+        store.engine(),
+        r#"
             (module
                 (import "host" "callback" (func $callback (result i64)))
                 (func $f (result i64) (call $callback))
                 (export "f" (func $f))
             )
         "#,
-        )?;
+    )?;
 
-        let ty = FuncType::new([], [ValType::I64]);
-        let host_func = Func::new(&mut store, ty, move |_caller, _params, results| {
-            let foo = 42;
-            // output an address on the stack
-            results[0] = Val::I64((&foo as *const i32) as usize as i64);
-            Ok(())
-        });
-        let export = wasmtime::Extern::Func(host_func);
-        let instance = Instance::new_async(&mut store, &module, &[export]).await?;
-        let mut results = [Val::I64(0)];
-        instance
-            .get_func(&mut store, "f")
-            .context("missing function export")?
-            .call_async(&mut store, &[], &mut results)
-            .await?;
-        // Make sure the stack address we wrote was within our custom stack range
-        let stack_address = results[0].i64().unwrap() as usize;
-        assert!(stack_creator.range().contains(&stack_address));
+    let ty = FuncType::new([], [ValType::I64]);
+    let host_func = Func::new(&mut store, ty, move |_caller, _params, results| {
+        let foo = 42;
+        // output an address on the stack
+        results[0] = Val::I64((&foo as *const i32) as usize as i64);
         Ok(())
-    }
+    });
+    let export = wasmtime::Extern::Func(host_func);
+    let instance = Instance::new_async(&mut store, &module, &[export]).await?;
+    let mut results = [Val::I64(0)];
+    instance
+        .get_func(&mut store, "f")
+        .context("missing function export")?
+        .call_async(&mut store, &[], &mut results)
+        .await?;
+    // Make sure the stack address we wrote was within our custom stack range
+    let stack_address = results[0].i64().unwrap() as usize;
+    assert!(stack_creator.range().contains(&stack_address));
+    Ok(())
 }

--- a/tests/all/stack_creator.rs
+++ b/tests/all/stack_creator.rs
@@ -1,0 +1,157 @@
+#[cfg(all(not(target_os = "windows"), not(miri)))]
+mod not_for_windows {
+    use anyhow::{bail, Context};
+    use std::{
+        alloc::{GlobalAlloc, Layout, System},
+        ops::Range,
+        ptr::NonNull,
+        sync::Arc,
+    };
+    use wasmtime::*;
+
+    fn align_up(v: usize, align: usize) -> usize {
+        return (v + (align - 1)) & (!(align - 1));
+    }
+
+    struct CustomStack {
+        base: NonNull<u8>,
+        len: usize,
+    }
+    unsafe impl Send for CustomStack {}
+    unsafe impl Sync for CustomStack {}
+    impl CustomStack {
+        fn new(base: NonNull<u8>, len: usize) -> Self {
+            CustomStack { base, len }
+        }
+    }
+    unsafe impl StackMemory for CustomStack {
+        fn top(&self) -> *mut u8 {
+            unsafe { self.base.as_ptr().add(self.len) }
+        }
+        fn range(&self) -> Range<usize> {
+            let base = self.base.as_ptr() as usize;
+            base..base + self.len
+        }
+    }
+
+    // A creator that allocates stacks on the heap instead of mmap'ing.
+    struct CustomStackCreator {
+        memory: NonNull<u8>,
+        size: usize,
+        layout: Layout,
+    }
+
+    unsafe impl Send for CustomStackCreator {}
+    unsafe impl Sync for CustomStackCreator {}
+    impl CustomStackCreator {
+        fn new() -> Result<Self> {
+            // 1MB
+            const MINIMUM_STACK_SIZE: usize = 1 * 1_024 * 1_024;
+            let page_size = rustix::param::page_size();
+            let size = align_up(MINIMUM_STACK_SIZE, page_size);
+            // Add an extra page for the guard page
+            let layout = Layout::from_size_align(size + page_size, page_size)
+                .context("unable to compute stack layout")?;
+            let memory = unsafe {
+                let mem = System.alloc(layout);
+                let notnull = NonNull::new(mem);
+                if let Some(mem) = notnull {
+                    // Mark guard page as protected
+                    rustix::mm::mprotect(
+                        mem.as_ptr().cast(),
+                        page_size,
+                        rustix::mm::MprotectFlags::empty(),
+                    )?;
+                }
+                notnull
+            }
+            .context("unable to allocate stack memory")?;
+            Ok(CustomStackCreator {
+                memory,
+                size,
+                layout,
+            })
+        }
+        fn range(&self) -> Range<usize> {
+            let page_size = rustix::param::page_size();
+            let base = unsafe { self.memory.as_ptr().add(page_size) as usize };
+            base..base + self.size
+        }
+    }
+    impl Drop for CustomStackCreator {
+        fn drop(&mut self) {
+            let page_size = rustix::param::page_size();
+            unsafe {
+                // Unprotect the guard page as the allocator could reuse it.
+                rustix::mm::mprotect(
+                    self.memory.as_ptr().cast(),
+                    page_size,
+                    rustix::mm::MprotectFlags::READ | rustix::mm::MprotectFlags::WRITE,
+                )
+                .unwrap();
+                System.dealloc(self.memory.as_ptr(), self.layout);
+            }
+        }
+    }
+    unsafe impl StackCreator for CustomStackCreator {
+        fn new_stack(&self, size: usize) -> Result<Box<dyn StackMemory>> {
+            if size != self.size {
+                bail!("must use the size we allocated for this stack memory creator");
+            }
+            let page_size = rustix::param::page_size();
+            // skip over the page size
+            let base_ptr = unsafe { self.memory.as_ptr().add(page_size) };
+            let base = NonNull::new(base_ptr).context("unable to compute stack base")?;
+            Ok(Box::new(CustomStack::new(base, self.size)))
+        }
+    }
+
+    fn config() -> (Store<()>, Arc<CustomStackCreator>) {
+        let stack_creator = Arc::new(CustomStackCreator::new().unwrap());
+        let mut config = Config::new();
+        config
+            .async_support(true)
+            .max_wasm_stack(stack_creator.size / 2)
+            .async_stack_size(stack_creator.size)
+            .with_host_stack(stack_creator.clone());
+        (
+            Store::new(&Engine::new(&config).unwrap(), ()),
+            stack_creator,
+        )
+    }
+
+    #[tokio::test]
+    async fn called_on_custom_heap_stack() -> Result<()> {
+        let (mut store, stack_creator) = config();
+        let module = Module::new(
+            store.engine(),
+            r#"
+            (module
+                (import "host" "callback" (func $callback (result i64)))
+                (func $f (result i64) (call $callback))
+                (export "f" (func $f))
+            )
+        "#,
+        )?;
+
+        let ty = FuncType::new([], [ValType::I64]);
+        let host_func = Func::new(&mut store, ty, move |_caller, _params, results| {
+            let foo = 42;
+            // output an address on the stack
+            results[0] = Val::I64((&foo as *const i32) as usize as i64);
+            Ok(())
+        });
+        let export = wasmtime::Extern::Func(host_func);
+        let instance = Instance::new_async(&mut store, &module, &[export]).await?;
+        let mut results = [Val::I64(0)];
+        instance
+            .get_func(&mut store, "f")
+            .context("missing function export")?
+            .call_async(&mut store, &[], &mut results)
+            .await?;
+        // Make sure the stack address we wrote was within our custom stack range
+        let stack_address = results[0].i64().unwrap() as usize;
+        assert!(stack_creator.range().contains(&stack_address));
+        Ok(())
+    }
+}


### PR DESCRIPTION
Introduces an API to allow embedders to allocate stacks for fibers using custom memory instead of mmap.

[Discussed on Zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime/topic/.E2.9C.94.20Custom.20allocator.20for.20Fibers)
