### PR TITLE
[14.0.0] Enable the `wasmtime serve` command by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -282,6 +282,7 @@ default = [
   "wasi-threads",
   "wasi-http",
   "pooling-allocator",
+  "serve",
 ]
 jitdump = ["wasmtime/jitdump"]
 vtune = ["wasmtime/vtune"]


### PR DESCRIPTION
This enables the `serve` subcommand by default on the CLI instead of having it behind an off-by-default feature. In general our default build is the "most featureful" while we still retain the ability to turn off everything if desired for custom builds. This additionally matches the current `main` branch where through other refactorings the `serve` command is now enabled by default.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
