### PR TITLE
Fix profiling the first function in a module

### DIFF
--- a/crates/jit/src/profiling.rs
+++ b/crates/jit/src/profiling.rs
@@ -76,7 +76,7 @@ pub trait ProfilingAgent: Send + Sync + 'static {
             }
             let address = sym.address();
             let size = sym.size();
-            if address == 0 || size == 0 {
+            if size == 0 {
                 continue;
             }
             if let Ok(name) = sym.name() {


### PR DESCRIPTION
This commit removes a clause in `register_module` which was preventing `perf` profiling the first function in a module because it was located at address 0. This check is relatively dated at this point and I think I originally added it in error (and/or it was copied from somewhere else), so this commit removes it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
