### PR TITLE
Update wasm-tools crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3101,18 +3101,18 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.35.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca90ba1b5b0a70d3d49473c5579951f3bddc78d47b59256d2f9d4922b150aca"
+checksum = "53ae0be20bf87918df4fa831bfbbd0b491d24aee407ed86360eae4c2c5608d38"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.9"
+version = "0.10.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14abc161bfda5b519aa229758b68f2a52b45a12b993808665c857d1a9a00223c"
+checksum = "5621910462c61a8efc3248fdfb1739bf649bb335b0df935c27b340418105f9d8"
 dependencies = [
  "anyhow",
  "indexmap 2.0.0",
@@ -3126,9 +3126,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-mutate"
-version = "0.2.38"
+version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1e04b0c049b0a0c42dd108a56c5c92500076747363d3bf1e83e7f0f8b4dfe4"
+checksum = "b39266e421acd09370e738fc042a5224d0014036ed919e68f1dd9a98a9b28f5a"
 dependencies = [
  "egg",
  "log",
@@ -3140,9 +3140,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.12.21"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef779c243bbf04d9f03333c2cb50b98047c6dcc2a1db0cc7d0691e4135064b4"
+checksum = "39217efc459328aa5a29a5bbf792e76f1ae7ebeedbf8878f8320b6a0a6544b06"
 dependencies = [
  "arbitrary",
  "flagset",
@@ -3192,9 +3192,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.115.0"
+version = "0.116.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e06c0641a4add879ba71ccb3a1e4278fd546f76f1eafb21d8f7b07733b547cd5"
+checksum = "53290b1276c5c2d47d694fb1a920538c01f51690e7e261acbe1d10c5fc306ea1"
 dependencies = [
  "indexmap 2.0.0",
  "semver",
@@ -3211,9 +3211,9 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e74458a9bc5cc9c7108abfa0fe4dc88d5abf1f3baf194df3264985f17d559b5e"
+checksum = "8f98260aa20f939518bcec1fac32c78898d5c68872e7363a4651f21f791b6c7e"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3388,7 +3388,7 @@ dependencies = [
  "wasmtime-wasi-nn",
  "wasmtime-wasi-threads",
  "wasmtime-wast",
- "wast 66.0.2",
+ "wast 67.0.0",
  "wat",
  "windows-sys",
 ]
@@ -3774,7 +3774,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 66.0.2",
+ "wast 67.0.0",
 ]
 
 [[package]]
@@ -3817,9 +3817,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "66.0.2"
+version = "67.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cb43b0ac6dd156f2c375735ccfd72b012a7c0a6e6d09503499b8d3cb6e6072"
+checksum = "36c2933efd77ff2398b83817a98984ffe4b67aefd9aa1d2c8e68e19b553f1c38"
 dependencies = [
  "leb128",
  "memchr",
@@ -3829,11 +3829,11 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e367582095d2903caeeea9acbb140e1db9c7677001efa4347c3687fd34fe7072"
+checksum = "c02905d13751dcb18f4e19f489d37a1bf139f519feaeef28d072a41a78e69a74"
 dependencies = [
- "wast 66.0.2",
+ "wast 67.0.0",
 ]
 
 [[package]]
@@ -4089,9 +4089,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7d92ce0ca6b6074059413a9581a637550c3a740581c854f9847ec293c8aed71"
+checksum = "38726c54a5d7c03cac28a2a8de1006cfe40397ddf6def3f836189033a413bc08"
 dependencies = [
  "bitflags 2.4.1",
  "wit-bindgen-rust-macro",
@@ -4099,9 +4099,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565b945ae074886071eccf9cdaf8ccd7b959c2b0d624095bea5fe62003e8b3e0"
+checksum = "c8bf1fddccaff31a1ad57432d8bfb7027a7e552969b6c68d6d8820dcf5c2371f"
 dependencies = [
  "anyhow",
  "wit-component",
@@ -4110,9 +4110,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5695ff4e41873ed9ce56d2787e6b5772bdad9e70e2c1d2d160621d1762257f4f"
+checksum = "0e7200e565124801e01b7b5ddafc559e1da1b2e1bed5364d669cd1d96fb88722"
 dependencies = [
  "anyhow",
  "heck",
@@ -4123,9 +4123,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91835ea4231da1fe7971679d505ba14be7826e192b6357f08465866ef482e08"
+checksum = "4ae33920ad8119fe72cf59eb00f127c0b256a236b9de029a1a10397b1f38bdbd"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4138,9 +4138,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87488b57a08e2cbbd076b325acbe7f8666965af174d69d5929cd373bd54547f"
+checksum = "480cc1a078b305c1b8510f7c455c76cbd008ee49935f3a6c5fd5e937d8d95b1e"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4157,9 +4157,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.12.1"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ace9943d89bbf3dbbc71b966da0e7302057b311f36a4ac3d65ddfef17b52cf"
+checksum = "43771ee863a16ec4ecf9da0fc65c3bbd4a1235c8e3da5f094b562894843dfa76"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,18 +209,18 @@ io-extras = "0.18.0"
 rustix = "0.38.8"
 is-terminal = "0.4.0"
 # wit-bindgen:
-wit-bindgen = { version = "0.13.0", default-features = false }
+wit-bindgen = { version = "0.13.1", default-features = false }
 
 # wasm-tools family:
-wasmparser = "0.115.0"
-wat = "1.0.77"
-wast = "66.0.2"
-wasmprinter = "0.2.70"
-wasm-encoder = "0.35.0"
-wasm-smith = "0.12.21"
-wasm-mutate = "0.2.38"
-wit-parser = "0.12.1"
-wit-component = "0.16.0"
+wasmparser = "0.116.0"
+wat = "1.0.78"
+wast = "67.0.0"
+wasmprinter = "0.2.71"
+wasm-encoder = "0.36.1"
+wasm-smith = "0.12.22"
+wasm-mutate = "0.2.39"
+wit-parser = "0.12.2"
+wit-component = "0.17.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/crates/environ/examples/factc.rs
+++ b/crates/environ/examples/factc.rs
@@ -129,13 +129,11 @@ impl Factc {
             .context("failed to validate input wasm")?;
         let wasm_types = wasm_types.as_ref();
         for i in 0..wasm_types.component_type_count() {
-            let ty = wasm_types.component_type_at(i);
-            let ty = match &wasm_types[ty] {
-                wasmparser::types::Type::ComponentFunc(_) => {
-                    types.convert_component_func_type(wasm_types, ty)?
-                }
+            let ty = match wasm_types.component_any_type_at(i) {
+                wasmparser::types::ComponentAnyTypeId::Func(id) => id,
                 _ => continue,
             };
+            let ty = types.convert_component_func_type(wasm_types, ty)?;
             adapters.push(Adapter {
                 lift_ty: ty,
                 lower_ty: ty,

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -8,8 +8,10 @@ use anyhow::{bail, Result};
 use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::mem;
-use wasmparser::types::{ComponentEntityType, TypeId, Types};
-use wasmparser::{Chunk, ComponentExternName, Encoding, Parser, Payload, Validator};
+use wasmparser::types::{
+    AliasableResourceId, ComponentEntityType, ComponentFuncTypeId, ComponentInstanceTypeId, Types,
+};
+use wasmparser::{Chunk, ComponentImportName, Encoding, Parser, Payload, Validator};
 
 mod adapt;
 pub use self::adapt::*;
@@ -165,22 +167,22 @@ struct Translation<'data> {
 #[allow(missing_docs)]
 enum LocalInitializer<'data> {
     // imports
-    Import(ComponentExternName<'data>, ComponentEntityType),
+    Import(ComponentImportName<'data>, ComponentEntityType),
 
     // canonical function sections
     Lower {
         func: ComponentFuncIndex,
-        lower_ty: TypeId,
+        lower_ty: ComponentFuncTypeId,
         canonical_abi: SignatureIndex,
         options: LocalCanonicalOptions,
     },
-    Lift(TypeId, FuncIndex, LocalCanonicalOptions),
+    Lift(ComponentFuncTypeId, FuncIndex, LocalCanonicalOptions),
 
     // resources
-    Resource(TypeId, WasmType, Option<FuncIndex>),
-    ResourceNew(TypeId, SignatureIndex),
-    ResourceRep(TypeId, SignatureIndex),
-    ResourceDrop(TypeId, SignatureIndex),
+    Resource(AliasableResourceId, WasmType, Option<FuncIndex>),
+    ResourceNew(AliasableResourceId, SignatureIndex),
+    ResourceRep(AliasableResourceId, SignatureIndex),
+    ResourceDrop(AliasableResourceId, SignatureIndex),
 
     // core wasm modules
     ModuleStatic(StaticModuleIndex),
@@ -193,7 +195,11 @@ enum LocalInitializer<'data> {
     ComponentStatic(StaticComponentIndex, ClosedOverVars),
 
     // component instances
-    ComponentInstantiate(ComponentIndex, HashMap<&'data str, ComponentItem>, TypeId),
+    ComponentInstantiate(
+        ComponentIndex,
+        HashMap<&'data str, ComponentItem>,
+        ComponentInstanceTypeId,
+    ),
     ComponentSynthetic(HashMap<&'data str, ComponentItem>),
 
     // alias section
@@ -414,7 +420,9 @@ impl<'a, 'data> Translator<'a, 'data> {
                     match ty? {
                         wasmparser::ComponentType::Resource { rep, dtor } => {
                             let rep = self.types.convert_valtype(rep);
-                            let id = types.component_type_at(component_type_index);
+                            let id = types
+                                .component_any_type_at(component_type_index)
+                                .unwrap_resource();
                             let dtor = dtor.map(FuncIndex::from_u32);
                             self.result
                                 .initializers
@@ -444,7 +452,7 @@ impl<'a, 'data> Translator<'a, 'data> {
                     let import = import?;
                     let types = self.validator.types(0).unwrap();
                     let ty = types
-                        .component_entity_type_of_import(import.name.as_str())
+                        .component_entity_type_of_import(import.name.0)
                         .unwrap();
                     self.result
                         .initializers
@@ -465,7 +473,7 @@ impl<'a, 'data> Translator<'a, 'data> {
                             core_func_index,
                             options,
                         } => {
-                            let ty = types.component_type_at(type_index);
+                            let ty = types.component_any_type_at(type_index).unwrap_func();
                             let func = FuncIndex::from_u32(core_func_index);
                             let options = self.canonical_options(&options);
                             LocalInitializer::Lift(ty, func, options)
@@ -488,19 +496,19 @@ impl<'a, 'data> Translator<'a, 'data> {
                             }
                         }
                         wasmparser::CanonicalFunction::ResourceNew { resource } => {
-                            let resource = types.component_type_at(resource);
+                            let resource = types.component_any_type_at(resource).unwrap_resource();
                             let ty = self.core_func_signature(core_func_index);
                             core_func_index += 1;
                             LocalInitializer::ResourceNew(resource, ty)
                         }
                         wasmparser::CanonicalFunction::ResourceDrop { resource } => {
-                            let resource = types.component_type_at(resource);
+                            let resource = types.component_any_type_at(resource).unwrap_resource();
                             let ty = self.core_func_signature(core_func_index);
                             core_func_index += 1;
                             LocalInitializer::ResourceDrop(resource, ty)
                         }
                         wasmparser::CanonicalFunction::ResourceRep { resource } => {
-                            let resource = types.component_type_at(resource);
+                            let resource = types.component_any_type_at(resource).unwrap_resource();
                             let ty = self.core_func_signature(core_func_index);
                             core_func_index += 1;
                             LocalInitializer::ResourceRep(resource, ty)
@@ -602,7 +610,7 @@ impl<'a, 'data> Translator<'a, 'data> {
                 for export in s {
                     let export = export?;
                     let item = self.kind_to_item(export.kind, export.index)?;
-                    let prev = self.result.exports.insert(export.name.as_str(), item);
+                    let prev = self.result.exports.insert(export.name.0, item);
                     assert!(prev.is_none());
                     self.result
                         .initializers
@@ -722,7 +730,7 @@ impl<'a, 'data> Translator<'a, 'data> {
         &mut self,
         component: ComponentIndex,
         raw_args: &[wasmparser::ComponentInstantiationArg<'data>],
-        ty: TypeId,
+        ty: ComponentInstanceTypeId,
     ) -> Result<LocalInitializer<'data>> {
         let mut args = HashMap::with_capacity(raw_args.len());
         for arg in raw_args {
@@ -742,7 +750,7 @@ impl<'a, 'data> Translator<'a, 'data> {
         let mut map = HashMap::with_capacity(exports.len());
         for export in exports {
             let idx = self.kind_to_item(export.kind, export.index)?;
-            map.insert(export.name.as_str(), idx);
+            map.insert(export.name.0, idx);
         }
 
         Ok(LocalInitializer::ComponentSynthetic(map))
@@ -775,7 +783,7 @@ impl<'a, 'data> Translator<'a, 'data> {
             }
             wasmparser::ComponentExternalKind::Type => {
                 let types = self.validator.types(0).unwrap();
-                let ty = types.component_type_at(index);
+                let ty = types.component_any_type_at(index);
                 ComponentItem::Type(ty)
             }
         })
@@ -883,7 +891,7 @@ impl<'a, 'data> Translator<'a, 'data> {
 
     fn core_func_signature(&mut self, idx: u32) -> SignatureIndex {
         let types = self.validator.types(0).unwrap();
-        let id = types.function_at(idx);
+        let id = types.core_function_at(idx);
         let ty = types[id].unwrap_func();
         let ty = self.types.convert_func_type(ty);
         self.types.module_types_builder().wasm_func_type(ty)

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -503,10 +503,6 @@ impl ComponentTypesBuilder {
             types::ComponentAnyTypeId::Defined(id) => {
                 TypeDef::Interface(self.defined_type(types, id)?)
             }
-            // TODO
-            // types::ComponentAnyTypeId::Module(_) => {
-            //     TypeDef::Module(self.convert_module(types, id)?)
-            // }
             types::ComponentAnyTypeId::Component(id) => {
                 TypeDef::Component(self.convert_component(types, id)?)
             }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -483,7 +483,7 @@ pub trait TypeConvert {
         match ty {
             wasmparser::HeapType::Func => WasmHeapType::Func,
             wasmparser::HeapType::Extern => WasmHeapType::Extern,
-            wasmparser::HeapType::Indexed(i) => self.lookup_heap_type(TypeIndex::from_u32(i)),
+            wasmparser::HeapType::Concrete(i) => self.lookup_heap_type(TypeIndex::from_u32(i)),
 
             wasmparser::HeapType::Any
             | wasmparser::HeapType::None

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1515,6 +1515,12 @@ criteria = "safe-to-deploy"
 delta = "0.2.146 -> 0.2.147"
 notes = "Only new type definitions and updating others for some platforms, no major changes"
 
+[[audits.libc]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.148 -> 0.2.149"
+notes = "Lots of new functions and constants for new platforms and nothing out of the ordinary for what one would expect of the `libc` crate."
+
 [[audits.libfuzzer-sys]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-run"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -845,9 +845,23 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasm-encoder]]
+version = "0.36.1"
+when = "2023-10-30"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wasm-metadata]]
 version = "0.10.9"
 when = "2023-10-14"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-metadata]]
+version = "0.10.10"
+when = "2023-10-30"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -859,9 +873,23 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasm-mutate]]
+version = "0.2.39"
+when = "2023-10-30"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wasm-smith]]
 version = "0.12.21"
 when = "2023-10-14"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-smith]]
+version = "0.12.22"
+when = "2023-10-30"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -873,9 +901,23 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasmparser]]
+version = "0.116.0"
+when = "2023-10-30"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wasmprinter]]
 version = "0.2.70"
 when = "2023-10-14"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasmprinter]]
+version = "0.2.71"
+when = "2023-10-30"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1037,9 +1079,23 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wast]]
+version = "67.0.0"
+when = "2023-10-30"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wat]]
 version = "1.0.77"
 when = "2023-10-14"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wat]]
+version = "1.0.78"
+when = "2023-10-30"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1159,9 +1215,23 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wit-bindgen]]
+version = "0.13.1"
+when = "2023-10-30"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wit-bindgen-core]]
 version = "0.13.0"
 when = "2023-10-18"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen-core]]
+version = "0.13.1"
+when = "2023-10-30"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1173,9 +1243,23 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wit-bindgen-rust]]
+version = "0.13.2"
+when = "2023-10-30"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wit-bindgen-rust-macro]]
 version = "0.13.0"
 when = "2023-10-18"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen-rust-macro]]
+version = "0.13.1"
+when = "2023-10-30"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1187,9 +1271,23 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wit-component]]
+version = "0.17.0"
+when = "2023-10-30"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wit-parser]]
 version = "0.12.1"
 when = "2023-10-18"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-parser]]
+version = "0.12.2"
+when = "2023-10-30"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1551,13 +1649,6 @@ who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.2.147 -> 0.2.148"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.libc]]
-who = "Jan-Erik Rediger <jrediger@mozilla.com>"
-criteria = "safe-to-deploy"
-delta = "0.2.148 -> 0.2.149"
-notes = "New defintions for a new target we don't use"
-aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.log]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -107,7 +107,7 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
     /// Resolves a function [`Callee`] from an index.
     pub fn callee_from_index(&self, idx: FuncIndex) -> Callee {
         let types = &self.translation.get_types();
-        let ty = types[types.function_at(idx.as_u32())].unwrap_func();
+        let ty = types[types.core_function_at(idx.as_u32())].unwrap_func();
         let ty = self.translation.module.convert_func_type(ty);
         let import = self.translation.module.is_imported_function(idx);
 

--- a/winch/filetests/src/lib.rs
+++ b/winch/filetests/src/lib.rs
@@ -156,7 +156,7 @@ mod test {
         let types = &translation.get_types();
 
         let index = module.func_index(f.0);
-        let sig = types[types.function_at(index.as_u32())].unwrap_func();
+        let sig = types[types.core_function_at(index.as_u32())].unwrap_func();
         let sig = translation.module.convert_func_type(&sig);
 
         let vmoffsets = VMOffsets::new(isa.pointer_bytes(), &translation.module);

--- a/winch/src/compile.rs
+++ b/winch/src/compile.rs
@@ -54,7 +54,7 @@ fn compile(
 ) -> Result<()> {
     let index = translation.module.func_index(f.0);
     let types = &translation.get_types();
-    let sig = types[types.function_at(index.as_u32())].unwrap_func();
+    let sig = types[types.core_function_at(index.as_u32())].unwrap_func();
     let sig = translation.module.convert_func_type(sig);
     let FunctionBodyData { body, validator } = f.1;
     let vmoffsets = VMOffsets::new(isa.pointer_bytes(), &translation.module);


### PR DESCRIPTION
This commit updates the wasm-tools family of crate for a number of notable updates:

* bytecodealliance/wasm-tools#1257 - wasmparser's ID-based infrastructure has been refactored to have more precise types for each ID rather than one all-purpose `TypeId`.
* bytecodealliance/wasm-tools#1262 - the implementation of "implementation imports" for the component model which both updates the binary format in addition to adding more syntactic forms of imports.
* bytecodealliance/wasm-tools#1260 - a new encoding scheme for component information for `wit-component` in objects (not used by Wasmtime but used by bindings generators).

Translation for components needed to be updated to account for the first change, but otherwise this was a straightforward update.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
