### PR TITLE
update ittapi to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,9 +1638,9 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "ittapi"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41e0d0b7b3b53d92a7e8b80ede3400112a6b8b4c98d1f5b8b16bb787c780582c"
+checksum = "6b996fe614c41395cdaedf3cf408a9534851090959d90d54a535f675550b64b1"
 dependencies = [
  "anyhow",
  "ittapi-sys",
@@ -1649,9 +1649,9 @@ dependencies = [
 
 [[package]]
 name = "ittapi-sys"
-version = "0.3.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f8763c96e54e6d6a0dccc2990d8b5e33e3313aaeae6185921a3f4c1614a77c"
+checksum = "52f5385394064fa2c886205dba02598013ce83d3e92d33dbdc0c52fe0e7bf4fc"
 dependencies = [
  "cc",
 ]

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -38,7 +38,7 @@ workspace = true
 features = ["Win32_System_Diagnostics_Debug"]
 
 [target.'cfg(all(target_arch = "x86_64", not(target_os = "android")))'.dependencies]
-ittapi = { version = "0.3.4", optional = true }
+ittapi = { version = "0.4.0", optional = true }
 
 [features]
 profiling = ['dep:wasmtime-jit-debug', 'dep:ittapi']

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1457,6 +1457,11 @@ criteria = "safe-to-deploy"
 delta = "0.3.1 -> 0.3.3"
 notes = "I am the author of this crate."
 
+[[audits.ittapi]]
+who = "rahulchaphalkar <rahul.s.chaphalkar@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.4.0"
+
 [[audits.ittapi-sys]]
 who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
@@ -1467,6 +1472,11 @@ who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
 delta = "0.3.1 -> 0.3.3"
 notes = "Unsafe code is due to auto-generated bindings to a widely-deployed C library."
+
+[[audits.ittapi-sys]]
+who = "rahulchaphalkar <rahul.s.chaphalkar@intel.com>"
+criteria = "safe-to-deploy"
+delta = "0.3.4 -> 0.4.0"
 
 [[audits.leb128]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"


### PR DESCRIPTION
Fixes the JIT Code visibility issue for VTune. Tested wasmtime cli with a simple Fibonacci fib.wasm file, and can see the following with vtune hotspots -

![pr_upload](https://github.com/bytecodealliance/wasmtime/assets/15642191/a949d6b3-9ad3-4308-84bb-0f49ed36a668)

Previously this was [Outside Any Module] along with trace file corruption log in vtune.

This change enables vtune profiler to be used for wasm code hotspots, microarchitecture analysis, disassembly viewing etc.

Fixes issues like this https://github.com/bytecodealliance/wasmtime/issues/5628

Ittapi change which fixes the issue is here https://github.com/intel/ittapi/pull/105