### PR TITLE
cranelift: Add egraph rules for `bswap`

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -145,3 +145,54 @@
 
 ;; (bitrev (bitrev x)) == x
 (rule (simplify (bitrev ty (bitrev ty x))) (subsume x))
+
+;; WebAssembly doesn't have a native byte-swapping instruction at this time so
+;; languages which have a byte-swapping operation will compile it down to bit
+;; shifting and twiddling. This attempts to pattern match what LLVM currently
+;; generates today for the Rust code `a.swap_bytes()`. This might be a bit
+;; brittle over time and/or with other possible LLVM backend optimizations, but
+;; it's at least one way to generate a byte swap.
+;;
+;; Technically this could be permuted quite a few ways and currently there's no
+;; easy way to match all of them, so only one is matched here.
+(rule (simplify (bor ty @ $I32
+    (bor ty
+      (ishl ty x (iconst ty (u64_from_imm64 24)))
+      (ishl ty
+        (band ty x (iconst ty (u64_from_imm64 0xff00)))
+        (iconst ty (u64_from_imm64 8))))
+    (bor ty
+      (band ty
+        (ushr ty x (iconst ty (u64_from_imm64 8)))
+        (iconst ty (u64_from_imm64 0xff00)))
+      (ushr ty x (iconst ty (u64_from_imm64 24))))))
+  (bswap ty x))
+
+(rule (simplify (bor ty @ $I64
+    (bor ty
+      (bor ty
+        (ishl ty x (iconst ty (u64_from_imm64 56)))
+        (ishl ty
+          (band ty x (iconst ty (u64_from_imm64 0xff00)))
+          (iconst ty (u64_from_imm64 40))))
+      (bor ty
+        (ishl ty
+          (band ty x (iconst ty (u64_from_imm64 0xff_0000)))
+          (iconst ty (u64_from_imm64 24)))
+        (ishl ty
+          (band ty x (iconst ty (u64_from_imm64 0xff00_0000)))
+          (iconst ty (u64_from_imm64 8)))))
+    (bor ty
+      (bor ty
+        (band ty
+          (ushr ty x (iconst ty (u64_from_imm64 8)))
+          (iconst ty (u64_from_imm64 0xff00_0000)))
+        (band ty
+          (ushr ty x (iconst ty (u64_from_imm64 24)))
+          (iconst ty (u64_from_imm64 0xff_0000))))
+      (bor ty
+        (band ty
+          (ushr ty x (iconst ty (u64_from_imm64 40)))
+          (iconst ty (u64_from_imm64 0xff00)))
+        (ushr ty x (iconst ty (u64_from_imm64 56)))))))
+  (bswap ty x))

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/zbb.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/zbb.wat
@@ -1,0 +1,88 @@
+;;! target = "riscv64"
+;;! compile = true
+;;! settings = ["has_zbb", "opt_level=speed"]
+
+(module
+  (func (export "bswap32") (param i32) (result i32)
+    local.get 0
+    i32.const 24
+    i32.shl
+    local.get 0
+    i32.const 65280
+    i32.and
+    i32.const 8
+    i32.shl
+    i32.or
+    local.get 0
+    i32.const 8
+    i32.shr_u
+    i32.const 65280
+    i32.and
+    local.get 0
+    i32.const 24
+    i32.shr_u
+    i32.or
+    i32.or
+  )
+
+  (func (export "bswap64") (param i64) (result i64)
+    local.get 0
+    i64.const 56
+    i64.shl
+    local.get 0
+    i64.const 65280
+    i64.and
+    i64.const 40
+    i64.shl
+    i64.or
+    local.get 0
+    i64.const 16711680
+    i64.and
+    i64.const 24
+    i64.shl
+    local.get 0
+    i64.const 4278190080
+    i64.and
+    i64.const 8
+    i64.shl
+    i64.or
+    i64.or
+    local.get 0
+    i64.const 8
+    i64.shr_u
+    i64.const 4278190080
+    i64.and
+    local.get 0
+    i64.const 24
+    i64.shr_u
+    i64.const 16711680
+    i64.and
+    i64.or
+    local.get 0
+    i64.const 40
+    i64.shr_u
+    i64.const 65280
+    i64.and
+    local.get 0
+    i64.const 56
+    i64.shr_u
+    i64.or
+    i64.or
+    i64.or
+  )
+)
+
+;; function u0:0:
+;; block0:
+;;   j label1
+;; block1:
+;;   rev8 a4,a0
+;;   srli a0,a4,32
+;;   ret
+;;
+;; function u0:1:
+;; block0:
+;;   j label1
+;; block1:
+;;   rev8 a0,a0
+;;   ret

--- a/cranelift/filetests/filetests/wasm/byteswap.wat
+++ b/cranelift/filetests/filetests/wasm/byteswap.wat
@@ -1,6 +1,6 @@
-;;! target = "riscv64"
-;;! compile = true
-;;! settings = ["has_zbb", "opt_level=speed"]
+;;! target = "x86_64"
+;;! optimize = true
+;;! settings = ["opt_level=speed"]
 
 (module
   (func (export "bswap32") (param i32) (result i32)
@@ -72,17 +72,22 @@
   )
 )
 
-;; function u0:0:
-;; block0:
-;;   j label1
-;; block1:
-;;   rev8 a4,a0
-;;   srli a0,a4,32
-;;   ret
+;; function u0:0(i32, i64 vmctx) -> i32 fast {
+;;                                 block0(v0: i32, v1: i64):
+;; @0057                               jump block1
 ;;
-;; function u0:1:
-;; block0:
-;;   j label1
-;; block1:
-;;   rev8 a0,a0
-;;   ret
+;;                                 block1:
+;;                                     v18 = bswap.i32 v0
+;;                                     v19 -> v18
+;; @0057                               return v18
+;; }
+;;
+;; function u0:1(i64, i64 vmctx) -> i64 fast {
+;;                                 block0(v0: i64, v1: i64):
+;; @00ad                               jump block1
+;;
+;;                                 block1:
+;;                                     v38 = bswap.i64 v0
+;;                                     v39 -> v38
+;; @00ad                               return v38
+;; }


### PR DESCRIPTION
WebAssembly doesn't currently have a byte-swapping instruction so this commit pattern matches what LLVM currently generates to simplify to a single `bswap` instruction in CLIF which can be lowered within each backend to respective native instructions.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
