### PR TITLE
wasi-http: Hold the incoming body worker handle in an Arc

### DIFF
--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 use anyhow::Context;
 use hyper::header::HeaderName;
-use std::any::Any;
+use std::{any::Any, sync::Arc};
 use wasmtime::component::Resource;
 use wasmtime_wasi::preview2::{
     bindings::io::streams::{InputStream, OutputStream},
@@ -744,6 +744,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFutureIncomingResponse f
             headers: FieldMap::from(parts.headers),
             body: Some(HostIncomingBodyBuilder {
                 body,
+                worker: Some(Arc::clone(&resp.worker)),
                 between_bytes_timeout: resp.between_bytes_timeout,
             }),
             worker: resp.worker,

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -268,7 +268,7 @@ async fn do_wasi_http_hash_all(override_send_request: bool) -> Result<()> {
                 Ok(view.table().push(HostFutureIncomingResponse::Ready(
                     handle(request.into_parts().0).map(|resp| IncomingResponseInternal {
                         resp,
-                        worker: preview2::spawn(future::ready(Ok(()))),
+                        worker: Arc::new(preview2::spawn(future::ready(Ok(())))),
                         between_bytes_timeout,
                     }),
                 ))?)


### PR DESCRIPTION
Hold the handle to the worker task in an `Arc` to allow us to keep the worker alive through either the `HostIncomingResponse` or the `HostIncomingBody` values that manage it through its lifetime.

I tested this by adding the `drop` call that @dicej mentioned in #7413 on #7412, and verifying that the test now passes.

Fixes #7413
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
