### PR TITLE
Fix parsing of new subcommands

### DIFF
--- a/src/old_cli.rs
+++ b/src/old_cli.rs
@@ -234,7 +234,8 @@ pub struct RunCommand {
 fn parse_module(s: OsString) -> anyhow::Result<PathBuf> {
     // Do not accept wasmtime subcommand names as the module name
     match s.to_str() {
-        Some("help") | Some("run") | Some("compile") => {
+        Some("help") | Some("run") | Some("compile") | Some("serve") | Some("explore")
+        | Some("settings") | Some("wast") | Some("config") => {
             bail!("module name cannot be the same as a subcommand")
         }
         _ => Ok(s.into()),


### PR DESCRIPTION
This commit updates the parsing of the old CLI to understand new subcommands to ensure that `wasmtime serve foo.wasm` isn't mistakenly interpreted in the old CLI as executing the module `serve` with the argument `foo.wasm`.

Closes #7396

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
