### PR TITLE
Fix native feature detect in "min" builds

### DIFF
--- a/ci/build-release-artifacts.sh
+++ b/ci/build-release-artifacts.sh
@@ -28,7 +28,7 @@ if [[ "$build" = *-min ]]; then
   export RUSTFLAGS=-Zlocation-detail=none
   export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1
   export CARGO_PROFILE_RELEASE_LTO=true
-  flags="-Zbuild-std=std,panic_abort --no-default-features -Zbuild-std-features="
+  flags="-Zbuild-std=std,panic_abort --no-default-features -Zbuild-std-features=std_detect_dlsym_getauxval"
   flags="$flags --features disable-logging"
 else
   # For release builds the CLI is built a bit more feature-ful than the Cargo


### PR DESCRIPTION
With a custom standard library disabling all features means disabling some support for feature-detection macros of the native platform. This meant that `wasmtime compile` output locally wasn't runnable in `wasmtime-min run` because it couldn't correctly detect that features were in fact available.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
