### PR TITLE
riscv64: Optimize `select_spectre_guard`

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1548,7 +1548,11 @@
 ;; rd ← rs1 ∧ ~(rs2)
 (decl rv_andn (XReg XReg) XReg)
 (rule (rv_andn rs1 rs2)
+  (if-let $true (has_zbb))
   (alu_rrr (AluOPRRR.Andn) rs1 rs2))
+(rule (rv_andn rs1 rs2)
+  (if-let $false (has_zbb))
+  (rv_and rs1 (rv_not rs2)))
 
 ;; Helper for emitting the `orn` ("Or Negated") instruction.
 ;; rd ← rs1 ∨ ~(rs2)
@@ -1982,16 +1986,6 @@
 
 (rule 0 (gen_bnot (ty_int_ref_scalar_64 _) x)
   (rv_not (value_regs_get x 0)))
-
-
-(decl gen_and (Type ValueRegs ValueRegs) ValueRegs)
-(rule 1 (gen_and $I128 x y)
-  (value_regs
-    (rv_and (value_regs_get x 0) (value_regs_get y 0))
-    (rv_and (value_regs_get x 1) (value_regs_get y 1))))
-
-(rule 0 (gen_and (fits_in_64 _) x y)
-  (rv_and (value_regs_get x 0) (value_regs_get y 0)))
 
 
 (decl gen_andi (XReg u64) XReg)

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -654,8 +654,13 @@
   (rv_rem x y))
 
 ;;;; Rules for `and` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-(rule 0 (lower (has_type (ty_int ty) (band x y)))
-  (gen_and ty x y))
+(rule -1 (lower (has_type (fits_in_64 ty) (band x y)))
+  (rv_and x y))
+
+(rule 0 (lower (has_type $I128 (band x y)))
+  (value_regs
+    (rv_and (value_regs_get x 0) (value_regs_get y 0))
+    (rv_and (value_regs_get x 1) (value_regs_get y 1))))
 
 ;; Special cases for when one operand is an immediate that fits in 12 bits.
 (rule 1 (lower (has_type (fits_in_64 (ty_int ty)) (band x (imm12_from_value y))))
@@ -2108,17 +2113,24 @@
 ;;
 ;; We don't have cmov's in RISC-V either, but we can emulate those using bitwise
 ;; operations, which is what we do below.
-(rule (lower (has_type ty (select_spectre_guard cmp @ (value_type cmp_ty) x @ (value_type arg_ty) y)))
-  (let (;; Build a mask that is 0 or -1 depending on the input comparision value.
-        ;; `lower_bmask` handles normalizing the input.
-        (mask ValueRegs (lower_bmask cmp arg_ty))
-        ;; Using the mask above we can select either `x` or `y` by
-        ;; performing a bitwise `and` on both sides and then merging them
-        ;; together. We know that only the bits of one of the sides will be selected.
-        ;; TODO: We can use `andn` here if we have `Zbb`
-        (lhs ValueRegs (gen_and arg_ty x mask))
-        (rhs ValueRegs (gen_and arg_ty y (gen_bnot arg_ty mask))))
-    (gen_or arg_ty lhs rhs)))
+
+;; Base case: use `gen_bmask` to generate a 0 mask or -1 mask from the value of
+;; `cmp`. This is then used with some bit twiddling to produce the final result.
+(rule 0 (lower (has_type (fits_in_64 _) (select_spectre_guard cmp x y)))
+  (let ((mask XReg (gen_bmask cmp)))
+    (rv_or (rv_and mask x) (rv_andn y mask))))
+(rule 1 (lower (has_type $I128 (select_spectre_guard cmp x y)))
+  (let ((mask XReg (gen_bmask cmp)))
+    (value_regs
+      (rv_or (rv_and mask (value_regs_get x 0)) (rv_andn (value_regs_get y 0) mask))
+      (rv_or (rv_and mask (value_regs_get x 1)) (rv_andn (value_regs_get y 1) mask)))))
+
+;; Special case when an argument is the constant zero as some ands and ors
+;; can be folded away.
+(rule 2 (lower (has_type (fits_in_64 _) (select_spectre_guard cmp (i64_from_iconst 0) y)))
+  (rv_andn y (gen_bmask cmp)))
+(rule 3 (lower (has_type (fits_in_64 _) (select_spectre_guard cmp x (i64_from_iconst 0))))
+  (rv_and x (gen_bmask cmp)))
 
 ;;;;;  Rules for `bmask`;;;;;;;;;
 (rule

--- a/cranelift/filetests/filetests/isa/riscv64/select_spectre_guard.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/select_spectre_guard.clif
@@ -17,7 +17,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   xori a3,a5,42
 ;   seqz a3,a3
 ;   sub a3,zero,a3
-;   and a4,a1,a3
+;   and a4,a3,a1
 ;   not a0,a3
 ;   and a2,a2,a0
 ;   or a0,a4,a2
@@ -30,7 +30,7 @@ block0(v0: i8, v1: i8, v2: i8):
 ;   xori a3, a5, 0x2a
 ;   seqz a3, a3
 ;   neg a3, a3
-;   and a4, a1, a3
+;   and a4, a3, a1
 ;   not a0, a3
 ;   and a2, a2, a0
 ;   or a0, a4, a2
@@ -51,7 +51,7 @@ block0(v0: i8, v1: i16, v2: i16):
 ;   xori a3,a5,42
 ;   seqz a3,a3
 ;   sub a3,zero,a3
-;   and a4,a1,a3
+;   and a4,a3,a1
 ;   not a0,a3
 ;   and a2,a2,a0
 ;   or a0,a4,a2
@@ -64,7 +64,7 @@ block0(v0: i8, v1: i16, v2: i16):
 ;   xori a3, a5, 0x2a
 ;   seqz a3, a3
 ;   neg a3, a3
-;   and a4, a1, a3
+;   and a4, a3, a1
 ;   not a0, a3
 ;   and a2, a2, a0
 ;   or a0, a4, a2
@@ -85,7 +85,7 @@ block0(v0: i8, v1: i32, v2: i32):
 ;   xori a3,a5,42
 ;   seqz a3,a3
 ;   sub a3,zero,a3
-;   and a4,a1,a3
+;   and a4,a3,a1
 ;   not a0,a3
 ;   and a2,a2,a0
 ;   or a0,a4,a2
@@ -98,7 +98,7 @@ block0(v0: i8, v1: i32, v2: i32):
 ;   xori a3, a5, 0x2a
 ;   seqz a3, a3
 ;   neg a3, a3
-;   and a4, a1, a3
+;   and a4, a3, a1
 ;   not a0, a3
 ;   and a2, a2, a0
 ;   or a0, a4, a2
@@ -119,7 +119,7 @@ block0(v0: i8, v1: i64, v2: i64):
 ;   xori a3,a5,42
 ;   seqz a3,a3
 ;   sub a3,zero,a3
-;   and a4,a1,a3
+;   and a4,a3,a1
 ;   not a0,a3
 ;   and a2,a2,a0
 ;   or a0,a4,a2
@@ -132,7 +132,7 @@ block0(v0: i8, v1: i64, v2: i64):
 ;   xori a3, a5, 0x2a
 ;   seqz a3, a3
 ;   neg a3, a3
-;   and a4, a1, a3
+;   and a4, a3, a1
 ;   not a0, a3
 ;   and a2, a2, a0
 ;   or a0, a4, a2
@@ -147,60 +147,37 @@ block0(v0: i8, v1: i128, v2: i128):
 }
 
 ; VCode:
-;   add sp,-16
-;   sd ra,8(sp)
-;   sd fp,0(sp)
-;   mv fp,sp
-;   sd s10,-8(sp)
-;   add sp,-16
 ; block0:
 ;   slli a5,a0,56
 ;   srai a5,a5,56
 ;   xori a5,a5,42
 ;   seqz a5,a5
 ;   sub a5,zero,a5
-;   and a0,a1,a5
-;   and a2,a2,a5
-;   not s10,a5
+;   and a0,a5,a1
 ;   not a1,a5
-;   and a3,a3,s10
-;   and a4,a4,a1
-;   or a0,a0,a3
-;   or a1,a2,a4
-;   add sp,+16
-;   ld s10,-8(sp)
-;   ld ra,8(sp)
-;   ld fp,0(sp)
-;   add sp,+16
+;   and a1,a3,a1
+;   or a0,a0,a1
+;   and a2,a5,a2
+;   not a5,a5
+;   and a1,a4,a5
+;   or a1,a2,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi sp, sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
-;   mv s0, sp
-;   sd s10, -8(sp)
-;   addi sp, sp, -0x10
-; block1: ; offset 0x18
 ;   slli a5, a0, 0x38
 ;   srai a5, a5, 0x38
 ;   xori a5, a5, 0x2a
 ;   seqz a5, a5
 ;   neg a5, a5
-;   and a0, a1, a5
-;   and a2, a2, a5
-;   not s10, a5
+;   and a0, a5, a1
 ;   not a1, a5
-;   and a3, a3, s10
-;   and a4, a4, a1
-;   or a0, a0, a3
-;   or a1, a2, a4
-;   addi sp, sp, 0x10
-;   ld s10, -8(sp)
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
+;   and a1, a3, a1
+;   or a0, a0, a1
+;   and a2, a5, a2
+;   not a5, a5
+;   and a1, a4, a5
+;   or a1, a2, a1
 ;   ret
 
 function %f(i16, i8, i8) -> i8 {
@@ -218,7 +195,7 @@ block0(v0: i16, v1: i8, v2: i8):
 ;   xori a3,a5,42
 ;   seqz a3,a3
 ;   sub a3,zero,a3
-;   and a4,a1,a3
+;   and a4,a3,a1
 ;   not a0,a3
 ;   and a2,a2,a0
 ;   or a0,a4,a2
@@ -231,7 +208,7 @@ block0(v0: i16, v1: i8, v2: i8):
 ;   xori a3, a5, 0x2a
 ;   seqz a3, a3
 ;   neg a3, a3
-;   and a4, a1, a3
+;   and a4, a3, a1
 ;   not a0, a3
 ;   and a2, a2, a0
 ;   or a0, a4, a2
@@ -252,7 +229,7 @@ block0(v0: i16, v1: i16, v2: i16):
 ;   xori a3,a5,42
 ;   seqz a3,a3
 ;   sub a3,zero,a3
-;   and a4,a1,a3
+;   and a4,a3,a1
 ;   not a0,a3
 ;   and a2,a2,a0
 ;   or a0,a4,a2
@@ -265,7 +242,7 @@ block0(v0: i16, v1: i16, v2: i16):
 ;   xori a3, a5, 0x2a
 ;   seqz a3, a3
 ;   neg a3, a3
-;   and a4, a1, a3
+;   and a4, a3, a1
 ;   not a0, a3
 ;   and a2, a2, a0
 ;   or a0, a4, a2
@@ -286,7 +263,7 @@ block0(v0: i16, v1: i32, v2: i32):
 ;   xori a3,a5,42
 ;   seqz a3,a3
 ;   sub a3,zero,a3
-;   and a4,a1,a3
+;   and a4,a3,a1
 ;   not a0,a3
 ;   and a2,a2,a0
 ;   or a0,a4,a2
@@ -299,7 +276,7 @@ block0(v0: i16, v1: i32, v2: i32):
 ;   xori a3, a5, 0x2a
 ;   seqz a3, a3
 ;   neg a3, a3
-;   and a4, a1, a3
+;   and a4, a3, a1
 ;   not a0, a3
 ;   and a2, a2, a0
 ;   or a0, a4, a2
@@ -320,7 +297,7 @@ block0(v0: i16, v1: i64, v2: i64):
 ;   xori a3,a5,42
 ;   seqz a3,a3
 ;   sub a3,zero,a3
-;   and a4,a1,a3
+;   and a4,a3,a1
 ;   not a0,a3
 ;   and a2,a2,a0
 ;   or a0,a4,a2
@@ -333,7 +310,7 @@ block0(v0: i16, v1: i64, v2: i64):
 ;   xori a3, a5, 0x2a
 ;   seqz a3, a3
 ;   neg a3, a3
-;   and a4, a1, a3
+;   and a4, a3, a1
 ;   not a0, a3
 ;   and a2, a2, a0
 ;   or a0, a4, a2
@@ -348,60 +325,37 @@ block0(v0: i16, v1: i128, v2: i128):
 }
 
 ; VCode:
-;   add sp,-16
-;   sd ra,8(sp)
-;   sd fp,0(sp)
-;   mv fp,sp
-;   sd s10,-8(sp)
-;   add sp,-16
 ; block0:
 ;   slli a5,a0,48
 ;   srai a5,a5,48
 ;   xori a5,a5,42
 ;   seqz a5,a5
 ;   sub a5,zero,a5
-;   and a0,a1,a5
-;   and a2,a2,a5
-;   not s10,a5
+;   and a0,a5,a1
 ;   not a1,a5
-;   and a3,a3,s10
-;   and a4,a4,a1
-;   or a0,a0,a3
-;   or a1,a2,a4
-;   add sp,+16
-;   ld s10,-8(sp)
-;   ld ra,8(sp)
-;   ld fp,0(sp)
-;   add sp,+16
+;   and a1,a3,a1
+;   or a0,a0,a1
+;   and a2,a5,a2
+;   not a5,a5
+;   and a1,a4,a5
+;   or a1,a2,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi sp, sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
-;   mv s0, sp
-;   sd s10, -8(sp)
-;   addi sp, sp, -0x10
-; block1: ; offset 0x18
 ;   slli a5, a0, 0x30
 ;   srai a5, a5, 0x30
 ;   xori a5, a5, 0x2a
 ;   seqz a5, a5
 ;   neg a5, a5
-;   and a0, a1, a5
-;   and a2, a2, a5
-;   not s10, a5
+;   and a0, a5, a1
 ;   not a1, a5
-;   and a3, a3, s10
-;   and a4, a4, a1
-;   or a0, a0, a3
-;   or a1, a2, a4
-;   addi sp, sp, 0x10
-;   ld s10, -8(sp)
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
+;   and a1, a3, a1
+;   or a0, a0, a1
+;   and a2, a5, a2
+;   not a5, a5
+;   and a1, a4, a5
+;   or a1, a2, a1
 ;   ret
 
 function %f(i32, i8, i8) -> i8 {
@@ -418,7 +372,7 @@ block0(v0: i32, v1: i8, v2: i8):
 ;   xori a5,a3,42
 ;   seqz a3,a5
 ;   sub a4,zero,a3
-;   and a3,a1,a4
+;   and a3,a4,a1
 ;   not a5,a4
 ;   and a1,a2,a5
 ;   or a0,a3,a1
@@ -430,7 +384,7 @@ block0(v0: i32, v1: i8, v2: i8):
 ;   xori a5, a3, 0x2a
 ;   seqz a3, a5
 ;   neg a4, a3
-;   and a3, a1, a4
+;   and a3, a4, a1
 ;   not a5, a4
 ;   and a1, a2, a5
 ;   or a0, a3, a1
@@ -450,7 +404,7 @@ block0(v0: i32, v1: i16, v2: i16):
 ;   xori a5,a3,42
 ;   seqz a3,a5
 ;   sub a4,zero,a3
-;   and a3,a1,a4
+;   and a3,a4,a1
 ;   not a5,a4
 ;   and a1,a2,a5
 ;   or a0,a3,a1
@@ -462,7 +416,7 @@ block0(v0: i32, v1: i16, v2: i16):
 ;   xori a5, a3, 0x2a
 ;   seqz a3, a5
 ;   neg a4, a3
-;   and a3, a1, a4
+;   and a3, a4, a1
 ;   not a5, a4
 ;   and a1, a2, a5
 ;   or a0, a3, a1
@@ -482,7 +436,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   xori a5,a3,42
 ;   seqz a3,a5
 ;   sub a4,zero,a3
-;   and a3,a1,a4
+;   and a3,a4,a1
 ;   not a5,a4
 ;   and a1,a2,a5
 ;   or a0,a3,a1
@@ -494,7 +448,7 @@ block0(v0: i32, v1: i32, v2: i32):
 ;   xori a5, a3, 0x2a
 ;   seqz a3, a5
 ;   neg a4, a3
-;   and a3, a1, a4
+;   and a3, a4, a1
 ;   not a5, a4
 ;   and a1, a2, a5
 ;   or a0, a3, a1
@@ -514,7 +468,7 @@ block0(v0: i32, v1: i64, v2: i64):
 ;   xori a5,a3,42
 ;   seqz a3,a5
 ;   sub a4,zero,a3
-;   and a3,a1,a4
+;   and a3,a4,a1
 ;   not a5,a4
 ;   and a1,a2,a5
 ;   or a0,a3,a1
@@ -526,7 +480,7 @@ block0(v0: i32, v1: i64, v2: i64):
 ;   xori a5, a3, 0x2a
 ;   seqz a3, a5
 ;   neg a4, a3
-;   and a3, a1, a4
+;   and a3, a4, a1
 ;   not a5, a4
 ;   and a1, a2, a5
 ;   or a0, a3, a1
@@ -545,15 +499,15 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   sext.w a5,a0
 ;   xori a5,a5,42
 ;   seqz a5,a5
-;   sub a0,zero,a5
-;   and a5,a1,a0
-;   and a1,a2,a0
-;   not a2,a0
-;   not a0,a0
-;   and a2,a3,a2
-;   and a3,a4,a0
-;   or a0,a5,a2
-;   or a1,a1,a3
+;   sub a5,zero,a5
+;   and a0,a5,a1
+;   not a1,a5
+;   and a3,a3,a1
+;   or a0,a0,a3
+;   and a1,a5,a2
+;   not a3,a5
+;   and a5,a4,a3
+;   or a1,a1,a5
 ;   ret
 ;
 ; Disassembled:
@@ -561,15 +515,15 @@ block0(v0: i32, v1: i128, v2: i128):
 ;   sext.w a5, a0
 ;   xori a5, a5, 0x2a
 ;   seqz a5, a5
-;   neg a0, a5
-;   and a5, a1, a0
-;   and a1, a2, a0
-;   not a2, a0
-;   not a0, a0
-;   and a2, a3, a2
-;   and a3, a4, a0
-;   or a0, a5, a2
-;   or a1, a1, a3
+;   neg a5, a5
+;   and a0, a5, a1
+;   not a1, a5
+;   and a3, a3, a1
+;   or a0, a0, a3
+;   and a1, a5, a2
+;   not a3, a5
+;   and a5, a4, a3
+;   or a1, a1, a5
 ;   ret
 
 function %f(i64, i8, i8) -> i8 {
@@ -585,7 +539,7 @@ block0(v0: i64, v1: i8, v2: i8):
 ;   xori a3,a0,42
 ;   seqz a5,a3
 ;   sub a0,zero,a5
-;   and a3,a1,a0
+;   and a3,a0,a1
 ;   not a4,a0
 ;   and a0,a2,a4
 ;   or a0,a3,a0
@@ -596,7 +550,7 @@ block0(v0: i64, v1: i8, v2: i8):
 ;   xori a3, a0, 0x2a
 ;   seqz a5, a3
 ;   neg a0, a5
-;   and a3, a1, a0
+;   and a3, a0, a1
 ;   not a4, a0
 ;   and a0, a2, a4
 ;   or a0, a3, a0
@@ -615,7 +569,7 @@ block0(v0: i64, v1: i16, v2: i16):
 ;   xori a3,a0,42
 ;   seqz a5,a3
 ;   sub a0,zero,a5
-;   and a3,a1,a0
+;   and a3,a0,a1
 ;   not a4,a0
 ;   and a0,a2,a4
 ;   or a0,a3,a0
@@ -626,7 +580,7 @@ block0(v0: i64, v1: i16, v2: i16):
 ;   xori a3, a0, 0x2a
 ;   seqz a5, a3
 ;   neg a0, a5
-;   and a3, a1, a0
+;   and a3, a0, a1
 ;   not a4, a0
 ;   and a0, a2, a4
 ;   or a0, a3, a0
@@ -645,7 +599,7 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   xori a3,a0,42
 ;   seqz a5,a3
 ;   sub a0,zero,a5
-;   and a3,a1,a0
+;   and a3,a0,a1
 ;   not a4,a0
 ;   and a0,a2,a4
 ;   or a0,a3,a0
@@ -656,7 +610,7 @@ block0(v0: i64, v1: i32, v2: i32):
 ;   xori a3, a0, 0x2a
 ;   seqz a5, a3
 ;   neg a0, a5
-;   and a3, a1, a0
+;   and a3, a0, a1
 ;   not a4, a0
 ;   and a0, a2, a4
 ;   or a0, a3, a0
@@ -675,7 +629,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   xori a3,a0,42
 ;   seqz a5,a3
 ;   sub a0,zero,a5
-;   and a3,a1,a0
+;   and a3,a0,a1
 ;   not a4,a0
 ;   and a0,a2,a4
 ;   or a0,a3,a0
@@ -686,7 +640,7 @@ block0(v0: i64, v1: i64, v2: i64):
 ;   xori a3, a0, 0x2a
 ;   seqz a5, a3
 ;   neg a0, a5
-;   and a3, a1, a0
+;   and a3, a0, a1
 ;   not a4, a0
 ;   and a0, a2, a4
 ;   or a0, a3, a0
@@ -708,19 +662,19 @@ block0(v0: i64, v1: i128, v2: i128):
 ;   sd s11,-8(sp)
 ;   add sp,-16
 ; block0:
-;   mv s11,a1
-;   xori a5,a0,42
-;   seqz a5,a5
-;   sub a1,zero,a5
-;   mv a5,s11
-;   and a5,a5,a1
-;   and a2,a2,a1
-;   not a0,a1
-;   not a1,a1
-;   and a0,a3,a0
-;   and a3,a4,a1
+;   mv s11,a3
+;   xori a3,a0,42
+;   seqz a5,a3
+;   sub a3,zero,a5
+;   and a5,a3,a1
+;   not a0,a3
+;   mv a1,s11
+;   and a0,a1,a0
 ;   or a0,a5,a0
-;   or a1,a2,a3
+;   and a1,a3,a2
+;   not a2,a3
+;   and a4,a4,a2
+;   or a1,a1,a4
 ;   add sp,+16
 ;   ld s11,-8(sp)
 ;   ld ra,8(sp)
@@ -737,19 +691,19 @@ block0(v0: i64, v1: i128, v2: i128):
 ;   sd s11, -8(sp)
 ;   addi sp, sp, -0x10
 ; block1: ; offset 0x18
-;   mv s11, a1
-;   xori a5, a0, 0x2a
-;   seqz a5, a5
-;   neg a1, a5
-;   mv a5, s11
-;   and a5, a5, a1
-;   and a2, a2, a1
-;   not a0, a1
-;   not a1, a1
-;   and a0, a3, a0
-;   and a3, a4, a1
+;   mv s11, a3
+;   xori a3, a0, 0x2a
+;   seqz a5, a3
+;   neg a3, a5
+;   and a5, a3, a1
+;   not a0, a3
+;   mv a1, s11
+;   and a0, a1, a0
 ;   or a0, a5, a0
-;   or a1, a2, a3
+;   and a1, a3, a2
+;   not a2, a3
+;   and a4, a4, a2
+;   or a1, a1, a4
 ;   addi sp, sp, 0x10
 ;   ld s11, -8(sp)
 ;   ld ra, 8(sp)
@@ -775,7 +729,7 @@ block0(v0: i128, v1: i8, v2: i8):
 ;   or a4,a0,a4
 ;   seqz a0,a4
 ;   sub a5,zero,a0
-;   and a1,a2,a5
+;   and a1,a5,a2
 ;   not a4,a5
 ;   and a5,a3,a4
 ;   or a0,a1,a5
@@ -790,7 +744,7 @@ block0(v0: i128, v1: i8, v2: i8):
 ;   or a4, a0, a4
 ;   seqz a0, a4
 ;   neg a5, a0
-;   and a1, a2, a5
+;   and a1, a5, a2
 ;   not a4, a5
 ;   and a5, a3, a4
 ;   or a0, a1, a5
@@ -814,7 +768,7 @@ block0(v0: i128, v1: i16, v2: i16):
 ;   or a4,a0,a4
 ;   seqz a0,a4
 ;   sub a5,zero,a0
-;   and a1,a2,a5
+;   and a1,a5,a2
 ;   not a4,a5
 ;   and a5,a3,a4
 ;   or a0,a1,a5
@@ -829,7 +783,7 @@ block0(v0: i128, v1: i16, v2: i16):
 ;   or a4, a0, a4
 ;   seqz a0, a4
 ;   neg a5, a0
-;   and a1, a2, a5
+;   and a1, a5, a2
 ;   not a4, a5
 ;   and a5, a3, a4
 ;   or a0, a1, a5
@@ -853,7 +807,7 @@ block0(v0: i128, v1: i32, v2: i32):
 ;   or a4,a0,a4
 ;   seqz a0,a4
 ;   sub a5,zero,a0
-;   and a1,a2,a5
+;   and a1,a5,a2
 ;   not a4,a5
 ;   and a5,a3,a4
 ;   or a0,a1,a5
@@ -868,7 +822,7 @@ block0(v0: i128, v1: i32, v2: i32):
 ;   or a4, a0, a4
 ;   seqz a0, a4
 ;   neg a5, a0
-;   and a1, a2, a5
+;   and a1, a5, a2
 ;   not a4, a5
 ;   and a5, a3, a4
 ;   or a0, a1, a5
@@ -892,7 +846,7 @@ block0(v0: i128, v1: i64, v2: i64):
 ;   or a4,a0,a4
 ;   seqz a0,a4
 ;   sub a5,zero,a0
-;   and a1,a2,a5
+;   and a1,a5,a2
 ;   not a4,a5
 ;   and a5,a3,a4
 ;   or a0,a1,a5
@@ -907,7 +861,7 @@ block0(v0: i128, v1: i64, v2: i64):
 ;   or a4, a0, a4
 ;   seqz a0, a4
 ;   neg a5, a0
-;   and a1, a2, a5
+;   and a1, a5, a2
 ;   not a4, a5
 ;   and a5, a3, a4
 ;   or a0, a1, a5
@@ -923,12 +877,6 @@ block0(v0: i128, v1: i128, v2: i128):
 }
 
 ; VCode:
-;   add sp,-16
-;   sd ra,8(sp)
-;   sd fp,0(sp)
-;   mv fp,sp
-;   sd s7,-8(sp)
-;   add sp,-16
 ; block0:
 ;   li a6,42
 ;   li a7,0
@@ -936,50 +884,33 @@ block0(v0: i128, v1: i128, v2: i128):
 ;   xor a1,a1,a7
 ;   or a0,a0,a1
 ;   seqz a0,a0
-;   sub s7,zero,a0
-;   and a1,a2,s7
-;   and a2,a3,s7
-;   not a0,s7
-;   not a3,s7
-;   and a0,a4,a0
-;   and a3,a5,a3
-;   or a0,a1,a0
+;   sub a1,zero,a0
+;   and a0,a1,a2
+;   not a2,a1
+;   and a2,a4,a2
+;   or a0,a0,a2
+;   and a2,a1,a3
+;   not a1,a1
+;   and a3,a5,a1
 ;   or a1,a2,a3
-;   add sp,+16
-;   ld s7,-8(sp)
-;   ld ra,8(sp)
-;   ld fp,0(sp)
-;   add sp,+16
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi sp, sp, -0x10
-;   sd ra, 8(sp)
-;   sd s0, 0(sp)
-;   mv s0, sp
-;   sd s7, -8(sp)
-;   addi sp, sp, -0x10
-; block1: ; offset 0x18
 ;   addi a6, zero, 0x2a
 ;   mv a7, zero
 ;   xor a0, a0, a6
 ;   xor a1, a1, a7
 ;   or a0, a0, a1
 ;   seqz a0, a0
-;   neg s7, a0
-;   and a1, a2, s7
-;   and a2, a3, s7
-;   not a0, s7
-;   not a3, s7
-;   and a0, a4, a0
-;   and a3, a5, a3
-;   or a0, a1, a0
+;   neg a1, a0
+;   and a0, a1, a2
+;   not a2, a1
+;   and a2, a4, a2
+;   or a0, a0, a2
+;   and a2, a1, a3
+;   not a1, a1
+;   and a3, a5, a1
 ;   or a1, a2, a3
-;   addi sp, sp, 0x10
-;   ld s7, -8(sp)
-;   ld ra, 8(sp)
-;   ld s0, 0(sp)
-;   addi sp, sp, 0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,40 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
+;;   slli a0,a0,32
+;;   srli a3,a0,32
 ;;   ld a4,8(a2)
 ;;   addi a4,a4,-4
-;;   sltu a0,a4,a5
-;;   ld a4,0(a2)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   sw a1,0(a2)
+;;   sltu a4,a4,a3
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sub a5,zero,a4
+;;   not a3,a5
+;;   and a3,a2,a3
+;;   sw a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   ld a4,8(a1)
-;;   addi a4,a4,-4
-;;   sltu a0,a4,a5
-;;   ld a4,0(a1)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   lw a0,0(a2)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   ld a3,8(a1)
+;;   addi a3,a3,-4
+;;   sltu a3,a3,a2
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   sub a5,zero,a3
+;;   not a2,a5
+;;   and a3,a1,a2
+;;   lw a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -41,48 +41,42 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a3,a3,32
-;;   ld a4,8(a2)
-;;   lui a5,-1
-;;   addi a5,a5,-4
-;;   add a4,a4,a5
-;;   sltu a4,a4,a3
+;;   slli a4,a0,32
+;;   srli a0,a4,32
+;;   ld a5,8(a2)
+;;   lui a4,-1
+;;   addi a3,a4,-4
+;;   add a5,a5,a3
+;;   sltu a5,a5,a0
 ;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   li a3,0
-;;   sub a4,zero,a4
-;;   and a0,a3,a4
-;;   not a3,a4
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   sw a1,0(a0)
+;;   add a0,a2,a0
+;;   lui a2,1
+;;   add a0,a0,a2
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a2,a0,a5
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a3,a2,32
-;;   ld a2,8(a1)
+;;   slli a4,a0,32
+;;   srli a0,a4,32
+;;   ld a5,8(a1)
 ;;   lui a4,-1
-;;   addi a4,a4,-4
-;;   add a2,a2,a4
-;;   sltu a2,a2,a3
-;;   ld a4,0(a1)
-;;   add a3,a4,a3
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   li a4,0
-;;   sub a5,zero,a2
-;;   and a0,a4,a5
-;;   not a2,a5
-;;   and a4,a3,a2
-;;   or a0,a0,a4
-;;   lw a0,0(a0)
+;;   addi a2,a4,-4
+;;   add a5,a5,a2
+;;   sltu a5,a5,a0
+;;   ld a1,0(a1)
+;;   add a0,a1,a0
+;;   lui a1,1
+;;   add a0,a0,a1
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a1,a0,a5
+;;   lw a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,54 +41,48 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   lui a3,262140
-;;   addi a4,a3,1
-;;   slli a0,a4,2
-;;   add a4,a5,a0
-;;   trap_if heap_oob##(a4 ult a5)
-;;   ld a0,8(a2)
-;;   sltu a0,a0,a4
+;;   slli a0,a0,32
+;;   srli a3,a0,32
+;;   lui a5,262140
+;;   addi a4,a5,1
+;;   slli a4,a4,2
+;;   add a4,a3,a4
+;;   trap_if heap_oob##(a4 ult a3)
+;;   ld a5,8(a2)
+;;   sltu a4,a5,a4
 ;;   ld a2,0(a2)
-;;   add a5,a2,a5
-;;   lui a4,65535
-;;   slli a2,a4,4
-;;   add a5,a5,a2
-;;   li a2,0
-;;   sub a4,zero,a0
-;;   and a3,a2,a4
-;;   not a0,a4
-;;   and a2,a5,a0
-;;   or a3,a3,a2
-;;   sw a1,0(a3)
+;;   add a2,a2,a3
+;;   lui a3,65535
+;;   slli a3,a3,4
+;;   add a2,a2,a3
+;;   sub a0,zero,a4
+;;   not a3,a0
+;;   and a4,a2,a3
+;;   sw a1,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   lui a2,262140
-;;   addi a4,a2,1
-;;   slli a0,a4,2
-;;   add a4,a5,a0
-;;   trap_if heap_oob##(a4 ult a5)
-;;   ld a0,8(a1)
-;;   sltu a0,a0,a4
-;;   ld a1,0(a1)
-;;   add a5,a1,a5
-;;   lui a4,65535
-;;   slli a1,a4,4
-;;   add a5,a5,a1
-;;   li a1,0
-;;   sub a2,zero,a0
-;;   and a3,a1,a2
-;;   not a0,a2
-;;   and a1,a5,a0
-;;   or a3,a3,a1
-;;   lw a0,0(a3)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   lui a5,262140
+;;   addi a3,a5,1
+;;   slli a3,a3,2
+;;   add a3,a2,a3
+;;   trap_if heap_oob##(a3 ult a2)
+;;   ld a4,8(a1)
+;;   sltu a3,a4,a3
+;;   ld a4,0(a1)
+;;   add a2,a4,a2
+;;   lui a1,65535
+;;   slli a4,a1,4
+;;   add a2,a2,a4
+;;   sub a0,zero,a3
+;;   not a3,a0
+;;   and a4,a2,a3
+;;   lw a0,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -41,40 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
+;;   slli a0,a0,32
+;;   srli a3,a0,32
 ;;   ld a4,8(a2)
-;;   sltu a3,a5,a4
-;;   xori a0,a3,1
-;;   ld a4,0(a2)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   sb a1,0(a2)
+;;   sltu a0,a3,a4
+;;   xori a4,a0,1
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sub a5,zero,a4
+;;   not a3,a5
+;;   and a3,a2,a3
+;;   sb a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   ld a4,8(a1)
-;;   sltu a3,a5,a4
-;;   xori a0,a3,1
-;;   ld a4,0(a1)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   lbu a0,0(a2)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   ld a3,8(a1)
+;;   sltu a0,a2,a3
+;;   xori a3,a0,1
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   sub a5,zero,a3
+;;   not a2,a5
+;;   and a3,a1,a2
+;;   lbu a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -41,48 +41,42 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a3,a3,32
-;;   ld a4,8(a2)
-;;   lui a5,-1
-;;   addi a5,a5,-1
-;;   add a4,a4,a5
-;;   sltu a4,a4,a3
+;;   slli a4,a0,32
+;;   srli a0,a4,32
+;;   ld a5,8(a2)
+;;   lui a4,-1
+;;   addi a3,a4,-1
+;;   add a5,a5,a3
+;;   sltu a5,a5,a0
 ;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   li a3,0
-;;   sub a4,zero,a4
-;;   and a0,a3,a4
-;;   not a3,a4
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   sb a1,0(a0)
+;;   add a0,a2,a0
+;;   lui a2,1
+;;   add a0,a0,a2
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a2,a0,a5
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a3,a2,32
-;;   ld a2,8(a1)
+;;   slli a4,a0,32
+;;   srli a0,a4,32
+;;   ld a5,8(a1)
 ;;   lui a4,-1
-;;   addi a4,a4,-1
-;;   add a2,a2,a4
-;;   sltu a2,a2,a3
-;;   ld a4,0(a1)
-;;   add a3,a4,a3
-;;   lui a4,1
-;;   add a3,a3,a4
-;;   li a4,0
-;;   sub a5,zero,a2
-;;   and a0,a4,a5
-;;   not a2,a5
-;;   and a4,a3,a2
-;;   or a0,a0,a4
-;;   lbu a0,0(a0)
+;;   addi a2,a4,-1
+;;   add a5,a5,a2
+;;   sltu a5,a5,a0
+;;   ld a1,0(a1)
+;;   add a0,a1,a0
+;;   lui a1,1
+;;   add a0,a0,a1
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a1,a0,a5
+;;   lbu a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,24 +41,21 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a3,a3,32
-;;   ld a4,[const(0)]
-;;   add a4,a3,a4
-;;   trap_if heap_oob##(a4 ult a3)
-;;   ld a5,8(a2)
-;;   sltu a4,a5,a4
-;;   ld a5,0(a2)
-;;   add a3,a5,a3
-;;   lui a2,65535
-;;   slli a5,a2,4
-;;   add a3,a3,a5
-;;   li a5,0
-;;   sub a0,zero,a4
-;;   and a2,a5,a0
-;;   not a4,a0
-;;   and a5,a3,a4
-;;   or a2,a2,a5
+;;   slli a4,a0,32
+;;   srli a0,a4,32
+;;   ld a5,[const(0)]
+;;   add a5,a0,a5
+;;   trap_if heap_oob##(a5 ult a0)
+;;   ld a3,8(a2)
+;;   sltu a3,a3,a5
+;;   ld a2,0(a2)
+;;   add a0,a2,a0
+;;   lui a5,65535
+;;   slli a2,a5,4
+;;   add a0,a0,a2
+;;   sub a4,zero,a3
+;;   not a2,a4
+;;   and a2,a0,a2
 ;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
@@ -66,25 +63,22 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a3,a2,32
-;;   ld a2,[const(0)]
-;;   add a2,a3,a2
-;;   trap_if heap_oob##(a2 ult a3)
-;;   ld a4,8(a1)
-;;   sltu a4,a4,a2
-;;   ld a5,0(a1)
-;;   add a3,a5,a3
-;;   lui a2,65535
-;;   slli a5,a2,4
-;;   add a3,a3,a5
-;;   li a5,0
-;;   sub a0,zero,a4
-;;   and a1,a5,a0
-;;   not a4,a0
-;;   and a5,a3,a4
-;;   or a1,a1,a5
-;;   lbu a0,0(a1)
+;;   slli a4,a0,32
+;;   srli a0,a4,32
+;;   ld a5,[const(0)]
+;;   add a5,a0,a5
+;;   trap_if heap_oob##(a5 ult a0)
+;;   ld a2,8(a1)
+;;   sltu a2,a2,a5
+;;   ld a1,0(a1)
+;;   add a0,a1,a0
+;;   lui a5,65535
+;;   slli a1,a5,4
+;;   add a0,a0,a1
+;;   sub a4,zero,a2
+;;   not a1,a4
+;;   and a2,a0,a1
+;;   lbu a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,18 +41,15 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a4,a3,32
-;;   ld a3,8(a2)
-;;   sltu a5,a3,a4
-;;   ld a3,0(a2)
-;;   add a3,a3,a4
-;;   li a4,0
-;;   sub a5,zero,a5
-;;   and a2,a4,a5
-;;   not a4,a5
-;;   and a5,a3,a4
-;;   or a2,a2,a5
+;;   slli a5,a0,32
+;;   srli a3,a5,32
+;;   ld a0,8(a2)
+;;   sltu a0,a0,a3
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sub a4,zero,a0
+;;   not a0,a4
+;;   and a2,a2,a0
 ;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
@@ -60,19 +57,16 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a4,a2,32
-;;   ld a3,8(a1)
-;;   sltu a5,a3,a4
-;;   ld a3,0(a1)
-;;   add a3,a3,a4
-;;   li a4,0
-;;   sub a5,zero,a5
-;;   and a1,a4,a5
-;;   not a4,a5
-;;   and a5,a3,a4
-;;   or a1,a1,a5
-;;   lw a0,0(a1)
+;;   slli a5,a0,32
+;;   srli a2,a5,32
+;;   ld a0,8(a1)
+;;   sltu a0,a0,a2
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   sub a4,zero,a0
+;;   not a0,a4
+;;   and a2,a1,a0
+;;   lw a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -41,42 +41,36 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   ld a5,8(a2)
-;;   sltu a5,a5,a0
+;;   slli a3,a0,32
+;;   srli a4,a3,32
+;;   ld a3,8(a2)
+;;   sltu a3,a3,a4
 ;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a2,1
-;;   add a0,a0,a2
-;;   li a2,0
-;;   sub a4,zero,a5
-;;   and a3,a2,a4
-;;   not a5,a4
-;;   and a2,a0,a5
-;;   or a3,a3,a2
-;;   sw a1,0(a3)
+;;   add a2,a2,a4
+;;   lui a4,1
+;;   add a2,a2,a4
+;;   sub a0,zero,a3
+;;   not a3,a0
+;;   and a4,a2,a3
+;;   sw a1,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   ld a5,8(a1)
-;;   sltu a5,a5,a0
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a1,1
-;;   add a0,a0,a1
-;;   li a1,0
-;;   sub a2,zero,a5
-;;   and a3,a1,a2
-;;   not a5,a2
-;;   and a1,a0,a5
-;;   or a3,a3,a1
-;;   lw a0,0(a3)
+;;   slli a2,a0,32
+;;   srli a3,a2,32
+;;   ld a2,8(a1)
+;;   sltu a2,a2,a3
+;;   ld a4,0(a1)
+;;   add a3,a4,a3
+;;   lui a4,1
+;;   add a3,a3,a4
+;;   sub a0,zero,a2
+;;   not a2,a0
+;;   and a4,a3,a2
+;;   lw a0,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,44 +41,38 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a3,a5,32
-;;   ld a0,8(a2)
-;;   sltu a0,a0,a3
-;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   lui a5,65535
-;;   slli a3,a5,4
-;;   add a2,a2,a3
-;;   li a3,0
-;;   sub a5,zero,a0
-;;   and a4,a3,a5
-;;   not a0,a5
-;;   and a2,a2,a0
-;;   or a4,a4,a2
-;;   sw a1,0(a4)
+;;   slli a3,a0,32
+;;   srli a4,a3,32
+;;   ld a3,8(a2)
+;;   sltu a3,a3,a4
+;;   ld a5,0(a2)
+;;   add a4,a5,a4
+;;   lui a2,65535
+;;   slli a5,a2,4
+;;   add a4,a4,a5
+;;   sub a2,zero,a3
+;;   not a3,a2
+;;   and a5,a4,a3
+;;   sw a1,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a2,a5,32
-;;   ld a0,8(a1)
-;;   sltu a0,a0,a2
-;;   ld a1,0(a1)
-;;   add a1,a1,a2
-;;   lui a5,65535
-;;   slli a2,a5,4
-;;   add a1,a1,a2
-;;   li a2,0
-;;   sub a3,zero,a0
-;;   and a4,a2,a3
-;;   not a0,a3
-;;   and a2,a1,a0
-;;   or a4,a4,a2
-;;   lw a0,0(a4)
+;;   slli a2,a0,32
+;;   srli a4,a2,32
+;;   ld a3,8(a1)
+;;   sltu a3,a3,a4
+;;   ld a5,0(a1)
+;;   add a4,a5,a4
+;;   lui a2,65535
+;;   slli a5,a2,4
+;;   add a4,a4,a5
+;;   sub a1,zero,a3
+;;   not a3,a1
+;;   and a5,a4,a3
+;;   lw a0,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -41,40 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
+;;   slli a0,a0,32
+;;   srli a3,a0,32
 ;;   ld a4,8(a2)
-;;   sltu a3,a5,a4
-;;   xori a0,a3,1
-;;   ld a4,0(a2)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   sb a1,0(a2)
+;;   sltu a0,a3,a4
+;;   xori a4,a0,1
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sub a5,zero,a4
+;;   not a3,a5
+;;   and a3,a2,a3
+;;   sb a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   ld a4,8(a1)
-;;   sltu a3,a5,a4
-;;   xori a0,a3,1
-;;   ld a4,0(a1)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   lbu a0,0(a2)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   ld a3,8(a1)
+;;   sltu a0,a2,a3
+;;   xori a3,a0,1
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   sub a5,zero,a3
+;;   not a2,a5
+;;   and a3,a1,a2
+;;   lbu a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -41,42 +41,36 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   ld a5,8(a2)
-;;   sltu a5,a5,a0
+;;   slli a3,a0,32
+;;   srli a4,a3,32
+;;   ld a3,8(a2)
+;;   sltu a3,a3,a4
 ;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a2,1
-;;   add a0,a0,a2
-;;   li a2,0
-;;   sub a4,zero,a5
-;;   and a3,a2,a4
-;;   not a5,a4
-;;   and a2,a0,a5
-;;   or a3,a3,a2
-;;   sb a1,0(a3)
+;;   add a2,a2,a4
+;;   lui a4,1
+;;   add a2,a2,a4
+;;   sub a0,zero,a3
+;;   not a3,a0
+;;   and a4,a2,a3
+;;   sb a1,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a4,a0,32
-;;   srli a0,a4,32
-;;   ld a5,8(a1)
-;;   sltu a5,a5,a0
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a1,1
-;;   add a0,a0,a1
-;;   li a1,0
-;;   sub a2,zero,a5
-;;   and a3,a1,a2
-;;   not a5,a2
-;;   and a1,a0,a5
-;;   or a3,a3,a1
-;;   lbu a0,0(a3)
+;;   slli a2,a0,32
+;;   srli a3,a2,32
+;;   ld a2,8(a1)
+;;   sltu a2,a2,a3
+;;   ld a4,0(a1)
+;;   add a3,a4,a3
+;;   lui a4,1
+;;   add a3,a3,a4
+;;   sub a0,zero,a2
+;;   not a2,a0
+;;   and a4,a3,a2
+;;   lbu a0,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,44 +41,38 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a3,a5,32
-;;   ld a0,8(a2)
-;;   sltu a0,a0,a3
-;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   lui a5,65535
-;;   slli a3,a5,4
-;;   add a2,a2,a3
-;;   li a3,0
-;;   sub a5,zero,a0
-;;   and a4,a3,a5
-;;   not a0,a5
-;;   and a2,a2,a0
-;;   or a4,a4,a2
-;;   sb a1,0(a4)
+;;   slli a3,a0,32
+;;   srli a4,a3,32
+;;   ld a3,8(a2)
+;;   sltu a3,a3,a4
+;;   ld a5,0(a2)
+;;   add a4,a5,a4
+;;   lui a2,65535
+;;   slli a5,a2,4
+;;   add a4,a4,a5
+;;   sub a2,zero,a3
+;;   not a3,a2
+;;   and a5,a4,a3
+;;   sb a1,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a2,a5,32
-;;   ld a0,8(a1)
-;;   sltu a0,a0,a2
-;;   ld a1,0(a1)
-;;   add a1,a1,a2
-;;   lui a5,65535
-;;   slli a2,a5,4
-;;   add a1,a1,a2
-;;   li a2,0
-;;   sub a3,zero,a0
-;;   and a4,a2,a3
-;;   not a0,a3
-;;   and a2,a1,a0
-;;   or a4,a4,a2
-;;   lbu a0,0(a4)
+;;   slli a2,a0,32
+;;   srli a4,a2,32
+;;   ld a3,8(a1)
+;;   sltu a3,a3,a4
+;;   ld a5,0(a1)
+;;   add a4,a5,a4
+;;   lui a2,65535
+;;   slli a5,a2,4
+;;   add a4,a4,a5
+;;   sub a1,zero,a3
+;;   not a3,a1
+;;   and a5,a4,a3
+;;   lbu a0,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,36 +41,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a3,8(a2)
-;;   addi a3,a3,-4
-;;   sltu a3,a3,a0
+;;   ld a5,8(a2)
+;;   addi a5,a5,-4
+;;   sltu a5,a5,a0
 ;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   sw a1,0(a0)
+;;   add a0,a2,a0
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a2,a0,a5
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,8(a1)
-;;   addi a2,a2,-4
-;;   sltu a3,a2,a0
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lw a0,0(a0)
+;;   ld a5,8(a1)
+;;   addi a5,a5,-4
+;;   sltu a5,a5,a0
+;;   ld a1,0(a1)
+;;   add a0,a1,a0
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a1,a0,a5
+;;   lw a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -42,43 +42,37 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a3,8(a2)
-;;   lui a5,-1
-;;   addi a4,a5,-4
+;;   lui a4,-1
+;;   addi a4,a4,-4
 ;;   add a3,a3,a4
 ;;   sltu a3,a3,a0
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a2,1
-;;   add a0,a0,a2
-;;   li a2,0
-;;   sub a3,zero,a3
-;;   and a4,a2,a3
-;;   not a2,a3
-;;   and a2,a0,a2
-;;   or a4,a4,a2
-;;   sw a1,0(a4)
+;;   ld a4,0(a2)
+;;   add a4,a4,a0
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   sub a2,zero,a3
+;;   not a3,a2
+;;   and a5,a4,a3
+;;   sw a1,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,8(a1)
-;;   lui a5,-1
-;;   addi a3,a5,-4
-;;   add a2,a2,a3
-;;   sltu a2,a2,a0
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a1,1
-;;   add a0,a0,a1
-;;   li a1,0
-;;   sub a2,zero,a2
-;;   and a4,a1,a2
-;;   not a1,a2
-;;   and a2,a0,a1
-;;   or a4,a4,a2
-;;   lw a0,0(a4)
+;;   ld a3,8(a1)
+;;   lui a2,-1
+;;   addi a4,a2,-4
+;;   add a3,a3,a4
+;;   sltu a3,a3,a0
+;;   ld a4,0(a1)
+;;   add a4,a4,a0
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   sub a1,zero,a3
+;;   not a3,a1
+;;   and a5,a4,a3
+;;   lw a0,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -42,23 +42,20 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,262140
-;;   addi a3,a3,1
-;;   slli a4,a3,2
-;;   add a3,a0,a4
-;;   trap_if heap_oob##(a3 ult a0)
-;;   ld a4,8(a2)
-;;   sltu a3,a4,a3
-;;   ld a4,0(a2)
-;;   add a4,a4,a0
-;;   lui a2,65535
-;;   slli a5,a2,4
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a3
-;;   and a2,a5,a0
-;;   not a3,a0
-;;   and a5,a4,a3
-;;   or a2,a2,a5
+;;   addi a5,a3,1
+;;   slli a3,a5,2
+;;   add a5,a0,a3
+;;   trap_if heap_oob##(a5 ult a0)
+;;   ld a3,8(a2)
+;;   sltu a3,a3,a5
+;;   ld a2,0(a2)
+;;   add a0,a2,a0
+;;   lui a5,65535
+;;   slli a2,a5,4
+;;   add a0,a0,a2
+;;   sub a4,zero,a3
+;;   not a2,a4
+;;   and a2,a0,a2
 ;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
@@ -66,25 +63,22 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a2,262140
-;;   addi a2,a2,1
-;;   slli a4,a2,2
-;;   add a2,a0,a4
-;;   trap_if heap_oob##(a2 ult a0)
-;;   ld a3,8(a1)
-;;   sltu a3,a3,a2
-;;   ld a4,0(a1)
-;;   add a4,a4,a0
-;;   lui a2,65535
-;;   slli a5,a2,4
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a3
-;;   and a1,a5,a0
-;;   not a3,a0
-;;   and a5,a4,a3
-;;   or a1,a1,a5
-;;   lw a0,0(a1)
+;;   lui a3,262140
+;;   addi a5,a3,1
+;;   slli a2,a5,2
+;;   add a5,a0,a2
+;;   trap_if heap_oob##(a5 ult a0)
+;;   ld a2,8(a1)
+;;   sltu a2,a2,a5
+;;   ld a1,0(a1)
+;;   add a0,a1,a0
+;;   lui a5,65535
+;;   slli a1,a5,4
+;;   add a0,a0,a1
+;;   sub a4,zero,a2
+;;   not a1,a4
+;;   and a2,a0,a1
+;;   lw a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -41,36 +41,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a3,8(a2)
-;;   sltu a3,a0,a3
-;;   xori a3,a3,1
-;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   sb a1,0(a0)
+;;   ld a5,8(a2)
+;;   sltu a4,a0,a5
+;;   xori a3,a4,1
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   sub a3,zero,a3
+;;   not a0,a3
+;;   and a2,a5,a0
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,8(a1)
-;;   sltu a2,a0,a2
-;;   xori a3,a2,1
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lbu a0,0(a0)
+;;   ld a5,8(a1)
+;;   sltu a4,a0,a5
+;;   xori a2,a4,1
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   sub a3,zero,a2
+;;   not a0,a3
+;;   and a1,a5,a0
+;;   lbu a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -42,43 +42,37 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a3,8(a2)
-;;   lui a5,-1
-;;   addi a4,a5,-1
+;;   lui a4,-1
+;;   addi a4,a4,-1
 ;;   add a3,a3,a4
 ;;   sltu a3,a3,a0
-;;   ld a2,0(a2)
-;;   add a0,a2,a0
-;;   lui a2,1
-;;   add a0,a0,a2
-;;   li a2,0
-;;   sub a3,zero,a3
-;;   and a4,a2,a3
-;;   not a2,a3
-;;   and a2,a0,a2
-;;   or a4,a4,a2
-;;   sb a1,0(a4)
+;;   ld a4,0(a2)
+;;   add a4,a4,a0
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   sub a2,zero,a3
+;;   not a3,a2
+;;   and a5,a4,a3
+;;   sb a1,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,8(a1)
-;;   lui a5,-1
-;;   addi a3,a5,-1
-;;   add a2,a2,a3
-;;   sltu a2,a2,a0
-;;   ld a1,0(a1)
-;;   add a0,a1,a0
-;;   lui a1,1
-;;   add a0,a0,a1
-;;   li a1,0
-;;   sub a2,zero,a2
-;;   and a4,a1,a2
-;;   not a1,a2
-;;   and a2,a0,a1
-;;   or a4,a4,a2
-;;   lbu a0,0(a4)
+;;   ld a3,8(a1)
+;;   lui a2,-1
+;;   addi a4,a2,-1
+;;   add a3,a3,a4
+;;   sltu a3,a3,a0
+;;   ld a4,0(a1)
+;;   add a4,a4,a0
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   sub a1,zero,a3
+;;   not a3,a1
+;;   and a5,a4,a3
+;;   lbu a0,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -45,42 +45,36 @@
 ;;   add a3,a0,a3
 ;;   trap_if heap_oob##(a3 ult a0)
 ;;   ld a4,8(a2)
-;;   sltu a3,a4,a3
-;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   lui a0,65535
-;;   slli a4,a0,4
-;;   add a2,a2,a4
-;;   li a4,0
-;;   sub a3,zero,a3
-;;   and a5,a4,a3
-;;   not a3,a3
-;;   and a3,a2,a3
-;;   or a5,a5,a3
-;;   sb a1,0(a5)
+;;   sltu a4,a4,a3
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   lui a3,65535
+;;   slli a0,a3,4
+;;   add a5,a5,a0
+;;   sub a2,zero,a4
+;;   not a4,a2
+;;   and a0,a5,a4
+;;   sb a1,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,[const(0)]
-;;   add a2,a0,a2
-;;   trap_if heap_oob##(a2 ult a0)
-;;   ld a3,8(a1)
-;;   sltu a2,a3,a2
-;;   ld a1,0(a1)
-;;   add a1,a1,a0
-;;   lui a0,65535
-;;   slli a3,a0,4
-;;   add a1,a1,a3
-;;   li a3,0
-;;   sub a4,zero,a2
-;;   and a5,a3,a4
-;;   not a2,a4
-;;   and a3,a1,a2
-;;   or a5,a5,a3
-;;   lbu a0,0(a5)
+;;   ld a3,[const(0)]
+;;   add a3,a0,a3
+;;   trap_if heap_oob##(a3 ult a0)
+;;   ld a4,8(a1)
+;;   sltu a4,a4,a3
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   lui a3,65535
+;;   slli a0,a3,4
+;;   add a5,a5,a0
+;;   sub a2,zero,a4
+;;   not a4,a2
+;;   and a0,a5,a4
+;;   lbu a0,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,34 +41,28 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a3,8(a2)
-;;   sltu a3,a3,a0
-;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a3,zero,a3
-;;   and a5,a4,a3
-;;   not a3,a3
-;;   and a3,a2,a3
-;;   or a5,a5,a3
-;;   sw a1,0(a5)
+;;   ld a4,8(a2)
+;;   sltu a4,a4,a0
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   sub a2,zero,a4
+;;   not a4,a2
+;;   and a0,a5,a4
+;;   sw a1,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,8(a1)
-;;   sltu a2,a2,a0
-;;   ld a1,0(a1)
-;;   add a1,a1,a0
-;;   li a3,0
-;;   sub a4,zero,a2
-;;   and a5,a3,a4
-;;   not a2,a4
-;;   and a3,a1,a2
-;;   or a5,a5,a3
-;;   lw a0,0(a5)
+;;   ld a4,8(a1)
+;;   sltu a4,a4,a0
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   sub a2,zero,a4
+;;   not a4,a2
+;;   and a0,a5,a4
+;;   lw a0,0(a0)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -43,16 +43,13 @@
 ;; block0:
 ;;   ld a3,8(a2)
 ;;   sltu a3,a3,a0
-;;   ld a4,0(a2)
-;;   add a4,a4,a0
-;;   lui a5,1
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a3
-;;   and a2,a5,a0
-;;   not a3,a0
-;;   and a5,a4,a3
-;;   or a2,a2,a5
+;;   ld a2,0(a2)
+;;   add a0,a2,a0
+;;   lui a2,1
+;;   add a0,a0,a2
+;;   sub a4,zero,a3
+;;   not a2,a4
+;;   and a2,a0,a2
 ;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
@@ -60,19 +57,16 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a3,8(a1)
-;;   sltu a3,a3,a0
-;;   ld a4,0(a1)
-;;   add a4,a4,a0
-;;   lui a5,1
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a3
-;;   and a1,a5,a0
-;;   not a3,a0
-;;   and a5,a4,a3
-;;   or a1,a1,a5
-;;   lw a0,0(a1)
+;;   ld a2,8(a1)
+;;   sltu a2,a2,a0
+;;   ld a1,0(a1)
+;;   add a0,a1,a0
+;;   lui a1,1
+;;   add a0,a0,a1
+;;   sub a4,zero,a2
+;;   not a1,a4
+;;   and a2,a0,a1
+;;   lw a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -41,40 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a4,8(a2)
-;;   sltu a4,a4,a0
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a3,65535
-;;   slli a0,a3,4
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a3,zero,a4
-;;   and a2,a0,a3
-;;   not a4,a3
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   sw a1,0(a2)
+;;   ld a3,8(a2)
+;;   sltu a4,a3,a0
+;;   ld a2,0(a2)
+;;   add a3,a2,a0
+;;   lui a0,65535
+;;   slli a2,a0,4
+;;   add a3,a3,a2
+;;   sub a5,zero,a4
+;;   not a2,a5
+;;   and a3,a3,a2
+;;   sw a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a4,8(a1)
-;;   sltu a4,a4,a0
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a3,65535
-;;   slli a0,a3,4
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a1,zero,a4
-;;   and a2,a0,a1
-;;   not a4,a1
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   lw a0,0(a2)
+;;   ld a2,8(a1)
+;;   sltu a3,a2,a0
+;;   ld a1,0(a1)
+;;   add a2,a1,a0
+;;   lui a0,65535
+;;   slli a4,a0,4
+;;   add a2,a2,a4
+;;   sub a5,zero,a3
+;;   not a1,a5
+;;   and a3,a2,a1
+;;   lw a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -41,36 +41,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a3,8(a2)
-;;   sltu a3,a0,a3
-;;   xori a3,a3,1
-;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   sb a1,0(a0)
+;;   ld a5,8(a2)
+;;   sltu a4,a0,a5
+;;   xori a3,a4,1
+;;   ld a5,0(a2)
+;;   add a5,a5,a0
+;;   sub a3,zero,a3
+;;   not a0,a3
+;;   and a2,a5,a0
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,8(a1)
-;;   sltu a2,a0,a2
-;;   xori a3,a2,1
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lbu a0,0(a0)
+;;   ld a5,8(a1)
+;;   sltu a4,a0,a5
+;;   xori a2,a4,1
+;;   ld a5,0(a1)
+;;   add a5,a5,a0
+;;   sub a3,zero,a2
+;;   not a0,a3
+;;   and a1,a5,a0
+;;   lbu a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -43,16 +43,13 @@
 ;; block0:
 ;;   ld a3,8(a2)
 ;;   sltu a3,a3,a0
-;;   ld a4,0(a2)
-;;   add a4,a4,a0
-;;   lui a5,1
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a3
-;;   and a2,a5,a0
-;;   not a3,a0
-;;   and a5,a4,a3
-;;   or a2,a2,a5
+;;   ld a2,0(a2)
+;;   add a0,a2,a0
+;;   lui a2,1
+;;   add a0,a0,a2
+;;   sub a4,zero,a3
+;;   not a2,a4
+;;   and a2,a0,a2
 ;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
@@ -60,19 +57,16 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a3,8(a1)
-;;   sltu a3,a3,a0
-;;   ld a4,0(a1)
-;;   add a4,a4,a0
-;;   lui a5,1
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a3
-;;   and a1,a5,a0
-;;   not a3,a0
-;;   and a5,a4,a3
-;;   or a1,a1,a5
-;;   lbu a0,0(a1)
+;;   ld a2,8(a1)
+;;   sltu a2,a2,a0
+;;   ld a1,0(a1)
+;;   add a0,a1,a0
+;;   lui a1,1
+;;   add a0,a0,a1
+;;   sub a4,zero,a2
+;;   not a1,a4
+;;   and a2,a0,a1
+;;   lbu a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -41,40 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a4,8(a2)
-;;   sltu a4,a4,a0
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a3,65535
-;;   slli a0,a3,4
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a3,zero,a4
-;;   and a2,a0,a3
-;;   not a4,a3
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   sb a1,0(a2)
+;;   ld a3,8(a2)
+;;   sltu a4,a3,a0
+;;   ld a2,0(a2)
+;;   add a3,a2,a0
+;;   lui a0,65535
+;;   slli a2,a0,4
+;;   add a3,a3,a2
+;;   sub a5,zero,a4
+;;   not a2,a5
+;;   and a3,a3,a2
+;;   sb a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a4,8(a1)
-;;   sltu a4,a4,a0
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a3,65535
-;;   slli a0,a3,4
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a1,zero,a4
-;;   and a2,a0,a1
-;;   not a4,a1
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   lbu a0,0(a2)
+;;   ld a2,8(a1)
+;;   sltu a3,a2,a0
+;;   ld a1,0(a1)
+;;   add a2,a1,a0
+;;   lui a0,65535
+;;   slli a4,a0,4
+;;   add a2,a2,a4
+;;   sub a5,zero,a3
+;;   not a1,a5
+;;   and a3,a2,a1
+;;   lbu a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -39,40 +39,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   lui a3,65536
-;;   addi a0,a3,-4
-;;   sltu a0,a0,a5
-;;   ld a4,0(a2)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   sw a1,0(a2)
+;;   slli a0,a0,32
+;;   srli a3,a0,32
+;;   lui a0,65536
+;;   addi a4,a0,-4
+;;   sltu a4,a4,a3
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sub a5,zero,a4
+;;   not a3,a5
+;;   and a3,a2,a3
+;;   sw a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   lui a3,65536
-;;   addi a0,a3,-4
-;;   sltu a0,a0,a5
-;;   ld a4,0(a1)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   lw a0,0(a2)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   lui a0,65536
+;;   addi a3,a0,-4
+;;   sltu a3,a3,a2
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   sub a5,zero,a3
+;;   not a2,a5
+;;   and a3,a1,a2
+;;   lw a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -39,44 +39,38 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a3,a5,32
-;;   lui a5,65535
-;;   addi a4,a5,-4
-;;   sltu a0,a4,a3
-;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   li a3,0
-;;   sub a5,zero,a0
-;;   and a4,a3,a5
-;;   not a0,a5
-;;   and a2,a2,a0
-;;   or a4,a4,a2
-;;   sw a1,0(a4)
+;;   slli a3,a0,32
+;;   srli a4,a3,32
+;;   lui a3,65535
+;;   addi a5,a3,-4
+;;   sltu a3,a5,a4
+;;   ld a5,0(a2)
+;;   add a4,a5,a4
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   sub a2,zero,a3
+;;   not a3,a2
+;;   and a5,a4,a3
+;;   sw a1,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a2,a5,32
-;;   lui a5,65535
-;;   addi a3,a5,-4
-;;   sltu a0,a3,a2
-;;   ld a1,0(a1)
-;;   add a1,a1,a2
-;;   lui a2,1
-;;   add a1,a1,a2
-;;   li a2,0
-;;   sub a3,zero,a0
-;;   and a4,a2,a3
-;;   not a0,a3
-;;   and a2,a1,a0
-;;   or a4,a4,a2
-;;   lw a0,0(a4)
+;;   slli a2,a0,32
+;;   srli a4,a2,32
+;;   lui a2,65535
+;;   addi a5,a2,-4
+;;   sltu a3,a5,a4
+;;   ld a5,0(a1)
+;;   add a4,a5,a4
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   sub a1,zero,a3
+;;   not a3,a1
+;;   and a5,a4,a3
+;;   lw a0,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -39,40 +39,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   lui a3,65536
-;;   addi a0,a3,-1
-;;   sltu a0,a0,a5
-;;   ld a4,0(a2)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   sb a1,0(a2)
+;;   slli a0,a0,32
+;;   srli a3,a0,32
+;;   lui a0,65536
+;;   addi a4,a0,-1
+;;   sltu a4,a4,a3
+;;   ld a2,0(a2)
+;;   add a2,a2,a3
+;;   sub a5,zero,a4
+;;   not a3,a5
+;;   and a3,a2,a3
+;;   sb a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   lui a3,65536
-;;   addi a0,a3,-1
-;;   sltu a0,a0,a5
-;;   ld a4,0(a1)
-;;   add a4,a4,a5
-;;   li a5,0
-;;   sub a0,zero,a0
-;;   and a2,a5,a0
-;;   not a5,a0
-;;   and a0,a4,a5
-;;   or a2,a2,a0
-;;   lbu a0,0(a2)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   lui a0,65536
+;;   addi a3,a0,-1
+;;   sltu a3,a3,a2
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   sub a5,zero,a3
+;;   not a2,a5
+;;   and a3,a1,a2
+;;   lbu a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -39,44 +39,38 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a3,a5,32
-;;   lui a5,65535
-;;   addi a4,a5,-1
-;;   sltu a0,a4,a3
-;;   ld a2,0(a2)
-;;   add a2,a2,a3
-;;   lui a3,1
-;;   add a2,a2,a3
-;;   li a3,0
-;;   sub a5,zero,a0
-;;   and a4,a3,a5
-;;   not a0,a5
-;;   and a2,a2,a0
-;;   or a4,a4,a2
-;;   sb a1,0(a4)
+;;   slli a3,a0,32
+;;   srli a4,a3,32
+;;   lui a3,65535
+;;   addi a5,a3,-1
+;;   sltu a3,a5,a4
+;;   ld a5,0(a2)
+;;   add a4,a5,a4
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   sub a2,zero,a3
+;;   not a3,a2
+;;   and a5,a4,a3
+;;   sb a1,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a5,a0,32
-;;   srli a2,a5,32
-;;   lui a5,65535
-;;   addi a3,a5,-1
-;;   sltu a0,a3,a2
-;;   ld a1,0(a1)
-;;   add a1,a1,a2
-;;   lui a2,1
-;;   add a1,a1,a2
-;;   li a2,0
-;;   sub a3,zero,a0
-;;   and a4,a2,a3
-;;   not a0,a3
-;;   and a2,a1,a0
-;;   or a4,a4,a2
-;;   lbu a0,0(a4)
+;;   slli a2,a0,32
+;;   srli a4,a2,32
+;;   lui a2,65535
+;;   addi a5,a2,-1
+;;   sltu a3,a5,a4
+;;   ld a5,0(a1)
+;;   add a4,a5,a4
+;;   lui a5,1
+;;   add a4,a4,a5
+;;   sub a1,zero,a3
+;;   not a3,a1
+;;   and a5,a4,a3
+;;   lbu a0,0(a5)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -39,36 +39,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a3,65536
-;;   addi a3,a3,-4
-;;   sltu a3,a3,a0
+;;   lui a4,65536
+;;   addi a3,a4,-4
+;;   sltu a5,a3,a0
 ;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   sw a1,0(a0)
+;;   add a0,a2,a0
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a2,a0,a5
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a2,65536
-;;   addi a3,a2,-4
-;;   sltu a3,a3,a0
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lw a0,0(a0)
+;;   lui a4,65536
+;;   addi a2,a4,-4
+;;   sltu a5,a2,a0
+;;   ld a1,0(a1)
+;;   add a0,a1,a0
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a1,a0,a5
+;;   lw a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -40,39 +40,33 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65535
-;;   addi a5,a3,-4
-;;   sltu a4,a5,a0
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a3,zero,a4
-;;   and a2,a0,a3
-;;   not a4,a3
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   sw a1,0(a2)
+;;   addi a3,a3,-4
+;;   sltu a3,a3,a0
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   lui a4,1
+;;   add a2,a2,a4
+;;   sub a5,zero,a3
+;;   not a3,a5
+;;   and a3,a2,a3
+;;   sw a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a3,65535
-;;   addi a5,a3,-4
-;;   sltu a4,a5,a0
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a1,zero,a4
-;;   and a2,a0,a1
-;;   not a4,a1
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   lw a0,0(a2)
+;;   lui a2,65535
+;;   addi a2,a2,-4
+;;   sltu a2,a2,a0
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   lui a3,1
+;;   add a1,a1,a3
+;;   sub a5,zero,a2
+;;   not a2,a5
+;;   and a3,a1,a2
+;;   lw a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -39,36 +39,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a3,65536
-;;   addi a3,a3,-1
-;;   sltu a3,a3,a0
+;;   lui a4,65536
+;;   addi a3,a4,-1
+;;   sltu a5,a3,a0
 ;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   sb a1,0(a0)
+;;   add a0,a2,a0
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a2,a0,a5
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a2,65536
-;;   addi a3,a2,-1
-;;   sltu a3,a3,a0
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lbu a0,0(a0)
+;;   lui a4,65536
+;;   addi a2,a4,-1
+;;   sltu a5,a2,a0
+;;   ld a1,0(a1)
+;;   add a0,a1,a0
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a1,a0,a5
+;;   lbu a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -40,39 +40,33 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65535
-;;   addi a5,a3,-1
-;;   sltu a4,a5,a0
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a3,zero,a4
-;;   and a2,a0,a3
-;;   not a4,a3
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   sb a1,0(a2)
+;;   addi a3,a3,-1
+;;   sltu a3,a3,a0
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   lui a4,1
+;;   add a2,a2,a4
+;;   sub a5,zero,a3
+;;   not a3,a5
+;;   and a3,a2,a3
+;;   sb a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a3,65535
-;;   addi a5,a3,-1
-;;   sltu a4,a5,a0
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a1,zero,a4
-;;   and a2,a0,a1
-;;   not a4,a1
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   lbu a0,0(a2)
+;;   lui a2,65535
+;;   addi a2,a2,-1
+;;   sltu a2,a2,a0
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   lui a3,1
+;;   add a1,a1,a3
+;;   sub a5,zero,a2
+;;   not a2,a5
+;;   and a3,a1,a2
+;;   lbu a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -39,36 +39,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a3,65536
-;;   addi a3,a3,-4
-;;   sltu a3,a3,a0
+;;   lui a4,65536
+;;   addi a3,a4,-4
+;;   sltu a5,a3,a0
 ;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   sw a1,0(a0)
+;;   add a0,a2,a0
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a2,a0,a5
+;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a2,65536
-;;   addi a3,a2,-4
-;;   sltu a3,a3,a0
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lw a0,0(a0)
+;;   lui a4,65536
+;;   addi a2,a4,-4
+;;   sltu a5,a2,a0
+;;   ld a1,0(a1)
+;;   add a0,a1,a0
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a1,a0,a5
+;;   lw a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -40,39 +40,33 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65535
-;;   addi a5,a3,-4
-;;   sltu a4,a5,a0
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a3,zero,a4
-;;   and a2,a0,a3
-;;   not a4,a3
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   sw a1,0(a2)
+;;   addi a3,a3,-4
+;;   sltu a3,a3,a0
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   lui a4,1
+;;   add a2,a2,a4
+;;   sub a5,zero,a3
+;;   not a3,a5
+;;   and a3,a2,a3
+;;   sw a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a3,65535
-;;   addi a5,a3,-4
-;;   sltu a4,a5,a0
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a1,zero,a4
-;;   and a2,a0,a1
-;;   not a4,a1
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   lw a0,0(a2)
+;;   lui a2,65535
+;;   addi a2,a2,-4
+;;   sltu a2,a2,a0
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   lui a3,1
+;;   add a1,a1,a3
+;;   sub a5,zero,a2
+;;   not a2,a5
+;;   and a3,a1,a2
+;;   lw a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -39,36 +39,30 @@
 
 ;; function u0:0:
 ;; block0:
-;;   lui a3,65536
-;;   addi a3,a3,-1
-;;   sltu a3,a3,a0
+;;   lui a4,65536
+;;   addi a3,a4,-1
+;;   sltu a5,a3,a0
 ;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   sb a1,0(a0)
+;;   add a0,a2,a0
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a2,a0,a5
+;;   sb a1,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a2,65536
-;;   addi a3,a2,-1
-;;   sltu a3,a3,a0
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   li a4,0
-;;   sub a5,zero,a3
-;;   and a0,a4,a5
-;;   not a3,a5
-;;   and a4,a2,a3
-;;   or a0,a0,a4
-;;   lbu a0,0(a0)
+;;   lui a4,65536
+;;   addi a2,a4,-1
+;;   sltu a5,a2,a0
+;;   ld a1,0(a1)
+;;   add a0,a1,a0
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a1,a0,a5
+;;   lbu a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -40,39 +40,33 @@
 ;; function u0:0:
 ;; block0:
 ;;   lui a3,65535
-;;   addi a5,a3,-1
-;;   sltu a4,a5,a0
-;;   ld a5,0(a2)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a3,zero,a4
-;;   and a2,a0,a3
-;;   not a4,a3
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   sb a1,0(a2)
+;;   addi a3,a3,-1
+;;   sltu a3,a3,a0
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   lui a4,1
+;;   add a2,a2,a4
+;;   sub a5,zero,a3
+;;   not a3,a5
+;;   and a3,a2,a3
+;;   sb a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   lui a3,65535
-;;   addi a5,a3,-1
-;;   sltu a4,a5,a0
-;;   ld a5,0(a1)
-;;   add a5,a5,a0
-;;   lui a0,1
-;;   add a5,a5,a0
-;;   li a0,0
-;;   sub a1,zero,a4
-;;   and a2,a0,a1
-;;   not a4,a1
-;;   and a0,a5,a4
-;;   or a2,a2,a0
-;;   lbu a0,0(a2)
+;;   lui a2,65535
+;;   addi a2,a2,-1
+;;   sltu a2,a2,a0
+;;   ld a1,0(a1)
+;;   add a1,a1,a0
+;;   lui a3,1
+;;   add a1,a1,a3
+;;   sub a5,zero,a2
+;;   not a2,a5
+;;   and a3,a1,a2
+;;   lbu a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret


### PR DESCRIPTION
This commit optimizes some `select_spectre_guard` patterns which are frequently generated with the wasm backend when dynamic bounds checks are enabled by pattern-matching when one of the values being selected is zero. This enables shaving off a few instructions which can be constant folded away.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
