### PR TITLE
fuzzgen: Add Alias Analysis Memflags to Loads and Stores

### DIFF
--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1135,7 +1135,7 @@ enum BlockTerminatorKind {
 
 /// Alias Analysis Category
 ///
-/// Our alias analysis pass supports 4 categories of accesses to destinguish
+/// Our alias analysis pass supports 4 categories of accesses to distinguish
 /// different regions. The "Other" region is the general case, and is the default
 /// Although they have highly suggestive names there is no difference between any
 /// of the categories.

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1179,6 +1179,9 @@ struct Resources {
     blocks_without_params: Vec<Block>,
     block_terminators: Vec<BlockTerminator>,
     func_refs: Vec<(Signature, SigRef, FuncRef)>,
+    /// This field is required to be sorted by stack slot size at all times.
+    /// We use this invariant when searching for stack slots with a given size.
+    /// See [FunctionGenerator::stack_slot_with_size]
     stack_slots: Vec<(StackSlot, StackSize, AACategory)>,
     usercalls: Vec<(UserExternalName, Signature)>,
     libcalls: Vec<LibCall>,


### PR DESCRIPTION
👋 Hey,

This is a follow up to #7215 and @jameysharp's comments on yesterdays cranelift meeting. @jameysharp suggested that we could add heaps to clif to start testing our alias analysis pass.

But having thought about it, there is nothing special about the "Heap" flag on `MemFlags`. It is only used by our alias analysis pass to optimize some accesses. The same happens with the other flags ("Table" and "VmCtx"). Additionally we already have a way to partition memory in the fuzzer, we call it stack slots. And we already enforce that memory accesses can't cross stack slots, so we also don't run into the risk of doing a partial store/load on a different region.

This PR tags each stack slot with a different Alias Analysis category (Although region might be a better name). Once we have that we just have to ensure that all accesses are correctly tagged, and we should be able to test all 4 categories.

I'm opening this as a draft since I still want to get some fuzzing on this. I suspect that if there is a bug to be found here, It's going to take a while to get those conditions. 