### PR TITLE
mpk: turn on `memory_protection_keys` during fuzzing

### DIFF
--- a/crates/fuzzing/src/generators/pooling_config.rs
+++ b/crates/fuzzing/src/generators/pooling_config.rs
@@ -1,6 +1,7 @@
 //! Generate instance limits for the pooling allocation strategy.
 
 use arbitrary::{Arbitrary, Unstructured};
+use wasmtime::MpkEnabled;
 
 /// Configuration for `wasmtime::PoolingAllocationStrategy`.
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -30,6 +31,9 @@ pub struct PoolingAllocationConfig {
 
     pub async_stack_zeroing: bool,
     pub async_stack_keep_resident: usize,
+
+    pub memory_protection_keys: MpkEnabled,
+    pub max_memory_protection_keys: usize,
 }
 
 impl PoolingAllocationConfig {
@@ -61,6 +65,8 @@ impl PoolingAllocationConfig {
 
         cfg.async_stack_zeroing(self.async_stack_zeroing);
         cfg.async_stack_keep_resident(self.async_stack_keep_resident);
+
+        cfg.memory_protection_keys(self.memory_protection_keys);
 
         cfg
     }
@@ -104,6 +110,9 @@ impl<'a> Arbitrary<'a> for PoolingAllocationConfig {
 
             async_stack_zeroing: u.arbitrary()?,
             async_stack_keep_resident: u.int_in_range(0..=1 << 20)?,
+
+            memory_protection_keys: u.choose(&[MpkEnabled::Auto, MpkEnabled::Disable])?.clone(),
+            max_memory_protection_keys: u.int_in_range(0..=20)?,
         })
     }
 }

--- a/crates/runtime/src/mpk/mod.rs
+++ b/crates/runtime/src/mpk/mod.rs
@@ -42,7 +42,7 @@ cfg_if::cfg_if! {
 }
 
 /// Describe the tri-state configuration of memory protection keys (MPK).
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum MpkEnabled {
     /// Use MPK if supported by the current system; fall back to guard regions
     /// otherwise.


### PR DESCRIPTION
This also twists the `max_memory_protection_keys` knob.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
