### PR TITLE
threads: use hex addresses in log messages

### DIFF
--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -565,7 +565,7 @@ impl SharedMemory {
     /// Implementation of `memory.atomic.notify` for this shared memory.
     pub fn atomic_notify(&self, addr_index: u64, count: u32) -> Result<u32, Trap> {
         validate_atomic_addr(&self.0.def.0, addr_index, 4, 4)?;
-        log::trace!("memory.atomic.notify(addr={addr_index}, count={count})");
+        log::trace!("memory.atomic.notify(addr={addr_index:#x}, count={count})");
         Ok(self.0.spot.unpark(addr_index, count))
     }
 
@@ -578,7 +578,7 @@ impl SharedMemory {
     ) -> Result<WaitResult, Trap> {
         let addr = validate_atomic_addr(&self.0.def.0, addr_index, 4, 4)?;
         log::trace!(
-            "memory.atomic.wait32(addr={addr_index}, expected={expected}, timeout={timeout:?})"
+            "memory.atomic.wait32(addr={addr_index:#x}, expected={expected}, timeout={timeout:?})"
         );
 
         // SAFETY: `addr_index` was validated by `validate_atomic_addr` above.
@@ -603,7 +603,7 @@ impl SharedMemory {
     ) -> Result<WaitResult, Trap> {
         let addr = validate_atomic_addr(&self.0.def.0, addr_index, 8, 8)?;
         log::trace!(
-            "memory.atomic.wait64(addr={addr_index}, expected={expected}, timeout={timeout:?})"
+            "memory.atomic.wait64(addr={addr_index:#x}, expected={expected}, timeout={timeout:?})"
         );
 
         // SAFETY: `addr_index` was validated by `validate_atomic_addr` above.


### PR DESCRIPTION
In #7220, we began logging the arguments of WebAssembly `wait` and `notify` as these instructions are executed. This change prints the addresses using hexadecimal, which is simply more convenient when dealing with addressing.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
