### PR TITLE
refactor: using emit_cmp helper to refactor lowering of selection ins…

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2082,7 +2082,7 @@
 ;; than one instruction for certain types (e.g., XMM-held, I128).
 
 (rule (lower (has_type ty (select (maybe_uextend (icmp cc a @ (value_type (fits_in_64 a_ty)) b)) x y)))
-      (lower_select_icmp ty (emit_cmp cc a b ) x y))
+      (lower_select_icmp ty (emit_cmp cc a b) x y))
 
 ;; Finally, we lower `select` from a condition value `c`. These rules are meant
 ;; to be the final, default lowerings if no other patterns matched above.

--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -2082,8 +2082,7 @@
 ;; than one instruction for certain types (e.g., XMM-held, I128).
 
 (rule (lower (has_type ty (select (maybe_uextend (icmp cc a @ (value_type (fits_in_64 a_ty)) b)) x y)))
-      (let ((size OperandSize (raw_operand_size_of_type a_ty)))
-           (with_flags (x64_cmp size b a) (cmove_from_values ty cc x y))))
+      (lower_select_icmp ty (emit_cmp cc a b ) x y))
 
 ;; Finally, we lower `select` from a condition value `c`. These rules are meant
 ;; to be the final, default lowerings if no other patterns matched above.
@@ -2098,6 +2097,10 @@
 (rule -2 (lower (has_type ty (select c @ (value_type $I128) x y)))
       (let ((cond_result IcmpCondResult (cmp_zero_i128 (CC.Z) c)))
         (select_icmp cond_result x y)))
+
+(decl lower_select_icmp (Type IcmpCondResult Value Value) InstOutput)
+(rule (lower_select_icmp ty (IcmpCondResult.Condition flags cc) x y)
+      (with_flags flags (cmove_from_values ty cc x y)))
 
 ;; Specializations for floating-point compares to generate a `mins*` or a
 ;; `maxs*` instruction. These are equivalent to the "pseudo-m{in,ax}"


### PR DESCRIPTION
This PR implements the second part of issue #5869 .

As lowering the `select` instruction based on  [`fcmp`](https://github.com/bytecodealliance/wasmtime/blob/9d8ca828d1888013b45570a94267778962846ad6/cranelift/codegen/src/isa/x64/lower.isle#L2073). I declare a helper function for lowering `icmp`-based select instruction.


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
