### PR TITLE
Add accessors and mutators for all state of `wasi:http/outgoing-request` and `outgoing-response`

### DIFF
--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -96,8 +96,22 @@ interface types {
       path-with-query: option<string>,
       scheme: option<scheme>,
       authority: option<string>,
-      headers: borrow<headers>
+      headers: headers
     );
+
+    method: func() -> method;
+    set-method: func(method: method);
+
+    path-with-query: func() -> option<string>;
+    set-path-with-query: func(path-with-query: option<string>);
+
+    scheme: func() -> option<scheme>;
+    set-scheme: func(scheme: option<scheme>);
+
+    authority: func() -> option<string>;
+    set-authority: func(authority: option<string>);
+
+    headers: func() -> /* child */ headers;
 
     // Will return the outgoing-body child at most once. If called more than
     // once, subsequent calls will return error.
@@ -175,6 +189,11 @@ interface types {
 
   resource outgoing-response {
     constructor(status-code: status-code, headers: borrow<headers>);
+
+    status-code: func() -> status-code;
+    set-status-code: func(status-code: status-code);
+
+    headers: func() -> /* child */ headers;
 
     /// Will give the child outgoing-response at most once. subsequent calls will
     /// return an error.

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -188,8 +188,11 @@ interface types {
 
     /// Finalize an outgoing body, optionally providing trailers. This must be
     /// called to signal that the response is complete. If the `outgoing-body` is
-    /// dropped without calling `outgoing-body-finalize`, the implementation
+    /// dropped without calling `outgoing-body-finish`, the implementation
     /// should treat the body as corrupted.
+    ///
+    /// Note that it's valid to call `finish` while one or more forwarding
+    /// operations on the body's output stream are ongoing or pending.
     finish: static func(this: outgoing-body, trailers: option<trailers>);
   }
 
@@ -198,7 +201,7 @@ interface types {
   /// `future<result<response, error>>` in advance of Preview3. Given a
   /// `future-incoming-response`, the client can call the non-blocking `get`
   /// method to get the result if it is available. If the result is not available,
-  /// the client can call `listen` to get a `pollable` that can be passed to
+  /// the client can call `subscribe` to get a `pollable` that can be passed to
   /// `wasi:io/poll.poll-list`.
   resource future-incoming-response {
     /// option indicates readiness.

--- a/crates/wasi-http/wit/deps/io/streams.wit
+++ b/crates/wasi-http/wit/deps/io/streams.wit
@@ -275,5 +275,50 @@ interface streams {
             /// The number of bytes to splice
             len: u64,
         ) -> result<u64, stream-error>;
+
+        /// Forward the entire contents of an `input-stream` to an `output-stream`
+        /// without blocking.
+        ///
+        /// Returns immediately, with the forwarding operation happening concurrently,
+        /// and only after any previously queued forwarding operations have completed.
+        /// Can be called multiple times, causing the input streams to be queued up
+        /// in order.
+        ///
+        /// `forward` takes ownership of `src`, ensuring that the forwarding operation
+        /// is unobservable by and cannot be influenced by the calling component.
+        ///
+        /// If forwarding any of the queued-up streams results in an error, the
+        /// `future-forward-result` will be resolved to a `result` containing that
+        /// error as well as a list containing the remaining, non-forwarded streams.
+        forward: func(
+            /// The stream to forward.
+            src: input-stream,
+        ) -> result<future-forward-result>;
+    }
+
+    /// The following block defines a special resource type used by the
+    /// `wasi:io/output-stream` interface to emulate
+    /// `future<result<response, error>>` in advance of Preview3. Given a
+    /// `future-forward-result`, the client can call the non-blocking `get`
+    /// method to get the result if it is available. If the result is not available,
+    /// the client can call `subscribe` to get a `pollable` that can be passed to
+    /// `wasi:io/poll.poll-list`.
+    resource future-forward-result {
+        /// Returns the status of the forwarding operation.
+        ///
+        /// The structure of the return value works as follows:
+        /// - The option indicates readiness.
+        /// - The outer result indicates you are allowed to get the inner result at
+        ///   most once. subsequent calls after ready will return an error here.
+        /// - The inner result indicates whether the forwarding operation succeeded
+        ///   and returns the number of bytes written if so.
+        /// - The tuple in the inner result's error case contains the error that
+        ///   occurred, as well as a list of any remaining streams that were not
+        ///   yet completely forwarded.
+        ///   The first stream in this list might have been partially forwarded.
+        get: func() -> option<result<result<u64, tuple<stream-error, list<input-stream>>>>>;
+
+        /// Returns a pollable that resolves once the forwarding operation completes.
+        subscribe: func() -> /* child */ pollable;
     }
 }


### PR DESCRIPTION
This change has two purposes:
    
1. adding the accessors enables treating the resource's representation of all state as canonical, instead of requiring a component to retain a copy of all state contained in the resource.
    
2. Adding mutators for all state supports use cases where it's required to change a request's/response's state after writing to its body. This is in particular the case when implementing preexisting systems or specifications, such as the WHATWG fetch spec used in JavaScript environments.

(Stacked on #7260)