### PR TITLE
Don't panic in `wasmtime serve` when `set` isn't called

### DIFF
--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -380,8 +380,11 @@ impl hyper::service::Service<Request> for ProxyHandler {
         });
 
         Box::pin(async move {
-            let resp = receiver.await.unwrap()?;
-            Ok(resp)
+            match receiver.await {
+                Ok(Ok(resp)) => Ok(resp),
+                Ok(Err(e)) => Err(e.into()),
+                Err(_) => bail!("guest never invoked `response-outparam::set` method"),
+            }
         })
     }
 }


### PR DESCRIPTION
This commit fixes a panic in the `wasmtime serve` CLI command when the `response-outparam::set` method was never invoked by the guest. In this situation return a more first-class error than a panic explaining what the guest should be doing.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
