### PR TITLE
wasi-http: Return an optional trailers from future-trailers.get

### DIFF
--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -251,8 +251,9 @@ interface types {
     ///
     /// The `result` represents that either the HTTP Request or Response body,
     /// as well as any trailers, were received successfully, or that an error
-    /// occured receiving them.
-    get: func() -> option<result<trailers, error>>;
+    /// occured receiving them. The optional `trailers` indicates whether or not
+    /// trailers were present in the body.
+    get: func() -> option<result<option<trailers>, error>>;
   }
 
   /// Represents an outgoing HTTP Response.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -251,8 +251,9 @@ interface types {
     ///
     /// The `result` represents that either the HTTP Request or Response body,
     /// as well as any trailers, were received successfully, or that an error
-    /// occured receiving them.
-    get: func() -> option<result<trailers, error>>;
+    /// occured receiving them. The optional `trailers` indicates whether or not
+    /// trailers were present in the body.
+    get: func() -> option<result<option<trailers>, error>>;
   }
 
   /// Represents an outgoing HTTP Response.


### PR DESCRIPTION
Avoid creating a new fields resource to represent the case where no trailers were present in an `incoming-body` by making the returned trailers optional. This mirrors the optional trailers parameter to `outgoing-body.finish`.

Fixes #7275 

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
