### PR TITLE
Update release date of Wasmtime 14.0.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,7 +12,7 @@ Unreleased.
 
 ## 14.0.0
 
-Unreleased.
+Released 2023-10-20
 
 One of the larger changes in this release is a redesign of Wasmtime's CLI
 arguments and where arguments are passed. This means that previous invocations


### PR DESCRIPTION
This is an [automated pull request][process] from CI which is updating
the release date of Wasmtime 14.0.0 to today. This PR's base branch
is `main` and a second PR will be coming to perform the actual
release which will be targeted at `release-14.0.0`.

[process]: https://docs.wasmtime.dev/contributing-release-process.html
