### PR TITLE
Gate some `clap` features behind the `default` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ wasmtime-wasi-nn = { workspace = true, optional = true }
 wasmtime-wasi-threads = { workspace = true, optional = true }
 wasmtime-wasi-http = { workspace = true, optional = true }
 wasmtime-runtime = { workspace = true }
-clap = { workspace = true, features = ["color", "suggestions", "derive"] }
+clap = { workspace = true }
 anyhow = { workspace = true }
 target-lexicon = { workspace = true }
 once_cell = { workspace = true }
@@ -228,7 +228,7 @@ anyhow = "1.0.22"
 windows-sys = "0.48.0"
 env_logger = "0.10"
 log = { version = "0.4.8", default-features = false }
-clap = { version = "4.3.12", features = ["color", "suggestions", "derive"] }
+clap = { version = "4.3.12", default-features = false, features = ["std", "derive"] }
 hashbrown = { version = "0.14", default-features = false }
 capstone = "0.9.0"
 once_cell = "1.12.0"
@@ -303,6 +303,11 @@ default = [
   "coredump",
   "addr2line",
   "debug-builtins",
+
+  # Enable some nice features of clap by default, but they come at a binary size
+  # cost, so allow disabling this through disabling of our own `default`
+  # feature.
+  "clap/default",
 ]
 
 # ========================================

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -44,7 +44,7 @@ indicatif = "0.13.0"
 thiserror = { workspace = true }
 walkdir = { workspace = true }
 anyhow = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ['default'] }
 similar = { workspace = true }
 toml = { workspace = true }
 serde = { workspace = true }

--- a/cranelift/isle/islec/Cargo.toml
+++ b/cranelift/isle/islec/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 [dependencies]
 cranelift-isle = { version = "*", path = "../isle/", features = ["fancy-errors", "logging"] }
 env_logger = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ['default'] }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -28,7 +28,7 @@ wasmprinter = { workspace = true, optional = true }
 wasmtime-component-util = { workspace = true, optional = true }
 
 [dev-dependencies]
-clap = { workspace = true }
+clap = { workspace = true, features = ['default'] }
 env_logger = { workspace = true }
 wat = { workspace = true }
 

--- a/winch/Cargo.toml
+++ b/winch/Cargo.toml
@@ -19,7 +19,7 @@ wasmtime-environ = { workspace = true }
 target-lexicon = { workspace = true }
 anyhow = { workspace = true }
 wasmparser = { workspace = true }
-clap = { workspace = true }
+clap = { workspace = true, features = ['default'] }
 wat = { workspace = true }
 cranelift-codegen = { workspace = true }
 capstone = { workspace = true }


### PR DESCRIPTION
While not a large amount of binary size if the purpose of the `--no-default-features` build is to showcase "minimal Wasmtime" then may as well try to make `clap` as small as possible.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
