### PR TITLE
[14.0.0] Bindgen multi-version support

### DIFF
--- a/crates/component-macro/test-helpers/src/lib.rs
+++ b/crates/component-macro/test-helpers/src/lib.rs
@@ -10,7 +10,7 @@ pub fn foreach(input: TokenStream) -> TokenStream {
     let mut result = Vec::new();
     for f in cwd.read_dir().unwrap() {
         let f = f.unwrap().path();
-        if f.extension().and_then(|s| s.to_str()) == Some("wit") {
+        if f.extension().and_then(|s| s.to_str()) == Some("wit") || f.is_dir() {
             let name = f.file_stem().unwrap().to_str().unwrap();
             let ident = Ident::new(&name.replace("-", "_"), Span::call_site());
             let path = f.to_str().unwrap();

--- a/crates/component-macro/tests/codegen/multiversion/deps/v1/root.wit
+++ b/crates/component-macro/tests/codegen/multiversion/deps/v1/root.wit
@@ -1,0 +1,5 @@
+package my:dep@0.1.0;
+
+interface a {
+  x: func();
+}

--- a/crates/component-macro/tests/codegen/multiversion/deps/v2/root.wit
+++ b/crates/component-macro/tests/codegen/multiversion/deps/v2/root.wit
@@ -1,0 +1,5 @@
+package my:dep@0.2.0;
+
+interface a {
+  x: func();
+}

--- a/crates/component-macro/tests/codegen/multiversion/root.wit
+++ b/crates/component-macro/tests/codegen/multiversion/root.wit
@@ -3,4 +3,5 @@ package foo:bar;
 world foo {
   import my:dep/a@0.1.0;
   import my:dep/a@0.2.0;
+  export my:dep/a@0.2.0;
 }

--- a/crates/component-macro/tests/codegen/multiversion/root.wit
+++ b/crates/component-macro/tests/codegen/multiversion/root.wit
@@ -1,0 +1,6 @@
+package foo:bar;
+
+world foo {
+  import my:dep/a@0.1.0;
+  import my:dep/a@0.2.0;
+}

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -473,7 +473,7 @@ impl Wasmtime {
                         format!(
                             "exports::{}::{}::{snake}::{camel}",
                             pkgname.namespace.to_snake_case(),
-                            pkgname.name.to_snake_case(),
+                            self.name_package_module(resolve, iface.package.unwrap()),
                         ),
                         format!(
                             "{}_{}_{snake}",


### PR DESCRIPTION
Backport of #7172 and #7196 which allows for multi-version support in the `bindgen!` macro.
