### PR TITLE
Expand further minimization section of documentation

### DIFF
--- a/docs/examples-minimal.md
+++ b/docs/examples-minimal.md
@@ -221,9 +221,8 @@ $ ls -l ./target/aarch64-apple-darwin/release/wasmtime
 Above shows an example of taking the default `cargo build` result of 130M down
 to a 2.1M binary for the `wasmtime` executable. Similar steps can be done to
 reduce the size of the C API binary artifact as well which currently produces a
-~2.8M dynamic library. This is currently the smallest that can be gained with
-the source-code as-is, but there's still possible size reductions which haven't
-been implemented yet.
+~2.8M dynamic library. This is currently the smallest size with the source code
+as-is, but there are more size reductions which haven't been implemented yet.
 
 This is a listing of some example sources of binary size. Some sources of binary
 size may not apply to custom embeddings since, for example, your custom
@@ -274,7 +273,7 @@ embedding might already not use WASI and might already not be included.
   from a compiled footprint point of view while not sacrificing everything in
   terms of performance. Note though that Winch is still under development.
 
-Above is some future avenues to take in terms of reducing the binary size of
+Above are some future avenues to take in terms of reducing the binary size of
 Wasmtime and various tradeoffs that can be made. The Wasmtime project is eager
 to hear embedder use cases/profiles if Wasmtime is not suitable for binary size
 reasons today. Please feel free to [open an


### PR DESCRIPTION
This commit fills out the page about producing minimal builds a bit more. The intention here is to provide examples of ideas about how to reduce size further as well as current limitations and how they can be evaluated.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
