### PR TITLE
riscv64: Fix missing extensions for 8/16-bit div/rem

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -556,7 +556,7 @@
 (rule 1 (lower (has_type (fits_in_16 ty) (sdiv x y @ (iconst imm))))
   (if-let $true (has_m))
   (if (safe_divisor_from_imm64 ty imm))
-  (rv_divw (sext x) y))
+  (rv_divw (sext x) (sext y)))
 
 (rule 2 (lower (has_type $I32 (sdiv x y)))
   (if-let $true (has_m))
@@ -604,7 +604,7 @@
 (rule 1 (lower (has_type (fits_in_16 ty) (urem x y @ (iconst imm))))
   (if-let $true (has_m))
   (if (safe_divisor_from_imm64 ty imm))
-  (rv_remuw (zext x) y))
+  (rv_remuw (zext x) (zext y)))
 
 (rule 2 (lower (has_type $I32 (urem x y)))
   (if-let $true (has_m))
@@ -633,7 +633,7 @@
 (rule 1 (lower (has_type (fits_in_16 ty) (srem x y @ (iconst imm))))
   (if-let $true (has_m))
   (if (safe_divisor_from_imm64 ty imm))
-  (rv_remw (sext x) y))
+  (rv_remw (sext x) (sext y)))
 
 (rule 2 (lower (has_type $I32 (srem x y)))
   (if-let $true (has_m))

--- a/cranelift/filetests/filetests/runtests/urem.clif
+++ b/cranelift/filetests/filetests/runtests/urem.clif
@@ -135,3 +135,13 @@ block0(v0: i8):
 ; run: %urem_imm_i8(-19) == 0
 ; run: %urem_imm_i8(0xC0) == 0
 ; run: %urem_imm_i8(0x80) == 2
+
+
+function %constant_inputs() -> i8  {
+block0:
+    v3 = iconst.i8 208
+    v11 = urem v3, v3  ; v3 = 208, v3 = 208
+    return v11
+}
+
+; run: %constant_inputs() == 0


### PR DESCRIPTION
This was mistakenly left out of my recent refactor for remainder/division.

Closes #7245

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
