### PR TITLE
Turn `request-options` into a resource

### DIFF
--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -1,6 +1,6 @@
 use crate::bindings::http::{
     outgoing_handler,
-    types::{RequestOptions, Scheme},
+    types::{self as http_types, Scheme},
 };
 use crate::types::{self, HostFutureIncomingResponse, OutgoingRequest};
 use crate::WasiHttpView;
@@ -15,24 +15,23 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
     fn handle(
         &mut self,
         request_id: Resource<HostOutgoingRequest>,
-        options: Option<RequestOptions>,
+        options: Option<Resource<http_types::RequestOptions>>,
     ) -> wasmtime::Result<Result<Resource<HostFutureIncomingResponse>, outgoing_handler::Error>>
     {
+        let opts = options.and_then(|opts| self.table().get(&opts).ok());
+
         let connect_timeout = Duration::from_millis(
-            options
-                .and_then(|opts| opts.connect_timeout_ms)
+            opts.and_then(|opts| opts.connect_timeout)
                 .unwrap_or(600 * 1000) as u64,
         );
 
         let first_byte_timeout = Duration::from_millis(
-            options
-                .and_then(|opts| opts.first_byte_timeout_ms)
+            opts.and_then(|opts| opts.first_byte_timeout)
                 .unwrap_or(600 * 1000) as u64,
         );
 
         let between_bytes_timeout = Duration::from_millis(
-            options
-                .and_then(|opts| opts.between_bytes_timeout_ms)
+            opts.and_then(|opts| opts.between_bytes_timeout)
                 .unwrap_or(600 * 1000) as u64,
         );
 

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -7,7 +7,6 @@ use crate::WasiHttpView;
 use bytes::Bytes;
 use http_body_util::{BodyExt, Empty};
 use hyper::Method;
-use std::time::Duration;
 use types::HostOutgoingRequest;
 use wasmtime::component::Resource;
 
@@ -20,20 +19,17 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
     {
         let opts = options.and_then(|opts| self.table().get(&opts).ok());
 
-        let connect_timeout = Duration::from_millis(
-            opts.and_then(|opts| opts.connect_timeout)
-                .unwrap_or(600 * 1000) as u64,
-        );
+        let connect_timeout = opts
+            .and_then(|opts| opts.connect_timeout)
+            .unwrap_or(std::time::Duration::from_millis(600 * 1000));
 
-        let first_byte_timeout = Duration::from_millis(
-            opts.and_then(|opts| opts.first_byte_timeout)
-                .unwrap_or(600 * 1000) as u64,
-        );
+        let first_byte_timeout = opts
+            .and_then(|opts| opts.first_byte_timeout)
+            .unwrap_or(std::time::Duration::from_millis(600 * 1000));
 
-        let between_bytes_timeout = Duration::from_millis(
-            opts.and_then(|opts| opts.between_bytes_timeout)
-                .unwrap_or(600 * 1000) as u64,
-        );
+        let between_bytes_timeout = opts
+            .and_then(|opts| opts.between_bytes_timeout)
+            .unwrap_or(std::time::Duration::from_millis(600 * 1000));
 
         let req = self.table().delete(request_id)?;
 

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -30,6 +30,7 @@ pub mod bindings {
             "wasi:http/types/outgoing-request": super::types::HostOutgoingRequest,
             "wasi:http/types/incoming-request": super::types::HostIncomingRequest,
             "wasi:http/types/fields": super::types::HostFields,
+            "wasi:http/types/request-options": super::types::HostRequestOptions,
         }
     });
 

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -264,9 +264,9 @@ pub struct HostOutgoingRequest {
 
 #[derive(Default)]
 pub struct HostRequestOptions {
-    pub connect_timeout: Option<u32>,
-    pub first_byte_timeout: Option<u32>,
-    pub between_bytes_timeout: Option<u32>,
+    pub connect_timeout: Option<std::time::Duration>,
+    pub first_byte_timeout: Option<std::time::Duration>,
+    pub between_bytes_timeout: Option<std::time::Duration>,
 }
 
 pub struct HostIncomingResponse {

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -262,6 +262,13 @@ pub struct HostOutgoingRequest {
     pub body: Option<HyperOutgoingBody>,
 }
 
+#[derive(Default)]
+pub struct HostRequestOptions {
+    pub connect_timeout: Option<u32>,
+    pub first_byte_timeout: Option<u32>,
+    pub between_bytes_timeout: Option<u32>,
+}
+
 pub struct HostIncomingResponse {
     pub status: u16,
     pub headers: FieldMap,

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -822,7 +822,11 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         &mut self,
         opts: Resource<types::RequestOptions>,
     ) -> wasmtime::Result<Option<u32>> {
-        Ok(self.table().get(&opts)?.connect_timeout)
+        Ok(self
+            .table()
+            .get(&opts)?
+            .connect_timeout
+            .and_then(|d| d.as_millis().try_into().ok()))
     }
 
     fn set_connect_timeout_ms(
@@ -830,7 +834,8 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         opts: Resource<types::RequestOptions>,
         ms: Option<u32>,
     ) -> wasmtime::Result<Result<(), ()>> {
-        self.table().get_mut(&opts)?.connect_timeout = ms;
+        self.table().get_mut(&opts)?.connect_timeout =
+            ms.map(|ms| std::time::Duration::from_millis(ms as u64));
         Ok(Ok(()))
     }
 
@@ -838,7 +843,11 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         &mut self,
         opts: Resource<types::RequestOptions>,
     ) -> wasmtime::Result<Option<u32>> {
-        Ok(self.table().get(&opts)?.first_byte_timeout)
+        Ok(self
+            .table()
+            .get(&opts)?
+            .first_byte_timeout
+            .and_then(|d| d.as_millis().try_into().ok()))
     }
 
     fn set_first_byte_timeout_ms(
@@ -846,7 +855,8 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         opts: Resource<types::RequestOptions>,
         ms: Option<u32>,
     ) -> wasmtime::Result<Result<(), ()>> {
-        self.table().get_mut(&opts)?.first_byte_timeout = ms;
+        self.table().get_mut(&opts)?.first_byte_timeout =
+            ms.map(|ms| std::time::Duration::from_millis(ms as u64));
         Ok(Ok(()))
     }
 
@@ -854,7 +864,11 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         &mut self,
         opts: Resource<types::RequestOptions>,
     ) -> wasmtime::Result<Option<u32>> {
-        Ok(self.table().get(&opts)?.between_bytes_timeout)
+        Ok(self
+            .table()
+            .get(&opts)?
+            .between_bytes_timeout
+            .and_then(|d| d.as_millis().try_into().ok()))
     }
 
     fn set_between_bytes_timeout_ms(
@@ -862,7 +876,8 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         opts: Resource<types::RequestOptions>,
         ms: Option<u32>,
     ) -> wasmtime::Result<Result<(), ()>> {
-        self.table().get_mut(&opts)?.between_bytes_timeout = ms;
+        self.table().get_mut(&opts)?.between_bytes_timeout =
+            ms.map(|ms| std::time::Duration::from_millis(ms as u64));
         Ok(Ok(()))
     }
 

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -829,9 +829,9 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         &mut self,
         opts: Resource<types::RequestOptions>,
         ms: Option<u32>,
-    ) -> wasmtime::Result<()> {
+    ) -> wasmtime::Result<Result<(), ()>> {
         self.table().get_mut(&opts)?.connect_timeout = ms;
-        Ok(())
+        Ok(Ok(()))
     }
 
     fn first_byte_timeout_ms(
@@ -845,9 +845,9 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         &mut self,
         opts: Resource<types::RequestOptions>,
         ms: Option<u32>,
-    ) -> wasmtime::Result<()> {
+    ) -> wasmtime::Result<Result<(), ()>> {
         self.table().get_mut(&opts)?.first_byte_timeout = ms;
-        Ok(())
+        Ok(Ok(()))
     }
 
     fn between_bytes_timeout_ms(
@@ -861,9 +861,9 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         &mut self,
         opts: Resource<types::RequestOptions>,
         ms: Option<u32>,
-    ) -> wasmtime::Result<()> {
+    ) -> wasmtime::Result<Result<(), ()>> {
         self.table().get_mut(&opts)?.between_bytes_timeout = ms;
-        Ok(())
+        Ok(Ok(()))
     }
 
     fn drop(&mut self, rep: Resource<types::RequestOptions>) -> wasmtime::Result<()> {

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -811,3 +811,63 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingBody for T {
         Ok(())
     }
 }
+
+impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
+    fn new(&mut self) -> wasmtime::Result<Resource<types::RequestOptions>> {
+        let id = self.table().push(types::RequestOptions::default())?;
+        Ok(id)
+    }
+
+    fn connect_timeout_ms(
+        &mut self,
+        opts: Resource<types::RequestOptions>,
+    ) -> wasmtime::Result<Option<u32>> {
+        Ok(self.table().get(&opts)?.connect_timeout)
+    }
+
+    fn set_connect_timeout_ms(
+        &mut self,
+        opts: Resource<types::RequestOptions>,
+        ms: Option<u32>,
+    ) -> wasmtime::Result<()> {
+        self.table().get_mut(&opts)?.connect_timeout = ms;
+        Ok(())
+    }
+
+    fn first_byte_timeout_ms(
+        &mut self,
+        opts: Resource<types::RequestOptions>,
+    ) -> wasmtime::Result<Option<u32>> {
+        Ok(self.table().get(&opts)?.first_byte_timeout)
+    }
+
+    fn set_first_byte_timeout_ms(
+        &mut self,
+        opts: Resource<types::RequestOptions>,
+        ms: Option<u32>,
+    ) -> wasmtime::Result<()> {
+        self.table().get_mut(&opts)?.first_byte_timeout = ms;
+        Ok(())
+    }
+
+    fn between_bytes_timeout_ms(
+        &mut self,
+        opts: Resource<types::RequestOptions>,
+    ) -> wasmtime::Result<Option<u32>> {
+        Ok(self.table().get(&opts)?.between_bytes_timeout)
+    }
+
+    fn set_between_bytes_timeout_ms(
+        &mut self,
+        opts: Resource<types::RequestOptions>,
+        ms: Option<u32>,
+    ) -> wasmtime::Result<()> {
+        self.table().get_mut(&opts)?.between_bytes_timeout = ms;
+        Ok(())
+    }
+
+    fn drop(&mut self, rep: Resource<types::RequestOptions>) -> wasmtime::Result<()> {
+        let _ = self.table().delete(rep)?;
+        Ok(())
+    }
+}

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -821,7 +821,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
     fn connect_timeout_ms(
         &mut self,
         opts: Resource<types::RequestOptions>,
-    ) -> wasmtime::Result<Option<u32>> {
+    ) -> wasmtime::Result<Option<types::Duration>> {
         let millis = self
             .table()
             .get(&opts)?
@@ -838,7 +838,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
     fn set_connect_timeout_ms(
         &mut self,
         opts: Resource<types::RequestOptions>,
-        ms: Option<u32>,
+        ms: Option<types::Duration>,
     ) -> wasmtime::Result<Result<(), ()>> {
         self.table().get_mut(&opts)?.connect_timeout =
             ms.map(|ms| std::time::Duration::from_millis(ms as u64));
@@ -848,7 +848,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
     fn first_byte_timeout_ms(
         &mut self,
         opts: Resource<types::RequestOptions>,
-    ) -> wasmtime::Result<Option<u32>> {
+    ) -> wasmtime::Result<Option<types::Duration>> {
         let millis = self
             .table()
             .get(&opts)?
@@ -865,7 +865,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
     fn set_first_byte_timeout_ms(
         &mut self,
         opts: Resource<types::RequestOptions>,
-        ms: Option<u32>,
+        ms: Option<types::Duration>,
     ) -> wasmtime::Result<Result<(), ()>> {
         self.table().get_mut(&opts)?.first_byte_timeout =
             ms.map(|ms| std::time::Duration::from_millis(ms as u64));
@@ -875,7 +875,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
     fn between_bytes_timeout_ms(
         &mut self,
         opts: Resource<types::RequestOptions>,
-    ) -> wasmtime::Result<Option<u32>> {
+    ) -> wasmtime::Result<Option<types::Duration>> {
         let millis = self
             .table()
             .get(&opts)?
@@ -892,7 +892,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
     fn set_between_bytes_timeout_ms(
         &mut self,
         opts: Resource<types::RequestOptions>,
-        ms: Option<u32>,
+        ms: Option<types::Duration>,
     ) -> wasmtime::Result<Result<(), ()>> {
         self.table().get_mut(&opts)?.between_bytes_timeout =
             ms.map(|ms| std::time::Duration::from_millis(ms as u64));

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -822,11 +822,17 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         &mut self,
         opts: Resource<types::RequestOptions>,
     ) -> wasmtime::Result<Option<u32>> {
-        Ok(self
+        let millis = self
             .table()
             .get(&opts)?
             .connect_timeout
-            .and_then(|d| d.as_millis().try_into().ok()))
+            .map(|d| d.as_millis());
+
+        if let Some(millis) = millis {
+            Ok(Some(millis.try_into()?))
+        } else {
+            Ok(None)
+        }
     }
 
     fn set_connect_timeout_ms(
@@ -843,11 +849,17 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         &mut self,
         opts: Resource<types::RequestOptions>,
     ) -> wasmtime::Result<Option<u32>> {
-        Ok(self
+        let millis = self
             .table()
             .get(&opts)?
             .first_byte_timeout
-            .and_then(|d| d.as_millis().try_into().ok()))
+            .map(|d| d.as_millis());
+
+        if let Some(millis) = millis {
+            Ok(Some(millis.try_into()?))
+        } else {
+            Ok(None)
+        }
     }
 
     fn set_first_byte_timeout_ms(
@@ -864,11 +876,17 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         &mut self,
         opts: Resource<types::RequestOptions>,
     ) -> wasmtime::Result<Option<u32>> {
-        Ok(self
+        let millis = self
             .table()
             .get(&opts)?
             .between_bytes_timeout
-            .and_then(|d| d.as_millis().try_into().ok()))
+            .map(|d| d.as_millis());
+
+        if let Some(millis) = millis {
+            Ok(Some(millis.try_into()?))
+        } else {
+            Ok(None)
+        }
     }
 
     fn set_between_bytes_timeout_ms(

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -230,22 +230,25 @@ interface types {
     /// The timeout for the initial connect to the HTTP Server.
     connect-timeout-ms: func() -> option<u32>;
 
-    /// Set the timeout for the initial connect to the HTTP Server.
-    set-connect-timeout-ms: func(ms: option<u32>);
+    /// Set the timeout for the initial connect to the HTTP Server. An error
+    /// return value indicates that this timeout is not supported.
+    set-connect-timeout-ms: func(ms: option<u32>) -> result;
 
     /// The timeout for receiving the first byte of the Response body.
     first-byte-timeout-ms: func() -> option<u32>;
 
-    /// Set the timeout for receiving the first byte of the Response body.
-    set-first-byte-timeout-ms: func(ms: option<u32>);
+    /// Set the timeout for receiving the first byte of the Response body. An
+    /// error return value indicates that this timeout is not supported.
+    set-first-byte-timeout-ms: func(ms: option<u32>) -> result;
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
     between-bytes-timeout-ms: func() -> option<u32>;
 
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
-    /// body stream.
-    set-between-bytes-timeout-ms: func(ms: option<u32>);
+    /// body stream. An error return value indicates that this timeout is not
+    /// supported.
+    set-between-bytes-timeout-ms: func(ms: option<u32>) -> result;
   }
 
   /// Represents the ability to send an HTTP Response.

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -2,6 +2,7 @@
 /// HTTP Requests and Responses, both incoming and outgoing, as well as
 /// their headers, trailers, and bodies.
 interface types {
+  use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05.{duration};
   use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream};
   use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
 
@@ -228,27 +229,27 @@ interface types {
     constructor();
 
     /// The timeout for the initial connect to the HTTP Server.
-    connect-timeout-ms: func() -> option<u32>;
+    connect-timeout-ms: func() -> option<duration>;
 
     /// Set the timeout for the initial connect to the HTTP Server. An error
     /// return value indicates that this timeout is not supported.
-    set-connect-timeout-ms: func(ms: option<u32>) -> result;
+    set-connect-timeout-ms: func(ms: option<duration>) -> result;
 
     /// The timeout for receiving the first byte of the Response body.
-    first-byte-timeout-ms: func() -> option<u32>;
+    first-byte-timeout-ms: func() -> option<duration>;
 
     /// Set the timeout for receiving the first byte of the Response body. An
     /// error return value indicates that this timeout is not supported.
-    set-first-byte-timeout-ms: func(ms: option<u32>) -> result;
+    set-first-byte-timeout-ms: func(ms: option<duration>) -> result;
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
-    between-bytes-timeout-ms: func() -> option<u32>;
+    between-bytes-timeout-ms: func() -> option<duration>;
 
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
     /// body stream. An error return value indicates that this timeout is not
     /// supported.
-    set-between-bytes-timeout-ms: func(ms: option<u32>) -> result;
+    set-between-bytes-timeout-ms: func(ms: option<duration>) -> result;
   }
 
   /// Represents the ability to send an HTTP Response.

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -223,21 +223,29 @@ interface types {
   ///
   /// These timeouts are separate from any the user may use to bound a
   /// blocking call to `wasi:io/poll.poll-list`.
-  ///
-  /// FIXME: Make this a resource to allow it to be optionally extended by
-  /// future evolution of the standard and/or other interfaces at some later
-  /// date?
-  record request-options {
+  resource request-options {
+    /// Construct a default `request-options` value.
+    constructor();
 
     /// The timeout for the initial connect to the HTTP Server.
-    connect-timeout-ms: option<u32>,
+    connect-timeout-ms: func() -> option<u32>;
+
+    /// Set the timeout for the initial connect to the HTTP Server.
+    set-connect-timeout-ms: func(ms: option<u32>);
 
     /// The timeout for receiving the first byte of the Response body.
-    first-byte-timeout-ms: option<u32>,
+    first-byte-timeout-ms: func() -> option<u32>;
+
+    /// Set the timeout for receiving the first byte of the Response body.
+    set-first-byte-timeout-ms: func(ms: option<u32>);
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
-    between-bytes-timeout-ms: option<u32>
+    between-bytes-timeout-ms: func() -> option<u32>;
+
+    /// Set the timeout for receiving subsequent chunks of bytes in the Response
+    /// body stream.
+    set-between-bytes-timeout-ms: func(ms: option<u32>);
   }
 
   /// Represents the ability to send an HTTP Response.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -230,22 +230,25 @@ interface types {
     /// The timeout for the initial connect to the HTTP Server.
     connect-timeout-ms: func() -> option<u32>;
 
-    /// Set the timeout for the initial connect to the HTTP Server.
-    set-connect-timeout-ms: func(ms: option<u32>);
+    /// Set the timeout for the initial connect to the HTTP Server. An error
+    /// return value indicates that this timeout is not supported.
+    set-connect-timeout-ms: func(ms: option<u32>) -> result;
 
     /// The timeout for receiving the first byte of the Response body.
     first-byte-timeout-ms: func() -> option<u32>;
 
-    /// Set the timeout for receiving the first byte of the Response body.
-    set-first-byte-timeout-ms: func(ms: option<u32>);
+    /// Set the timeout for receiving the first byte of the Response body. An
+    /// error return value indicates that this timeout is not supported.
+    set-first-byte-timeout-ms: func(ms: option<u32>) -> result;
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
     between-bytes-timeout-ms: func() -> option<u32>;
 
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
-    /// body stream.
-    set-between-bytes-timeout-ms: func(ms: option<u32>);
+    /// body stream. An error return value indicates that this timeout is not
+    /// supported.
+    set-between-bytes-timeout-ms: func(ms: option<u32>) -> result;
   }
 
   /// Represents the ability to send an HTTP Response.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -2,6 +2,7 @@
 /// HTTP Requests and Responses, both incoming and outgoing, as well as
 /// their headers, trailers, and bodies.
 interface types {
+  use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05.{duration};
   use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream};
   use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
 
@@ -228,27 +229,27 @@ interface types {
     constructor();
 
     /// The timeout for the initial connect to the HTTP Server.
-    connect-timeout-ms: func() -> option<u32>;
+    connect-timeout-ms: func() -> option<duration>;
 
     /// Set the timeout for the initial connect to the HTTP Server. An error
     /// return value indicates that this timeout is not supported.
-    set-connect-timeout-ms: func(ms: option<u32>) -> result;
+    set-connect-timeout-ms: func(ms: option<duration>) -> result;
 
     /// The timeout for receiving the first byte of the Response body.
-    first-byte-timeout-ms: func() -> option<u32>;
+    first-byte-timeout-ms: func() -> option<duration>;
 
     /// Set the timeout for receiving the first byte of the Response body. An
     /// error return value indicates that this timeout is not supported.
-    set-first-byte-timeout-ms: func(ms: option<u32>) -> result;
+    set-first-byte-timeout-ms: func(ms: option<duration>) -> result;
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
-    between-bytes-timeout-ms: func() -> option<u32>;
+    between-bytes-timeout-ms: func() -> option<duration>;
 
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
     /// body stream. An error return value indicates that this timeout is not
     /// supported.
-    set-between-bytes-timeout-ms: func(ms: option<u32>) -> result;
+    set-between-bytes-timeout-ms: func(ms: option<duration>) -> result;
   }
 
   /// Represents the ability to send an HTTP Response.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -223,21 +223,29 @@ interface types {
   ///
   /// These timeouts are separate from any the user may use to bound a
   /// blocking call to `wasi:io/poll.poll-list`.
-  ///
-  /// FIXME: Make this a resource to allow it to be optionally extended by
-  /// future evolution of the standard and/or other interfaces at some later
-  /// date?
-  record request-options {
+  resource request-options {
+    /// Construct a default `request-options` value.
+    constructor();
 
     /// The timeout for the initial connect to the HTTP Server.
-    connect-timeout-ms: option<u32>,
+    connect-timeout-ms: func() -> option<u32>;
+
+    /// Set the timeout for the initial connect to the HTTP Server.
+    set-connect-timeout-ms: func(ms: option<u32>);
 
     /// The timeout for receiving the first byte of the Response body.
-    first-byte-timeout-ms: option<u32>,
+    first-byte-timeout-ms: func() -> option<u32>;
+
+    /// Set the timeout for receiving the first byte of the Response body.
+    set-first-byte-timeout-ms: func(ms: option<u32>);
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
-    between-bytes-timeout-ms: option<u32>
+    between-bytes-timeout-ms: func() -> option<u32>;
+
+    /// Set the timeout for receiving subsequent chunks of bytes in the Response
+    /// body stream.
+    set-between-bytes-timeout-ms: func(ms: option<u32>);
   }
 
   /// Represents the ability to send an HTTP Response.


### PR DESCRIPTION
As we'd like to be able to modify `request-options` in the future without breaking compatibility with older guests, turn `request-options` into a resource. This allows us to expose getters and setters instead of fields on a record, which gives the embedder flexibility in what additional options are allowed.

Fixes #7409 
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
