### PR TITLE
Release Wasmtime 13.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-array-literals"
-version = "13.0.0"
+version = "13.0.1"
 
 [[package]]
 name = "byteorder"
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -574,14 +574,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -609,25 +609,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.100.0"
+version = "0.100.1"
 
 [[package]]
 name = "cranelift-control"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "serde",
  "serde_derive",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.0",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.100.0"
+version = "0.100.1"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "verify-component-adapter"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "wasmparser 0.112.0",
@@ -3003,7 +3003,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3026,7 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.3.3",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "byte-array-literals",
  "object",
@@ -3081,7 +3081,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3305,7 +3305,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3346,14 +3346,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3370,7 +3370,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3394,7 +3394,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "base64",
@@ -3416,7 +3416,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3466,7 +3466,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3494,11 +3494,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "13.0.0"
+version = "13.0.1"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3535,7 +3535,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -3574,7 +3574,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "backtrace",
  "cc",
@@ -3656,7 +3656,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3681,7 +3681,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "object",
  "once_cell",
@@ -3691,7 +3691,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "cc",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3749,7 +3749,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "openvino",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "log",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3856,7 +3856,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "heck",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "13.0.0"
+version = "13.0.1"
 
 [[package]]
 name = "wast"
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "anyhow",
  "heck",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "13.0.0"
+version = "13.0.1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4012,7 +4012,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "13.0.0"
+version = "13.0.1"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -130,58 +130,58 @@ edition = "2021"
 rust-version = "1.70.0"
 
 [workspace.dependencies]
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=13.0.0" }
-wasmtime = { path = "crates/wasmtime", version = "13.0.0", default-features = false }
-wasmtime-cache = { path = "crates/cache", version = "=13.0.0" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=13.0.0" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=13.0.0" }
-wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=13.0.0" }
-wasmtime-winch = { path = "crates/winch", version = "=13.0.0" }
-wasmtime-environ = { path = "crates/environ", version = "=13.0.0" }
-wasmtime-explorer = { path = "crates/explorer", version = "=13.0.0" }
-wasmtime-fiber = { path = "crates/fiber", version = "=13.0.0" }
-wasmtime-types = { path = "crates/types", version = "13.0.0" }
-wasmtime-jit = { path = "crates/jit", version = "=13.0.0" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=13.0.0" }
-wasmtime-runtime = { path = "crates/runtime", version = "=13.0.0" }
-wasmtime-wast = { path = "crates/wast", version = "=13.0.0" }
-wasmtime-wasi = { path = "crates/wasi", version = "13.0.0", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=13.0.0", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "13.0.0" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "13.0.0" }
-wasmtime-component-util = { path = "crates/component-util", version = "=13.0.0" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=13.0.0" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=13.0.0" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=13.0.0" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=13.0.1" }
+wasmtime = { path = "crates/wasmtime", version = "13.0.1", default-features = false }
+wasmtime-cache = { path = "crates/cache", version = "=13.0.1" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=13.0.1" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=13.0.1" }
+wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=13.0.1" }
+wasmtime-winch = { path = "crates/winch", version = "=13.0.1" }
+wasmtime-environ = { path = "crates/environ", version = "=13.0.1" }
+wasmtime-explorer = { path = "crates/explorer", version = "=13.0.1" }
+wasmtime-fiber = { path = "crates/fiber", version = "=13.0.1" }
+wasmtime-types = { path = "crates/types", version = "13.0.1" }
+wasmtime-jit = { path = "crates/jit", version = "=13.0.1" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=13.0.1" }
+wasmtime-runtime = { path = "crates/runtime", version = "=13.0.1" }
+wasmtime-wast = { path = "crates/wast", version = "=13.0.1" }
+wasmtime-wasi = { path = "crates/wasi", version = "13.0.1", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=13.0.1", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "13.0.1" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "13.0.1" }
+wasmtime-component-util = { path = "crates/component-util", version = "=13.0.1" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=13.0.1" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=13.0.1" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=13.0.1" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=13.0.0", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=13.0.0" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=13.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=13.0.0" }
-wasi-tokio = { path = "crates/wasi-common/tokio", version = "=13.0.0" }
-wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=13.0.0" }
+wiggle = { path = "crates/wiggle", version = "=13.0.1", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=13.0.1" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=13.0.1" }
+wasi-common = { path = "crates/wasi-common", version = "=13.0.1" }
+wasi-tokio = { path = "crates/wasi-common/tokio", version = "=13.0.1" }
+wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=13.0.1" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=13.0.0" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=13.0.0" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=13.0.1" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=13.0.1" }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.100.0" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.100.0" }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.100.0" }
-cranelift-entity = { path = "cranelift/entity", version = "0.100.0" }
-cranelift-native = { path = "cranelift/native", version = "0.100.0" }
-cranelift-module = { path = "cranelift/module", version = "0.100.0" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.100.0" }
-cranelift-reader = { path = "cranelift/reader", version = "0.100.0" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.100.1" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.100.1" }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.100.1" }
+cranelift-entity = { path = "cranelift/entity", version = "0.100.1" }
+cranelift-native = { path = "cranelift/native", version = "0.100.1" }
+cranelift-module = { path = "cranelift/module", version = "0.100.1" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.100.1" }
+cranelift-reader = { path = "cranelift/reader", version = "0.100.1" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.100.0" }
-cranelift-jit = { path = "cranelift/jit", version = "0.100.0" }
+cranelift-object = { path = "cranelift/object", version = "0.100.1" }
+cranelift-jit = { path = "cranelift/jit", version = "0.100.1" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.100.0" }
-cranelift-control = { path = "cranelift/control", version = "0.100.0" }
-cranelift = { path = "cranelift/umbrella", version = "0.100.0" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.100.1" }
+cranelift-control = { path = "cranelift/control", version = "0.100.1" }
+cranelift = { path = "cranelift/umbrella", version = "0.100.1" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.11.0" }
+winch-codegen = { path = "winch/codegen", version = "=0.11.1" }
 winch-filetests = { path = "winch/filetests" }
 winch-test-macros = { path = "winch/test-macros" }
 

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.100.0"
+version = "0.100.1"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.100.0"
+version = "0.100.1"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -16,7 +16,7 @@ edition.workspace = true
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.100.0" }
+cranelift-codegen-shared = { path = "./shared", version = "0.100.1" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -41,8 +41,8 @@ criterion = { version = "0.5.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.100.0" }
-cranelift-isle = { path = "../isle/isle", version = "=0.100.0" }
+cranelift-codegen-meta = { path = "meta", version = "0.100.1" }
+cranelift-isle = { path = "../isle/isle", version = "=0.100.1" }
 
 [features]
 default = ["std", "unwind", "host-arch"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.100.0"
+version = "0.100.1"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -12,4 +12,4 @@ edition.workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.100.0" }
+cranelift-codegen-shared = { path = "../shared", version = "0.100.1" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.100.0"
+version = "0.100.1"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.100.0"
+version = "0.100.1"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.100.0"
+version = "0.100.1"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.100.0"
+version = "0.100.1"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.100.0"
+version = "0.100.1"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.100.0"
+version = "0.100.1"
 
 [dependencies]
 codespan-reporting = { version = "0.11.1", optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.100.0"
+version = "0.100.1"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.100.0"
+version = "0.100.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.100.0"
+version = "0.100.1"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.100.0"
+version = "0.100.1"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.100.0"
+version = "0.100.1"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.100.0"
+version = "0.100.1"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.100.0"
+version = "0.100.1"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.100.0"
+version = "0.100.1"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -199,7 +199,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "13.0.0"
+#define WASMTIME_VERSION "13.0.1"
 /**
  * \brief Wasmtime major version number.
  */
@@ -211,7 +211,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 0
+#define WASMTIME_VERSION_PATCH 1
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -5,189 +5,381 @@
 version = "0.100.0"
 audited_as = "0.98.1"
 
+[[unpublished.cranelift]]
+version = "0.100.1"
+audited_as = "0.100.0"
+
 [[unpublished.cranelift-bforest]]
 version = "0.100.0"
 audited_as = "0.98.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.100.1"
+audited_as = "0.100.0"
 
 [[unpublished.cranelift-codegen]]
 version = "0.100.0"
 audited_as = "0.98.1"
 
+[[unpublished.cranelift-codegen]]
+version = "0.100.1"
+audited_as = "0.100.0"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.100.0"
 audited_as = "0.98.1"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.100.1"
+audited_as = "0.100.0"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.100.0"
 audited_as = "0.98.1"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.100.1"
+audited_as = "0.100.0"
+
 [[unpublished.cranelift-control]]
 version = "0.100.0"
 audited_as = "0.98.1"
+
+[[unpublished.cranelift-control]]
+version = "0.100.1"
+audited_as = "0.100.0"
 
 [[unpublished.cranelift-entity]]
 version = "0.100.0"
 audited_as = "0.98.1"
 
+[[unpublished.cranelift-entity]]
+version = "0.100.1"
+audited_as = "0.100.0"
+
 [[unpublished.cranelift-frontend]]
 version = "0.100.0"
 audited_as = "0.98.1"
+
+[[unpublished.cranelift-frontend]]
+version = "0.100.1"
+audited_as = "0.100.0"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.100.0"
 audited_as = "0.98.1"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.100.1"
+audited_as = "0.100.0"
+
 [[unpublished.cranelift-isle]]
 version = "0.100.0"
 audited_as = "0.98.1"
+
+[[unpublished.cranelift-isle]]
+version = "0.100.1"
+audited_as = "0.100.0"
 
 [[unpublished.cranelift-jit]]
 version = "0.100.0"
 audited_as = "0.98.1"
 
+[[unpublished.cranelift-jit]]
+version = "0.100.1"
+audited_as = "0.100.0"
+
 [[unpublished.cranelift-module]]
 version = "0.100.0"
 audited_as = "0.98.1"
+
+[[unpublished.cranelift-module]]
+version = "0.100.1"
+audited_as = "0.100.0"
 
 [[unpublished.cranelift-native]]
 version = "0.100.0"
 audited_as = "0.98.1"
 
+[[unpublished.cranelift-native]]
+version = "0.100.1"
+audited_as = "0.100.0"
+
 [[unpublished.cranelift-object]]
 version = "0.100.0"
 audited_as = "0.98.1"
+
+[[unpublished.cranelift-object]]
+version = "0.100.1"
+audited_as = "0.100.0"
 
 [[unpublished.cranelift-reader]]
 version = "0.100.0"
 audited_as = "0.98.1"
 
+[[unpublished.cranelift-reader]]
+version = "0.100.1"
+audited_as = "0.100.0"
+
 [[unpublished.cranelift-serde]]
 version = "0.100.0"
 audited_as = "0.98.1"
+
+[[unpublished.cranelift-serde]]
+version = "0.100.1"
+audited_as = "0.100.0"
 
 [[unpublished.cranelift-wasm]]
 version = "0.100.0"
 audited_as = "0.98.1"
 
+[[unpublished.cranelift-wasm]]
+version = "0.100.1"
+audited_as = "0.100.0"
+
 [[unpublished.wasi-cap-std-sync]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasi-cap-std-sync]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasi-common]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasi-common]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasi-tokio]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasi-tokio]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime-cache]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime-cache]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-cli]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-cli]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-component-macro]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-component-macro]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime-component-util]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime-component-util]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-cranelift]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-cranelift]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime-cranelift-shared]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-environ]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-environ]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime-explorer]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime-explorer]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-fiber]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-fiber]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime-jit]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime-jit]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-runtime]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-runtime]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime-types]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime-types]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-wasi]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-wasi]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-wast]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-wast]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wasmtime-winch]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wasmtime-winch]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wiggle]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wiggle]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wiggle-generate]]
 version = "13.0.0"
 audited_as = "11.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "13.0.1"
+audited_as = "13.0.0"
+
 [[unpublished.wiggle-macro]]
 version = "13.0.0"
 audited_as = "11.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "13.0.1"
+audited_as = "13.0.0"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -196,6 +388,10 @@ audited_as = "0.1.0"
 [[unpublished.winch-codegen]]
 version = "0.11.0"
 audited_as = "0.9.1"
+
+[[unpublished.winch-codegen]]
+version = "0.11.1"
+audited_as = "0.11.0"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -371,9 +567,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.100.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.98.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.100.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -383,9 +591,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.100.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.98.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.100.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -395,9 +615,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.100.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.98.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.100.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -407,9 +639,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.100.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.98.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.100.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -419,9 +663,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.100.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.98.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.100.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -431,9 +687,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.100.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.98.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.100.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -443,9 +711,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.100.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.98.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.100.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -455,15 +735,33 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.100.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.98.1"
 when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.100.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.98.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.100.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -801,15 +1099,33 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-cap-std-sync]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-common]]
 version = "11.0.1"
 when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-tokio]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasi-tokio]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -994,9 +1310,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1006,9 +1334,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1018,9 +1358,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1030,9 +1382,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1042,9 +1406,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cranelift-shared]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-environ]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-environ]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1054,9 +1430,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-explorer]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-fiber]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-fiber]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1066,9 +1454,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1078,9 +1478,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-runtime]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-runtime]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1090,9 +1502,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-types]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1102,9 +1526,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-http]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-nn]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-nn]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1114,9 +1550,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-threads]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wast]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wast]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1126,9 +1574,21 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-winch]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wit-bindgen]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wit-bindgen]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1186,15 +1646,33 @@ when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "11.0.1"
 when = "2023-07-24"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "13.0.0"
+when = "2023-09-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "11.0.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "13.0.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1215,6 +1693,12 @@ user-name = "Andrew Gallant"
 [[publisher.winch-codegen]]
 version = "0.9.1"
 when = "2023-07-24"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.11.0"
+when = "2023-09-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.11.0"
+version = "0.11.1"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 13.0.1, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
