### PR TITLE
Remove broken links from WASI-intro.md

### DIFF
--- a/docs/WASI-intro.md
+++ b/docs/WASI-intro.md
@@ -40,7 +40,7 @@ Currently the options are [Wasmtime] and the [browser polyfill], though we
 intend WASI to be implementable in many wasm VMs.
 
 [Wasmtime]: https://github.com/bytecodealliance/wasmtime
-[browser polyfill]: https://wasi.dev/polyfill/
+[browser polyfill]: https://github.com/bjorn3/browser_wasi_shim
 
 ### Wasmtime
 
@@ -52,9 +52,7 @@ or `cargo run --bin wasmtime foo.wasm`.
 
 ### The browser polyfill
 
-The polyfill is online [here](https://wasi.dev/polyfill/).
-
-The source is [here](https://github.com/bytecodealliance/wasmtime/tree/main/crates/wasi-c/js-polyfill).
+The source is [here](https://github.com/bjorn3/browser_wasi_shim).
 
 ## Where can I learn more?
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

The link to js-polyfill was broken and https://wasi.dev/polyfill/ points to [this repository](https://github.com/bjorn3/browser_wasi_shim) which is now linked in the docs