### PR TITLE
egraphs: Avoid producing iconst.i128 nodes

### DIFF
--- a/cranelift/codegen/src/opts/bitops.isle
+++ b/cranelift/codegen/src/opts/bitops.isle
@@ -129,7 +129,7 @@
 ;; (ne ty (iconst 0) v) is also canonicalized into this form via another rule
 (rule (simplify (ne cty v (iconst _ (u64_from_imm64 0))))
       (if-let c (truthy v))
-      (if-let (value_type ty) c)
+      (if-let (value_type (ty_int_ref_scalar_64 ty)) c)
       (ne cty c (iconst ty (imm64 0))))
 
 

--- a/cranelift/filetests/filetests/egraph/icmp.clif
+++ b/cranelift/filetests/filetests/egraph/icmp.clif
@@ -36,3 +36,24 @@ block0(v1: i64, v2: i64):
 ;     return v4
 ; }
 
+function %icmp_simplify_does_not_build_iconst_i128() -> i8 {
+block0:
+    v0 = iconst.i64 0x6350_5050_5050_3750
+    v1 = iconcat v0, v0
+    v2 = bmask.i8 v1
+    v3 = iconst.i8 0
+    v4 = icmp ugt v2, v3
+    return v4
+}
+
+; function %icmp_simplify_does_not_build_iconst_i128() -> i8 fast {
+; block0:
+;     v0 = iconst.i64 0x6350_5050_5050_3750
+;     v1 = iconcat v0, v0  ; v0 = 0x6350_5050_5050_3750, v0 = 0x6350_5050_5050_3750
+;     v2 = bmask.i8 v1
+;     v3 = iconst.i8 0
+;     v5 = icmp ne v2, v3  ; v3 = 0
+;     v6 -> v5
+;     return v5
+; }
+


### PR DESCRIPTION
👋 Hey,

This PR fixes an issue with an egraphs rule, where it could accidentally transform a `icmp` and produce a `iconst.i128` along the way. The fix here is to disable this rule for i128.

Fixes #7229