### PR TITLE
Update rustix to 0.38.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2262,9 +2262,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.38.14"
+version = "0.38.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
+checksum = "2b426b0506e5d50a7d8dafcf2e81471400deb602392c7dd110815afb4eaf02a3"
 dependencies = [
  "bitflags 2.4.1",
  "errno",

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -3,195 +3,195 @@
 
 [[unpublished.cranelift]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-bforest]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-codegen]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-control]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-entity]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-frontend]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-isle]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-jit]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-module]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-native]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-object]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-reader]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-serde]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-wasm]]
 version = "0.102.0"
-audited_as = "0.101.1"
+audited_as = "0.101.2"
 
 [[unpublished.wasi-cap-std-sync]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasi-common]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasi-tokio]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-cache]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-cli]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-component-macro]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-component-util]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-cranelift]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-environ]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-explorer]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-fiber]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-jit]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-runtime]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-types]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-wasi]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-wast]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-winch]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wiggle]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wiggle-generate]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wiggle-macro]]
 version = "15.0.0"
-audited_as = "14.0.1"
+audited_as = "14.0.2"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -199,7 +199,7 @@ audited_as = "0.1.0"
 
 [[unpublished.winch-codegen]]
 version = "0.13.0"
-audited_as = "0.12.1"
+audited_as = "0.12.2"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -370,104 +370,104 @@ user-login = "epage"
 user-name = "Ed Page"
 
 [[publisher.cranelift]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-wasm]]
-version = "0.101.1"
-when = "2023-10-23"
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -640,8 +640,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.rustix]]
-version = "0.38.14"
-when = "2023-09-20"
+version = "0.38.21"
+when = "2023-10-26"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -722,13 +722,6 @@ user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
-[[publisher.target-lexicon]]
-version = "0.12.12"
-when = "2023-10-19"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
 [[publisher.termcolor]]
 version = "1.1.3"
 when = "2022-03-02"
@@ -786,20 +779,20 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.wasi-cap-std-sync]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasi-common]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasi-tokio]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -881,152 +874,152 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasmtime]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-asm-macros]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cache]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-macro]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-util]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift-shared]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-explorer]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-fiber]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-debug]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-icache-coherence]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-runtime]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-types]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-winch]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wit-bindgen]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wmemcheck]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1045,20 +1038,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "14.0.1"
-when = "2023-10-23"
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1077,8 +1070,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "0.12.1"
-when = "2023-10-23"
+version = "0.12.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
Completes the upgrade from #7370 with bytecodealliance/rustix#901 being published to crates.io.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
