### PR TITLE
PCC: verification primitives for dynamic range checks.

### DIFF
--- a/cranelift/codegen/src/ir/pcc.rs
+++ b/cranelift/codegen/src/ir/pcc.rs
@@ -1288,7 +1288,7 @@ impl<'a> FactContext<'a> {
     /// Apply a known inequality to rewrite dynamic bounds using transitivity, if possible.
     ///
     /// Given that `lhs >= rhs` (if not `strict`) or `lhs > rhs` (if
-    /// `strict`), update `fact.
+    /// `strict`), update `fact`.
     pub fn apply_inequality(
         &self,
         fact: &Fact,

--- a/cranelift/codegen/src/isa/aarch64/lower.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower.rs
@@ -136,7 +136,10 @@ impl LowerBackend for AArch64Backend {
         ctx: &FactContext<'_>,
         vcode: &mut VCode<Self::MInst>,
         inst: InsnIndex,
+        state: &mut pcc::FactFlowState,
     ) -> PccResult<()> {
-        pcc::check(ctx, vcode, inst)
+        pcc::check(ctx, vcode, inst, state)
     }
+
+    type FactFlowState = pcc::FactFlowState;
 }

--- a/cranelift/codegen/src/isa/aarch64/pcc.rs
+++ b/cranelift/codegen/src/isa/aarch64/pcc.rs
@@ -300,18 +300,11 @@ pub(crate) fn check(
 
                 // True side: lhs <= rhs, not strict.
                 let rn = get_fact_or_default(vcode, rn, 64);
-                trace!("rn = {rn:?}");
-                let rn = ctx.apply_inequality(&rn, &cmp_lhs, &cmp_rhs, false);
-                trace!(" -> rn = {rn:?}");
+                let rn = ctx.apply_inequality(&rn, &cmp_lhs, &cmp_rhs, InequalityKind::Loose);
                 // false side: rhs < lhs, strict.
                 let rm = get_fact_or_default(vcode, rm, 64);
-                trace!("rm = {rm:?}");
-                let rm = ctx.apply_inequality(&rm, &cmp_rhs, &cmp_lhs, true);
-                trace!(" -> rm = {rm:?}");
-
+                let rm = ctx.apply_inequality(&rm, &cmp_rhs, &cmp_lhs, InequalityKind::Strict);
                 let union = Fact::union(&rn, &rm);
-                trace!("union = {union:?}");
-
                 // Union the two facts.
                 clamp_range(ctx, 64, 64, union)
             })

--- a/cranelift/codegen/src/isa/riscv64/lower.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower.rs
@@ -30,4 +30,6 @@ impl LowerBackend for Riscv64Backend {
         // right now riscv64 not support this feature.
         None
     }
+
+    type FactFlowState = ();
 }

--- a/cranelift/codegen/src/isa/s390x/lower.rs
+++ b/cranelift/codegen/src/isa/s390x/lower.rs
@@ -25,4 +25,6 @@ impl LowerBackend for S390xBackend {
     ) -> Option<()> {
         isle::lower_branch(ctx, self, ir_inst, targets)
     }
+
+    type FactFlowState = ();
 }

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -2007,7 +2007,7 @@ impl fmt::Display for ShiftKind {
 
 /// These indicate condition code tests.  Not all are represented since not all are useful in
 /// compiler-generated code.
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 #[repr(u8)]
 pub enum CC {
     ///  overflow

--- a/cranelift/codegen/src/isa/x64/lower.rs
+++ b/cranelift/codegen/src/isa/x64/lower.rs
@@ -345,7 +345,10 @@ impl LowerBackend for X64Backend {
         ctx: &FactContext<'_>,
         vcode: &mut VCode<Self::MInst>,
         inst: InsnIndex,
+        state: &mut pcc::FactFlowState,
     ) -> PccResult<()> {
-        pcc::check(ctx, vcode, inst)
+        pcc::check(ctx, vcode, inst, state)
     }
+
+    type FactFlowState = pcc::FactFlowState;
 }

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -391,7 +391,7 @@ pub(crate) fn check(
                     )
                 })
             }
-            Imm8Reg::Reg { .. } => undefined_result(ctx, vcode, dst, 64, 64),
+            Imm8Reg::Reg { .. } => undefined_result(ctx, vcode, dst, 64, size.to_bits().into()),
         },
 
         Inst::ShiftR { size, dst, .. } => {

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -450,15 +450,12 @@ pub(crate) fn check(
                 check_output(ctx, vcode, dst.to_writable_reg(), &[], |vcode| {
                     // See comments in aarch64::pcc CSel for more details on this.
                     let in_true = get_fact_or_default(vcode, reg, 64);
-                    trace!("in_true = {:?}", in_true);
-                    let in_true = ctx.apply_inequality(&in_true, &cmp_lhs, &cmp_rhs, false);
-                    trace!("in_true = {:?}", in_true);
+                    let in_true =
+                        ctx.apply_inequality(&in_true, &cmp_lhs, &cmp_rhs, InequalityKind::Loose);
                     let in_false = get_fact_or_default(vcode, alternative.to_reg(), 64);
-                    trace!("in_false = {:?}", in_false);
-                    let in_false = ctx.apply_inequality(&in_false, &cmp_rhs, &cmp_lhs, true);
-                    trace!("in_false = {:?}", in_false);
+                    let in_false =
+                        ctx.apply_inequality(&in_false, &cmp_rhs, &cmp_lhs, InequalityKind::Strict);
                     let union = Fact::union(&in_true, &in_false);
-                    trace!("union = {:?}", union);
                     clamp_range(ctx, 64, 64, union)
                 })
             }

--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -148,6 +148,9 @@ pub trait LowerBackend {
         None
     }
 
+    /// The type of state carried between `check_fact` invocations.
+    type FactFlowState: Default + Clone + Debug;
+
     /// Check any facts about an instruction, given VCode with facts
     /// on VRegs. Takes mutable `VCode` so that it can propagate some
     /// kinds of facts automatically.
@@ -156,6 +159,7 @@ pub trait LowerBackend {
         _ctx: &FactContext<'_>,
         _vcode: &mut VCode<Self::MInst>,
         _inst: InsnIndex,
+        _state: &mut Self::FactFlowState,
     ) -> PccResult<()> {
         Err(PccError::UnimplementedBackend)
     }

--- a/cranelift/filetests/filetests/pcc/succeed/dynamic.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/dynamic.clif
@@ -1,0 +1,42 @@
+test compile
+set enable_pcc=true
+target aarch64
+target x86_64
+
+;; Equivalent to a Wasm `i64.load` from a dynamic memory.
+function %f0(i64 vmctx, i32) -> i64 {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned checked gv0+0 ;; base
+    gv2 = load.i64 notrap aligned checked gv0+8 ;; size
+    
+    ;; mock vmctx struct:
+    mt0 = struct 16 {
+        0: i64 readonly ! dynamic_mem(mt1, 0, 0),
+        8: i64 readonly ! dynamic_range(64, gv2, gv2),
+    }
+    ;; mock dynamic memory: dynamic range, plus 2GiB guard
+    mt1 = dynamic_memory gv2 + 0x8000_0000
+
+block0(v0 ! mem(mt0, 0, 0): i64, v1: i32):
+    v2 ! range(64, 0, 0xffff_ffff)            = uextend.i64 v1       ;; extended Wasm offset
+    v3 ! dynamic_mem(mt1, 0, 0)               = global_value.i64 gv1 ;; base
+    v4 ! dynamic_range(64, gv2, gv2)          = global_value.i64 gv2 ;; size
+    v5 ! compare(uge, v2, gv2)                = icmp.i64 uge v2, v4  ;; bounds-check compare of extended Wasm offset to size
+    v6 ! dynamic_mem(mt1, 0, v2)              = iadd.i64 v3, v2      ;; compute access address: memory base plus extended Wasm offset
+    v7 ! dynamic_mem(mt1, 0, 0, nullable)     = iconst.i64 0         ;; null pointer for speculative path
+    v8 ! dynamic_mem(mt1, 0, gv2-1, nullable) = select_spectre_guard v5, v7, v6  ;; if OOB, pick null, otherwise the real address
+    v9                                        = load.i64 checked v8
+    return v9
+}
+
+;; select sees:
+;;  v5 ! compare(uge, v2, gv2)
+;;  v6 ! dynamic_mem(mt1, 0, v2)
+;;  v7 ! dynamic_mem(mt0, 0, 0, nullable)
+;;
+;; preprocess:
+;; v6' (assuming compare is false) = dynamic_mem(mt1, 0, gv2-1)
+;; v7' (assuming compare is true)  = dynamic_mem(mt1, 0, 0, nullable)
+;;
+;; take the union of range and nullability:
+;; dynamic_mem(mt1, 0, gv2-1, nullable)

--- a/cranelift/filetests/filetests/pcc/succeed/dynamic.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/dynamic.clif
@@ -17,12 +17,12 @@ function %f0(i64 vmctx, i32) -> i64 {
     ;; mock dynamic memory: dynamic range, plus 2GiB guard
     mt1 = dynamic_memory gv2 + 0x8000_0000
 
-block0(v0 ! mem(mt0, 0, 0): i64, v1: i32):
-    v2 ! range(64, 0, 0xffff_ffff)            = uextend.i64 v1       ;; extended Wasm offset
+block0(v0 ! mem(mt0, 0, 0): i64, v1 ! dynamic_range(32, v1, v1): i32):
+    v2 ! dynamic_range(64, v1, v1)            = uextend.i64 v1       ;; extended Wasm offset
     v3 ! dynamic_mem(mt1, 0, 0)               = global_value.i64 gv1 ;; base
     v4 ! dynamic_range(64, gv2, gv2)          = global_value.i64 gv2 ;; size
-    v5 ! compare(uge, v2, gv2)                = icmp.i64 uge v2, v4  ;; bounds-check compare of extended Wasm offset to size
-    v6 ! dynamic_mem(mt1, 0, v2)              = iadd.i64 v3, v2      ;; compute access address: memory base plus extended Wasm offset
+    v5 ! compare(uge, v1, gv2)                = icmp.i64 uge v2, v4  ;; bounds-check compare of extended Wasm offset to size
+    v6 ! dynamic_mem(mt1, v1, v1)              = iadd.i64 v3, v2      ;; compute access address: memory base plus extended Wasm offset
     v7 ! dynamic_mem(mt1, 0, 0, nullable)     = iconst.i64 0         ;; null pointer for speculative path
     v8 ! dynamic_mem(mt1, 0, gv2-1, nullable) = select_spectre_guard v5, v7, v6  ;; if OOB, pick null, otherwise the real address
     v9                                        = load.i64 checked v8
@@ -30,8 +30,8 @@ block0(v0 ! mem(mt0, 0, 0): i64, v1: i32):
 }
 
 ;; select sees:
-;;  v5 ! compare(uge, v2, gv2)
-;;  v6 ! dynamic_mem(mt1, 0, v2)
+;;  v5 ! compare(uge, v1, gv2)
+;;  v6 ! dynamic_mem(mt1, v1, v1)
 ;;  v7 ! dynamic_mem(mt0, 0, 0, nullable)
 ;;
 ;; preprocess:

--- a/cranelift/filetests/filetests/pcc/succeed/dynamic.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/dynamic.clif
@@ -22,7 +22,7 @@ block0(v0 ! mem(mt0, 0, 0): i64, v1 ! dynamic_range(32, v1, v1): i32):
     v3 ! dynamic_mem(mt1, 0, 0)               = global_value.i64 gv1 ;; base
     v4 ! dynamic_range(64, gv2, gv2)          = global_value.i64 gv2 ;; size
     v5 ! compare(uge, v1, gv2)                = icmp.i64 uge v2, v4  ;; bounds-check compare of extended Wasm offset to size
-    v6 ! dynamic_mem(mt1, v1, v1)              = iadd.i64 v3, v2      ;; compute access address: memory base plus extended Wasm offset
+    v6 ! dynamic_mem(mt1, v1, v1)             = iadd.i64 v3, v2      ;; compute access address: memory base plus extended Wasm offset
     v7 ! dynamic_mem(mt1, 0, 0, nullable)     = iconst.i64 0         ;; null pointer for speculative path
     v8 ! dynamic_mem(mt1, 0, gv2-1, nullable) = select_spectre_guard v5, v7, v6  ;; if OOB, pick null, otherwise the real address
     v9                                        = load.i64 checked v8

--- a/cranelift/reader/src/parser.rs
+++ b/cranelift/reader/src/parser.rs
@@ -2369,9 +2369,14 @@ impl<'a> Parser<'a> {
     //
     // base-expr ::= GlobalValue(base)
     //             | Value(base)
+    //             | "max"
     //             | (epsilon)
     fn parse_base_expr(&mut self) -> ParseResult<BaseExpr> {
         match self.token() {
+            Some(Token::Identifier("max")) => {
+                self.consume();
+                Ok(BaseExpr::Max)
+            }
             Some(Token::GlobalValue(..)) => {
                 let gv = self.match_gv("expected global value")?;
                 Ok(BaseExpr::GlobalValue(gv))


### PR DESCRIPTION
This PR adds new kinds of facts on value `dynamic_range`, `dynamic_mem`, and `compare`; a new kind of memory type `dynamic_memory`; and a notion of symbolic expressions (a sum of either an SSA value or global value and a static offset) for min and max values in those ranges that are just rich enough to express the expected CLIF sequence for Wasm dynamic memory bounds-checks with Spectre mitigations (cmp/select rather than control-flow-based). It is sufficient to validate the following

```
; Equivalent to a Wasm `i64.load` from a dynamic memory.                                                                                                                                     
function %f0(i64 vmctx, i32) -> i64 {                                                                                                                                                         
    gv0 = vmctx                                                                                                                                                                               
    gv1 = load.i64 notrap aligned checked gv0+0 ;; base                                                                                                                                       
    gv2 = load.i64 notrap aligned checked gv0+8 ;; size                                                                                                                                       
                                                                                                                                                                                              
    ;; mock vmctx struct:                                                                                                                                                                     
    mt0 = struct 16 {                                                                                                                                                                         
        0: i64 readonly ! dynamic_mem(mt1, 0, 0),                                                                                                                                             
        8: i64 readonly ! dynamic_range(64, gv2, gv2),                                                                                                                                        
    }                                                                                                                                                                                         
    ;; mock dynamic memory: dynamic range, plus 2GiB guard                                                                                                                                    
    mt1 = dynamic_memory gv2 + 0x8000_0000                                                                                                                                                    
                                                                                                                                                                                              
block0(v0 ! mem(mt0, 0, 0): i64, v1 ! dynamic_range(32, v1, v1): i32):                                                                                                                        
    v2 ! dynamic_range(64, v1, v1)            = uextend.i64 v1       ;; extended Wasm offset                                                                                                  
    v3 ! dynamic_mem(mt1, 0, 0)               = global_value.i64 gv1 ;; base                                                                                                                  
    v4 ! dynamic_range(64, gv2, gv2)          = global_value.i64 gv2 ;; size                                                                                                                  
    v5 ! compare(uge, v1, gv2)                = icmp.i64 uge v2, v4  ;; bounds-check compare of extended Wasm offset to size                                                                  
    v6 ! dynamic_mem(mt1, v1, v1)              = iadd.i64 v3, v2      ;; compute access address: memory base plus extended Wasm offset                                                        
    v7 ! dynamic_mem(mt1, 0, 0, nullable)     = iconst.i64 0         ;; null pointer for speculative path                                                                                     
    v8 ! dynamic_mem(mt1, 0, gv2-1, nullable) = select_spectre_guard v5, v7, v6  ;; if OOB, pick null, otherwise the real address                                                             
    v9                                        = load.i64 checked v8                                                                                                                           
    return v9                                                                                                                                                                                 
}  
```

on both x86-64 and aarch64.

The first half of this was:

Co-authored-by: Nick Fitzgerald <fitzgen@gmail.com>