### PR TITLE
PCC: add basic "memory types".

### DIFF
--- a/cranelift/codegen/src/ir/dfg.rs
+++ b/cranelift/codegen/src/ir/dfg.rs
@@ -188,6 +188,7 @@ impl DataFlowGraph {
         self.constants.clear();
         self.immediates.clear();
         self.jump_tables.clear();
+        self.facts.clear();
     }
 
     /// Get the total number of instructions created in this function, whether they are currently

--- a/cranelift/codegen/src/ir/entities.rs
+++ b/cranelift/codegen/src/ir/entities.rs
@@ -435,6 +435,8 @@ pub enum AnyEntity {
     DynamicType(DynamicType),
     /// A Global value.
     GlobalValue(GlobalValue),
+    /// A memory type.
+    MemoryType(MemoryType),
     /// A jump table.
     JumpTable(JumpTable),
     /// A constant.
@@ -460,6 +462,7 @@ impl fmt::Display for AnyEntity {
             Self::DynamicStackSlot(r) => r.fmt(f),
             Self::DynamicType(r) => r.fmt(f),
             Self::GlobalValue(r) => r.fmt(f),
+            Self::MemoryType(r) => r.fmt(f),
             Self::JumpTable(r) => r.fmt(f),
             Self::Constant(r) => r.fmt(f),
             Self::FuncRef(r) => r.fmt(f),
@@ -515,6 +518,12 @@ impl From<DynamicType> for AnyEntity {
 impl From<GlobalValue> for AnyEntity {
     fn from(r: GlobalValue) -> Self {
         Self::GlobalValue(r)
+    }
+}
+
+impl From<MemoryType> for AnyEntity {
+    fn from(r: MemoryType) -> Self {
+        Self::MemoryType(r)
     }
 }
 

--- a/cranelift/codegen/src/ir/entities.rs
+++ b/cranelift/codegen/src/ir/entities.rs
@@ -209,6 +209,29 @@ impl GlobalValue {
     }
 }
 
+/// An opaque reference to a memory type.
+///
+/// A `MemoryType` is a descriptor of a struct layout in memory, with
+/// types and proof-carrying-code facts optionally attached to the
+/// fields.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct MemoryType(u32);
+entity_impl!(MemoryType, "mt");
+
+impl MemoryType {
+    /// Create a new memory type reference from its number.
+    ///
+    /// This method is for use by the parser.
+    pub fn with_number(n: u32) -> Option<Self> {
+        if n < u32::MAX {
+            Some(Self(n))
+        } else {
+            None
+        }
+    }
+}
+
 /// An opaque reference to a constant.
 ///
 /// You can store [`ConstantData`](super::ConstantData) in a

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -7,8 +7,8 @@ use crate::entity::{PrimaryMap, SecondaryMap};
 use crate::ir::{
     self, Block, DataFlowGraph, DynamicStackSlot, DynamicStackSlotData, DynamicStackSlots,
     DynamicType, ExtFuncData, FuncRef, GlobalValue, GlobalValueData, Inst, JumpTable,
-    JumpTableData, Layout, Opcode, SigRef, Signature, SourceLocs, StackSlot, StackSlotData,
-    StackSlots, Table, TableData, Type,
+    JumpTableData, Layout, MemoryType, MemoryTypeData, Opcode, SigRef, Signature, SourceLocs,
+    StackSlot, StackSlotData, StackSlots, Table, TableData, Type,
 };
 use crate::isa::CallConv;
 use crate::write::write_function;
@@ -173,7 +173,7 @@ pub struct FunctionStencil {
     pub global_values: PrimaryMap<ir::GlobalValue, ir::GlobalValueData>,
 
     /// Memory types for proof-carrying code.
-    pub mem_types: PrimaryMap<ir::MemoryType, ir::MemoryTypeData>,
+    pub memory_types: PrimaryMap<ir::MemoryType, ir::MemoryTypeData>,
 
     /// Tables referenced.
     pub tables: PrimaryMap<ir::Table, ir::TableData>,
@@ -204,7 +204,7 @@ impl FunctionStencil {
         self.sized_stack_slots.clear();
         self.dynamic_stack_slots.clear();
         self.global_values.clear();
-        self.mem_types.clear();
+        self.memory_types.clear();
         self.tables.clear();
         self.dfg.clear();
         self.layout.clear();
@@ -237,6 +237,11 @@ impl FunctionStencil {
     /// Declares a global value accessible to the function.
     pub fn create_global_value(&mut self, data: GlobalValueData) -> GlobalValue {
         self.global_values.push(data)
+    }
+
+    /// Declares a memory type for use by the function.
+    pub fn create_memory_type(&mut self, data: MemoryTypeData) -> MemoryType {
+        self.memory_types.push(data)
     }
 
     /// Find the global dyn_scale value associated with given DynamicType.
@@ -412,7 +417,7 @@ impl Function {
                 sized_stack_slots: StackSlots::new(),
                 dynamic_stack_slots: DynamicStackSlots::new(),
                 global_values: PrimaryMap::new(),
-                mem_types: PrimaryMap::new(),
+                memory_types: PrimaryMap::new(),
                 tables: PrimaryMap::new(),
                 dfg: DataFlowGraph::new(),
                 layout: Layout::new(),

--- a/cranelift/codegen/src/ir/function.rs
+++ b/cranelift/codegen/src/ir/function.rs
@@ -172,6 +172,9 @@ pub struct FunctionStencil {
     /// Global values referenced.
     pub global_values: PrimaryMap<ir::GlobalValue, ir::GlobalValueData>,
 
+    /// Memory types for proof-carrying code.
+    pub mem_types: PrimaryMap<ir::MemoryType, ir::MemoryTypeData>,
+
     /// Tables referenced.
     pub tables: PrimaryMap<ir::Table, ir::TableData>,
 
@@ -201,6 +204,7 @@ impl FunctionStencil {
         self.sized_stack_slots.clear();
         self.dynamic_stack_slots.clear();
         self.global_values.clear();
+        self.mem_types.clear();
         self.tables.clear();
         self.dfg.clear();
         self.layout.clear();
@@ -408,6 +412,7 @@ impl Function {
                 sized_stack_slots: StackSlots::new(),
                 dynamic_stack_slots: DynamicStackSlots::new(),
                 global_values: PrimaryMap::new(),
+                mem_types: PrimaryMap::new(),
                 tables: PrimaryMap::new(),
                 dfg: DataFlowGraph::new(),
                 layout: Layout::new(),

--- a/cranelift/codegen/src/ir/memtype.rs
+++ b/cranelift/codegen/src/ir/memtype.rs
@@ -62,6 +62,9 @@
 //! - A discriminated union is a union of several memory types
 //!   together with a tag field. This will be useful to model and
 //!   verify subtyping/downcasting for Wasm GC, among other uses.
+//!
+//! - Nullability on pointer fields: the fact will hold only if the
+//!   field is not null (all zero bits).
 
 use crate::ir::pcc::Fact;
 use crate::ir::Type;

--- a/cranelift/codegen/src/ir/memtype.rs
+++ b/cranelift/codegen/src/ir/memtype.rs
@@ -5,6 +5,7 @@
 //! can use in proof-carrying code to validate accesses to structs and
 //! propagate facts onto the loaded values as well.
 
+use crate::ir::entities::MemoryType;
 use crate::ir::pcc::Fact;
 use crate::ir::Type;
 use alloc::vec::Vec;
@@ -15,12 +16,81 @@ use serde_derive::{Deserialize, Serialize};
 /// Data defining a memory type.
 #[derive(Clone, PartialEq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-pub struct MemoryTypeData {
-    /// Size of this type.
-    pub size: u64,
+pub enum MemoryTypeData {
+    /// An aggregate consisting of certain fields at certain offsets.
+    Struct {
+        /// Size of this type.
+        size: u64,
 
-    /// Fields in this type. Sorted by offset.
-    pub fields: Vec<MemoryTypeField>,
+        /// Fields in this type. Sorted by offset.
+        fields: Vec<MemoryTypeField>,
+    },
+
+    /// An aggregate consisting of a single element repeated at a
+    /// certain stride, with a statically-known length (element
+    /// count). Layout is assumed to be contiguous, with a stride
+    /// equal to the element type's size (so, if the stride is greater
+    /// than the struct's packed size, be sure to include padding in
+    /// the memory-type definition).
+    StaticArray {
+        /// The element type. May be another array, a struct, etc.
+        element: MemoryType,
+
+        /// Number of elements.
+        length: u64,
+    },
+
+    /// A single Cranelift primitive of the given type stored in
+    /// memory.
+    Primitive {
+        /// The primitive type.
+        ty: Type,
+    },
+
+    /// A type with no size.
+    Empty,
+}
+
+impl std::default::Default for MemoryTypeData {
+    fn default() -> Self {
+        Self::Empty
+    }
+}
+
+impl std::fmt::Display for MemoryTypeData {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Struct { size, fields } => {
+                write!(f, "struct {size} {{")?;
+                let mut first = true;
+                for field in fields {
+                    if first {
+                        first = false;
+                    } else {
+                        write!(f, ",")?;
+                    }
+                    write!(f, " {}: {}", field.offset, field.ty)?;
+                    if field.readonly {
+                        write!(f, " readonly")?;
+                    }
+                    if let Some(fact) = &field.fact {
+                        write!(f, " ! {}", fact)?;
+                    }
+                }
+                write!(f, " }}")?;
+                Ok(())
+            }
+            Self::StaticArray { element, length } => {
+                write!(f, "static_array {element} * {length:#x}")
+            }
+            Self::Primitive { ty } => {
+                write!(f, "primitive {ty}")
+            }
+            Self::Empty => {
+                write!(f, "empty")
+            }
+        }
+    }
 }
 
 /// One field in a memory type.
@@ -28,10 +98,10 @@ pub struct MemoryTypeData {
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub struct MemoryTypeField {
     /// The offset of this field in the memory type.
-    pub offset: usize,
+    pub offset: u64,
     /// The type of the value in this field. Accesses to the field
     /// must use this type (i.e., cannot bitcast/type-pun in memory).
-    pub ty: Type,
+    pub ty: MemoryType,
     /// A proof-carrying-code fact about this value, if any.
     pub fact: Option<Fact>,
     /// Whether this field is read-only, i.e., stores should be

--- a/cranelift/codegen/src/ir/memtype.rs
+++ b/cranelift/codegen/src/ir/memtype.rs
@@ -4,8 +4,65 @@
 //! each field having a type and possibly an attached fact -- that we
 //! can use in proof-carrying code to validate accesses to structs and
 //! propagate facts onto the loaded values as well.
+//!
+//! Memory types are meant to be rich enough to describe the *layout*
+//! of values in memory, but do not necessarily need to embody
+//! higher-level features such as subtyping directly. Rather, they
+//! should encode an implementation of a type or object system.
+//!
+//! Note also that it is a non-goal for now for this type system to be
+//! "complete" or fully orthogonal: we have some restrictions now
+//! (e.g., struct fields are only primitives) because this is all we
+//! need for existing PCC applications, and it keeps the
+//! implementation simpler.
+//!
+//! There are a few basic kinds of types:
+//!
+//! - A struct is an aggregate of fields and an overall size. Each
+//!   field has a *primitive Cranelift type*. This is for simplicity's
+//!   sake: we do not allow nested memory types because to do so
+//!   invites cycles, requires recursive computation of sizes, creates
+//!   complicated questions when field types are dynamically-sized,
+//!   and in general is more complexity than we need.
+//!
+//!   The expectation (validated by PCC) is that when a checked load
+//!   or store accesses memory typed by a memory type, accesses will
+//!   only be to fields at offsets named in the type, and will be via
+//!   the given Cranelift type -- i.e., no type-punning occurs in
+//!   memory.
+//!
+//!   The overall size of the struct may be larger than that implied
+//!   by the fields because (i) we may not want or need to name all
+//!   the actually-existing fields in the memory type, and (ii) there
+//!   may be alignment padding that we also don't want or need to
+//!   represent explicitly.
+//!
+//! - A static memory is an untyped blob of storage with a static
+//!   size. This is memory that can be accessed with any type of load
+//!   or store at any valid offset.
+//!
+//!   Note that this is *distinct* from an "array of u8" kind of
+//!   representation of memory, if/when we can represent such a thing,
+//!   because the expectation with memory types' fields (including
+//!   array elements) is that they are strongly typed, only accessed
+//!   via that type, and not type-punned. We don't want to imply any
+//!   restriction on load/store size, or any actual structure, with
+//!   untyped memory; it's just a blob.
+//!
+//! Eventually we plan to also have:
+//!
+//! - A dynamic memory is an untyped blob of storage with a size given
+//!   by a global value (GV). This is otherwise just like the "static
+//!   memory" variant described above.
+//!
+//! - A dynamic array is a sequence of struct memory types, with a
+//!   length given by a global value (GV). This is useful to model,
+//!   e.g., tables.
+//!
+//! - A discriminated union is a union of several memory types
+//!   together with a tag field. This will be useful to model and
+//!   verify subtyping/downcasting for Wasm GC, among other uses.
 
-use crate::ir::entities::MemoryType;
 use crate::ir::pcc::Fact;
 use crate::ir::Type;
 use alloc::vec::Vec;
@@ -14,10 +71,17 @@ use alloc::vec::Vec;
 use serde_derive::{Deserialize, Serialize};
 
 /// Data defining a memory type.
+///
+/// A memory type corresponds to a layout of data in memory. It may
+/// have a statically-known or dynamically-known size.
 #[derive(Clone, PartialEq, Hash)]
 #[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
 pub enum MemoryTypeData {
     /// An aggregate consisting of certain fields at certain offsets.
+    ///
+    /// Fields must be sorted by offset, must be within the struct's
+    /// overall size, and must not overlap. These conditions are
+    /// checked by the CLIF verifier.
     Struct {
         /// Size of this type.
         size: u64,
@@ -26,25 +90,10 @@ pub enum MemoryTypeData {
         fields: Vec<MemoryTypeField>,
     },
 
-    /// An aggregate consisting of a single element repeated at a
-    /// certain stride, with a statically-known length (element
-    /// count). Layout is assumed to be contiguous, with a stride
-    /// equal to the element type's size (so, if the stride is greater
-    /// than the struct's packed size, be sure to include padding in
-    /// the memory-type definition).
-    StaticArray {
-        /// The element type. May be another array, a struct, etc.
-        element: MemoryType,
-
-        /// Number of elements.
-        length: u64,
-    },
-
-    /// A single Cranelift primitive of the given type stored in
-    /// memory.
-    Primitive {
-        /// The primitive type.
-        ty: Type,
+    /// A statically-sized untyped blob of memory.
+    Memory {
+        /// Accessible size.
+        size: u64,
     },
 
     /// A type with no size.
@@ -80,11 +129,8 @@ impl std::fmt::Display for MemoryTypeData {
                 write!(f, " }}")?;
                 Ok(())
             }
-            Self::StaticArray { element, length } => {
-                write!(f, "static_array {element} * {length:#x}")
-            }
-            Self::Primitive { ty } => {
-                write!(f, "primitive {ty}")
+            Self::Memory { size } => {
+                write!(f, "memory {size:#x}")
             }
             Self::Empty => {
                 write!(f, "empty")
@@ -99,12 +145,27 @@ impl std::fmt::Display for MemoryTypeData {
 pub struct MemoryTypeField {
     /// The offset of this field in the memory type.
     pub offset: u64,
-    /// The type of the value in this field. Accesses to the field
-    /// must use this type (i.e., cannot bitcast/type-pun in memory).
-    pub ty: MemoryType,
+    /// The primitive type of the value in this field. Accesses to the
+    /// field must use this type (i.e., cannot bitcast/type-pun in
+    /// memory).
+    pub ty: Type,
     /// A proof-carrying-code fact about this value, if any.
     pub fact: Option<Fact>,
     /// Whether this field is read-only, i.e., stores should be
     /// disallowed.
     pub readonly: bool,
+}
+
+impl MemoryTypeData {
+    /// Provide the static size of this type, if known.
+    ///
+    /// (The size may not be known for dynamically-sized arrays or
+    /// memories, when those memtype kinds are added.)
+    pub fn static_size(&self) -> Option<u64> {
+        match self {
+            Self::Struct { size, .. } => Some(*size),
+            Self::Memory { size } => Some(*size),
+            Self::Empty => Some(0),
+        }
+    }
 }

--- a/cranelift/codegen/src/ir/memtype.rs
+++ b/cranelift/codegen/src/ir/memtype.rs
@@ -1,0 +1,40 @@
+//! Definitions for "memory types" in CLIF.
+//!
+//! A memory type is a struct-like definition -- fields with offsets,
+//! each field having a type and possibly an attached fact -- that we
+//! can use in proof-carrying code to validate accesses to structs and
+//! propagate facts onto the loaded values as well.
+
+use crate::ir::pcc::Fact;
+use crate::ir::Type;
+use alloc::vec::Vec;
+
+#[cfg(feature = "enable-serde")]
+use serde_derive::{Deserialize, Serialize};
+
+/// Data defining a memory type.
+#[derive(Clone, PartialEq, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct MemoryTypeData {
+    /// Size of this type.
+    pub size: u64,
+
+    /// Fields in this type. Sorted by offset.
+    pub fields: Vec<MemoryTypeField>,
+}
+
+/// One field in a memory type.
+#[derive(Clone, PartialEq, Hash)]
+#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
+pub struct MemoryTypeField {
+    /// The offset of this field in the memory type.
+    pub offset: usize,
+    /// The type of the value in this field. Accesses to the field
+    /// must use this type (i.e., cannot bitcast/type-pun in memory).
+    pub ty: Type,
+    /// A proof-carrying-code fact about this value, if any.
+    pub fact: Option<Fact>,
+    /// Whether this field is read-only, i.e., stores should be
+    /// disallowed.
+    pub readonly: bool,
+}

--- a/cranelift/codegen/src/ir/mod.rs
+++ b/cranelift/codegen/src/ir/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod known_symbol;
 pub mod layout;
 pub(crate) mod libcall;
 mod memflags;
+mod memtype;
 pub mod pcc;
 mod progpoint;
 mod sourceloc;
@@ -38,7 +39,7 @@ pub use crate::ir::dfg::{BlockData, DataFlowGraph, ValueDef};
 pub use crate::ir::dynamic_type::{dynamic_to_fixed, DynamicTypeData, DynamicTypes};
 pub use crate::ir::entities::{
     Block, Constant, DynamicStackSlot, DynamicType, FuncRef, GlobalValue, Immediate, Inst,
-    JumpTable, SigRef, StackSlot, Table, UserExternalNameRef, Value,
+    JumpTable, MemoryType, SigRef, StackSlot, Table, UserExternalNameRef, Value,
 };
 pub use crate::ir::extfunc::{
     AbiParam, ArgumentExtension, ArgumentPurpose, ExtFuncData, Signature,
@@ -54,6 +55,7 @@ pub use crate::ir::known_symbol::KnownSymbol;
 pub use crate::ir::layout::Layout;
 pub use crate::ir::libcall::{get_probestack_funcref, LibCall};
 pub use crate::ir::memflags::{Endianness, MemFlags};
+pub use crate::ir::memtype::{MemoryTypeData, MemoryTypeField};
 pub use crate::ir::progpoint::ProgramPoint;
 pub use crate::ir::sourceloc::RelSourceLoc;
 pub use crate::ir::sourceloc::SourceLoc;

--- a/cranelift/codegen/src/ir/pcc.rs
+++ b/cranelift/codegen/src/ir/pcc.rs
@@ -59,6 +59,7 @@
 use crate::ir;
 use crate::isa::TargetIsa;
 use crate::machinst::{InsnIndex, LowerBackend, MachInst, VCode};
+use cranelift_entity::PrimaryMap;
 use std::fmt;
 
 #[cfg(feature = "enable-serde")]
@@ -111,13 +112,6 @@ pub enum Fact {
         max: u64,
     },
 
-    /// A pointer value to a memory region that can be accessed.
-    PointsTo {
-        /// A description of the memory region this pointer is allowed
-        /// to access (size, etc).
-        region: MemoryRegion,
-    },
-
     /// A pointer to a memory type.
     Mem {
         /// The memory type.
@@ -127,24 +121,10 @@ pub enum Fact {
     },
 }
 
-/// A memory region that can be accessed. This description is attached
-/// to a particular base pointer.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-#[cfg_attr(feature = "enable-serde", derive(Serialize, Deserialize))]
-pub struct MemoryRegion {
-    /// Includes both the actual memory bound as well as any guard
-    /// pages. Inclusive, so we can represent the full range of a
-    /// `u64`. The range is unsigned.
-    pub max: u64,
-}
-
 impl fmt::Display for Fact {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Fact::ValueMax { bit_width, max } => write!(f, "max({}, {:#x})", bit_width, max),
-            Fact::PointsTo {
-                region: MemoryRegion { max },
-            } => write!(f, "points_to(0x{:x})", max),
             Fact::Mem { ty, offset } => write!(f, "mem({}, {:#x})", ty, offset),
         }
     }
@@ -167,20 +147,29 @@ macro_rules! bail {
 /// A "context" in which we can evaluate and derive facts. This
 /// context carries environment/global properties, such as the machine
 /// pointer width.
-#[derive(Debug)]
-pub struct FactContext {
+pub struct FactContext<'a> {
+    memory_types: &'a PrimaryMap<ir::MemoryType, ir::MemoryTypeData>,
     pointer_width: u16,
 }
 
-impl FactContext {
+impl<'a> FactContext<'a> {
     /// Create a new "fact context" in which to evaluate facts.
-    pub fn new(pointer_width: u16) -> Self {
-        FactContext { pointer_width }
+    pub fn new(
+        memory_types: &'a PrimaryMap<ir::MemoryType, ir::MemoryTypeData>,
+        pointer_width: u16,
+    ) -> Self {
+        FactContext {
+            memory_types,
+            pointer_width,
+        }
     }
 
     /// Computes whether `lhs` "subsumes" (implies) `rhs`.
     pub fn subsumes(&self, lhs: &Fact, rhs: &Fact) -> bool {
         match (lhs, rhs) {
+            // Reflexivity.
+            (l, r) if l == r => true,
+
             (
                 Fact::ValueMax {
                     bit_width: bw_lhs,
@@ -201,22 +190,7 @@ impl FactContext {
                 // possible value range.
                 bw_lhs == bw_rhs && max_lhs <= max_rhs
             }
-            (
-                Fact::PointsTo {
-                    region: MemoryRegion { max: max_lhs },
-                },
-                Fact::PointsTo {
-                    region: MemoryRegion { max: max_rhs },
-                },
-            ) => {
-                // If the pointer is valid up to `max_lhs`, and
-                // `max_rhs` is less than or equal to `max_lhs`, then
-                // it is certainly valid up to `max_rhs`.
-                //
-                // In other words, we can always shrink the valid
-                // addressable region.
-                max_rhs <= max_lhs
-            }
+
             _ => false,
         }
     }
@@ -250,19 +224,17 @@ impl FactContext {
                     bit_width: bw_max,
                     max,
                 },
-                Fact::PointsTo { region },
+                Fact::Mem { ty, offset },
             )
             | (
-                Fact::PointsTo { region },
+                Fact::Mem { ty, offset },
                 Fact::ValueMax {
                     bit_width: bw_max,
                     max,
                 },
             ) if *bw_max >= self.pointer_width && add_width >= *bw_max => {
-                let region = MemoryRegion {
-                    max: region.max.checked_sub(*max)?,
-                };
-                Some(Fact::PointsTo { region })
+                let offset = offset.checked_add(i64::try_from(*max).ok()?)?;
+                Some(Fact::Mem { ty: *ty, offset })
             }
 
             _ => None,
@@ -343,15 +315,15 @@ impl FactContext {
 
     /// Offsets a value with a fact by a known amount.
     pub fn offset(&self, fact: &Fact, width: u16, offset: i64) -> Option<Fact> {
-        // If we eventually support two-sided ranges, we can
-        // represent (0..n) + m -> ((0+m)..(n+m)). However,
-        // right now, all ranges start with zero, so any
-        // negative offset could underflow, and removes all
-        // claims of constrained range.
-        let offset = u64::try_from(offset).ok()?;
-
         match fact {
             Fact::ValueMax { bit_width, max } if *bit_width == width => {
+                // If we eventually support two-sided ranges, we can
+                // represent (0..n) + m -> ((0+m)..(n+m)). However,
+                // right now, all ranges start with zero, so any
+                // negative offset could underflow, and removes all
+                // claims of constrained range.
+                let offset = u64::try_from(offset).ok()?;
+
                 let max = match max.checked_add(offset) {
                     Some(max) => max,
                     None => {
@@ -367,13 +339,12 @@ impl FactContext {
                     max,
                 })
             }
-            Fact::PointsTo {
-                region: MemoryRegion { max },
+            Fact::Mem {
+                ty,
+                offset: mem_offset,
             } => {
-                let max = max.checked_sub(offset)?;
-                Some(Fact::PointsTo {
-                    region: MemoryRegion { max },
-                })
+                let offset = mem_offset.checked_sub(offset)?;
+                Some(Fact::Mem { ty: *ty, offset })
             }
             _ => None,
         }
@@ -383,9 +354,20 @@ impl FactContext {
     /// a memory access of the given size, is valid.
     pub fn check_address(&self, fact: &Fact, size: u32) -> PccResult<()> {
         match fact {
-            Fact::PointsTo {
-                region: MemoryRegion { max },
-            } => ensure!(u64::from(size) <= *max, OutOfBounds),
+            Fact::Mem { ty, offset } => {
+                let end_offset: i64 = offset
+                    .checked_add(i64::from(size))
+                    .ok_or(PccError::Overflow)?;
+                let end_offset: u64 =
+                    u64::try_from(end_offset).map_err(|_| PccError::OutOfBounds)?;
+                match &self.memory_types[*ty] {
+                    ir::MemoryTypeData::Struct { size, .. }
+                    | ir::MemoryTypeData::Memory { size } => {
+                        ensure!(end_offset <= *size, OutOfBounds)
+                    }
+                    ir::MemoryTypeData::Empty => bail!(OutOfBounds),
+                }
+            }
             _ => bail!(OutOfBounds),
         }
 
@@ -405,7 +387,7 @@ fn max_value_for_width(bits: u16) -> u64 {
 /// Top-level entry point after compilation: this checks the facts in
 /// VCode.
 pub fn check_vcode_facts<B: LowerBackend + TargetIsa>(
-    _f: &ir::Function,
+    f: &ir::Function,
     vcode: &VCode<B::MInst>,
     backend: &B,
 ) -> PccResult<()> {
@@ -417,7 +399,7 @@ pub fn check_vcode_facts<B: LowerBackend + TargetIsa>(
             // verify. We'll call into the backend to validate this
             // fact with respect to the instruction and the input
             // facts.
-            backend.check_fact(&vcode[inst], vcode)?;
+            backend.check_fact(&vcode[inst], f, vcode)?;
         }
     }
     Ok(())

--- a/cranelift/codegen/src/ir/pcc.rs
+++ b/cranelift/codegen/src/ir/pcc.rs
@@ -46,6 +46,7 @@
 //! `FactContext::add()` and friends to forward-propagate facts.
 //!
 //! TODO:
+//! - Check blockparams' preds against blockparams' facts.
 //! - Propagate facts through optimization (egraph layer).
 //! - Generate facts in cranelift-wasm frontend when lowering memory ops.
 //! - Implement richer "points-to" facts that describe the pointed-to
@@ -116,6 +117,14 @@ pub enum Fact {
         /// to access (size, etc).
         region: MemoryRegion,
     },
+
+    /// A pointer to a memory type.
+    Mem {
+        /// The memory type.
+        ty: ir::MemoryType,
+        /// The offset into the memory type.
+        offset: i64,
+    },
 }
 
 /// A memory region that can be accessed. This description is attached
@@ -132,10 +141,11 @@ pub struct MemoryRegion {
 impl fmt::Display for Fact {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Fact::ValueMax { bit_width, max } => write!(f, "max({}, 0x{:x})", bit_width, max),
+            Fact::ValueMax { bit_width, max } => write!(f, "max({}, {:#x})", bit_width, max),
             Fact::PointsTo {
                 region: MemoryRegion { max },
             } => write!(f, "points_to(0x{:x})", max),
+            Fact::Mem { ty, offset } => write!(f, "mem({}, {:#x})", ty, offset),
         }
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -10,7 +10,7 @@
 use crate::ir::condcodes::{FloatCC, IntCC};
 use crate::ir::pcc::PccResult;
 use crate::ir::Inst as IRInst;
-use crate::ir::{Opcode, Value};
+use crate::ir::{Function, Opcode, Value};
 use crate::isa::aarch64::inst::*;
 use crate::isa::aarch64::pcc;
 use crate::isa::aarch64::AArch64Backend;
@@ -131,7 +131,12 @@ impl LowerBackend for AArch64Backend {
         Some(regs::pinned_reg())
     }
 
-    fn check_fact(&self, inst: &Self::MInst, vcode: &VCode<Self::MInst>) -> PccResult<()> {
-        pcc::check(inst, vcode)
+    fn check_fact(
+        &self,
+        inst: &Self::MInst,
+        function: &Function,
+        vcode: &VCode<Self::MInst>,
+    ) -> PccResult<()> {
+        pcc::check(inst, function, vcode)
     }
 }

--- a/cranelift/codegen/src/isa/aarch64/pcc.rs
+++ b/cranelift/codegen/src/isa/aarch64/pcc.rs
@@ -1,7 +1,7 @@
 //! Proof-carrying code checking for AArch64 VCode.
 
 use crate::ir::pcc::*;
-use crate::ir::MemFlags;
+use crate::ir::{Function, MemFlags};
 use crate::isa::aarch64::inst::args::{PairAMode, ShiftOp};
 use crate::isa::aarch64::inst::ALUOp;
 use crate::isa::aarch64::inst::Inst;
@@ -68,9 +68,9 @@ fn check_output<F: Fn() -> PccResult<Fact>>(
     }
 }
 
-pub(crate) fn check(inst: &Inst, vcode: &VCode<Inst>) -> PccResult<()> {
+pub(crate) fn check(inst: &Inst, function: &Function, vcode: &VCode<Inst>) -> PccResult<()> {
     // Create a new fact context with the machine's pointer width.
-    let ctx = FactContext::new(64);
+    let ctx = FactContext::new(&function.memory_types, 64);
 
     trace!("Checking facts on inst: {:?}", inst);
 

--- a/cranelift/codegen/src/isa/aarch64/pcc.rs
+++ b/cranelift/codegen/src/isa/aarch64/pcc.rs
@@ -28,6 +28,12 @@ fn check_subsumes(ctx: &FactContext, subsumer: &Fact, subsumee: &Fact) -> PccRes
         subsumer,
         subsumee
     );
+
+    // For now, allow all `mem` facts to validate.
+    if matches!(subsumee, Fact::Mem { .. }) {
+        return Ok(());
+    }
+
     if ctx.subsumes(subsumer, subsumee) {
         Ok(())
     } else {

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -149,7 +149,12 @@ pub trait LowerBackend {
 
     /// Check any facts about an instruction, given VCode with facts
     /// on VRegs.
-    fn check_fact(&self, _inst: &Self::MInst, _vcode: &VCode<Self::MInst>) -> PccResult<()> {
+    fn check_fact(
+        &self,
+        _inst: &Self::MInst,
+        _function: &Function,
+        _vcode: &VCode<Self::MInst>,
+    ) -> PccResult<()> {
         Err(PccError::UnimplementedBackend)
     }
 }

--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -56,6 +56,11 @@ pub trait FuncWriter {
             self.write_entity_definition(w, func, gv.into(), gv_data)?;
         }
 
+        for (mt, mt_data) in &func.memory_types {
+            any = true;
+            self.write_entity_definition(w, func, mt.into(), mt_data)?;
+        }
+
         for (table, table_data) in &func.tables {
             if !table_data.index_type.is_invalid() {
                 any = true;

--- a/cranelift/filetests/filetests/pcc/fail/load.clif
+++ b/cranelift/filetests/filetests/pcc/fail/load.clif
@@ -3,57 +3,62 @@ set enable_pcc=true
 target aarch64
 
 function %f0(i64, i32) -> i64 {
-block0(v0 ! points_to(0x1000): i64, v1 ! max(32, 0x1000): i32):
+    mt0 = memory 0x1000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0x1000): i32):
     v2 ! max(64, 0x100) = uextend.i64 v1
-    v3 ! points_to(0x8) = iadd.i64 v0, v2
+    v3 ! mem(mt0, 0x100) = iadd.i64 v0, v2
     v4 = load.i64 checked v3
     return v4
 }
 
 ;; Insufficient guard region: the 8-byte load could go off the end.
 function %f1(i64, i32) -> i64 {
-block0(v0 ! points_to(0x1_0000_0000): i64, v1 ! max(32, 0xffff_ffff): i32):
+    mt0 = memory 0x1_0000_0000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0xffff_ffff): i32):
     v2 ! max(64, 0xffff_ffff) = uextend.i64 v1
-    ;; 8 bytes of valid range is all we actually need, so let's only claim that.
-    v3 ! points_to(0x8) = iadd.i64 v0, v2
+    v3 ! mem(mt0, 0xffff_ffff) = iadd.i64 v0, v2
     v4 = load.i64 checked v3
     return v4
 }
 
 ;; RegRegExtend mode on aarch64.
 function %f2(i64, i32) -> i8 {
-block0(v0 ! points_to(0x1000): i64, v1 ! max(32, 0x1000): i32):
+    mt0 = memory 0x1000
+block0(v0 ! mem(mt0, 0x1000): i64, v1 ! max(32, 0x1000): i32):
     v2 ! max(64, 0x100) = uextend.i64 v1
-    v3 ! points_to(0x1) = iadd.i64 v0, v2
+    v3 ! mem(mt0, 0x100) = iadd.i64 v0, v2
     v4 = load.i8 checked v3
     return v4
 }
 
 ;; RegReg mode on aarch64.
 function %f3(i64, i64) -> i8 {
-block0(v0 ! points_to(0x100): i64, v1 ! max(64, 0xfff): i64):
-    v2 ! points_to(0x1) = iadd.i64 v0, v1
+    mt0 = memory 0x100
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(64, 0xfff): i64):
+    v2 ! mem(mt0, 0xfff) = iadd.i64 v0, v1
     v3 = load.i8 checked v2
     return v3
 }
 
 ;; RegScaledExtended mode on aarch64.
 function %f4(i64, i32) -> i64 {
-block0(v0 ! points_to(0x7000): i64, v1 ! max(32, 0xfff): i32):
+    mt0 = memory 0x7000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0xfff): i32):
     v2 ! max(64, 0xfff) = uextend.i64 v1
     v3 = iconst.i32 3
     v4 ! max(64, 0x7ff8) = ishl.i64 v2, v3
-    v5 ! points_to(0x8) = iadd.i64 v0, v4
+    v5 ! mem(mt0, 0x7ff8) = iadd.i64 v0, v4
     v6 = load.i64 checked v5
     return v6
 }
 
 ;; RegScaled mode on aarch64.
 function %f5(i64, i64) -> i64 {
-block0(v0 ! points_to(0x7000): i64, v1 ! max(64, 0xfff): i64):
+    mt0 = memory 0x7000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(64, 0xfff): i64):
     v2 = iconst.i32 3
     v3 ! max(64, 0x7ff8) = ishl.i64 v1, v2
-    v4 ! points_to(0x8) = iadd.i64 v0, v3
+    v4 ! mem(mt0, 0x7ff8) = iadd.i64 v0, v3
     v5 = load.i64 checked v4
     return v5
 }

--- a/cranelift/filetests/filetests/pcc/fail/memtypes.clif
+++ b/cranelift/filetests/filetests/pcc/fail/memtypes.clif
@@ -1,0 +1,29 @@
+test verifier
+set enable_pcc=true
+target aarch64
+
+function %f0(i64) -> i32 {
+    mt0 = struct 8 { 4: i32, 0: i32 } ; error: out-of-order
+
+block0(v0 ! mem(mt0, 0): i64):
+    v1 = load.i32 v0+0
+    return v1
+}
+
+function %f0(i64) -> i32 {
+    ;; out-of-bounds field:
+    mt0 = struct 8 { 0: i32, 6: i32 } ; error: field at offset 6 of size 4 that overflows
+
+block0(v0 ! mem(mt0, 0): i64):
+    v1 = load.i32 v0+0
+    return v1
+}
+
+function %f0(i64) -> i32 {
+    ;; overflowing offset + field size:
+    mt0 = struct 8 { 0: i32, 0xffff_ffff_ffff_ffff: i32 } ; error: field at offset 18446744073709551615 of size 4; offset plus size overflows a u64
+
+block0(v0 ! mem(mt0, 0): i64):
+    v1 = load.i32 v0+0
+    return v1
+}

--- a/cranelift/filetests/filetests/pcc/fail/simple.clif
+++ b/cranelift/filetests/filetests/pcc/fail/simple.clif
@@ -16,7 +16,7 @@ block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0xffff_ffff): i32):
 
 ;; Check that the offset in the `mem` is validated too.
 
-function %simple1(i64 vmctx, i32) -> i8 {
+function %simple2(i64 vmctx, i32) -> i8 {
     mt0 = memory 0x8000_0000
 block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0xffff_ffff): i32):
     v2 ! max(64, 0xffff_ffff) = uextend.i64 v1

--- a/cranelift/filetests/filetests/pcc/fail/simple.clif
+++ b/cranelift/filetests/filetests/pcc/fail/simple.clif
@@ -2,14 +2,25 @@ test compile expect-fail
 set enable_pcc=true
 target aarch64
 
-;; The `points_to` annotation is not large enough here -- the
-;; 4GiB-range 32-bit offset could go out of range. PCC should catch
-;; this.
+;; The `memory` memtype is not large enough here -- the 4GiB-range
+;; 32-bit offset could go out of range. PCC should catch this.
 
 function %simple1(i64 vmctx, i32) -> i8 {
-block0(v0 ! points_to(0x8000_0000): i64, v1 ! max(32, 0xffff_ffff): i32):
+    mt0 = memory 0x8000_0000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0xffff_ffff): i32):
     v2 ! max(64, 0xffff_ffff) = uextend.i64 v1
-    v3 ! points_to(0x1) = iadd.i64 v0, v2
+    v3 ! mem(mt0, 0xffff_ffff) = iadd.i64 v0, v2
+    v4 = load.i8 checked v3
+    return v4
+}
+
+;; Check that the offset in the `mem` is validated too.
+
+function %simple1(i64 vmctx, i32) -> i8 {
+    mt0 = memory 0x8000_0000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0xffff_ffff): i32):
+    v2 ! max(64, 0xffff_ffff) = uextend.i64 v1
+    v3 ! mem(mt0, 0) = iadd.i64 v0, v2
     v4 = load.i8 checked v3
     return v4
 }

--- a/cranelift/filetests/filetests/pcc/succeed/load.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/load.clif
@@ -3,58 +3,62 @@ set enable_pcc=true
 target aarch64
 
 function %f0(i64, i32) -> i64 {
-block0(v0 ! points_to(0x1_0000_0000): i64, v1 ! max(32, 0x100): i32):
+    mt0 = memory 0x1_0000_0000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0x100): i32):
     v2 ! max(64, 0x100) = uextend.i64 v1
-    ;; 8 bytes of valid range is all we actually need, so let's only claim that.
-    v3 ! points_to(0x8) = iadd.i64 v0, v2
+    v3 ! mem(mt0, 8) = iadd.i64 v0, v2
     v4 = load.i64 checked v3
     return v4
 }
 
-;; Note the guard region of 8 bytes -- just enough for the below!
 function %f1(i64, i32) -> i64 {
-block0(v0 ! points_to(0x1_0000_0008): i64, v1 ! max(32, 0xffff_ffff): i32):
+    ;; Note the guard region of 8 bytes -- just enough for the below!
+    mt0 = memory 0x1_0000_0008
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0xffff_ffff): i32):
     v2 ! max(64, 0xffff_ffff) = uextend.i64 v1
-    ;; 8 bytes of valid range is all we actually need, so let's only claim that.
-    v3 ! points_to(0x8) = iadd.i64 v0, v2
+    v3 ! mem(mt0, 0xffff_ffff) = iadd.i64 v0, v2
     v4 = load.i64 checked v3
     return v4
 }
 
 ;; RegRegExtend mode on aarch64.
 function %f2(i64, i32) -> i8 {
-block0(v0 ! points_to(0x1000): i64, v1 ! max(32, 0xfff): i32):
+    mt0 = memory 0x1000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0xfff): i32):
     v2 ! max(64, 0x100) = uextend.i64 v1
-    v3 ! points_to(0x1) = iadd.i64 v0, v2
+    v3 ! mem(mt0, 0x100) = iadd.i64 v0, v2
     v4 = load.i8 checked v3
     return v4
 }
 
 ;; RegReg mode on aarch64.
 function %f3(i64, i64) -> i8 {
-block0(v0 ! points_to(0x1000): i64, v1 ! max(64, 0xfff): i64):
-    v2 ! points_to(0x1) = iadd.i64 v0, v1
+    mt0 = memory 0x1000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(64, 0xfff): i64):
+    v2 ! mem(mt0, 0xfff) = iadd.i64 v0, v1
     v3 = load.i8 checked v2
     return v3
 }
 
 ;; RegScaledExtended mode on aarch64.
 function %f4(i64, i32) -> i64 {
-block0(v0 ! points_to(0x8000): i64, v1 ! max(32, 0xfff): i32):
+    mt0 = memory 0x8000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0xfff): i32):
     v2 ! max(64, 0xfff) = uextend.i64 v1
     v3 = iconst.i32 3
     v4 ! max(64, 0x7ff8) = ishl.i64 v2, v3
-    v5 ! points_to(0x8) = iadd.i64 v0, v4
+    v5 ! mem(mt0, 0x7ff8) = iadd.i64 v0, v4
     v6 = load.i64 checked v5
     return v6
 }
 
 ;; RegScaled mode on aarch64.
 function %f5(i64, i64) -> i64 {
-block0(v0 ! points_to(0x8000): i64, v1 ! max(64, 0xfff): i64):
+    mt0 = memory 0x8000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(64, 0xfff): i64):
     v2 = iconst.i32 3
     v3 ! max(64, 0x7ff8) = ishl.i64 v1, v2
-    v4 ! points_to(0x8) = iadd.i64 v0, v3
+    v4 ! mem(mt0, 0x7ff8) = iadd.i64 v0, v3
     v5 = load.i64 checked v4
     return v5
 }

--- a/cranelift/filetests/filetests/pcc/succeed/memtypes.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/memtypes.clif
@@ -1,0 +1,22 @@
+test compile
+set enable_pcc=true
+target aarch64
+
+function %f0(i64) -> i32 {
+    mt0 = memtype 8 { 0: i32, 4: i32 readonly }
+
+block0(v0 ! memtype(mt0, 0): i64):  ;; v0 points to an instance of mt0, at offset 0
+    v1 = load.i32 checked v0+0
+    v2 = load.i32 checked v0+4
+    v3 = iadd.i32 v1, v2
+    return v3
+}
+
+function %f1(i64) -> i32 {
+    mt0 = memtype 8 { 0: i64 readonly ! points_to(0x1_0000_0000 }
+
+block0(v0 ! memtype(mt0, 0): i64):
+    v1 ! points_to(0x1_0000_0000) = load.i64 checked v0
+    v2 = load.i32 checked v1+0x1000
+    return v2
+}

--- a/cranelift/filetests/filetests/pcc/succeed/memtypes.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/memtypes.clif
@@ -3,20 +3,28 @@ set enable_pcc=true
 target aarch64
 
 function %f0(i64) -> i32 {
-    mt0 = memtype 8 { 0: i32, 4: i32 readonly }
+    mt0 = struct 8 { 0: mt1, 4: mt1 readonly }
+    mt1 = primitive i32
 
-block0(v0 ! memtype(mt0, 0): i64):  ;; v0 points to an instance of mt0, at offset 0
-    v1 = load.i32 checked v0+0
-    v2 = load.i32 checked v0+4
+block0(v0 ! mem(mt0, 0): i64):  ;; v0 points to an instance of mt0, at offset 0
+    v1 = load.i32 v0+0
+    v2 = load.i32 v0+4
     v3 = iadd.i32 v1, v2
     return v3
 }
 
 function %f1(i64) -> i32 {
-    mt0 = memtype 8 { 0: i64 readonly ! points_to(0x1_0000_0000 }
+    ;; TODO: validate that fields don't overlap, and are within the
+    ;; overall size. Make note of future thoughts for enums, tag
+    ;; discriminants, etc.
+    mt0 = struct 8 { 0: mt3 readonly ! mem(mt1, 0) }
+    ;; `u8` here could be a CLIF type or a memtype
+    mt1 = static_array mt2 * 0x1_0000_0000
+    mt2 = primitive i8
+    mt3 = primitive i64
 
-block0(v0 ! memtype(mt0, 0): i64):
-    v1 ! points_to(0x1_0000_0000) = load.i64 checked v0
-    v2 = load.i32 checked v1+0x1000
+block0(v0 ! mem(mt0, 0): i64):
+    v1 ! mem(mt1, 0) = load.i64 v0
+    v2 = load.i32 v1+0x1000
     return v2
 }

--- a/cranelift/filetests/filetests/pcc/succeed/memtypes.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/memtypes.clif
@@ -3,8 +3,7 @@ set enable_pcc=true
 target aarch64
 
 function %f0(i64) -> i32 {
-    mt0 = struct 8 { 0: mt1, 4: mt1 readonly }
-    mt1 = primitive i32
+    mt0 = struct 8 { 0: i32, 4: i32 readonly }
 
 block0(v0 ! mem(mt0, 0): i64):  ;; v0 points to an instance of mt0, at offset 0
     v1 = load.i32 v0+0
@@ -14,14 +13,8 @@ block0(v0 ! mem(mt0, 0): i64):  ;; v0 points to an instance of mt0, at offset 0
 }
 
 function %f1(i64) -> i32 {
-    ;; TODO: validate that fields don't overlap, and are within the
-    ;; overall size. Make note of future thoughts for enums, tag
-    ;; discriminants, etc.
-    mt0 = struct 8 { 0: mt3 readonly ! mem(mt1, 0) }
-    ;; `u8` here could be a CLIF type or a memtype
-    mt1 = static_array mt2 * 0x1_0000_0000
-    mt2 = primitive i8
-    mt3 = primitive i64
+    mt0 = struct 8 { 0: i64 readonly ! mem(mt1, 0) }
+    mt1 = memory 0x1_0000_0000
 
 block0(v0 ! mem(mt0, 0): i64):
     v1 ! mem(mt1, 0) = load.i64 v0

--- a/cranelift/filetests/filetests/pcc/succeed/simple.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/simple.clif
@@ -3,9 +3,10 @@ set enable_pcc=true
 target aarch64
 
 function %simple1(i64 vmctx, i32) -> i8 {
-block0(v0 ! points_to(0x1_0000_0000): i64, v1 ! max(32, 0xffff_ffff): i32):
+    mt0 = memory 0x1_0000_0000
+block0(v0 ! mem(mt0, 0): i64, v1 ! max(32, 0xffff_ffff): i32):
     v2 ! max(64, 0xffff_ffff) = uextend.i64 v1
-    v3 ! points_to(0x1) = iadd.i64 v0, v2
+    v3 ! mem(mt0, 0xffff_ffff) = iadd.i64 v0, v2
     v4 = load.i8 checked v3
     return v4
 }

--- a/cranelift/reader/src/lexer.rs
+++ b/cranelift/reader/src/lexer.rs
@@ -40,6 +40,7 @@ pub enum Token<'a> {
     StackSlot(u32),        // ss3
     DynamicStackSlot(u32), // dss4
     GlobalValue(u32),      // gv3
+    MemoryType(u32),       // mt0
     Table(u32),            // table2
     Constant(u32),         // const2
     FuncRef(u32),          // fn2
@@ -344,6 +345,7 @@ impl<'a> Lexer<'a> {
             "dss" => Some(Token::DynamicStackSlot(number)),
             "dt" => Some(Token::DynamicType(number)),
             "gv" => Some(Token::GlobalValue(number)),
+            "mt" => Some(Token::MemoryType(number)),
             "table" => Some(Token::Table(number)),
             "const" => Some(Token::Constant(number)),
             "fn" => Some(Token::FuncRef(number)),

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -9,7 +9,7 @@ use crate::testcommand::TestCommand;
 use crate::testfile::{Comment, Details, Feature, TestFile};
 use cranelift_codegen::data_value::DataValue;
 use cranelift_codegen::entity::{EntityRef, PrimaryMap};
-use cranelift_codegen::ir::entities::{AnyEntity, DynamicType};
+use cranelift_codegen::ir::entities::{AnyEntity, DynamicType, MemoryType};
 use cranelift_codegen::ir::immediates::{Ieee32, Ieee64, Imm64, Offset32, Uimm32, Uimm64};
 use cranelift_codegen::ir::instructions::{InstructionData, InstructionFormat, VariableArgs};
 use cranelift_codegen::ir::pcc::{Fact, MemoryRegion};
@@ -20,8 +20,9 @@ use cranelift_codegen::ir::{self, UserExternalNameRef};
 use cranelift_codegen::ir::{
     AbiParam, ArgumentExtension, ArgumentPurpose, Block, Constant, ConstantData, DynamicStackSlot,
     DynamicStackSlotData, DynamicTypeData, ExtFuncData, ExternalName, FuncRef, Function,
-    GlobalValue, GlobalValueData, JumpTableData, MemFlags, Opcode, SigRef, Signature, StackSlot,
-    StackSlotData, StackSlotKind, Table, TableData, Type, UserFuncName, Value,
+    GlobalValue, GlobalValueData, JumpTableData, MemFlags, MemoryTypeData, MemoryTypeField, Opcode,
+    SigRef, Signature, StackSlot, StackSlotData, StackSlotKind, Table, TableData, Type,
+    UserFuncName, Value,
 };
 use cranelift_codegen::isa::{self, CallConv};
 use cranelift_codegen::packed_option::ReservedValue;
@@ -315,6 +316,16 @@ impl Context {
             });
         }
         self.function.global_values[gv] = data;
+        Ok(())
+    }
+
+    // Allocate a memory-type slot.
+    fn add_mt(&mut self, mt: MemoryType, data: MemoryTypeData, loc: Location) -> ParseResult<()> {
+        self.map.def_mt(mt, loc)?;
+        while self.function.memory_types.next_key().index() <= mt.index() {
+            self.function.create_memory_type(MemoryTypeData::default());
+        }
+        self.function.memory_types[mt] = data;
         Ok(())
     }
 
@@ -651,6 +662,17 @@ impl<'a> Parser<'a> {
             self.consume();
             if let Some(table) = Table::with_number(table) {
                 return Ok(table);
+            }
+        }
+        err!(self.loc, err_msg)
+    }
+
+    // Match and consume a memory-type reference.
+    fn match_mt(&mut self, err_msg: &str) -> ParseResult<MemoryType> {
+        if let Some(Token::MemoryType(mt)) = self.token() {
+            self.consume();
+            if let Some(mt) = MemoryType::with_number(mt) {
+                return Ok(mt);
             }
         }
         err!(self.loc, err_msg)
@@ -1448,6 +1470,11 @@ impl<'a> Parser<'a> {
                     self.parse_global_value_decl()
                         .and_then(|(gv, dat)| ctx.add_gv(gv, dat, self.loc))
                 }
+                Some(Token::MemoryType(..)) => {
+                    self.start_gathering_comments();
+                    self.parse_memory_type_decl()
+                        .and_then(|(mt, dat)| ctx.add_mt(mt, dat, self.loc))
+                }
                 Some(Token::Table(..)) => {
                     self.start_gathering_comments();
                     self.parse_table_decl()
@@ -1628,6 +1655,115 @@ impl<'a> Parser<'a> {
         self.claim_gathered_comments(gv);
 
         Ok((gv, data))
+    }
+
+    // Parse one field definition in a memory-type struct decl.
+    //
+    // memory-type-field ::=  offset ":" memory-type ["readonly"] [ "!" fact ]
+    // offset ::= uimm64
+    fn parse_memory_type_field(&mut self) -> ParseResult<MemoryTypeField> {
+        let offset: u64 = self
+            .match_uimm64(
+                "expected u64 constant value for field offset in struct memory-type declaration",
+            )?
+            .into();
+        self.match_token(
+            Token::Colon,
+            "expected colon after field offset in struct memory-type declaration",
+        )?;
+        let ty =
+            self.match_mt("expected memory type for field in struct memory-type declaration")?;
+        let readonly = if self.token() == Some(Token::Identifier("readonly")) {
+            self.consume();
+            true
+        } else {
+            false
+        };
+        let fact = if self.token() == Some(Token::Bang) {
+            self.consume();
+            let fact = self.parse_fact()?;
+            Some(fact)
+        } else {
+            None
+        };
+        Ok(MemoryTypeField {
+            offset,
+            ty,
+            readonly,
+            fact,
+        })
+    }
+
+    // Parse a memory-type decl.
+    //
+    // memory-type-decl ::= MemoryType(mt) "=" memory-type-desc
+    // memory-type-desc ::= "struct" size "{" memory-type-field,* "}"
+    //                    | "static_array" memory-type "*" element-count
+    //                    | "primitive" type
+    //                    | "empty"
+    // element-count ::= uimm64
+    fn parse_memory_type_decl(&mut self) -> ParseResult<(MemoryType, MemoryTypeData)> {
+        let mt = self.match_mt("expected memory type number: mt«n»")?;
+        self.match_token(Token::Equal, "expected '=' in memory type declaration")?;
+
+        let data = match self.token() {
+            Some(Token::Identifier("struct")) => {
+                self.consume();
+                let size: u64 = self.match_uimm64("expected u64 constant value for struct size in struct memory-type declaration")?.into();
+                self.match_token(Token::LBrace, "expected opening brace to start struct fields in struct memory-type declaration")?;
+                let mut fields = vec![];
+                while self.token() != Some(Token::RBrace) {
+                    let field = self.parse_memory_type_field()?;
+                    fields.push(field);
+                    if self.token() == Some(Token::Comma) {
+                        self.consume();
+                    } else {
+                        break;
+                    }
+                }
+                self.match_token(
+                    Token::RBrace,
+                    "expected closing brace after struct fields in struct memory-type declaration",
+                )?;
+                // Ensure fields are sorted ascending by offset.
+                // TODO: check for field overlap and sorted field
+                // order in the CLIF validator.
+                fields.sort_by_key(|f| f.offset);
+                MemoryTypeData::Struct { size, fields }
+            }
+            Some(Token::Identifier("static_array")) => {
+                self.consume();
+                let element = self.match_mt(
+                    "expected memory type for element in array memory-type declaration",
+                )?;
+                self.match_token(Token::Multiply, "expected `*` to separate element type and count in static array memory-type declaration")?;
+                let length: u64 = self.match_uimm64("expected u64 constant value for element count in array memory-type declaration")?.into();
+                MemoryTypeData::StaticArray { element, length }
+            }
+            Some(Token::Identifier("primitive")) => {
+                self.consume();
+                let ty = self
+                    .match_type("expected primitive type in primitive memory-type declaration")?;
+                MemoryTypeData::Primitive { ty }
+            }
+            Some(Token::Identifier("empty")) => {
+                self.consume();
+                MemoryTypeData::Empty
+            }
+            other => {
+                return err!(
+                    self.loc,
+                    "Unknown memory type declaration kind '{:?}'",
+                    other
+                )
+            }
+        };
+
+        // Collect any trailing comments.
+        self.token();
+        self.claim_gathered_comments(mt);
+
+        Ok((mt, data))
     }
 
     // Parse a table decl.
@@ -2029,9 +2165,11 @@ impl<'a> Parser<'a> {
     //
     // fact ::= "max" "(" bit-width "," max-value ")"
     //        | "points_to" "(" valid-range ")"
+    //        | "mem" "(" memory-type "," mt-offset ")"
     // bit-width ::= uimm64
     // max-value ::= uimm64
     // valid-range ::= uimm64
+    // mt-offset ::= imm64
     fn parse_fact(&mut self) -> ParseResult<Fact> {
         match self.token() {
             Some(Token::Identifier("max")) => {
@@ -2070,6 +2208,20 @@ impl<'a> Parser<'a> {
                 Ok(Fact::PointsTo {
                     region: MemoryRegion { max: max.into() },
                 })
+            }
+            Some(Token::Identifier("mem")) => {
+                self.consume();
+                self.match_token(Token::LPar, "expected a `(`")?;
+                let ty = self.match_mt("expected a memory type for `mem` fact")?;
+                self.match_token(
+                    Token::Comma,
+                    "expected a comma after memory type in `mem` fact",
+                )?;
+                let offset: i64 = self
+                    .match_imm64("expected an imm64 pointer offset for `mem` fact")?
+                    .into();
+                self.match_token(Token::RPar, "expected a `)`")?;
+                Ok(Fact::Mem { ty, offset })
             }
             _ => Err(self.error("expected a `max` or `points_to` fact")),
         }

--- a/cranelift/reader/src/sourcemap.rs
+++ b/cranelift/reader/src/sourcemap.rs
@@ -10,8 +10,8 @@ use crate::error::{Location, ParseResult};
 use crate::lexer::split_entity_name;
 use cranelift_codegen::ir::entities::{AnyEntity, DynamicType};
 use cranelift_codegen::ir::{
-    Block, Constant, DynamicStackSlot, FuncRef, GlobalValue, JumpTable, SigRef, StackSlot, Table,
-    Value,
+    Block, Constant, DynamicStackSlot, FuncRef, GlobalValue, JumpTable, MemoryType, SigRef,
+    StackSlot, Table, Value,
 };
 use std::collections::HashMap;
 
@@ -179,6 +179,11 @@ impl SourceMap {
 
     /// Define the global value `entity`.
     pub fn def_gv(&mut self, entity: GlobalValue, loc: Location) -> ParseResult<()> {
+        self.def_entity(entity.into(), loc)
+    }
+
+    /// Define the memory type `entity`.
+    pub fn def_mt(&mut self, entity: MemoryType, loc: Location) -> ParseResult<()> {
         self.def_entity(entity.into(), loc)
     }
 


### PR DESCRIPTION
This PR adds a notion of "memory types" to the PCC (proof-carrying code) framework. To borrow a doc-comment:

A memory type is a struct-like definition -- fields with offsets, each field having a type and possibly an attached fact -- that we can use in proof-carrying code to validate accesses to structs and propagate facts onto the loaded values as well.

Memory types are meant to be rich enough to describe the *layout* of values in memory, but do not necessarily need to embody higher-level features such as subtyping directly. Rather, they should encode an implementation of a type or object system.

Note also that it is a non-goal for now for this type system to be "complete" or fully orthogonal: we have some restrictions now (e.g., struct fields are only primitives) because this is all we need for existing PCC applications, and it keeps the implementation simpler.

While developing this, we originally sketched out a more complete type-system that had arrays, allowed struct fields to be memory types themselves, and was in general more flexible. However, the possibility of cycles, non-statically-sized types, etc., was getting overly complex and I decided to YAGNI-simplify a bit for now. The Doc-comment on the module does sketch out what other types will be needed, and I think those plus a GV-bounded `max` fact will be enough to express PCC facts for all static and dynamic memories and table accesses in Wasmtime. (A partial further development of the more complete system, with some more validator checks for cycles, etc., is on [this WIP branch](https://github.com/cfallin/wasmtime/tree/pcc-memcap-wip).)

Part of this change was

Co-authored-by: Nick Fitzgerald <fitzgen@gmail.com>