### PR TITLE
Remove some unnecessary world versions

### DIFF
--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -3,7 +3,7 @@ pub mod bindings {
 
     wit_bindgen::generate!({
         path: "../wasi-http/wit",
-        world: "wasi:http/proxy@0.2.0-rc-2023-10-18",
+        world: "wasi:http/proxy",
         exports: {
             "wasi:http/incoming-handler": T,
         },

--- a/crates/wasi-http/src/proxy.rs
+++ b/crates/wasi-http/src/proxy.rs
@@ -2,7 +2,7 @@ use crate::{bindings, WasiHttpView};
 use wasmtime_wasi::preview2;
 
 wasmtime::component::bindgen!({
-    world: "wasi:http/proxy@0.2.0-rc-2023-10-18",
+    world: "wasi:http/proxy",
     tracing: true,
     async: true,
     with: {
@@ -40,7 +40,7 @@ pub mod sync {
     use wasmtime_wasi::preview2;
 
     wasmtime::component::bindgen!({
-        world: "wasi:http/proxy@0.2.0-rc-2023-10-18",
+        world: "wasi:http/proxy",
         tracing: true,
         async: false,
         with: {

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -30,7 +30,7 @@ pub mod bindings {
     #[cfg(feature = "command")]
     wit_bindgen::generate!({
         path: "../wasi/wit",
-        world: "wasi:cli/command@0.2.0-rc-2023-10-18",
+        world: "wasi:cli/command",
         std_feature,
         raw_strings,
         // Automatically generated bindings for these functions will allocate

--- a/crates/wasi/src/preview2/command.rs
+++ b/crates/wasi/src/preview2/command.rs
@@ -1,7 +1,7 @@
 use crate::preview2::WasiView;
 
 wasmtime::component::bindgen!({
-    world: "wasi:cli/command@0.2.0-rc-2023-10-18",
+    world: "wasi:cli/command",
     tracing: true,
     async: true,
     with: {
@@ -60,7 +60,7 @@ pub mod sync {
     use crate::preview2::WasiView;
 
     wasmtime::component::bindgen!({
-        world: "wasi:cli/command@0.2.0-rc-2023-10-18",
+        world: "wasi:cli/command",
         tracing: true,
         async: false,
         with: {

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -93,7 +93,7 @@ pub mod bindings {
 
     wasmtime::component::bindgen!({
         path: "wit",
-        interfaces: "include wasi:cli/reactor@0.2.0-rc-2023-10-18;",
+        world: "wasi:cli/reactor",
         tracing: true,
         async: {
             // Only these functions are `async` and everything else is sync


### PR DESCRIPTION
With updates to `wit-parser` and `wit-bindgen` some of these versions are now optional and can be omitted.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
