### PR TITLE
Add support for `::` in `--dir` to old CLI

### DIFF
--- a/src/old_cli.rs
+++ b/src/old_cli.rs
@@ -748,7 +748,10 @@ impl RunCommand {
         let mut dirs = Vec::new();
 
         for host in old_dirs {
-            dirs.push((host.clone(), host));
+            let mut parts = host.splitn(2, "::");
+            let host = parts.next().unwrap();
+            let guest = parts.next().unwrap_or(host);
+            dirs.push((host.to_string(), guest.to_string()));
         }
 
         if preview2 {

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1160,6 +1160,19 @@ warning: this CLI invocation of Wasmtime is going to break in the future -- for
     );
     assert_eq!(String::from_utf8_lossy(&output.stderr), "");
 
+    // the `--dir` flag prints no warning when used with `::`
+    let dir = tempfile::tempdir()?;
+    std::fs::write(dir.path().join("bar.txt"), b"And stood awhile in thought")?;
+    let output = get_wasmtime_command()?
+        .args(&[
+            "run",
+            &format!("--dir={}::/", dir.path().to_str().unwrap()),
+            test_programs_artifacts::CLI_FILE_READ,
+        ])
+        .output()?;
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "");
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "");
+
     Ok(())
 }
 


### PR DESCRIPTION
In Wasmtime 13 and prior the `--dir` argument was unconditionally used to open a host dir as the same name and in the guest. In Wasmtime 14+ though this argument is being repurposed with an optional trailing `::GUEST` to configure the guest directory. This means that `--dir`-with-remapping behavior is actually unusable without the environment variable configuration from #7385 due to it parsing differently in the old and the new.

This commit updates the situation by adding `::`-parsing to the old CLI meaning that both the old and the new parse this the same way. This will break any scripts that open host directories with two colons in their path, but that seems niche enough we can handle that later.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
