### PR TITLE
Support reset_fuel in store APIs

### DIFF
--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -165,6 +165,23 @@ WASM_API_EXTERN void wasmtime_context_gc(wasmtime_context_t* context);
 WASM_API_EXTERN wasmtime_error_t *wasmtime_context_add_fuel(wasmtime_context_t *store, uint64_t fuel);
 
 /**
+ * \brief Set fuel to this context's store for wasm to consume while executing.
+ *
+ * For this method to work fuel consumption must be enabled via
+ * #wasmtime_config_consume_fuel_set. By default a store starts with 0 fuel
+ * for wasm to execute with (meaning it will immediately trap).
+ * This function must be called for the store to have
+ * some fuel to allow WebAssembly to execute.
+ *
+ * Note that at this time when fuel is entirely consumed it will cause
+ * wasm to trap. More usages of fuel are planned for the future.
+ *
+ * If fuel is not enabled within this store then an error is returned. If fuel
+ * is successfully added then NULL is returned.
+ */
+WASM_API_EXTERN wasmtime_error_t *wasmtime_context_set_fuel(wasmtime_context_t *store, uint64_t fuel);
+
+/**
  * \brief Returns the amount of fuel consumed by this context's store execution
  * so far.
  *

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -156,8 +156,10 @@ WASM_API_EXTERN void wasmtime_context_gc(wasmtime_context_t* context);
  * This function must be called for the store to have
  * some fuel to allow WebAssembly to execute.
  *
- * Note that at this time when fuel is entirely consumed it will cause
- * wasm to trap. More usages of fuel are planned for the future.
+ * Note by default when fuel is entirely consumed it will cause
+ * wasm to trap. If async_support is enabled, you can use 
+ * #wasmtime_context_out_of_fuel_async_yield and the async APIs to yield
+ * execution instead.
  *
  * If fuel is not enabled within this store then an error is returned. If fuel
  * is successfully added then NULL is returned.
@@ -173,8 +175,10 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_context_add_fuel(wasmtime_context_t *
  * This function must be called for the store to have
  * some fuel to allow WebAssembly to execute.
  *
- * Note that at this time when fuel is entirely consumed it will cause
- * wasm to trap. More usages of fuel are planned for the future.
+ * Note by default when fuel is entirely consumed it will cause
+ * wasm to trap. If async_support is enabled, you can use 
+ * #wasmtime_context_out_of_fuel_async_yield and the async APIs to yield
+ * execution instead.
  *
  * If fuel is not enabled within this store then an error is returned. If fuel
  * is successfully added then NULL is returned.

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -179,7 +179,7 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_context_add_fuel(wasmtime_context_t *
  * If fuel is not enabled within this store then an error is returned. If fuel
  * is successfully added then NULL is returned.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_context_set_fuel(wasmtime_context_t *store, uint64_t fuel);
+WASM_API_EXTERN wasmtime_error_t *wasmtime_context_reset_fuel(wasmtime_context_t *store, uint64_t fuel);
 
 /**
  * \brief Returns the amount of fuel consumed by this context's store execution

--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -217,6 +217,14 @@ pub extern "C" fn wasmtime_context_add_fuel(
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_context_set_fuel(
+    mut store: CStoreContextMut<'_>,
+    fuel: u64,
+) -> Option<Box<wasmtime_error_t>> {
+    crate::handle_result(store.set_fuel(fuel), |()| {})
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_context_fuel_consumed(store: CStoreContext<'_>, fuel: &mut u64) -> bool {
     match store.fuel_consumed() {
         Some(amt) => {

--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -217,11 +217,11 @@ pub extern "C" fn wasmtime_context_add_fuel(
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_context_set_fuel(
+pub extern "C" fn wasmtime_context_reset_fuel(
     mut store: CStoreContextMut<'_>,
     fuel: u64,
 ) -> Option<Box<wasmtime_error_t>> {
-    crate::handle_result(store.set_fuel(fuel), |()| {})
+    crate::handle_result(store.reset_fuel(fuel), |()| {})
 }
 
 #[no_mangle]

--- a/crates/wasmtime/src/func.rs
+++ b/crates/wasmtime/src/func.rs
@@ -1902,6 +1902,13 @@ impl<T> Caller<'_, T> {
         self.store.fuel_consumed()
     }
 
+    /// Returns the remaining fuel in the store.
+    ///
+    /// For more information see [`Store::fuel_remaining`](crate::Store::fuel_remaining)
+    pub fn fuel_remaining(&self) -> Option<u64> {
+        self.store.fuel_remaining()
+    }
+
     /// Inject more fuel into this store to be consumed when executing wasm code.
     ///
     /// For more information see [`Store::add_fuel`](crate::Store::add_fuel)

--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -792,10 +792,10 @@ impl<T> Store<T> {
     /// If fuel consumption is not enabled via
     /// [`Config::consume_fuel`](crate::Config::consume_fuel) then this
     /// function will return `None`. Also note that fuel, if enabled, must be
-    /// originally configured via [`Store::add_fuel`] or [`Store::set_fuel`].
+    /// originally configured via [`Store::add_fuel`] or [`Store::reset_fuel`].
     ///
     /// Note that this function returns the amount of fuel consumed since the
-    /// last time [`set_fuel`][Store::set_fuel] was called, or since the creation
+    /// last time [`reset_fuel`][Store::reset_fuel] was called, or since the creation
     /// of the store if it's never been called.
     pub fn fuel_consumed(&self) -> Option<u64> {
         self.inner.fuel_consumed()
@@ -845,8 +845,8 @@ impl<T> Store<T> {
     ///
     /// This function will return an error if fuel consumption is not enabled via
     /// [`Config::consume_fuel`](crate::Config::consume_fuel).
-    pub fn set_fuel(&mut self, fuel: u64) -> Result<()> {
-        self.inner.set_fuel(fuel)
+    pub fn reset_fuel(&mut self, fuel: u64) -> Result<()> {
+        self.inner.reset_fuel(fuel)
     }
 
     /// Synthetically consumes fuel from this [`Store`].
@@ -1138,9 +1138,9 @@ impl<'a, T> StoreContextMut<'a, T> {
 
     /// Set the fuel for this store to be consumed when executing wasm code.
     ///
-    /// For more information see [`Store::set_fuel`]
-    pub fn set_fuel(&mut self, fuel: u64) -> Result<()> {
-        self.0.set_fuel(fuel)
+    /// For more information see [`Store::reset_fuel`]
+    pub fn reset_fuel(&mut self, fuel: u64) -> Result<()> {
+        self.0.reset_fuel(fuel)
     }
 
     /// Configures this `Store` to trap whenever fuel runs out.
@@ -1593,7 +1593,7 @@ impl StoreOpaque {
         }
     }
 
-    fn set_fuel(&mut self, fuel: u64) -> Result<()> {
+    fn reset_fuel(&mut self, fuel: u64) -> Result<()> {
         anyhow::ensure!(
             self.engine().config().tunables.consume_fuel,
             "fuel is not configured in this store"

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -147,7 +147,7 @@ fn manual_fuel() {
     assert_eq!(store.fuel_consumed(), Some(10_000));
     assert_eq!(store.consume_fuel(2_500).unwrap(), 2_500);
     assert_eq!(store.fuel_consumed(), Some(12_500));
-    store.set_fuel(5_000).unwrap();
+    store.reset_fuel(5_000).unwrap();
     assert_eq!(store.fuel_consumed(), Some(0));
     assert_eq!(store.consume_fuel(2_500).unwrap(), 2_500);
     assert_eq!(store.fuel_consumed(), Some(2_500));

--- a/tests/all/fuel.rs
+++ b/tests/all/fuel.rs
@@ -143,6 +143,14 @@ fn manual_fuel() {
     assert_eq!(store.consume_fuel(1).unwrap(), 0);
     assert_eq!(store.consume_fuel(0).unwrap(), 0);
     assert_eq!(store.fuel_remaining(), Some(0));
+    store.add_fuel(5_000).unwrap();
+    assert_eq!(store.fuel_consumed(), Some(10_000));
+    assert_eq!(store.consume_fuel(2_500).unwrap(), 2_500);
+    assert_eq!(store.fuel_consumed(), Some(12_500));
+    store.set_fuel(5_000).unwrap();
+    assert_eq!(store.fuel_consumed(), Some(0));
+    assert_eq!(store.consume_fuel(2_500).unwrap(), 2_500);
+    assert_eq!(store.fuel_consumed(), Some(2_500));
 }
 
 #[test]
@@ -168,7 +176,9 @@ fn host_function_consumes_all() {
     store.add_fuel(FUEL).unwrap();
     let func = Func::wrap(&mut store, |mut caller: Caller<'_, ()>| {
         let consumed = caller.fuel_consumed().unwrap();
-        assert_eq!(caller.consume_fuel((FUEL - consumed) - 1).unwrap(), 1);
+        let remaining = caller.fuel_remaining().unwrap();
+        assert_eq!(remaining, FUEL - consumed);
+        assert_eq!(caller.consume_fuel(remaining - 1).unwrap(), 1);
     });
 
     let instance = Instance::new(&mut store, &module, &[func.into()]).unwrap();


### PR DESCRIPTION
Add a simpler interface to reset the amount of fuel in a store.

Fixes: https://github.com/bytecodealliance/wasmtime/issues/5109

A continuation of https://github.com/bytecodealliance/wasmtime/pull/5220, which has stalled. To make it more obvious that `consumed_fuel` is reset, I've changed the name to this method to be `reset_fuel`.
