### PR TITLE
wasi-http: Fallible fields set and append

### DIFF
--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -20,7 +20,8 @@ impl bindings::exports::wasi::http::incoming_handler::Guest for T {
         let resp = bindings::wasi::http::types::OutgoingResponse::new(200, hdrs);
         let body = resp.body().expect("outgoing response");
 
-        bindings::wasi::http::types::ResponseOutparam::set(outparam, Ok(resp));
+        bindings::wasi::http::types::ResponseOutparam::set(outparam, Ok(resp))
+            .expect("sending the response");
 
         let out = body.write().expect("outgoing stream");
         out.blocking_write_and_flush(b"hello, world!")

--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -20,8 +20,7 @@ impl bindings::exports::wasi::http::incoming_handler::Guest for T {
         let resp = bindings::wasi::http::types::OutgoingResponse::new(200, hdrs);
         let body = resp.body().expect("outgoing response");
 
-        bindings::wasi::http::types::ResponseOutparam::set(outparam, Ok(resp))
-            .expect("sending the response");
+        bindings::wasi::http::types::ResponseOutparam::set(outparam, Ok(resp));
 
         let out = body.write().expect("outgoing stream");
         out.blocking_write_and_flush(b"hello, world!")

--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -16,7 +16,7 @@ struct T;
 
 impl bindings::exports::wasi::http::incoming_handler::Guest for T {
     fn handle(_request: IncomingRequest, outparam: ResponseOutparam) {
-        let hdrs = bindings::wasi::http::types::Headers::new(&[]);
+        let hdrs = bindings::wasi::http::types::Headers::new();
         let resp = bindings::wasi::http::types::OutgoingResponse::new(200, hdrs);
         let body = resp.body().expect("outgoing response");
 

--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -57,7 +57,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
             let mut body =
                 executor::outgoing_body(response.body().expect("response should be writable"));
 
-            ResponseOutparam::set(response_out, Ok(response));
+            ResponseOutparam::set(response_out, Ok(response)).expect("sending the response");
 
             while let Some((url, result)) = results.next().await {
                 let payload = match result {
@@ -86,7 +86,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
             let mut body =
                 executor::outgoing_body(response.body().expect("response should be writable"));
 
-            ResponseOutparam::set(response_out, Ok(response));
+            ResponseOutparam::set(response_out, Ok(response)).expect("sending the response");
 
             let mut stream =
                 executor::incoming_body(request.consume().expect("request should be readable"));
@@ -112,7 +112,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
 
             let body = response.body().expect("response should be writable");
 
-            ResponseOutparam::set(response_out, Ok(response));
+            ResponseOutparam::set(response_out, Ok(response)).expect("sending the response");
 
             OutgoingBody::finish(body, None);
         }

--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -51,7 +51,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
 
             let response = OutgoingResponse::new(
                 200,
-                Fields::new(&[("content-type".to_string(), b"text/plain".to_vec())]),
+                Fields::from_list(&[("content-type".to_string(), b"text/plain".to_vec())]).unwrap(),
             );
 
             let mut body =
@@ -75,12 +75,13 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
         (Method::Post, Some("/echo")) => {
             let response = OutgoingResponse::new(
                 200,
-                Fields::new(
+                Fields::from_list(
                     &headers
                         .into_iter()
                         .filter_map(|(k, v)| (k == "content-type").then_some((k, v)))
                         .collect::<Vec<_>>(),
-                ),
+                )
+                .unwrap(),
             );
 
             let mut body =
@@ -108,7 +109,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
         }
 
         _ => {
-            let response = OutgoingResponse::new(405, Fields::new(&[]));
+            let response = OutgoingResponse::new(405, Fields::new());
 
             let body = response.body().expect("response should be writable");
 
@@ -137,7 +138,7 @@ async fn hash(url: &Url) -> Result<String> {
                 String::new()
             }
         )),
-        Fields::new(&[]),
+        Fields::new(),
     );
 
     let response = executor::outgoing_request_send(request).await?;

--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -57,7 +57,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
             let mut body =
                 executor::outgoing_body(response.body().expect("response should be writable"));
 
-            ResponseOutparam::set(response_out, Ok(response)).expect("sending the response");
+            ResponseOutparam::set(response_out, Ok(response));
 
             while let Some((url, result)) = results.next().await {
                 let payload = match result {
@@ -86,7 +86,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
             let mut body =
                 executor::outgoing_body(response.body().expect("response should be writable"));
 
-            ResponseOutparam::set(response_out, Ok(response)).expect("sending the response");
+            ResponseOutparam::set(response_out, Ok(response));
 
             let mut stream =
                 executor::incoming_body(request.consume().expect("request should be readable"));
@@ -112,7 +112,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
 
             let body = response.body().expect("response should be writable");
 
-            ResponseOutparam::set(response_out, Ok(response)).expect("sending the response");
+            ResponseOutparam::set(response_out, Ok(response));
 
             OutgoingBody::finish(body, None);
         }

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
@@ -1,0 +1,24 @@
+use test_programs::wasi::http::types::{Headers, Method, Scheme};
+
+fn main() {
+    let hdrs = Headers::new(&[]);
+    assert!(hdrs
+        .append(&"malformed header name".to_owned(), &b"bad".to_vec())
+        .is_err());
+
+    let addr = std::env::var("HTTP_SERVER").unwrap();
+    let err = test_programs::http::request(
+        Method::Get,
+        Scheme::Http,
+        &addr,
+        "/get?some=arg&goes=here",
+        None,
+        Some(&[("transfer-encoding".to_owned(), b"bad".to_vec())]),
+    )
+    .expect_err("invalid request");
+
+    assert_eq!(
+        err.to_string(),
+        "Error::HeaderNameError(\"forbidden header\")"
+    );
+}

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
@@ -1,7 +1,7 @@
 use test_programs::wasi::http::types::{HeaderError, Headers};
 
 fn main() {
-    let hdrs = Headers::new(&[]);
+    let hdrs = Headers::new();
     assert!(matches!(
         hdrs.append(&"malformed header name".to_owned(), &b"ok value".to_vec()),
         Err(HeaderError::InvalidSyntax)
@@ -41,5 +41,20 @@ fn main() {
             &b"keep-alive".to_vec()
         ),
         Err(HeaderError::Forbidden)
+    ));
+
+    assert!(matches!(
+        Headers::from_list(&[("bad header".to_owned(), b"value".to_vec())]),
+        Err(HeaderError::InvalidSyntax)
+    ));
+
+    assert!(matches!(
+        Headers::from_list(&[("custom-forbidden-header".to_owned(), b"value".to_vec())]),
+        Err(HeaderError::Forbidden)
+    ));
+
+    assert!(matches!(
+        Headers::from_list(&[("ok-header-name".to_owned(), b"bad\nvalue".to_vec())]),
+        Err(HeaderError::InvalidSyntax)
     ));
 }

--- a/crates/test-programs/src/bin/http_outbound_request_response_build.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_response_build.rs
@@ -3,10 +3,11 @@ use test_programs::wasi::http::types as http_types;
 fn main() {
     println!("Called _start");
     {
-        let headers = http_types::Headers::new(&[(
+        let headers = http_types::Headers::from_list(&[(
             "Content-Type".to_string(),
             "application/json".to_string().into_bytes(),
-        )]);
+        )])
+        .unwrap();
         let request = http_types::OutgoingRequest::new(
             &http_types::Method::Get,
             None,
@@ -21,10 +22,11 @@ fn main() {
             .unwrap();
     }
     {
-        let headers = http_types::Headers::new(&[(
+        let headers = http_types::Headers::from_list(&[(
             "Content-Type".to_string(),
             "application/text".to_string().into_bytes(),
-        )]);
+        )])
+        .unwrap();
         let response = http_types::OutgoingResponse::new(200, headers);
         let outgoing_body = response.body().unwrap();
         let response_body = outgoing_body.write().unwrap();

--- a/crates/test-programs/src/http.rs
+++ b/crates/test-programs/src/http.rs
@@ -42,7 +42,7 @@ pub fn request(
     fn header_val(v: &str) -> Vec<u8> {
         v.to_string().into_bytes()
     }
-    let headers = http_types::Headers::new(
+    let headers = http_types::Headers::from_list(
         &[
             &[
                 ("User-agent".to_string(), header_val("WASI-HTTP/0.0.1")),
@@ -51,7 +51,7 @@ pub fn request(
             additional_headers.unwrap_or(&[]),
         ]
         .concat(),
-    );
+    )?;
 
     let request = http_types::OutgoingRequest::new(
         &method,

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -1,6 +1,6 @@
 use crate::bindings::http::{
     outgoing_handler,
-    types::{self as http_types, RequestOptions, Scheme},
+    types::{RequestOptions, Scheme},
 };
 use crate::types::{self, HostFutureIncomingResponse, OutgoingRequest};
 use crate::WasiHttpView;
@@ -84,12 +84,6 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
             .header(hyper::header::HOST, &authority);
 
         for (k, v) in req.headers.iter() {
-            if self.is_forbidden_request_header(k) {
-                return Ok(Err(http_types::Error::HeaderNameError(
-                    "forbidden header".to_owned(),
-                )));
-            }
-
             builder = builder.header(k, v);
         }
 

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -1,6 +1,6 @@
 use crate::bindings::http::{
     outgoing_handler,
-    types::{RequestOptions, Scheme},
+    types::{self as http_types, RequestOptions, Scheme},
 };
 use crate::types::{self, HostFutureIncomingResponse, OutgoingRequest};
 use crate::WasiHttpView;
@@ -84,6 +84,12 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
             .header(hyper::header::HOST, &authority);
 
         for (k, v) in req.headers.iter() {
+            if self.is_forbidden_request_header(k) {
+                return Ok(Err(http_types::Error::HeaderNameError(
+                    "forbidden header".to_owned(),
+                )));
+            }
+
             builder = builder.header(k, v);
         }
 

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use anyhow::Context;
 use http_body_util::BodyExt;
+use hyper::header::HeaderName;
 use std::any::Any;
 use std::time::Duration;
 use tokio::net::TcpStream;
@@ -64,6 +65,14 @@ pub trait WasiHttpView: Send {
         Self: Sized,
     {
         default_send_request(self, request)
+    }
+
+    fn is_forbidden_request_header(&mut self, name: &HeaderName) -> bool {
+        default_is_forbidden_request_header(name)
+    }
+
+    fn is_forbidden_response_header(&mut self, name: &HeaderName) -> bool {
+        default_is_forbidden_response_header(name)
     }
 }
 
@@ -165,6 +174,22 @@ pub fn default_send_request(
     let fut = view.table().push(HostFutureIncomingResponse::new(handle))?;
 
     Ok(fut)
+}
+
+pub fn default_is_forbidden_request_header(name: &HeaderName) -> bool {
+    use hyper::header;
+
+    const FORBIDDEN: &'static [HeaderName] = &[header::TRANSFER_ENCODING];
+
+    FORBIDDEN.contains(name)
+}
+
+pub fn default_is_forbidden_response_header(name: &HeaderName) -> bool {
+    use hyper::header;
+
+    const FORBIDDEN: &'static [HeaderName] = &[header::TRANSFER_ENCODING];
+
+    FORBIDDEN.contains(name)
 }
 
 pub fn timeout_error(kind: &str) -> anyhow::Error {

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -67,12 +67,8 @@ pub trait WasiHttpView: Send {
         default_send_request(self, request)
     }
 
-    fn is_forbidden_request_header(&mut self, name: &HeaderName) -> bool {
-        default_is_forbidden_request_header(name)
-    }
-
-    fn is_forbidden_response_header(&mut self, name: &HeaderName) -> bool {
-        default_is_forbidden_response_header(name)
+    fn is_forbidden_header(&mut self, _name: &HeaderName) -> bool {
+        false
     }
 }
 
@@ -174,22 +170,6 @@ pub fn default_send_request(
     let fut = view.table().push(HostFutureIncomingResponse::new(handle))?;
 
     Ok(fut)
-}
-
-pub fn default_is_forbidden_request_header(name: &HeaderName) -> bool {
-    use hyper::header;
-
-    const FORBIDDEN: &'static [HeaderName] = &[header::TRANSFER_ENCODING];
-
-    FORBIDDEN.contains(name)
-}
-
-pub fn default_is_forbidden_response_header(name: &HeaderName) -> bool {
-    use hyper::header;
-
-    const FORBIDDEN: &'static [HeaderName] = &[header::TRANSFER_ENCODING];
-
-    FORBIDDEN.contains(name)
 }
 
 pub fn timeout_error(kind: &str) -> anyhow::Error {

--- a/crates/wasi-http/tests/all/async_.rs
+++ b/crates/wasi-http/tests/all/async_.rs
@@ -50,6 +50,12 @@ async fn http_outbound_request_invalid_version() -> Result<()> {
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn http_outbound_request_invalid_header() -> Result<()> {
+    let server = Server::http2()?;
+    run(HTTP_OUTBOUND_REQUEST_INVALID_HEADER_COMPONENT, &server).await
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn http_outbound_request_unknown_method() -> Result<()> {
     let server = Server::http1()?;
     run(HTTP_OUTBOUND_REQUEST_UNKNOWN_METHOD_COMPONENT, &server).await

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -72,6 +72,10 @@ impl WasiHttpView for Ctx {
             types::default_send_request(self, request)
         }
     }
+
+    fn is_forbidden_header(&mut self, name: &hyper::header::HeaderName) -> bool {
+        name.as_str() == "custom-forbidden-header"
+    }
 }
 
 fn store(engine: &Engine, server: &Server) -> Store<Ctx> {

--- a/crates/wasi-http/tests/all/sync.rs
+++ b/crates/wasi-http/tests/all/sync.rs
@@ -49,6 +49,12 @@ fn http_outbound_request_invalid_version() -> Result<()> {
 }
 
 #[test_log::test]
+fn http_outbound_request_invalid_header() -> Result<()> {
+    let server = Server::http2()?;
+    run(HTTP_OUTBOUND_REQUEST_INVALID_HEADER_COMPONENT, &server)
+}
+
+#[test_log::test]
 fn http_outbound_request_unknown_method() -> Result<()> {
     let server = Server::http1()?;
     run(HTTP_OUTBOUND_REQUEST_UNKNOWN_METHOD_COMPONENT, &server)

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -56,6 +56,9 @@ interface types {
   /// Headers and Trailers.
   resource fields {
 
+    /// Construct an empty HTTP Fields.
+    constructor();
+
     /// Construct an HTTP Fields.
     ///
     /// The list represents each key-value pair in the Fields. Keys
@@ -66,7 +69,12 @@ interface types {
     /// Value, represented as a list of bytes. In a valid Fields, all keys
     /// and values are valid UTF-8 strings. However, values are not always
     /// well-formed, so they are represented as a raw list of bytes.
-    constructor(entries: list<tuple<field-key,field-value>>);
+    ///
+    /// An error result will be returned if any header or value was
+    /// syntactically invalid, or if a header was forbidden.
+    from-list: static func(
+      entries: list<tuple<field-key,field-value>>
+    ) -> result<fields, header-error>;
 
     /// Get all of the values corresponding to a key.
     get: func(name: field-key) -> list<field-value>;

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -34,7 +34,13 @@ interface types {
     timeout-error(string),
     protocol-error(string),
     unexpected-error(string),
-    header-name-error(string),
+  }
+
+  /// This tyep enumerates the different kinds of errors that may occur when
+  /// setting or appending to a `fields` resource.
+  variant header-error {
+    invalid-syntax,
+    forbidden,
   }
 
   /// Field keys are always strings.
@@ -67,7 +73,10 @@ interface types {
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.
-    set: func(name: field-key, value: list<field-value>) -> result<_, error>;
+    ///
+    /// The operation can fail if the name or value arguments are invalid, or if
+    /// the name is forbidden.
+    set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
@@ -75,7 +84,10 @@ interface types {
 
     /// Append a value for a key. Does not change or delete any existing
     /// values for that key.
-    append: func(name: field-key, value: field-value) -> result<_, error>;
+    ///
+    /// The operation can fail if the name or value arguments are invalid, or if
+    /// the name is forbidden.
+    append: func(name: field-key, value: field-value) -> result<_, header-error>;
 
 
     /// Retrieve the full set of keys and values in the Fields. Like the

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -33,7 +33,8 @@ interface types {
     invalid-url(string),
     timeout-error(string),
     protocol-error(string),
-    unexpected-error(string)
+    unexpected-error(string),
+    header-name-error(string),
   }
 
   /// Field keys are always strings.
@@ -66,7 +67,7 @@ interface types {
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.
-    set: func(name: field-key, value: list<field-value>);
+    set: func(name: field-key, value: list<field-value>) -> result<_, error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
@@ -74,7 +75,7 @@ interface types {
 
     /// Append a value for a key. Does not change or delete any existing
     /// values for that key.
-    append: func(name: field-key, value: field-value);
+    append: func(name: field-key, value: field-value) -> result<_, error>;
 
 
     /// Retrieve the full set of keys and values in the Fields. Like the

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -33,7 +33,7 @@ interface types {
     invalid-url(string),
     timeout-error(string),
     protocol-error(string),
-    unexpected-error(string),
+    unexpected-error(string)
   }
 
   /// This tyep enumerates the different kinds of errors that may occur when

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -56,6 +56,9 @@ interface types {
   /// Headers and Trailers.
   resource fields {
 
+    /// Construct an empty HTTP Fields.
+    constructor();
+
     /// Construct an HTTP Fields.
     ///
     /// The list represents each key-value pair in the Fields. Keys
@@ -66,7 +69,12 @@ interface types {
     /// Value, represented as a list of bytes. In a valid Fields, all keys
     /// and values are valid UTF-8 strings. However, values are not always
     /// well-formed, so they are represented as a raw list of bytes.
-    constructor(entries: list<tuple<field-key,field-value>>);
+    ///
+    /// An error result will be returned if any header or value was
+    /// syntactically invalid, or if a header was forbidden.
+    from-list: static func(
+      entries: list<tuple<field-key,field-value>>
+    ) -> result<fields, header-error>;
 
     /// Get all of the values corresponding to a key.
     get: func(name: field-key) -> list<field-value>;

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -34,7 +34,13 @@ interface types {
     timeout-error(string),
     protocol-error(string),
     unexpected-error(string),
-    header-name-error(string),
+  }
+
+  /// This tyep enumerates the different kinds of errors that may occur when
+  /// setting or appending to a `fields` resource.
+  variant header-error {
+    invalid-syntax,
+    forbidden,
   }
 
   /// Field keys are always strings.
@@ -67,7 +73,10 @@ interface types {
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.
-    set: func(name: field-key, value: list<field-value>) -> result<_, error>;
+    ///
+    /// The operation can fail if the name or value arguments are invalid, or if
+    /// the name is forbidden.
+    set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
@@ -75,7 +84,10 @@ interface types {
 
     /// Append a value for a key. Does not change or delete any existing
     /// values for that key.
-    append: func(name: field-key, value: field-value) -> result<_, error>;
+    ///
+    /// The operation can fail if the name or value arguments are invalid, or if
+    /// the name is forbidden.
+    append: func(name: field-key, value: field-value) -> result<_, header-error>;
 
 
     /// Retrieve the full set of keys and values in the Fields. Like the

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -33,7 +33,8 @@ interface types {
     invalid-url(string),
     timeout-error(string),
     protocol-error(string),
-    unexpected-error(string)
+    unexpected-error(string),
+    header-name-error(string),
   }
 
   /// Field keys are always strings.
@@ -66,7 +67,7 @@ interface types {
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.
-    set: func(name: field-key, value: list<field-value>);
+    set: func(name: field-key, value: list<field-value>) -> result<_, error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
@@ -74,7 +75,7 @@ interface types {
 
     /// Append a value for a key. Does not change or delete any existing
     /// values for that key.
-    append: func(name: field-key, value: field-value);
+    append: func(name: field-key, value: field-value) -> result<_, error>;
 
 
     /// Retrieve the full set of keys and values in the Fields. Like the

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -33,7 +33,7 @@ interface types {
     invalid-url(string),
     timeout-error(string),
     protocol-error(string),
-    unexpected-error(string),
+    unexpected-error(string)
   }
 
   /// This tyep enumerates the different kinds of errors that may occur when


### PR DESCRIPTION
This PR makes the `fields.set` and `fields.append` methods fallible, and introduces a new error type for describing the ways in which those operations can fail. Additionally it adds a notion of forbidden headers, which will always include the following:

* Connection
* Keep-Alive
* Proxy-Authenticate
* Proxy-Authorization
* Proxy-Connection
* TE
* Transfer-Encoding
* Upgrade
* HTTP2-Settings

There's an embedder-defined hook for adding additional header name validation, but that underlying set of headers can't be altered.

Fixes #7270