### PR TITLE
Restore the `rlib` crate-type to the C API

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -11,7 +11,7 @@ publish = false
 
 [lib]
 name = "wasmtime"
-crate-type = ["staticlib", "cdylib"]
+crate-type = ["staticlib", "cdylib", "rlib"]
 doc = false
 test = false
 doctest = false


### PR DESCRIPTION
This was mistakenly removed during #7300 with some local testing I was doing. This will eventually be required to get a minimal build of the C API but for now I didn't intend on deleting this so I wanted to rectify my mistake.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
