### PR TITLE
Refactor x64 asm methods to extract xmm logic in Winch

### DIFF
--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -380,7 +380,7 @@ impl Masm for MacroAssembler {
         self.load_constant(&mask, scratch_gpr, size);
         let scratch_xmm = regs::scratch_xmm();
         self.asm.gpr_to_xmm(scratch_gpr, scratch_xmm, size);
-        self.asm.xor_rr(scratch_xmm, dst, size);
+        self.asm.xmm_xor_rr(scratch_xmm, dst, size);
     }
 
     fn float_abs(&mut self, dst: Reg, size: OperandSize) {
@@ -394,13 +394,13 @@ impl Masm for MacroAssembler {
         self.load_constant(&mask, scratch_gpr, size);
         let scratch_xmm = regs::scratch_xmm();
         self.asm.gpr_to_xmm(scratch_gpr, scratch_xmm, size);
-        self.asm.and_rr(scratch_xmm, dst, size);
+        self.asm.xmm_and_rr(scratch_xmm, dst, size);
     }
 
     fn float_round(&mut self, mode: RoundingMode, context: &mut CodeGenContext, size: OperandSize) {
         if self.flags.has_sse41() {
             let src = context.pop_to_reg(self, None);
-            self.asm.rounds(src.into(), src.into(), mode, size);
+            self.asm.xmm_rounds_rr(src.into(), src.into(), mode, size);
             context.stack.push(src.into());
         } else {
             FnCall::emit::<Self, Self::Ptr, _>(self, context, |context| {


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Refactor x86 microassembler methods such that separate methods are used to operate on XMM registers as opposed to operating on general purpose registers. Also rename methods that operate on multiple XMM registers to use the format `xmm_operation_rr` to be consistent with the naming convention in the rest of the struct.