### PR TITLE
Add compatibility shims for Wasmtime 13 CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,6 +3391,7 @@ dependencies = [
  "env_logger 0.10.0",
  "filecheck",
  "http-body-util",
+ "humantime 2.1.0",
  "hyper",
  "libc",
  "listenfd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ serde_json = { workspace = true }
 wasmparser = { workspace = true }
 tracing = { workspace = true }
 log = { workspace = true }
+humantime = { workspace = true }
 
 async-trait = { workspace = true }
 bytes = { workspace = true }
@@ -266,6 +267,7 @@ syn = "2.0.25"
 test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ['fmt', 'env-filter', 'ansi', 'tracing-log'] }
 url = "2.3.1"
+humantime = "2.0.0"
 
 # =============================================================================
 #
@@ -309,6 +311,10 @@ default = [
   # cost, so allow disabling this through disabling of our own `default`
   # feature.
   "clap/default",
+
+  # By default include compatibility with the "old" CLI from Wasmtime 13 and
+  # prior.
+  "old-cli",
 ]
 
 # ========================================
@@ -347,6 +353,9 @@ profiling = ["wasmtime/profiling"]
 coredump = ["wasmtime-cli-flags/coredump"]
 addr2line = ["wasmtime/addr2line"]
 debug-builtins = ["wasmtime/debug-builtins"]
+
+# Enables compatibility shims with Wasmtime 13 and prior's CLI.
+old-cli = []
 
 # CLI subcommands for the `wasmtime` executable. See `wasmtime $cmd --help`
 # for more information on each subcommand.

--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -15,7 +15,7 @@ file-per-thread-logger = { workspace = true, optional = true }
 tracing-subscriber = { workspace = true, optional = true }
 rayon = { version = "1.5.0", optional = true }
 wasmtime = { workspace = true }
-humantime = "2.0.0"
+humantime = { workspace = true }
 
 [features]
 pooling-allocator = []

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -39,6 +39,7 @@ fn init_file_per_thread_logger(prefix: &'static str) {
 }
 
 wasmtime_option_group! {
+    #[derive(PartialEq, Clone)]
     pub struct OptimizeOptions {
         /// Optimization level of generated code (0-2, s; default: 0)
         pub opt_level: Option<wasmtime::OptLevel>,
@@ -74,6 +75,7 @@ wasmtime_option_group! {
 }
 
 wasmtime_option_group! {
+    #[derive(PartialEq, Clone)]
     pub struct CodegenOptions {
         /// Either `cranelift` or `winch`.
         ///
@@ -103,6 +105,7 @@ wasmtime_option_group! {
 }
 
 wasmtime_option_group! {
+    #[derive(PartialEq, Clone)]
     pub struct DebugOptions {
         /// Enable generation of DWARF debug information in compiled code.
         pub debug_info: Option<bool>,
@@ -122,6 +125,7 @@ wasmtime_option_group! {
 }
 
 wasmtime_option_group! {
+    #[derive(PartialEq, Clone)]
     pub struct WasmOptions {
         /// Enable canonicalization of all NaN values.
         pub nan_canonicalization: Option<bool>,
@@ -212,6 +216,7 @@ wasmtime_option_group! {
 }
 
 wasmtime_option_group! {
+    #[derive(PartialEq, Clone)]
     pub struct WasiOptions {
         /// Enable support for WASI common APIs
         pub common: Option<bool>,
@@ -256,14 +261,14 @@ wasmtime_option_group! {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WasiNnGraph {
     pub format: String,
     pub dir: String,
 }
 
 /// Common options for commands that translate WebAssembly modules
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 pub struct CommonOptions {
     // These options groups are used to parse `-O` and such options but aren't
     // the raw form consumed by the CLI. Instead they're pushed into the `pub`
@@ -560,5 +565,33 @@ impl CommonOptions {
             }
         }
         Ok(())
+    }
+}
+
+impl PartialEq for CommonOptions {
+    fn eq(&self, other: &CommonOptions) -> bool {
+        let mut me = self.clone();
+        me.configure();
+        let mut other = other.clone();
+        other.configure();
+        let CommonOptions {
+            opts_raw: _,
+            codegen_raw: _,
+            debug_raw: _,
+            wasm_raw: _,
+            wasi_raw: _,
+            configured: _,
+
+            opts,
+            codegen,
+            debug,
+            wasm,
+            wasi,
+        } = me;
+        opts == other.opts
+            && codegen == other.codegen
+            && debug == other.debug
+            && wasm == other.wasm
+            && wasi == other.wasi
     }
 }

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -15,6 +15,7 @@ use std::time::Duration;
 #[macro_export]
 macro_rules! wasmtime_option_group {
     (
+        $(#[$attr:meta])*
         pub struct $opts:ident {
             $(
                 $(#[doc = $doc:tt])*
@@ -32,6 +33,7 @@ macro_rules! wasmtime_option_group {
         }
     ) => {
         #[derive(Default, Debug)]
+        $(#[$attr])*
         pub struct $opts {
             $(
                 pub $opt: $container<$payload>,
@@ -41,7 +43,7 @@ macro_rules! wasmtime_option_group {
             )?
         }
 
-        #[derive(Clone, Debug)]
+        #[derive(Clone, Debug,PartialEq)]
         #[allow(non_camel_case_types)]
         enum $option {
             $(
@@ -106,7 +108,7 @@ macro_rules! wasmtime_option_group {
 }
 
 /// Parser registered with clap which handles parsing the `...` in `-O ...`.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CommaSeparated<T>(pub Vec<T>);
 
 impl<T> ValueParserFactory for CommaSeparated<T>
@@ -366,10 +368,7 @@ impl WasmtimeOptionValue for wasmtime::Strategy {
         match String::parse(val)?.as_str() {
             "cranelift" => Ok(wasmtime::Strategy::Cranelift),
             "winch" => Ok(wasmtime::Strategy::Winch),
-            other => bail!(
-                "unknown optimization level `{}`, only 0,1,2,s accepted",
-                other
-            ),
+            other => bail!("unknown compiler `{other}` only `cranelift` and `winch` accepted",),
         }
     }
 }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1866,7 +1866,7 @@ impl fmt::Debug for Config {
 ///
 /// This is used as an argument to the [`Config::strategy`] method.
 #[non_exhaustive]
-#[derive(Clone, Debug, Copy)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
 pub enum Strategy {
     /// An indicator that the compilation strategy should be automatically
     /// selected.

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -183,7 +183,7 @@ warning: this CLI invocation of Wasmtime will be parsed differently in future
          however this behavior can also be temporarily configured with an
          environment variable:
 
-         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silences this warning, or
+         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silence this warning, or
          - WASMTIME_NEW_CLI=1 to indicate new semantics are desired and use the latest behavior\
 "
                     );
@@ -236,7 +236,7 @@ warning: this CLI invocation of Wasmtime is going to break in the future -- for
          however this behavior can also be temporarily configured with an
          environment variable:
 
-         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silences this warning, or
+         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silence this warning, or
          - WASMTIME_NEW_CLI=1 to indicate new semantics are desired and see the error\
 "
                 );

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -176,20 +176,34 @@ mod old_cli {
                     eprintln!(
                         "\
 warning: this CLI invocation of Wasmtime will be parsed differently in future
-         Wasmtime versions, see this online issue for more information:
+         Wasmtime versions, but its interpretation is not changing yet -- see
+         this online issue for more information:
          https://github.com/bytecodealliance/wasmtime/issues/7384
-         you can use `WASMTIME_NEW_CLI=0` to temporarily disable this warning\
+
+         CLI parsing can be temporarily configured with an environment variable:
+
+         - WASMTIME_NEW_CLI=0 to silence this warning and not change behavior, or
+         - WASMTIME_NEW_CLI=1 to force using the new behavior\
 "
                     );
                     old.execute()
                 } else {
+                    // this error message is not statically reachable due to
+                    // `DEFAULT_OLD_BEHAVIOR=true` at this time, but when that
+                    // changes this should be updated to have a more accurate
+                    // set of text.
+                    assert!(false);
                     eprintln!(
                         "\
 warning: this CLI invocation of Wasmtime is parsed differently now than it was
-         in Wasmtime 13 and prior, and the new semantics are going to be used
-         instead of the old semantics -- see this issue for more information:
+         prior, and the new semantics are going to be used instead of the old
+         semantics -- see this issue for more information:
          https://github.com/bytecodealliance/wasmtime/issues/7384
-         you can use `WASMTIME_NEW_CLI=1` to disable this warning\
+
+         CLI parsing can be temporarily configured with an environment variable:
+
+         - WASMTIME_NEW_CLI=0 to use the old CLI parsing behavior, or
+         - WASMTIME_NEW_CLI=1 to silence this warning and not change behavior\
 "
                     );
                     new.execute()
@@ -212,10 +226,14 @@ warning: this CLI invocation of Wasmtime is parsed differently now than it was
             (Err(_new), Ok(old)) => {
                 eprintln!(
                     "\
-warning: this CLI invocation of Wasmtime is going to break in the future, for
+warning: this CLI invocation of Wasmtime is going to break in the future -- for
          more information see this issue online:
          https://github.com/bytecodealliance/wasmtime/issues/7384
-         use `WASMTIME_NEW_CLI=0` to temporarily disable this warning\
+
+         CLI parsing can be temporarily configured with an environment variable:
+
+         - WASMTIME_NEW_CLI=0 to silence this warning and not change behavior, or
+         - WASMTIME_NEW_CLI=1 to see how this command breaks with new syntax\
 "
                 );
                 old.execute()

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -176,14 +176,15 @@ mod old_cli {
                     eprintln!(
                         "\
 warning: this CLI invocation of Wasmtime will be parsed differently in future
-         Wasmtime versions, but its interpretation is not changing yet -- see
-         this online issue for more information:
+         Wasmtime versions -- see this online issue for more information:
          https://github.com/bytecodealliance/wasmtime/issues/7384
 
-         CLI parsing can be temporarily configured with an environment variable:
+         Wasmtime will now execute with the old (<= Wasmtime 13) CLI parsing,
+         however this behavior can also be temporarily configured with an
+         environment variable:
 
-         - WASMTIME_NEW_CLI=0 to silence this warning and not change behavior, or
-         - WASMTIME_NEW_CLI=1 to force using the new behavior\
+         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silences this warning, or
+         - WASMTIME_NEW_CLI=1 to indicate new semantics are desired and use the latest behavior\
 "
                     );
                     old.execute()
@@ -195,15 +196,16 @@ warning: this CLI invocation of Wasmtime will be parsed differently in future
                     assert!(false);
                     eprintln!(
                         "\
-warning: this CLI invocation of Wasmtime is parsed differently now than it was
-         prior, and the new semantics are going to be used instead of the old
-         semantics -- see this issue for more information:
+warning: this CLI invocation of Wasmtime is parsed differently than it was
+         previously -- see this online issue for more information:
          https://github.com/bytecodealliance/wasmtime/issues/7384
 
-         CLI parsing can be temporarily configured with an environment variable:
+         Wasmtime will now execute with the new (>= Wasmtime XXX) CLI parsing,
+         however this behavior can also be temporarily configured with an
+         environment variable:
 
-         - WASMTIME_NEW_CLI=0 to use the old CLI parsing behavior, or
-         - WASMTIME_NEW_CLI=1 to silence this warning and not change behavior\
+         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired instead of the new, or
+         - WASMTIME_NEW_CLI=1 to indicate new semantics are desired and silences this warning\
 "
                     );
                     new.execute()
@@ -230,10 +232,12 @@ warning: this CLI invocation of Wasmtime is going to break in the future -- for
          more information see this issue online:
          https://github.com/bytecodealliance/wasmtime/issues/7384
 
-         CLI parsing can be temporarily configured with an environment variable:
+         Wasmtime will now execute with the old (<= Wasmtime 13) CLI parsing,
+         however this behavior can also be temporarily configured with an
+         environment variable:
 
-         - WASMTIME_NEW_CLI=0 to silence this warning and not change behavior, or
-         - WASMTIME_NEW_CLI=1 to see how this command breaks with new syntax\
+         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silences this warning, or
+         - WASMTIME_NEW_CLI=1 to indicate new semantics are desired and see the error\
 "
                 );
                 old.execute()

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -7,7 +7,7 @@ use anyhow::Result;
 use clap::Parser;
 
 /// Wasmtime WebAssembly Runtime
-#[derive(Parser)]
+#[derive(Parser, PartialEq)]
 #[clap(
     version,
     after_help = "If a subcommand is not provided, the `run` subcommand will be used.\n\
@@ -40,7 +40,7 @@ struct Wasmtime {
     run: wasmtime_cli::commands::RunCommand,
 }
 
-#[derive(Parser)]
+#[derive(Parser, PartialEq)]
 enum Subcommand {
     /// Runs a WebAssembly module
     Run(wasmtime_cli::commands::RunCommand),
@@ -99,11 +99,176 @@ impl Wasmtime {
 }
 
 fn main() -> Result<()> {
-    Wasmtime::parse().execute()
+    #[cfg(feature = "old-cli")]
+    return old_cli::main();
+
+    #[cfg(not(feature = "old-cli"))]
+    return Wasmtime::parse().execute();
 }
 
 #[test]
 fn verify_cli() {
     use clap::CommandFactory;
     Wasmtime::command().debug_assert()
+}
+
+#[cfg(feature = "old-cli")]
+mod old_cli {
+    use crate::Wasmtime;
+    use anyhow::{bail, Result};
+    use clap::error::ErrorKind;
+    use clap::Parser;
+    use wasmtime_cli::old_cli as old;
+
+    enum WhichCli {
+        Old,
+        New,
+        Unspecified,
+    }
+
+    const DEFAULT_OLD_BEHAVIOR: bool = true;
+
+    fn which_cli() -> Result<WhichCli> {
+        Ok(match std::env::var("WASMTIME_NEW_CLI") {
+            Ok(s) if s == "0" => WhichCli::Old,
+            Ok(s) if s == "1" => WhichCli::New,
+            Ok(_) => bail!("the `WASMTIME_NEW_CLI` should either be `0` or `1`"),
+            Err(_) => WhichCli::Unspecified,
+        })
+    }
+
+    pub fn main() -> Result<()> {
+        match which_cli()? {
+            // If the old or the new CLI is explicitly selected, then run that
+            // variant no questions asked.
+            WhichCli::New => return Wasmtime::parse().execute(),
+            WhichCli::Old => return try_parse_old().unwrap_or_else(|e| e.exit()).execute(),
+
+            // fall through below to run an unspecified version of the CLI
+            WhichCli::Unspecified => {}
+        }
+
+        // Here it's not specified which version of the CLI should be used, so
+        // both the old and the new CLI parsers are used and depending on the
+        // results an execution happens.
+        let new = Wasmtime::try_parse();
+        let old = try_parse_old();
+        match (new, old) {
+            // Both parsers succeeded. This means that it's likely that no
+            // options to configure execution, e.g. `--disable-logging`, were
+            // used in the old parser or the new.
+            //
+            // The result of parsing can still differ though. For example:
+            //
+            //      wasmtime foo.wasm --invoke foo
+            //
+            // would previously be parsed as passing `--invoke` to Wasmtime but
+            // the new parser instead parses that as passing the flag to
+            // `foo.wasm`.
+            //
+            // In this situation use the `DEFAULT_OLD_BEHAVIOR` constant to
+            // dictate which wins and additionally print a warning message.
+            (Ok(new), Ok(old)) => {
+                if new == old {
+                    return new.execute();
+                }
+                if DEFAULT_OLD_BEHAVIOR {
+                    eprintln!(
+                        "\
+warning: this CLI invocation of Wasmtime will be parsed differently in future
+         Wasmtime versions, see this online issue for more information:
+         https://github.com/bytecodealliance/wasmtime/issues/7384
+         you can use `WASMTIME_NEW_CLI=0` to temporarily disable this warning\
+"
+                    );
+                    old.execute()
+                } else {
+                    eprintln!(
+                        "\
+warning: this CLI invocation of Wasmtime is parsed differently now than it was
+         in Wasmtime 13 and prior, and the new semantics are going to be used
+         instead of the old semantics -- see this issue for more information:
+         https://github.com/bytecodealliance/wasmtime/issues/7384
+         you can use `WASMTIME_NEW_CLI=1` to disable this warning\
+"
+                    );
+                    new.execute()
+                }
+            }
+
+            // Here the new parser succeeded where the old one failed. This
+            // could indicate for example that new options are being passed on
+            // the CLI.
+            //
+            // In this situation assume that the new parser is what's intended
+            // so execute those semantics.
+            (Ok(new), Err(_old)) => new.execute(),
+
+            // Here the new parser failed and the old parser succeeded. This
+            // could indicate for example passing old CLI flags.
+            //
+            // Here assume that the old semantics are desired but emit a warning
+            // indicating that this will change in the future.
+            (Err(_new), Ok(old)) => {
+                eprintln!(
+                    "\
+warning: this CLI invocation of Wasmtime is going to break in the future, for
+         more information see this issue online:
+         https://github.com/bytecodealliance/wasmtime/issues/7384
+         use `WASMTIME_NEW_CLI=0` to temporarily disable this warning\
+"
+                );
+                old.execute()
+            }
+
+            // Both parsers failed to parse the CLI invocation.
+            //
+            // This could mean that someone manually passed an old flag
+            // incorrectly. This could also mean that a new flag was passed
+            // incorrectly. Clap also models `--help` requests as errors here so
+            // this could also mean that a `--help` flag was passed.
+            //
+            // The current assumption in any case is that there's a human
+            // interacting with the CLI at this point. They may or may not be
+            // aware of the old CLI vs new CLI but if we're going to print an
+            // error message then now's probably as good a time as any to nudge
+            // them towards the new CLI. Any preexisting scripts which parsed
+            // the old CLI should not hit this case which means that all old
+            // succesful parses will not go through here.
+            //
+            // In any case, display the error for the new CLI, including new
+            // help text.
+            (Err(new), Err(_old)) => new.exit(),
+        }
+    }
+
+    fn try_parse_old() -> clap::error::Result<Wasmtime> {
+        match old::Wasmtime::try_parse() {
+            Ok(old) => Ok(convert(old)),
+            Err(e) => {
+                if let ErrorKind::InvalidSubcommand | ErrorKind::UnknownArgument = e.kind() {
+                    if let Ok(run) = old::RunCommand::try_parse() {
+                        return Ok(Wasmtime {
+                            subcommand: None,
+                            run: run.convert(),
+                        });
+                    }
+                }
+                Err(e)
+            }
+        }
+    }
+
+    fn convert(old: old::Wasmtime) -> Wasmtime {
+        let subcommand = match old {
+            old::Wasmtime::Compile(c) => crate::Subcommand::Compile(c.convert()),
+            old::Wasmtime::Run(c) => crate::Subcommand::Run(c.convert()),
+        };
+        let mut run = wasmtime_cli::commands::RunCommand::parse_from::<_, &str>(["x", "y"]);
+        run.module_and_args = Vec::new();
+        Wasmtime {
+            subcommand: Some(subcommand),
+            run,
+        }
+    }
 }

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -29,7 +29,7 @@ static AFTER_HELP: Lazy<String> = Lazy::new(|| {
 });
 
 /// Compiles a WebAssembly module.
-#[derive(Parser)]
+#[derive(Parser, PartialEq)]
 #[structopt(
     name = "compile",
     version,
@@ -37,23 +37,24 @@ static AFTER_HELP: Lazy<String> = Lazy::new(|| {
 )]
 pub struct CompileCommand {
     #[clap(flatten)]
-    common: CommonOptions,
+    #[allow(missing_docs)]
+    pub common: CommonOptions,
 
     /// The target triple; default is the host triple
     #[clap(long, value_name = "TARGET")]
-    target: Option<String>,
+    pub target: Option<String>,
 
     /// The path of the output compiled module; defaults to <MODULE>.cwasm
     #[clap(short = 'o', long, value_name = "OUTPUT")]
-    output: Option<PathBuf>,
+    pub output: Option<PathBuf>,
 
     /// The directory path to write clif files into, one clif file per wasm function.
     #[clap(long = "emit-clif", value_name = "PATH")]
-    emit_clif: Option<PathBuf>,
+    pub emit_clif: Option<PathBuf>,
 
     /// The path of the WebAssembly to compile
     #[clap(index = 1, value_name = "MODULE")]
-    module: PathBuf,
+    pub module: PathBuf,
 }
 
 impl CompileCommand {

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -7,14 +7,14 @@ const CONFIG_NEW_AFTER_HELP: &str =
     "If no file path is specified, the system configuration file path will be used.";
 
 /// Controls Wasmtime configuration settings
-#[derive(Parser)]
+#[derive(Parser, PartialEq)]
 #[clap(name = "config")]
 pub struct ConfigCommand {
     #[clap(subcommand)]
     subcommand: ConfigSubcommand,
 }
 
-#[derive(clap::Subcommand)]
+#[derive(clap::Subcommand, PartialEq)]
 enum ConfigSubcommand {
     /// Creates a new Wasmtime configuration file
     #[clap(after_help = CONFIG_NEW_AFTER_HELP)]
@@ -31,7 +31,7 @@ impl ConfigCommand {
 }
 
 /// Creates a new Wasmtime configuration file
-#[derive(Parser)]
+#[derive(Parser, PartialEq)]
 #[clap(name = "new", after_help = CONFIG_NEW_AFTER_HELP)]
 pub struct ConfigNewCommand {
     /// The path of the new configuration file

--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use wasmtime_cli_flags::CommonOptions;
 
 /// Explore the compilation of a WebAssembly module to native code.
-#[derive(Parser)]
+#[derive(Parser, PartialEq)]
 #[clap(name = "explore")]
 pub struct ExploreCommand {
     #[clap(flatten)]

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -54,11 +54,12 @@ fn parse_preloads(s: &str) -> Result<(String, PathBuf)> {
 }
 
 /// Runs a WebAssembly module
-#[derive(Parser)]
+#[derive(Parser, PartialEq)]
 #[structopt(name = "run")]
 pub struct RunCommand {
     #[clap(flatten)]
-    run: RunCommon,
+    #[allow(missing_docs)]
+    pub run: RunCommon,
 
     /// Grant access of a host directory to a guest.
     ///
@@ -67,7 +68,7 @@ pub struct RunCommand {
     /// then the `HOST` directory is opened and made available as the name
     /// `GUEST` in the guest.
     #[clap(long = "dir", value_name = "HOST_DIR[::GUEST_DIR]", value_parser = parse_dirs)]
-    dirs: Vec<(String, String)>,
+    pub dirs: Vec<(String, String)>,
 
     /// Pass an environment variable to the program.
     ///
@@ -77,11 +78,11 @@ pub struct RunCommand {
     /// has in the calling process for the guest, or in other words it will
     /// cause the environment variable `FOO` to be inherited.
     #[clap(long = "env", number_of_values = 1, value_name = "NAME[=VAL]", value_parser = parse_env_var)]
-    vars: Vec<(String, Option<String>)>,
+    pub vars: Vec<(String, Option<String>)>,
 
     /// The name of the function to run
     #[clap(long, value_name = "FUNCTION")]
-    invoke: Option<String>,
+    pub invoke: Option<String>,
 
     /// Load the given WebAssembly module before the main module
     #[clap(
@@ -90,7 +91,7 @@ pub struct RunCommand {
         value_name = "NAME=MODULE_PATH",
         value_parser = parse_preloads,
     )]
-    preloads: Vec<(String, PathBuf)>,
+    pub preloads: Vec<(String, PathBuf)>,
 
     /// The WebAssembly module to run and arguments to pass to it.
     ///
@@ -98,7 +99,7 @@ pub struct RunCommand {
     /// arguments unless the `--invoke` CLI argument is passed in which case
     /// arguments will be interpreted as arguments to the function specified.
     #[clap(value_name = "WASM", trailing_var_arg = true, required = true)]
-    module_and_args: Vec<OsString>,
+    pub module_and_args: Vec<OsString>,
 }
 
 enum CliLinker {

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -64,7 +64,7 @@ const DEFAULT_ADDR: std::net::SocketAddr = std::net::SocketAddr::new(
 );
 
 /// Runs a WebAssembly module
-#[derive(Parser)]
+#[derive(Parser, PartialEq)]
 #[structopt(name = "serve")]
 pub struct ServeCommand {
     #[clap(flatten)]

--- a/src/commands/settings.rs
+++ b/src/commands/settings.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use wasmtime_environ::{CompilerBuilder, FlagValue, Setting, SettingKind};
 
 /// Displays available Cranelift settings for a target.
-#[derive(Parser)]
+#[derive(Parser, PartialEq)]
 #[clap(name = "run")]
 pub struct SettingsCommand {
     /// The target triple to get the settings for; defaults to the host triple.

--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -8,7 +8,7 @@ use wasmtime_cli_flags::CommonOptions;
 use wasmtime_wast::WastContext;
 
 /// Runs a WebAssembly test script file
-#[derive(Parser)]
+#[derive(Parser, PartialEq)]
 #[clap(name = "wast", version)]
 pub struct WastCommand {
     #[clap(flatten)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -35,7 +35,7 @@ impl RunTarget {
 }
 
 /// Common command line arguments for run commands.
-#[derive(Parser)]
+#[derive(Parser, PartialEq)]
 pub struct RunCommon {
     #[clap(flatten)]
     pub common: CommonOptions,
@@ -216,7 +216,7 @@ impl RunCommon {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub enum Profile {
     Native(wasmtime::ProfilingStrategy),
     Guest { path: String, interval: Duration },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,6 @@
 pub mod commands;
 
 pub(crate) mod common;
+
+#[cfg(feature = "old-cli")]
+pub mod old_cli;

--- a/src/old_cli.rs
+++ b/src/old_cli.rs
@@ -1,0 +1,993 @@
+#![allow(missing_docs)]
+
+use anyhow::{bail, Result};
+use clap::builder::{OsStringValueParser, TypedValueParser};
+use clap::Parser;
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Wasmtime WebAssembly Runtime
+#[derive(Parser)]
+#[clap(
+    version,
+    after_help = "If a subcommand is not provided, the `run` subcommand will be used.\n\
+                  \n\
+                  Usage examples:\n\
+                  \n\
+                  Running a WebAssembly module with a start function:\n\
+                  \n  \
+                  wasmtime example.wasm
+                  \n\
+                  Passing command line arguments to a WebAssembly module:\n\
+                  \n  \
+                  wasmtime example.wasm arg1 arg2 arg3\n\
+                  \n\
+                  Invoking a specific function (e.g. `add`) in a WebAssembly module:\n\
+                  \n  \
+                  wasmtime example.wasm --invoke add 1 2\n"
+)]
+pub enum Wasmtime {
+    /// Compiles a WebAssembly module.
+    Compile(CompileCommand),
+    /// Runs a WebAssembly module
+    Run(RunCommand),
+}
+
+#[test]
+fn verify_cli() {
+    use clap::CommandFactory;
+    Wasmtime::command().debug_assert()
+}
+
+#[derive(Parser)]
+pub enum Subcommand {
+    /// Compiles a WebAssembly module.
+    Compile(CompileCommand),
+    /// Runs a WebAssembly module
+    Run(RunCommand),
+}
+
+#[derive(Parser)]
+#[structopt(name = "run", trailing_var_arg = true)]
+pub struct RunCommand {
+    #[clap(flatten)]
+    common: CommonOptions,
+
+    /// Allow unknown exports when running commands.
+    #[clap(long = "allow-unknown-exports")]
+    allow_unknown_exports: bool,
+
+    /// Allow the main module to import unknown functions, using an
+    /// implementation that immediately traps, when running commands.
+    #[clap(long = "trap-unknown-imports")]
+    trap_unknown_imports: bool,
+
+    /// Allow the main module to import unknown functions, using an
+    /// implementation that returns default values, when running commands.
+    #[clap(long = "default-values-unknown-imports")]
+    default_values_unknown_imports: bool,
+
+    /// Allow executing precompiled WebAssembly modules as `*.cwasm` files.
+    ///
+    /// Note that this option is not safe to pass if the module being passed in
+    /// is arbitrary user input. Only `wasmtime`-precompiled modules generated
+    /// via the `wasmtime compile` command or equivalent should be passed as an
+    /// argument with this option specified.
+    #[clap(long = "allow-precompiled")]
+    allow_precompiled: bool,
+
+    /// Inherit environment variables and file descriptors following the
+    /// systemd listen fd specification (UNIX only)
+    #[clap(long = "listenfd")]
+    listenfd: bool,
+
+    /// Grant access to the given TCP listen socket
+    #[clap(
+        long = "tcplisten",
+        number_of_values = 1,
+        value_name = "SOCKET ADDRESS"
+    )]
+    tcplisten: Vec<String>,
+
+    /// Grant access to the given host directory
+    #[clap(long = "dir", number_of_values = 1, value_name = "DIRECTORY")]
+    dirs: Vec<String>,
+
+    /// Pass an environment variable to the program.
+    ///
+    /// The `--env FOO=BAR` form will set the environment variable named `FOO`
+    /// to the value `BAR` for the guest program using WASI. The `--env FOO`
+    /// form will set the environment variable named `FOO` to the same value it
+    /// has in the calling process for the guest, or in other words it will
+    /// cause the environment variable `FOO` to be inherited.
+    #[clap(long = "env", number_of_values = 1, value_name = "NAME[=VAL]", value_parser = parse_env_var)]
+    vars: Vec<(String, Option<String>)>,
+
+    /// The name of the function to run
+    #[clap(long, value_name = "FUNCTION")]
+    invoke: Option<String>,
+
+    /// Grant access to a guest directory mapped as a host directory
+    #[clap(long = "mapdir", number_of_values = 1, value_name = "GUEST_DIR::HOST_DIR", value_parser = parse_map_dirs)]
+    map_dirs: Vec<(String, String)>,
+
+    /// Pre-load machine learning graphs (i.e., models) for use by wasi-nn.
+    ///
+    /// Each use of the flag will preload a ML model from the host directory
+    /// using the given model encoding. The model will be mapped to the
+    /// directory name: e.g., `--wasi-nn-graph openvino:/foo/bar` will preload
+    /// an OpenVINO model named `bar`. Note that which model encodings are
+    /// available is dependent on the backends implemented in the
+    /// `wasmtime_wasi_nn` crate.
+    #[clap(long = "wasi-nn-graph", value_name = "FORMAT::HOST_DIR", value_parser = parse_graphs)]
+    graphs: Vec<(String, String)>,
+
+    /// The path of the WebAssembly module to run
+    #[clap(
+		required = true,
+        value_name = "MODULE",
+        value_parser = OsStringValueParser::new().try_map(parse_module),
+    )]
+    module: PathBuf,
+
+    /// Load the given WebAssembly module before the main module
+    #[clap(
+        long = "preload",
+        number_of_values = 1,
+        value_name = "NAME=MODULE_PATH",
+        value_parser = parse_preloads,
+    )]
+    preloads: Vec<(String, PathBuf)>,
+
+    /// Maximum execution time of wasm code before timing out (1, 2s, 100ms, etc)
+    #[clap(
+        long = "wasm-timeout",
+        value_name = "TIME",
+        value_parser = parse_dur,
+    )]
+    wasm_timeout: Option<Duration>,
+
+    /// Profiling strategy (valid options are: perfmap, jitdump, vtune, guest)
+    ///
+    /// The perfmap, jitdump, and vtune profiling strategies integrate Wasmtime
+    /// with external profilers such as `perf`. The guest profiling strategy
+    /// enables in-process sampling and will write the captured profile to
+    /// `wasmtime-guest-profile.json` by default which can be viewed at
+    /// https://profiler.firefox.com/.
+    ///
+    /// The `guest` option can be additionally configured as:
+    ///
+    ///     --profile=guest[,path[,interval]]
+    ///
+    /// where `path` is where to write the profile and `interval` is the
+    /// duration between samples. When used with `--wasm-timeout` the timeout
+    /// will be rounded up to the nearest multiple of this interval.
+    #[clap(
+        long,
+        value_name = "STRATEGY",
+        value_parser = parse_profile,
+    )]
+    profile: Option<Profile>,
+
+    /// Enable coredump generation after a WebAssembly trap.
+    #[clap(long = "coredump-on-trap", value_name = "PATH")]
+    coredump_on_trap: Option<String>,
+
+    // NOTE: this must come last for trailing varargs
+    /// The arguments to pass to the module
+    #[clap(value_name = "ARGS")]
+    module_args: Vec<String>,
+
+    /// Maximum size, in bytes, that a linear memory is allowed to reach.
+    ///
+    /// Growth beyond this limit will cause `memory.grow` instructions in
+    /// WebAssembly modules to return -1 and fail.
+    #[clap(long, value_name = "BYTES")]
+    max_memory_size: Option<usize>,
+
+    /// Maximum size, in table elements, that a table is allowed to reach.
+    #[clap(long)]
+    max_table_elements: Option<u32>,
+
+    /// Maximum number of WebAssembly instances allowed to be created.
+    #[clap(long)]
+    max_instances: Option<usize>,
+
+    /// Maximum number of WebAssembly tables allowed to be created.
+    #[clap(long)]
+    max_tables: Option<usize>,
+
+    /// Maximum number of WebAssembly linear memories allowed to be created.
+    #[clap(long)]
+    max_memories: Option<usize>,
+
+    /// Force a trap to be raised on `memory.grow` and `table.grow` failure
+    /// instead of returning -1 from these instructions.
+    ///
+    /// This is not necessarily a spec-compliant option to enable but can be
+    /// useful for tracking down a backtrace of what is requesting so much
+    /// memory, for example.
+    #[clap(long)]
+    trap_on_grow_failure: bool,
+
+    /// Indicates that the implementation of WASI preview1 should be backed by
+    /// the preview2 implementation for components.
+    ///
+    /// This will become the default in the future and this option will be
+    /// removed. For now this is primarily here for testing.
+    #[clap(long)]
+    preview2: bool,
+
+    /// Enables memory error checking.
+    ///
+    /// See wmemcheck.md for documentation on how to use.
+    #[clap(long)]
+    wmemcheck: bool,
+
+    /// Flag for WASI preview2 to inherit the host's network within the guest so
+    /// it has full access to all addresses/ports/etc.
+    #[clap(long)]
+    inherit_network: bool,
+}
+fn parse_module(s: OsString) -> anyhow::Result<PathBuf> {
+    // Do not accept wasmtime subcommand names as the module name
+    match s.to_str() {
+        Some("help") | Some("run") | Some("compile") => {
+            bail!("module name cannot be the same as a subcommand")
+        }
+        _ => Ok(s.into()),
+    }
+}
+
+#[derive(Clone)]
+pub enum Profile {
+    Native(wasmtime::ProfilingStrategy),
+    Guest { path: String, interval: Duration },
+}
+
+fn parse_env_var(s: &str) -> Result<(String, Option<String>)> {
+    let mut parts = s.splitn(2, '=');
+    Ok((
+        parts.next().unwrap().to_string(),
+        parts.next().map(|s| s.to_string()),
+    ))
+}
+
+fn parse_map_dirs(s: &str) -> Result<(String, String)> {
+    let parts: Vec<&str> = s.split("::").collect();
+    if parts.len() != 2 {
+        bail!("must contain exactly one double colon ('::')");
+    }
+    Ok((parts[0].into(), parts[1].into()))
+}
+
+fn parse_graphs(s: &str) -> Result<(String, String)> {
+    let parts: Vec<&str> = s.split("::").collect();
+    if parts.len() != 2 {
+        bail!("must contain exactly one double colon ('::')");
+    }
+    Ok((parts[0].into(), parts[1].into()))
+}
+
+fn parse_dur(s: &str) -> Result<Duration> {
+    // assume an integer without a unit specified is a number of seconds ...
+    if let Ok(val) = s.parse() {
+        return Ok(Duration::from_secs(val));
+    }
+    // ... otherwise try to parse it with units such as `3s` or `300ms`
+    let dur = humantime::parse_duration(s)?;
+    Ok(dur)
+}
+
+fn parse_preloads(s: &str) -> Result<(String, PathBuf)> {
+    let parts: Vec<&str> = s.splitn(2, '=').collect();
+    if parts.len() != 2 {
+        bail!("must contain exactly one equals character ('=')");
+    }
+    Ok((parts[0].into(), parts[1].into()))
+}
+
+fn parse_profile(s: &str) -> Result<Profile> {
+    let parts = s.split(',').collect::<Vec<_>>();
+    match &parts[..] {
+        ["perfmap"] => Ok(Profile::Native(wasmtime::ProfilingStrategy::PerfMap)),
+        ["jitdump"] => Ok(Profile::Native(wasmtime::ProfilingStrategy::JitDump)),
+        ["vtune"] => Ok(Profile::Native(wasmtime::ProfilingStrategy::VTune)),
+        ["guest"] => Ok(Profile::Guest {
+            path: "wasmtime-guest-profile.json".to_string(),
+            interval: Duration::from_millis(10),
+        }),
+        ["guest", path] => Ok(Profile::Guest {
+            path: path.to_string(),
+            interval: Duration::from_millis(10),
+        }),
+        ["guest", path, dur] => Ok(Profile::Guest {
+            path: path.to_string(),
+            interval: parse_dur(dur)?,
+        }),
+        _ => bail!("unknown profiling strategy: {s}"),
+    }
+}
+
+/// Compiles a WebAssembly module.
+#[derive(Parser)]
+pub struct CompileCommand {
+    #[clap(flatten)]
+    pub common: CommonOptions,
+
+    /// The target triple; default is the host triple
+    #[clap(long, value_name = "TARGET")]
+    pub target: Option<String>,
+
+    /// The path of the output compiled module; defaults to <MODULE>.cwasm
+    #[clap(short = 'o', long, value_name = "OUTPUT")]
+    pub output: Option<PathBuf>,
+
+    /// The directory path to write clif files into, one clif file per wasm function.
+    #[clap(long = "emit-clif", value_name = "PATH")]
+    pub emit_clif: Option<PathBuf>,
+
+    /// The path of the WebAssembly to compile
+    #[clap(index = 1, value_name = "MODULE")]
+    pub module: PathBuf,
+}
+
+/// Common options for commands that translate WebAssembly modules
+#[derive(Parser)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct CommonOptions {
+    /// Use specified configuration file
+    #[clap(long, value_name = "CONFIG_PATH")]
+    pub config: Option<PathBuf>,
+
+    /// Disable logging
+    #[clap(long, conflicts_with = "log_to_files")]
+    pub disable_logging: bool,
+
+    /// Log to per-thread log files instead of stderr
+    #[clap(long)]
+    pub log_to_files: bool,
+
+    /// Generate debug information
+    #[clap(short = 'g')]
+    pub debug_info: bool,
+
+    /// Disable cache system
+    #[clap(long)]
+    pub disable_cache: bool,
+
+    /// Disable parallel compilation
+    #[clap(long)]
+    pub disable_parallel_compilation: bool,
+
+    /// Enable or disable WebAssembly features
+    #[clap(long, value_name = "FEATURE,FEATURE,...", value_parser = parse_wasm_features)]
+    pub wasm_features: Option<WasmFeatures>,
+
+    /// Enable or disable WASI modules
+    #[clap(long, value_name = "MODULE,MODULE,...", value_parser = parse_wasi_modules)]
+    pub wasi_modules: Option<WasiModules>,
+
+    /// Generate jitdump file (supported on --features=profiling build)
+    /// Run optimization passes on translated functions, on by default
+    #[clap(short = 'O', long)]
+    pub optimize: bool,
+
+    /// Optimization level for generated functions
+    /// Supported levels: 0 (none), 1, 2 (most), or s (size); default is "most"
+    #[clap(
+        long,
+        value_name = "LEVEL",
+        value_parser = parse_opt_level,
+        verbatim_doc_comment,
+    )]
+    pub opt_level: Option<wasmtime::OptLevel>,
+
+    /// Set a Cranelift setting to a given value.
+    /// Use `wasmtime settings` to list Cranelift settings for a target.
+    #[clap(
+        long = "cranelift-set",
+        value_name = "NAME=VALUE",
+        number_of_values = 1,
+        verbatim_doc_comment,
+        value_parser = parse_cranelift_flag,
+    )]
+    pub cranelift_set: Vec<(String, String)>,
+
+    /// Enable a Cranelift boolean setting or preset.
+    /// Use `wasmtime settings` to list Cranelift settings for a target.
+    #[clap(
+        long,
+        value_name = "SETTING",
+        number_of_values = 1,
+        verbatim_doc_comment
+    )]
+    pub cranelift_enable: Vec<String>,
+
+    /// Maximum size in bytes of wasm memory before it becomes dynamically
+    /// relocatable instead of up-front-reserved.
+    #[clap(long, value_name = "MAXIMUM")]
+    pub static_memory_maximum_size: Option<u64>,
+
+    /// Force using a "static" style for all wasm memories
+    #[clap(long)]
+    pub static_memory_forced: bool,
+
+    /// Byte size of the guard region after static memories are allocated
+    #[clap(long, value_name = "SIZE")]
+    pub static_memory_guard_size: Option<u64>,
+
+    /// Byte size of the guard region after dynamic memories are allocated
+    #[clap(long, value_name = "SIZE")]
+    pub dynamic_memory_guard_size: Option<u64>,
+
+    /// Bytes to reserve at the end of linear memory for growth for dynamic
+    /// memories.
+    #[clap(long, value_name = "SIZE")]
+    pub dynamic_memory_reserved_for_growth: Option<u64>,
+
+    /// Enable Cranelift's internal debug verifier (expensive)
+    #[clap(long)]
+    pub enable_cranelift_debug_verifier: bool,
+
+    /// Enable Cranelift's internal NaN canonicalization
+    #[clap(long)]
+    pub enable_cranelift_nan_canonicalization: bool,
+
+    /// Enable execution fuel with N units fuel, where execution will trap after
+    /// running out of fuel.
+    ///
+    /// Most WebAssembly instructions consume 1 unit of fuel. Some instructions,
+    /// such as `nop`, `drop`, `block`, and `loop`, consume 0 units, as any
+    /// execution cost associated with them involves other instructions which do
+    /// consume fuel.
+    #[clap(long, value_name = "N")]
+    pub fuel: Option<u64>,
+
+    /// Executing wasm code will yield when a global epoch counter
+    /// changes, allowing for async operation without blocking the
+    /// executor.
+    #[clap(long)]
+    pub epoch_interruption: bool,
+
+    /// Disable the on-by-default address map from native code to wasm code
+    #[clap(long)]
+    pub disable_address_map: bool,
+
+    /// Disable the default of attempting to initialize linear memory via a
+    /// copy-on-write mapping
+    #[clap(long)]
+    pub disable_memory_init_cow: bool,
+
+    /// Enable the pooling allocator, in place of the on-demand
+    /// allocator.
+    #[cfg(feature = "pooling-allocator")]
+    #[clap(long)]
+    pub pooling_allocator: bool,
+
+    /// Maximum stack size, in bytes, that wasm is allowed to consume before a
+    /// stack overflow is reported.
+    #[clap(long)]
+    pub max_wasm_stack: Option<usize>,
+
+    /// Whether or not to force deterministic and host-independent behavior of
+    /// the relaxed-simd instructions.
+    ///
+    /// By default these instructions may have architecture-specific behavior as
+    /// allowed by the specification, but this can be used to force the behavior
+    /// of these instructions to match the deterministic behavior classified in
+    /// the specification. Note that enabling this option may come at a
+    /// performance cost.
+    #[clap(long)]
+    pub relaxed_simd_deterministic: bool,
+
+    /// Explicitly specify the name of the compiler to use for WebAssembly.
+    ///
+    /// Currently only `cranelift` and `winch` are supported, but not all builds
+    /// of Wasmtime have both built in.
+    #[clap(long)]
+    pub compiler: Option<String>,
+}
+
+fn parse_opt_level(opt_level: &str) -> Result<wasmtime::OptLevel> {
+    match opt_level {
+        "s" => Ok(wasmtime::OptLevel::SpeedAndSize),
+        "0" => Ok(wasmtime::OptLevel::None),
+        "1" => Ok(wasmtime::OptLevel::Speed),
+        "2" => Ok(wasmtime::OptLevel::Speed),
+        other => bail!(
+            "unknown optimization level `{}`, only 0,1,2,s accepted",
+            other
+        ),
+    }
+}
+
+#[derive(Default, Clone, Copy)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
+pub struct WasmFeatures {
+    pub reference_types: Option<bool>,
+    pub multi_value: Option<bool>,
+    pub bulk_memory: Option<bool>,
+    pub simd: Option<bool>,
+    pub relaxed_simd: Option<bool>,
+    pub tail_call: Option<bool>,
+    pub threads: Option<bool>,
+    pub multi_memory: Option<bool>,
+    pub memory64: Option<bool>,
+    pub component_model: Option<bool>,
+    pub function_references: Option<bool>,
+}
+
+const SUPPORTED_WASM_FEATURES: &[(&str, &str)] = &[
+    ("all", "enables all supported WebAssembly features"),
+    (
+        "bulk-memory",
+        "enables support for bulk memory instructions",
+    ),
+    (
+        "multi-memory",
+        "enables support for the multi-memory proposal",
+    ),
+    ("multi-value", "enables support for multi-value functions"),
+    ("reference-types", "enables support for reference types"),
+    ("simd", "enables support for proposed SIMD instructions"),
+    (
+        "relaxed-simd",
+        "enables support for the relaxed simd proposal",
+    ),
+    ("tail-call", "enables support for WebAssembly tail calls"),
+    ("threads", "enables support for WebAssembly threads"),
+    ("memory64", "enables support for 64-bit memories"),
+    ("component-model", "enables support for the component model"),
+    (
+        "function-references",
+        "enables support for typed function references",
+    ),
+];
+
+fn parse_wasm_features(features: &str) -> Result<WasmFeatures> {
+    let features = features.trim();
+
+    let mut all = None;
+    let mut values: HashMap<_, _> = SUPPORTED_WASM_FEATURES
+        .iter()
+        .map(|(name, _)| (name.to_string(), None))
+        .collect();
+
+    if features == "all" {
+        all = Some(true);
+    } else if features == "-all" {
+        all = Some(false);
+    } else {
+        for feature in features.split(',') {
+            let feature = feature.trim();
+
+            if feature.is_empty() {
+                continue;
+            }
+
+            let (feature, value) = if feature.starts_with('-') {
+                (&feature[1..], false)
+            } else {
+                (feature, true)
+            };
+
+            if feature == "all" {
+                bail!("'all' cannot be specified with other WebAssembly features");
+            }
+
+            match values.get_mut(feature) {
+                Some(v) => *v = Some(value),
+                None => bail!("unsupported WebAssembly feature '{}'", feature),
+            }
+        }
+    }
+
+    Ok(WasmFeatures {
+        reference_types: all.or(values["reference-types"]),
+        multi_value: all.or(values["multi-value"]),
+        bulk_memory: all.or(values["bulk-memory"]),
+        simd: all.or(values["simd"]),
+        relaxed_simd: all.or(values["relaxed-simd"]),
+        tail_call: all.or(values["tail-call"]),
+        threads: all.or(values["threads"]),
+        multi_memory: all.or(values["multi-memory"]),
+        memory64: all.or(values["memory64"]),
+        #[cfg(feature = "component-model")]
+        component_model: all.or(values["component-model"]),
+        function_references: all.or(values["function-references"]),
+    })
+}
+
+/// Select which WASI modules are available at runtime for use by Wasm programs.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WasiModules {
+    /// Enable the wasi-common implementation; eventually this should be split into its separate
+    /// parts once the implementation allows for it (e.g. wasi-fs, wasi-clocks, etc.).
+    pub wasi_common: Option<bool>,
+
+    /// Enable the experimental wasi-nn implementation.
+    pub wasi_nn: Option<bool>,
+
+    /// Enable the experimental wasi-threads implementation.
+    pub wasi_threads: Option<bool>,
+
+    /// Enable the experimental wasi-http implementation
+    pub wasi_http: Option<bool>,
+}
+
+fn parse_wasi_modules(modules: &str) -> Result<WasiModules> {
+    let modules = modules.trim();
+    match modules {
+        "default" => Ok(WasiModules::default()),
+        "-default" => Ok(WasiModules::none()),
+        _ => {
+            // Starting from the default set of WASI modules, enable or disable a list of
+            // comma-separated modules.
+            let mut wasi_modules = WasiModules::default();
+            let mut set = |module: &str, enable: bool| match module {
+                "" => Ok(()),
+                "wasi-common" => Ok(wasi_modules.wasi_common = Some(enable)),
+                "experimental-wasi-nn" => Ok(wasi_modules.wasi_nn = Some(enable)),
+                "experimental-wasi-threads" => Ok(wasi_modules.wasi_threads = Some(enable)),
+                "experimental-wasi-http" => Ok(wasi_modules.wasi_http = Some(enable)),
+                "default" => bail!("'default' cannot be specified with other WASI modules"),
+                _ => bail!("unsupported WASI module '{}'", module),
+            };
+
+            for module in modules.split(',') {
+                let module = module.trim();
+                let (module, value) = if module.starts_with('-') {
+                    (&module[1..], false)
+                } else {
+                    (module, true)
+                };
+                set(module, value)?;
+            }
+
+            Ok(wasi_modules)
+        }
+    }
+}
+
+impl Default for WasiModules {
+    fn default() -> Self {
+        Self {
+            wasi_common: None,
+            wasi_nn: None,
+            wasi_threads: None,
+            wasi_http: None,
+        }
+    }
+}
+
+impl WasiModules {
+    /// Enable no modules.
+    fn none() -> Self {
+        Self {
+            wasi_common: Some(false),
+            wasi_nn: Some(false),
+            wasi_threads: Some(false),
+            wasi_http: Some(false),
+        }
+    }
+}
+
+fn parse_cranelift_flag(name_and_value: &str) -> Result<(String, String)> {
+    let mut split = name_and_value.splitn(2, '=');
+    let name = if let Some(name) = split.next() {
+        name.to_string()
+    } else {
+        bail!("missing name in cranelift flag");
+    };
+    let value = if let Some(value) = split.next() {
+        value.to_string()
+    } else {
+        bail!("missing value in cranelift flag");
+    };
+    Ok((name, value))
+}
+
+impl CompileCommand {
+    pub fn convert(self) -> crate::commands::CompileCommand {
+        let CompileCommand {
+            common,
+            target,
+            output,
+            emit_clif,
+            module,
+        } = self;
+
+        crate::commands::CompileCommand {
+            common: common.convert(),
+            target,
+            output,
+            emit_clif,
+            module,
+        }
+    }
+}
+
+impl RunCommand {
+    pub fn convert(self) -> crate::commands::RunCommand {
+        let RunCommand {
+            common,
+            allow_unknown_exports,
+            trap_unknown_imports,
+            default_values_unknown_imports,
+            allow_precompiled,
+            listenfd,
+            tcplisten,
+            dirs: old_dirs,
+            vars,
+            invoke,
+            map_dirs,
+            graphs,
+            preloads,
+            wasm_timeout,
+            profile,
+            coredump_on_trap,
+            max_memory_size,
+            max_table_elements,
+            max_instances,
+            max_tables,
+            max_memories,
+            trap_on_grow_failure,
+            wmemcheck,
+            module,
+            module_args,
+            preview2,
+            inherit_network,
+        } = self;
+
+        let mut common = common.convert();
+
+        let mut dirs = Vec::new();
+
+        for host in old_dirs {
+            dirs.push((host.clone(), host));
+        }
+
+        if preview2 {
+            common.wasi.preview2 = Some(true);
+        }
+        if wmemcheck {
+            common.wasm.wmemcheck = Some(true);
+        }
+        if trap_on_grow_failure {
+            common.wasm.trap_on_grow_failure = Some(true);
+        }
+        if let Some(max) = max_memories {
+            common.wasm.max_memories = Some(max);
+        }
+        if let Some(max) = max_tables {
+            common.wasm.max_tables = Some(max);
+        }
+        if let Some(max) = max_instances {
+            common.wasm.max_instances = Some(max);
+        }
+        if let Some(max) = max_memory_size {
+            common.wasm.max_memory_size = Some(max);
+        }
+        if let Some(max) = max_table_elements {
+            common.wasm.max_table_elements = Some(max);
+        }
+        if let Some(path) = coredump_on_trap {
+            common.debug.coredump = Some(path);
+        }
+        if let Some(timeout) = wasm_timeout {
+            common.wasm.timeout = Some(timeout);
+        }
+        if trap_unknown_imports {
+            common.wasm.unknown_imports_trap = Some(true);
+        }
+        if default_values_unknown_imports {
+            common.wasm.unknown_imports_default = Some(true);
+        }
+        common.wasi.tcplisten = tcplisten;
+        if listenfd {
+            common.wasi.listenfd = Some(true);
+        }
+        if allow_unknown_exports {
+            common.wasm.unknown_exports_allow = Some(true);
+        }
+        if inherit_network {
+            common.wasi.inherit_network = Some(true);
+        }
+
+        for (format, dir) in graphs {
+            common
+                .wasi
+                .nn_graph
+                .push(wasmtime_cli_flags::WasiNnGraph { format, dir });
+        }
+
+        for (guest, host) in map_dirs {
+            dirs.push((host, guest));
+        }
+
+        let run = crate::common::RunCommon {
+            common,
+            allow_precompiled,
+            profile: profile.map(|p| p.convert()),
+        };
+
+        let mut module_and_args = vec![module.into()];
+        module_and_args.extend(module_args.into_iter().map(|s| s.into()));
+        crate::commands::RunCommand {
+            run,
+            dirs,
+            vars,
+            invoke,
+            preloads,
+            module_and_args,
+        }
+    }
+}
+
+impl CommonOptions {
+    pub fn convert(self) -> wasmtime_cli_flags::CommonOptions {
+        let CommonOptions {
+            config,
+            disable_logging,
+            log_to_files,
+            debug_info,
+            disable_cache,
+            disable_parallel_compilation,
+            wasm_features,
+            wasi_modules,
+            optimize,
+            opt_level,
+            cranelift_set,
+            cranelift_enable,
+            static_memory_maximum_size,
+            static_memory_forced,
+            static_memory_guard_size,
+            dynamic_memory_guard_size,
+            dynamic_memory_reserved_for_growth,
+            enable_cranelift_debug_verifier,
+            enable_cranelift_nan_canonicalization,
+            fuel,
+            epoch_interruption,
+            disable_address_map,
+            disable_memory_init_cow,
+            pooling_allocator,
+            max_wasm_stack,
+            relaxed_simd_deterministic,
+            compiler,
+        } = self;
+
+        let mut ret = wasmtime_cli_flags::CommonOptions::parse_from::<_, String>([]);
+        match compiler.as_deref() {
+            Some("cranelift") => ret.codegen.compiler = Some(wasmtime::Strategy::Cranelift),
+            Some("winch") => ret.codegen.compiler = Some(wasmtime::Strategy::Winch),
+
+            // Plumbing an error up from this point is a bit onerous. Let's
+            // just hope that no one was using this from the old CLI and passing
+            // invalid values.
+            Some(_) => {}
+
+            None => {}
+        }
+        if relaxed_simd_deterministic {
+            ret.wasm.relaxed_simd_deterministic = Some(true);
+        }
+        ret.wasm.max_wasm_stack = max_wasm_stack;
+        if pooling_allocator {
+            ret.opts.pooling_allocator = Some(true);
+        }
+        if disable_memory_init_cow {
+            ret.opts.memory_init_cow = Some(false);
+        }
+        if disable_address_map {
+            ret.debug.address_map = Some(false);
+        }
+        if epoch_interruption {
+            ret.wasm.epoch_interruption = Some(true);
+        }
+        if enable_cranelift_debug_verifier {
+            ret.codegen.cranelift_debug_verifier = Some(true);
+        }
+        if enable_cranelift_nan_canonicalization {
+            ret.wasm.nan_canonicalization = Some(true);
+        }
+        if let Some(fuel) = fuel {
+            ret.wasm.fuel = Some(fuel);
+        }
+        if let Some(amt) = dynamic_memory_reserved_for_growth {
+            ret.opts.dynamic_memory_reserved_for_growth = Some(amt);
+        }
+        if let Some(amt) = dynamic_memory_guard_size {
+            ret.opts.dynamic_memory_guard_size = Some(amt);
+        }
+        if let Some(amt) = static_memory_guard_size {
+            ret.opts.static_memory_guard_size = Some(amt);
+        }
+        if static_memory_forced {
+            ret.opts.static_memory_forced = Some(true);
+        }
+        if let Some(amt) = static_memory_maximum_size {
+            ret.opts.static_memory_maximum_size = Some(amt);
+        }
+        if let Some(level) = opt_level {
+            ret.opts.opt_level = Some(level);
+        }
+        if disable_cache {
+            ret.codegen.cache = Some(false);
+        }
+        if debug_info {
+            ret.debug.debug_info = Some(true);
+        }
+        if optimize {
+            ret.opts.opt_level = Some(wasmtime::OptLevel::Speed);
+        }
+        if disable_parallel_compilation {
+            ret.codegen.parallel_compilation = Some(false);
+        }
+        if log_to_files {
+            ret.debug.log_to_files = Some(true);
+        }
+        if disable_logging {
+            ret.debug.logging = Some(false);
+        }
+        if let Some(path) = config {
+            ret.codegen.cache_config = Some(path.display().to_string());
+        }
+        for (key, val) in cranelift_set {
+            ret.codegen.cranelift.push((key, Some(val)));
+        }
+        for key in cranelift_enable {
+            ret.codegen.cranelift.push((key, None));
+        }
+        if let Some(features) = wasm_features {
+            let WasmFeatures {
+                reference_types,
+                multi_value,
+                bulk_memory,
+                simd,
+                relaxed_simd,
+                tail_call,
+                threads,
+                multi_memory,
+                memory64,
+                component_model,
+                function_references,
+            } = features;
+            ret.wasm.reference_types = reference_types;
+            ret.wasm.multi_value = multi_value;
+            ret.wasm.bulk_memory = bulk_memory;
+            ret.wasm.simd = simd;
+            ret.wasm.relaxed_simd = relaxed_simd;
+            ret.wasm.tail_call = tail_call;
+            ret.wasm.threads = threads;
+            ret.wasm.multi_memory = multi_memory;
+            ret.wasm.memory64 = memory64;
+            ret.wasm.component_model = component_model;
+            ret.wasm.function_references = function_references;
+        }
+        if let Some(modules) = wasi_modules {
+            let WasiModules {
+                wasi_common,
+                wasi_nn,
+                wasi_threads,
+                wasi_http,
+            } = modules;
+            ret.wasi.http = wasi_http;
+            ret.wasi.nn = wasi_nn;
+            ret.wasi.threads = wasi_threads;
+            ret.wasi.common = wasi_common;
+        }
+        ret
+    }
+}
+
+impl Profile {
+    pub fn convert(self) -> crate::common::Profile {
+        match self {
+            Profile::Native(s) => crate::common::Profile::Native(s),
+            Profile::Guest { path, interval } => crate::common::Profile::Guest { path, interval },
+        }
+    }
+}

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1016,9 +1016,14 @@ fn old_cli_warn_if_ambiguous_flags() -> Result<()> {
         String::from_utf8_lossy(&output.stderr),
         "\
 warning: this CLI invocation of Wasmtime will be parsed differently in future
-         Wasmtime versions, see this online issue for more information:
+         Wasmtime versions, but its interpretation is not changing yet -- see
+         this online issue for more information:
          https://github.com/bytecodealliance/wasmtime/issues/7384
-         you can use `WASMTIME_NEW_CLI=0` to temporarily disable this warning
+
+         CLI parsing can be temporarily configured with an environment variable:
+
+         - WASMTIME_NEW_CLI=0 to silence this warning and not change behavior, or
+         - WASMTIME_NEW_CLI=1 to force using the new behavior
 warning: using `--invoke` with a function that returns values is experimental and may break in the future
 "
     );
@@ -1116,10 +1121,14 @@ warning: using `--invoke` with a function that returns values is experimental an
     assert_eq!(
         String::from_utf8_lossy(&output.stderr),
         "\
-warning: this CLI invocation of Wasmtime is going to break in the future, for
+warning: this CLI invocation of Wasmtime is going to break in the future -- for
          more information see this issue online:
          https://github.com/bytecodealliance/wasmtime/issues/7384
-         use `WASMTIME_NEW_CLI=0` to temporarily disable this warning
+
+         CLI parsing can be temporarily configured with an environment variable:
+
+         - WASMTIME_NEW_CLI=0 to silence this warning and not change behavior, or
+         - WASMTIME_NEW_CLI=1 to see how this command breaks with new syntax
 "
     );
 

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1016,14 +1016,15 @@ fn old_cli_warn_if_ambiguous_flags() -> Result<()> {
         String::from_utf8_lossy(&output.stderr),
         "\
 warning: this CLI invocation of Wasmtime will be parsed differently in future
-         Wasmtime versions, but its interpretation is not changing yet -- see
-         this online issue for more information:
+         Wasmtime versions -- see this online issue for more information:
          https://github.com/bytecodealliance/wasmtime/issues/7384
 
-         CLI parsing can be temporarily configured with an environment variable:
+         Wasmtime will now execute with the old (<= Wasmtime 13) CLI parsing,
+         however this behavior can also be temporarily configured with an
+         environment variable:
 
-         - WASMTIME_NEW_CLI=0 to silence this warning and not change behavior, or
-         - WASMTIME_NEW_CLI=1 to force using the new behavior
+         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silences this warning, or
+         - WASMTIME_NEW_CLI=1 to indicate new semantics are desired and use the latest behavior
 warning: using `--invoke` with a function that returns values is experimental and may break in the future
 "
     );
@@ -1125,10 +1126,12 @@ warning: this CLI invocation of Wasmtime is going to break in the future -- for
          more information see this issue online:
          https://github.com/bytecodealliance/wasmtime/issues/7384
 
-         CLI parsing can be temporarily configured with an environment variable:
+         Wasmtime will now execute with the old (<= Wasmtime 13) CLI parsing,
+         however this behavior can also be temporarily configured with an
+         environment variable:
 
-         - WASMTIME_NEW_CLI=0 to silence this warning and not change behavior, or
-         - WASMTIME_NEW_CLI=1 to see how this command breaks with new syntax
+         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silences this warning, or
+         - WASMTIME_NEW_CLI=1 to indicate new semantics are desired and see the error
 "
     );
 

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1023,7 +1023,7 @@ warning: this CLI invocation of Wasmtime will be parsed differently in future
          however this behavior can also be temporarily configured with an
          environment variable:
 
-         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silences this warning, or
+         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silence this warning, or
          - WASMTIME_NEW_CLI=1 to indicate new semantics are desired and use the latest behavior
 warning: using `--invoke` with a function that returns values is experimental and may break in the future
 "
@@ -1130,7 +1130,7 @@ warning: this CLI invocation of Wasmtime is going to break in the future -- for
          however this behavior can also be temporarily configured with an
          environment variable:
 
-         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silences this warning, or
+         - WASMTIME_NEW_CLI=0 to indicate old semantics are desired and silence this warning, or
          - WASMTIME_NEW_CLI=1 to indicate new semantics are desired and see the error
 "
     );


### PR DESCRIPTION
This commit introduces a compatibility shim for the Wasmtime 13 CLI and prior. The goal of this commit is to address concerns raised in #7336 and other locations as well. While the new CLI cannot be un-shipped at this point this PR attempts to ameliorate the situation somewhat through a few avenues:

* A complete copy of the old CLI parser is now included in `wasmtime` by default.
* The `WASMTIME_NEW_CLI=0` environment variable can force usage of the old CLI parser for the `run` and `compile` commands.
* The `WASMTIME_NEW_CLI=1` environment variable can force usage of the new CLI parser.
* Otherwise both the old and the new CLI parser are executed. Depending on the result one is selected to be executed, possibly with a warning printed.
* If both CLI parsers succeed but produce the same result, then no warning is emitted and execution continues as usual.
* If both CLI parsers succeed but produce different results then a warning is emitted indicating this. The warning points to #7384 which has further examples of how to squash the warning. The warning also mentions the above env var to turn the warning off. In this situation the old semantics are used at this time instead of the new semantics. It's intended that eventually this will change in the future.
* If the new CLI succeeds and the old CLI fails then the new semantics are executed without warning.
* If the old CLI succeeds and the new CLI fails then a warning is issued and the old semantics are used.
* If both the old and the new CLI fail to parse then the error message for the new CLI is emitted.

Note that this doesn't add up to a perfect transition. The hope is that most of the major cases of change at the very least have something printed. My plan is to land this on `main` and then backport it to the 14.0.0 branch as a 14.0.3 release.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
