### PR TITLE
Release Wasmtime 14.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-array-literals"
-version = "14.0.1"
+version = "14.0.2"
 
 [[package]]
 name = "byteorder"
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -574,14 +574,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -609,25 +609,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.101.1"
+version = "0.101.2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "serde",
  "serde_derive",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.0",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.101.1"
+version = "0.101.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "verify-component-adapter"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -2993,7 +2993,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "bitflags 2.3.3",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "byte-array-literals",
  "object",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3309,14 +3309,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3445,7 +3445,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3461,11 +3461,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "14.0.1"
+version = "14.0.2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3488,7 +3488,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3540,7 +3540,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3554,7 +3554,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "backtrace",
  "cc",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "object",
  "once_cell",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "cc",
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3773,7 +3773,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "openvino",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -3808,7 +3808,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3823,7 +3823,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -3833,7 +3833,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "14.0.1"
+version = "14.0.2"
 
 [[package]]
 name = "wast"
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "14.0.1"
+version = "14.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3979,7 +3979,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,7 +128,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "14.0.1"
+version = "14.0.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -136,58 +136,58 @@ edition = "2021"
 rust-version = "1.70.0"
 
 [workspace.dependencies]
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=14.0.1" }
-wasmtime = { path = "crates/wasmtime", version = "14.0.1", default-features = false }
-wasmtime-cache = { path = "crates/cache", version = "=14.0.1" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=14.0.1" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=14.0.1" }
-wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=14.0.1" }
-wasmtime-winch = { path = "crates/winch", version = "=14.0.1" }
-wasmtime-environ = { path = "crates/environ", version = "=14.0.1" }
-wasmtime-explorer = { path = "crates/explorer", version = "=14.0.1" }
-wasmtime-fiber = { path = "crates/fiber", version = "=14.0.1" }
-wasmtime-types = { path = "crates/types", version = "14.0.1" }
-wasmtime-jit = { path = "crates/jit", version = "=14.0.1" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=14.0.1" }
-wasmtime-runtime = { path = "crates/runtime", version = "=14.0.1" }
-wasmtime-wast = { path = "crates/wast", version = "=14.0.1" }
-wasmtime-wasi = { path = "crates/wasi", version = "14.0.1", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=14.0.1", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "14.0.1" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "14.0.1" }
-wasmtime-component-util = { path = "crates/component-util", version = "=14.0.1" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=14.0.1" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=14.0.1" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=14.0.1" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=14.0.2" }
+wasmtime = { path = "crates/wasmtime", version = "14.0.2", default-features = false }
+wasmtime-cache = { path = "crates/cache", version = "=14.0.2" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=14.0.2" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=14.0.2" }
+wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=14.0.2" }
+wasmtime-winch = { path = "crates/winch", version = "=14.0.2" }
+wasmtime-environ = { path = "crates/environ", version = "=14.0.2" }
+wasmtime-explorer = { path = "crates/explorer", version = "=14.0.2" }
+wasmtime-fiber = { path = "crates/fiber", version = "=14.0.2" }
+wasmtime-types = { path = "crates/types", version = "14.0.2" }
+wasmtime-jit = { path = "crates/jit", version = "=14.0.2" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=14.0.2" }
+wasmtime-runtime = { path = "crates/runtime", version = "=14.0.2" }
+wasmtime-wast = { path = "crates/wast", version = "=14.0.2" }
+wasmtime-wasi = { path = "crates/wasi", version = "14.0.2", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=14.0.2", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "14.0.2" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "14.0.2" }
+wasmtime-component-util = { path = "crates/component-util", version = "=14.0.2" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=14.0.2" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=14.0.2" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=14.0.2" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=14.0.1", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=14.0.1" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=14.0.1" }
-wasi-common = { path = "crates/wasi-common", version = "=14.0.1" }
-wasi-tokio = { path = "crates/wasi-common/tokio", version = "=14.0.1" }
-wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=14.0.1" }
+wiggle = { path = "crates/wiggle", version = "=14.0.2", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=14.0.2" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=14.0.2" }
+wasi-common = { path = "crates/wasi-common", version = "=14.0.2" }
+wasi-tokio = { path = "crates/wasi-common/tokio", version = "=14.0.2" }
+wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=14.0.2" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=14.0.1" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=14.0.1" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=14.0.2" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=14.0.2" }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.101.1" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.101.1", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.101.1" }
-cranelift-entity = { path = "cranelift/entity", version = "0.101.1" }
-cranelift-native = { path = "cranelift/native", version = "0.101.1" }
-cranelift-module = { path = "cranelift/module", version = "0.101.1" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.101.1" }
-cranelift-reader = { path = "cranelift/reader", version = "0.101.1" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.101.2" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.101.2", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.101.2" }
+cranelift-entity = { path = "cranelift/entity", version = "0.101.2" }
+cranelift-native = { path = "cranelift/native", version = "0.101.2" }
+cranelift-module = { path = "cranelift/module", version = "0.101.2" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.101.2" }
+cranelift-reader = { path = "cranelift/reader", version = "0.101.2" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.101.1" }
-cranelift-jit = { path = "cranelift/jit", version = "0.101.1" }
+cranelift-object = { path = "cranelift/object", version = "0.101.2" }
+cranelift-jit = { path = "cranelift/jit", version = "0.101.2" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.101.1" }
-cranelift-control = { path = "cranelift/control", version = "0.101.1" }
-cranelift = { path = "cranelift/umbrella", version = "0.101.1" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.101.2" }
+cranelift-control = { path = "cranelift/control", version = "0.101.2" }
+cranelift = { path = "cranelift/umbrella", version = "0.101.2" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.12.1" }
+winch-codegen = { path = "winch/codegen", version = "=0.12.2" }
 winch-filetests = { path = "winch/filetests" }
 winch-test-macros = { path = "winch/test-macros" }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,16 @@
 --------------------------------------------------------------------------------
 
+## 14.0.2
+
+Released 2023-10-25
+
+### Fixed
+
+* Make the `wasmtime::unix` module accessible on macOS again.
+  [#7360](https://github.com/bytecodealliance/wasmtime/pull/7360)
+
+--------------------------------------------------------------------------------
+
 ## 14.0.1
 
 Released 2023-10-23

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 ## 14.0.2
 
-Released 2023-10-25
+Released 2023-10-26
 
 ### Fixed
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,18 @@
 --------------------------------------------------------------------------------
 
+## 14.0.1
+
+Released 2023-10-23
+
+### Fixed
+
+* Cranelift: preserve uext and sext flags for parameters on x86\_64 and apple
+  aarch64. Note that this does not affect Wasmtime and is only intended for
+  Cranelift embedders such as `rustc_codegen_cranelift`.
+  [#7333](https://github.com/bytecodealliance/wasmtime/pull/7333)
+
+--------------------------------------------------------------------------------
+
 ## 14.0.0
 
 Released 2023-10-20.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,11 @@ Released 2023-10-26
 * Make the `wasmtime::unix` module accessible on macOS again.
   [#7360](https://github.com/bytecodealliance/wasmtime/pull/7360)
 
+* Inter-crate dependencies between `cranelift-*` crates now disable the
+  `default` feature meaning that it's possible for embedders to depend on
+  `cranelift-codegen` as well without the `default` feature.
+  [#7369](https://github.com/bytecodealliance/wasmtime/pull/7369)
+
 --------------------------------------------------------------------------------
 
 ## 14.0.1

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.101.1"
+version = "0.101.2"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.101.1"
+version = "0.101.2"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -16,7 +16,7 @@ edition.workspace = true
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.101.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.101.2" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -41,8 +41,8 @@ criterion = { version = "0.5.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.101.1" }
-cranelift-isle = { path = "../isle/isle", version = "=0.101.1" }
+cranelift-codegen-meta = { path = "meta", version = "0.101.2" }
+cranelift-isle = { path = "../isle/isle", version = "=0.101.2" }
 
 [features]
 default = ["std", "unwind", "host-arch"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.101.1"
+version = "0.101.2"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -12,4 +12,4 @@ edition.workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.101.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.101.2" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.101.1"
+version = "0.101.2"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.101.1"
+version = "0.101.2"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.101.1"
+version = "0.101.2"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.101.1"
+version = "0.101.2"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.101.1"
+version = "0.101.2"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.101.1"
+version = "0.101.2"
 
 [dependencies]
 codespan-reporting = { version = "0.11.1", optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.101.1"
+version = "0.101.2"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.101.1"
+version = "0.101.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.101.1"
+version = "0.101.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.101.1"
+version = "0.101.2"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.101.1"
+version = "0.101.2"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.101.1"
+version = "0.101.2"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.101.1"
+version = "0.101.2"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.101.1"
+version = "0.101.2"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -200,7 +200,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "14.0.1"
+#define WASMTIME_VERSION "14.0.2"
 /**
  * \brief Wasmtime major version number.
  */
@@ -212,7 +212,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 1
+#define WASMTIME_VERSION_PATCH 2
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -13,6 +13,10 @@ audited_as = "0.99.1"
 version = "0.101.1"
 audited_as = "0.101.0"
 
+[[unpublished.cranelift]]
+version = "0.101.2"
+audited_as = "0.101.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -24,6 +28,10 @@ audited_as = "0.99.1"
 [[unpublished.cranelift-bforest]]
 version = "0.101.1"
 audited_as = "0.101.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.101.2"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-codegen]]
 version = "0.100.0"
@@ -37,6 +45,10 @@ audited_as = "0.99.1"
 version = "0.101.1"
 audited_as = "0.101.0"
 
+[[unpublished.cranelift-codegen]]
+version = "0.101.2"
+audited_as = "0.101.1"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -48,6 +60,10 @@ audited_as = "0.99.1"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.101.1"
 audited_as = "0.101.0"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.101.2"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.100.0"
@@ -61,6 +77,10 @@ audited_as = "0.99.1"
 version = "0.101.1"
 audited_as = "0.101.0"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.101.2"
+audited_as = "0.101.1"
+
 [[unpublished.cranelift-control]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -72,6 +92,10 @@ audited_as = "0.99.1"
 [[unpublished.cranelift-control]]
 version = "0.101.1"
 audited_as = "0.101.0"
+
+[[unpublished.cranelift-control]]
+version = "0.101.2"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-entity]]
 version = "0.100.0"
@@ -85,6 +109,10 @@ audited_as = "0.99.1"
 version = "0.101.1"
 audited_as = "0.101.0"
 
+[[unpublished.cranelift-entity]]
+version = "0.101.2"
+audited_as = "0.101.1"
+
 [[unpublished.cranelift-frontend]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -96,6 +124,10 @@ audited_as = "0.99.1"
 [[unpublished.cranelift-frontend]]
 version = "0.101.1"
 audited_as = "0.101.0"
+
+[[unpublished.cranelift-frontend]]
+version = "0.101.2"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.100.0"
@@ -109,6 +141,10 @@ audited_as = "0.99.1"
 version = "0.101.1"
 audited_as = "0.101.0"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.101.2"
+audited_as = "0.101.1"
+
 [[unpublished.cranelift-isle]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -120,6 +156,10 @@ audited_as = "0.99.1"
 [[unpublished.cranelift-isle]]
 version = "0.101.1"
 audited_as = "0.101.0"
+
+[[unpublished.cranelift-isle]]
+version = "0.101.2"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-jit]]
 version = "0.100.0"
@@ -133,6 +173,10 @@ audited_as = "0.99.1"
 version = "0.101.1"
 audited_as = "0.101.0"
 
+[[unpublished.cranelift-jit]]
+version = "0.101.2"
+audited_as = "0.101.1"
+
 [[unpublished.cranelift-module]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -144,6 +188,10 @@ audited_as = "0.99.1"
 [[unpublished.cranelift-module]]
 version = "0.101.1"
 audited_as = "0.101.0"
+
+[[unpublished.cranelift-module]]
+version = "0.101.2"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-native]]
 version = "0.100.0"
@@ -157,6 +205,10 @@ audited_as = "0.99.1"
 version = "0.101.1"
 audited_as = "0.101.0"
 
+[[unpublished.cranelift-native]]
+version = "0.101.2"
+audited_as = "0.101.1"
+
 [[unpublished.cranelift-object]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -168,6 +220,10 @@ audited_as = "0.99.1"
 [[unpublished.cranelift-object]]
 version = "0.101.1"
 audited_as = "0.101.0"
+
+[[unpublished.cranelift-object]]
+version = "0.101.2"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-reader]]
 version = "0.100.0"
@@ -181,6 +237,10 @@ audited_as = "0.99.1"
 version = "0.101.1"
 audited_as = "0.101.0"
 
+[[unpublished.cranelift-reader]]
+version = "0.101.2"
+audited_as = "0.101.1"
+
 [[unpublished.cranelift-serde]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -193,6 +253,10 @@ audited_as = "0.99.1"
 version = "0.101.1"
 audited_as = "0.101.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.101.2"
+audited_as = "0.101.1"
+
 [[unpublished.cranelift-wasm]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -205,6 +269,10 @@ audited_as = "0.99.1"
 version = "0.101.1"
 audited_as = "0.101.0"
 
+[[unpublished.cranelift-wasm]]
+version = "0.101.2"
+audited_as = "0.101.1"
+
 [[unpublished.wasi-cap-std-sync]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -216,6 +284,10 @@ audited_as = "12.0.1"
 [[unpublished.wasi-cap-std-sync]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasi-cap-std-sync]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasi-common]]
 version = "13.0.0"
@@ -229,6 +301,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasi-common]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasi-tokio]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -240,6 +316,10 @@ audited_as = "12.0.1"
 [[unpublished.wasi-tokio]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasi-tokio]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime]]
 version = "13.0.0"
@@ -253,6 +333,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -264,6 +348,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-asm-macros]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-cache]]
 version = "13.0.0"
@@ -277,6 +365,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-cache]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -288,6 +380,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-cli]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "13.0.0"
@@ -301,6 +397,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-component-macro]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -312,6 +412,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-component-macro]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-component-macro]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-component-util]]
 version = "13.0.0"
@@ -325,6 +429,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-component-util]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-cranelift]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -336,6 +444,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-cranelift]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "13.0.0"
@@ -349,6 +461,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-cranelift-shared]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-environ]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -360,6 +476,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-environ]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-environ]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-explorer]]
 version = "13.0.0"
@@ -373,6 +493,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-explorer]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-fiber]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -384,6 +508,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-fiber]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-fiber]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-jit]]
 version = "13.0.0"
@@ -397,6 +525,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-jit]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -408,6 +540,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-jit-debug]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "13.0.0"
@@ -421,6 +557,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-runtime]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -432,6 +572,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-runtime]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-runtime]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-types]]
 version = "13.0.0"
@@ -445,6 +589,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-types]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-wasi]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -456,6 +604,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-wasi]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-wasi]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "13.0.0"
@@ -469,6 +621,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -480,6 +636,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-wasi-nn]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "13.0.0"
@@ -493,6 +653,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-wast]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -504,6 +668,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-wast]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-wast]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-winch]]
 version = "13.0.0"
@@ -517,6 +685,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-winch]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -528,6 +700,10 @@ audited_as = "12.0.1"
 [[unpublished.wasmtime-wit-bindgen]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "14.0.0"
@@ -537,6 +713,10 @@ audited_as = "13.0.0"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wiggle]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -548,6 +728,10 @@ audited_as = "12.0.1"
 [[unpublished.wiggle]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wiggle]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wiggle-generate]]
 version = "13.0.0"
@@ -561,6 +745,10 @@ audited_as = "12.0.1"
 version = "14.0.1"
 audited_as = "14.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "14.0.2"
+audited_as = "14.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -572,6 +760,10 @@ audited_as = "12.0.1"
 [[unpublished.wiggle-macro]]
 version = "14.0.1"
 audited_as = "14.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "14.0.2"
+audited_as = "14.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -588,6 +780,10 @@ audited_as = "0.10.1"
 [[unpublished.winch-codegen]]
 version = "0.12.1"
 audited_as = "0.12.0"
+
+[[unpublished.winch-codegen]]
+version = "0.12.2"
+audited_as = "0.12.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -782,6 +978,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.101.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -797,6 +999,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.101.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -818,6 +1026,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.101.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -833,6 +1047,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-meta]]
 version = "0.101.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -854,6 +1074,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.101.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -869,6 +1095,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-control]]
 version = "0.101.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -890,6 +1122,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.101.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -905,6 +1143,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-frontend]]
 version = "0.101.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -926,6 +1170,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.101.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -941,6 +1191,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-isle]]
 version = "0.101.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -962,6 +1218,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.101.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -977,6 +1239,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-module]]
 version = "0.101.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -998,6 +1266,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.101.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1013,6 +1287,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-object]]
 version = "0.101.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1034,6 +1314,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.101.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1052,6 +1338,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.101.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1067,6 +1359,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.101.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1423,6 +1721,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-cap-std-sync]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-common]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1441,6 +1745,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-tokio]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1456,6 +1766,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasi-tokio]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasi-tokio]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1778,6 +2094,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1793,6 +2115,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1814,6 +2142,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1829,6 +2163,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1850,6 +2190,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1865,6 +2211,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1886,6 +2238,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1901,6 +2259,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1922,6 +2286,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cranelift-shared]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-environ]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1937,6 +2307,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-environ]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-environ]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1958,6 +2334,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-explorer]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-fiber]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1973,6 +2355,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-fiber]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-fiber]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1994,6 +2382,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2009,6 +2403,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-debug]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2030,6 +2430,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-runtime]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2045,6 +2451,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-runtime]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-runtime]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2066,6 +2478,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-types]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2081,6 +2499,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2102,6 +2526,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-http]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-nn]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2117,6 +2547,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-nn]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-nn]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2138,6 +2574,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-threads]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wast]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2153,6 +2595,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wast]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wast]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2174,6 +2622,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-winch]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wit-bindgen]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2189,6 +2643,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wit-bindgen]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wit-bindgen]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2201,6 +2661,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2306,6 +2772,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2324,6 +2796,12 @@ when = "2023-10-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "14.0.1"
+when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2339,6 +2817,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "14.0.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2371,6 +2855,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.12.0"
 when = "2023-10-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.12.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.12.1"
+version = "0.12.2"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 14.0.2, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
