### PR TITLE
Implement stream splice, delete forward

### DIFF
--- a/crates/test-programs/src/bin/cli_splice_stdin.rs
+++ b/crates/test-programs/src/bin/cli_splice_stdin.rs
@@ -1,0 +1,24 @@
+use test_programs::wasi::cli::{stdin, stdout};
+use test_programs::wasi::io::streams::StreamError;
+
+fn main() {
+    println!("before splice");
+    let stdout = stdout::get_stdout();
+    let stdin = stdin::get_stdin();
+
+    let mut spliced = 0;
+    loop {
+        match stdout.blocking_splice(&stdin, 4096) {
+            Ok(n) => spliced += n as usize,
+            Err(StreamError::Closed) => break,
+            Err(StreamError::LastOperationFailed(f)) => {
+                panic!("stream failure: {}", f.to_debug_string())
+            }
+        }
+    }
+    let _ = stdin;
+    stdout.blocking_flush().unwrap();
+    let _ = stdout;
+
+    println!("\ncompleted splicing {spliced} bytes");
+}

--- a/crates/wasi-http/wit/deps/io/streams.wit
+++ b/crates/wasi-http/wit/deps/io/streams.wit
@@ -248,12 +248,9 @@ interface streams {
         ///
         /// This function returns the number of bytes transferred; it may be less
         /// than `len`.
-        ///
-        /// Unlike other I/O functions, this function blocks until all the data
-        /// read from the input stream has been written to the output stream.
         splice: func(
             /// The stream to read from
-            src: input-stream,
+            src: borrow<input-stream>,
             /// The number of bytes to splice
             len: u64,
         ) -> result<u64, stream-error>;
@@ -261,29 +258,12 @@ interface streams {
         /// Read from one stream and write to another, with blocking.
         ///
         /// This is similar to `splice`, except that it blocks until at least
-        /// one byte can be read.
+        /// one byte can be read, and written.
         blocking-splice: func(
             /// The stream to read from
-            src: input-stream,
+            src: borrow<input-stream>,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<u64, stream-error>;
-
-        /// Forward the entire contents of an input stream to an output stream.
-        ///
-        /// This function repeatedly reads from the input stream and writes
-        /// the data to the output stream, until the end of the input stream
-        /// is reached, or an error is encountered.
-        ///
-        /// Unlike other I/O functions, this function blocks until the end
-        /// of the input stream is seen and all the data has been written to
-        /// the output stream.
-        ///
-        /// This function returns the number of bytes transferred, and the status of
-        /// the output stream.
-        forward: func(
-            /// The stream to read from
-            src: input-stream
         ) -> result<u64, stream-error>;
     }
 }

--- a/crates/wasi-http/wit/deps/io/streams.wit
+++ b/crates/wasi-http/wit/deps/io/streams.wit
@@ -246,6 +246,15 @@ interface streams {
 
         /// Read from one stream and write to another.
         ///
+        /// The behavior of splice is equivelant to:
+        /// 1. calling `check-write` on the `output-stream`
+        /// 2. calling `read` on the `input-stream` with the smaller of the
+        /// `check-write` permitted length and the `len` provided to `splice`
+        /// 3. calling `write` on the `output-stream` with that read data.
+        ///
+        /// Any error reported by the call to `check-write`, `read`, or
+        /// `write` ends the splice and reports that error.
+        ///
         /// This function returns the number of bytes transferred; it may be less
         /// than `len`.
         splice: func(
@@ -257,8 +266,9 @@ interface streams {
 
         /// Read from one stream and write to another, with blocking.
         ///
-        /// This is similar to `splice`, except that it blocks until at least
-        /// one byte can be read, and written.
+        /// This is similar to `splice`, except that it blocks until the
+        /// `output-stream` is ready for writing, and the `input-stream`
+        /// is ready for reading, before performing the `splice`.
         blocking-splice: func(
             /// The stream to read from
             src: borrow<input-stream>,

--- a/crates/wasi/wit/deps/io/streams.wit
+++ b/crates/wasi/wit/deps/io/streams.wit
@@ -248,12 +248,9 @@ interface streams {
         ///
         /// This function returns the number of bytes transferred; it may be less
         /// than `len`.
-        ///
-        /// Unlike other I/O functions, this function blocks until all the data
-        /// read from the input stream has been written to the output stream.
         splice: func(
             /// The stream to read from
-            src: input-stream,
+            src: borrow<input-stream>,
             /// The number of bytes to splice
             len: u64,
         ) -> result<u64, stream-error>;
@@ -261,29 +258,12 @@ interface streams {
         /// Read from one stream and write to another, with blocking.
         ///
         /// This is similar to `splice`, except that it blocks until at least
-        /// one byte can be read.
+        /// one byte can be read, and written.
         blocking-splice: func(
             /// The stream to read from
-            src: input-stream,
+            src: borrow<input-stream>,
             /// The number of bytes to splice
             len: u64,
-        ) -> result<u64, stream-error>;
-
-        /// Forward the entire contents of an input stream to an output stream.
-        ///
-        /// This function repeatedly reads from the input stream and writes
-        /// the data to the output stream, until the end of the input stream
-        /// is reached, or an error is encountered.
-        ///
-        /// Unlike other I/O functions, this function blocks until the end
-        /// of the input stream is seen and all the data has been written to
-        /// the output stream.
-        ///
-        /// This function returns the number of bytes transferred, and the status of
-        /// the output stream.
-        forward: func(
-            /// The stream to read from
-            src: input-stream
         ) -> result<u64, stream-error>;
     }
 }

--- a/crates/wasi/wit/deps/io/streams.wit
+++ b/crates/wasi/wit/deps/io/streams.wit
@@ -246,6 +246,15 @@ interface streams {
 
         /// Read from one stream and write to another.
         ///
+        /// The behavior of splice is equivelant to:
+        /// 1. calling `check-write` on the `output-stream`
+        /// 2. calling `read` on the `input-stream` with the smaller of the
+        /// `check-write` permitted length and the `len` provided to `splice`
+        /// 3. calling `write` on the `output-stream` with that read data.
+        ///
+        /// Any error reported by the call to `check-write`, `read`, or
+        /// `write` ends the splice and reports that error.
+        ///
         /// This function returns the number of bytes transferred; it may be less
         /// than `len`.
         splice: func(
@@ -257,8 +266,9 @@ interface streams {
 
         /// Read from one stream and write to another, with blocking.
         ///
-        /// This is similar to `splice`, except that it blocks until at least
-        /// one byte can be read, and written.
+        /// This is similar to `splice`, except that it blocks until the
+        /// `output-stream` is ready for writing, and the `input-stream`
+        /// is ready for reading, before performing the `splice`.
         blocking-splice: func(
             /// The stream to read from
             src: borrow<input-stream>,

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1063,6 +1063,39 @@ mod test_programs {
     }
 
     #[test]
+    fn cli_splice_stdin() -> Result<()> {
+        let mut child = get_wasmtime_command()?
+            .args(&["run", "-Wcomponent-model", CLI_SPLICE_STDIN_COMPONENT])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .stdin(Stdio::piped())
+            .spawn()?;
+        let msg = "So rested he by the Tumtum tree";
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(msg.as_bytes())
+            .unwrap();
+        let output = child.wait_with_output()?;
+        assert!(output.status.success());
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !stderr.is_empty() {
+            eprintln!("{stderr}");
+        }
+
+        assert_eq!(
+            format!(
+                "before splice\n{msg}\ncompleted splicing {} bytes\n",
+                msg.as_bytes().len()
+            ),
+            stdout
+        );
+        Ok(())
+    }
+
+    #[test]
     fn cli_env() -> Result<()> {
         run_wasmtime(&[
             "run",


### PR DESCRIPTION
This PR implements `output-stream.splice` and `blocking-splice`.

The wit definitions for these functions has been changed to take a `borrow<input-stream>`, rather than the owned resource.

Splice performs the equivalent to:
* uses `check-write` to determine how much input is accepted by the `output-stream`.
* uses `read` to read up to that much (or the `len` bound provided by caller) from the `input-stream`
* uses `write` to write the read data to the `output-stream`.

By implementing this in the host using the `HostInputStream` and `HostOutputStream` traits, the read and write are done in terms of `Bytes` representation, so there are zero copies of the underlying data made as part of the splice.

A blocking splice waits for both read and write readiness before performing those operations.

The `output-stream.forward` method has been deleted from the wit. We believe that the fusion of an `output-stream` into an `input-stream` (which gives up ownership of both resources, and happens perpetually in the background) is a worthwhile concept to implement some day, but it raises various questions on how progress and errors can be reported, and whether the background work can outlive the calling component, so rather than open that can of worms now we are going to ask users to implement it with their own event loops using `splice` for now, and look at adding it again in the future.