### PR TITLE
Swap the order of directories in `--dir`

### DIFF
--- a/ci/run-wasi-nn-example.sh
+++ b/ci/run-wasi-nn-example.sh
@@ -39,7 +39,7 @@ pushd $WASMTIME_DIR/crates/wasi-nn/examples/classification-example
 cargo build --release --target=wasm32-wasi
 cp target/wasm32-wasi/release/wasi-nn-example.wasm $TMP_DIR
 popd
-cargo run -- run --dir fixture::$TMP_DIR -S nn $TMP_DIR/wasi-nn-example.wasm
+cargo run -- run --dir $TMP_DIR::fixture -S nn $TMP_DIR/wasi-nn-example.wasm
 
 # Build and run another example, this time using Wasmtime's graph flag to
 # preload the model.
@@ -47,7 +47,7 @@ pushd $WASMTIME_DIR/crates/wasi-nn/examples/classification-example-named
 cargo build --release --target=wasm32-wasi
 cp target/wasm32-wasi/release/wasi-nn-example-named.wasm $TMP_DIR
 popd
-cargo run -- run --dir fixture::$TMP_DIR -S nn,nn-graph=openvino::$TMP_DIR \
+cargo run -- run --dir $TMP_DIR::fixture -S nn,nn-graph=openvino::$TMP_DIR \
     $TMP_DIR/wasi-nn-example-named.wasm
 
 # Clean up the temporary directory only if it was not specified (users may want

--- a/docs/WASI-tutorial.md
+++ b/docs/WASI-tutorial.md
@@ -240,7 +240,7 @@ links as well.
 `wasmtime` also has the ability to remap directories:
 
 ```
-$ wasmtime --dir=. --dir=/tmp::/var/tmp demo.wasm test.txt /tmp/somewhere.txt
+$ wasmtime --dir=. --dir=/var/tmp::/tmp demo.wasm test.txt /tmp/somewhere.txt
 $ cat /var/tmp/somewhere.txt
 hello world
 ```

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -37,12 +37,12 @@ fn parse_env_var(s: &str) -> Result<(String, Option<String>)> {
 
 fn parse_dirs(s: &str) -> Result<(String, String)> {
     let mut parts = s.split("::");
-    let guest = parts.next().unwrap();
-    let host = match parts.next() {
-        Some(host) => host,
-        None => guest,
+    let host = parts.next().unwrap();
+    let guest = match parts.next() {
+        Some(guest) => guest,
+        None => host,
     };
-    Ok((guest.into(), host.into()))
+    Ok((host.into(), guest.into()))
 }
 
 fn parse_preloads(s: &str) -> Result<(String, PathBuf)> {
@@ -62,11 +62,11 @@ pub struct RunCommand {
 
     /// Grant access of a host directory to a guest.
     ///
-    /// If specified as just `GUEST_DIR` then the same directory name on the
-    /// host is made available within the guest. If specified as `GUEST::HOST`
+    /// If specified as just `HOST_DIR` then the same directory name on the
+    /// host is made available within the guest. If specified as `HOST::GUEST`
     /// then the `HOST` directory is opened and made available as the name
     /// `GUEST` in the guest.
-    #[clap(long = "dir", value_name = "GUEST_DIR[::HOST_DIR]", value_parser = parse_dirs)]
+    #[clap(long = "dir", value_name = "HOST_DIR[::GUEST_DIR]", value_parser = parse_dirs)]
     dirs: Vec<(String, String)>,
 
     /// Pass an environment variable to the program.
@@ -233,7 +233,7 @@ impl RunCommand {
     fn compute_preopen_dirs(&self) -> Result<Vec<(String, Dir)>> {
         let mut preopen_dirs = Vec::new();
 
-        for (guest, host) in self.dirs.iter() {
+        for (host, guest) in self.dirs.iter() {
             preopen_dirs.push((
                 guest.clone(),
                 Dir::open_ambient_dir(host, ambient_authority())

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1116,7 +1116,7 @@ mod test_programs {
         run_wasmtime(&[
             "run",
             "-Wcomponent-model",
-            &format!("--dir=/::{}", dir.path().to_str().unwrap()),
+            &format!("--dir={}::/", dir.path().to_str().unwrap()),
             CLI_FILE_READ_COMPONENT,
         ])?;
         Ok(())
@@ -1132,7 +1132,7 @@ mod test_programs {
         run_wasmtime(&[
             "run",
             "-Wcomponent-model",
-            &format!("--dir=/::{}", dir.path().to_str().unwrap()),
+            &format!("--dir={}::/", dir.path().to_str().unwrap()),
             CLI_FILE_APPEND_COMPONENT,
         ])?;
 
@@ -1157,7 +1157,7 @@ mod test_programs {
         run_wasmtime(&[
             "run",
             "-Wcomponent-model",
-            &format!("--dir=/::{}", dir.path().to_str().unwrap()),
+            &format!("--dir={}::/", dir.path().to_str().unwrap()),
             CLI_FILE_DIR_SYNC_COMPONENT,
         ])?;
 
@@ -1211,7 +1211,7 @@ mod test_programs {
         run_wasmtime(&[
             "run",
             "-Wcomponent-model",
-            &format!("--dir=/::{}", dir.path().to_str().unwrap()),
+            &format!("--dir={}::/", dir.path().to_str().unwrap()),
             CLI_DIRECTORY_LIST_COMPONENT,
         ])?;
         Ok(())

--- a/tests/all/wasi_testsuite.rs
+++ b/tests/all/wasi_testsuite.rs
@@ -110,7 +110,7 @@ fn build_command<P: AsRef<Path>>(module: P, extra_flags: &[&str], spec: &Spec) -
     if let Some(dirs) = &spec.dirs {
         for dir in dirs {
             cmd.arg("--dir");
-            cmd.arg(format!("{}::{}", dir, parent_dir.join(dir).display()));
+            cmd.arg(format!("{}::{}", parent_dir.join(dir).display(), dir));
         }
     }
     // Add environment variables as CLI arguments.


### PR DESCRIPTION
This commit changes the `--dir` argument on the `wasmtime` CLI to be `HOST::GUEST` rather than `GUEST::HOST`. This matches Docker for example and is a little more consistent with only `--dir path` where the first argument is always treated as a host directory.

In terms of breaking-ness the movement from `--mapdir` to `--dir` hasn't been released with Wasmtime 14 yet so my hope is that this can land on both `main` and Wasmtime 14.0.0 before it's released to avoid any breakage other than existing scripts migrating from `--mapdir` to `--dir`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
