### PR TITLE
Allow disabling the host-arch feature of cranelift-codegen

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=15.0.0" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
 cranelift-wasm = { path = "cranelift/wasm", version = "0.102.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.102.0" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.102.0", default-features = false, features = ["std", "unwind"] }
 cranelift-frontend = { path = "cranelift/frontend", version = "0.102.0" }
 cranelift-entity = { path = "cranelift/entity", version = "0.102.0" }
 cranelift-native = { path = "cranelift/native", version = "0.102.0" }

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 log = { workspace = true }
 wasmtime-environ = { workspace = true }
 cranelift-wasm = { workspace = true }
-cranelift-codegen = { workspace = true }
+cranelift-codegen = { workspace = true, features = ["default"] }
 cranelift-frontend = { workspace = true }
 cranelift-entity = { workspace = true }
 cranelift-native = { workspace = true }


### PR DESCRIPTION
This is required to compile for a target which doesn't have a cranelift backend. Before this change using any of the cranelift crates that depend on cranelift-codegen would forcefully enable all default features and thus host-arch. With this change only the std and unwind features are still forcefully enabled as cranelift-codegen doesn't compile with either disabled.

Required for https://github.com/rust-lang/rust/pull/81746