### PR TITLE
cranelift: Add some libcalls to `test interpret`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "similar",
+ "smallvec",
  "target-lexicon",
  "thiserror",
  "toml",

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -26,7 +26,7 @@ num_cpus = "1.8.0"
 target-lexicon = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
-similar ={ workspace = true }
+similar = { workspace = true }
 wat.workspace = true
 toml = { workspace = true }
 serde = { workspace = true }
@@ -34,3 +34,4 @@ serde_derive = { workspace = true }
 cranelift-wasm.workspace = true
 wasmparser.workspace = true
 cranelift.workspace = true
+smallvec = { workspace = true }

--- a/cranelift/filetests/filetests/runtests/call_libcall.clif
+++ b/cranelift/filetests/filetests/runtests/call_libcall.clif
@@ -1,6 +1,9 @@
+test interpret
 test run
 target x86_64
-; AArch64 Does not have these libcalls
+target aarch64
+target aarch64 sign_return_address
+target aarch64 has_pauth sign_return_address
 target s390x
 target riscv64
 target riscv64 has_c has_zcb


### PR DESCRIPTION
👋 Hey,

This is a follow up to one of @alexcrichton 's [comments](https://github.com/bytecodealliance/wasmtime/pull/7203#issuecomment-1758980302) in #7203, where he found some fuzzing issues with RISC-V. I'm still investigating those, but this solves one of them.

Fuzzgen can currently [generate a number of libcalls](https://github.com/bytecodealliance/wasmtime/blob/ed68661976554b8ea967d7d3ca2f2e0741323aad/fuzz/fuzz_targets/cranelift-fuzzgen.rs#L283-L291), these also need to be given a [handler when building the interpreter](https://github.com/bytecodealliance/wasmtime/blob/ed68661976554b8ea967d7d3ca2f2e0741323aad/fuzz/fuzz_targets/cranelift-fuzzgen.rs#L301-L312). We currently have that in the fuzzgen interpreter, but don't have an equivalent in `test interpret`, so when copying a failing clif case from fuzzgen it's possible to get a second error if the testcase references some libcall.

I've been currently just stripping out libcalls from failing clif cases, but probably should have addressed this a while ago.

This adds the same libcalls that we have in the fuzzer, it might be worth having a default interpreter implementation in `cranelift-interpreter` that adds these, not entirely sure.