### PR TITLE
riscv64: Refactor float-to-int trapping conversions 

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -767,6 +767,8 @@
 (type CSR (enum
   ;; Floating-Point Dynamic Rounding Mode
   (Frm)
+  ;; Floating-Point Exception Flags
+  (Fflags)
 ))
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1759,29 +1759,13 @@
 
 ;; `Zicsr` Extension Instructions
 
-;; Helper for emitting the `csrrwi` instruction.
-(decl rv_csrrwi (CSR UImm5) XReg)
-(rule (rv_csrrwi csr imm)
-  (csr_imm (CsrImmOP.CsrRWI) csr imm))
-
 ;; This is a special case of `csrrwi` when the CSR is the `frm` CSR.
-(decl rv_fsrmi (FRM) XReg)
-(rule (rv_fsrmi frm) (rv_csrrwi (CSR.Frm) frm))
-
-
-;; Helper for emitting the `csrw` instruction. This is a special case of
-;; `csrrw` where the destination register is always `x0`.
-(decl rv_csrw (CSR XReg) Unit)
-(rule (rv_csrw csr rs)
-  (csr_reg_dst_zero (CsrRegOP.CsrRW) csr rs))
+(decl rv_fsrmi_swap (FRM) XReg)
+(rule (rv_fsrmi_swap frm) (rv_csrrwi_swap (CSR.Frm) frm))
 
 ;; This is a special case of `csrw` when the CSR is the `frm` CSR.
-(decl rv_fsrm (XReg) Unit)
-(rule (rv_fsrm rs) (rv_csrw (CSR.Frm) rs))
-
-
-
-
+(decl rv_fsrm (XReg) SideEffectNoResult)
+(rule (rv_fsrm rs) (rv_csrrw (CSR.Frm) rs))
 
 ;; Generate a mask for the bit-width of the given type
 (decl pure shift_mask (Type) u64)
@@ -2033,18 +2017,91 @@
             (_ Unit (emit (MInst.Lui dst imm))))
         dst))
 
-;; Helper for emitting `MInst.CsrImm` instructions.
-(decl csr_imm (CsrImmOP CSR UImm5) XReg)
+;; Helper for emitting a `MInst.CsrReg` instruction that writes the result to
+;; x0 and discards it.
+(decl csr_reg (CsrRegOP CSR XReg) SideEffectNoResult)
+(rule (csr_reg op csr rs)
+  (SideEffectNoResult.Inst (MInst.CsrReg op (writable_zero_reg) rs csr)))
+
+;; Helper for emitting a `MInst.CsrReg` instruction that writes the result to
+;; an allocatable register to get used later.
+(decl csr_reg_result (CsrRegOP CSR XReg) XReg)
+(rule (csr_reg_result op csr rs)
+      (let ((dst WritableXReg (temp_writable_xreg))
+            (_ Unit (emit (MInst.CsrReg op dst rs csr))))
+        dst))
+
+;; Helper for emitting the `csrrw` instruction which reads the value into x0
+;; and discard the result.
+(decl rv_csrrw (CSR XReg) SideEffectNoResult)
+(rule (rv_csrrw csr rs) (csr_reg (CsrRegOP.CsrRW) csr rs))
+
+;; Helper for emitting the `csrrw` instruction "Atomic Read/Write CSR".
+;;
+;; The old value is returned in an integer register.
+(decl rv_csrrw_swap (CSR XReg) XReg)
+(rule (rv_csrrw_swap csr rs) (csr_reg_result (CsrRegOP.CsrRW) csr rs))
+
+;; Helper for emitting the `csrrs` instruction which reads the value into x0
+;; and discard the result.
+(decl rv_csrrs (CSR XReg) SideEffectNoResult)
+(rule (rv_csrrs csr rs) (csr_reg (CsrRegOP.CsrRS) csr rs))
+
+;; Helper for emitting the `csrrs` instruction "Atomic Read and Set Bits in CSR"
+;;
+;; The old value is returned in an integer register.
+(decl rv_csrrs_swap (CSR XReg) XReg)
+(rule (rv_csrrs_swap csr rs) (csr_reg_result (CsrRegOP.CsrRS) csr rs))
+
+;; Helper for emitting the `csrrc` instruction which reads the value into x0
+;; and discard the result.
+(decl rv_csrrc (CSR XReg) SideEffectNoResult)
+(rule (rv_csrrc csr rc) (csr_reg (CsrRegOP.CsrRC) csr rc))
+
+;; Helper for emitting the `csrrc` instruction "Atomic Read and Clear Bits in
+;; CSR"
+;;
+;; The old value is returned in an integer register.
+(decl rv_csrrc_swap (CSR XReg) XReg)
+(rule (rv_csrrc_swap csr rc) (csr_reg_result (CsrRegOP.CsrRC) csr rc))
+
+;; Helper for emitting `MInst.CsrImm` instructions where the result is stored
+;; in the zero register and discarded.
+(decl csr_imm (CsrImmOP CSR UImm5) SideEffectNoResult)
 (rule (csr_imm op csr imm)
+      (SideEffectNoResult.Inst (MInst.CsrImm op (writable_zero_reg) imm csr)))
+
+;; Helper for emitting `MInst.CsrImm` instructions which has a result in an
+;; allocatable register.
+(decl csr_imm_result (CsrImmOP CSR UImm5) XReg)
+(rule (csr_imm_result op csr imm)
       (let ((dst WritableXReg (temp_writable_xreg))
             (_ Unit (emit (MInst.CsrImm op dst imm csr))))
         dst))
 
-;; Helper for emitting a `MInst.CsrReg` instruction that writes the result to x0.
-(decl csr_reg_dst_zero (CsrRegOP CSR XReg) Unit)
-(rule (csr_reg_dst_zero op csr rs)
-      (emit (MInst.CsrReg op (writable_zero_reg) rs csr)))
+;; Same as `rv_csrrw` but uses an immediate instead of register operand.
+(decl rv_csrrwi (CSR UImm5) SideEffectNoResult)
+(rule (rv_csrrwi csr imm) (csr_imm (CsrImmOP.CsrRWI) csr imm))
 
+;; Same as `rv_csrrw_swap` but uses an immediate instead of register operand.
+(decl rv_csrrwi_swap (CSR UImm5) XReg)
+(rule (rv_csrrwi_swap csr imm) (csr_imm_result (CsrImmOP.CsrRWI) csr imm))
+
+;; Same as `rv_csrrs` but uses an immediate instead of register operand.
+(decl rv_csrrsi (CSR UImm5) SideEffectNoResult)
+(rule (rv_csrrsi csr imm) (csr_imm (CsrImmOP.CsrRSI) csr imm))
+
+;; Same as `rv_csrrs_swap` but uses an immediate instead of register operand.
+(decl rv_csrrsi_swap (CSR UImm5) XReg)
+(rule (rv_csrrsi_swap csr imm) (csr_imm_result (CsrImmOP.CsrRSI) csr imm))
+
+;; Same as `rv_csrrc` but uses an immediate instead of register operand.
+(decl rv_csrrci (CSR UImm5) SideEffectNoResult)
+(rule (rv_csrrci csr imm) (csr_imm (CsrImmOP.CsrRCI) csr imm))
+
+;; Same as `rv_csrrc_swap` but uses an immediate instead of register operand.
+(decl rv_csrrci_swap (CSR UImm5) XReg)
+(rule (rv_csrrci_swap csr imm) (csr_imm_result (CsrImmOP.CsrRCI) csr imm))
 
 
 (decl select_addi (Type) AluOPRRI)

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -1694,12 +1694,14 @@ impl Display for CsrImmOP {
 impl CSR {
     pub(crate) fn bits(self) -> Imm12 {
         Imm12::from_i16(match self {
-            CSR::Frm => 0x0002,
+            CSR::Fflags => 0x001,
+            CSR::Frm => 0x002,
         })
     }
 
     pub(crate) fn name(self) -> &'static str {
         match self {
+            CSR::Fflags => "fflags",
             CSR::Frm => "frm",
         }
     }

--- a/cranelift/codegen/src/isa/riscv64/inst_vector.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst_vector.isle
@@ -1855,10 +1855,10 @@
 ;; In the general case we need to first switch into the appropriate rounding mode.
 (rule 0 (gen_vfcvt_x_f x frm vstate)
   (let (;; Set the rounding mode and save the current mode
-        (saved_frm XReg (rv_fsrmi frm))
+        (saved_frm XReg (rv_fsrmi_swap frm))
         (res VReg (rv_vfcvt_x_f_v x (unmasked) vstate))
         ;; Restore the previous rounding mode
-        (_ Unit (rv_fsrm saved_frm)))
+        (_ Unit (emit_side_effect (rv_fsrm saved_frm))))
     res))
 
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -2235,40 +2235,51 @@
 ;; RISC-V float-to-integer conversion does not trap, but Cranelift semantics are
 ;; to trap. This manually performs checks for NaN and out-of-bounds values and
 ;; traps in such cases.
-;;
-;; TODO: could this perhaps be more optimal through inspection of the `fcsr`?
-;; Unsure whether that needs to be preserved across function calls and/or would
-;; cause other problems. Also unsure whether it's actually more performant.
-(rule (lower (has_type ity (fcvt_to_uint v @ (value_type fty))))
+(rule 0 (lower (has_type (ty_8_or_16 ity) (fcvt_to_uint v @ (value_type fty))))
   (let ((_ InstOutput (gen_trapz (rv_feq fty v v) (TrapCode.BadConversionToInteger)))
         (min FReg (imm fty (fcvt_umin_bound fty $false)))
         (_ InstOutput (gen_trapnz (rv_fle fty v min) (TrapCode.IntegerOverflow)))
         (max FReg (imm fty (fcvt_umax_bound fty ity $false)))
         (_ InstOutput (gen_trapnz (rv_fge fty v max) (TrapCode.IntegerOverflow))))
-    (lower_inbounds_fcvt_to_uint ity fty v)))
+    (rv_fcvtwu fty (FRM.RTZ) v)))
 
-(decl lower_inbounds_fcvt_to_uint (Type Type FReg) XReg)
-(rule 0 (lower_inbounds_fcvt_to_uint (fits_in_32 _) fty v)
-  (rv_fcvtwu fty (FRM.RTZ) v))
-(rule 1 (lower_inbounds_fcvt_to_uint $I64 fty v)
-  (rv_fcvtlu fty (FRM.RTZ) v))
+;; For 32/64-bit destinations we can avoid some manual checks against the
+;; min/max bounds and instead use the fflags CSR to detect, after the fact,
+;; if any exceptions were flagged during the conversion operation.
+;;
+;; NaN is still tested explicitly to generate a different kind of trap, but
+;; after that the fflags CSR is cleared. After the conversion operation itself
+;; the CSR is read and the "NV" flag is tested. This flag is bit 5 in the
+;; register and if it's set it means that the original operands wasn't in-range
+;; for the destination type and a trap is generated indicating as such.
+(rule 1 (lower (has_type (ty_32_or_64 ity) (fcvt_to_uint v @ (value_type fty))))
+  (let ((_ InstOutput (gen_trapz (rv_feq fty v v) (TrapCode.BadConversionToInteger)))
+        (_ Unit (emit_side_effect (rv_csrrw (CSR.Fflags) (zero_reg))))
+        (result XReg (lower_fcvt_to_uint_sat fty ity v))
+        (fflags XReg (rv_csrrs_swap (CSR.Fflags) (zero_reg)))
+        (is_invalid_op XReg (rv_andi fflags (imm12_const 0x10)))
+        (_ InstOutput (gen_trapnz is_invalid_op (TrapCode.IntegerOverflow))))
+    result))
 
 ;;;;;  Rules for `fcvt_to_sint`;;;;;;;;;
 
 ;; NB: see above with `fcvt_to_uint` as this is similar
-(rule (lower (has_type ity (fcvt_to_sint v @ (value_type fty))))
+(rule 0 (lower (has_type ity (fcvt_to_sint v @ (value_type fty))))
   (let ((_ InstOutput (gen_trapz (rv_feq fty v v) (TrapCode.BadConversionToInteger)))
         (min FReg (imm fty (fcvt_smin_bound fty ity $false)))
         (_ InstOutput (gen_trapnz (rv_fle fty v min) (TrapCode.IntegerOverflow)))
         (max FReg (imm fty (fcvt_smax_bound fty ity $false)))
         (_ InstOutput (gen_trapnz (rv_fge fty v max) (TrapCode.IntegerOverflow))))
-    (lower_inbounds_fcvt_to_sint ity fty v)))
+    (rv_fcvtw fty (FRM.RTZ) v)))
 
-(decl lower_inbounds_fcvt_to_sint (Type Type FReg) XReg)
-(rule 0 (lower_inbounds_fcvt_to_sint (fits_in_32 _) fty v)
-  (rv_fcvtw fty (FRM.RTZ) v))
-(rule 1 (lower_inbounds_fcvt_to_sint $I64 fty v)
-  (rv_fcvtl fty (FRM.RTZ) v))
+(rule 1 (lower (has_type (ty_32_or_64 ity) (fcvt_to_sint v @ (value_type fty))))
+  (let ((_ InstOutput (gen_trapz (rv_feq fty v v) (TrapCode.BadConversionToInteger)))
+        (_ Unit (emit_side_effect (rv_csrrw (CSR.Fflags) (zero_reg))))
+        (result XReg (lower_fcvt_to_sint_sat fty ity v))
+        (fflags XReg (rv_csrrs_swap (CSR.Fflags) (zero_reg)))
+        (is_invalid_op XReg (rv_andi fflags (imm12_const 0x10)))
+        (_ InstOutput (gen_trapnz is_invalid_op (TrapCode.IntegerOverflow))))
+    result))
 
 ;;;;;  Rules for `fcvt_to_sint_sat`;;;;;;;;;
 

--- a/cranelift/filetests/filetests/isa/riscv64/float.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/float.clif
@@ -596,15 +596,11 @@ block0(v0: f32):
 ; block0:
 ;   feq.s a2,fa0,fa0
 ;   trap_if bad_toint##(a2 eq zero)
-;   lui a5,-264192
-;   fmv.w.x fa1,a5
-;   fle.s a3,fa0,fa1
-;   trap_if int_ovf##(a3 ne zero)
-;   lui a0,325632
-;   fmv.w.x fa2,a0
-;   fle.s a4,fa2,fa0
-;   trap_if int_ovf##(a4 ne zero)
+;   csrrw zero,fflags,zero
 ;   fcvt.wu.s a0,fa0,rtz
+;   csrrs a2,fflags,zero
+;   andi a4,a2,16
+;   trap_if int_ovf##(a4 ne zero)
 ;   ret
 ;
 ; Disassembled:
@@ -612,17 +608,12 @@ block0(v0: f32):
 ;   feq.s a2, fa0, fa0
 ;   bnez a2, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
-;   lui a5, 0xbf800
-;   fmv.w.x fa1, a5
-;   fle.s a3, fa0, fa1
-;   beqz a3, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   lui a0, 0x4f800
-;   fmv.w.x fa2, a0
-;   fle.s a4, fa2, fa0
+;   fsflags zero
+;   fcvt.wu.s a0, fa0, rtz
+;   frflags a2
+;   andi a4, a2, 0x10
 ;   beqz a4, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   fcvt.wu.s a0, fa0, rtz
 ;   ret
 
 function %f34(f32) -> i32 {
@@ -635,16 +626,11 @@ block0(v0: f32):
 ; block0:
 ;   feq.s a2,fa0,fa0
 ;   trap_if bad_toint##(a2 eq zero)
-;   lui a5,-200704
-;   addi a1,a5,1
-;   fmv.w.x fa3,a1
-;   fle.s a5,fa0,fa3
-;   trap_if int_ovf##(a5 ne zero)
-;   lui a2,323584
-;   fmv.w.x fa4,a2
-;   fle.s a0,fa4,fa0
-;   trap_if int_ovf##(a0 ne zero)
+;   csrrw zero,fflags,zero
 ;   fcvt.w.s a0,fa0,rtz
+;   csrrs a2,fflags,zero
+;   andi a4,a2,16
+;   trap_if int_ovf##(a4 ne zero)
 ;   ret
 ;
 ; Disassembled:
@@ -652,18 +638,12 @@ block0(v0: f32):
 ;   feq.s a2, fa0, fa0
 ;   bnez a2, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
-;   lui a5, 0xcf000
-;   addi a1, a5, 1
-;   fmv.w.x fa3, a1
-;   fle.s a5, fa0, fa3
-;   beqz a5, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   lui a2, 0x4f000
-;   fmv.w.x fa4, a2
-;   fle.s a0, fa4, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fsflags zero
 ;   fcvt.w.s a0, fa0, rtz
+;   frflags a2
+;   andi a4, a2, 0x10
+;   beqz a4, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   ret
 
 function %f35(f32) -> i64 {
@@ -676,15 +656,11 @@ block0(v0: f32):
 ; block0:
 ;   feq.s a2,fa0,fa0
 ;   trap_if bad_toint##(a2 eq zero)
-;   lui a5,-264192
-;   fmv.w.x fa1,a5
-;   fle.s a3,fa0,fa1
-;   trap_if int_ovf##(a3 ne zero)
-;   lui a0,391168
-;   fmv.w.x fa2,a0
-;   fle.s a4,fa2,fa0
-;   trap_if int_ovf##(a4 ne zero)
+;   csrrw zero,fflags,zero
 ;   fcvt.lu.s a0,fa0,rtz
+;   csrrs a2,fflags,zero
+;   andi a4,a2,16
+;   trap_if int_ovf##(a4 ne zero)
 ;   ret
 ;
 ; Disassembled:
@@ -692,17 +668,12 @@ block0(v0: f32):
 ;   feq.s a2, fa0, fa0
 ;   bnez a2, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
-;   lui a5, 0xbf800
-;   fmv.w.x fa1, a5
-;   fle.s a3, fa0, fa1
-;   beqz a3, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   lui a0, 0x5f800
-;   fmv.w.x fa2, a0
-;   fle.s a4, fa2, fa0
+;   fsflags zero
+;   fcvt.lu.s a0, fa0, rtz
+;   frflags a2
+;   andi a4, a2, 0x10
 ;   beqz a4, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   fcvt.lu.s a0, fa0, rtz
 ;   ret
 
 function %f36(f32) -> i64 {
@@ -715,16 +686,11 @@ block0(v0: f32):
 ; block0:
 ;   feq.s a2,fa0,fa0
 ;   trap_if bad_toint##(a2 eq zero)
-;   lui a5,-135168
-;   addi a1,a5,1
-;   fmv.w.x fa3,a1
-;   fle.s a5,fa0,fa3
-;   trap_if int_ovf##(a5 ne zero)
-;   lui a2,389120
-;   fmv.w.x fa4,a2
-;   fle.s a0,fa4,fa0
-;   trap_if int_ovf##(a0 ne zero)
+;   csrrw zero,fflags,zero
 ;   fcvt.l.s a0,fa0,rtz
+;   csrrs a2,fflags,zero
+;   andi a4,a2,16
+;   trap_if int_ovf##(a4 ne zero)
 ;   ret
 ;
 ; Disassembled:
@@ -732,18 +698,12 @@ block0(v0: f32):
 ;   feq.s a2, fa0, fa0
 ;   bnez a2, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
-;   lui a5, 0xdf000
-;   addi a1, a5, 1
-;   fmv.w.x fa3, a1
-;   fle.s a5, fa0, fa3
-;   beqz a5, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   lui a2, 0x5f000
-;   fmv.w.x fa4, a2
-;   fle.s a0, fa4, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fsflags zero
 ;   fcvt.l.s a0, fa0, rtz
+;   frflags a2
+;   andi a4, a2, 0x10
+;   beqz a4, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   ret
 
 function %f37(f64) -> i32 {
@@ -756,17 +716,11 @@ block0(v0: f64):
 ; block0:
 ;   feq.d a2,fa0,fa0
 ;   trap_if bad_toint##(a2 eq zero)
-;   lui a5,3071
-;   slli a1,a5,40
-;   fmv.d.x fa3,a1
-;   fle.d a5,fa0,fa3
-;   trap_if int_ovf##(a5 ne zero)
-;   lui a2,1055
-;   slli a4,a2,40
-;   fmv.d.x fa1,a4
-;   fle.d a2,fa1,fa0
-;   trap_if int_ovf##(a2 ne zero)
+;   csrrw zero,fflags,zero
 ;   fcvt.wu.d a0,fa0,rtz
+;   csrrs a2,fflags,zero
+;   andi a4,a2,16
+;   trap_if int_ovf##(a4 ne zero)
 ;   ret
 ;
 ; Disassembled:
@@ -774,19 +728,12 @@ block0(v0: f64):
 ;   feq.d a2, fa0, fa0
 ;   bnez a2, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
-;   lui a5, 0xbff
-;   slli a1, a5, 0x28
-;   fmv.d.x fa3, a1
-;   fle.d a5, fa0, fa3
-;   beqz a5, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   lui a2, 0x41f
-;   slli a4, a2, 0x28
-;   fmv.d.x fa1, a4
-;   fle.d a2, fa1, fa0
-;   beqz a2, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fsflags zero
 ;   fcvt.wu.d a0, fa0, rtz
+;   frflags a2
+;   andi a4, a2, 0x10
+;   beqz a4, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   ret
 
 function %f38(f64) -> i32 {
@@ -799,16 +746,11 @@ block0(v0: f64):
 ; block0:
 ;   feq.d a2,fa0,fa0
 ;   trap_if bad_toint##(a2 eq zero)
-;   ld a5,[const(0)]
-;   fmv.d.x fa1,a5
-;   fle.d a3,fa0,fa1
-;   trap_if int_ovf##(a3 ne zero)
-;   lui a0,527
-;   slli a2,a0,41
-;   fmv.d.x fa4,a2
-;   fle.d a0,fa4,fa0
-;   trap_if int_ovf##(a0 ne zero)
+;   csrrw zero,fflags,zero
 ;   fcvt.w.d a0,fa0,rtz
+;   csrrs a2,fflags,zero
+;   andi a4,a2,16
+;   trap_if int_ovf##(a4 ne zero)
 ;   ret
 ;
 ; Disassembled:
@@ -816,23 +758,13 @@ block0(v0: f64):
 ;   feq.d a2, fa0, fa0
 ;   bnez a2, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
-;   auipc a5, 0
-;   ld a5, 0x3c(a5)
-;   fmv.d.x fa1, a5
-;   fle.d a3, fa0, fa1
-;   beqz a3, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   lui a0, 0x20f
-;   slli a2, a0, 0x29
-;   fmv.d.x fa4, a2
-;   fle.d a0, fa4, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fsflags zero
 ;   fcvt.w.d a0, fa0, rtz
+;   frflags a2
+;   andi a4, a2, 0x10
+;   beqz a4, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   ret
-;   .byte 0x00, 0x00, 0x00, 0x00
-;   .byte 0x00, 0x00, 0x20, 0x00
-;   .byte 0x00, 0x00, 0xe0, 0xc1
 
 function %f39(f64) -> i64 {
 block0(v0: f64):
@@ -844,17 +776,11 @@ block0(v0: f64):
 ; block0:
 ;   feq.d a2,fa0,fa0
 ;   trap_if bad_toint##(a2 eq zero)
-;   lui a5,3071
-;   slli a1,a5,40
-;   fmv.d.x fa3,a1
-;   fle.d a5,fa0,fa3
-;   trap_if int_ovf##(a5 ne zero)
-;   lui a2,1087
-;   slli a4,a2,40
-;   fmv.d.x fa1,a4
-;   fle.d a2,fa1,fa0
-;   trap_if int_ovf##(a2 ne zero)
+;   csrrw zero,fflags,zero
 ;   fcvt.lu.d a0,fa0,rtz
+;   csrrs a2,fflags,zero
+;   andi a4,a2,16
+;   trap_if int_ovf##(a4 ne zero)
 ;   ret
 ;
 ; Disassembled:
@@ -862,19 +788,12 @@ block0(v0: f64):
 ;   feq.d a2, fa0, fa0
 ;   bnez a2, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
-;   lui a5, 0xbff
-;   slli a1, a5, 0x28
-;   fmv.d.x fa3, a1
-;   fle.d a5, fa0, fa3
-;   beqz a5, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   lui a2, 0x43f
-;   slli a4, a2, 0x28
-;   fmv.d.x fa1, a4
-;   fle.d a2, fa1, fa0
-;   beqz a2, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fsflags zero
 ;   fcvt.lu.d a0, fa0, rtz
+;   frflags a2
+;   andi a4, a2, 0x10
+;   beqz a4, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   ret
 
 function %f40(f64) -> i64 {
@@ -887,16 +806,11 @@ block0(v0: f64):
 ; block0:
 ;   feq.d a2,fa0,fa0
 ;   trap_if bad_toint##(a2 eq zero)
-;   ld a5,[const(0)]
-;   fmv.d.x fa1,a5
-;   fle.d a3,fa0,fa1
-;   trap_if int_ovf##(a3 ne zero)
-;   lui a0,543
-;   slli a2,a0,41
-;   fmv.d.x fa4,a2
-;   fle.d a0,fa4,fa0
-;   trap_if int_ovf##(a0 ne zero)
+;   csrrw zero,fflags,zero
 ;   fcvt.l.d a0,fa0,rtz
+;   csrrs a2,fflags,zero
+;   andi a4,a2,16
+;   trap_if int_ovf##(a4 ne zero)
 ;   ret
 ;
 ; Disassembled:
@@ -904,23 +818,13 @@ block0(v0: f64):
 ;   feq.d a2, fa0, fa0
 ;   bnez a2, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: bad_toint
-;   auipc a5, 0
-;   ld a5, 0x3c(a5)
-;   fmv.d.x fa1, a5
-;   fle.d a3, fa0, fa1
-;   beqz a3, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
-;   lui a0, 0x21f
-;   slli a2, a0, 0x29
-;   fmv.d.x fa4, a2
-;   fle.d a0, fa4, fa0
-;   beqz a0, 8
-;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
+;   fsflags zero
 ;   fcvt.l.d a0, fa0, rtz
+;   frflags a2
+;   andi a4, a2, 0x10
+;   beqz a4, 8
+;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: int_ovf
 ;   ret
-;   .byte 0x00, 0x00, 0x00, 0x00
-;   .byte 0x01, 0x00, 0x00, 0x00
-;   .byte 0x00, 0x00, 0xe0, 0xc3
 
 function %f41(i32) -> f32 {
 block0(v0: i32):


### PR DESCRIPTION
This commit refactors the `fcvt_to_{s,u}int` conversions in the riscv64
backend to build on the work in https://github.com/bytecodealliance/wasmtime/pull/7327. These two instructions currently
have multiple branches in them to check for traps when the float is out
of bounds. This is additionally signaled via the `fflags` CSR however so
this is an attempt to trim some branches/constants/etc and instead check
the `fflags` CSR after the operation. This requires clearing the CSR
just beforehand, however. This additionally doesn't work for 8/16-bit
types because the hardware doesn't set flags for those.