### PR TITLE
Sync with upstream wasi-http

### DIFF
--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -17,8 +17,8 @@ struct T;
 impl bindings::exports::wasi::http::incoming_handler::Guest for T {
     fn handle(_request: IncomingRequest, outparam: ResponseOutparam) {
         let hdrs = bindings::wasi::http::types::Headers::new(&[]);
-        let resp = bindings::wasi::http::types::OutgoingResponse::new(200, &hdrs);
-        let body = resp.write().expect("outgoing response");
+        let resp = bindings::wasi::http::types::OutgoingResponse::new(200, hdrs);
+        let body = resp.body().expect("outgoing response");
 
         bindings::wasi::http::types::ResponseOutparam::set(outparam, Ok(resp));
 

--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -51,11 +51,11 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
 
             let response = OutgoingResponse::new(
                 200,
-                &Fields::new(&[("content-type".to_string(), b"text/plain".to_vec())]),
+                Fields::new(&[("content-type".to_string(), b"text/plain".to_vec())]),
             );
 
             let mut body =
-                executor::outgoing_body(response.write().expect("response should be writable"));
+                executor::outgoing_body(response.body().expect("response should be writable"));
 
             ResponseOutparam::set(response_out, Ok(response));
 
@@ -75,7 +75,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
         (Method::Post, Some("/echo")) => {
             let response = OutgoingResponse::new(
                 200,
-                &Fields::new(
+                Fields::new(
                     &headers
                         .into_iter()
                         .filter_map(|(k, v)| (k == "content-type").then_some((k, v)))
@@ -84,7 +84,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
             );
 
             let mut body =
-                executor::outgoing_body(response.write().expect("response should be writable"));
+                executor::outgoing_body(response.body().expect("response should be writable"));
 
             ResponseOutparam::set(response_out, Ok(response));
 
@@ -108,9 +108,9 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
         }
 
         _ => {
-            let response = OutgoingResponse::new(405, &Fields::new(&[]));
+            let response = OutgoingResponse::new(405, Fields::new(&[]));
 
-            let body = response.write().expect("response should be writable");
+            let body = response.body().expect("response should be writable");
 
             ResponseOutparam::set(response_out, Ok(response));
 
@@ -137,7 +137,7 @@ async fn hash(url: &Url) -> Result<String> {
                 String::new()
             }
         )),
-        &Fields::new(&[]),
+        Fields::new(&[]),
     );
 
     let response = executor::outgoing_request_send(request).await?;

--- a/crates/test-programs/src/bin/http_outbound_request_response_build.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_response_build.rs
@@ -12,9 +12,9 @@ fn main() {
             None,
             Some(&http_types::Scheme::Https),
             Some("www.example.com"),
-            &headers,
+            headers,
         );
-        let outgoing_body = request.write().unwrap();
+        let outgoing_body = request.body().unwrap();
         let request_body = outgoing_body.write().unwrap();
         request_body
             .blocking_write_and_flush("request-body".as_bytes())
@@ -25,8 +25,8 @@ fn main() {
             "Content-Type".to_string(),
             "application/text".to_string().into_bytes(),
         )]);
-        let response = http_types::OutgoingResponse::new(200, &headers);
-        let outgoing_body = response.write().unwrap();
+        let response = http_types::OutgoingResponse::new(200, headers);
+        let outgoing_body = response.body().unwrap();
         let response_body = outgoing_body.write().unwrap();
         response_body
             .blocking_write_and_flush("response-body".as_bytes())

--- a/crates/test-programs/src/http.rs
+++ b/crates/test-programs/src/http.rs
@@ -58,11 +58,11 @@ pub fn request(
         Some(path_with_query),
         Some(&scheme),
         Some(authority),
-        &headers,
+        headers,
     );
 
     let outgoing_body = request
-        .write()
+        .body()
         .map_err(|_| anyhow!("outgoing request write failed"))?;
 
     if let Some(mut buf) = body {

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -193,6 +193,51 @@ fn invalid_url(e: std::io::Error) -> anyhow::Error {
     ))
 }
 
+impl From<http::Method> for types::Method {
+    fn from(method: http::Method) -> Self {
+        if method == http::Method::GET {
+            types::Method::Get
+        } else if method == hyper::Method::HEAD {
+            types::Method::Head
+        } else if method == hyper::Method::POST {
+            types::Method::Post
+        } else if method == hyper::Method::PUT {
+            types::Method::Put
+        } else if method == hyper::Method::DELETE {
+            types::Method::Delete
+        } else if method == hyper::Method::CONNECT {
+            types::Method::Connect
+        } else if method == hyper::Method::OPTIONS {
+            types::Method::Options
+        } else if method == hyper::Method::TRACE {
+            types::Method::Trace
+        } else if method == hyper::Method::PATCH {
+            types::Method::Patch
+        } else {
+            types::Method::Other(method.to_string())
+        }
+    }
+}
+
+impl TryInto<http::Method> for types::Method {
+    type Error = http::method::InvalidMethod;
+
+    fn try_into(self) -> Result<http::Method, Self::Error> {
+        match self {
+            Method::Get => Ok(http::Method::GET),
+            Method::Head => Ok(http::Method::HEAD),
+            Method::Post => Ok(http::Method::POST),
+            Method::Put => Ok(http::Method::PUT),
+            Method::Delete => Ok(http::Method::DELETE),
+            Method::Connect => Ok(http::Method::CONNECT),
+            Method::Options => Ok(http::Method::OPTIONS),
+            Method::Trace => Ok(http::Method::TRACE),
+            Method::Patch => Ok(http::Method::PATCH),
+            Method::Other(s) => http::Method::from_bytes(s.as_bytes()),
+        }
+    }
+}
+
 pub struct HostIncomingRequest {
     pub parts: http::request::Parts,
     pub body: Option<HostIncomingBodyBuilder>,
@@ -206,8 +251,8 @@ pub struct HostResponseOutparam {
 pub struct HostOutgoingRequest {
     pub method: Method,
     pub scheme: Option<Scheme>,
-    pub path_with_query: String,
-    pub authority: String,
+    pub path_with_query: Option<String>,
+    pub authority: Option<String>,
     pub headers: FieldMap,
     pub body: Option<HyperOutgoingBody>,
 }

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -127,17 +127,73 @@ interface types {
   resource outgoing-request {
 
     /// Construct a new `outgoing-request`.
+    ///
+    /// * `method` represents the HTTP Method for the Request.
+    /// * `path-with-query` is the combination of the HTTP Path and Query for
+    ///    the Request. When `none`, this represents an empty Path and empty
+    ///    Query.
+    /// * `scheme` is the HTTP Related Scheme for the Request. When `none`,
+    ///    the implementation may choose an appropriate default scheme.
+    /// * `authority` is the HTTP Authority for the Request. A value of `none`
+    ///    may be used with Related Schemes which do not require an Authority.
+    ///    The HTTP and HTTPS schemes always require an authority.
+    /// * `headers` is the HTTP Headers for the Request.
+    ///
+    /// It is possible to construct, or manipulate with the accessor functions
+    /// below, an `outgoing-request` with an invalid combination of `scheme`
+    /// and `authority`, or `headers` which are not permitted to be sent.
+    /// It is the obligation of the `outgoing-handler.handle` implementation
+    /// to reject invalid constructions of `outgoing-request`.
     constructor(
       method: method,
       path-with-query: option<string>,
       scheme: option<scheme>,
       authority: option<string>,
-      headers: borrow<headers>
+      headers: headers
     );
 
-    /// Will return the outgoing-body child at most once. If called more than
-    /// once, subsequent calls will return error.
-    write: func() -> result<outgoing-body>;
+    /// Returns the resource corresponding to the outgoing Body for this
+    /// Request.
+    ///
+    /// Returns success on the first call: the `outgoing-body` resource for
+    /// this `outgoing-response` can be retrieved at most once. Subsequent
+    /// calls will return error.
+    body: func() -> result<outgoing-body>;
+
+    /// Get the Method for the Request.
+    method: func() -> method;
+    /// Set the Method for the Request.
+    set-method: func(method: method);
+
+    /// Get the combination of the HTTP Path and Query for the Request.
+    /// When `none`, this represents an empty Path and empty Query.
+    path-with-query: func() -> option<string>;
+    /// Set the combination of the HTTP Path and Query for the Request.
+    /// When `none`, this represents an empty Path and empty Query.
+    set-path-with-query: func(path-with-query: option<string>);
+
+    /// Get the HTTP Related Scheme for the Request. When `none`, the
+    /// implementation may choose an appropriate default scheme.
+    scheme: func() -> option<scheme>;
+    /// Set the HTTP Related Scheme for the Request. When `none`, the
+    /// implementation may choose an appropriate default scheme.
+    set-scheme: func(scheme: option<scheme>);
+
+    /// Get the HTTP Authority for the Request. A value of `none` may be used
+    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// HTTPS schemes always require an authority.
+    authority: func() -> option<string>;
+    /// Set the HTTP Authority for the Request. A value of `none` may be used
+    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// HTTPS schemes always require an authority.
+    set-authority: func(authority: option<string>);
+
+    /// Get the headers associated with the Request.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `outgoing-request` is dropped, or its ownership is transfered to
+    /// another component by e.g. `outgoing-handler.handle`.
+    headers: func() -> headers;
   }
 
   /// Parameters for making an HTTP Request. Each of these parameters is an
@@ -176,6 +232,9 @@ interface types {
     /// This method consumes the `response-outparam` to ensure that it is
     /// called at most once. If it is never called, the implementation
     /// will respond with an error.
+    ///
+    /// The user may provide an `error` to `response` to allow the
+    /// implementation determine how to respond with an HTTP error response.
     set: static func(
       param: response-outparam,
       response: result<outgoing-response, error>,
@@ -260,16 +319,29 @@ interface types {
   resource outgoing-response {
 
     /// Construct an `outgoing-response`.
-    constructor(status-code: status-code, headers: borrow<headers>);
+    ///
+    /// * `status-code` is the HTTP Status Code for the Response.
+    /// * `headers` is the HTTP Headers for the Response.
+    constructor(status-code: status-code, headers: headers);
+
+    /// Get the HTTP Status Code for the Response.
+    status-code: func() -> status-code;
+    /// Set the HTTP Status Code for the Response.
+    set-status-code: func(status-code: status-code);
+
+    /// Get the headers associated with the Request.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `outgoing-request` is dropped, or its ownership is transfered to
+    /// another component by e.g. `outgoing-handler.handle`.
+    headers: func() -> headers;
 
     /// Returns the resource corresponding to the outgoing Body for this Response.
     ///
     /// Returns success on the first call: the `outgoing-body` resource for
-    /// this `outgoing-response` can be retrieved at most once. Sunsequent
+    /// this `outgoing-response` can be retrieved at most once. Subsequent
     /// calls will return error.
-    ///
-    /// FIXME: rename this method to `body`.
-    write: func() -> result<outgoing-body>;
+    body: func() -> result<outgoing-body>;
   }
 
   /// Represents an outgoing HTTP Request or Response's Body.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -127,17 +127,73 @@ interface types {
   resource outgoing-request {
 
     /// Construct a new `outgoing-request`.
+    ///
+    /// * `method` represents the HTTP Method for the Request.
+    /// * `path-with-query` is the combination of the HTTP Path and Query for
+    ///    the Request. When `none`, this represents an empty Path and empty
+    ///    Query.
+    /// * `scheme` is the HTTP Related Scheme for the Request. When `none`,
+    ///    the implementation may choose an appropriate default scheme.
+    /// * `authority` is the HTTP Authority for the Request. A value of `none`
+    ///    may be used with Related Schemes which do not require an Authority.
+    ///    The HTTP and HTTPS schemes always require an authority.
+    /// * `headers` is the HTTP Headers for the Request.
+    ///
+    /// It is possible to construct, or manipulate with the accessor functions
+    /// below, an `outgoing-request` with an invalid combination of `scheme`
+    /// and `authority`, or `headers` which are not permitted to be sent.
+    /// It is the obligation of the `outgoing-handler.handle` implementation
+    /// to reject invalid constructions of `outgoing-request`.
     constructor(
       method: method,
       path-with-query: option<string>,
       scheme: option<scheme>,
       authority: option<string>,
-      headers: borrow<headers>
+      headers: headers
     );
 
-    /// Will return the outgoing-body child at most once. If called more than
-    /// once, subsequent calls will return error.
-    write: func() -> result<outgoing-body>;
+    /// Returns the resource corresponding to the outgoing Body for this
+    /// Request.
+    ///
+    /// Returns success on the first call: the `outgoing-body` resource for
+    /// this `outgoing-response` can be retrieved at most once. Subsequent
+    /// calls will return error.
+    body: func() -> result<outgoing-body>;
+
+    /// Get the Method for the Request.
+    method: func() -> method;
+    /// Set the Method for the Request.
+    set-method: func(method: method);
+
+    /// Get the combination of the HTTP Path and Query for the Request.
+    /// When `none`, this represents an empty Path and empty Query.
+    path-with-query: func() -> option<string>;
+    /// Set the combination of the HTTP Path and Query for the Request.
+    /// When `none`, this represents an empty Path and empty Query.
+    set-path-with-query: func(path-with-query: option<string>);
+
+    /// Get the HTTP Related Scheme for the Request. When `none`, the
+    /// implementation may choose an appropriate default scheme.
+    scheme: func() -> option<scheme>;
+    /// Set the HTTP Related Scheme for the Request. When `none`, the
+    /// implementation may choose an appropriate default scheme.
+    set-scheme: func(scheme: option<scheme>);
+
+    /// Get the HTTP Authority for the Request. A value of `none` may be used
+    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// HTTPS schemes always require an authority.
+    authority: func() -> option<string>;
+    /// Set the HTTP Authority for the Request. A value of `none` may be used
+    /// with Related Schemes which do not require an Authority. The HTTP and
+    /// HTTPS schemes always require an authority.
+    set-authority: func(authority: option<string>);
+
+    /// Get the headers associated with the Request.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `outgoing-request` is dropped, or its ownership is transfered to
+    /// another component by e.g. `outgoing-handler.handle`.
+    headers: func() -> headers;
   }
 
   /// Parameters for making an HTTP Request. Each of these parameters is an
@@ -176,6 +232,9 @@ interface types {
     /// This method consumes the `response-outparam` to ensure that it is
     /// called at most once. If it is never called, the implementation
     /// will respond with an error.
+    ///
+    /// The user may provide an `error` to `response` to allow the
+    /// implementation determine how to respond with an HTTP error response.
     set: static func(
       param: response-outparam,
       response: result<outgoing-response, error>,
@@ -260,16 +319,29 @@ interface types {
   resource outgoing-response {
 
     /// Construct an `outgoing-response`.
-    constructor(status-code: status-code, headers: borrow<headers>);
+    ///
+    /// * `status-code` is the HTTP Status Code for the Response.
+    /// * `headers` is the HTTP Headers for the Response.
+    constructor(status-code: status-code, headers: headers);
+
+    /// Get the HTTP Status Code for the Response.
+    status-code: func() -> status-code;
+    /// Set the HTTP Status Code for the Response.
+    set-status-code: func(status-code: status-code);
+
+    /// Get the headers associated with the Request.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `outgoing-request` is dropped, or its ownership is transfered to
+    /// another component by e.g. `outgoing-handler.handle`.
+    headers: func() -> headers;
 
     /// Returns the resource corresponding to the outgoing Body for this Response.
     ///
     /// Returns success on the first call: the `outgoing-body` resource for
-    /// this `outgoing-response` can be retrieved at most once. Sunsequent
+    /// this `outgoing-response` can be retrieved at most once. Subsequent
     /// calls will return error.
-    ///
-    /// FIXME: rename this method to `body`.
-    write: func() -> result<outgoing-body>;
+    body: func() -> result<outgoing-body>;
   }
 
   /// Represents an outgoing HTTP Request or Response's Body.


### PR DESCRIPTION
Add implementations of all the new getter/setter methods for the request and response resources, and handle the signature change to outgoing request/response constructors.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
