### PR TITLE
Relax no_delay assertion in tcp sockopts test

### DIFF
--- a/crates/test-programs/src/bin/preview2_tcp_sockopts.rs
+++ b/crates/test-programs/src/bin/preview2_tcp_sockopts.rs
@@ -12,8 +12,10 @@ fn test_tcp_sockopt_defaults(family: IpAddressFamily) {
         sock.ipv6_only().unwrap(); // Only verify that it has a default value at all, but either value is valid.
     }
 
-    sock.keep_alive().unwrap(); // Only verify that it has a default value at all, but either value is valid.
-    assert_eq!(sock.no_delay().unwrap(), false);
+    // Only verify that it has a default value at all, but either value is valid.
+    sock.keep_alive().unwrap();
+    sock.no_delay().unwrap();
+
     assert!(sock.unicast_hop_limit().unwrap() > 0);
     assert!(sock.receive_buffer_size().unwrap() > 0);
     assert!(sock.send_buffer_size().unwrap() > 0);


### PR DESCRIPTION
Addresses the failure at https://github.com/bytecodealliance/wasmtime/actions/runs/6645435155/job/18056751781

<details>

```
---- async_::preview2_tcp_sockopts stdout ----
preopen: TempDir { path: "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\wasi_components_preview2_tcp_sockopts.component_AJmWpM" }
[guest] stderr:
thread 'main' panicked at crates\test-programs\src\bin\preview2_tcp_sockopts.rs:16:5:
assertion `left == right` failed
  left: true
 right: false
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

===
thread 'async_::preview2_tcp_sockopts' panicked at crates\wasi\tests\all\async_.rs:305:55:
called `Result::unwrap()` on an `Err` value: error while executing at wasm backtrace:
    0: 0x11fc3 - <unknown>!__rust_start_panic
    1: 0x11e13 - <unknown>!rust_panic
    2: 0x11df0 - <unknown>!std::panicking::rust_panic_with_hook::hc93abff18edee779
    3: 0x1119c - <unknown>!std::panicking::begin_panic_handler::{{closure}}::h922bcdd9c6fdedfb
    4: 0x110c9 - <unknown>!std::sys_common::backtrace::__rust_end_short_backtrace::h2597d6ecb1d3419e
    5: 0x1170b - <unknown>!rust_begin_unwind
    6: 0x16693 - <unknown>!core::panicking::panic_fmt::h35d9e7e9c02f9eb5
    7: 0x18778 - <unknown>!core::panicking::assert_failed_inner::h1349768c866a993e
    8: 0x2bb7 - <unknown>!core::panicking::assert_failed::hfff6c709fc76e6d9
    9: 0x2fff - <unknown>!preview2_tcp_sockopts::test_tcp_sockopt_defaults::h6ddd327a0789600d
   10: 0x7791 - <unknown>!preview2_tcp_sockopts::main::he71c63222c6e5513
   11: 0x20b9 - <unknown>!core::ops::function::FnOnce::call_once::h1de15351afbb525d
   12: 0x2090 - <unknown>!std::sys_common::backtrace::__rust_begin_short_backtrace::h958e61dc07273f6f
   13: 0x2171 - <unknown>!std::rt::lang_start::{{closure}}::hb580c779a4c8841c
   14: 0xf5f7 - <unknown>!std::rt::lang_start_internal::h394de9c4666f4612
   15: 0x211c - <unknown>!std::rt::lang_start::h8991cdf32c426374
   16: 0x7939 - <unknown>!__main_void
   17: 0x206b - <unknown>!_start
   18: 0x2e6667 - wit-component:adapter:wasi_snapshot_preview1!wasi:cli/run@0.2.0-rc-2023-11-05#run
note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information

Caused by:
    wasm trap: wasm `unreachable` instruction executed
stack backtrace:
   0: rust_begin_unwind
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library\std\src/panicking.rs:595:5
   1: core::panicking::panic_fmt
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library\core\src/panicking.rs:67:14
   2: core::result::unwrap_failed
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library\core\src/result.rs:1652:5
   3: core::result::Result<T,E>::unwrap
   4: all::async_::preview2_tcp_sockopts::{{closure}}::test_impl::{{closure}}
   5: all::async_::preview2_tcp_sockopts::{{closure}}
   6: <core::pin::Pin<P> as core::future::future::Future>::poll
   7: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
   8: tokio::runtime::park::CachedParkThread::block_on
   9: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
  10: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
  11: tokio::runtime::context::runtime::enter_runtime
  12: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
  13: tokio::runtime::runtime::Runtime::block_on
  14: all::async_::preview2_tcp_sockopts
  15: all::async_::preview2_tcp_sockopts::{{closure}}
  16: core::ops::function::FnOnce::call_once
  17: core::ops::function::FnOnce::call_once
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library\core\src\ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

---- sync::preview2_tcp_sockopts stdout ----
preopen: TempDir { path: "C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\wasi_components_preview2_tcp_sockopts.component_xYoyAl" }
[guest] stderr:
thread 'main' panicked at crates\test-programs\src\bin\preview2_tcp_sockopts.rs:16:5:
assertion `left == right` failed
  left: true
 right: false
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

===
thread 'sync::preview2_tcp_sockopts' panicked at crates\wasi\tests\all\sync.rs:250:49:
called `Result::unwrap()` on an `Err` value: error while executing at wasm backtrace:
    0: 0x11fc3 - <unknown>!__rust_start_panic
    1: 0x11e13 - <unknown>!rust_panic
    2: 0x11df0 - <unknown>!std::panicking::rust_panic_with_hook::hc93abff18edee779
    3: 0x1119c - <unknown>!std::panicking::begin_panic_handler::{{closure}}::h922bcdd9c6fdedfb
    4: 0x110c9 - <unknown>!std::sys_common::backtrace::__rust_end_short_backtrace::h2597d6ecb1d3419e
    5: 0x1170b - <unknown>!rust_begin_unwind
    6: 0x16693 - <unknown>!core::panicking::panic_fmt::h35d9e7e9c02f9eb5
    7: 0x18778 - <unknown>!core::panicking::assert_failed_inner::h1349768c866a993e
    8: 0x2bb7 - <unknown>!core::panicking::assert_failed::hfff6c709fc76e6d9
    9: 0x2fff - <unknown>!preview2_tcp_sockopts::test_tcp_sockopt_defaults::h6ddd327a0789600d
   10: 0x7791 - <unknown>!preview2_tcp_sockopts::main::he71c63222c6e5513
   11: 0x20b9 - <unknown>!core::ops::function::FnOnce::call_once::h1de15351afbb525d
   12: 0x2090 - <unknown>!std::sys_common::backtrace::__rust_begin_short_backtrace::h958e61dc07273f6f
   13: 0x2171 - <unknown>!std::rt::lang_start::{{closure}}::hb580c779a4c8841c
   14: 0xf5f7 - <unknown>!std::rt::lang_start_internal::h394de9c4666f4612
   15: 0x211c - <unknown>!std::rt::lang_start::h8991cdf32c426374
   16: 0x7939 - <unknown>!__main_void
   17: 0x206b - <unknown>!_start
   18: 0x2e6667 - wit-component:adapter:wasi_snapshot_preview1!wasi:cli/run@0.2.0-rc-2023-11-05#run
note: using the `WASMTIME_BACKTRACE_DETAILS=1` environment variable may show more debugging information

Caused by:
    wasm trap: wasm `unreachable` instruction executed
stack backtrace:
   0: rust_begin_unwind
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library\std\src/panicking.rs:595:5
   1: core::panicking::panic_fmt
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library\core\src/panicking.rs:67:14
   2: core::result::unwrap_failed
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library\core\src/result.rs:1652:5
   3: core::result::Result<T,E>::unwrap
   4: all::sync::preview2_tcp_sockopts::test_impl
   5: all::sync::preview2_tcp_sockopts
   6: all::sync::preview2_tcp_sockopts::{{closure}}
   7: core::ops::function::FnOnce::call_once
   8: core::ops::function::FnOnce::call_once
             at /rustc/cc66ad468955717ab92600c770da8c1601a4ff33/library\core\src\ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.


failures:
    async_::preview2_tcp_sockopts
    sync::preview2_tcp_sockopts

test result: FAILED. 170 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 216.38s
```

</details>

cc @badeend 