### PR TITLE
Update some crates to align on latest `rustix`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -387,7 +387,7 @@ jobs:
     env:
       QEMU_BUILD_VERSION: 8.1.1
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix: ${{ fromJson(needs.determine.outputs.test-matrix) }}
     steps:
     - uses: actions/checkout@v3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,9 +2262,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.20"
+version = "0.38.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
 dependencies = [
  "bitflags 2.4.1",
  "errno",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,9 +194,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "block-buffer"
@@ -257,7 +257,7 @@ checksum = "b779b2d0a001c125b4584ad586268fb4b92d957bff8d26d7fe0dd78283faa814"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "io-lifetimes 2.0.2",
+ "io-lifetimes",
  "windows-sys",
 ]
 
@@ -269,7 +269,7 @@ checksum = "6ffc30dee200c20b4dcb80572226f42658e1d9c4b668656d7cc59c33d50e396e"
 dependencies = [
  "cap-primitives",
  "cap-std",
- "rustix 0.38.8",
+ "rustix",
  "smallvec",
 ]
 
@@ -282,10 +282,10 @@ dependencies = [
  "ambient-authority",
  "fs-set-times",
  "io-extras",
- "io-lifetimes 2.0.2",
+ "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 0.38.8",
+ "rustix",
  "windows-sys",
  "winx",
 ]
@@ -308,8 +308,8 @@ checksum = "84bade423fa6403efeebeafe568fdb230e8c590a275fba2ba978dd112efcf6e9"
 dependencies = [
  "cap-primitives",
  "io-extras",
- "io-lifetimes 2.0.2",
- "rustix 0.38.8",
+ "io-lifetimes",
+ "rustix",
 ]
 
 [[package]]
@@ -320,7 +320,7 @@ checksum = "7b9e3348a3510c4619b4c7a7bcdef09a71221da18f266bda3ed6b9aea2c509e2"
 dependencies = [
  "cap-std",
  "rand",
- "rustix 0.38.8",
+ "rustix",
  "uuid",
 ]
 
@@ -332,7 +332,7 @@ checksum = "f8f52b3c8f4abfe3252fd0a071f3004aaa3b18936ec97bdbd8763ce03aff6247"
 dependencies = [
  "cap-primitives",
  "once_cell",
- "rustix 0.38.8",
+ "rustix",
  "winx",
 ]
 
@@ -1115,12 +1115,9 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fd-lock"
@@ -1129,7 +1126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b0377f1edc77dbd1118507bc7a66e4ab64d2b90c66f90726dc801e73a8c68f9"
 dependencies = [
  "cfg-if",
- "rustix 0.38.8",
+ "rustix",
  "windows-sys",
 ]
 
@@ -1192,8 +1189,8 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd738b84894214045e8414eaded76359b4a5773f0a0a56b16575110739cdcf39"
 dependencies = [
- "io-lifetimes 2.0.2",
- "rustix 0.38.8",
+ "io-lifetimes",
+ "rustix",
  "windows-sys",
 ]
 
@@ -1283,7 +1280,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d12c0aed7f1e24276a241aadc4cb8ea9f83000f34bc062b7cc2d51e3b0fabd"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "debugid",
  "fxhash",
  "serde",
@@ -1563,18 +1560,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d3c230ee517ee76b1cc593b52939ff68deda3fae9e41eca426c6b4993df51c4"
 dependencies = [
- "io-lifetimes 2.0.2",
- "windows-sys",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
-dependencies = [
- "hermit-abi 0.3.0",
- "libc",
+ "io-lifetimes",
  "windows-sys",
 ]
 
@@ -1592,13 +1578,12 @@ checksum = "879d54834c8c76457ef4293a689b2a8c59b076067ad77b15efafbb05f92a592b"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.0",
- "io-lifetimes 1.0.10",
- "rustix 0.37.13",
+ "rustix",
  "windows-sys",
 ]
 
@@ -1688,9 +1673,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -1721,15 +1706,9 @@ checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.3"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "listenfd"
@@ -1783,11 +1762,11 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memfd"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc89ccdc6e10d6907450f753537ebc5c5d3460d2e4e62ea74bd571db62c0f9e"
+checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.37.13",
+ "rustix",
 ]
 
 [[package]]
@@ -2283,29 +2262,15 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.37.13"
+version = "0.38.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
+checksum = "67ce50cb2e16c2903e30d1cbccfd8387a74b9d4c938b6a4c5ec6cc7556f7a8a0"
 dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes 1.0.10",
- "libc",
- "linux-raw-sys 0.3.3",
- "windows-sys",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
-dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "errno",
  "itoa",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys",
  "once_cell",
  "windows-sys",
 ]
@@ -2593,12 +2558,12 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27ce32341b2c0b70c144bbf35627fdc1ef18c76ced5e5e7b3ee8b5ba6b2ab6a0"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "cap-fs-ext",
  "cap-std",
  "fd-lock",
- "io-lifetimes 2.0.2",
- "rustix 0.38.8",
+ "io-lifetimes",
+ "rustix",
  "windows-sys",
  "winx",
 ]
@@ -2611,15 +2576,14 @@ checksum = "d7fa7e55043acb85fca6b3c01485a2eeb6b69c5d21002e273c79e465f43b7ac1"
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
- "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.13",
+ "rustix",
  "windows-sys",
 ]
 
@@ -3019,9 +2983,9 @@ dependencies = [
  "cap-time-ext",
  "fs-set-times",
  "io-extras",
- "io-lifetimes 2.0.2",
+ "io-lifetimes",
  "once_cell",
- "rustix 0.38.8",
+ "rustix",
  "system-interface",
  "tempfile",
  "tracing",
@@ -3034,12 +2998,12 @@ name = "wasi-common"
 version = "15.0.0"
 dependencies = [
  "anyhow",
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "cap-rand",
  "cap-std",
  "io-extras",
  "log",
- "rustix 0.38.8",
+ "rustix",
  "tempfile",
  "test-log",
  "test-programs-artifacts",
@@ -3072,8 +3036,8 @@ dependencies = [
  "cap-std",
  "cap-tempfile",
  "io-extras",
- "io-lifetimes 2.0.2",
- "rustix 0.38.8",
+ "io-lifetimes",
+ "rustix",
  "tempfile",
  "tokio",
  "wasi-cap-std-sync",
@@ -3366,7 +3330,7 @@ dependencies = [
  "log",
  "once_cell",
  "pretty_env_logger 0.5.0",
- "rustix 0.38.8",
+ "rustix",
  "serde",
  "serde_derive",
  "sha2",
@@ -3398,7 +3362,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "rayon",
- "rustix 0.38.8",
+ "rustix",
  "serde",
  "serde_derive",
  "serde_json",
@@ -3557,7 +3521,7 @@ dependencies = [
  "backtrace",
  "cc",
  "cfg-if",
- "rustix 0.38.8",
+ "rustix",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
  "windows-sys",
@@ -3632,7 +3596,7 @@ dependencies = [
  "log",
  "object",
  "rustc-demangle",
- "rustix 0.38.8",
+ "rustix",
  "serde",
  "serde_derive",
  "target-lexicon",
@@ -3649,7 +3613,7 @@ version = "15.0.0"
 dependencies = [
  "object",
  "once_cell",
- "rustix 0.38.8",
+ "rustix",
  "wasmtime-versioned-export-macros",
 ]
 
@@ -3680,7 +3644,7 @@ dependencies = [
  "paste",
  "proptest",
  "rand",
- "rustix 0.38.8",
+ "rustix",
  "sptr",
  "wasm-encoder",
  "wasmtime-asm-macros",
@@ -3718,7 +3682,7 @@ version = "15.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "bytes",
  "cap-fs-ext",
  "cap-net-ext",
@@ -3728,11 +3692,11 @@ dependencies = [
  "fs-set-times",
  "futures",
  "io-extras",
- "io-lifetimes 2.0.2",
+ "io-lifetimes",
  "libc",
  "log",
  "once_cell",
- "rustix 0.38.8",
+ "rustix",
  "system-interface",
  "tempfile",
  "test-log",
@@ -3903,7 +3867,7 @@ version = "15.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "proptest",
  "thiserror",
  "tokio",
@@ -4117,7 +4081,7 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857cedf8371f690bb6782a3e2b065c54d1b6661be068aaf3eac8b45e813fdf8"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "windows-sys",
 ]
 
@@ -4127,7 +4091,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7d92ce0ca6b6074059413a9581a637550c3a740581c854f9847ec293c8aed71"
 dependencies = [
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "wit-bindgen-rust-macro",
 ]
 
@@ -4177,7 +4141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e87488b57a08e2cbbd076b325acbe7f8666965af174d69d5929cd373bd54547f"
 dependencies = [
  "anyhow",
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "indexmap 2.0.0",
  "log",
  "serde",

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1162,6 +1162,15 @@ this crate has to do with iterators and `Result` and such. No `unsafe` or
 anything like that, all looks good.
 """
 
+[[audits.fastrand]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "2.0.0 -> 2.0.1"
+notes = """
+This update had a few doc updates but no otherwise-substantial source code
+updates.
+"""
+
 [[audits.fd-lock]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -1578,6 +1587,12 @@ who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
 delta = "0.6.2 -> 0.6.3"
 notes = "Just a dependency version bump and documentation update"
+
+[[audits.memfd]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.6.3 -> 0.6.4"
+notes = "This commit only updated the dependency `rustix`, so same as before."
 
 [[audits.memoffset]]
 who = "Alex Crichton <alex@alexcrichton.com>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -372,10 +372,6 @@ notes = "we are exempting tokio, hyper, and their tightly coupled dependencies b
 version = "0.13.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.instant]]
-version = "0.1.12"
-criteria = "safe-to-deploy"
-
 [[exemptions.ipnet]]
 version = "2.5.0"
 criteria = "safe-to-deploy"
@@ -504,10 +500,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.redox_syscall]]
 version = "0.2.13"
-criteria = "safe-to-deploy"
-
-[[exemptions.redox_syscall]]
-version = "0.3.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.redox_users]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -640,8 +640,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.rustix]]
-version = "0.38.20"
-when = "2023-10-19"
+version = "0.38.14"
+when = "2023-09-20"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -3,195 +3,195 @@
 
 [[unpublished.cranelift]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-bforest]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-codegen]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-control]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-entity]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-jit]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-module]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-native]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-object]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-reader]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.cranelift-wasm]]
 version = "0.102.0"
-audited_as = "0.100.0"
+audited_as = "0.101.1"
 
 [[unpublished.wasi-cap-std-sync]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasi-common]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasi-tokio]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-cache]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-cli]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-component-macro]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-component-util]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-cranelift]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-environ]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-explorer]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-fiber]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-jit]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-runtime]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-types]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-winch]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wiggle]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wiggle-generate]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wiggle-macro]]
 version = "15.0.0"
-audited_as = "13.0.0"
+audited_as = "14.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -199,7 +199,7 @@ audited_as = "0.1.0"
 
 [[unpublished.winch-codegen]]
 version = "0.13.0"
-audited_as = "0.11.0"
+audited_as = "0.12.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -370,104 +370,104 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.cranelift]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-wasm]]
-version = "0.100.0"
-when = "2023-09-20"
+version = "0.101.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -541,6 +541,13 @@ user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
+[[publisher.is-terminal]]
+version = "0.4.9"
+when = "2023-07-06"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
 [[publisher.itoa]]
 version = "1.0.1"
 when = "2021-12-12"
@@ -563,8 +570,8 @@ user-login = "Amanieu"
 user-name = "Amanieu d'Antras"
 
 [[publisher.linux-raw-sys]]
-version = "0.4.3"
-when = "2023-06-14"
+version = "0.4.10"
+when = "2023-10-09"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -633,8 +640,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.rustix]]
-version = "0.38.8"
-when = "2023-08-10"
+version = "0.38.20"
+when = "2023-10-19"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -772,20 +779,20 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.wasi-cap-std-sync]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasi-common]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasi-tokio]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -867,152 +874,152 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasmtime]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-asm-macros]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cache]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-macro]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-util]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift-shared]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-explorer]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-fiber]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-debug]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-icache-coherence]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-runtime]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-types]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-winch]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wit-bindgen]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wmemcheck]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1031,20 +1038,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "13.0.0"
-when = "2023-09-20"
+version = "14.0.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1063,8 +1070,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "0.11.0"
-when = "2023-09-20"
+version = "0.12.1"
+when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1239,6 +1246,12 @@ criteria = "safe-to-deploy"
 version = "0.3.1"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.instant]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-run"
+version = "0.1.12"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.google.audits.libfuzzer-sys]]
 who = "ChromeOS"
 criteria = "safe-to-run"
@@ -1371,6 +1384,19 @@ criteria = "safe-to-deploy"
 delta = "2.2.1 -> 2.3.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.bitflags]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "2.3.3 -> 2.4.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.bitflags]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "2.4.0 -> 2.4.1"
+notes = "Only allowing new clippy lints"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.bytes]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
@@ -1429,6 +1455,12 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Nicolas Silva <nical@fastmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.9.3 -> 0.10.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fastrand]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.9.0 -> 2.0.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.flagset]]
@@ -1506,6 +1538,19 @@ criteria = "safe-to-deploy"
 version = "1.4.0"
 notes = "I have read over the macros, and audited the unsafe code."
 aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.libc]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.147 -> 0.2.148"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.libc]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.148 -> 0.2.149"
+notes = "New defintions for a new target we don't use"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.log]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
@@ -1625,6 +1670,18 @@ version = "1.9.3"
 notes = "All code written or reviewed by Josh Stone or Niko Matsakis."
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.redox_syscall]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.13 -> 0.2.16"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.redox_syscall]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.16 -> 0.3.5"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.rustc-hash]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"
@@ -1646,6 +1703,12 @@ aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supp
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.4.6 -> 0.4.7"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.tempfile]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "3.6.0 -> 3.8.0"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.toml]]


### PR DESCRIPTION
This commit addresses some dependabot warnings showing up on the Wasmtime repository by updating all dependencies to using the latest `rustix` release.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
