### PR TITLE
Fix the wrong cmake path in wasi example comments

### DIFF
--- a/examples/wasi/main.c
+++ b/examples/wasi/main.c
@@ -3,7 +3,7 @@ Example of instantiating a WebAssembly which uses WASI imports.
 
 You can compile and run this example on Linux with:
 
-   cmake example/
+   cmake examples/
    cargo build --release -p wasmtime-c-api
    cc examples/wasi/main.c \
        -I crates/c-api/include \

--- a/examples/wasi/main.rs
+++ b/examples/wasi/main.rs
@@ -2,7 +2,7 @@
 
 /*
 You can execute this example with:
-    cmake example/
+    cmake examples/
     cargo run --example wasi
 */
 


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
