### PR TITLE
Remove usage of `BTreeMap` for compiler flags

### DIFF
--- a/crates/cranelift-shared/src/lib.rs
+++ b/crates/cranelift-shared/src/lib.rs
@@ -3,7 +3,6 @@ use cranelift_codegen::{
     ir::{self, ExternalName, UserExternalNameRef},
     settings, FinalizedMachReloc, FinalizedRelocTarget, MachTrap,
 };
-use std::collections::BTreeMap;
 use wasmtime_environ::{FlagValue, FuncIndex, Trap, TrapInformation};
 
 pub mod isa_builder;
@@ -37,16 +36,16 @@ pub enum RelocationTarget {
 /// Converts cranelift_codegen settings to the wasmtime_environ equivalent.
 pub fn clif_flags_to_wasmtime(
     flags: impl IntoIterator<Item = settings::Value>,
-) -> BTreeMap<String, FlagValue> {
+) -> Vec<(&'static str, FlagValue<'static>)> {
     flags
         .into_iter()
-        .map(|val| (val.name.to_string(), to_flag_value(&val)))
+        .map(|val| (val.name, to_flag_value(&val)))
         .collect()
 }
 
-fn to_flag_value(v: &settings::Value) -> FlagValue {
+fn to_flag_value(v: &settings::Value) -> FlagValue<'static> {
     match v.kind() {
-        settings::SettingKind::Enum => FlagValue::Enum(v.as_enum().unwrap().into()),
+        settings::SettingKind::Enum => FlagValue::Enum(v.as_enum().unwrap()),
         settings::SettingKind::Num => FlagValue::Num(v.as_num().unwrap()),
         settings::SettingKind::Bool => FlagValue::Bool(v.as_bool().unwrap()),
         settings::SettingKind::Preset => unreachable!(),

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -23,7 +23,6 @@ use object::write::{Object, StandardSegment, SymbolId};
 use object::{RelocationEncoding, RelocationKind, SectionKind};
 use std::any::Any;
 use std::cmp;
-use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::mem;
@@ -522,11 +521,11 @@ impl wasmtime_environ::Compiler for Compiler {
         self.isa.triple()
     }
 
-    fn flags(&self) -> BTreeMap<String, FlagValue> {
+    fn flags(&self) -> Vec<(&'static str, FlagValue<'static>)> {
         wasmtime_cranelift_shared::clif_flags_to_wasmtime(self.isa.flags().iter())
     }
 
-    fn isa_flags(&self) -> BTreeMap<String, FlagValue> {
+    fn isa_flags(&self) -> Vec<(&'static str, FlagValue<'static>)> {
         wasmtime_cranelift_shared::clif_flags_to_wasmtime(self.isa.isa_flags())
     }
 

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -12,7 +12,6 @@ use object::{Architecture, BinaryFormat, FileFlags};
 use serde_derive::{Deserialize, Serialize};
 use std::any::Any;
 use std::borrow::Cow;
-use std::collections::BTreeMap;
 use std::fmt;
 use std::path;
 use std::sync::Arc;
@@ -348,10 +347,10 @@ pub trait Compiler: Send + Sync {
     }
 
     /// Returns a list of configured settings for this compiler.
-    fn flags(&self) -> BTreeMap<String, FlagValue>;
+    fn flags(&self) -> Vec<(&'static str, FlagValue<'static>)>;
 
     /// Same as [`Compiler::flags`], but ISA-specific (a cranelift-ism)
-    fn isa_flags(&self) -> BTreeMap<String, FlagValue>;
+    fn isa_flags(&self) -> Vec<(&'static str, FlagValue<'static>)>;
 
     /// Get a flag indicating whether branch protection is enabled.
     fn is_branch_protection_enabled(&self) -> bool;
@@ -383,16 +382,16 @@ pub trait Compiler: Send + Sync {
 
 /// Value of a configured setting for a [`Compiler`]
 #[derive(Serialize, Deserialize, Hash, Eq, PartialEq, Debug)]
-pub enum FlagValue {
+pub enum FlagValue<'a> {
     /// Name of the value that has been configured for this setting.
-    Enum(Cow<'static, str>),
+    Enum(&'a str),
     /// The numerical value of the configured settings.
     Num(u8),
     /// Whether the setting is on or off.
     Bool(bool),
 }
 
-impl fmt::Display for FlagValue {
+impl fmt::Display for FlagValue<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::Enum(v) => v.fmt(f),

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -534,10 +534,9 @@ mod test {
         let engine = Engine::default();
         let mut metadata = Metadata::new(&engine);
 
-        metadata.shared_flags.insert(
-            "preserve_frame_pointers".to_string(),
-            FlagValue::Bool(false),
-        );
+        metadata
+            .shared_flags
+            .push(("preserve_frame_pointers", FlagValue::Bool(false)));
 
         match metadata.check_compatible(&engine) {
             Ok(_) => unreachable!(),
@@ -560,7 +559,7 @@ Caused by:
 
         metadata
             .isa_flags
-            .insert("not_a_flag".to_string(), FlagValue::Bool(true));
+            .push(("not_a_flag", FlagValue::Bool(true)));
 
         match metadata.check_compatible(&engine) {
             Ok(_) => unreachable!(),

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -26,7 +26,6 @@ use anyhow::{anyhow, bail, Context, Result};
 use object::write::{Object, StandardSegment};
 use object::{File, FileFlags, Object as _, ObjectSection, SectionKind};
 use serde_derive::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use std::str::FromStr;
 use wasmtime_environ::obj;
 use wasmtime_environ::{FlagValue, ObjectKind, Tunables};

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -210,11 +210,11 @@ impl wasmtime_environ::Compiler for Compiler {
         self.isa.triple()
     }
 
-    fn flags(&self) -> std::collections::BTreeMap<String, wasmtime_environ::FlagValue> {
+    fn flags(&self) -> Vec<(&'static str, wasmtime_environ::FlagValue<'static>)> {
         wasmtime_cranelift_shared::clif_flags_to_wasmtime(self.isa.flags().iter())
     }
 
-    fn isa_flags(&self) -> std::collections::BTreeMap<String, wasmtime_environ::FlagValue> {
+    fn isa_flags(&self) -> Vec<(&'static str, wasmtime_environ::FlagValue<'static>)> {
         wasmtime_cranelift_shared::clif_flags_to_wasmtime(self.isa.isa_flags())
     }
 

--- a/src/commands/settings.rs
+++ b/src/commands/settings.rs
@@ -45,7 +45,7 @@ struct Settings {
     bools: Vec<SettingData>,
     presets: Vec<SettingData>,
 
-    inferred: Option<Vec<String>>,
+    inferred: Option<Vec<&'static str>>,
 }
 
 impl Settings {


### PR DESCRIPTION
No need for a datastructure here really, a simple list with static strings works alright.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
