### PR TITLE
Implement support for `thread` in `*.wast` tests

### DIFF
--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -3,8 +3,10 @@ use crate::component;
 use crate::core;
 use crate::spectest::*;
 use anyhow::{anyhow, bail, Context as _, Error, Result};
+use std::collections::HashMap;
 use std::path::Path;
 use std::str;
+use std::thread;
 use wasmtime::*;
 use wast::lexer::Lexer;
 use wast::parser::{self, ParseBuffer};
@@ -62,7 +64,10 @@ enum Export {
     Component(component::Func),
 }
 
-impl<T> WastContext<T> {
+impl<T> WastContext<T>
+where
+    T: Clone + Send + 'static,
+{
     /// Construct a new instance of `WastContext`.
     pub fn new(store: Store<T>) -> Self {
         // Spec tests will redefine the same module/name sometimes, so we need
@@ -361,26 +366,54 @@ impl<T> WastContext<T> {
         let buf = ParseBuffer::new_with_lexer(lexer).map_err(adjust_wast)?;
         let ast = parser::parse::<Wast>(&buf).map_err(adjust_wast)?;
 
-        for directive in ast.directives {
-            let sp = directive.span();
-            if log::log_enabled!(log::Level::Debug) {
-                let (line, col) = sp.linecol_in(wast);
-                log::debug!("running directive on {}:{}:{}", filename, line + 1, col);
-            }
-            self.run_directive(directive)
-                .map_err(|e| match e.downcast() {
-                    Ok(err) => adjust_wast(err).into(),
-                    Err(e) => e,
-                })
-                .with_context(|| {
-                    let (line, col) = sp.linecol_in(wast);
-                    format!("failed directive on {}:{}:{}", filename, line + 1, col)
-                })?;
-        }
-        Ok(())
+        self.run_directives(ast.directives, filename, wast)
     }
 
-    fn run_directive(&mut self, directive: WastDirective) -> Result<()> {
+    fn run_directives(
+        &mut self,
+        directives: Vec<WastDirective<'_>>,
+        filename: &str,
+        wast: &str,
+    ) -> Result<()> {
+        let adjust_wast = |mut err: wast::Error| {
+            err.set_path(filename.as_ref());
+            err.set_text(wast);
+            err
+        };
+
+        thread::scope(|scope| {
+            let mut threads = HashMap::new();
+            for directive in directives {
+                let sp = directive.span();
+                if log::log_enabled!(log::Level::Debug) {
+                    let (line, col) = sp.linecol_in(wast);
+                    log::debug!("running directive on {}:{}:{}", filename, line + 1, col);
+                }
+                self.run_directive(directive, filename, wast, &scope, &mut threads)
+                    .map_err(|e| match e.downcast() {
+                        Ok(err) => adjust_wast(err).into(),
+                        Err(e) => e,
+                    })
+                    .with_context(|| {
+                        let (line, col) = sp.linecol_in(wast);
+                        format!("failed directive on {}:{}:{}", filename, line + 1, col)
+                    })?;
+            }
+            Ok(())
+        })
+    }
+
+    fn run_directive<'a>(
+        &mut self,
+        directive: WastDirective<'a>,
+        filename: &'a str,
+        wast: &'a str,
+        scope: &'a thread::Scope<'a, '_>,
+        threads: &mut HashMap<&'a str, thread::ScopedJoinHandle<'a, Result<()>>>,
+    ) -> Result<()>
+    where
+        T: 'a,
+    {
         use wast::WastDirective::*;
 
         match directive {
@@ -466,9 +499,39 @@ impl<T> WastContext<T> {
             }
             AssertException { .. } => bail!("unimplemented assert_exception"),
 
-            Thread(_) => bail!("unimplemented `thread`"),
+            Thread(thread) => {
+                let mut core_linker = Linker::new(self.store.engine());
+                if let Some(id) = thread.shared_module {
+                    let items = self
+                        .core_linker
+                        .iter(&mut self.store)
+                        .filter(|(module, _, _)| *module == id.name())
+                        .collect::<Vec<_>>();
+                    for (module, name, item) in items {
+                        core_linker.define(&mut self.store, module, name, item)?;
+                    }
+                }
+                let mut child_cx = WastContext {
+                    current: None,
+                    core_linker,
+                    #[cfg(feature = "component-model")]
+                    component_linker: component::Linker::new(self.store.engine()),
+                    store: Store::new(self.store.engine(), self.store.data().clone()),
+                };
+                let name = thread.name.name();
+                let child =
+                    scope.spawn(move || child_cx.run_directives(thread.directives, filename, wast));
+                threads.insert(name, child);
+            }
 
-            Wait { .. } => bail!("unimplemented `wait`"),
+            Wait { thread, .. } => {
+                let name = thread.name();
+                threads
+                    .remove(name)
+                    .ok_or_else(|| anyhow!("no thread named `{name}`"))?
+                    .join()
+                    .unwrap()?;
+            }
         }
 
         Ok(())

--- a/tests/misc_testsuite/threads/LB.wast
+++ b/tests/misc_testsuite/threads/LB.wast
@@ -1,0 +1,62 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 10 shared)
+    (func (export "run")
+      (local i32)
+      (i32.load (i32.const 4))
+      (local.set 0)
+      (i32.store (i32.const 0) (i32.const 1))
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.load (i32.const 0))
+      (local.set 0)
+      (i32.store (i32.const 4) (i32.const 1))
+
+      ;; store results for checking
+      (i32.store (i32.const 32) (local.get 0))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "Mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 0 || L_0 = 1) && (L_1 = 0 || L_1 = 1)
+
+    (i32.or (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 0) (i32.const 0)))
+    (i32.or (i32.eq (local.get 1) (i32.const 1)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.and)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/tests/misc_testsuite/threads/LB_atomic.wast
+++ b/tests/misc_testsuite/threads/LB_atomic.wast
@@ -1,0 +1,64 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 10 shared)
+    (func (export "run")
+      (local i32)
+      (i32.atomic.load (i32.const 4))
+      (local.set 0)
+      (i32.atomic.store (i32.const 0) (i32.const 1))
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.atomic.load (i32.const 0))
+      (local.set 0)
+      (i32.atomic.store (i32.const 4) (i32.const 1))
+
+      ;; store results for checking
+      (i32.store (i32.const 32) (local.get 0))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "Mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 0 && L_1 = 0) || (L_0 = 0 && L_1 = 1) || (L_0 = 1 && L_1 = 0)
+
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 1)))
+    (i32.and (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.or)
+    (i32.or)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/tests/misc_testsuite/threads/MP.wast
+++ b/tests/misc_testsuite/threads/MP.wast
@@ -1,0 +1,59 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 10 shared)
+    (func (export "run")
+      (i32.store (i32.const 0) (i32.const 42))
+      (i32.store (i32.const 4) (i32.const 1))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32 i32)
+      (i32.load (i32.const 4))
+      (local.set 0)
+      (i32.load (i32.const 0))
+      (local.set 1)
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+      (i32.store (i32.const 32) (local.get 1))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "Mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 0 || L_0 = 1) && (L_1 = 0 || L_1 = 42)
+
+    (i32.or (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 0) (i32.const 0)))
+    (i32.or (i32.eq (local.get 1) (i32.const 42)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.and)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/tests/misc_testsuite/threads/MP_atomic.wast
+++ b/tests/misc_testsuite/threads/MP_atomic.wast
@@ -1,0 +1,61 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 10 shared)
+    (func (export "run")
+      (i32.atomic.store (i32.const 0) (i32.const 42))
+      (i32.atomic.store (i32.const 4) (i32.const 1))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32 i32)
+      (i32.atomic.load (i32.const 4))
+      (local.set 0)
+      (i32.atomic.load (i32.const 0))
+      (local.set 1)
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+      (i32.store (i32.const 32) (local.get 1))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "Mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 1 && L_1 = 42) || (L_0 = 0 && L_1 = 0) || (L_0 = 0 && L_1 = 42)
+
+    (i32.and (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 1) (i32.const 42)))
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 42)))
+    (i32.or)
+    (i32.or)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/tests/misc_testsuite/threads/MP_wait.wast
+++ b/tests/misc_testsuite/threads/MP_wait.wast
@@ -1,0 +1,61 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 10 shared)
+    (func (export "run")
+      (i32.atomic.store (i32.const 0) (i32.const 42))
+      (i32.atomic.store (i32.const 4) (i32.const 1))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32 i32)
+      (i32.atomic.load (i32.const 4))
+      (local.set 0)
+      (i32.atomic.load (i32.const 0))
+      (local.set 1)
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+      (i32.store (i32.const 32) (local.get 1))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "Mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 1 && L_1 = 42) || (L_0 = 0 && L_1 = 0) || (L_0 = 0 && L_1 = 42)
+
+    (i32.and (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 1) (i32.const 42)))
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 42)))
+    (i32.or)
+    (i32.or)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/tests/misc_testsuite/threads/SB.wast
+++ b/tests/misc_testsuite/threads/SB.wast
@@ -1,0 +1,62 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 10 shared)
+    (func (export "run")
+      (local i32)
+      (i32.store (i32.const 0) (i32.const 1))
+      (i32.load (i32.const 4))
+      (local.set 0)
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.store (i32.const 4) (i32.const 1))
+      (i32.load (i32.const 0))
+      (local.set 0)
+
+      ;; store results for checking
+      (i32.store (i32.const 32) (local.get 0))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "Mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 0 || L_0 = 1) && (L_1 = 0 || L_1 = 1)
+
+    (i32.or (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 0) (i32.const 0)))
+    (i32.or (i32.eq (local.get 1) (i32.const 1)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.and)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/tests/misc_testsuite/threads/SB_atomic.wast
+++ b/tests/misc_testsuite/threads/SB_atomic.wast
@@ -1,0 +1,64 @@
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 10 shared)
+    (func (export "run")
+      (local i32)
+      (i32.atomic.store (i32.const 0) (i32.const 1))
+      (i32.atomic.load (i32.const 4))
+      (local.set 0)
+
+      ;; store results for checking
+      (i32.store (i32.const 24) (local.get 0))
+    )
+  )
+  (invoke "run")
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "run")
+      (local i32)
+      (i32.atomic.store (i32.const 4) (i32.const 1))
+      (i32.atomic.load (i32.const 0))
+      (local.set 0)
+
+      ;; store results for checking
+      (i32.store (i32.const 32) (local.get 0))
+    )
+  )
+
+  (invoke "run")
+)
+
+(wait $T1)
+(wait $T2)
+
+(module $Check
+  (memory (import "Mem" "shared") 1 1 shared)
+
+  (func (export "check") (result i32)
+    (local i32 i32)
+    (i32.load (i32.const 24))
+    (local.set 0)
+    (i32.load (i32.const 32))
+    (local.set 1)
+
+    ;; allowed results: (L_0 = 1 && L_1 = 1) || (L_0 = 0 && L_1 = 1) || (L_0 = 1 && L_1 = 0)
+
+    (i32.and (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 1) (i32.const 1)))
+    (i32.and (i32.eq (local.get 0) (i32.const 0)) (i32.eq (local.get 1) (i32.const 1)))
+    (i32.and (i32.eq (local.get 0) (i32.const 1)) (i32.eq (local.get 1) (i32.const 0)))
+    (i32.or)
+    (i32.or)
+    (return)
+  )
+)
+
+(assert_return (invoke $Check "check") (i32.const 1))

--- a/tests/misc_testsuite/threads/wait_notify.wast
+++ b/tests/misc_testsuite/threads/wait_notify.wast
@@ -1,0 +1,41 @@
+;; test that looping notify eventually unblocks a parallel waiting thread
+(module $Mem
+  (memory (export "shared") 1 1 shared)
+)
+
+(thread $T1 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 10 shared)
+    (func (export "run") (result i32)
+      (memory.atomic.wait32 (i32.const 0) (i32.const 0) (i64.const -1))
+    )
+  )
+  ;; test that this thread eventually gets unblocked
+  (assert_return (invoke "run") (i32.const 0))
+)
+
+(thread $T2 (shared (module $Mem))
+  (register "mem" $Mem)
+  (module
+    (memory (import "mem" "shared") 1 1 shared)
+    (func (export "notify-0") (result i32)
+      (memory.atomic.notify (i32.const 0) (i32.const 0))
+    )
+    (func (export "notify-1-while")
+      (loop
+        (i32.const 1)
+        (memory.atomic.notify (i32.const 0) (i32.const 1))
+        (i32.ne)
+        (br_if 0)
+      )
+    )
+  )
+  ;; notifying with a count of 0 will not unblock
+  (assert_return (invoke "notify-0") (i32.const 0))
+  ;; loop until something is notified
+  (assert_return (invoke "notify-1-while"))
+)
+
+(wait $T1)
+(wait $T2)


### PR DESCRIPTION
This commit implements support for `thread` and `wait` in `*.wast` files and imports the upstream spec test suite from the `threads` proposal. This additionally and hopefully makes it a bit easier to write threaded tests in the future if necessary too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
