### PR TITLE
Add vet for target-lexicon again

### DIFF
--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -722,6 +722,13 @@ user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
+[[publisher.target-lexicon]]
+version = "0.12.12"
+when = "2023-10-19"
+user-id = 6825
+user-login = "sunfishcode"
+user-name = "Dan Gohman"
+
 [[publisher.termcolor]]
 version = "1.1.3"
 when = "2022-03-02"


### PR DESCRIPTION
This vet was originally added in #7380 but I accidentally deleted it in #7387 with a call to `cargo vet prune`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
