### PR TITLE
Minor logging tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3393,7 +3393,6 @@ dependencies = [
  "tempfile",
  "test-programs-artifacts",
  "tokio",
- "tracing-subscriber",
  "walkdir",
  "wasm-encoder",
  "wasmparser",
@@ -3423,8 +3422,8 @@ dependencies = [
  "clap",
  "file-per-thread-logger",
  "humantime 2.1.0",
- "pretty_env_logger 0.5.0",
  "rayon",
+ "tracing-subscriber",
  "wasmtime",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,6 @@ wasmtime-runtime = { workspace = true }
 clap = { workspace = true, features = ["color", "suggestions", "derive"] }
 anyhow = { workspace = true }
 target-lexicon = { workspace = true }
-tracing-subscriber = { workspace = true }
 once_cell = { workspace = true }
 listenfd = "1.0.0"
 wat = { workspace = true }

--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -12,7 +12,7 @@ edition.workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true }
 file-per-thread-logger = { workspace = true }
-pretty_env_logger = { workspace = true }
+tracing-subscriber = { workspace = true }
 rayon = "1.5.0"
 wasmtime = { workspace = true }
 humantime = "2.0.0"

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -5,7 +5,9 @@
 
 use anyhow::Result;
 use clap::Parser;
+use std::io::IsTerminal;
 use std::time::Duration;
+use tracing_subscriber::{EnvFilter, FmtSubscriber};
 use wasmtime::Config;
 
 pub mod opt;
@@ -328,7 +330,13 @@ impl CommonOptions {
             let prefix = "wasmtime.dbg.";
             init_file_per_thread_logger(prefix);
         } else {
-            pretty_env_logger::init();
+            let mut b = FmtSubscriber::builder()
+                .with_writer(std::io::stderr)
+                .with_env_filter(EnvFilter::from_env("WASMTIME_LOG"));
+            if std::io::stderr().is_terminal() {
+                b = b.with_ansi(true);
+            }
+            b.init();
         }
     }
 

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -82,16 +82,6 @@ impl Wasmtime {
 }
 
 fn main() -> Result<()> {
-    use std::io::IsTerminal;
-    use tracing_subscriber::{EnvFilter, FmtSubscriber};
-
-    let mut b = FmtSubscriber::builder()
-        .with_writer(std::io::stderr)
-        .with_env_filter(EnvFilter::from_env("WASMTIME_LOG"));
-    if std::io::stderr().is_terminal() {
-        b = b.with_ansi(true);
-    }
-    b.init();
     Wasmtime::parse().execute()
 }
 

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -32,7 +32,7 @@ pub fn get_wasmtime_command() -> Result<Command> {
     // If we're running tests with a "runner" then we might be doing something
     // like cross-emulation, so spin up the emulator rather than the tests
     // itself, which may not be natively executable.
-    let mut cmd = if let Some((_, runner)) = runner {
+    let cmd = if let Some((_, runner)) = runner {
         let mut parts = runner.split_whitespace();
         let mut cmd = Command::new(parts.next().unwrap());
         for arg in parts {
@@ -43,10 +43,6 @@ pub fn get_wasmtime_command() -> Result<Command> {
     } else {
         Command::new(&me)
     };
-
-    if let Ok(val) = std::env::var("WASMTIME_LOG") {
-        cmd.env("WASMTIME_LOG", val);
-    }
 
     Ok(cmd)
 }


### PR DESCRIPTION
Some things I noticed from #7239 which are very much not critical but I figure might be nice-to-haves:

* Move the logging configuration to the `wasmtime-cli-flags` crate with the other logging configuration to keep it in one place.
* Remove `pretty_env_logger` since `tracing-subscriber` probably supplants it.
* Don't explicitly inherit env vars in tests since that happens automatically with `Command`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
