### PR TITLE
Use wasi-http::Error in the wasi-http implementation

### DIFF
--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -82,11 +82,9 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
             builder = builder.header(k, v);
         }
 
-        let body = req.body.unwrap_or_else(|| {
-            Empty::<Bytes>::new()
-                .map_err(|_| anyhow::anyhow!("empty error"))
-                .boxed()
-        });
+        let body = req
+            .body
+            .unwrap_or_else(|| Empty::<Bytes>::new().map_err(|_| unreachable!()).boxed());
 
         let request = builder.body(body).map_err(types::http_protocol_error)?;
 

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -66,12 +66,6 @@ impl From<std::io::Error> for crate::bindings::http::types::Error {
     }
 }
 
-impl From<http::Error> for crate::bindings::http::types::Error {
-    fn from(err: http::Error) -> Self {
-        Self::InvalidUrl(err.to_string())
-    }
-}
-
 impl From<hyper::Error> for crate::bindings::http::types::Error {
     fn from(err: hyper::Error) -> Self {
         let message = err.message().to_string();

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -734,7 +734,8 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFutureIncomingResponse f
                     return Ok(Some(Ok(Err(e))));
                 }
 
-                Ok(resp) => resp,
+                Ok(Ok(resp)) => resp,
+                Ok(Err(e)) => return Ok(Some(Ok(Err(e)))),
             };
 
         let (parts, body) = resp.resp.into_parts();
@@ -752,6 +753,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFutureIncomingResponse f
 
         Ok(Some(Ok(Ok(resp))))
     }
+
     fn subscribe(
         &mut self,
         id: Resource<HostFutureIncomingResponse>,

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -265,13 +265,16 @@ async fn do_wasi_http_hash_all(override_send_request: bool) -> Result<()> {
                       between_bytes_timeout,
                       ..
                   }| {
-                Ok(view.table().push(HostFutureIncomingResponse::Ready(
-                    handle(request.into_parts().0).map(|resp| IncomingResponseInternal {
+                let response = handle(request.into_parts().0).map(|resp| {
+                    Ok(IncomingResponseInternal {
                         resp,
                         worker: Arc::new(preview2::spawn(future::ready(Ok(())))),
                         between_bytes_timeout,
-                    }),
-                ))?)
+                    })
+                });
+                Ok(view
+                    .table()
+                    .push(HostFutureIncomingResponse::Ready(response))?)
             },
         ) as RequestSender)
     } else {
@@ -375,7 +378,7 @@ async fn wasi_http_echo() -> Result<()> {
         .header("content-type", "application/octet-stream")
         .body(BoxBody::new(StreamBody::new(stream::iter(
             body.chunks(16 * 1024)
-                .map(|chunk| Ok::<_, anyhow::Error>(Frame::data(Bytes::copy_from_slice(chunk))))
+                .map(|chunk| Ok::<_, Error>(Frame::data(Bytes::copy_from_slice(chunk))))
                 .collect::<Vec<_>>(),
         ))))?;
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -363,9 +363,9 @@ impl hyper::service::Service<Request> for ProxyHandler {
 
             let mut store = inner.cmd.new_store(&inner.engine, req_id)?;
 
-            let req = store.data_mut().new_incoming_request(
-                req.map(|body| body.map_err(|e| anyhow::anyhow!(e)).boxed()),
-            )?;
+            let req = store
+                .data_mut()
+                .new_incoming_request(req.map(|body| body.map_err(|e| e.into()).boxed()))?;
 
             let out = store.data_mut().new_response_outparam(sender)?;
 


### PR DESCRIPTION
Currently any error in `WasiHttpView::send_request` will result in a trap instead of an error being returned back from the call to `outgoing_handler::handle`. This moves a large amount of the `Result` types in the implementation from `anyhow::Error` to `types::Error`. `HostFutureIncomingResponse` now contains a `anyhow::Result<Result<IncomingResponseInternal, types::Error>>` to keep track of both trappable errors and errors that will be returned to the caller. 