### PR TITLE
[14.0.0] Add support for `::` in `--dir` to old CLI 

### DIFF
--- a/src/old_cli.rs
+++ b/src/old_cli.rs
@@ -748,7 +748,10 @@ impl RunCommand {
         let mut dirs = Vec::new();
 
         for host in old_dirs {
-            dirs.push((host.clone(), host));
+            let mut parts = host.splitn(2, "::");
+            let host = parts.next().unwrap();
+            let guest = parts.next().unwrap_or(host);
+            dirs.push((host.to_string(), guest.to_string()));
         }
 
         if preview2 {


### PR DESCRIPTION
This is a backport of #7416 to the 14.0.0 branch