### PR TITLE
[release-14.0] Backport removal of `posix-signals-on-macos`

### DIFF
--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -448,9 +448,7 @@ pub use anyhow::{Error, Result};
 pub mod component;
 
 cfg_if::cfg_if! {
-    if #[cfg(all(target_os = "macos", not(feature = "posix-signals-on-macos")))] {
-        // no extensions for macOS at this time
-    } else if #[cfg(unix)] {
+    if #[cfg(unix)] {
         pub mod unix;
     } else if #[cfg(windows)] {
         pub mod windows;


### PR DESCRIPTION
Remove the leftover usage of `posix-signals-on-macos` (#7360)

This follows up #6807 and removes the last remaining reference to the removed `posix-signals-on-macos` feature flag.

Note that `lib.rs` now imports `mod unix` on MacOS. This change is similar to the change in `traphandlers.rs` in #6807. It is needed for hosts that use signals instead of Mach ports on MacOs.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
