### PR TITLE
Fix concurrent invocations of `preview2_tcp_bind` test

### DIFF
--- a/crates/test-programs/src/bin/preview2_tcp_bind.rs
+++ b/crates/test-programs/src/bin/preview2_tcp_bind.rs
@@ -23,12 +23,16 @@ fn test_tcp_bind_specific_port(net: &Network, ip: IpAddress) {
     let bind_addr = IpSocketAddress::new(ip, PORT);
 
     let sock = TcpSocket::new(ip.family()).unwrap();
-    sock.blocking_bind(net, bind_addr).unwrap();
+    match sock.blocking_bind(net, bind_addr) {
+        Ok(()) => {
+            let bound_addr = sock.local_address().unwrap();
 
-    let bound_addr = sock.local_address().unwrap();
-
-    assert_eq!(bind_addr.ip(), bound_addr.ip());
-    assert_eq!(bind_addr.port(), bound_addr.port());
+            assert_eq!(bind_addr.ip(), bound_addr.ip());
+            assert_eq!(bind_addr.port(), bound_addr.port());
+        }
+        Err(ErrorCode::AddressInUse) => {}
+        Err(e) => panic!("error: {e}"),
+    }
 }
 
 /// Two sockets may not be actively bound to the same address at the same time.


### PR DESCRIPTION
When binding a specific port allow `AddressInUse` errors to be returned in case the test is being concurrently run.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
