### PR TITLE
[14.0.0] Fix a flaky TCP-related test

### DIFF
--- a/crates/test-programs/wasi-sockets-tests/src/bin/tcp_sockopts.rs
+++ b/crates/test-programs/wasi-sockets-tests/src/bin/tcp_sockopts.rs
@@ -103,7 +103,7 @@ fn test_tcp_sockopt_inheritance(net: &Network, family: IpAddressFamily) {
     let bound_addr = listener.local_address().unwrap();
     let client = TcpSocket::new(family).unwrap();
     client.blocking_connect(&net, bound_addr).unwrap();
-    let (accepted_client, _, _) = listener.accept().unwrap();
+    let (accepted_client, _, _) = listener.blocking_accept().unwrap();
 
     // Verify options on accepted socket:
     {
@@ -157,7 +157,7 @@ fn test_tcp_sockopt_after_listen(net: &Network, family: IpAddressFamily) {
 
     let client = TcpSocket::new(family).unwrap();
     client.blocking_connect(&net, bound_addr).unwrap();
-    let (accepted_client, _, _) = listener.accept().unwrap();
+    let (accepted_client, _, _) = listener.blocking_accept().unwrap();
 
     // Verify options on accepted socket:
     {


### PR DESCRIPTION
This incorporates some flakiness related fixes from https://github.com/bytecodealliance/wasmtime/pull/7182 to the 14.0.0 branch, but only small portions of that PR rather than the whole thing.