### PR TITLE
Enable threads, multi-memory, and relaxed-simd by default

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -230,10 +230,6 @@ impl Config {
         ret.wasm_simd(true);
         ret.wasm_backtrace_details(WasmBacktraceDetails::Environment);
 
-        ret.wasm_relaxed_simd(false);
-        ret.wasm_threads(false);
-        ret.wasm_multi_memory(false);
-
         // This is on-by-default in `wasmparser` since it's a stage 4+ proposal
         // but it's not implemented in Wasmtime yet so disable it.
         ret.features.tail_call = false;
@@ -660,31 +656,23 @@ impl Config {
         self
     }
 
-    /// Configures whether the WebAssembly threads proposal will be enabled for
-    /// compilation.
-    ///
-    /// The [WebAssembly threads proposal][threads] is not currently fully
-    /// standardized and is undergoing development. Additionally the support in
-    /// wasmtime itself is still being worked on. Support for this feature can
-    /// be enabled through this method for appropriate wasm modules.
+    /// Configures whether the WebAssembly [threads] proposal will be enabled
+    /// for compilation.
     ///
     /// This feature gates items such as shared memories and atomic
-    /// instructions. Note that the threads feature depends on the
-    /// bulk memory feature, which is enabled by default.
+    /// instructions. Note that the threads feature depends on the bulk memory
+    /// feature, which is enabled by default. Additionally note that while the
+    /// wasm feature is called "threads" it does not actually include the
+    /// ability to spawn threads. Spawning threads is part of the [wasi-threads]
+    /// proposal which is a separately gated feature in Wasmtime.
     ///
-    /// This is `false` by default.
+    /// Embeddings of Wasmtime are able to build their own custom threading
+    /// scheme on top of the core wasm threads proposal, however.
     ///
-    /// > **Note**: Wasmtime does not implement everything for the wasm threads
-    /// > spec at this time, so bugs, panics, and possibly segfaults should be
-    /// > expected. This should not be enabled in a production setting right
-    /// > now.
-    ///
-    /// # Errors
-    ///
-    /// The validation of this feature are deferred until the engine is being built,
-    /// and thus may cause `Engine::new` fail if the `bulk_memory` feature is disabled.
+    /// This is `true` by default.
     ///
     /// [threads]: https://github.com/webassembly/threads
+    /// [wasi-threads]: https://github.com/webassembly/wasi-threads
     pub fn wasm_threads(&mut self, enable: bool) -> &mut Self {
         self.features.threads = enable;
         self
@@ -750,15 +738,13 @@ impl Config {
     /// Configures whether the WebAssembly Relaxed SIMD proposal will be
     /// enabled for compilation.
     ///
-    /// The [WebAssembly Relaxed SIMD proposal][proposal] is not, at the time of
-    /// this writing, at stage 4. The relaxed SIMD proposal adds new
-    /// instructions to WebAssembly which, for some specific inputs, are allowed
-    /// to produce different results on different hosts. More-or-less this
-    /// proposal enables exposing platform-specific semantics of SIMD
-    /// instructions in a controlled fashion to a WebAssembly program. From an
-    /// embedder's perspective this means that WebAssembly programs may execute
-    /// differently depending on whether the host is x86_64 or AArch64, for
-    /// example.
+    /// The relaxed SIMD proposal adds new instructions to WebAssembly which,
+    /// for some specific inputs, are allowed to produce different results on
+    /// different hosts. More-or-less this proposal enables exposing
+    /// platform-specific semantics of SIMD instructions in a controlled
+    /// fashion to a WebAssembly program. From an embedder's perspective this
+    /// means that WebAssembly programs may execute differently depending on
+    /// whether the host is x86_64 or AArch64, for example.
     ///
     /// By default Wasmtime lowers relaxed SIMD instructions to the fastest
     /// lowering for the platform it's running on. This means that, by default,
@@ -768,7 +754,7 @@ impl Config {
     /// deterministic behavior across all platforms, as classified by the
     /// specification, at the cost of performance.
     ///
-    /// This is `false` by default.
+    /// This is `true` by default.
     ///
     /// [proposal]: https://github.com/webassembly/relaxed-simd
     pub fn wasm_relaxed_simd(&mut self, enable: bool) -> &mut Self {
@@ -840,7 +826,7 @@ impl Config {
     /// This feature gates modules having more than one linear memory
     /// declaration or import.
     ///
-    /// This is `false` by default.
+    /// This is `true` by default.
     ///
     /// [proposal]: https://github.com/webassembly/multi-memory
     pub fn wasm_multi_memory(&mut self, enable: bool) -> &mut Self {

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -629,27 +629,27 @@ Caused by:
     #[test]
     fn test_feature_mismatch() -> Result<()> {
         let mut config = Config::new();
-        config.wasm_simd(true);
+        config.wasm_threads(true);
 
         let engine = Engine::new(&config)?;
         let mut metadata = Metadata::new(&engine);
-        metadata.features.simd = false;
+        metadata.features.threads = false;
 
         match metadata.check_compatible(&engine) {
             Ok(_) => unreachable!(),
-            Err(e) => assert_eq!(e.to_string(), "Module was compiled without WebAssembly SIMD support but it is enabled for the host"),
+            Err(e) => assert_eq!(e.to_string(), "Module was compiled without WebAssembly threads support but it is enabled for the host"),
         }
 
         let mut config = Config::new();
-        config.wasm_simd(false);
+        config.wasm_threads(false);
 
         let engine = Engine::new(&config)?;
         let mut metadata = Metadata::new(&engine);
-        metadata.features.simd = true;
+        metadata.features.threads = true;
 
         match metadata.check_compatible(&engine) {
             Ok(_) => unreachable!(),
-            Err(e) => assert_eq!(e.to_string(), "Module was compiled with WebAssembly SIMD support but it is not enabled for the host"),
+            Err(e) => assert_eq!(e.to_string(), "Module was compiled with WebAssembly threads support but it is not enabled for the host"),
         }
 
         Ok(())

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -43,7 +43,7 @@ fn caches_across_engines() {
         // differ in wasm features enabled (which can affect
         // runtime/compilation settings)
         let res = Module::deserialize(
-            &Engine::new(Config::new().wasm_simd(false)).unwrap(),
+            &Engine::new(Config::new().wasm_threads(false)).unwrap(),
             &bytes,
         );
         assert!(res.is_err());

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -182,7 +182,7 @@ fn serialize_not_overly_massive() -> Result<()> {
 #[cfg_attr(any(not(target_arch = "x86_64"), miri), ignore)]
 fn missing_sse_and_floats_still_works() -> Result<()> {
     let mut config = Config::new();
-    config.wasm_simd(false);
+    config.wasm_simd(false).wasm_relaxed_simd(false);
     unsafe {
         config.cranelift_flag_set("has_sse41", "false");
     }


### PR DESCRIPTION
This commit enables by default three proposals that were advanced to stage 4 in the proposal process at last week's in-person CG meeting. These proposals are:

* `threads` - atomic instructions and shared memory
* `multi-memory` - the ability to have more than one linear memory
* `relaxed-simd` - new simd instructions that may differ across platforms

These proposals are now all enabled by default in Wasmtime. Note that they can still be selectively disabled via `Config` options.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
