### PR TITLE
PCC: rework default-facts somewhat.

### DIFF
--- a/cranelift/codegen/src/ir/memtype.rs
+++ b/cranelift/codegen/src/ir/memtype.rs
@@ -160,12 +160,9 @@ pub struct MemoryTypeField {
 }
 
 impl MemoryTypeField {
-    /// Get the fact, if any, on a field. Fills in a default inferred
-    /// fact based on the type if no explicit fact is present.
+    /// Get the fact, if any, on a field.
     pub fn fact(&self) -> Option<&Fact> {
-        self.fact
-            .as_ref()
-            .or_else(|| Fact::infer_from_type(self.ty))
+        self.fact.as_ref()
     }
 }
 

--- a/cranelift/codegen/src/ir/pcc.rs
+++ b/cranelift/codegen/src/ir/pcc.rs
@@ -230,14 +230,6 @@ impl<'a> FactContext<'a> {
             // Reflexivity.
             (l, r) if l == r => true,
 
-            // Any value on the LHS subsumes a minimal (always-true)
-            // fact about the max value of a given bitwidth on the
-            // RHS: e.g., no matter the value, the bottom 8 bits will
-            // always be <= 255.
-            (_, Fact::ValueMax { bit_width, max }) if *max == max_value_for_width(*bit_width) => {
-                true
-            }
-
             (
                 Fact::ValueMax {
                     bit_width: bw_lhs,
@@ -487,8 +479,7 @@ impl<'a> FactContext<'a> {
     pub fn load<'b>(&'b self, fact: &Fact, access_ty: ir::Type) -> PccResult<Option<&'b Fact>> {
         Ok(self
             .struct_field(fact, access_ty)?
-            .and_then(|field| field.fact())
-            .or_else(|| Fact::infer_from_type(access_ty)))
+            .and_then(|field| field.fact()))
     }
 
     /// Check a store.

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1287,16 +1287,15 @@ impl<I: VCodeInst> VCode<I> {
         op
     }
 
+    /// Get the type of a VReg.
+    pub fn vreg_type(&self, vreg: VReg) -> Type {
+        self.vreg_types[vreg.vreg()]
+    }
+
     /// Get the fact, if any, for a given VReg.
     pub fn vreg_fact(&self, vreg: VReg) -> Option<&Fact> {
         let vreg = self.resolve_vreg_alias(vreg);
-        match &self.facts[vreg.vreg()] {
-            // The vreg has a stated fact -- return that.
-            Some(fact) => Some(fact),
-            // The vreg has no fact, but maybe we can infer a minimal
-            // one (e.g., an integer range) from the type.
-            None => Fact::infer_from_type(self.vreg_types[vreg.vreg()]),
-        }
+        self.facts[vreg.vreg()].as_ref()
     }
 
     /// Does a given instruction define any facts?


### PR DESCRIPTION
This removes the need for the awkward "max-range fact is subsumed by anything" rule noted by @fitzgen in [this
comment](https://github.com/bytecodealliance/wasmtime/pull/7231#discussion_r1358573147). It also makes checking a little more efficient and logically clear, as only the facts that the frontend/producer added are verified, rather than all default facts as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
