### PR TITLE
Release Wasmtime 14.0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-array-literals"
-version = "14.0.2"
+version = "14.0.3"
 
 [[package]]
 name = "byteorder"
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -574,14 +574,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "anyhow",
  "bincode",
@@ -609,25 +609,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.101.2"
+version = "0.101.3"
 
 [[package]]
 name = "cranelift-control"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "serde",
  "serde_derive",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.0",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.101.2"
+version = "0.101.3"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "verify-component-adapter"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -2993,7 +2993,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "bitflags 2.3.3",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "byte-array-literals",
  "object",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3309,14 +3309,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "base64",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3462,11 +3462,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "14.0.2"
+version = "14.0.3"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "backtrace",
  "cc",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "object",
  "once_cell",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "cc",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "openvino",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "log",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "log",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "heck",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "14.0.2"
+version = "14.0.3"
 
 [[package]]
 name = "wast"
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "anyhow",
  "heck",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "14.0.2"
+version = "14.0.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3980,7 +3980,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "14.0.2"
+version = "14.0.3"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -137,58 +137,58 @@ edition = "2021"
 rust-version = "1.70.0"
 
 [workspace.dependencies]
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=14.0.2" }
-wasmtime = { path = "crates/wasmtime", version = "14.0.2", default-features = false }
-wasmtime-cache = { path = "crates/cache", version = "=14.0.2" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=14.0.2" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=14.0.2" }
-wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=14.0.2" }
-wasmtime-winch = { path = "crates/winch", version = "=14.0.2" }
-wasmtime-environ = { path = "crates/environ", version = "=14.0.2" }
-wasmtime-explorer = { path = "crates/explorer", version = "=14.0.2" }
-wasmtime-fiber = { path = "crates/fiber", version = "=14.0.2" }
-wasmtime-types = { path = "crates/types", version = "14.0.2" }
-wasmtime-jit = { path = "crates/jit", version = "=14.0.2" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=14.0.2" }
-wasmtime-runtime = { path = "crates/runtime", version = "=14.0.2" }
-wasmtime-wast = { path = "crates/wast", version = "=14.0.2" }
-wasmtime-wasi = { path = "crates/wasi", version = "14.0.2", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=14.0.2", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "14.0.2" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "14.0.2" }
-wasmtime-component-util = { path = "crates/component-util", version = "=14.0.2" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=14.0.2" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=14.0.2" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=14.0.2" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=14.0.3" }
+wasmtime = { path = "crates/wasmtime", version = "14.0.3", default-features = false }
+wasmtime-cache = { path = "crates/cache", version = "=14.0.3" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=14.0.3" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=14.0.3" }
+wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=14.0.3" }
+wasmtime-winch = { path = "crates/winch", version = "=14.0.3" }
+wasmtime-environ = { path = "crates/environ", version = "=14.0.3" }
+wasmtime-explorer = { path = "crates/explorer", version = "=14.0.3" }
+wasmtime-fiber = { path = "crates/fiber", version = "=14.0.3" }
+wasmtime-types = { path = "crates/types", version = "14.0.3" }
+wasmtime-jit = { path = "crates/jit", version = "=14.0.3" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=14.0.3" }
+wasmtime-runtime = { path = "crates/runtime", version = "=14.0.3" }
+wasmtime-wast = { path = "crates/wast", version = "=14.0.3" }
+wasmtime-wasi = { path = "crates/wasi", version = "14.0.3", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=14.0.3", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "14.0.3" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "14.0.3" }
+wasmtime-component-util = { path = "crates/component-util", version = "=14.0.3" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=14.0.3" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=14.0.3" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=14.0.3" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=14.0.2", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=14.0.2" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=14.0.2" }
-wasi-common = { path = "crates/wasi-common", version = "=14.0.2" }
-wasi-tokio = { path = "crates/wasi-common/tokio", version = "=14.0.2" }
-wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=14.0.2" }
+wiggle = { path = "crates/wiggle", version = "=14.0.3", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=14.0.3" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=14.0.3" }
+wasi-common = { path = "crates/wasi-common", version = "=14.0.3" }
+wasi-tokio = { path = "crates/wasi-common/tokio", version = "=14.0.3" }
+wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=14.0.3" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=14.0.2" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=14.0.2" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=14.0.3" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=14.0.3" }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.101.2" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.101.2", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.101.2" }
-cranelift-entity = { path = "cranelift/entity", version = "0.101.2" }
-cranelift-native = { path = "cranelift/native", version = "0.101.2" }
-cranelift-module = { path = "cranelift/module", version = "0.101.2" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.101.2" }
-cranelift-reader = { path = "cranelift/reader", version = "0.101.2" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.101.3" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.101.3", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.101.3" }
+cranelift-entity = { path = "cranelift/entity", version = "0.101.3" }
+cranelift-native = { path = "cranelift/native", version = "0.101.3" }
+cranelift-module = { path = "cranelift/module", version = "0.101.3" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.101.3" }
+cranelift-reader = { path = "cranelift/reader", version = "0.101.3" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.101.2" }
-cranelift-jit = { path = "cranelift/jit", version = "0.101.2" }
+cranelift-object = { path = "cranelift/object", version = "0.101.3" }
+cranelift-jit = { path = "cranelift/jit", version = "0.101.3" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.101.2" }
-cranelift-control = { path = "cranelift/control", version = "0.101.2" }
-cranelift = { path = "cranelift/umbrella", version = "0.101.2" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.101.3" }
+cranelift-control = { path = "cranelift/control", version = "0.101.3" }
+cranelift = { path = "cranelift/umbrella", version = "0.101.3" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.12.2" }
+winch-codegen = { path = "winch/codegen", version = "=0.12.3" }
 winch-filetests = { path = "winch/filetests" }
 winch-test-macros = { path = "winch/test-macros" }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,7 +10,7 @@ Released 2023-10-29
   transition from the 13.0.0 CLI arguments and parsing to the changes in 14.0.0.
   CLI commands should now warn if they no longer work with the new parser, but
   still execute as they previously did. This behavior can be controlled via a
-  new `WASMTIME_NEW_CLI` env var if necessary.
+  new `WASMTIME_NEW_CLI` environment variable if necessary.
   [#7385](https://github.com/bytecodealliance/wasmtime/pull/7385)
 
 * The `serve` subcommand of the `wasmtime` CLI is now enabled by default for the

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,24 @@
 --------------------------------------------------------------------------------
 
+## 14.0.3
+
+Released 2023-10-29
+
+### Fixed
+
+* The `wasmtime` executable will now attempt to more gracefully handle the
+  transition from the 13.0.0 CLI arguments and parsing to the changes in 14.0.0.
+  CLI commands should now warn if they no longer work with the new parser, but
+  still execute as they previously did. This behavior can be controlled via a
+  new `WASMTIME_NEW_CLI` env var if necessary.
+  [#7385](https://github.com/bytecodealliance/wasmtime/pull/7385)
+
+* The `serve` subcommand of the `wasmtime` CLI is now enabled by default for the
+  `wasmtime` executable.
+  [#7392](https://github.com/bytecodealliance/wasmtime/pull/7392)
+
+--------------------------------------------------------------------------------
+
 ## 14.0.2
 
 Released 2023-10-26

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.101.2"
+version = "0.101.3"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.101.2"
+version = "0.101.3"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -16,7 +16,7 @@ edition.workspace = true
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.101.2" }
+cranelift-codegen-shared = { path = "./shared", version = "0.101.3" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -41,8 +41,8 @@ criterion = { version = "0.5.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.101.2" }
-cranelift-isle = { path = "../isle/isle", version = "=0.101.2" }
+cranelift-codegen-meta = { path = "meta", version = "0.101.3" }
+cranelift-isle = { path = "../isle/isle", version = "=0.101.3" }
 
 [features]
 default = ["std", "unwind", "host-arch"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.101.2"
+version = "0.101.3"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -12,4 +12,4 @@ edition.workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.101.2" }
+cranelift-codegen-shared = { path = "../shared", version = "0.101.3" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.101.2"
+version = "0.101.3"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.101.2"
+version = "0.101.3"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.101.2"
+version = "0.101.3"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.101.2"
+version = "0.101.3"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.101.2"
+version = "0.101.3"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.101.2"
+version = "0.101.3"
 
 [dependencies]
 codespan-reporting = { version = "0.11.1", optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.101.2"
+version = "0.101.3"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.101.2"
+version = "0.101.3"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.101.2"
+version = "0.101.3"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.101.2"
+version = "0.101.3"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.101.2"
+version = "0.101.3"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.101.2"
+version = "0.101.3"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.101.2"
+version = "0.101.3"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.101.2"
+version = "0.101.3"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -200,7 +200,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "14.0.2"
+#define WASMTIME_VERSION "14.0.3"
 /**
  * \brief Wasmtime major version number.
  */
@@ -212,7 +212,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 2
+#define WASMTIME_VERSION_PATCH 3
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -17,6 +17,10 @@ audited_as = "0.101.0"
 version = "0.101.2"
 audited_as = "0.101.1"
 
+[[unpublished.cranelift]]
+version = "0.101.3"
+audited_as = "0.101.2"
+
 [[unpublished.cranelift-bforest]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -32,6 +36,10 @@ audited_as = "0.101.0"
 [[unpublished.cranelift-bforest]]
 version = "0.101.2"
 audited_as = "0.101.1"
+
+[[unpublished.cranelift-bforest]]
+version = "0.101.3"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-codegen]]
 version = "0.100.0"
@@ -49,6 +57,10 @@ audited_as = "0.101.0"
 version = "0.101.2"
 audited_as = "0.101.1"
 
+[[unpublished.cranelift-codegen]]
+version = "0.101.3"
+audited_as = "0.101.2"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -64,6 +76,10 @@ audited_as = "0.101.0"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.101.2"
 audited_as = "0.101.1"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.101.3"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.100.0"
@@ -81,6 +97,10 @@ audited_as = "0.101.0"
 version = "0.101.2"
 audited_as = "0.101.1"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.101.3"
+audited_as = "0.101.2"
+
 [[unpublished.cranelift-control]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -96,6 +116,10 @@ audited_as = "0.101.0"
 [[unpublished.cranelift-control]]
 version = "0.101.2"
 audited_as = "0.101.1"
+
+[[unpublished.cranelift-control]]
+version = "0.101.3"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-entity]]
 version = "0.100.0"
@@ -113,6 +137,10 @@ audited_as = "0.101.0"
 version = "0.101.2"
 audited_as = "0.101.1"
 
+[[unpublished.cranelift-entity]]
+version = "0.101.3"
+audited_as = "0.101.2"
+
 [[unpublished.cranelift-frontend]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -128,6 +156,10 @@ audited_as = "0.101.0"
 [[unpublished.cranelift-frontend]]
 version = "0.101.2"
 audited_as = "0.101.1"
+
+[[unpublished.cranelift-frontend]]
+version = "0.101.3"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.100.0"
@@ -145,6 +177,10 @@ audited_as = "0.101.0"
 version = "0.101.2"
 audited_as = "0.101.1"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.101.3"
+audited_as = "0.101.2"
+
 [[unpublished.cranelift-isle]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -160,6 +196,10 @@ audited_as = "0.101.0"
 [[unpublished.cranelift-isle]]
 version = "0.101.2"
 audited_as = "0.101.1"
+
+[[unpublished.cranelift-isle]]
+version = "0.101.3"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-jit]]
 version = "0.100.0"
@@ -177,6 +217,10 @@ audited_as = "0.101.0"
 version = "0.101.2"
 audited_as = "0.101.1"
 
+[[unpublished.cranelift-jit]]
+version = "0.101.3"
+audited_as = "0.101.2"
+
 [[unpublished.cranelift-module]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -192,6 +236,10 @@ audited_as = "0.101.0"
 [[unpublished.cranelift-module]]
 version = "0.101.2"
 audited_as = "0.101.1"
+
+[[unpublished.cranelift-module]]
+version = "0.101.3"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-native]]
 version = "0.100.0"
@@ -209,6 +257,10 @@ audited_as = "0.101.0"
 version = "0.101.2"
 audited_as = "0.101.1"
 
+[[unpublished.cranelift-native]]
+version = "0.101.3"
+audited_as = "0.101.2"
+
 [[unpublished.cranelift-object]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -224,6 +276,10 @@ audited_as = "0.101.0"
 [[unpublished.cranelift-object]]
 version = "0.101.2"
 audited_as = "0.101.1"
+
+[[unpublished.cranelift-object]]
+version = "0.101.3"
+audited_as = "0.101.2"
 
 [[unpublished.cranelift-reader]]
 version = "0.100.0"
@@ -241,6 +297,10 @@ audited_as = "0.101.0"
 version = "0.101.2"
 audited_as = "0.101.1"
 
+[[unpublished.cranelift-reader]]
+version = "0.101.3"
+audited_as = "0.101.2"
+
 [[unpublished.cranelift-serde]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -257,6 +317,10 @@ audited_as = "0.101.0"
 version = "0.101.2"
 audited_as = "0.101.1"
 
+[[unpublished.cranelift-serde]]
+version = "0.101.3"
+audited_as = "0.101.2"
+
 [[unpublished.cranelift-wasm]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -273,6 +337,10 @@ audited_as = "0.101.0"
 version = "0.101.2"
 audited_as = "0.101.1"
 
+[[unpublished.cranelift-wasm]]
+version = "0.101.3"
+audited_as = "0.101.2"
+
 [[unpublished.wasi-cap-std-sync]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -288,6 +356,10 @@ audited_as = "14.0.0"
 [[unpublished.wasi-cap-std-sync]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasi-cap-std-sync]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasi-common]]
 version = "13.0.0"
@@ -305,6 +377,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasi-common]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasi-tokio]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -320,6 +396,10 @@ audited_as = "14.0.0"
 [[unpublished.wasi-tokio]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasi-tokio]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime]]
 version = "13.0.0"
@@ -337,6 +417,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -352,6 +436,10 @@ audited_as = "14.0.0"
 [[unpublished.wasmtime-asm-macros]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-cache]]
 version = "13.0.0"
@@ -369,6 +457,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-cache]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-cli]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -384,6 +476,10 @@ audited_as = "14.0.0"
 [[unpublished.wasmtime-cli]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasmtime-cli]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "13.0.0"
@@ -401,6 +497,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-component-macro]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -416,6 +516,10 @@ audited_as = "14.0.0"
 [[unpublished.wasmtime-component-macro]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasmtime-component-macro]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-component-util]]
 version = "13.0.0"
@@ -433,6 +537,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-component-util]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-cranelift]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -448,6 +556,10 @@ audited_as = "14.0.0"
 [[unpublished.wasmtime-cranelift]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasmtime-cranelift]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "13.0.0"
@@ -465,6 +577,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-cranelift-shared]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-environ]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -480,6 +596,10 @@ audited_as = "14.0.0"
 [[unpublished.wasmtime-environ]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasmtime-environ]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-explorer]]
 version = "13.0.0"
@@ -497,6 +617,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-explorer]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-fiber]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -512,6 +636,10 @@ audited_as = "14.0.0"
 [[unpublished.wasmtime-fiber]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasmtime-fiber]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-jit]]
 version = "13.0.0"
@@ -529,6 +657,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-jit]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -544,6 +676,10 @@ audited_as = "14.0.0"
 [[unpublished.wasmtime-jit-debug]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "13.0.0"
@@ -561,6 +697,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-runtime]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -576,6 +716,10 @@ audited_as = "14.0.0"
 [[unpublished.wasmtime-runtime]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasmtime-runtime]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-types]]
 version = "13.0.0"
@@ -593,6 +737,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-types]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-wasi]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -608,6 +756,10 @@ audited_as = "14.0.0"
 [[unpublished.wasmtime-wasi]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasmtime-wasi]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "13.0.0"
@@ -625,6 +777,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -640,6 +796,10 @@ audited_as = "14.0.0"
 [[unpublished.wasmtime-wasi-nn]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "13.0.0"
@@ -657,6 +817,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-wast]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -673,6 +837,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-wast]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-winch]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -689,6 +857,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-winch]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -704,6 +876,10 @@ audited_as = "14.0.0"
 [[unpublished.wasmtime-wit-bindgen]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "14.0.0"
@@ -717,6 +893,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wiggle]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -733,6 +913,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wiggle]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wiggle-generate]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -749,6 +933,10 @@ audited_as = "14.0.0"
 version = "14.0.2"
 audited_as = "14.0.1"
 
+[[unpublished.wiggle-generate]]
+version = "14.0.3"
+audited_as = "14.0.2"
+
 [[unpublished.wiggle-macro]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -764,6 +952,10 @@ audited_as = "14.0.0"
 [[unpublished.wiggle-macro]]
 version = "14.0.2"
 audited_as = "14.0.1"
+
+[[unpublished.wiggle-macro]]
+version = "14.0.3"
+audited_as = "14.0.2"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -784,6 +976,10 @@ audited_as = "0.12.0"
 [[unpublished.winch-codegen]]
 version = "0.12.2"
 audited_as = "0.12.1"
+
+[[unpublished.winch-codegen]]
+version = "0.12.3"
+audited_as = "0.12.2"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -984,6 +1180,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.101.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1005,6 +1207,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.101.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1032,6 +1240,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.101.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1053,6 +1267,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-meta]]
 version = "0.101.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1080,6 +1300,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.101.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1101,6 +1327,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-control]]
 version = "0.101.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1128,6 +1360,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.101.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1149,6 +1387,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-frontend]]
 version = "0.101.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1176,6 +1420,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.101.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1197,6 +1447,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-isle]]
 version = "0.101.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1224,6 +1480,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.101.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1245,6 +1507,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-module]]
 version = "0.101.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1272,6 +1540,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.101.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1293,6 +1567,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-object]]
 version = "0.101.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1320,6 +1600,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.101.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1344,6 +1630,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.101.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1365,6 +1657,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.101.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.101.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1727,6 +2025,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-cap-std-sync]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-common]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1751,6 +2055,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-tokio]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -1772,6 +2082,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasi-tokio]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasi-tokio]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2100,6 +2416,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2121,6 +2443,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2148,6 +2476,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2169,6 +2503,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2196,6 +2536,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2217,6 +2563,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2244,6 +2596,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2265,6 +2623,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2292,6 +2656,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cranelift-shared]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-environ]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2313,6 +2683,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-environ]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-environ]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2340,6 +2716,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-explorer]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-fiber]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2361,6 +2743,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-fiber]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-fiber]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2388,6 +2776,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2409,6 +2803,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-debug]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2436,6 +2836,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-runtime]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2457,6 +2863,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-runtime]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-runtime]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2484,6 +2896,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-types]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2505,6 +2923,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2532,6 +2956,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-http]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-nn]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2553,6 +2983,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-nn]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-nn]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2580,6 +3016,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-threads]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wast]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2604,6 +3046,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2628,6 +3076,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-winch]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wit-bindgen]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2649,6 +3103,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wit-bindgen]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wit-bindgen]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2667,6 +3127,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2778,6 +3244,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2802,6 +3274,12 @@ when = "2023-10-23"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "14.0.2"
+when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2823,6 +3301,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "14.0.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "14.0.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2861,6 +3345,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.12.1"
 when = "2023-10-23"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.12.2"
+when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.12.2"
+version = "0.12.3"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 14.0.3, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
