### PR TITLE
Fix a possible panic in clock subscription

### DIFF
--- a/crates/test-programs/src/bin/preview2_sleep.rs
+++ b/crates/test-programs/src/bin/preview2_sleep.rs
@@ -1,15 +1,27 @@
 use test_programs::wasi::{clocks::monotonic_clock, io::poll};
 
 fn main() {
-    // Sleep ten milliseconds.  Note that we call the relevant host functions directly rather than go through
-    // libstd, since we want to ensure we're calling `monotonic_clock::subscribe` with an `absolute` parameter of
-    // `true`, which libstd won't necessarily do (but which e.g. CPython _will_ do).
-    eprintln!("calling subscribe");
-    let p = monotonic_clock::subscribe(monotonic_clock::now() + 10_000_000, true);
-    dbg!(&p as *const _);
-    let list = &[&p];
-    dbg!(list.as_ptr());
-    eprintln!("calling poll");
-    poll::poll_list(list);
-    eprintln!("done");
+    sleep_10ms();
+    sleep_0ms();
+    sleep_backwards_in_time();
+}
+
+fn sleep_10ms() {
+    let dur = 10_000_000;
+    let p = monotonic_clock::subscribe(monotonic_clock::now() + dur, true);
+    poll::poll_one(&p);
+    let p = monotonic_clock::subscribe(dur, false);
+    poll::poll_one(&p);
+}
+
+fn sleep_0ms() {
+    let p = monotonic_clock::subscribe(monotonic_clock::now(), true);
+    poll::poll_one(&p);
+    let p = monotonic_clock::subscribe(0, false);
+    poll::poll_one(&p);
+}
+
+fn sleep_backwards_in_time() {
+    let p = monotonic_clock::subscribe(monotonic_clock::now() - 1, true);
+    poll::poll_one(&p);
 }

--- a/crates/wasi/src/preview2/host/clocks.rs
+++ b/crates/wasi/src/preview2/host/clocks.rs
@@ -55,7 +55,7 @@ impl<T: WasiView> monotonic_clock::Host for T {
     fn subscribe(&mut self, when: Instant, absolute: bool) -> anyhow::Result<Resource<Pollable>> {
         let clock_now = self.ctx().monotonic_clock.now();
         let duration = if absolute {
-            Duration::from_nanos(when - clock_now)
+            Duration::from_nanos(when.saturating_sub(clock_now))
         } else {
             Duration::from_nanos(when)
         };


### PR DESCRIPTION
Change an `a - b` expression to `a.saturating_sub(b)` to handle the case when a clock is subscribed to an instance/duration in the past.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
