### PR TITLE
mpk: maintain mapping of pkey ID to stripe ID

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2374,7 +2374,8 @@ impl PoolingAllocationConfig {
     ///   supported
     /// - `disable`: never use MPK
     ///
-    /// By default this value is `disabled`, but may become `auto` in future releases.
+    /// By default this value is `disabled`, but may become `auto` in future
+    /// releases.
     ///
     /// __WARNING__: this configuration options is still experimental--use at
     /// your own risk! MPK uses kernel and CPU features to protect memory


### PR DESCRIPTION
Previously, we assumed that the Wasmtime engine would be able to
allocate keys 1-15 from the OS, in that order. (Recall that Linux
reserves key 0 for itself). While enabling various tests for MPK,
tests in `wasmtime_fuzzing::oracles` would fail because Wasmtime could
only start allocating at key 2, e.g.; it turns out that the
`diff_v8::smoke` test instantiates V8 which happens to allocate a key
for itself.

The reason for the "allocate keys 1-15 in order" assumption was that the
logic for calculating the stripe each key owned was very simple: `key -
1`. We needed some way to map each key ID to the stripe ID it is
associated with.

With this change, we maintain a little bit more state in order to make
the mapping less brittle. `ProtectionKey` stores the "key ID to slice
ID" mapping as an additional `u32` in the struct. This means that,
regardless of what other code in the process allocates MPK keys,
Wasmtime should be able to work fine with the remaining keys it can
allocate.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
