### PR TITLE
wasmtime: Fix Bench API Build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -281,6 +281,9 @@ jobs:
     # Check that benchmarks of the cranelift project build
     - run: cargo check --benches -p cranelift-codegen
 
+    # Check that the bench-api compiles
+    - run: cargo check -p wasmtime-bench-api
+
     # Check some feature combinations of the `wasmtime-c-api` crate
     - run: cargo check -p wasmtime-c-api --no-default-features
     - run: cargo check -p wasmtime-c-api --no-default-features --features wat

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -18,8 +18,10 @@ doctest = false
 anyhow = { workspace = true }
 shuffling-allocator = { version = "1.1.1", optional = true }
 target-lexicon = { workspace = true }
-wasmtime = { workspace = true, features = ["cache", "cranelift"] }
-wasmtime-cli-flags = { workspace = true, default-features = true }
+wasmtime = { workspace = true, default-features = true }
+wasmtime-cli-flags = { workspace = true, default-features = true, features = [
+    "cranelift",
+] }
 wasmtime-wasi = { workspace = true, default-features = true }
 wasmtime-wasi-nn = { workspace = true, optional = true }
 wasi-cap-std-sync = { workspace = true }

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -18,7 +18,7 @@ doctest = false
 anyhow = { workspace = true }
 shuffling-allocator = { version = "1.1.1", optional = true }
 target-lexicon = { workspace = true }
-wasmtime = { workspace = true }
+wasmtime = { workspace = true, features = ["cache", "cranelift"] }
 wasmtime-cli-flags = { workspace = true, default-features = true }
 wasmtime-wasi = { workspace = true, default-features = true }
 wasmtime-wasi-nn = { workspace = true, optional = true }


### PR DESCRIPTION
👋 Hey,

It looks like the bench-api package is broken and no longer builds. I think we just need to add the default features to get the necessary API's enabled.

I've also added a check in CI that runs `cargo check` on this package to ensure that this does not regress in the future. 