### PR TITLE
Print a message on `wasmtime serve` startup

### DIFF
--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -250,6 +250,8 @@ impl ServeCommand {
 
         let listener = tokio::net::TcpListener::bind(self.addr).await?;
 
+        eprintln!("Serving HTTP on http://{}/", listener.local_addr()?);
+
         let _epoch_thread = if let Some(timeout) = self.run.common.wasm.timeout {
             Some(EpochThread::spawn(timeout, engine.clone()))
         } else {


### PR DESCRIPTION
Print a message on `wasmtime serve` startup showing the address that `wasmtime` is listening for requests on, so that users know what it's doing, and can copy+past the URL into curl or a browser to start using it.

For example:

```
$ wasmtime serve target/wasm32-wasi/debug/hello_wasi_http.wasm
Serving HTTP on http://0.0.0.0:8080/
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
