### PR TITLE
Fix file writes in preview 2 implementation

### DIFF
--- a/crates/test-programs/src/bin/preview1_file_write.rs
+++ b/crates/test-programs/src/bin/preview1_file_write.rs
@@ -1,0 +1,106 @@
+use std::{env, process};
+use test_programs::preview1::open_scratch_directory;
+
+unsafe fn test_file_long_write(dir_fd: wasi::Fd, filename: &str) {
+    // Open a file for writing
+    let file_fd = wasi::path_open(
+        dir_fd,
+        0,
+        filename,
+        wasi::OFLAGS_CREAT,
+        wasi::RIGHTS_FD_WRITE,
+        0,
+        0,
+    )
+    .expect("creating a file for writing");
+
+    let mut content = Vec::new();
+    // 16 byte string, 4096 times, is 64k
+    for n in 0..4096 {
+        let chunk = format!("123456789 {n:05} ");
+        assert_eq!(chunk.as_str().as_bytes().len(), 16);
+        content.extend_from_slice(chunk.as_str().as_bytes());
+    }
+
+    // Write to the file
+    let nwritten = wasi::fd_write(
+        file_fd,
+        &[wasi::Ciovec {
+            buf: content.as_slice().as_ptr() as *const _,
+            buf_len: content.len(),
+        }],
+    )
+    .expect("writing file content");
+    assert_eq!(nwritten, content.len(), "nwritten bytes check");
+
+    let stat = wasi::fd_filestat_get(file_fd).expect("reading file stats");
+    assert_eq!(
+        stat.size,
+        content.len() as u64,
+        "file should be size of content",
+    );
+
+    wasi::fd_close(file_fd).expect("closing the file");
+    // Open the file for reading
+    let file_fd = wasi::path_open(dir_fd, 0, filename, 0, wasi::RIGHTS_FD_READ, 0, 0)
+        .expect("open the file for reading");
+
+    // Read the file's contents
+    let buffer = &mut [0u8; 100];
+    let nread = wasi::fd_read(
+        file_fd,
+        &[wasi::Iovec {
+            buf: buffer.as_mut_ptr(),
+            buf_len: buffer.len(),
+        }],
+    )
+    .expect("reading first chunk file content");
+
+    assert_eq!(nread, buffer.len(), "read first chunk");
+    assert_eq!(
+        buffer,
+        &content[..buffer.len()],
+        "contents of first read chunk"
+    );
+
+    let end_cursor = content.len() - buffer.len();
+    wasi::fd_seek(file_fd, end_cursor as i64, wasi::WHENCE_SET)
+        .expect("seeking to end of file minus buffer size");
+
+    let nread = wasi::fd_read(
+        file_fd,
+        &[wasi::Iovec {
+            buf: buffer.as_mut_ptr(),
+            buf_len: buffer.len(),
+        }],
+    )
+    .expect("reading end chunk of file content");
+
+    assert_eq!(nread, buffer.len(), "read end chunk len");
+    assert_eq!(buffer, &content[end_cursor..], "contents of end read chunk");
+
+    wasi::fd_close(file_fd).expect("closing the file");
+}
+
+fn main() {
+    let mut args = env::args();
+    let prog = args.next().unwrap();
+    let arg = if let Some(arg) = args.next() {
+        arg
+    } else {
+        eprintln!("usage: {} <scratch directory>", prog);
+        process::exit(1);
+    };
+
+    // Open scratch directory
+    let dir_fd = match open_scratch_directory(&arg) {
+        Ok(dir_fd) => dir_fd,
+        Err(err) => {
+            eprintln!("{}", err);
+            process::exit(1)
+        }
+    };
+
+    // Run the tests.
+    unsafe { test_file_long_write(dir_fd, "long_write.txt") }
+}

--- a/crates/wasi-common/tests/all/async_.rs
+++ b/crates/wasi-common/tests/all/async_.rs
@@ -291,3 +291,7 @@ async fn preview1_path_open_preopen() {
 async fn preview1_unicode_output() {
     run(PREVIEW1_UNICODE_OUTPUT, true).await.unwrap()
 }
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn preview1_file_write() {
+    run(PREVIEW1_FILE_WRITE, true).await.unwrap()
+}

--- a/crates/wasi-common/tests/all/sync.rs
+++ b/crates/wasi-common/tests/all/sync.rs
@@ -273,3 +273,7 @@ fn preview1_path_open_preopen() {
 fn preview1_unicode_output() {
     run(PREVIEW1_UNICODE_OUTPUT, true).unwrap()
 }
+#[test_log::test]
+fn preview1_file_write() {
+    run(PREVIEW1_FILE_WRITE, true).unwrap()
+}

--- a/crates/wasi/tests/all/async_.rs
+++ b/crates/wasi/tests/all/async_.rs
@@ -287,6 +287,10 @@ async fn preview1_path_open_preopen() {
 async fn preview1_unicode_output() {
     run(PREVIEW1_UNICODE_OUTPUT_COMPONENT, true).await.unwrap()
 }
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn preview1_file_write() {
+    run(PREVIEW1_FILE_WRITE_COMPONENT, false).await.unwrap()
+}
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn preview2_sleep() {

--- a/crates/wasi/tests/all/preview1.rs
+++ b/crates/wasi/tests/all/preview1.rs
@@ -245,3 +245,7 @@ async fn preview1_path_open_preopen() {
 async fn preview1_unicode_output() {
     run(PREVIEW1_UNICODE_OUTPUT, true).await.unwrap()
 }
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn preview1_file_write() {
+    run(PREVIEW1_FILE_WRITE, true).await.unwrap()
+}

--- a/crates/wasi/tests/all/sync.rs
+++ b/crates/wasi/tests/all/sync.rs
@@ -232,6 +232,10 @@ fn preview1_path_open_preopen() {
 fn preview1_unicode_output() {
     run(PREVIEW1_UNICODE_OUTPUT_COMPONENT, true).unwrap()
 }
+#[test_log::test]
+fn preview1_file_write() {
+    run(PREVIEW1_FILE_WRITE_COMPONENT, false).unwrap()
+}
 
 #[test_log::test]
 fn preview2_sleep() {


### PR DESCRIPTION
In https://github.com/bytecodealliance/wasmtime/pull/7130, there was a regression introduced in FileOutputStream where the position cursor was not updated after each write. This affects all file writes except for when the file is opened for appending.

This PR also adds a test which performs a larger (64k) write to a file than any prior tests.

Fixes #7390

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
