### PR TITLE
Attempt to automatically configure release notes

### DIFF
--- a/.github/actions/github-release/main.js
+++ b/.github/actions/github-release/main.js
@@ -91,13 +91,25 @@ async function runOnce() {
   } catch (e) {
     console.log("ERROR: ", JSON.stringify(e, null, 2));
     core.info(`creating a release`);
+
+    const releaseNotes = fs.readFileSync('RELEASES.md').toString();
+    let notes = null;
+    const opts = {
+      owner,
+      repo,
+      tag_name: name,
+      prerelease: name === 'dev',
+    };
+    if (name !== 'dev') {
+      for (let x of releaseNotes.split(/^-+$/m)) {
+        if (x.indexOf(name.substring(1)) == -1)
+          continue;
+        opts.body = x;
+        break;
+      }
+    }
     try {
-      release = await octokit.rest.repos.createRelease({
-        owner,
-        repo,
-        tag_name: name,
-        prerelease: name === 'dev',
-      });
+      release = await octokit.rest.repos.createRelease(opts);
     } catch(e) {
       console.log("ERROR: ", JSON.stringify(e, null, 2));
       core.info(`fetching one more time`);

--- a/.github/actions/github-release/main.js
+++ b/.github/actions/github-release/main.js
@@ -101,7 +101,7 @@ async function runOnce() {
       prerelease: name === 'dev',
     };
     if (name !== 'dev') {
-      for (let x of releaseNotes.split(/^-+$/m)) {
+      for (let x of releaseNotes.split(/^---+$/m)) {
         if (x.indexOf(name.substring(1)) == -1)
           continue;
         opts.body = x;


### PR DESCRIPTION
This commit is an attempt to tackle #7068 by configuring the release notes in Github Releases with the handwritten release notes from `RELEASES.md`. The basic idea here is to split the markdown file on `-----` delimiters and then find the one which matches the version being released. Once one is found the `body` field of the API call to create the release is configured.

Closes https://github.com/bytecodealliance/wasmtime/issues/7068