### PR TITLE
riscv64: Implement some `Zbs` extension lowerings

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1659,6 +1659,15 @@
 (rule (rv_bseti rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Bseti) rs1 imm))
 
+;; `Zbs` Extension Instructions
+
+(decl rv_bclr (XReg XReg) XReg)
+(rule (rv_bclr rs1 rs2)
+  (alu_rrr (AluOPRRR.Bclr) rs1 rs2))
+
+(decl rv_bclri (XReg Imm12) XReg)
+(rule (rv_bclri rs1 imm)
+  (alu_rr_imm12 (AluOPRRI.Bclri) rs1 imm))
 
 ;; `Zbkb` Extension Instructions
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1654,11 +1654,6 @@
 (rule (rv_brev8 rs1)
   (alu_rr_funct12 (AluOPRRI.Brev8) rs1))
 
-;; Helper for emitting the `bseti` ("Single-Bit Set Immediate") instruction.
-(decl rv_bseti (XReg Imm12) XReg)
-(rule (rv_bseti rs1 imm)
-  (alu_rr_imm12 (AluOPRRI.Bseti) rs1 imm))
-
 ;; `Zbs` Extension Instructions
 
 (decl rv_bclr (XReg XReg) XReg)
@@ -1684,6 +1679,15 @@
 (decl rv_binvi (XReg Imm12) XReg)
 (rule (rv_binvi rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Binvi) rs1 imm))
+
+(decl rv_bset (XReg XReg) XReg)
+(rule (rv_bset rs1 rs2)
+  (alu_rrr (AluOPRRR.Bset) rs1 rs2))
+
+;; Helper for emitting the `bseti` ("Single-Bit Set Immediate") instruction.
+(decl rv_bseti (XReg Imm12) XReg)
+(rule (rv_bseti rs1 imm)
+  (alu_rr_imm12 (AluOPRRI.Bseti) rs1 imm))
 
 ;; `Zbkb` Extension Instructions
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1677,6 +1677,14 @@
 (rule (rv_bexti rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Bexti) rs1 imm))
 
+(decl rv_binv (XReg XReg) XReg)
+(rule (rv_binv rs1 rs2)
+  (alu_rrr (AluOPRRR.Binv) rs1 rs2))
+
+(decl rv_binvi (XReg Imm12) XReg)
+(rule (rv_binvi rs1 imm)
+  (alu_rr_imm12 (AluOPRRI.Binvi) rs1 imm))
+
 ;; `Zbkb` Extension Instructions
 
 ;; Helper for emitting the `pack` ("Pack low halves of registers") instruction.

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1669,6 +1669,14 @@
 (rule (rv_bclri rs1 imm)
   (alu_rr_imm12 (AluOPRRI.Bclri) rs1 imm))
 
+(decl rv_bext (XReg XReg) XReg)
+(rule (rv_bext rs1 rs2)
+  (alu_rrr (AluOPRRR.Bext) rs1 rs2))
+
+(decl rv_bexti (XReg Imm12) XReg)
+(rule (rv_bexti rs1 imm)
+  (alu_rr_imm12 (AluOPRRI.Bexti) rs1 imm))
+
 ;; `Zbkb` Extension Instructions
 
 ;; Helper for emitting the `pack` ("Pack low halves of registers") instruction.

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -710,6 +710,8 @@
   (if-let x_imm (replicated_imm5 x))
   (rv_vand_vi y x_imm (unmasked) ty))
 
+;; `bclr{,i}` specializations from `zbs`
+
 (rule 13 (lower (has_type $I32 (band x (bnot (ishl (i64_from_iconst 1) y)))))
   (if-let $true (has_zbs))
   (rv_bclr x (rv_andi y (imm12_const 31))))
@@ -726,6 +728,46 @@
 (decl pure partial bclr_imm (Type u64) Imm12)
 (extern constructor bclr_imm bclr_imm)
 
+;; `bext{,i}` specializations from `zbs`
+
+(rule 15 (lower (has_type $I32 (band (ushr x y) (u64_from_iconst 1))))
+  (if-let $true (has_zbs))
+  (rv_bext x (rv_andi y (imm12_const 31))))
+(rule 15 (lower (has_type $I32 (band (sshr x y) (u64_from_iconst 1))))
+  (if-let $true (has_zbs))
+  (rv_bext x (rv_andi y (imm12_const 31))))
+(rule 15 (lower (has_type $I32 (band (u64_from_iconst 1) (ushr x y))))
+  (if-let $true (has_zbs))
+  (rv_bext x (rv_andi y (imm12_const 31))))
+(rule 15 (lower (has_type $I32 (band (u64_from_iconst 1) (sshr x y))))
+  (if-let $true (has_zbs))
+  (rv_bext x (rv_andi y (imm12_const 31))))
+
+(rule 15 (lower (has_type $I64 (band (ushr x y) (u64_from_iconst 1))))
+  (if-let $true (has_zbs))
+  (rv_bext x y))
+(rule 15 (lower (has_type $I64 (band (sshr x y) (u64_from_iconst 1))))
+  (if-let $true (has_zbs))
+  (rv_bext x y))
+(rule 15 (lower (has_type $I64 (band (u64_from_iconst 1) (ushr x y))))
+  (if-let $true (has_zbs))
+  (rv_bext x y))
+(rule 15 (lower (has_type $I64 (band (u64_from_iconst 1) (sshr x y))))
+  (if-let $true (has_zbs))
+  (rv_bext x y))
+
+(rule 16 (lower (has_type $I32 (band (ushr x (imm12_from_value y)) (u64_from_iconst 1))))
+  (if-let $true (has_zbs))
+  (rv_bexti x (imm12_and y 31)))
+(rule 16 (lower (has_type $I32 (band (sshr x (imm12_from_value y)) (u64_from_iconst 1))))
+  (if-let $true (has_zbs))
+  (rv_bexti x (imm12_and y 31)))
+(rule 16 (lower (has_type $I64 (band (ushr x (imm12_from_value y)) (u64_from_iconst 1))))
+  (if-let $true (has_zbs))
+  (rv_bexti x (imm12_and y 63)))
+(rule 16 (lower (has_type $I64 (band (sshr x (imm12_from_value y)) (u64_from_iconst 1))))
+  (if-let $true (has_zbs))
+  (rv_bexti x (imm12_and y 63)))
 
 ;;;; Rules for `or` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 0 (lower (has_type (ty_int ty) (bor x y)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -710,6 +710,22 @@
   (if-let x_imm (replicated_imm5 x))
   (rv_vand_vi y x_imm (unmasked) ty))
 
+(rule 13 (lower (has_type $I32 (band x (bnot (ishl (i64_from_iconst 1) y)))))
+  (if-let $true (has_zbs))
+  (rv_bclr x (rv_andi y (imm12_const 31))))
+
+(rule 13 (lower (has_type $I64 (band x (bnot (ishl (i64_from_iconst 1) y)))))
+  (if-let $true (has_zbs))
+  (rv_bclr x y))
+
+(rule 14 (lower (has_type (fits_in_64 ty) (band x (u64_from_iconst n))))
+  (if-let $true (has_zbs))
+  (if-let imm (bclr_imm ty n))
+  (rv_bclri x imm))
+
+(decl pure partial bclr_imm (Type u64) Imm12)
+(extern constructor bclr_imm bclr_imm)
+
 
 ;;;; Rules for `or` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 0 (lower (has_type (ty_int ty) (bor x y)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -863,6 +863,33 @@
   (if-let x_imm (replicated_imm5 x))
   (rv_vxor_vi y x_imm (unmasked) ty))
 
+;; `binv{,i}` specializations from `zbs`
+
+(rule 13 (lower (has_type $I32 (bxor x (ishl (i64_from_iconst 1) y))))
+  (if-let $true (has_zbs))
+  (rv_binv x (rv_andi y (imm12_const 31))))
+(rule 14 (lower (has_type $I32 (bxor (ishl (i64_from_iconst 1) y) x)))
+  (if-let $true (has_zbs))
+  (rv_binv x (rv_andi y (imm12_const 31))))
+
+(rule 13 (lower (has_type $I64 (bxor x (ishl (i64_from_iconst 1) y))))
+  (if-let $true (has_zbs))
+  (rv_binv x y))
+(rule 14 (lower (has_type $I64 (bxor (ishl (i64_from_iconst 1) y) x)))
+  (if-let $true (has_zbs))
+  (rv_binv x y))
+
+(rule 15 (lower (has_type (fits_in_64 _) (bxor x (u64_from_iconst n))))
+  (if-let $true (has_zbs))
+  (if-let imm (binv_imm n))
+  (rv_binvi x imm))
+(rule 16 (lower (has_type (fits_in_64 _) (bxor (u64_from_iconst n) x)))
+  (if-let $true (has_zbs))
+  (if-let imm (binv_imm n))
+  (rv_binvi x imm))
+
+(decl pure partial binv_imm (u64) Imm12)
+(extern constructor binv_imm binv_imm)
 
 ;;;; Rules for `bnot` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 0 (lower (has_type (ty_scalar ty) (bnot x)))

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -826,6 +826,33 @@
   (if-let x_imm (replicated_imm5 x))
   (rv_vor_vi y x_imm (unmasked) ty))
 
+;; `bset{,i}` specializations from `zbs`
+
+(rule 13 (lower (has_type $I32 (bor x (ishl (i64_from_iconst 1) y))))
+  (if-let $true (has_zbs))
+  (rv_bset x (rv_andi y (imm12_const 31))))
+(rule 14 (lower (has_type $I32 (bor (ishl (i64_from_iconst 1) y) x)))
+  (if-let $true (has_zbs))
+  (rv_bset x (rv_andi y (imm12_const 31))))
+
+(rule 13 (lower (has_type $I64 (bor x (ishl (i64_from_iconst 1) y))))
+  (if-let $true (has_zbs))
+  (rv_bset x y))
+(rule 14 (lower (has_type $I64 (bor (ishl (i64_from_iconst 1) y) x)))
+  (if-let $true (has_zbs))
+  (rv_bset x y))
+
+(rule 15 (lower (has_type (fits_in_64 _) (bor x (u64_from_iconst n))))
+  (if-let $true (has_zbs))
+  (if-let imm (bseti_imm n))
+  (rv_bseti x imm))
+(rule 16 (lower (has_type (fits_in_64 _) (bor (u64_from_iconst n) x)))
+  (if-let $true (has_zbs))
+  (if-let imm (bseti_imm n))
+  (rv_bseti x imm))
+
+(decl pure partial bseti_imm (u64) Imm12)
+(extern constructor bseti_imm bseti_imm)
 
 ;;;; Rules for `xor` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 0 (lower (has_type (fits_in_64 (ty_int ty)) (bxor x y)))
@@ -881,15 +908,15 @@
 
 (rule 15 (lower (has_type (fits_in_64 _) (bxor x (u64_from_iconst n))))
   (if-let $true (has_zbs))
-  (if-let imm (binv_imm n))
+  (if-let imm (binvi_imm n))
   (rv_binvi x imm))
 (rule 16 (lower (has_type (fits_in_64 _) (bxor (u64_from_iconst n) x)))
   (if-let $true (has_zbs))
-  (if-let imm (binv_imm n))
+  (if-let imm (binvi_imm n))
   (rv_binvi x imm))
 
-(decl pure partial binv_imm (u64) Imm12)
-(extern constructor binv_imm binv_imm)
+(decl pure partial binvi_imm (u64) Imm12)
+(extern constructor binvi_imm binvi_imm)
 
 ;;;; Rules for `bnot` ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 (rule 0 (lower (has_type (ty_scalar ty) (bnot x)))

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -532,11 +532,14 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         Imm12::maybe_from_u64(neg.trailing_zeros().into())
     }
 
-    fn binv_imm(&mut self, i: u64) -> Option<Imm12> {
+    fn binvi_imm(&mut self, i: u64) -> Option<Imm12> {
         if i.count_ones() != 1 {
             return None;
         }
         Imm12::maybe_from_u64(i.trailing_zeros().into())
+    }
+    fn bseti_imm(&mut self, i: u64) -> Option<Imm12> {
+        self.binvi_imm(i)
     }
 }
 

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -521,6 +521,16 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
     fn vec_alu_rr_dst_type(&mut self, op: &VecAluOpRR) -> Type {
         MInst::canonical_type_for_rc(op.dst_regclass())
     }
+
+    fn bclr_imm(&mut self, ty: Type, i: u64) -> Option<Imm12> {
+        // Only consider those bits in the immediate which are up to the width
+        // of `ty`.
+        let neg = !i & (u64::MAX >> (64 - ty.bits()));
+        if neg.count_ones() != 1 {
+            return None;
+        }
+        Imm12::maybe_from_u64(neg.trailing_zeros().into())
+    }
 }
 
 /// The main entry point for lowering with ISLE.

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -531,6 +531,13 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         }
         Imm12::maybe_from_u64(neg.trailing_zeros().into())
     }
+
+    fn binv_imm(&mut self, i: u64) -> Option<Imm12> {
+        if i.count_ones() != 1 {
+            return None;
+        }
+        Imm12::maybe_from_u64(i.trailing_zeros().into())
+    }
 }
 
 /// The main entry point for lowering with ISLE.

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/zbs.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/zbs.wat
@@ -1,0 +1,66 @@
+;;! target = "riscv64"
+;;! compile = true
+;;! settings = ["has_zbs", "opt_level=speed"]
+
+(module
+  (func (export "bclr32") (param i32 i32) (result i32)
+    (i32.and (local.get 0) (i32.xor (i32.shl (i32.const 1) (local.get 1)) (i32.const -1)))
+  )
+  (func (export "bclr64") (param i64 i64) (result i64)
+    (i64.and (local.get 0) (i64.xor (i64.shl (i64.const 1) (local.get 1)) (i64.const -1)))
+  )
+  (func (export "bclri32_4") (param i32) (result i32)
+    (i32.and (local.get 0) (i32.xor (i32.shl (i32.const 1) (i32.const 4)) (i32.const -1)))
+  )
+  (func (export "bclri32_20") (param i32) (result i32)
+    (i32.and (local.get 0) (i32.xor (i32.shl (i32.const 1) (i32.const 20)) (i32.const -1)))
+  )
+  (func (export "bclri64_4") (param i64) (result i64)
+    (i64.and (local.get 0) (i64.xor (i64.shl (i64.const 1) (i64.const 4)) (i64.const -1)))
+  )
+  (func (export "bclri64_52") (param i64) (result i64)
+    (i64.and (local.get 0) (i64.xor (i64.shl (i64.const 1) (i64.const 52)) (i64.const -1)))
+  )
+)
+;; function u0:0:
+;; block0:
+;;   j label1
+;; block1:
+;;   andi a5,a1,31
+;;   bclr a0,a0,a5
+;;   ret
+;;
+;; function u0:1:
+;; block0:
+;;   j label1
+;; block1:
+;;   bclr a0,a0,a1
+;;   ret
+;;
+;; function u0:2:
+;; block0:
+;;   j label1
+;; block1:
+;;   bclri a0,a0,4
+;;   ret
+;;
+;; function u0:3:
+;; block0:
+;;   j label1
+;; block1:
+;;   bclri a0,a0,20
+;;   ret
+;;
+;; function u0:4:
+;; block0:
+;;   j label1
+;; block1:
+;;   bclri a0,a0,4
+;;   ret
+;;
+;; function u0:5:
+;; block0:
+;;   j label1
+;; block1:
+;;   bclri a0,a0,52
+;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/zbs.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/zbs.wat
@@ -21,6 +21,56 @@
   (func (export "bclri64_52") (param i64) (result i64)
     (i64.and (local.get 0) (i64.xor (i64.shl (i64.const 1) (i64.const 52)) (i64.const -1)))
   )
+
+  (func (export "bext32_1") (param i32 i32) (result i32)
+    (i32.and (i32.shr_u (local.get 0) (local.get 1)) (i32.const 1))
+  )
+  (func (export "bext32_2") (param i32 i32) (result i32)
+    (i32.and (i32.shr_s (local.get 0) (local.get 1)) (i32.const 1))
+  )
+  (func (export "bext32_3") (param i32 i32) (result i32)
+    (i32.and (i32.const 1) (i32.shr_u (local.get 0) (local.get 1)))
+  )
+  (func (export "bext32_4") (param i32 i32) (result i32)
+    (i32.and (i32.const 1) (i32.shr_s (local.get 0) (local.get 1)))
+  )
+  (func (export "bext64_1") (param i64 i64) (result i64)
+    (i64.and (i64.shr_u (local.get 0) (local.get 1)) (i64.const 1))
+  )
+  (func (export "bext64_2") (param i64 i64) (result i64)
+    (i64.and (i64.shr_s (local.get 0) (local.get 1)) (i64.const 1))
+  )
+  (func (export "bext64_3") (param i64 i64) (result i64)
+    (i64.and (i64.const 1) (i64.shr_u (local.get 0) (local.get 1)))
+  )
+  (func (export "bext64_4") (param i64 i64) (result i64)
+    (i64.and (i64.const 1) (i64.shr_s (local.get 0) (local.get 1)))
+  )
+
+  (func (export "bexti32_1") (param i32) (result i32)
+    (i32.and (i32.shr_u (local.get 0) (i32.const 10)) (i32.const 1))
+  )
+  (func (export "bexti32_2") (param i32) (result i32)
+    (i32.and (i32.shr_s (local.get 0) (i32.const 20)) (i32.const 1))
+  )
+  (func (export "bexti32_3") (param i32) (result i32)
+    (i32.and (i32.shr_u (i32.const 1) (local.get 0) (i32.const 30)))
+  )
+  (func (export "bexti32_4") (param i32) (result i32)
+    (i32.and (i32.shr_s (i32.const 1) (local.get 0) (i32.const 40)))
+  )
+  (func (export "bexti64_1") (param i64) (result i64)
+    (i64.and (i64.shr_u (local.get 0) (i64.const 10)) (i64.const 1))
+  )
+  (func (export "bexti64_2") (param i64) (result i64)
+    (i64.and (i64.shr_s (local.get 0) (i64.const 20)) (i64.const 1))
+  )
+  (func (export "bexti64_3") (param i64) (result i64)
+    (i64.and (i64.shr_u (i64.const 1) (local.get 0) (i64.const 30)))
+  )
+  (func (export "bexti64_4") (param i64) (result i64)
+    (i64.and (i64.shr_s (i64.const 1) (local.get 0) (i64.const 40)))
+  )
 )
 ;; function u0:0:
 ;; block0:
@@ -63,4 +113,120 @@
 ;;   j label1
 ;; block1:
 ;;   bclri a0,a0,52
+;;   ret
+;;
+;; function u0:6:
+;; block0:
+;;   j label1
+;; block1:
+;;   andi a5,a1,31
+;;   bext a0,a0,a5
+;;   ret
+;;
+;; function u0:7:
+;; block0:
+;;   j label1
+;; block1:
+;;   andi a5,a1,31
+;;   bext a0,a0,a5
+;;   ret
+;;
+;; function u0:8:
+;; block0:
+;;   j label1
+;; block1:
+;;   andi a5,a1,31
+;;   bext a0,a0,a5
+;;   ret
+;;
+;; function u0:9:
+;; block0:
+;;   j label1
+;; block1:
+;;   andi a5,a1,31
+;;   bext a0,a0,a5
+;;   ret
+;;
+;; function u0:10:
+;; block0:
+;;   j label1
+;; block1:
+;;   bext a0,a0,a1
+;;   ret
+;;
+;; function u0:11:
+;; block0:
+;;   j label1
+;; block1:
+;;   bext a0,a0,a1
+;;   ret
+;;
+;; function u0:12:
+;; block0:
+;;   j label1
+;; block1:
+;;   bext a0,a0,a1
+;;   ret
+;;
+;; function u0:13:
+;; block0:
+;;   j label1
+;; block1:
+;;   bext a0,a0,a1
+;;   ret
+;;
+;; function u0:14:
+;; block0:
+;;   j label1
+;; block1:
+;;   bexti a0,a0,10
+;;   ret
+;;
+;; function u0:15:
+;; block0:
+;;   j label1
+;; block1:
+;;   bexti a0,a0,20
+;;   ret
+;;
+;; function u0:16:
+;; block0:
+;;   j label1
+;; block1:
+;;   bexti a0,a0,30
+;;   ret
+;;
+;; function u0:17:
+;; block0:
+;;   j label1
+;; block1:
+;;   bexti a0,a0,8
+;;   ret
+;;
+;; function u0:18:
+;; block0:
+;;   j label1
+;; block1:
+;;   bexti a0,a0,10
+;;   ret
+;;
+;; function u0:19:
+;; block0:
+;;   j label1
+;; block1:
+;;   bexti a0,a0,20
+;;   ret
+;;
+;; function u0:20:
+;; block0:
+;;   j label1
+;; block1:
+;;   bexti a0,a0,30
+;;   ret
+;;
+;; function u0:21:
+;; block0:
+;;   j label1
+;; block1:
+;;   bexti a0,a0,40
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/zbs.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/zbs.wat
@@ -71,6 +71,31 @@
   (func (export "bexti64_4") (param i64) (result i64)
     (i64.and (i64.shr_s (i64.const 1) (local.get 0) (i64.const 40)))
   )
+
+  (func (export "binv32_1") (param i32 i32) (result i32)
+    (i32.xor (local.get 0) (i32.shl (i32.const 1) (local.get 1)))
+  )
+  (func (export "binv32_2") (param i32 i32) (result i32)
+    (i32.xor (i32.shl (i32.const 1) (local.get 1)) (local.get 0))
+  )
+  (func (export "binv64_1") (param i64 i64) (result i64)
+    (i64.xor (local.get 0) (i64.shl (i64.const 1) (local.get 1)))
+  )
+  (func (export "binv64_2") (param i64 i64) (result i64)
+    (i64.xor (i64.shl (i64.const 1) (local.get 1)) (local.get 0))
+  )
+  (func (export "binvi32_1") (param i32) (result i32)
+    (i32.xor (local.get 0) (i32.shl (i32.const 1) (i32.const 10)))
+  )
+  (func (export "binvi32_2") (param i32) (result i32)
+    (i32.xor (i32.shl (i32.const 1) (i32.const 20)) (local.get 0))
+  )
+  (func (export "binvi64_1") (param i64) (result i64)
+    (i64.xor (local.get 0) (i64.shl (i64.const 1) (i64.const 30)))
+  )
+  (func (export "binvi64_2") (param i64) (result i64)
+    (i64.xor (i64.shl (i64.const 1) (i64.const 40)) (local.get 0))
+  )
 )
 ;; function u0:0:
 ;; block0:
@@ -229,4 +254,62 @@
 ;;   j label1
 ;; block1:
 ;;   bexti a0,a0,40
+;;   ret
+;;
+;; function u0:22:
+;; block0:
+;;   j label1
+;; block1:
+;;   andi a5,a1,31
+;;   binv a0,a0,a5
+;;   ret
+;;
+;; function u0:23:
+;; block0:
+;;   j label1
+;; block1:
+;;   andi a5,a1,31
+;;   binv a0,a0,a5
+;;   ret
+;;
+;; function u0:24:
+;; block0:
+;;   j label1
+;; block1:
+;;   binv a0,a0,a1
+;;   ret
+;;
+;; function u0:25:
+;; block0:
+;;   j label1
+;; block1:
+;;   binv a0,a0,a1
+;;   ret
+;;
+;; function u0:26:
+;; block0:
+;;   j label1
+;; block1:
+;;   binvi a0,a0,10
+;;   ret
+;;
+;; function u0:27:
+;; block0:
+;;   j label1
+;; block1:
+;;   binvi a0,a0,20
+;;   ret
+;;
+;; function u0:28:
+;; block0:
+;;   j label1
+;; block1:
+;;   binvi a0,a0,30
+;;   ret
+;;
+;; function u0:29:
+;; block0:
+;;   j label1
+;; block1:
+;;   binvi a0,a0,40
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/zbs.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/zbs.wat
@@ -96,6 +96,31 @@
   (func (export "binvi64_2") (param i64) (result i64)
     (i64.xor (i64.shl (i64.const 1) (i64.const 40)) (local.get 0))
   )
+
+  (func (export "bset32_1") (param i32 i32) (result i32)
+    (i32.or (local.get 0) (i32.shl (i32.const 1) (local.get 1)))
+  )
+  (func (export "bset32_2") (param i32 i32) (result i32)
+    (i32.or (i32.shl (i32.const 1) (local.get 1)) (local.get 0))
+  )
+  (func (export "bset64_1") (param i64 i64) (result i64)
+    (i64.or (local.get 0) (i64.shl (i64.const 1) (local.get 1)))
+  )
+  (func (export "bset64_2") (param i64 i64) (result i64)
+    (i64.or (i64.shl (i64.const 1) (local.get 1)) (local.get 0))
+  )
+  (func (export "bseti32_1") (param i32) (result i32)
+    (i32.or (local.get 0) (i32.shl (i32.const 1) (i32.const 10)))
+  )
+  (func (export "bseti32_2") (param i32) (result i32)
+    (i32.or (i32.shl (i32.const 1) (i32.const 20)) (local.get 0))
+  )
+  (func (export "bseti64_1") (param i64) (result i64)
+    (i64.or (local.get 0) (i64.shl (i64.const 1) (i64.const 30)))
+  )
+  (func (export "bseti64_2") (param i64) (result i64)
+    (i64.or (i64.shl (i64.const 1) (i64.const 40)) (local.get 0))
+  )
 )
 ;; function u0:0:
 ;; block0:
@@ -312,4 +337,62 @@
 ;;   j label1
 ;; block1:
 ;;   binvi a0,a0,40
+;;   ret
+;;
+;; function u0:30:
+;; block0:
+;;   j label1
+;; block1:
+;;   andi a5,a1,31
+;;   bset a0,a0,a5
+;;   ret
+;;
+;; function u0:31:
+;; block0:
+;;   j label1
+;; block1:
+;;   andi a5,a1,31
+;;   bset a0,a0,a5
+;;   ret
+;;
+;; function u0:32:
+;; block0:
+;;   j label1
+;; block1:
+;;   bset a0,a0,a1
+;;   ret
+;;
+;; function u0:33:
+;; block0:
+;;   j label1
+;; block1:
+;;   bset a0,a0,a1
+;;   ret
+;;
+;; function u0:34:
+;; block0:
+;;   j label1
+;; block1:
+;;   bseti a0,a0,10
+;;   ret
+;;
+;; function u0:35:
+;; block0:
+;;   j label1
+;; block1:
+;;   bseti a0,a0,20
+;;   ret
+;;
+;; function u0:36:
+;; block0:
+;;   j label1
+;; block1:
+;;   bseti a0,a0,30
+;;   ret
+;;
+;; function u0:37:
+;; block0:
+;;   j label1
+;; block1:
+;;   bseti a0,a0,40
 ;;   ret


### PR DESCRIPTION
This commit extends the riscv64 backend with instructions from the `Zbs` extension. I did this awhile back for the bmi{1,2} instructions for x64 and this is mostly for completeness's sake rather than performance or anything like that, and because I had a long plane ride!