### PR TITLE
Replace usage of tabs in `wasi:sockets` with spaces

### DIFF
--- a/crates/wasi-http/wit/deps/sockets/instance-network.wit
+++ b/crates/wasi-http/wit/deps/sockets/instance-network.wit
@@ -1,9 +1,9 @@
 
 /// This interface provides a value-export of the default network handle..
 interface instance-network {
-	use network.{network};
+    use network.{network};
 
-	/// Get a handle to the default network.
-	instance-network: func() -> network;
+    /// Get a handle to the default network.
+    instance-network: func() -> network;
 
 }

--- a/crates/wasi-http/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi-http/wit/deps/sockets/ip-name-lookup.wit
@@ -1,61 +1,61 @@
 
 interface ip-name-lookup {
-	use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
-	use network.{network, error-code, ip-address, ip-address-family};
+    use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
+    use network.{network, error-code, ip-address, ip-address-family};
 
 
-	/// Resolve an internet host name to a list of IP addresses.
-	///
-	/// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
-	///
-	/// # Parameters
-	/// - `name`: The name to look up. IP addresses are not allowed. Unicode domain names are automatically converted
-	///     to ASCII using IDNA encoding.
-	/// - `address-family`: If provided, limit the results to addresses of this specific address family.
-	/// - `include-unavailable`: When set to true, this function will also return addresses of which the runtime
-	///   thinks (or knows) can't be connected to at the moment. For example, this will return IPv6 addresses on
-	///   systems without an active IPv6 interface. Notes:
-	///     - Even when no public IPv6 interfaces are present or active, names like "localhost" can still resolve to an IPv6 address.
-	///     - Whatever is "available" or "unavailable" is volatile and can change everytime a network cable is unplugged.
-	///
-	/// This function never blocks. It either immediately fails or immediately returns successfully with a `resolve-address-stream`
-	/// that can be used to (asynchronously) fetch the results.
-	///
-	/// At the moment, the stream never completes successfully with 0 items. Ie. the first call
-	/// to `resolve-next-address` never returns `ok(none)`. This may change in the future.
-	///
-	/// # Typical errors
-	/// - `invalid-argument`:     `name` is a syntactically invalid domain name.
-	/// - `invalid-argument`:     `name` is an IP address.
-	/// - `not-supported`:        The specified `address-family` is not supported. (EAI_FAMILY)
-	///
-	/// # References:
-	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
-	/// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
-	/// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
-	/// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
-	resolve-addresses: func(network: borrow<network>, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error-code>;
+    /// Resolve an internet host name to a list of IP addresses.
+    ///
+    /// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
+    ///
+    /// # Parameters
+    /// - `name`: The name to look up. IP addresses are not allowed. Unicode domain names are automatically converted
+    ///     to ASCII using IDNA encoding.
+    /// - `address-family`: If provided, limit the results to addresses of this specific address family.
+    /// - `include-unavailable`: When set to true, this function will also return addresses of which the runtime
+    ///   thinks (or knows) can't be connected to at the moment. For example, this will return IPv6 addresses on
+    ///   systems without an active IPv6 interface. Notes:
+    ///     - Even when no public IPv6 interfaces are present or active, names like "localhost" can still resolve to an IPv6 address.
+    ///     - Whatever is "available" or "unavailable" is volatile and can change everytime a network cable is unplugged.
+    ///
+    /// This function never blocks. It either immediately fails or immediately returns successfully with a `resolve-address-stream`
+    /// that can be used to (asynchronously) fetch the results.
+    ///
+    /// At the moment, the stream never completes successfully with 0 items. Ie. the first call
+    /// to `resolve-next-address` never returns `ok(none)`. This may change in the future.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:     `name` is a syntactically invalid domain name.
+    /// - `invalid-argument`:     `name` is an IP address.
+    /// - `not-supported`:        The specified `address-family` is not supported. (EAI_FAMILY)
+    ///
+    /// # References:
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
+    /// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
+    resolve-addresses: func(network: borrow<network>, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error-code>;
 
-	resource resolve-address-stream {
-		/// Returns the next address from the resolver.
-		///
-		/// This function should be called multiple times. On each call, it will
-		/// return the next address in connection order preference. If all
-		/// addresses have been exhausted, this function returns `none`.
-		///
-		/// This function never returns IPv4-mapped IPv6 addresses.
-		///
-		/// # Typical errors
-		/// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
-		/// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
-		/// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
-		/// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
-		resolve-next-address: func() -> result<option<ip-address>, error-code>;
+    resource resolve-address-stream {
+        /// Returns the next address from the resolver.
+        ///
+        /// This function should be called multiple times. On each call, it will
+        /// return the next address in connection order preference. If all
+        /// addresses have been exhausted, this function returns `none`.
+        ///
+        /// This function never returns IPv4-mapped IPv6 addresses.
+        ///
+        /// # Typical errors
+        /// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
+        /// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
+        /// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
+        /// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
+        resolve-next-address: func() -> result<option<ip-address>, error-code>;
 
-		/// Create a `pollable` which will resolve once the stream is ready for I/O.
-		///
-		/// Note: this function is here for WASI Preview2 only.
-		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable;
-	}
+        /// Create a `pollable` which will resolve once the stream is ready for I/O.
+        ///
+        /// Note: this function is here for WASI Preview2 only.
+        /// It's planned to be removed when `future` is natively supported in Preview3.
+        subscribe: func() -> pollable;
+    }
 }

--- a/crates/wasi-http/wit/deps/sockets/network.wit
+++ b/crates/wasi-http/wit/deps/sockets/network.wit
@@ -1,147 +1,147 @@
 
 interface network {
-	/// An opaque resource that represents access to (a subset of) the network.
-	/// This enables context-based security for networking.
-	/// There is no need for this to map 1:1 to a physical network interface.
-	resource network;
+    /// An opaque resource that represents access to (a subset of) the network.
+    /// This enables context-based security for networking.
+    /// There is no need for this to map 1:1 to a physical network interface.
+    resource network;
 
-	/// Error codes.
-	///
-	/// In theory, every API can return any error code.
-	/// In practice, API's typically only return the errors documented per API
-	/// combined with a couple of errors that are always possible:
-	/// - `unknown`
-	/// - `access-denied`
-	/// - `not-supported`
-	/// - `out-of-memory`
-	/// - `concurrency-conflict`
-	///
-	/// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
-	enum error-code {
-		// ### GENERAL ERRORS ###
+    /// Error codes.
+    ///
+    /// In theory, every API can return any error code.
+    /// In practice, API's typically only return the errors documented per API
+    /// combined with a couple of errors that are always possible:
+    /// - `unknown`
+    /// - `access-denied`
+    /// - `not-supported`
+    /// - `out-of-memory`
+    /// - `concurrency-conflict`
+    ///
+    /// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
+    enum error-code {
+        // ### GENERAL ERRORS ###
 
-		/// Unknown error
-		unknown,
+        /// Unknown error
+        unknown,
 
-		/// Access denied.
-		///
-		/// POSIX equivalent: EACCES, EPERM
-		access-denied,
+        /// Access denied.
+        ///
+        /// POSIX equivalent: EACCES, EPERM
+        access-denied,
 
-		/// The operation is not supported.
-		///
-		/// POSIX equivalent: EOPNOTSUPP
-		not-supported,
+        /// The operation is not supported.
+        ///
+        /// POSIX equivalent: EOPNOTSUPP
+        not-supported,
 
-		/// One of the arguments is invalid.
-		/// 
-		/// POSIX equivalent: EINVAL
-		invalid-argument,
+        /// One of the arguments is invalid.
+        ///
+        /// POSIX equivalent: EINVAL
+        invalid-argument,
 
-		/// Not enough memory to complete the operation.
-		///
-		/// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
-		out-of-memory,
+        /// Not enough memory to complete the operation.
+        ///
+        /// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
+        out-of-memory,
 
-		/// The operation timed out before it could finish completely.
-		timeout,
+        /// The operation timed out before it could finish completely.
+        timeout,
 
-		/// This operation is incompatible with another asynchronous operation that is already in progress.
-		///
-		/// POSIX equivalent: EALREADY
-		concurrency-conflict,
+        /// This operation is incompatible with another asynchronous operation that is already in progress.
+        ///
+        /// POSIX equivalent: EALREADY
+        concurrency-conflict,
 
-		/// Trying to finish an asynchronous operation that:
-		/// - has not been started yet, or:
-		/// - was already finished by a previous `finish-*` call.
-		///
-		/// Note: this is scheduled to be removed when `future`s are natively supported.
-		not-in-progress,
+        /// Trying to finish an asynchronous operation that:
+        /// - has not been started yet, or:
+        /// - was already finished by a previous `finish-*` call.
+        ///
+        /// Note: this is scheduled to be removed when `future`s are natively supported.
+        not-in-progress,
 
-		/// The operation has been aborted because it could not be completed immediately.
-		///
-		/// Note: this is scheduled to be removed when `future`s are natively supported.
-		would-block,
-
-
-
-		// ### TCP & UDP SOCKET ERRORS ###
-
-		/// The operation is not valid in the socket's current state.
-		invalid-state,
-
-		/// A new socket resource could not be created because of a system limit.
-		new-socket-limit,
-
-		/// A bind operation failed because the provided address is not an address that the `network` can bind to.
-		address-not-bindable,
-
-		/// A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
-		address-in-use,
-
-		/// The remote address is not reachable
-		remote-unreachable,
+        /// The operation has been aborted because it could not be completed immediately.
+        ///
+        /// Note: this is scheduled to be removed when `future`s are natively supported.
+        would-block,
 
 
-		// ### TCP SOCKET ERRORS ###
 
-		/// The connection was forcefully rejected
-		connection-refused,
+        // ### TCP & UDP SOCKET ERRORS ###
 
-		/// The connection was reset.
-		connection-reset,
+        /// The operation is not valid in the socket's current state.
+        invalid-state,
 
-		/// A connection was aborted.
-		connection-aborted,
+        /// A new socket resource could not be created because of a system limit.
+        new-socket-limit,
+
+        /// A bind operation failed because the provided address is not an address that the `network` can bind to.
+        address-not-bindable,
+
+        /// A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
+        address-in-use,
+
+        /// The remote address is not reachable
+        remote-unreachable,
 
 
-		// ### UDP SOCKET ERRORS ###
-		datagram-too-large,
+        // ### TCP SOCKET ERRORS ###
+
+        /// The connection was forcefully rejected
+        connection-refused,
+
+        /// The connection was reset.
+        connection-reset,
+
+        /// A connection was aborted.
+        connection-aborted,
 
 
-		// ### NAME LOOKUP ERRORS ###
+        // ### UDP SOCKET ERRORS ###
+        datagram-too-large,
 
-		/// Name does not exist or has no suitable associated IP addresses.
-		name-unresolvable,
 
-		/// A temporary failure in name resolution occurred.
-		temporary-resolver-failure,
+        // ### NAME LOOKUP ERRORS ###
 
-		/// A permanent failure in name resolution occurred.
-		permanent-resolver-failure,
-	}
+        /// Name does not exist or has no suitable associated IP addresses.
+        name-unresolvable,
 
-	enum ip-address-family {
-		/// Similar to `AF_INET` in POSIX.
-		ipv4,
+        /// A temporary failure in name resolution occurred.
+        temporary-resolver-failure,
 
-		/// Similar to `AF_INET6` in POSIX.
-		ipv6,
-	}
+        /// A permanent failure in name resolution occurred.
+        permanent-resolver-failure,
+    }
 
-	type ipv4-address = tuple<u8, u8, u8, u8>;
-	type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
+    enum ip-address-family {
+        /// Similar to `AF_INET` in POSIX.
+        ipv4,
 
-	variant ip-address {
-		ipv4(ipv4-address),
-		ipv6(ipv6-address),
-	}
+        /// Similar to `AF_INET6` in POSIX.
+        ipv6,
+    }
 
-	record ipv4-socket-address {
-		port: u16, // sin_port
-		address: ipv4-address, // sin_addr
-	}
+    type ipv4-address = tuple<u8, u8, u8, u8>;
+    type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
 
-	record ipv6-socket-address {
-		port: u16, // sin6_port
-		flow-info: u32, // sin6_flowinfo
-		address: ipv6-address, // sin6_addr
-		scope-id: u32, // sin6_scope_id
-	}
+    variant ip-address {
+        ipv4(ipv4-address),
+        ipv6(ipv6-address),
+    }
 
-	variant ip-socket-address {
-		ipv4(ipv4-socket-address),
-		ipv6(ipv6-socket-address),
-	}
+    record ipv4-socket-address {
+        port: u16, // sin_port
+        address: ipv4-address, // sin_addr
+    }
+
+    record ipv6-socket-address {
+        port: u16, // sin6_port
+        flow-info: u32, // sin6_flowinfo
+        address: ipv6-address, // sin6_addr
+        scope-id: u32, // sin6_scope_id
+    }
+
+    variant ip-socket-address {
+        ipv4(ipv4-socket-address),
+        ipv6(ipv6-socket-address),
+    }
 
 }

--- a/crates/wasi-http/wit/deps/sockets/tcp-create-socket.wit
+++ b/crates/wasi-http/wit/deps/sockets/tcp-create-socket.wit
@@ -1,26 +1,26 @@
 
 interface tcp-create-socket {
-	use network.{network, error-code, ip-address-family};
-	use tcp.{tcp-socket};
+    use network.{network, error-code, ip-address-family};
+    use tcp.{tcp-socket};
 
-	/// Create a new TCP socket.
-	///
-	/// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
-	///
-	/// This function does not require a network capability handle. This is considered to be safe because
-	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`listen`/`connect`
-	/// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
-	///
-	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
-	///
-	/// # Typical errors
-	/// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
-	/// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-	///
-	/// # References
-	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
-	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
-	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
-	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
+    /// Create a new TCP socket.
+    ///
+    /// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
+    ///
+    /// This function does not require a network capability handle. This is considered to be safe because
+    /// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`listen`/`connect`
+    /// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+    ///
+    /// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+    ///
+    /// # Typical errors
+    /// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+    /// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+    /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+    create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
 }

--- a/crates/wasi-http/wit/deps/sockets/tcp.wit
+++ b/crates/wasi-http/wit/deps/sockets/tcp.wit
@@ -1,268 +1,268 @@
 
 interface tcp {
-	use wasi:io/streams@0.2.0-rc-2023-10-18.{input-stream, output-stream};
-	use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
-	use network.{network, error-code, ip-socket-address, ip-address-family};
+    use wasi:io/streams@0.2.0-rc-2023-10-18.{input-stream, output-stream};
+    use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
+    use network.{network, error-code, ip-socket-address, ip-address-family};
 
-	enum shutdown-type {
-		/// Similar to `SHUT_RD` in POSIX.
-		receive,
+    enum shutdown-type {
+        /// Similar to `SHUT_RD` in POSIX.
+        receive,
 
-		/// Similar to `SHUT_WR` in POSIX.
-		send,
+        /// Similar to `SHUT_WR` in POSIX.
+        send,
 
-		/// Similar to `SHUT_RDWR` in POSIX.
-		both,
-	}
+        /// Similar to `SHUT_RDWR` in POSIX.
+        both,
+    }
 
 
-	/// A TCP socket handle.
-	resource tcp-socket {
-		/// Bind the socket to a specific network on the provided IP address and port.
-		///
-		/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
-		/// network interface(s) to bind to.
-		/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
-		///
-		/// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
-		/// implicitly bind the socket.
-		///
-		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		///
-		/// # Typical `start` errors
-		/// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
-		/// - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
-		/// - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL)
-		/// - `invalid-state`:             The socket is already bound. (EINVAL)
-		///
-		/// # Typical `finish` errors
-		/// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
-		/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
-		/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
-		/// - `not-in-progress`:           A `bind` operation is not in progress.
-		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
-		/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
-		finish-bind: func() -> result<_, error-code>;
+    /// A TCP socket handle.
+    resource tcp-socket {
+        /// Bind the socket to a specific network on the provided IP address and port.
+        ///
+        /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+        /// network interface(s) to bind to.
+        /// If the TCP/UDP port is zero, the socket will be bound to a random free port.
+        ///
+        /// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
+        /// implicitly bind the socket.
+        ///
+        /// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+        ///
+        /// # Typical `start` errors
+        /// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+        /// - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
+        /// - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL)
+        /// - `invalid-state`:             The socket is already bound. (EINVAL)
+        ///
+        /// # Typical `finish` errors
+        /// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+        /// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+        /// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+        /// - `not-in-progress`:           A `bind` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+        /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+        start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+        finish-bind: func() -> result<_, error-code>;
 
-		/// Connect to a remote endpoint.
-		///
-		/// On success:
-		/// - the socket is transitioned into the Connection state
-		/// - a pair of streams is returned that can be used to read & write to the connection
-		///
-		/// POSIX mentions:
-		/// > If connect() fails, the state of the socket is unspecified. Conforming applications should
-		/// > close the file descriptor and create a new socket before attempting to reconnect.
-		///
-		/// WASI prescribes the following behavior:
-		/// - If `connect` fails because an input/state validation error, the socket should remain usable.
-		/// - If a connection was actually attempted but failed, the socket should become unusable for further network communication.
-		///   Besides `drop`, any method after such a failure may return an error.
-		///
-		/// # Typical `start` errors
-		/// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
-		/// - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
-		/// - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL, EADDRNOTAVAIL on Illumos)
-		/// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
-		/// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
-		/// - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
-		/// - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
-		/// - `invalid-state`:             The socket is already in the Connection state. (EISCONN)
-		/// - `invalid-state`:             The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)
-		///
-		/// # Typical `finish` errors
-		/// - `timeout`:                   Connection timed out. (ETIMEDOUT)
-		/// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
-		/// - `connection-reset`:          The connection was reset. (ECONNRESET)
-		/// - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
-		/// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
-		/// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
-		/// - `not-in-progress`:           A `connect` operation is not in progress.
-		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
-		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
-		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
-		finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
+        /// Connect to a remote endpoint.
+        ///
+        /// On success:
+        /// - the socket is transitioned into the Connection state
+        /// - a pair of streams is returned that can be used to read & write to the connection
+        ///
+        /// POSIX mentions:
+        /// > If connect() fails, the state of the socket is unspecified. Conforming applications should
+        /// > close the file descriptor and create a new socket before attempting to reconnect.
+        ///
+        /// WASI prescribes the following behavior:
+        /// - If `connect` fails because an input/state validation error, the socket should remain usable.
+        /// - If a connection was actually attempted but failed, the socket should become unusable for further network communication.
+        ///   Besides `drop`, any method after such a failure may return an error.
+        ///
+        /// # Typical `start` errors
+        /// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+        /// - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
+        /// - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL, EADDRNOTAVAIL on Illumos)
+        /// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
+        /// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
+        /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
+        /// - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+        /// - `invalid-state`:             The socket is already in the Connection state. (EISCONN)
+        /// - `invalid-state`:             The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)
+        ///
+        /// # Typical `finish` errors
+        /// - `timeout`:                   Connection timed out. (ETIMEDOUT)
+        /// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
+        /// - `connection-reset`:          The connection was reset. (ECONNRESET)
+        /// - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
+        /// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+        /// - `not-in-progress`:           A `connect` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+        /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+        /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+        start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+        finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
 
-		/// Start listening for new connections.
-		///
-		/// Transitions the socket into the Listener state.
-		///
-		/// Unlike POSIX:
-		/// - this function is async. This enables interactive WASI hosts to inject permission prompts.
-		/// - the socket must already be explicitly bound.
-		///
-		/// # Typical `start` errors
-		/// - `invalid-state`:             The socket is not bound to any local address. (EDESTADDRREQ)
-		/// - `invalid-state`:             The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
-		/// - `invalid-state`:             The socket is already in the Listener state.
-		///
-		/// # Typical `finish` errors
-		/// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
-		/// - `not-in-progress`:           A `listen` operation is not in progress.
-		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
-		/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
-		start-listen: func() -> result<_, error-code>;
-		finish-listen: func() -> result<_, error-code>;
+        /// Start listening for new connections.
+        ///
+        /// Transitions the socket into the Listener state.
+        ///
+        /// Unlike POSIX:
+        /// - this function is async. This enables interactive WASI hosts to inject permission prompts.
+        /// - the socket must already be explicitly bound.
+        ///
+        /// # Typical `start` errors
+        /// - `invalid-state`:             The socket is not bound to any local address. (EDESTADDRREQ)
+        /// - `invalid-state`:             The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
+        /// - `invalid-state`:             The socket is already in the Listener state.
+        ///
+        /// # Typical `finish` errors
+        /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
+        /// - `not-in-progress`:           A `listen` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
+        /// - <https://man7.org/linux/man-pages/man2/listen.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
+        start-listen: func() -> result<_, error-code>;
+        finish-listen: func() -> result<_, error-code>;
 
-		/// Accept a new client socket.
-		///
-		/// The returned socket is bound and in the Connection state. The following properties are inherited from the listener socket:
-		/// - `address-family`
-		/// - `ipv6-only`
-		/// - `keep-alive`
-		/// - `no-delay`
-		/// - `unicast-hop-limit`
-		/// - `receive-buffer-size`
-		/// - `send-buffer-size`
-		///
-		/// On success, this function returns the newly accepted client socket along with
-		/// a pair of streams that can be used to read & write to the connection.
-		///
-		/// # Typical errors
-		/// - `invalid-state`:      Socket is not in the Listener state. (EINVAL)
-		/// - `would-block`:        No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
-		/// - `connection-aborted`: An incoming connection was pending, but was terminated by the client before this listener could accept it. (ECONNABORTED)
-		/// - `new-socket-limit`:   The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
-		/// - <https://man7.org/linux/man-pages/man2/accept.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-		accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
+        /// Accept a new client socket.
+        ///
+        /// The returned socket is bound and in the Connection state. The following properties are inherited from the listener socket:
+        /// - `address-family`
+        /// - `ipv6-only`
+        /// - `keep-alive`
+        /// - `no-delay`
+        /// - `unicast-hop-limit`
+        /// - `receive-buffer-size`
+        /// - `send-buffer-size`
+        ///
+        /// On success, this function returns the newly accepted client socket along with
+        /// a pair of streams that can be used to read & write to the connection.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`:      Socket is not in the Listener state. (EINVAL)
+        /// - `would-block`:        No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
+        /// - `connection-aborted`: An incoming connection was pending, but was terminated by the client before this listener could accept it. (ECONNABORTED)
+        /// - `new-socket-limit`:   The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
+        /// - <https://man7.org/linux/man-pages/man2/accept.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
+        accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
 
-		/// Get the bound local address.
-		///
-		/// POSIX mentions:
-		/// > If the socket has not been bound to a local name, the value
-		/// > stored in the object pointed to by `address` is unspecified.
-		///
-		/// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
-		///
-		/// # Typical errors
-		/// - `invalid-state`: The socket is not bound to any local address.
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
-		/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
-		/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-		local-address: func() -> result<ip-socket-address, error-code>;
+        /// Get the bound local address.
+        ///
+        /// POSIX mentions:
+        /// > If the socket has not been bound to a local name, the value
+        /// > stored in the object pointed to by `address` is unspecified.
+        ///
+        /// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not bound to any local address.
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+        /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+        /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+        local-address: func() -> result<ip-socket-address, error-code>;
 
-		/// Get the remote address.
-		///
-		/// # Typical errors
-		/// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
-		/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-		remote-address: func() -> result<ip-socket-address, error-code>;
+        /// Get the remote address.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+        /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+        remote-address: func() -> result<ip-socket-address, error-code>;
 
-		/// Whether this is a IPv4 or IPv6 socket.
-		///
-		/// Equivalent to the SO_DOMAIN socket option.
-		address-family: func() -> ip-address-family;
+        /// Whether this is a IPv4 or IPv6 socket.
+        ///
+        /// Equivalent to the SO_DOMAIN socket option.
+        address-family: func() -> ip-address-family;
 
-		/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-		///
-		/// Equivalent to the IPV6_V6ONLY socket option.
-		///
-		/// # Typical errors
-		/// - `invalid-state`:        (set) The socket is already bound.
-		/// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
-		/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
-		ipv6-only: func() -> result<bool, error-code>;
-		set-ipv6-only: func(value: bool) -> result<_, error-code>;
+        /// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
+        ///
+        /// Equivalent to the IPV6_V6ONLY socket option.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`:        (set) The socket is already bound.
+        /// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
+        /// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
+        ipv6-only: func() -> result<bool, error-code>;
+        set-ipv6-only: func(value: bool) -> result<_, error-code>;
 
-		/// Hints the desired listen queue size. Implementations are free to ignore this.
-		///
-		/// # Typical errors
-		/// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
-		/// - `invalid-state`:        (set) The socket is already in the Connection state.
-		set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
+        /// Hints the desired listen queue size. Implementations are free to ignore this.
+        ///
+        /// # Typical errors
+        /// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
+        /// - `invalid-state`:        (set) The socket is already in the Connection state.
+        set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
 
-		/// Equivalent to the SO_KEEPALIVE socket option.
-		keep-alive: func() -> result<bool, error-code>;
-		set-keep-alive: func(value: bool) -> result<_, error-code>;
+        /// Equivalent to the SO_KEEPALIVE socket option.
+        keep-alive: func() -> result<bool, error-code>;
+        set-keep-alive: func(value: bool) -> result<_, error-code>;
 
-		/// Equivalent to the TCP_NODELAY socket option.
-		///
-		/// The default value is `false`.
-		no-delay: func() -> result<bool, error-code>;
-		set-no-delay: func(value: bool) -> result<_, error-code>;
+        /// Equivalent to the TCP_NODELAY socket option.
+        ///
+        /// The default value is `false`.
+        no-delay: func() -> result<bool, error-code>;
+        set-no-delay: func(value: bool) -> result<_, error-code>;
 
-		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-		///
-		/// # Typical errors
-		/// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-		/// - `invalid-state`:        (set) The socket is already in the Connection state.
-		/// - `invalid-state`:        (set) The socket is already in the Listener state.
-		unicast-hop-limit: func() -> result<u8, error-code>;
-		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
+        /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+        /// - `invalid-state`:        (set) The socket is already in the Connection state.
+        /// - `invalid-state`:        (set) The socket is already in the Listener state.
+        unicast-hop-limit: func() -> result<u8, error-code>;
+        set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
 
-		/// The kernel buffer space reserved for sends/receives on this socket.
-		///
-		/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
-		/// 	In other words, after setting a value, reading the same setting back may return a different value.
-		///
-		/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
-		/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
-		/// 	for internal metadata structures.
-		///
-		/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-		///
-		/// # Typical errors
-		/// - `invalid-state`:        (set) The socket is already in the Connection state.
-		/// - `invalid-state`:        (set) The socket is already in the Listener state.
-		receive-buffer-size: func() -> result<u64, error-code>;
-		set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
-		send-buffer-size: func() -> result<u64, error-code>;
-		set-send-buffer-size: func(value: u64) -> result<_, error-code>;
+        /// The kernel buffer space reserved for sends/receives on this socket.
+        ///
+        /// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
+        ///     In other words, after setting a value, reading the same setting back may return a different value.
+        ///
+        /// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
+        ///     actual data to be sent/received by the application, because the kernel might also use the buffer space
+        ///     for internal metadata structures.
+        ///
+        /// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`:        (set) The socket is already in the Connection state.
+        /// - `invalid-state`:        (set) The socket is already in the Listener state.
+        receive-buffer-size: func() -> result<u64, error-code>;
+        set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+        send-buffer-size: func() -> result<u64, error-code>;
+        set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
-		/// Create a `pollable` which will resolve once the socket is ready for I/O.
-		///
-		/// Note: this function is here for WASI Preview2 only.
-		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable;
+        /// Create a `pollable` which will resolve once the socket is ready for I/O.
+        ///
+        /// Note: this function is here for WASI Preview2 only.
+        /// It's planned to be removed when `future` is natively supported in Preview3.
+        subscribe: func() -> pollable;
 
-		/// Initiate a graceful shutdown.
-		///
-		/// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
-		///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.
-		///   Any data still in the receive queue at time of calling `shutdown` will be discarded.
-		/// - send: the socket is not expecting to send any more data to the peer. All subsequent write
-		///   operations on the `output-stream` associated with this socket will return an error.
-		/// - both: same effect as receive & send combined.
-		///
-		/// The shutdown function does not close (drop) the socket.
-		///
-		/// # Typical errors
-		/// - `invalid-state`: The socket is not in the Connection state. (ENOTCONN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
-		/// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
-		shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
-	}
+        /// Initiate a graceful shutdown.
+        ///
+        /// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
+        ///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.
+        ///   Any data still in the receive queue at time of calling `shutdown` will be discarded.
+        /// - send: the socket is not expecting to send any more data to the peer. All subsequent write
+        ///   operations on the `output-stream` associated with this socket will return an error.
+        /// - both: same effect as receive & send combined.
+        ///
+        /// The shutdown function does not close (drop) the socket.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not in the Connection state. (ENOTCONN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
+        /// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
+        shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
+    }
 }

--- a/crates/wasi-http/wit/deps/sockets/udp-create-socket.wit
+++ b/crates/wasi-http/wit/deps/sockets/udp-create-socket.wit
@@ -1,26 +1,26 @@
 
 interface udp-create-socket {
-	use network.{network, error-code, ip-address-family};
-	use udp.{udp-socket};
+    use network.{network, error-code, ip-address-family};
+    use udp.{udp-socket};
 
-	/// Create a new UDP socket.
-	///
-	/// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)` in POSIX.
-	///
-	/// This function does not require a network capability handle. This is considered to be safe because
-	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect` is called,
-	/// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
-	///
-	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
-	///
-	/// # Typical errors
-	/// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
-	/// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-	///
-	/// # References:
-	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
-	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
-	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
-	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
+    /// Create a new UDP socket.
+    ///
+    /// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)` in POSIX.
+    ///
+    /// This function does not require a network capability handle. This is considered to be safe because
+    /// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect` is called,
+    /// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+    ///
+    /// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+    ///
+    /// # Typical errors
+    /// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+    /// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+    ///
+    /// # References:
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+    /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+    create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
 }

--- a/crates/wasi-http/wit/deps/sockets/udp.wit
+++ b/crates/wasi-http/wit/deps/sockets/udp.wit
@@ -1,213 +1,213 @@
 
 interface udp {
-	use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
-	use network.{network, error-code, ip-socket-address, ip-address-family};
+    use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
+    use network.{network, error-code, ip-socket-address, ip-address-family};
 
 
-	record datagram {
-		data: list<u8>, // Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
-		remote-address: ip-socket-address,
+    record datagram {
+        data: list<u8>, // Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
+        remote-address: ip-socket-address,
 
-		/// Possible future additions:
-		/// local-address: ip-socket-address, // IP_PKTINFO / IP_RECVDSTADDR / IPV6_PKTINFO
-		/// local-interface: u32, // IP_PKTINFO / IP_RECVIF
-		/// ttl: u8, // IP_RECVTTL
-		/// dscp: u6, // IP_RECVTOS
-		/// ecn: u2, // IP_RECVTOS
-	}
+        /// Possible future additions:
+        /// local-address: ip-socket-address, // IP_PKTINFO / IP_RECVDSTADDR / IPV6_PKTINFO
+        /// local-interface: u32, // IP_PKTINFO / IP_RECVIF
+        /// ttl: u8, // IP_RECVTTL
+        /// dscp: u6, // IP_RECVTOS
+        /// ecn: u2, // IP_RECVTOS
+    }
 
 
 
-	/// A UDP socket handle.
-	resource udp-socket {
-		/// Bind the socket to a specific network on the provided IP address and port.
-		///
-		/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
-		/// network interface(s) to bind to.
-		/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
-		///
-		/// When a socket is not explicitly bound, the first invocation to connect will implicitly bind the socket.
-		///
-		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		///
-		/// # Typical `start` errors
-		/// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
-		/// - `invalid-state`:             The socket is already bound. (EINVAL)
-		///
-		/// # Typical `finish` errors
-		/// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
-		/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
-		/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
-		/// - `not-in-progress`:           A `bind` operation is not in progress.
-		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
-		/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
-		finish-bind: func() -> result<_, error-code>;
+    /// A UDP socket handle.
+    resource udp-socket {
+        /// Bind the socket to a specific network on the provided IP address and port.
+        ///
+        /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+        /// network interface(s) to bind to.
+        /// If the TCP/UDP port is zero, the socket will be bound to a random free port.
+        ///
+        /// When a socket is not explicitly bound, the first invocation to connect will implicitly bind the socket.
+        ///
+        /// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+        ///
+        /// # Typical `start` errors
+        /// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+        /// - `invalid-state`:             The socket is already bound. (EINVAL)
+        ///
+        /// # Typical `finish` errors
+        /// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+        /// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+        /// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+        /// - `not-in-progress`:           A `bind` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+        /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+        start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+        finish-bind: func() -> result<_, error-code>;
 
-		/// Set the destination address.
-		///
-		/// The local-address is updated based on the best network path to `remote-address`.
-		///
-		/// When a destination address is set:
-		/// - all receive operations will only return datagrams sent from the provided `remote-address`.
-		/// - the `send` function can only be used to send to this destination.
-		///
-		/// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
-		///
-		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		///
-		/// # Typical `start` errors
-		/// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
-		/// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
-		/// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
-		/// - `invalid-argument`:          The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
-		/// - `invalid-argument`:          The socket is already bound to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
-		///
-		/// # Typical `finish` errors
-		/// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
-		/// - `not-in-progress`:           A `connect` operation is not in progress.
-		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
-		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
-		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
-		finish-connect: func() -> result<_, error-code>;
+        /// Set the destination address.
+        ///
+        /// The local-address is updated based on the best network path to `remote-address`.
+        ///
+        /// When a destination address is set:
+        /// - all receive operations will only return datagrams sent from the provided `remote-address`.
+        /// - the `send` function can only be used to send to this destination.
+        ///
+        /// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
+        ///
+        /// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+        ///
+        /// # Typical `start` errors
+        /// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+        /// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
+        /// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-argument`:          The socket is already bound to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+        ///
+        /// # Typical `finish` errors
+        /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+        /// - `not-in-progress`:           A `connect` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+        /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+        /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+        start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+        finish-connect: func() -> result<_, error-code>;
 
-		/// Receive messages on the socket.
-		///
-		/// This function attempts to receive up to `max-results` datagrams on the socket without blocking.
-		/// The returned list may contain fewer elements than requested, but never more.
-		/// If `max-results` is 0, this function returns successfully with an empty list.
-		///
-		/// # Typical errors
-		/// - `invalid-state`:      The socket is not bound to any local address. (EINVAL)
-		/// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
-		/// - `would-block`:        There is no pending data available to be read at the moment. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
-		/// - <https://man7.org/linux/man-pages/man2/recv.2.html>
-		/// - <https://man7.org/linux/man-pages/man2/recvmmsg.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
-		/// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-		receive: func(max-results: u64) -> result<list<datagram>, error-code>;
+        /// Receive messages on the socket.
+        ///
+        /// This function attempts to receive up to `max-results` datagrams on the socket without blocking.
+        /// The returned list may contain fewer elements than requested, but never more.
+        /// If `max-results` is 0, this function returns successfully with an empty list.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`:      The socket is not bound to any local address. (EINVAL)
+        /// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `would-block`:        There is no pending data available to be read at the moment. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
+        /// - <https://man7.org/linux/man-pages/man2/recv.2.html>
+        /// - <https://man7.org/linux/man-pages/man2/recvmmsg.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
+        /// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
+        receive: func(max-results: u64) -> result<list<datagram>, error-code>;
 
-		/// Send messages on the socket.
-		///
-		/// This function attempts to send all provided `datagrams` on the socket without blocking and
-		/// returns how many messages were actually sent (or queued for sending).
-		///
-		/// This function semantically behaves the same as iterating the `datagrams` list and sequentially
-		/// sending each individual datagram until either the end of the list has been reached or the first error occurred.
-		/// If at least one datagram has been sent successfully, this function never returns an error.
-		///
-		/// If the input list is empty, the function returns `ok(0)`.
-		///
-		/// The remote address option is required. To send a message to the "connected" peer,
-		/// call `remote-address` to get their address.
-		///
-		/// # Typical errors
-		/// - `invalid-argument`:        The `remote-address` has the wrong address family. (EAFNOSUPPORT)
-		/// - `invalid-argument`:        `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
-		/// - `invalid-argument`:        The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
-		/// - `invalid-argument`:        The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
-		/// - `invalid-argument`:        The socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`. (EISCONN)
-		/// - `invalid-state`:           The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.
-		/// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
-		/// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
-		/// - `would-block`:             The send buffer is currently full. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
-		/// - <https://man7.org/linux/man-pages/man2/send.2.html>
-		/// - <https://man7.org/linux/man-pages/man2/sendmmsg.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-		send: func(datagrams: list<datagram>) -> result<u64, error-code>;
+        /// Send messages on the socket.
+        ///
+        /// This function attempts to send all provided `datagrams` on the socket without blocking and
+        /// returns how many messages were actually sent (or queued for sending).
+        ///
+        /// This function semantically behaves the same as iterating the `datagrams` list and sequentially
+        /// sending each individual datagram until either the end of the list has been reached or the first error occurred.
+        /// If at least one datagram has been sent successfully, this function never returns an error.
+        ///
+        /// If the input list is empty, the function returns `ok(0)`.
+        ///
+        /// The remote address option is required. To send a message to the "connected" peer,
+        /// call `remote-address` to get their address.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:        The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+        /// - `invalid-argument`:        `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
+        /// - `invalid-argument`:        The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-argument`:        The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-argument`:        The socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`. (EISCONN)
+        /// - `invalid-state`:           The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.
+        /// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
+        /// - `would-block`:             The send buffer is currently full. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
+        /// - <https://man7.org/linux/man-pages/man2/send.2.html>
+        /// - <https://man7.org/linux/man-pages/man2/sendmmsg.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
+        send: func(datagrams: list<datagram>) -> result<u64, error-code>;
 
-		/// Get the current bound address.
-		///
-		/// POSIX mentions:
-		/// > If the socket has not been bound to a local name, the value
-		/// > stored in the object pointed to by `address` is unspecified.
-		///
-		/// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
-		///
-		/// # Typical errors
-		/// - `invalid-state`: The socket is not bound to any local address.
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
-		/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
-		/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-		local-address: func() -> result<ip-socket-address, error-code>;
+        /// Get the current bound address.
+        ///
+        /// POSIX mentions:
+        /// > If the socket has not been bound to a local name, the value
+        /// > stored in the object pointed to by `address` is unspecified.
+        ///
+        /// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not bound to any local address.
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+        /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+        /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+        local-address: func() -> result<ip-socket-address, error-code>;
 
-		/// Get the address set with `connect`.
-		///
-		/// # Typical errors
-		/// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
-		/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-		remote-address: func() -> result<ip-socket-address, error-code>;
+        /// Get the address set with `connect`.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+        /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+        remote-address: func() -> result<ip-socket-address, error-code>;
 
-		/// Whether this is a IPv4 or IPv6 socket.
-		///
-		/// Equivalent to the SO_DOMAIN socket option.
-		address-family: func() -> ip-address-family;
+        /// Whether this is a IPv4 or IPv6 socket.
+        ///
+        /// Equivalent to the SO_DOMAIN socket option.
+        address-family: func() -> ip-address-family;
 
-		/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-		///
-		/// Equivalent to the IPV6_V6ONLY socket option.
-		///
-		/// # Typical errors
-		/// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
-		/// - `invalid-state`:        (set) The socket is already bound.
-		/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
-		ipv6-only: func() -> result<bool, error-code>;
-		set-ipv6-only: func(value: bool) -> result<_, error-code>;
+        /// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
+        ///
+        /// Equivalent to the IPV6_V6ONLY socket option.
+        ///
+        /// # Typical errors
+        /// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
+        /// - `invalid-state`:        (set) The socket is already bound.
+        /// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
+        ipv6-only: func() -> result<bool, error-code>;
+        set-ipv6-only: func(value: bool) -> result<_, error-code>;
 
-		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-		unicast-hop-limit: func() -> result<u8, error-code>;
-		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
+        /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+        unicast-hop-limit: func() -> result<u8, error-code>;
+        set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
 
-		/// The kernel buffer space reserved for sends/receives on this socket.
-		///
-		/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
-		/// 	In other words, after setting a value, reading the same setting back may return a different value.
-		///
-		/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
-		/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
-		/// 	for internal metadata structures.
-		///
-		/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-		receive-buffer-size: func() -> result<u64, error-code>;
-		set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
-		send-buffer-size: func() -> result<u64, error-code>;
-		set-send-buffer-size: func(value: u64) -> result<_, error-code>;
+        /// The kernel buffer space reserved for sends/receives on this socket.
+        ///
+        /// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
+        ///     In other words, after setting a value, reading the same setting back may return a different value.
+        ///
+        /// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
+        ///     actual data to be sent/received by the application, because the kernel might also use the buffer space
+        ///     for internal metadata structures.
+        ///
+        /// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+        receive-buffer-size: func() -> result<u64, error-code>;
+        set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+        send-buffer-size: func() -> result<u64, error-code>;
+        set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
-		/// Create a `pollable` which will resolve once the socket is ready for I/O.
-		///
-		/// Note: this function is here for WASI Preview2 only.
-		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable;
-	}
+        /// Create a `pollable` which will resolve once the socket is ready for I/O.
+        ///
+        /// Note: this function is here for WASI Preview2 only.
+        /// It's planned to be removed when `future` is natively supported in Preview3.
+        subscribe: func() -> pollable;
+    }
 }

--- a/crates/wasi/wit/deps/sockets/instance-network.wit
+++ b/crates/wasi/wit/deps/sockets/instance-network.wit
@@ -1,9 +1,9 @@
 
 /// This interface provides a value-export of the default network handle..
 interface instance-network {
-	use network.{network};
+    use network.{network};
 
-	/// Get a handle to the default network.
-	instance-network: func() -> network;
+    /// Get a handle to the default network.
+    instance-network: func() -> network;
 
 }

--- a/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
@@ -1,61 +1,61 @@
 
 interface ip-name-lookup {
-	use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
-	use network.{network, error-code, ip-address, ip-address-family};
+    use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
+    use network.{network, error-code, ip-address, ip-address-family};
 
 
-	/// Resolve an internet host name to a list of IP addresses.
-	///
-	/// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
-	///
-	/// # Parameters
-	/// - `name`: The name to look up. IP addresses are not allowed. Unicode domain names are automatically converted
-	///     to ASCII using IDNA encoding.
-	/// - `address-family`: If provided, limit the results to addresses of this specific address family.
-	/// - `include-unavailable`: When set to true, this function will also return addresses of which the runtime
-	///   thinks (or knows) can't be connected to at the moment. For example, this will return IPv6 addresses on
-	///   systems without an active IPv6 interface. Notes:
-	///     - Even when no public IPv6 interfaces are present or active, names like "localhost" can still resolve to an IPv6 address.
-	///     - Whatever is "available" or "unavailable" is volatile and can change everytime a network cable is unplugged.
-	///
-	/// This function never blocks. It either immediately fails or immediately returns successfully with a `resolve-address-stream`
-	/// that can be used to (asynchronously) fetch the results.
-	///
-	/// At the moment, the stream never completes successfully with 0 items. Ie. the first call
-	/// to `resolve-next-address` never returns `ok(none)`. This may change in the future.
-	///
-	/// # Typical errors
-	/// - `invalid-argument`:     `name` is a syntactically invalid domain name.
-	/// - `invalid-argument`:     `name` is an IP address.
-	/// - `not-supported`:        The specified `address-family` is not supported. (EAI_FAMILY)
-	///
-	/// # References:
-	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
-	/// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
-	/// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
-	/// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
-	resolve-addresses: func(network: borrow<network>, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error-code>;
+    /// Resolve an internet host name to a list of IP addresses.
+    ///
+    /// See the wasi-socket proposal README.md for a comparison with getaddrinfo.
+    ///
+    /// # Parameters
+    /// - `name`: The name to look up. IP addresses are not allowed. Unicode domain names are automatically converted
+    ///     to ASCII using IDNA encoding.
+    /// - `address-family`: If provided, limit the results to addresses of this specific address family.
+    /// - `include-unavailable`: When set to true, this function will also return addresses of which the runtime
+    ///   thinks (or knows) can't be connected to at the moment. For example, this will return IPv6 addresses on
+    ///   systems without an active IPv6 interface. Notes:
+    ///     - Even when no public IPv6 interfaces are present or active, names like "localhost" can still resolve to an IPv6 address.
+    ///     - Whatever is "available" or "unavailable" is volatile and can change everytime a network cable is unplugged.
+    ///
+    /// This function never blocks. It either immediately fails or immediately returns successfully with a `resolve-address-stream`
+    /// that can be used to (asynchronously) fetch the results.
+    ///
+    /// At the moment, the stream never completes successfully with 0 items. Ie. the first call
+    /// to `resolve-next-address` never returns `ok(none)`. This may change in the future.
+    ///
+    /// # Typical errors
+    /// - `invalid-argument`:     `name` is a syntactically invalid domain name.
+    /// - `invalid-argument`:     `name` is an IP address.
+    /// - `not-supported`:        The specified `address-family` is not supported. (EAI_FAMILY)
+    ///
+    /// # References:
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getaddrinfo.html>
+    /// - <https://man7.org/linux/man-pages/man3/getaddrinfo.3.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/ws2tcpip/nf-ws2tcpip-getaddrinfo>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=getaddrinfo&sektion=3>
+    resolve-addresses: func(network: borrow<network>, name: string, address-family: option<ip-address-family>, include-unavailable: bool) -> result<resolve-address-stream, error-code>;
 
-	resource resolve-address-stream {
-		/// Returns the next address from the resolver.
-		///
-		/// This function should be called multiple times. On each call, it will
-		/// return the next address in connection order preference. If all
-		/// addresses have been exhausted, this function returns `none`.
-		///
-		/// This function never returns IPv4-mapped IPv6 addresses.
-		///
-		/// # Typical errors
-		/// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
-		/// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
-		/// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
-		/// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
-		resolve-next-address: func() -> result<option<ip-address>, error-code>;
+    resource resolve-address-stream {
+        /// Returns the next address from the resolver.
+        ///
+        /// This function should be called multiple times. On each call, it will
+        /// return the next address in connection order preference. If all
+        /// addresses have been exhausted, this function returns `none`.
+        ///
+        /// This function never returns IPv4-mapped IPv6 addresses.
+        ///
+        /// # Typical errors
+        /// - `name-unresolvable`:          Name does not exist or has no suitable associated IP addresses. (EAI_NONAME, EAI_NODATA, EAI_ADDRFAMILY)
+        /// - `temporary-resolver-failure`: A temporary failure in name resolution occurred. (EAI_AGAIN)
+        /// - `permanent-resolver-failure`: A permanent failure in name resolution occurred. (EAI_FAIL)
+        /// - `would-block`:                A result is not available yet. (EWOULDBLOCK, EAGAIN)
+        resolve-next-address: func() -> result<option<ip-address>, error-code>;
 
-		/// Create a `pollable` which will resolve once the stream is ready for I/O.
-		///
-		/// Note: this function is here for WASI Preview2 only.
-		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable;
-	}
+        /// Create a `pollable` which will resolve once the stream is ready for I/O.
+        ///
+        /// Note: this function is here for WASI Preview2 only.
+        /// It's planned to be removed when `future` is natively supported in Preview3.
+        subscribe: func() -> pollable;
+    }
 }

--- a/crates/wasi/wit/deps/sockets/network.wit
+++ b/crates/wasi/wit/deps/sockets/network.wit
@@ -1,147 +1,147 @@
 
 interface network {
-	/// An opaque resource that represents access to (a subset of) the network.
-	/// This enables context-based security for networking.
-	/// There is no need for this to map 1:1 to a physical network interface.
-	resource network;
+    /// An opaque resource that represents access to (a subset of) the network.
+    /// This enables context-based security for networking.
+    /// There is no need for this to map 1:1 to a physical network interface.
+    resource network;
 
-	/// Error codes.
-	///
-	/// In theory, every API can return any error code.
-	/// In practice, API's typically only return the errors documented per API
-	/// combined with a couple of errors that are always possible:
-	/// - `unknown`
-	/// - `access-denied`
-	/// - `not-supported`
-	/// - `out-of-memory`
-	/// - `concurrency-conflict`
-	///
-	/// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
-	enum error-code {
-		// ### GENERAL ERRORS ###
+    /// Error codes.
+    ///
+    /// In theory, every API can return any error code.
+    /// In practice, API's typically only return the errors documented per API
+    /// combined with a couple of errors that are always possible:
+    /// - `unknown`
+    /// - `access-denied`
+    /// - `not-supported`
+    /// - `out-of-memory`
+    /// - `concurrency-conflict`
+    ///
+    /// See each individual API for what the POSIX equivalents are. They sometimes differ per API.
+    enum error-code {
+        // ### GENERAL ERRORS ###
 
-		/// Unknown error
-		unknown,
+        /// Unknown error
+        unknown,
 
-		/// Access denied.
-		///
-		/// POSIX equivalent: EACCES, EPERM
-		access-denied,
+        /// Access denied.
+        ///
+        /// POSIX equivalent: EACCES, EPERM
+        access-denied,
 
-		/// The operation is not supported.
-		///
-		/// POSIX equivalent: EOPNOTSUPP
-		not-supported,
+        /// The operation is not supported.
+        ///
+        /// POSIX equivalent: EOPNOTSUPP
+        not-supported,
 
-		/// One of the arguments is invalid.
-		/// 
-		/// POSIX equivalent: EINVAL
-		invalid-argument,
+        /// One of the arguments is invalid.
+        ///
+        /// POSIX equivalent: EINVAL
+        invalid-argument,
 
-		/// Not enough memory to complete the operation.
-		///
-		/// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
-		out-of-memory,
+        /// Not enough memory to complete the operation.
+        ///
+        /// POSIX equivalent: ENOMEM, ENOBUFS, EAI_MEMORY
+        out-of-memory,
 
-		/// The operation timed out before it could finish completely.
-		timeout,
+        /// The operation timed out before it could finish completely.
+        timeout,
 
-		/// This operation is incompatible with another asynchronous operation that is already in progress.
-		///
-		/// POSIX equivalent: EALREADY
-		concurrency-conflict,
+        /// This operation is incompatible with another asynchronous operation that is already in progress.
+        ///
+        /// POSIX equivalent: EALREADY
+        concurrency-conflict,
 
-		/// Trying to finish an asynchronous operation that:
-		/// - has not been started yet, or:
-		/// - was already finished by a previous `finish-*` call.
-		///
-		/// Note: this is scheduled to be removed when `future`s are natively supported.
-		not-in-progress,
+        /// Trying to finish an asynchronous operation that:
+        /// - has not been started yet, or:
+        /// - was already finished by a previous `finish-*` call.
+        ///
+        /// Note: this is scheduled to be removed when `future`s are natively supported.
+        not-in-progress,
 
-		/// The operation has been aborted because it could not be completed immediately.
-		///
-		/// Note: this is scheduled to be removed when `future`s are natively supported.
-		would-block,
-
-
-
-		// ### TCP & UDP SOCKET ERRORS ###
-
-		/// The operation is not valid in the socket's current state.
-		invalid-state,
-
-		/// A new socket resource could not be created because of a system limit.
-		new-socket-limit,
-
-		/// A bind operation failed because the provided address is not an address that the `network` can bind to.
-		address-not-bindable,
-
-		/// A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
-		address-in-use,
-
-		/// The remote address is not reachable
-		remote-unreachable,
+        /// The operation has been aborted because it could not be completed immediately.
+        ///
+        /// Note: this is scheduled to be removed when `future`s are natively supported.
+        would-block,
 
 
-		// ### TCP SOCKET ERRORS ###
 
-		/// The connection was forcefully rejected
-		connection-refused,
+        // ### TCP & UDP SOCKET ERRORS ###
 
-		/// The connection was reset.
-		connection-reset,
+        /// The operation is not valid in the socket's current state.
+        invalid-state,
 
-		/// A connection was aborted.
-		connection-aborted,
+        /// A new socket resource could not be created because of a system limit.
+        new-socket-limit,
+
+        /// A bind operation failed because the provided address is not an address that the `network` can bind to.
+        address-not-bindable,
+
+        /// A bind operation failed because the provided address is already in use or because there are no ephemeral ports available.
+        address-in-use,
+
+        /// The remote address is not reachable
+        remote-unreachable,
 
 
-		// ### UDP SOCKET ERRORS ###
-		datagram-too-large,
+        // ### TCP SOCKET ERRORS ###
+
+        /// The connection was forcefully rejected
+        connection-refused,
+
+        /// The connection was reset.
+        connection-reset,
+
+        /// A connection was aborted.
+        connection-aborted,
 
 
-		// ### NAME LOOKUP ERRORS ###
+        // ### UDP SOCKET ERRORS ###
+        datagram-too-large,
 
-		/// Name does not exist or has no suitable associated IP addresses.
-		name-unresolvable,
 
-		/// A temporary failure in name resolution occurred.
-		temporary-resolver-failure,
+        // ### NAME LOOKUP ERRORS ###
 
-		/// A permanent failure in name resolution occurred.
-		permanent-resolver-failure,
-	}
+        /// Name does not exist or has no suitable associated IP addresses.
+        name-unresolvable,
 
-	enum ip-address-family {
-		/// Similar to `AF_INET` in POSIX.
-		ipv4,
+        /// A temporary failure in name resolution occurred.
+        temporary-resolver-failure,
 
-		/// Similar to `AF_INET6` in POSIX.
-		ipv6,
-	}
+        /// A permanent failure in name resolution occurred.
+        permanent-resolver-failure,
+    }
 
-	type ipv4-address = tuple<u8, u8, u8, u8>;
-	type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
+    enum ip-address-family {
+        /// Similar to `AF_INET` in POSIX.
+        ipv4,
 
-	variant ip-address {
-		ipv4(ipv4-address),
-		ipv6(ipv6-address),
-	}
+        /// Similar to `AF_INET6` in POSIX.
+        ipv6,
+    }
 
-	record ipv4-socket-address {
-		port: u16, // sin_port
-		address: ipv4-address, // sin_addr
-	}
+    type ipv4-address = tuple<u8, u8, u8, u8>;
+    type ipv6-address = tuple<u16, u16, u16, u16, u16, u16, u16, u16>;
 
-	record ipv6-socket-address {
-		port: u16, // sin6_port
-		flow-info: u32, // sin6_flowinfo
-		address: ipv6-address, // sin6_addr
-		scope-id: u32, // sin6_scope_id
-	}
+    variant ip-address {
+        ipv4(ipv4-address),
+        ipv6(ipv6-address),
+    }
 
-	variant ip-socket-address {
-		ipv4(ipv4-socket-address),
-		ipv6(ipv6-socket-address),
-	}
+    record ipv4-socket-address {
+        port: u16, // sin_port
+        address: ipv4-address, // sin_addr
+    }
+
+    record ipv6-socket-address {
+        port: u16, // sin6_port
+        flow-info: u32, // sin6_flowinfo
+        address: ipv6-address, // sin6_addr
+        scope-id: u32, // sin6_scope_id
+    }
+
+    variant ip-socket-address {
+        ipv4(ipv4-socket-address),
+        ipv6(ipv6-socket-address),
+    }
 
 }

--- a/crates/wasi/wit/deps/sockets/tcp-create-socket.wit
+++ b/crates/wasi/wit/deps/sockets/tcp-create-socket.wit
@@ -1,26 +1,26 @@
 
 interface tcp-create-socket {
-	use network.{network, error-code, ip-address-family};
-	use tcp.{tcp-socket};
+    use network.{network, error-code, ip-address-family};
+    use tcp.{tcp-socket};
 
-	/// Create a new TCP socket.
-	///
-	/// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
-	///
-	/// This function does not require a network capability handle. This is considered to be safe because
-	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`listen`/`connect`
-	/// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
-	///
-	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
-	///
-	/// # Typical errors
-	/// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
-	/// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-	///
-	/// # References
-	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
-	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
-	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
-	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
+    /// Create a new TCP socket.
+    ///
+    /// Similar to `socket(AF_INET or AF_INET6, SOCK_STREAM, IPPROTO_TCP)` in POSIX.
+    ///
+    /// This function does not require a network capability handle. This is considered to be safe because
+    /// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`listen`/`connect`
+    /// is called, the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+    ///
+    /// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+    ///
+    /// # Typical errors
+    /// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+    /// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+    ///
+    /// # References
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+    /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+    create-tcp-socket: func(address-family: ip-address-family) -> result<tcp-socket, error-code>;
 }

--- a/crates/wasi/wit/deps/sockets/tcp.wit
+++ b/crates/wasi/wit/deps/sockets/tcp.wit
@@ -1,268 +1,268 @@
 
 interface tcp {
-	use wasi:io/streams@0.2.0-rc-2023-10-18.{input-stream, output-stream};
-	use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
-	use network.{network, error-code, ip-socket-address, ip-address-family};
+    use wasi:io/streams@0.2.0-rc-2023-10-18.{input-stream, output-stream};
+    use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
+    use network.{network, error-code, ip-socket-address, ip-address-family};
 
-	enum shutdown-type {
-		/// Similar to `SHUT_RD` in POSIX.
-		receive,
+    enum shutdown-type {
+        /// Similar to `SHUT_RD` in POSIX.
+        receive,
 
-		/// Similar to `SHUT_WR` in POSIX.
-		send,
+        /// Similar to `SHUT_WR` in POSIX.
+        send,
 
-		/// Similar to `SHUT_RDWR` in POSIX.
-		both,
-	}
+        /// Similar to `SHUT_RDWR` in POSIX.
+        both,
+    }
 
 
-	/// A TCP socket handle.
-	resource tcp-socket {
-		/// Bind the socket to a specific network on the provided IP address and port.
-		///
-		/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
-		/// network interface(s) to bind to.
-		/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
-		///
-		/// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
-		/// implicitly bind the socket.
-		///
-		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		///
-		/// # Typical `start` errors
-		/// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
-		/// - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
-		/// - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL)
-		/// - `invalid-state`:             The socket is already bound. (EINVAL)
-		///
-		/// # Typical `finish` errors
-		/// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
-		/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
-		/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
-		/// - `not-in-progress`:           A `bind` operation is not in progress.
-		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
-		/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
-		finish-bind: func() -> result<_, error-code>;
+    /// A TCP socket handle.
+    resource tcp-socket {
+        /// Bind the socket to a specific network on the provided IP address and port.
+        ///
+        /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+        /// network interface(s) to bind to.
+        /// If the TCP/UDP port is zero, the socket will be bound to a random free port.
+        ///
+        /// When a socket is not explicitly bound, the first invocation to a listen or connect operation will
+        /// implicitly bind the socket.
+        ///
+        /// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+        ///
+        /// # Typical `start` errors
+        /// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+        /// - `invalid-argument`:          `local-address` is not a unicast address. (EINVAL)
+        /// - `invalid-argument`:          `local-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL)
+        /// - `invalid-state`:             The socket is already bound. (EINVAL)
+        ///
+        /// # Typical `finish` errors
+        /// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+        /// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+        /// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+        /// - `not-in-progress`:           A `bind` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+        /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+        start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+        finish-bind: func() -> result<_, error-code>;
 
-		/// Connect to a remote endpoint.
-		///
-		/// On success:
-		/// - the socket is transitioned into the Connection state
-		/// - a pair of streams is returned that can be used to read & write to the connection
-		///
-		/// POSIX mentions:
-		/// > If connect() fails, the state of the socket is unspecified. Conforming applications should
-		/// > close the file descriptor and create a new socket before attempting to reconnect.
-		///
-		/// WASI prescribes the following behavior:
-		/// - If `connect` fails because an input/state validation error, the socket should remain usable.
-		/// - If a connection was actually attempted but failed, the socket should become unusable for further network communication.
-		///   Besides `drop`, any method after such a failure may return an error.
-		///
-		/// # Typical `start` errors
-		/// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
-		/// - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
-		/// - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL, EADDRNOTAVAIL on Illumos)
-		/// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
-		/// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
-		/// - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
-		/// - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
-		/// - `invalid-state`:             The socket is already in the Connection state. (EISCONN)
-		/// - `invalid-state`:             The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)
-		///
-		/// # Typical `finish` errors
-		/// - `timeout`:                   Connection timed out. (ETIMEDOUT)
-		/// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
-		/// - `connection-reset`:          The connection was reset. (ECONNRESET)
-		/// - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
-		/// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
-		/// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
-		/// - `not-in-progress`:           A `connect` operation is not in progress.
-		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
-		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
-		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
-		finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
+        /// Connect to a remote endpoint.
+        ///
+        /// On success:
+        /// - the socket is transitioned into the Connection state
+        /// - a pair of streams is returned that can be used to read & write to the connection
+        ///
+        /// POSIX mentions:
+        /// > If connect() fails, the state of the socket is unspecified. Conforming applications should
+        /// > close the file descriptor and create a new socket before attempting to reconnect.
+        ///
+        /// WASI prescribes the following behavior:
+        /// - If `connect` fails because an input/state validation error, the socket should remain usable.
+        /// - If a connection was actually attempted but failed, the socket should become unusable for further network communication.
+        ///   Besides `drop`, any method after such a failure may return an error.
+        ///
+        /// # Typical `start` errors
+        /// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+        /// - `invalid-argument`:          `remote-address` is not a unicast address. (EINVAL, ENETUNREACH on Linux, EAFNOSUPPORT on MacOS)
+        /// - `invalid-argument`:          `remote-address` is an IPv4-mapped IPv6 address, but the socket has `ipv6-only` enabled. (EINVAL, EADDRNOTAVAIL on Illumos)
+        /// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
+        /// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EADDRNOTAVAIL on Windows)
+        /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EADDRNOTAVAIL on Windows)
+        /// - `invalid-argument`:          The socket is already attached to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+        /// - `invalid-state`:             The socket is already in the Connection state. (EISCONN)
+        /// - `invalid-state`:             The socket is already in the Listener state. (EOPNOTSUPP, EINVAL on Windows)
+        ///
+        /// # Typical `finish` errors
+        /// - `timeout`:                   Connection timed out. (ETIMEDOUT)
+        /// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
+        /// - `connection-reset`:          The connection was reset. (ECONNRESET)
+        /// - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
+        /// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+        /// - `not-in-progress`:           A `connect` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+        /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+        /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+        start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+        finish-connect: func() -> result<tuple<input-stream, output-stream>, error-code>;
 
-		/// Start listening for new connections.
-		///
-		/// Transitions the socket into the Listener state.
-		///
-		/// Unlike POSIX:
-		/// - this function is async. This enables interactive WASI hosts to inject permission prompts.
-		/// - the socket must already be explicitly bound.
-		///
-		/// # Typical `start` errors
-		/// - `invalid-state`:             The socket is not bound to any local address. (EDESTADDRREQ)
-		/// - `invalid-state`:             The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
-		/// - `invalid-state`:             The socket is already in the Listener state.
-		///
-		/// # Typical `finish` errors
-		/// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
-		/// - `not-in-progress`:           A `listen` operation is not in progress.
-		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
-		/// - <https://man7.org/linux/man-pages/man2/listen.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
-		start-listen: func() -> result<_, error-code>;
-		finish-listen: func() -> result<_, error-code>;
+        /// Start listening for new connections.
+        ///
+        /// Transitions the socket into the Listener state.
+        ///
+        /// Unlike POSIX:
+        /// - this function is async. This enables interactive WASI hosts to inject permission prompts.
+        /// - the socket must already be explicitly bound.
+        ///
+        /// # Typical `start` errors
+        /// - `invalid-state`:             The socket is not bound to any local address. (EDESTADDRREQ)
+        /// - `invalid-state`:             The socket is already in the Connection state. (EISCONN, EINVAL on BSD)
+        /// - `invalid-state`:             The socket is already in the Listener state.
+        ///
+        /// # Typical `finish` errors
+        /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE)
+        /// - `not-in-progress`:           A `listen` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html>
+        /// - <https://man7.org/linux/man-pages/man2/listen.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=listen&sektion=2>
+        start-listen: func() -> result<_, error-code>;
+        finish-listen: func() -> result<_, error-code>;
 
-		/// Accept a new client socket.
-		///
-		/// The returned socket is bound and in the Connection state. The following properties are inherited from the listener socket:
-		/// - `address-family`
-		/// - `ipv6-only`
-		/// - `keep-alive`
-		/// - `no-delay`
-		/// - `unicast-hop-limit`
-		/// - `receive-buffer-size`
-		/// - `send-buffer-size`
-		///
-		/// On success, this function returns the newly accepted client socket along with
-		/// a pair of streams that can be used to read & write to the connection.
-		///
-		/// # Typical errors
-		/// - `invalid-state`:      Socket is not in the Listener state. (EINVAL)
-		/// - `would-block`:        No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
-		/// - `connection-aborted`: An incoming connection was pending, but was terminated by the client before this listener could accept it. (ECONNABORTED)
-		/// - `new-socket-limit`:   The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
-		/// - <https://man7.org/linux/man-pages/man2/accept.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
-		accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
+        /// Accept a new client socket.
+        ///
+        /// The returned socket is bound and in the Connection state. The following properties are inherited from the listener socket:
+        /// - `address-family`
+        /// - `ipv6-only`
+        /// - `keep-alive`
+        /// - `no-delay`
+        /// - `unicast-hop-limit`
+        /// - `receive-buffer-size`
+        /// - `send-buffer-size`
+        ///
+        /// On success, this function returns the newly accepted client socket along with
+        /// a pair of streams that can be used to read & write to the connection.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`:      Socket is not in the Listener state. (EINVAL)
+        /// - `would-block`:        No pending connections at the moment. (EWOULDBLOCK, EAGAIN)
+        /// - `connection-aborted`: An incoming connection was pending, but was terminated by the client before this listener could accept it. (ECONNABORTED)
+        /// - `new-socket-limit`:   The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html>
+        /// - <https://man7.org/linux/man-pages/man2/accept.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=accept&sektion=2>
+        accept: func() -> result<tuple<tcp-socket, input-stream, output-stream>, error-code>;
 
-		/// Get the bound local address.
-		///
-		/// POSIX mentions:
-		/// > If the socket has not been bound to a local name, the value
-		/// > stored in the object pointed to by `address` is unspecified.
-		///
-		/// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
-		///
-		/// # Typical errors
-		/// - `invalid-state`: The socket is not bound to any local address.
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
-		/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
-		/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-		local-address: func() -> result<ip-socket-address, error-code>;
+        /// Get the bound local address.
+        ///
+        /// POSIX mentions:
+        /// > If the socket has not been bound to a local name, the value
+        /// > stored in the object pointed to by `address` is unspecified.
+        ///
+        /// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not bound to any local address.
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+        /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+        /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+        local-address: func() -> result<ip-socket-address, error-code>;
 
-		/// Get the remote address.
-		///
-		/// # Typical errors
-		/// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
-		/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-		remote-address: func() -> result<ip-socket-address, error-code>;
+        /// Get the remote address.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+        /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+        remote-address: func() -> result<ip-socket-address, error-code>;
 
-		/// Whether this is a IPv4 or IPv6 socket.
-		///
-		/// Equivalent to the SO_DOMAIN socket option.
-		address-family: func() -> ip-address-family;
+        /// Whether this is a IPv4 or IPv6 socket.
+        ///
+        /// Equivalent to the SO_DOMAIN socket option.
+        address-family: func() -> ip-address-family;
 
-		/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-		///
-		/// Equivalent to the IPV6_V6ONLY socket option.
-		///
-		/// # Typical errors
-		/// - `invalid-state`:        (set) The socket is already bound.
-		/// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
-		/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
-		ipv6-only: func() -> result<bool, error-code>;
-		set-ipv6-only: func(value: bool) -> result<_, error-code>;
+        /// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
+        ///
+        /// Equivalent to the IPV6_V6ONLY socket option.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`:        (set) The socket is already bound.
+        /// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
+        /// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
+        ipv6-only: func() -> result<bool, error-code>;
+        set-ipv6-only: func(value: bool) -> result<_, error-code>;
 
-		/// Hints the desired listen queue size. Implementations are free to ignore this.
-		///
-		/// # Typical errors
-		/// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
-		/// - `invalid-state`:        (set) The socket is already in the Connection state.
-		set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
+        /// Hints the desired listen queue size. Implementations are free to ignore this.
+        ///
+        /// # Typical errors
+        /// - `not-supported`:        (set) The platform does not support changing the backlog size after the initial listen.
+        /// - `invalid-state`:        (set) The socket is already in the Connection state.
+        set-listen-backlog-size: func(value: u64) -> result<_, error-code>;
 
-		/// Equivalent to the SO_KEEPALIVE socket option.
-		keep-alive: func() -> result<bool, error-code>;
-		set-keep-alive: func(value: bool) -> result<_, error-code>;
+        /// Equivalent to the SO_KEEPALIVE socket option.
+        keep-alive: func() -> result<bool, error-code>;
+        set-keep-alive: func(value: bool) -> result<_, error-code>;
 
-		/// Equivalent to the TCP_NODELAY socket option.
-		///
-		/// The default value is `false`.
-		no-delay: func() -> result<bool, error-code>;
-		set-no-delay: func(value: bool) -> result<_, error-code>;
+        /// Equivalent to the TCP_NODELAY socket option.
+        ///
+        /// The default value is `false`.
+        no-delay: func() -> result<bool, error-code>;
+        set-no-delay: func(value: bool) -> result<_, error-code>;
 
-		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-		///
-		/// # Typical errors
-		/// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
-		/// - `invalid-state`:        (set) The socket is already in the Connection state.
-		/// - `invalid-state`:        (set) The socket is already in the Listener state.
-		unicast-hop-limit: func() -> result<u8, error-code>;
-		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
+        /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:     (set) The TTL value must be 1 or higher.
+        /// - `invalid-state`:        (set) The socket is already in the Connection state.
+        /// - `invalid-state`:        (set) The socket is already in the Listener state.
+        unicast-hop-limit: func() -> result<u8, error-code>;
+        set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
 
-		/// The kernel buffer space reserved for sends/receives on this socket.
-		///
-		/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
-		/// 	In other words, after setting a value, reading the same setting back may return a different value.
-		///
-		/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
-		/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
-		/// 	for internal metadata structures.
-		///
-		/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-		///
-		/// # Typical errors
-		/// - `invalid-state`:        (set) The socket is already in the Connection state.
-		/// - `invalid-state`:        (set) The socket is already in the Listener state.
-		receive-buffer-size: func() -> result<u64, error-code>;
-		set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
-		send-buffer-size: func() -> result<u64, error-code>;
-		set-send-buffer-size: func(value: u64) -> result<_, error-code>;
+        /// The kernel buffer space reserved for sends/receives on this socket.
+        ///
+        /// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
+        ///     In other words, after setting a value, reading the same setting back may return a different value.
+        ///
+        /// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
+        ///     actual data to be sent/received by the application, because the kernel might also use the buffer space
+        ///     for internal metadata structures.
+        ///
+        /// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`:        (set) The socket is already in the Connection state.
+        /// - `invalid-state`:        (set) The socket is already in the Listener state.
+        receive-buffer-size: func() -> result<u64, error-code>;
+        set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+        send-buffer-size: func() -> result<u64, error-code>;
+        set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
-		/// Create a `pollable` which will resolve once the socket is ready for I/O.
-		///
-		/// Note: this function is here for WASI Preview2 only.
-		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable;
+        /// Create a `pollable` which will resolve once the socket is ready for I/O.
+        ///
+        /// Note: this function is here for WASI Preview2 only.
+        /// It's planned to be removed when `future` is natively supported in Preview3.
+        subscribe: func() -> pollable;
 
-		/// Initiate a graceful shutdown.
-		///
-		/// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
-		///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.
-		///   Any data still in the receive queue at time of calling `shutdown` will be discarded.
-		/// - send: the socket is not expecting to send any more data to the peer. All subsequent write
-		///   operations on the `output-stream` associated with this socket will return an error.
-		/// - both: same effect as receive & send combined.
-		///
-		/// The shutdown function does not close (drop) the socket.
-		///
-		/// # Typical errors
-		/// - `invalid-state`: The socket is not in the Connection state. (ENOTCONN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
-		/// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
-		shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
-	}
+        /// Initiate a graceful shutdown.
+        ///
+        /// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
+        ///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.
+        ///   Any data still in the receive queue at time of calling `shutdown` will be discarded.
+        /// - send: the socket is not expecting to send any more data to the peer. All subsequent write
+        ///   operations on the `output-stream` associated with this socket will return an error.
+        /// - both: same effect as receive & send combined.
+        ///
+        /// The shutdown function does not close (drop) the socket.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not in the Connection state. (ENOTCONN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html>
+        /// - <https://man7.org/linux/man-pages/man2/shutdown.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-shutdown>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=shutdown&sektion=2>
+        shutdown: func(shutdown-type: shutdown-type) -> result<_, error-code>;
+    }
 }

--- a/crates/wasi/wit/deps/sockets/udp-create-socket.wit
+++ b/crates/wasi/wit/deps/sockets/udp-create-socket.wit
@@ -1,26 +1,26 @@
 
 interface udp-create-socket {
-	use network.{network, error-code, ip-address-family};
-	use udp.{udp-socket};
+    use network.{network, error-code, ip-address-family};
+    use udp.{udp-socket};
 
-	/// Create a new UDP socket.
-	///
-	/// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)` in POSIX.
-	///
-	/// This function does not require a network capability handle. This is considered to be safe because
-	/// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect` is called,
-	/// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
-	///
-	/// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
-	///
-	/// # Typical errors
-	/// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
-	/// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
-	///
-	/// # References:
-	/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
-	/// - <https://man7.org/linux/man-pages/man2/socket.2.html>
-	/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
-	/// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
-	create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
+    /// Create a new UDP socket.
+    ///
+    /// Similar to `socket(AF_INET or AF_INET6, SOCK_DGRAM, IPPROTO_UDP)` in POSIX.
+    ///
+    /// This function does not require a network capability handle. This is considered to be safe because
+    /// at time of creation, the socket is not bound to any `network` yet. Up to the moment `bind`/`connect` is called,
+    /// the socket is effectively an in-memory configuration object, unable to communicate with the outside world.
+    ///
+    /// All sockets are non-blocking. Use the wasi-poll interface to block on asynchronous operations.
+    ///
+    /// # Typical errors
+    /// - `not-supported`:     The specified `address-family` is not supported. (EAFNOSUPPORT)
+    /// - `new-socket-limit`:  The new socket resource could not be created because of a system limit. (EMFILE, ENFILE)
+    ///
+    /// # References:
+    /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html>
+    /// - <https://man7.org/linux/man-pages/man2/socket.2.html>
+    /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasocketw>
+    /// - <https://man.freebsd.org/cgi/man.cgi?query=socket&sektion=2>
+    create-udp-socket: func(address-family: ip-address-family) -> result<udp-socket, error-code>;
 }

--- a/crates/wasi/wit/deps/sockets/udp.wit
+++ b/crates/wasi/wit/deps/sockets/udp.wit
@@ -1,213 +1,213 @@
 
 interface udp {
-	use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
-	use network.{network, error-code, ip-socket-address, ip-address-family};
+    use wasi:io/poll@0.2.0-rc-2023-10-18.{pollable};
+    use network.{network, error-code, ip-socket-address, ip-address-family};
 
 
-	record datagram {
-		data: list<u8>, // Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
-		remote-address: ip-socket-address,
+    record datagram {
+        data: list<u8>, // Theoretical max size: ~64 KiB. In practice, typically less than 1500 bytes.
+        remote-address: ip-socket-address,
 
-		/// Possible future additions:
-		/// local-address: ip-socket-address, // IP_PKTINFO / IP_RECVDSTADDR / IPV6_PKTINFO
-		/// local-interface: u32, // IP_PKTINFO / IP_RECVIF
-		/// ttl: u8, // IP_RECVTTL
-		/// dscp: u6, // IP_RECVTOS
-		/// ecn: u2, // IP_RECVTOS
-	}
+        /// Possible future additions:
+        /// local-address: ip-socket-address, // IP_PKTINFO / IP_RECVDSTADDR / IPV6_PKTINFO
+        /// local-interface: u32, // IP_PKTINFO / IP_RECVIF
+        /// ttl: u8, // IP_RECVTTL
+        /// dscp: u6, // IP_RECVTOS
+        /// ecn: u2, // IP_RECVTOS
+    }
 
 
 
-	/// A UDP socket handle.
-	resource udp-socket {
-		/// Bind the socket to a specific network on the provided IP address and port.
-		///
-		/// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
-		/// network interface(s) to bind to.
-		/// If the TCP/UDP port is zero, the socket will be bound to a random free port.
-		///
-		/// When a socket is not explicitly bound, the first invocation to connect will implicitly bind the socket.
-		///
-		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		///
-		/// # Typical `start` errors
-		/// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
-		/// - `invalid-state`:             The socket is already bound. (EINVAL)
-		///
-		/// # Typical `finish` errors
-		/// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
-		/// - `address-in-use`:            Address is already in use. (EADDRINUSE)
-		/// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
-		/// - `not-in-progress`:           A `bind` operation is not in progress.
-		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
-		/// - <https://man7.org/linux/man-pages/man2/bind.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
-		start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
-		finish-bind: func() -> result<_, error-code>;
+    /// A UDP socket handle.
+    resource udp-socket {
+        /// Bind the socket to a specific network on the provided IP address and port.
+        ///
+        /// If the IP address is zero (`0.0.0.0` in IPv4, `::` in IPv6), it is left to the implementation to decide which
+        /// network interface(s) to bind to.
+        /// If the TCP/UDP port is zero, the socket will be bound to a random free port.
+        ///
+        /// When a socket is not explicitly bound, the first invocation to connect will implicitly bind the socket.
+        ///
+        /// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+        ///
+        /// # Typical `start` errors
+        /// - `invalid-argument`:          The `local-address` has the wrong address family. (EAFNOSUPPORT, EFAULT on Windows)
+        /// - `invalid-state`:             The socket is already bound. (EINVAL)
+        ///
+        /// # Typical `finish` errors
+        /// - `address-in-use`:            No ephemeral ports available. (EADDRINUSE, ENOBUFS on Windows)
+        /// - `address-in-use`:            Address is already in use. (EADDRINUSE)
+        /// - `address-not-bindable`:      `local-address` is not an address that the `network` can bind to. (EADDRNOTAVAIL)
+        /// - `not-in-progress`:           A `bind` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html>
+        /// - <https://man7.org/linux/man-pages/man2/bind.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-bind>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=bind&sektion=2&format=html>
+        start-bind: func(network: borrow<network>, local-address: ip-socket-address) -> result<_, error-code>;
+        finish-bind: func() -> result<_, error-code>;
 
-		/// Set the destination address.
-		///
-		/// The local-address is updated based on the best network path to `remote-address`.
-		///
-		/// When a destination address is set:
-		/// - all receive operations will only return datagrams sent from the provided `remote-address`.
-		/// - the `send` function can only be used to send to this destination.
-		///
-		/// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
-		///
-		/// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
-		///
-		/// # Typical `start` errors
-		/// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
-		/// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
-		/// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
-		/// - `invalid-argument`:          The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
-		/// - `invalid-argument`:          The socket is already bound to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
-		///
-		/// # Typical `finish` errors
-		/// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
-		/// - `not-in-progress`:           A `connect` operation is not in progress.
-		/// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
-		/// - <https://man7.org/linux/man-pages/man2/connect.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
-		/// - <https://man.freebsd.org/cgi/man.cgi?connect>
-		start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
-		finish-connect: func() -> result<_, error-code>;
+        /// Set the destination address.
+        ///
+        /// The local-address is updated based on the best network path to `remote-address`.
+        ///
+        /// When a destination address is set:
+        /// - all receive operations will only return datagrams sent from the provided `remote-address`.
+        /// - the `send` function can only be used to send to this destination.
+        ///
+        /// Note that this function does not generate any network traffic and the peer is not aware of this "connection".
+        ///
+        /// Unlike in POSIX, this function is async. This enables interactive WASI hosts to inject permission prompts.
+        ///
+        /// # Typical `start` errors
+        /// - `invalid-argument`:          The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+        /// - `invalid-argument`:          `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
+        /// - `invalid-argument`:          The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-argument`:          The socket is already bound to a different network. The `network` passed to `connect` must be identical to the one passed to `bind`.
+        ///
+        /// # Typical `finish` errors
+        /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
+        /// - `not-in-progress`:           A `connect` operation is not in progress.
+        /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
+        /// - <https://man7.org/linux/man-pages/man2/connect.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-connect>
+        /// - <https://man.freebsd.org/cgi/man.cgi?connect>
+        start-connect: func(network: borrow<network>, remote-address: ip-socket-address) -> result<_, error-code>;
+        finish-connect: func() -> result<_, error-code>;
 
-		/// Receive messages on the socket.
-		///
-		/// This function attempts to receive up to `max-results` datagrams on the socket without blocking.
-		/// The returned list may contain fewer elements than requested, but never more.
-		/// If `max-results` is 0, this function returns successfully with an empty list.
-		///
-		/// # Typical errors
-		/// - `invalid-state`:      The socket is not bound to any local address. (EINVAL)
-		/// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
-		/// - `would-block`:        There is no pending data available to be read at the moment. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
-		/// - <https://man7.org/linux/man-pages/man2/recv.2.html>
-		/// - <https://man7.org/linux/man-pages/man2/recvmmsg.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
-		/// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
-		receive: func(max-results: u64) -> result<list<datagram>, error-code>;
+        /// Receive messages on the socket.
+        ///
+        /// This function attempts to receive up to `max-results` datagrams on the socket without blocking.
+        /// The returned list may contain fewer elements than requested, but never more.
+        /// If `max-results` is 0, this function returns successfully with an empty list.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`:      The socket is not bound to any local address. (EINVAL)
+        /// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `would-block`:        There is no pending data available to be read at the moment. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html>
+        /// - <https://man7.org/linux/man-pages/man2/recv.2.html>
+        /// - <https://man7.org/linux/man-pages/man2/recvmmsg.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recv>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-recvfrom>
+        /// - <https://learn.microsoft.com/en-us/previous-versions/windows/desktop/legacy/ms741687(v=vs.85)>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=recv&sektion=2>
+        receive: func(max-results: u64) -> result<list<datagram>, error-code>;
 
-		/// Send messages on the socket.
-		///
-		/// This function attempts to send all provided `datagrams` on the socket without blocking and
-		/// returns how many messages were actually sent (or queued for sending).
-		///
-		/// This function semantically behaves the same as iterating the `datagrams` list and sequentially
-		/// sending each individual datagram until either the end of the list has been reached or the first error occurred.
-		/// If at least one datagram has been sent successfully, this function never returns an error.
-		///
-		/// If the input list is empty, the function returns `ok(0)`.
-		///
-		/// The remote address option is required. To send a message to the "connected" peer,
-		/// call `remote-address` to get their address.
-		///
-		/// # Typical errors
-		/// - `invalid-argument`:        The `remote-address` has the wrong address family. (EAFNOSUPPORT)
-		/// - `invalid-argument`:        `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
-		/// - `invalid-argument`:        The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
-		/// - `invalid-argument`:        The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
-		/// - `invalid-argument`:        The socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`. (EISCONN)
-		/// - `invalid-state`:           The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.
-		/// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
-		/// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
-		/// - `would-block`:             The send buffer is currently full. (EWOULDBLOCK, EAGAIN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
-		/// - <https://man7.org/linux/man-pages/man2/send.2.html>
-		/// - <https://man7.org/linux/man-pages/man2/sendmmsg.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
-		send: func(datagrams: list<datagram>) -> result<u64, error-code>;
+        /// Send messages on the socket.
+        ///
+        /// This function attempts to send all provided `datagrams` on the socket without blocking and
+        /// returns how many messages were actually sent (or queued for sending).
+        ///
+        /// This function semantically behaves the same as iterating the `datagrams` list and sequentially
+        /// sending each individual datagram until either the end of the list has been reached or the first error occurred.
+        /// If at least one datagram has been sent successfully, this function never returns an error.
+        ///
+        /// If the input list is empty, the function returns `ok(0)`.
+        ///
+        /// The remote address option is required. To send a message to the "connected" peer,
+        /// call `remote-address` to get their address.
+        ///
+        /// # Typical errors
+        /// - `invalid-argument`:        The `remote-address` has the wrong address family. (EAFNOSUPPORT)
+        /// - `invalid-argument`:        `remote-address` is a non-IPv4-mapped IPv6 address, but the socket was bound to a specific IPv4-mapped IPv6 address. (or vice versa)
+        /// - `invalid-argument`:        The IP address in `remote-address` is set to INADDR_ANY (`0.0.0.0` / `::`). (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-argument`:        The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
+        /// - `invalid-argument`:        The socket is in "connected" mode and the `datagram.remote-address` does not match the address passed to `connect`. (EISCONN)
+        /// - `invalid-state`:           The socket is not bound to any local address. Unlike POSIX, this function does not perform an implicit bind.
+        /// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
+        /// - `would-block`:             The send buffer is currently full. (EWOULDBLOCK, EAGAIN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html>
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html>
+        /// - <https://man7.org/linux/man-pages/man2/send.2.html>
+        /// - <https://man7.org/linux/man-pages/man2/sendmmsg.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-send>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-sendto>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsasendmsg>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=send&sektion=2>
+        send: func(datagrams: list<datagram>) -> result<u64, error-code>;
 
-		/// Get the current bound address.
-		///
-		/// POSIX mentions:
-		/// > If the socket has not been bound to a local name, the value
-		/// > stored in the object pointed to by `address` is unspecified.
-		///
-		/// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
-		///
-		/// # Typical errors
-		/// - `invalid-state`: The socket is not bound to any local address.
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
-		/// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
-		/// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
-		local-address: func() -> result<ip-socket-address, error-code>;
+        /// Get the current bound address.
+        ///
+        /// POSIX mentions:
+        /// > If the socket has not been bound to a local name, the value
+        /// > stored in the object pointed to by `address` is unspecified.
+        ///
+        /// WASI is stricter and requires `local-address` to return `invalid-state` when the socket hasn't been bound yet.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not bound to any local address.
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html>
+        /// - <https://man7.org/linux/man-pages/man2/getsockname.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getsockname>
+        /// - <https://man.freebsd.org/cgi/man.cgi?getsockname>
+        local-address: func() -> result<ip-socket-address, error-code>;
 
-		/// Get the address set with `connect`.
-		///
-		/// # Typical errors
-		/// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
-		///
-		/// # References
-		/// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
-		/// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
-		/// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
-		/// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
-		remote-address: func() -> result<ip-socket-address, error-code>;
+        /// Get the address set with `connect`.
+        ///
+        /// # Typical errors
+        /// - `invalid-state`: The socket is not connected to a remote address. (ENOTCONN)
+        ///
+        /// # References
+        /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html>
+        /// - <https://man7.org/linux/man-pages/man2/getpeername.2.html>
+        /// - <https://learn.microsoft.com/en-us/windows/win32/api/winsock/nf-winsock-getpeername>
+        /// - <https://man.freebsd.org/cgi/man.cgi?query=getpeername&sektion=2&n=1>
+        remote-address: func() -> result<ip-socket-address, error-code>;
 
-		/// Whether this is a IPv4 or IPv6 socket.
-		///
-		/// Equivalent to the SO_DOMAIN socket option.
-		address-family: func() -> ip-address-family;
+        /// Whether this is a IPv4 or IPv6 socket.
+        ///
+        /// Equivalent to the SO_DOMAIN socket option.
+        address-family: func() -> ip-address-family;
 
-		/// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
-		///
-		/// Equivalent to the IPV6_V6ONLY socket option.
-		///
-		/// # Typical errors
-		/// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
-		/// - `invalid-state`:        (set) The socket is already bound.
-		/// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
-		ipv6-only: func() -> result<bool, error-code>;
-		set-ipv6-only: func(value: bool) -> result<_, error-code>;
+        /// Whether IPv4 compatibility (dual-stack) mode is disabled or not.
+        ///
+        /// Equivalent to the IPV6_V6ONLY socket option.
+        ///
+        /// # Typical errors
+        /// - `not-supported`:        (get/set) `this` socket is an IPv4 socket.
+        /// - `invalid-state`:        (set) The socket is already bound.
+        /// - `not-supported`:        (set) Host does not support dual-stack sockets. (Implementations are not required to.)
+        ipv6-only: func() -> result<bool, error-code>;
+        set-ipv6-only: func(value: bool) -> result<_, error-code>;
 
-		/// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
-		unicast-hop-limit: func() -> result<u8, error-code>;
-		set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
+        /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
+        unicast-hop-limit: func() -> result<u8, error-code>;
+        set-unicast-hop-limit: func(value: u8) -> result<_, error-code>;
 
-		/// The kernel buffer space reserved for sends/receives on this socket.
-		///
-		/// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
-		/// 	In other words, after setting a value, reading the same setting back may return a different value.
-		///
-		/// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
-		/// 	actual data to be sent/received by the application, because the kernel might also use the buffer space
-		/// 	for internal metadata structures.
-		///
-		/// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
-		receive-buffer-size: func() -> result<u64, error-code>;
-		set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
-		send-buffer-size: func() -> result<u64, error-code>;
-		set-send-buffer-size: func(value: u64) -> result<_, error-code>;
+        /// The kernel buffer space reserved for sends/receives on this socket.
+        ///
+        /// Note #1: an implementation may choose to cap or round the buffer size when setting the value.
+        ///     In other words, after setting a value, reading the same setting back may return a different value.
+        ///
+        /// Note #2: there is not necessarily a direct relationship between the kernel buffer size and the bytes of
+        ///     actual data to be sent/received by the application, because the kernel might also use the buffer space
+        ///     for internal metadata structures.
+        ///
+        /// Equivalent to the SO_RCVBUF and SO_SNDBUF socket options.
+        receive-buffer-size: func() -> result<u64, error-code>;
+        set-receive-buffer-size: func(value: u64) -> result<_, error-code>;
+        send-buffer-size: func() -> result<u64, error-code>;
+        set-send-buffer-size: func(value: u64) -> result<_, error-code>;
 
-		/// Create a `pollable` which will resolve once the socket is ready for I/O.
-		///
-		/// Note: this function is here for WASI Preview2 only.
-		/// It's planned to be removed when `future` is natively supported in Preview3.
-		subscribe: func() -> pollable;
-	}
+        /// Create a `pollable` which will resolve once the socket is ready for I/O.
+        ///
+        /// Note: this function is here for WASI Preview2 only.
+        /// It's planned to be removed when `future` is natively supported in Preview3.
+        subscribe: func() -> pollable;
+    }
 }


### PR DESCRIPTION
While valid in WIT I keep finding it jarring to have different indentation in `wasi:sockets`. Additionally all other WASI WITs are using four spaces or two, so make it a bit more consistent.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
