### PR TITLE
wasi-sockets: Sync up UDP implementation & tests with TCP

### DIFF
--- a/crates/test-programs/src/bin/preview2_tcp_connect.rs
+++ b/crates/test-programs/src/bin/preview2_tcp_connect.rs
@@ -27,7 +27,7 @@ fn test_tcp_connect_port_0(net: &Network, family: IpAddressFamily) {
     ));
 }
 
-/// Bind should validate the address family.
+/// Connect should validate the address family.
 fn test_tcp_connect_wrong_family(net: &Network, family: IpAddressFamily) {
     let wrong_ip = match family {
         IpAddressFamily::Ipv4 => IpAddress::IPV6_LOOPBACK,

--- a/crates/test-programs/src/bin/preview2_tcp_sample_application.rs
+++ b/crates/test-programs/src/bin/preview2_tcp_sample_application.rs
@@ -3,7 +3,7 @@ use test_programs::wasi::sockets::network::{
 };
 use test_programs::wasi::sockets::tcp::TcpSocket;
 
-fn test_sample_application(family: IpAddressFamily, bind_address: IpSocketAddress) {
+fn test_tcp_sample_application(family: IpAddressFamily, bind_address: IpSocketAddress) {
     let first_message = b"Hello, world!";
     let second_message = b"Greetings, planet!";
 
@@ -54,14 +54,14 @@ fn test_sample_application(family: IpAddressFamily, bind_address: IpSocketAddres
 }
 
 fn main() {
-    test_sample_application(
+    test_tcp_sample_application(
         IpAddressFamily::Ipv4,
         IpSocketAddress::Ipv4(Ipv4SocketAddress {
             port: 0,                 // use any free port
             address: (127, 0, 0, 1), // localhost
         }),
     );
-    test_sample_application(
+    test_tcp_sample_application(
         IpAddressFamily::Ipv6,
         IpSocketAddress::Ipv6(Ipv6SocketAddress {
             port: 0,                           // use any free port

--- a/crates/test-programs/src/bin/preview2_udp_bind.rs
+++ b/crates/test-programs/src/bin/preview2_udp_bind.rs
@@ -1,0 +1,126 @@
+use test_programs::wasi::sockets::network::{
+    ErrorCode, IpAddress, IpAddressFamily, IpSocketAddress, Network,
+};
+use test_programs::wasi::sockets::udp::UdpSocket;
+
+/// Bind a socket and let the system determine a port.
+fn test_udp_bind_ephemeral_port(net: &Network, ip: IpAddress) {
+    let bind_addr = IpSocketAddress::new(ip, 0);
+
+    let sock = UdpSocket::new(ip.family()).unwrap();
+    sock.blocking_bind(net, bind_addr).unwrap();
+
+    let bound_addr = sock.local_address().unwrap();
+
+    assert_eq!(bind_addr.ip(), bound_addr.ip());
+    assert_ne!(bind_addr.port(), bound_addr.port());
+}
+
+/// Bind a socket on a specified port.
+fn test_udp_bind_specific_port(net: &Network, ip: IpAddress) {
+    const PORT: u16 = 54321;
+
+    let bind_addr = IpSocketAddress::new(ip, PORT);
+
+    let sock = UdpSocket::new(ip.family()).unwrap();
+    sock.blocking_bind(net, bind_addr).unwrap();
+
+    let bound_addr = sock.local_address().unwrap();
+
+    assert_eq!(bind_addr.ip(), bound_addr.ip());
+    assert_eq!(bind_addr.port(), bound_addr.port());
+}
+
+/// Two sockets may not be actively bound to the same address at the same time.
+fn test_udp_bind_addrinuse(net: &Network, ip: IpAddress) {
+    let bind_addr = IpSocketAddress::new(ip, 0);
+
+    let sock1 = UdpSocket::new(ip.family()).unwrap();
+    sock1.blocking_bind(net, bind_addr).unwrap();
+
+    let bound_addr = sock1.local_address().unwrap();
+
+    let sock2 = UdpSocket::new(ip.family()).unwrap();
+    assert!(matches!(
+        sock2.blocking_bind(net, bound_addr),
+        Err(ErrorCode::AddressInUse)
+    ));
+}
+
+// Try binding to an address that is not configured on the system.
+fn test_udp_bind_addrnotavail(net: &Network, ip: IpAddress) {
+    let bind_addr = IpSocketAddress::new(ip, 0);
+
+    let sock = UdpSocket::new(ip.family()).unwrap();
+
+    assert!(matches!(
+        sock.blocking_bind(net, bind_addr),
+        Err(ErrorCode::AddressNotBindable)
+    ));
+}
+
+/// Bind should validate the address family.
+fn test_udp_bind_wrong_family(net: &Network, family: IpAddressFamily) {
+    let wrong_ip = match family {
+        IpAddressFamily::Ipv4 => IpAddress::IPV6_LOOPBACK,
+        IpAddressFamily::Ipv6 => IpAddress::IPV4_LOOPBACK,
+    };
+
+    let sock = UdpSocket::new(family).unwrap();
+    let result = sock.blocking_bind(net, IpSocketAddress::new(wrong_ip, 0));
+
+    assert!(matches!(result, Err(ErrorCode::InvalidArgument)));
+}
+
+fn test_udp_bind_dual_stack(net: &Network) {
+    let sock = UdpSocket::new(IpAddressFamily::Ipv6).unwrap();
+    let addr = IpSocketAddress::new(IpAddress::IPV4_MAPPED_LOOPBACK, 0);
+
+    // Even on platforms that don't support dualstack sockets,
+    // setting ipv6_only to true (disabling dualstack mode) should work.
+    sock.set_ipv6_only(true).unwrap();
+
+    // Binding an IPv4-mapped-IPv6 address on a ipv6-only socket should fail:
+    assert!(matches!(
+        sock.blocking_bind(net, addr),
+        Err(ErrorCode::InvalidArgument)
+    ));
+
+    sock.set_ipv6_only(false).unwrap();
+
+    sock.blocking_bind(net, addr).unwrap();
+
+    let bound_addr = sock.local_address().unwrap();
+
+    assert_eq!(bound_addr.family(), IpAddressFamily::Ipv6);
+}
+
+fn main() {
+    const RESERVED_IPV4_ADDRESS: IpAddress = IpAddress::Ipv4((192, 0, 2, 0)); // Reserved for documentation and examples.
+    const RESERVED_IPV6_ADDRESS: IpAddress = IpAddress::Ipv6((0x2001, 0x0db8, 0, 0, 0, 0, 0, 0)); // Reserved for documentation and examples.
+
+    let net = Network::default();
+
+    test_udp_bind_ephemeral_port(&net, IpAddress::IPV4_LOOPBACK);
+    test_udp_bind_ephemeral_port(&net, IpAddress::IPV6_LOOPBACK);
+    test_udp_bind_ephemeral_port(&net, IpAddress::IPV4_UNSPECIFIED);
+    test_udp_bind_ephemeral_port(&net, IpAddress::IPV6_UNSPECIFIED);
+
+    test_udp_bind_specific_port(&net, IpAddress::IPV4_LOOPBACK);
+    test_udp_bind_specific_port(&net, IpAddress::IPV6_LOOPBACK);
+    test_udp_bind_specific_port(&net, IpAddress::IPV4_UNSPECIFIED);
+    test_udp_bind_specific_port(&net, IpAddress::IPV6_UNSPECIFIED);
+
+    test_udp_bind_addrinuse(&net, IpAddress::IPV4_LOOPBACK);
+    test_udp_bind_addrinuse(&net, IpAddress::IPV6_LOOPBACK);
+    test_udp_bind_addrinuse(&net, IpAddress::IPV4_UNSPECIFIED);
+    test_udp_bind_addrinuse(&net, IpAddress::IPV6_UNSPECIFIED);
+
+    test_udp_bind_addrnotavail(&net, RESERVED_IPV4_ADDRESS);
+    test_udp_bind_addrnotavail(&net, RESERVED_IPV6_ADDRESS);
+
+    test_udp_bind_wrong_family(&net, IpAddressFamily::Ipv4);
+    test_udp_bind_wrong_family(&net, IpAddressFamily::Ipv6);
+
+    test_udp_bind_dual_stack(&net);
+}

--- a/crates/test-programs/src/bin/preview2_udp_connect.rs
+++ b/crates/test-programs/src/bin/preview2_udp_connect.rs
@@ -3,6 +3,8 @@ use test_programs::wasi::sockets::network::{
 };
 use test_programs::wasi::sockets::udp::UdpSocket;
 
+const SOME_PORT: u16 = 47; // If the tests pass, this will never actually be connected to.
+
 fn test_udp_connect_disconnect_reconnect(net: &Network, family: IpAddressFamily) {
     let unspecified_addr = IpSocketAddress::new(IpAddress::new_unspecified(family), 0);
     let remote1 = IpSocketAddress::new(IpAddress::new_loopback(family), 4321);
@@ -33,9 +35,107 @@ fn test_udp_connect_disconnect_reconnect(net: &Network, family: IpAddressFamily)
     assert_eq!(client.remote_address(), Ok(remote1));
 }
 
+/// `0.0.0.0` / `::` is not a valid remote address in WASI.
+fn test_udp_connect_unspec(net: &Network, family: IpAddressFamily) {
+    let addr = IpSocketAddress::new(IpAddress::new_unspecified(family), SOME_PORT);
+    let sock = UdpSocket::new(family).unwrap();
+    sock.blocking_bind_unspecified(&net).unwrap();
+
+    assert!(matches!(
+        sock.stream(Some(addr)),
+        Err(ErrorCode::InvalidArgument)
+    ));
+}
+
+/// 0 is not a valid remote port.
+fn test_udp_connect_port_0(net: &Network, family: IpAddressFamily) {
+    let addr = IpSocketAddress::new(IpAddress::new_loopback(family), 0);
+    let sock = UdpSocket::new(family).unwrap();
+    sock.blocking_bind_unspecified(&net).unwrap();
+
+    assert!(matches!(
+        sock.stream(Some(addr)),
+        Err(ErrorCode::InvalidArgument)
+    ));
+}
+
+/// Connect should validate the address family.
+fn test_udp_connect_wrong_family(net: &Network, family: IpAddressFamily) {
+    let wrong_ip = match family {
+        IpAddressFamily::Ipv4 => IpAddress::IPV6_LOOPBACK,
+        IpAddressFamily::Ipv6 => IpAddress::IPV4_LOOPBACK,
+    };
+    let remote_addr = IpSocketAddress::new(wrong_ip, SOME_PORT);
+
+    let sock = UdpSocket::new(family).unwrap();
+    sock.blocking_bind_unspecified(&net).unwrap();
+
+    assert!(matches!(
+        sock.stream(Some(remote_addr)),
+        Err(ErrorCode::InvalidArgument)
+    ));
+}
+
+fn test_udp_connect_dual_stack(net: &Network) {
+    // Set-up:
+    let v4_server = UdpSocket::new(IpAddressFamily::Ipv4).unwrap();
+    v4_server
+        .blocking_bind(&net, IpSocketAddress::new(IpAddress::IPV4_LOOPBACK, 0))
+        .unwrap();
+
+    let v4_server_addr = v4_server.local_address().unwrap();
+    let v6_server_addr =
+        IpSocketAddress::new(IpAddress::IPV4_MAPPED_LOOPBACK, v4_server_addr.port());
+
+    // Tests:
+    {
+        let v6_client = UdpSocket::new(IpAddressFamily::Ipv6).unwrap();
+
+        // Even on platforms that don't support dualstack sockets,
+        // setting ipv6_only to true (disabling dualstack mode) should work.
+        v6_client.set_ipv6_only(true).unwrap();
+
+        v6_client.blocking_bind_unspecified(&net).unwrap();
+
+        // Connecting to an IPv4-mapped-IPv6 address on an ipv6-only socket should fail:
+        assert!(matches!(
+            v6_client.stream(Some(v6_server_addr)),
+            Err(ErrorCode::InvalidArgument)
+        ));
+    }
+
+    {
+        let v6_client = UdpSocket::new(IpAddressFamily::Ipv6).unwrap();
+
+        v6_client.set_ipv6_only(false).unwrap();
+        v6_client.blocking_bind_unspecified(&net).unwrap();
+        v6_client.stream(Some(v6_server_addr)).unwrap();
+
+        assert_eq!(
+            v6_client.local_address().unwrap().family(),
+            IpAddressFamily::Ipv6
+        );
+        assert_eq!(
+            v6_client.remote_address().unwrap().family(),
+            IpAddressFamily::Ipv6
+        );
+    }
+}
+
 fn main() {
     let net = Network::default();
 
     test_udp_connect_disconnect_reconnect(&net, IpAddressFamily::Ipv4);
     test_udp_connect_disconnect_reconnect(&net, IpAddressFamily::Ipv6);
+
+    test_udp_connect_unspec(&net, IpAddressFamily::Ipv4);
+    test_udp_connect_unspec(&net, IpAddressFamily::Ipv6);
+
+    test_udp_connect_port_0(&net, IpAddressFamily::Ipv4);
+    test_udp_connect_port_0(&net, IpAddressFamily::Ipv6);
+
+    test_udp_connect_wrong_family(&net, IpAddressFamily::Ipv4);
+    test_udp_connect_wrong_family(&net, IpAddressFamily::Ipv6);
+
+    test_udp_connect_dual_stack(&net);
 }

--- a/crates/test-programs/src/bin/preview2_udp_sample_application.rs
+++ b/crates/test-programs/src/bin/preview2_udp_sample_application.rs
@@ -3,7 +3,7 @@ use test_programs::wasi::sockets::network::{
 };
 use test_programs::wasi::sockets::udp::{OutgoingDatagram, UdpSocket};
 
-fn test_sample_application(family: IpAddressFamily, bind_address: IpSocketAddress) {
+fn test_udp_sample_application(family: IpAddressFamily, bind_address: IpSocketAddress) {
     let unspecified_addr = IpSocketAddress::new(IpAddress::new_unspecified(family), 0);
 
     let first_message = &[];
@@ -72,15 +72,61 @@ fn test_sample_application(family: IpAddressFamily, bind_address: IpSocketAddres
     }
 }
 
+fn test_udp_dual_stack_conversation() {
+    let net = Network::default();
+
+    let v4_server = UdpSocket::new(IpAddressFamily::Ipv4).unwrap();
+    v4_server
+        .blocking_bind(&net, IpSocketAddress::new(IpAddress::IPV4_LOOPBACK, 0))
+        .unwrap();
+    let (server_incoming, server_outgoing) = v4_server.stream(None).unwrap();
+
+    let v4_server_addr = v4_server.local_address().unwrap();
+    let v6_server_addr =
+        IpSocketAddress::new(IpAddress::IPV4_MAPPED_LOOPBACK, v4_server_addr.port());
+
+    let v6_client = UdpSocket::new(IpAddressFamily::Ipv6).unwrap();
+
+    v6_client.set_ipv6_only(false).unwrap();
+    v6_client.blocking_bind_unspecified(&net).unwrap();
+    let (client_incoming, client_outgoing) = v6_client.stream(None).unwrap();
+
+    // Send from v6 client to v4 server:
+    client_outgoing
+        .blocking_send(&[OutgoingDatagram {
+            data: "Hi!".into(),
+            remote_address: Some(v6_server_addr),
+        }])
+        .unwrap();
+
+    // Receive from v6 client on v4 server:
+    let results = server_incoming.blocking_receive(1..1).unwrap();
+    let msg = results.first().unwrap();
+    assert_eq!(msg.remote_address.family(), IpAddressFamily::Ipv4);
+
+    // Send from v4 server to v6 client:
+    server_outgoing
+        .blocking_send(&[OutgoingDatagram {
+            data: msg.data.clone(),
+            remote_address: Some(msg.remote_address),
+        }])
+        .unwrap();
+
+    // Receive from v4 server on v6 client:
+    let results = client_incoming.blocking_receive(1..1).unwrap();
+    let msg = results.first().unwrap();
+    assert_eq!(msg.remote_address.family(), IpAddressFamily::Ipv6);
+}
+
 fn main() {
-    test_sample_application(
+    test_udp_sample_application(
         IpAddressFamily::Ipv4,
         IpSocketAddress::Ipv4(Ipv4SocketAddress {
             port: 0,                 // use any free port
             address: (127, 0, 0, 1), // localhost
         }),
     );
-    test_sample_application(
+    test_udp_sample_application(
         IpAddressFamily::Ipv6,
         IpSocketAddress::Ipv6(Ipv6SocketAddress {
             port: 0,                           // use any free port
@@ -89,4 +135,6 @@ fn main() {
             scope_id: 0,
         }),
     );
+
+    test_udp_dual_stack_conversation();
 }

--- a/crates/test-programs/src/bin/preview2_udp_sockopts.rs
+++ b/crates/test-programs/src/bin/preview2_udp_sockopts.rs
@@ -1,0 +1,68 @@
+use test_programs::wasi::sockets::network::{ErrorCode, IpAddressFamily};
+use test_programs::wasi::sockets::udp::UdpSocket;
+
+fn test_udp_sockopt_defaults(family: IpAddressFamily) {
+    let sock = UdpSocket::new(family).unwrap();
+
+    assert_eq!(sock.address_family(), family);
+
+    if family == IpAddressFamily::Ipv6 {
+        sock.ipv6_only().unwrap(); // Only verify that it has a default value at all, but either value is valid.
+    }
+
+    assert!(sock.unicast_hop_limit().unwrap() > 0);
+    assert!(sock.receive_buffer_size().unwrap() > 0);
+    assert!(sock.send_buffer_size().unwrap() > 0);
+}
+
+fn test_udp_sockopt_input_ranges(family: IpAddressFamily) {
+    let sock = UdpSocket::new(family).unwrap();
+
+    if family == IpAddressFamily::Ipv6 {
+        assert!(matches!(sock.set_ipv6_only(true), Ok(_)));
+        assert!(matches!(sock.set_ipv6_only(false), Ok(_)));
+    }
+
+    assert!(matches!(
+        sock.set_unicast_hop_limit(0),
+        Err(ErrorCode::InvalidArgument)
+    ));
+    assert!(matches!(sock.set_unicast_hop_limit(1), Ok(_)));
+    assert!(matches!(sock.set_unicast_hop_limit(u8::MAX), Ok(_)));
+
+    assert!(matches!(sock.set_receive_buffer_size(0), Ok(_))); // Unsupported sizes should be silently capped.
+    assert!(matches!(sock.set_receive_buffer_size(u64::MAX), Ok(_))); // Unsupported sizes should be silently capped.
+    assert!(matches!(sock.set_send_buffer_size(0), Ok(_))); // Unsupported sizes should be silently capped.
+    assert!(matches!(sock.set_send_buffer_size(u64::MAX), Ok(_))); // Unsupported sizes should be silently capped.
+}
+
+fn test_udp_sockopt_readback(family: IpAddressFamily) {
+    let sock = UdpSocket::new(family).unwrap();
+
+    if family == IpAddressFamily::Ipv6 {
+        sock.set_ipv6_only(true).unwrap();
+        assert_eq!(sock.ipv6_only().unwrap(), true);
+        sock.set_ipv6_only(false).unwrap();
+        assert_eq!(sock.ipv6_only().unwrap(), false);
+    }
+
+    sock.set_unicast_hop_limit(42).unwrap();
+    assert_eq!(sock.unicast_hop_limit().unwrap(), 42);
+
+    sock.set_receive_buffer_size(0x10000).unwrap();
+    assert_eq!(sock.receive_buffer_size().unwrap(), 0x10000);
+
+    sock.set_send_buffer_size(0x10000).unwrap();
+    assert_eq!(sock.send_buffer_size().unwrap(), 0x10000);
+}
+
+fn main() {
+    test_udp_sockopt_defaults(IpAddressFamily::Ipv4);
+    test_udp_sockopt_defaults(IpAddressFamily::Ipv6);
+
+    test_udp_sockopt_input_ranges(IpAddressFamily::Ipv4);
+    test_udp_sockopt_input_ranges(IpAddressFamily::Ipv6);
+
+    test_udp_sockopt_readback(IpAddressFamily::Ipv4);
+    test_udp_sockopt_readback(IpAddressFamily::Ipv6);
+}

--- a/crates/test-programs/src/bin/preview2_udp_states.rs
+++ b/crates/test-programs/src/bin/preview2_udp_states.rs
@@ -1,0 +1,135 @@
+use test_programs::wasi::sockets::network::{
+    ErrorCode, IpAddress, IpAddressFamily, IpSocketAddress, Network,
+};
+use test_programs::wasi::sockets::udp::UdpSocket;
+
+fn test_udp_unbound_state_invariants(family: IpAddressFamily) {
+    let sock = UdpSocket::new(family).unwrap();
+
+    // Skipping: udp::start_bind
+    assert!(matches!(sock.finish_bind(), Err(ErrorCode::NotInProgress)));
+
+    assert!(matches!(sock.stream(None), Err(ErrorCode::InvalidState)));
+
+    assert!(matches!(sock.local_address(), Err(ErrorCode::InvalidState)));
+    assert!(matches!(
+        sock.remote_address(),
+        Err(ErrorCode::InvalidState)
+    ));
+    assert_eq!(sock.address_family(), family);
+
+    if family == IpAddressFamily::Ipv6 {
+        assert!(matches!(sock.ipv6_only(), Ok(_)));
+
+        // Even on platforms that don't support dualstack sockets,
+        // setting ipv6_only to true (disabling dualstack mode) should work.
+        assert!(matches!(sock.set_ipv6_only(true), Ok(_)));
+    } else {
+        assert!(matches!(sock.ipv6_only(), Err(ErrorCode::NotSupported)));
+        assert!(matches!(
+            sock.set_ipv6_only(true),
+            Err(ErrorCode::NotSupported)
+        ));
+    }
+
+    assert!(matches!(sock.unicast_hop_limit(), Ok(_)));
+    assert!(matches!(sock.set_unicast_hop_limit(255), Ok(_)));
+    assert!(matches!(sock.receive_buffer_size(), Ok(_)));
+    assert!(matches!(sock.set_receive_buffer_size(16000), Ok(_)));
+    assert!(matches!(sock.send_buffer_size(), Ok(_)));
+    assert!(matches!(sock.set_send_buffer_size(16000), Ok(_)));
+}
+
+fn test_udp_bound_state_invariants(net: &Network, family: IpAddressFamily) {
+    let bind_address = IpSocketAddress::new(IpAddress::new_loopback(family), 0);
+    let sock = UdpSocket::new(family).unwrap();
+    sock.blocking_bind(net, bind_address).unwrap();
+
+    assert!(matches!(
+        sock.start_bind(net, bind_address),
+        Err(ErrorCode::InvalidState)
+    ));
+    assert!(matches!(sock.finish_bind(), Err(ErrorCode::NotInProgress)));
+    // Skipping: udp::stream
+
+    assert!(matches!(sock.local_address(), Ok(_)));
+    assert!(matches!(
+        sock.remote_address(),
+        Err(ErrorCode::InvalidState)
+    ));
+    assert_eq!(sock.address_family(), family);
+
+    if family == IpAddressFamily::Ipv6 {
+        assert!(matches!(sock.ipv6_only(), Ok(_)));
+        assert!(matches!(
+            sock.set_ipv6_only(true),
+            Err(ErrorCode::InvalidState)
+        ));
+    } else {
+        assert!(matches!(sock.ipv6_only(), Err(ErrorCode::NotSupported)));
+        assert!(matches!(
+            sock.set_ipv6_only(true),
+            Err(ErrorCode::NotSupported)
+        ));
+    }
+
+    assert!(matches!(sock.unicast_hop_limit(), Ok(_)));
+    assert!(matches!(sock.set_unicast_hop_limit(255), Ok(_)));
+    assert!(matches!(sock.receive_buffer_size(), Ok(_)));
+    assert!(matches!(sock.set_receive_buffer_size(16000), Ok(_)));
+    assert!(matches!(sock.send_buffer_size(), Ok(_)));
+    assert!(matches!(sock.set_send_buffer_size(16000), Ok(_)));
+}
+
+fn test_udp_connected_state_invariants(net: &Network, family: IpAddressFamily) {
+    let bind_address = IpSocketAddress::new(IpAddress::new_loopback(family), 0);
+    let connect_address = IpSocketAddress::new(IpAddress::new_loopback(family), 54321);
+    let sock = UdpSocket::new(family).unwrap();
+    sock.blocking_bind(net, bind_address).unwrap();
+    sock.stream(Some(connect_address)).unwrap();
+
+    assert!(matches!(
+        sock.start_bind(net, bind_address),
+        Err(ErrorCode::InvalidState)
+    ));
+    assert!(matches!(sock.finish_bind(), Err(ErrorCode::NotInProgress)));
+    // Skipping: udp::stream
+
+    assert!(matches!(sock.local_address(), Ok(_)));
+    assert!(matches!(sock.remote_address(), Ok(_)));
+    assert_eq!(sock.address_family(), family);
+
+    if family == IpAddressFamily::Ipv6 {
+        assert!(matches!(sock.ipv6_only(), Ok(_)));
+        assert!(matches!(
+            sock.set_ipv6_only(true),
+            Err(ErrorCode::InvalidState)
+        ));
+    } else {
+        assert!(matches!(sock.ipv6_only(), Err(ErrorCode::NotSupported)));
+        assert!(matches!(
+            sock.set_ipv6_only(true),
+            Err(ErrorCode::NotSupported)
+        ));
+    }
+
+    assert!(matches!(sock.unicast_hop_limit(), Ok(_)));
+    assert!(matches!(sock.set_unicast_hop_limit(255), Ok(_)));
+    assert!(matches!(sock.receive_buffer_size(), Ok(_)));
+    assert!(matches!(sock.set_receive_buffer_size(16000), Ok(_)));
+    assert!(matches!(sock.send_buffer_size(), Ok(_)));
+    assert!(matches!(sock.set_send_buffer_size(16000), Ok(_)));
+}
+
+fn main() {
+    let net = Network::default();
+
+    test_udp_unbound_state_invariants(IpAddressFamily::Ipv4);
+    test_udp_unbound_state_invariants(IpAddressFamily::Ipv6);
+
+    test_udp_bound_state_invariants(&net, IpAddressFamily::Ipv4);
+    test_udp_bound_state_invariants(&net, IpAddressFamily::Ipv6);
+
+    test_udp_connected_state_invariants(&net, IpAddressFamily::Ipv4);
+    test_udp_connected_state_invariants(&net, IpAddressFamily::Ipv6);
+}

--- a/crates/test-programs/src/sockets.rs
+++ b/crates/test-programs/src/sockets.rs
@@ -144,6 +144,13 @@ impl UdpSocket {
             }
         }
     }
+
+    pub fn blocking_bind_unspecified(&self, network: &Network) -> Result<(), ErrorCode> {
+        let ip = IpAddress::new_unspecified(self.address_family());
+        let port = 0;
+
+        self.blocking_bind(network, IpSocketAddress::new(ip, port))
+    }
 }
 
 impl OutgoingDatagramStream {

--- a/crates/wasi-http/wit/deps/sockets/tcp.wit
+++ b/crates/wasi-http/wit/deps/sockets/tcp.wit
@@ -81,7 +81,7 @@ interface tcp {
         /// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
         /// - `connection-reset`:          The connection was reset. (ECONNRESET)
         /// - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
-        /// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
         /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
         /// - `not-in-progress`:           A `connect` operation is not in progress.
         /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)

--- a/crates/wasi-http/wit/deps/sockets/udp.wit
+++ b/crates/wasi-http/wit/deps/sockets/udp.wit
@@ -97,7 +97,8 @@ interface udp {
         /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
         /// - `invalid-state`:             The socket is not bound.
         /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
-        /// - `remote-unreachable`:        The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `remote-unreachable`:        The remote address is not reachable. (ECONNRESET, ENETRESET, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+        /// - `connection-refused`:        The connection was refused. (ECONNREFUSED)
         ///
         /// # References
         /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
@@ -190,7 +191,8 @@ interface udp {
         /// This function never returns `error(would-block)`.
         ///
         /// # Typical errors
-        /// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `remote-unreachable`: The remote address is not reachable. (ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+        /// - `connection-refused`: The connection was refused. (ECONNREFUSED)
         ///
         /// # References
         /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
@@ -246,7 +248,8 @@ interface udp {
         /// - `invalid-argument`:        The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
         /// - `invalid-argument`:        The socket is in "connected" mode and `remote-address` is `some` value that does not match the address passed to `stream`. (EISCONN)
         /// - `invalid-argument`:        The socket is not "connected" and no value for `remote-address` was provided. (EDESTADDRREQ)
-        /// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `remote-unreachable`:      The remote address is not reachable. (ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+        /// - `connection-refused`:      The connection was refused. (ECONNREFUSED)
         /// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
         ///
         /// # References

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -331,6 +331,9 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
 
         match socket.tcp_state {
             TcpState::Connected => {}
+            TcpState::Connecting | TcpState::ConnectReady => {
+                return Err(ErrorCode::ConcurrencyConflict.into())
+            }
             _ => return Err(ErrorCode::InvalidState.into()),
         }
 

--- a/crates/wasi/src/preview2/host/udp.rs
+++ b/crates/wasi/src/preview2/host/udp.rs
@@ -1,4 +1,5 @@
 use crate::preview2::host::network::util;
+use crate::preview2::network::SocketAddressFamily;
 use crate::preview2::{
     bindings::{
         sockets::network::{ErrorCode, IpAddressFamily, IpSocketAddress, Network},
@@ -10,7 +11,7 @@ use crate::preview2::{
 use crate::preview2::{Pollable, SocketError, SocketResult, WasiView};
 use anyhow::anyhow;
 use async_trait::async_trait;
-use cap_net_ext::{AddressFamily, PoolExt};
+use cap_net_ext::PoolExt;
 use io_lifetimes::AsSocketlike;
 use rustix::io::Errno;
 use rustix::net::sockopt;
@@ -43,14 +44,22 @@ impl<T: WasiView> udp::HostUdpSocket for T {
             UdpState::Bound | UdpState::Connected => return Err(ErrorCode::InvalidState.into()),
         }
 
-        let binder = network.pool.udp_binder(local_address)?;
+        util::validate_address_family(&local_address, &socket.family)?;
 
-        // Perform the OS bind call.
-        binder.bind_existing_udp_socket(
-            &*socket
+        {
+            let binder = network.pool.udp_binder(local_address)?;
+            let udp_socket = &*socket
                 .udp_socket()
-                .as_socketlike_view::<cap_std::net::UdpSocket>(),
-        )?;
+                .as_socketlike_view::<cap_std::net::UdpSocket>();
+
+            // Perform the OS bind call.
+            util::udp_bind(udp_socket, &binder).map_err(|error| {
+                match Errno::from_io_error(&error) {
+                    Some(Errno::AFNOSUPPORT) => ErrorCode::InvalidArgument, // Just in case our own validations weren't sufficient.
+                    _ => ErrorCode::from(error),
+                }
+            })?;
+        }
 
         let socket = table.get_mut(&this)?;
         socket.udp_state = UdpState::BindStarted;
@@ -111,7 +120,19 @@ impl<T: WasiView> udp::HostUdpSocket for T {
 
         // Step #2: (Re)connect
         if let Some(connect_addr) = remote_address {
-            rustix::net::connect(socket.udp_socket(), &connect_addr)?;
+            util::validate_remote_address(&connect_addr)?;
+            util::validate_address_family(&connect_addr, &socket.family)?;
+
+            rustix::net::connect(socket.udp_socket(), &connect_addr).map_err(
+                |error| match error {
+                    Errno::AFNOSUPPORT => ErrorCode::InvalidArgument, // Just in case our own validations weren't sufficient.
+                    Errno::INPROGRESS => {
+                        log::debug!("UDP connect returned EINPROGRESS, which should never happen");
+                        ErrorCode::Unknown
+                    }
+                    _ => ErrorCode::from(error),
+                },
+            )?;
             socket.udp_state = UdpState::Connected;
         }
 
@@ -122,6 +143,7 @@ impl<T: WasiView> udp::HostUdpSocket for T {
         let outgoing_stream = OutgoingDatagramStream {
             inner: socket.inner.clone(),
             remote_address,
+            family: socket.family,
             send_state: SendState::Idle,
         };
 
@@ -134,6 +156,13 @@ impl<T: WasiView> udp::HostUdpSocket for T {
     fn local_address(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<IpSocketAddress> {
         let table = self.table();
         let socket = table.get(&this)?;
+
+        match socket.udp_state {
+            UdpState::Default => return Err(ErrorCode::InvalidState.into()),
+            UdpState::BindStarted => return Err(ErrorCode::ConcurrencyConflict.into()),
+            _ => {}
+        }
+
         let addr = socket
             .udp_socket()
             .as_socketlike_view::<std::net::UdpSocket>()
@@ -144,6 +173,12 @@ impl<T: WasiView> udp::HostUdpSocket for T {
     fn remote_address(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<IpSocketAddress> {
         let table = self.table();
         let socket = table.get(&this)?;
+
+        match socket.udp_state {
+            UdpState::Connected => {}
+            _ => return Err(ErrorCode::InvalidState.into()),
+        }
+
         let addr = socket
             .udp_socket()
             .as_socketlike_view::<std::net::UdpSocket>()
@@ -157,39 +192,51 @@ impl<T: WasiView> udp::HostUdpSocket for T {
     ) -> Result<IpAddressFamily, anyhow::Error> {
         let table = self.table();
         let socket = table.get(&this)?;
+
         match socket.family {
-            AddressFamily::Ipv4 => Ok(IpAddressFamily::Ipv4),
-            AddressFamily::Ipv6 => Ok(IpAddressFamily::Ipv6),
+            SocketAddressFamily::Ipv4 => Ok(IpAddressFamily::Ipv4),
+            SocketAddressFamily::Ipv6 { .. } => Ok(IpAddressFamily::Ipv6),
         }
     }
 
     fn ipv6_only(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<bool> {
         let table = self.table();
         let socket = table.get(&this)?;
-        Ok(sockopt::get_ipv6_v6only(socket.udp_socket())?)
+
+        match socket.family {
+            SocketAddressFamily::Ipv4 => Err(ErrorCode::NotSupported.into()),
+            SocketAddressFamily::Ipv6 { v6only } => Ok(v6only),
+        }
     }
 
     fn set_ipv6_only(&mut self, this: Resource<udp::UdpSocket>, value: bool) -> SocketResult<()> {
-        let table = self.table();
-        let socket = table.get(&this)?;
-        Ok(sockopt::set_ipv6_v6only(socket.udp_socket(), value)?)
+        let table = self.table_mut();
+        let socket = table.get_mut(&this)?;
+
+        match socket.family {
+            SocketAddressFamily::Ipv4 => Err(ErrorCode::NotSupported.into()),
+            SocketAddressFamily::Ipv6 { .. } => match socket.udp_state {
+                UdpState::Default => {
+                    sockopt::set_ipv6_v6only(socket.udp_socket(), value)?;
+                    socket.family = SocketAddressFamily::Ipv6 { v6only: value };
+                    Ok(())
+                }
+                UdpState::BindStarted => Err(ErrorCode::ConcurrencyConflict.into()),
+                _ => Err(ErrorCode::InvalidState.into()),
+            },
+        }
     }
 
     fn unicast_hop_limit(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<u8> {
         let table = self.table();
         let socket = table.get(&this)?;
 
-        // We don't track whether the socket is IPv4 or IPv6 so try one and
-        // fall back to the other.
-        match sockopt::get_ipv6_unicast_hops(socket.udp_socket()) {
-            Ok(value) => Ok(value),
-            Err(Errno::NOPROTOOPT) => {
-                let value = sockopt::get_ip_ttl(socket.udp_socket())?;
-                let value = value.try_into().unwrap();
-                Ok(value)
-            }
-            Err(err) => Err(err.into()),
-        }
+        let ttl = match socket.family {
+            SocketAddressFamily::Ipv4 => util::get_ip_ttl(socket.udp_socket())?,
+            SocketAddressFamily::Ipv6 { .. } => util::get_ipv6_unicast_hops(socket.udp_socket())?,
+        };
+
+        Ok(ttl)
     }
 
     fn set_unicast_hop_limit(
@@ -200,19 +247,22 @@ impl<T: WasiView> udp::HostUdpSocket for T {
         let table = self.table();
         let socket = table.get(&this)?;
 
-        // We don't track whether the socket is IPv4 or IPv6 so try one and
-        // fall back to the other.
-        match sockopt::set_ipv6_unicast_hops(socket.udp_socket(), Some(value)) {
-            Ok(()) => Ok(()),
-            Err(Errno::NOPROTOOPT) => Ok(sockopt::set_ip_ttl(socket.udp_socket(), value.into())?),
-            Err(err) => Err(err.into()),
+        match socket.family {
+            SocketAddressFamily::Ipv4 => util::set_ip_ttl(socket.udp_socket(), value)?,
+            SocketAddressFamily::Ipv6 { .. } => {
+                util::set_ipv6_unicast_hops(socket.udp_socket(), value)?
+            }
         }
+
+        Ok(())
     }
 
     fn receive_buffer_size(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<u64> {
         let table = self.table();
         let socket = table.get(&this)?;
-        Ok(sockopt::get_socket_recv_buffer_size(socket.udp_socket())? as u64)
+
+        let value = util::get_socket_recv_buffer_size(socket.udp_socket())?;
+        Ok(value as u64)
     }
 
     fn set_receive_buffer_size(
@@ -222,17 +272,18 @@ impl<T: WasiView> udp::HostUdpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let value = value.try_into().map_err(|_| ErrorCode::OutOfMemory)?;
-        Ok(sockopt::set_socket_recv_buffer_size(
-            socket.udp_socket(),
-            value,
-        )?)
+        let value = value.try_into().unwrap_or(usize::MAX);
+
+        util::set_socket_recv_buffer_size(socket.udp_socket(), value)?;
+        Ok(())
     }
 
     fn send_buffer_size(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<u64> {
         let table = self.table();
         let socket = table.get(&this)?;
-        Ok(sockopt::get_socket_send_buffer_size(socket.udp_socket())? as u64)
+
+        let value = util::get_socket_send_buffer_size(socket.udp_socket())?;
+        Ok(value as u64)
     }
 
     fn set_send_buffer_size(
@@ -242,11 +293,10 @@ impl<T: WasiView> udp::HostUdpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let value = value.try_into().map_err(|_| ErrorCode::OutOfMemory)?;
-        Ok(sockopt::set_socket_send_buffer_size(
-            socket.udp_socket(),
-            value,
-        )?)
+        let value = value.try_into().unwrap_or(usize::MAX);
+
+        util::set_socket_send_buffer_size(socket.udp_socket(), value)?;
+        Ok(())
     }
 
     fn subscribe(&mut self, this: Resource<udp::UdpSocket>) -> anyhow::Result<Resource<Pollable>> {
@@ -277,6 +327,7 @@ impl<T: WasiView> udp::HostIncomingDatagramStream for T {
         ) -> SocketResult<Option<udp::IncomingDatagram>> {
             let mut buf = [0; MAX_UDP_DATAGRAM_SIZE];
             let (size, received_addr) = stream.inner.try_recv_from(&mut buf)?;
+            debug_assert!(size <= buf.len());
 
             match stream.remote_address {
                 Some(connected_addr) if connected_addr != received_addr => {
@@ -396,6 +447,9 @@ impl<T: WasiView> udp::HostOutgoingDatagramStream for T {
                 }
                 _ => return Err(ErrorCode::InvalidArgument.into()),
             };
+
+            util::validate_remote_address(&addr)?;
+            util::validate_address_family(&addr, &stream.family)?;
 
             // FIXME: check permission to send to `addr`.
             if stream.remote_address == Some(addr) {

--- a/crates/wasi/src/preview2/network.rs
+++ b/crates/wasi/src/preview2/network.rs
@@ -28,3 +28,9 @@ impl From<rustix::io::Errno> for SocketError {
         ErrorCode::from(error).into()
     }
 }
+
+#[derive(Copy, Clone)]
+pub enum SocketAddressFamily {
+    Ipv4,
+    Ipv6 { v6only: bool },
+}

--- a/crates/wasi/src/preview2/tcp.rs
+++ b/crates/wasi/src/preview2/tcp.rs
@@ -1,3 +1,4 @@
+use super::network::SocketAddressFamily;
 use super::{HostInputStream, HostOutputStream, StreamError};
 use crate::preview2::{
     with_ambient_tokio_runtime, AbortOnDropJoinHandle, InputStream, OutputStream, Subscribe,
@@ -72,12 +73,6 @@ pub struct TcpSocket {
     /// The manually configured TTL. `None` means: no preference, use system default.
     #[cfg(target_os = "macos")]
     pub(crate) hop_limit: Option<u8>,
-}
-
-#[derive(Copy, Clone)]
-pub(crate) enum SocketAddressFamily {
-    Ipv4,
-    Ipv6 { v6only: bool },
 }
 
 pub(crate) struct TcpReadStream {

--- a/crates/wasi/tests/all/async_.rs
+++ b/crates/wasi/tests/all/async_.rs
@@ -319,8 +319,12 @@ async fn preview2_tcp_bind() {
     run(PREVIEW2_TCP_BIND_COMPONENT, false).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn preview2_udp_connect() {
-    run(PREVIEW2_UDP_CONNECT_COMPONENT, false).await.unwrap()
+async fn preview2_tcp_connect() {
+    run(PREVIEW2_TCP_CONNECT_COMPONENT, false).await.unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn preview2_udp_sockopts() {
+    run(PREVIEW2_UDP_SOCKOPTS_COMPONENT, false).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn preview2_udp_sample_application() {
@@ -329,8 +333,16 @@ async fn preview2_udp_sample_application() {
         .unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
-async fn preview2_tcp_connect() {
-    run(PREVIEW2_TCP_CONNECT_COMPONENT, false).await.unwrap()
+async fn preview2_udp_states() {
+    run(PREVIEW2_UDP_STATES_COMPONENT, false).await.unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn preview2_udp_bind() {
+    run(PREVIEW2_UDP_BIND_COMPONENT, false).await.unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn preview2_udp_connect() {
+    run(PREVIEW2_UDP_CONNECT_COMPONENT, false).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn preview2_stream_pollable_correct() {

--- a/crates/wasi/tests/all/sync.rs
+++ b/crates/wasi/tests/all/sync.rs
@@ -262,16 +262,28 @@ fn preview2_tcp_bind() {
     run(PREVIEW2_TCP_BIND_COMPONENT, false).unwrap()
 }
 #[test_log::test]
-fn preview2_udp_connect() {
-    run(PREVIEW2_UDP_CONNECT_COMPONENT, false).unwrap()
+fn preview2_tcp_connect() {
+    run(PREVIEW2_TCP_CONNECT_COMPONENT, false).unwrap()
+}
+#[test_log::test]
+fn preview2_udp_sockopts() {
+    run(PREVIEW2_UDP_SOCKOPTS_COMPONENT, false).unwrap()
 }
 #[test_log::test]
 fn preview2_udp_sample_application() {
     run(PREVIEW2_UDP_SAMPLE_APPLICATION_COMPONENT, false).unwrap()
 }
 #[test_log::test]
-fn preview2_tcp_connect() {
-    run(PREVIEW2_TCP_CONNECT_COMPONENT, false).unwrap()
+fn preview2_udp_states() {
+    run(PREVIEW2_UDP_STATES_COMPONENT, false).unwrap()
+}
+#[test_log::test]
+fn preview2_udp_bind() {
+    run(PREVIEW2_UDP_BIND_COMPONENT, false).unwrap()
+}
+#[test_log::test]
+fn preview2_udp_connect() {
+    run(PREVIEW2_UDP_CONNECT_COMPONENT, false).unwrap()
 }
 #[test_log::test]
 fn preview2_stream_pollable_correct() {

--- a/crates/wasi/wit/deps/sockets/tcp.wit
+++ b/crates/wasi/wit/deps/sockets/tcp.wit
@@ -81,7 +81,7 @@ interface tcp {
         /// - `connection-refused`:        The connection was forcefully rejected. (ECONNREFUSED)
         /// - `connection-reset`:          The connection was reset. (ECONNRESET)
         /// - `connection-aborted`:        The connection was aborted. (ECONNABORTED)
-        /// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `remote-unreachable`:        The remote address is not reachable. (EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
         /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
         /// - `not-in-progress`:           A `connect` operation is not in progress.
         /// - `would-block`:               Can't finish the operation, it is still in progress. (EWOULDBLOCK, EAGAIN)

--- a/crates/wasi/wit/deps/sockets/udp.wit
+++ b/crates/wasi/wit/deps/sockets/udp.wit
@@ -97,7 +97,8 @@ interface udp {
         /// - `invalid-argument`:          The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
         /// - `invalid-state`:             The socket is not bound.
         /// - `address-in-use`:            Tried to perform an implicit bind, but there were no ephemeral ports available. (EADDRINUSE, EADDRNOTAVAIL on Linux, EAGAIN on BSD)
-        /// - `remote-unreachable`:        The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `remote-unreachable`:        The remote address is not reachable. (ECONNRESET, ENETRESET, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+        /// - `connection-refused`:        The connection was refused. (ECONNREFUSED)
         ///
         /// # References
         /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html>
@@ -190,7 +191,8 @@ interface udp {
         /// This function never returns `error(would-block)`.
         ///
         /// # Typical errors
-        /// - `remote-unreachable`: The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `remote-unreachable`: The remote address is not reachable. (ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+        /// - `connection-refused`: The connection was refused. (ECONNREFUSED)
         ///
         /// # References
         /// - <https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html>
@@ -246,7 +248,8 @@ interface udp {
         /// - `invalid-argument`:        The port in `remote-address` is set to 0. (EDESTADDRREQ, EADDRNOTAVAIL)
         /// - `invalid-argument`:        The socket is in "connected" mode and `remote-address` is `some` value that does not match the address passed to `stream`. (EISCONN)
         /// - `invalid-argument`:        The socket is not "connected" and no value for `remote-address` was provided. (EDESTADDRREQ)
-        /// - `remote-unreachable`:      The remote address is not reachable. (ECONNREFUSED, ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN)
+        /// - `remote-unreachable`:      The remote address is not reachable. (ECONNRESET, ENETRESET on Windows, EHOSTUNREACH, EHOSTDOWN, ENETUNREACH, ENETDOWN, ENONET)
+        /// - `connection-refused`:      The connection was refused. (ECONNREFUSED)
         /// - `datagram-too-large`:      The datagram is too large. (EMSGSIZE)
         ///
         /// # References


### PR DESCRIPTION
No major functional changes:
- Moved the validation utility methods out of tcp.rs and into network.rs so that the UDP implementation can use them too.
- Extracted most platform compatibility fixes out into separate functions and moved them to a place where they can be used by UDP too.
- Applied those validations and compatibility fixes to the UDP implementation as well.
- Copied the TCP tests and adjusted them to work with UDP