### PR TITLE
Release Wasmtime 14.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-array-literals"
-version = "14.0.0"
+version = "14.0.1"
 
 [[package]]
 name = "byteorder"
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -574,14 +574,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -609,25 +609,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.101.0"
+version = "0.101.1"
 
 [[package]]
 name = "cranelift-control"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.0",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.101.0"
+version = "0.101.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "verify-component-adapter"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -2993,7 +2993,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.3.3",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "byte-array-literals",
  "object",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3309,14 +3309,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3461,11 +3461,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "14.0.0"
+version = "14.0.1"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "object",
  "once_cell",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "openvino",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "heck",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "14.0.0"
+version = "14.0.1"
 
 [[package]]
 name = "wast"
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "anyhow",
  "heck",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "14.0.0"
+version = "14.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3979,7 +3979,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "14.0.0"
+version = "14.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -136,58 +136,58 @@ edition = "2021"
 rust-version = "1.70.0"
 
 [workspace.dependencies]
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=14.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "14.0.0", default-features = false }
-wasmtime-cache = { path = "crates/cache", version = "=14.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=14.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=14.0.0" }
-wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=14.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=14.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=14.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=14.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=14.0.0" }
-wasmtime-types = { path = "crates/types", version = "14.0.0" }
-wasmtime-jit = { path = "crates/jit", version = "=14.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=14.0.0" }
-wasmtime-runtime = { path = "crates/runtime", version = "=14.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=14.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "14.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=14.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "14.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "14.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=14.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=14.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=14.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=14.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=14.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "14.0.1", default-features = false }
+wasmtime-cache = { path = "crates/cache", version = "=14.0.1" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=14.0.1" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=14.0.1" }
+wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=14.0.1" }
+wasmtime-winch = { path = "crates/winch", version = "=14.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=14.0.1" }
+wasmtime-explorer = { path = "crates/explorer", version = "=14.0.1" }
+wasmtime-fiber = { path = "crates/fiber", version = "=14.0.1" }
+wasmtime-types = { path = "crates/types", version = "14.0.1" }
+wasmtime-jit = { path = "crates/jit", version = "=14.0.1" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=14.0.1" }
+wasmtime-runtime = { path = "crates/runtime", version = "=14.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=14.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "14.0.1", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=14.0.1", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "14.0.1" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "14.0.1" }
+wasmtime-component-util = { path = "crates/component-util", version = "=14.0.1" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=14.0.1" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=14.0.1" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=14.0.1" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=14.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=14.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=14.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=14.0.0" }
-wasi-tokio = { path = "crates/wasi-common/tokio", version = "=14.0.0" }
-wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=14.0.0" }
+wiggle = { path = "crates/wiggle", version = "=14.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=14.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=14.0.1" }
+wasi-common = { path = "crates/wasi-common", version = "=14.0.1" }
+wasi-tokio = { path = "crates/wasi-common/tokio", version = "=14.0.1" }
+wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=14.0.1" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=14.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=14.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=14.0.1" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=14.0.1" }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.101.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.101.0" }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.101.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.101.0" }
-cranelift-native = { path = "cranelift/native", version = "0.101.0" }
-cranelift-module = { path = "cranelift/module", version = "0.101.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.101.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.101.0" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.101.1" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.101.1" }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.101.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.101.1" }
+cranelift-native = { path = "cranelift/native", version = "0.101.1" }
+cranelift-module = { path = "cranelift/module", version = "0.101.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.101.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.101.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.101.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.101.0" }
+cranelift-object = { path = "cranelift/object", version = "0.101.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.101.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.101.0" }
-cranelift-control = { path = "cranelift/control", version = "0.101.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.101.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.101.1" }
+cranelift-control = { path = "cranelift/control", version = "0.101.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.101.1" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.12.0" }
+winch-codegen = { path = "winch/codegen", version = "=0.12.1" }
 winch-filetests = { path = "winch/filetests" }
 winch-test-macros = { path = "winch/test-macros" }
 

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.101.0"
+version = "0.101.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.101.0"
+version = "0.101.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -16,7 +16,7 @@ edition.workspace = true
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.101.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.101.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -41,8 +41,8 @@ criterion = { version = "0.5.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.101.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.101.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.101.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.101.1" }
 
 [features]
 default = ["std", "unwind", "host-arch"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.101.0"
+version = "0.101.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -12,4 +12,4 @@ edition.workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.101.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.101.1" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.101.0"
+version = "0.101.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.101.0"
+version = "0.101.1"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.101.0"
+version = "0.101.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.101.0"
+version = "0.101.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.101.0"
+version = "0.101.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.101.0"
+version = "0.101.1"
 
 [dependencies]
 codespan-reporting = { version = "0.11.1", optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.101.0"
+version = "0.101.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.101.0"
+version = "0.101.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.101.0"
+version = "0.101.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.101.0"
+version = "0.101.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.101.0"
+version = "0.101.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.101.0"
+version = "0.101.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.101.0"
+version = "0.101.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.101.0"
+version = "0.101.1"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -200,7 +200,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "14.0.0"
+#define WASMTIME_VERSION "14.0.1"
 /**
  * \brief Wasmtime major version number.
  */
@@ -212,7 +212,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 0
+#define WASMTIME_VERSION_PATCH 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.98.1"
 version = "0.101.0"
 audited_as = "0.99.1"
 
+[[unpublished.cranelift]]
+version = "0.101.1"
+audited_as = "0.101.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -16,6 +20,10 @@ audited_as = "0.98.1"
 [[unpublished.cranelift-bforest]]
 version = "0.101.0"
 audited_as = "0.99.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.101.1"
+audited_as = "0.101.0"
 
 [[unpublished.cranelift-codegen]]
 version = "0.100.0"
@@ -25,6 +33,10 @@ audited_as = "0.98.1"
 version = "0.101.0"
 audited_as = "0.99.1"
 
+[[unpublished.cranelift-codegen]]
+version = "0.101.1"
+audited_as = "0.101.0"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -32,6 +44,10 @@ audited_as = "0.98.1"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.101.0"
 audited_as = "0.99.1"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.101.1"
+audited_as = "0.101.0"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.100.0"
@@ -41,6 +57,10 @@ audited_as = "0.98.1"
 version = "0.101.0"
 audited_as = "0.99.1"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.101.1"
+audited_as = "0.101.0"
+
 [[unpublished.cranelift-control]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -48,6 +68,10 @@ audited_as = "0.98.1"
 [[unpublished.cranelift-control]]
 version = "0.101.0"
 audited_as = "0.99.1"
+
+[[unpublished.cranelift-control]]
+version = "0.101.1"
+audited_as = "0.101.0"
 
 [[unpublished.cranelift-entity]]
 version = "0.100.0"
@@ -57,6 +81,10 @@ audited_as = "0.98.1"
 version = "0.101.0"
 audited_as = "0.99.1"
 
+[[unpublished.cranelift-entity]]
+version = "0.101.1"
+audited_as = "0.101.0"
+
 [[unpublished.cranelift-frontend]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -64,6 +92,10 @@ audited_as = "0.98.1"
 [[unpublished.cranelift-frontend]]
 version = "0.101.0"
 audited_as = "0.99.1"
+
+[[unpublished.cranelift-frontend]]
+version = "0.101.1"
+audited_as = "0.101.0"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.100.0"
@@ -73,6 +105,10 @@ audited_as = "0.98.1"
 version = "0.101.0"
 audited_as = "0.99.1"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.101.1"
+audited_as = "0.101.0"
+
 [[unpublished.cranelift-isle]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -80,6 +116,10 @@ audited_as = "0.98.1"
 [[unpublished.cranelift-isle]]
 version = "0.101.0"
 audited_as = "0.99.1"
+
+[[unpublished.cranelift-isle]]
+version = "0.101.1"
+audited_as = "0.101.0"
 
 [[unpublished.cranelift-jit]]
 version = "0.100.0"
@@ -89,6 +129,10 @@ audited_as = "0.98.1"
 version = "0.101.0"
 audited_as = "0.99.1"
 
+[[unpublished.cranelift-jit]]
+version = "0.101.1"
+audited_as = "0.101.0"
+
 [[unpublished.cranelift-module]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -96,6 +140,10 @@ audited_as = "0.98.1"
 [[unpublished.cranelift-module]]
 version = "0.101.0"
 audited_as = "0.99.1"
+
+[[unpublished.cranelift-module]]
+version = "0.101.1"
+audited_as = "0.101.0"
 
 [[unpublished.cranelift-native]]
 version = "0.100.0"
@@ -105,6 +153,10 @@ audited_as = "0.98.1"
 version = "0.101.0"
 audited_as = "0.99.1"
 
+[[unpublished.cranelift-native]]
+version = "0.101.1"
+audited_as = "0.101.0"
+
 [[unpublished.cranelift-object]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -112,6 +164,10 @@ audited_as = "0.98.1"
 [[unpublished.cranelift-object]]
 version = "0.101.0"
 audited_as = "0.99.1"
+
+[[unpublished.cranelift-object]]
+version = "0.101.1"
+audited_as = "0.101.0"
 
 [[unpublished.cranelift-reader]]
 version = "0.100.0"
@@ -121,6 +177,10 @@ audited_as = "0.98.1"
 version = "0.101.0"
 audited_as = "0.99.1"
 
+[[unpublished.cranelift-reader]]
+version = "0.101.1"
+audited_as = "0.101.0"
+
 [[unpublished.cranelift-serde]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -128,6 +188,10 @@ audited_as = "0.98.1"
 [[unpublished.cranelift-serde]]
 version = "0.101.0"
 audited_as = "0.99.1"
+
+[[unpublished.cranelift-serde]]
+version = "0.101.1"
+audited_as = "0.101.0"
 
 [[unpublished.cranelift-wasm]]
 version = "0.100.0"
@@ -137,6 +201,10 @@ audited_as = "0.98.1"
 version = "0.101.0"
 audited_as = "0.99.1"
 
+[[unpublished.cranelift-wasm]]
+version = "0.101.1"
+audited_as = "0.101.0"
+
 [[unpublished.wasi-cap-std-sync]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -144,6 +212,10 @@ audited_as = "11.0.1"
 [[unpublished.wasi-cap-std-sync]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasi-cap-std-sync]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasi-common]]
 version = "13.0.0"
@@ -153,6 +225,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasi-common]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasi-tokio]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -160,6 +236,10 @@ audited_as = "11.0.1"
 [[unpublished.wasi-tokio]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasi-tokio]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime]]
 version = "13.0.0"
@@ -169,6 +249,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -176,6 +260,10 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-asm-macros]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-cache]]
 version = "13.0.0"
@@ -185,6 +273,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime-cache]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-cli]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -192,6 +284,10 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-cli]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-cli]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "13.0.0"
@@ -201,6 +297,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-component-macro]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -208,6 +308,10 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-component-macro]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-component-macro]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-component-util]]
 version = "13.0.0"
@@ -217,6 +321,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime-component-util]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-cranelift]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -224,6 +332,10 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-cranelift]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "13.0.0"
@@ -233,6 +345,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime-cranelift-shared]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-environ]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -240,6 +356,10 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-environ]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-environ]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-explorer]]
 version = "13.0.0"
@@ -249,6 +369,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime-explorer]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-fiber]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -256,6 +380,10 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-fiber]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-fiber]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-jit]]
 version = "13.0.0"
@@ -265,6 +393,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime-jit]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -272,6 +404,10 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-jit-debug]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "13.0.0"
@@ -281,6 +417,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-runtime]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -288,6 +428,10 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-runtime]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-runtime]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-types]]
 version = "13.0.0"
@@ -297,6 +441,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime-types]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-wasi]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -304,6 +452,10 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-wasi]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-wasi]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "13.0.0"
@@ -313,6 +465,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -320,6 +476,10 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-wasi-nn]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "13.0.0"
@@ -329,6 +489,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-wast]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -336,6 +500,10 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-wast]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-wast]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-winch]]
 version = "13.0.0"
@@ -345,6 +513,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wasmtime-winch]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -352,11 +524,19 @@ audited_as = "11.0.1"
 [[unpublished.wasmtime-wit-bindgen]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "14.0.0"
 audited_as = "13.0.0"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wiggle]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -364,6 +544,10 @@ audited_as = "11.0.1"
 [[unpublished.wiggle]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wiggle]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wiggle-generate]]
 version = "13.0.0"
@@ -373,6 +557,10 @@ audited_as = "11.0.1"
 version = "14.0.0"
 audited_as = "12.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "14.0.1"
+audited_as = "14.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -380,6 +568,10 @@ audited_as = "11.0.1"
 [[unpublished.wiggle-macro]]
 version = "14.0.0"
 audited_as = "12.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "14.0.1"
+audited_as = "14.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -392,6 +584,10 @@ audited_as = "0.9.1"
 [[unpublished.winch-codegen]]
 version = "0.12.0"
 audited_as = "0.10.1"
+
+[[unpublished.winch-codegen]]
+version = "0.12.1"
+audited_as = "0.12.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -580,6 +776,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.101.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -589,6 +791,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.99.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.101.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -604,6 +812,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.101.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -613,6 +827,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-meta]]
 version = "0.99.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.101.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -628,6 +848,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.101.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -637,6 +863,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-control]]
 version = "0.99.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.101.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -652,6 +884,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.101.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -661,6 +899,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-frontend]]
 version = "0.99.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.101.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -676,6 +920,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.101.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -685,6 +935,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-isle]]
 version = "0.99.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.101.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -700,6 +956,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.101.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -709,6 +971,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-module]]
 version = "0.99.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.101.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -724,6 +992,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.101.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -733,6 +1007,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-object]]
 version = "0.99.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.101.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -748,6 +1028,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.101.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -760,6 +1046,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.101.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -769,6 +1061,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.99.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.101.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1119,6 +1417,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-cap-std-sync]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-common]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1131,6 +1435,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-tokio]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1140,6 +1450,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasi-tokio]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasi-tokio]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1456,6 +1772,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1465,6 +1787,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1480,6 +1808,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1489,6 +1823,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1504,6 +1844,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1513,6 +1859,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1528,6 +1880,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1537,6 +1895,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1552,6 +1916,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cranelift-shared]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-environ]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1561,6 +1931,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-environ]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-environ]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1576,6 +1952,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-explorer]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-fiber]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1585,6 +1967,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-fiber]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-fiber]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1600,6 +1988,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1609,6 +2003,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-debug]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1624,6 +2024,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-runtime]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1633,6 +2039,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-runtime]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-runtime]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1648,6 +2060,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-types]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1657,6 +2075,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1672,6 +2096,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-http]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-nn]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1681,6 +2111,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-nn]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-nn]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1696,6 +2132,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-threads]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wast]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1705,6 +2147,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wast]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wast]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1720,6 +2168,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-winch]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wit-bindgen]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1729,12 +2183,24 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wit-bindgen]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wit-bindgen]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wmemcheck]]
 version = "13.0.0"
 when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1834,6 +2300,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1846,6 +2318,12 @@ when = "2023-08-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "14.0.0"
+when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1855,6 +2333,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "12.0.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "14.0.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1881,6 +2365,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.10.1"
 when = "2023-08-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.12.0"
+when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.12.0"
+version = "0.12.1"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 14.0.1, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
