### PR TITLE
Release Wasmtime 14.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-array-literals"
-version = "14.0.3"
+version = "14.0.4"
 
 [[package]]
 name = "byteorder"
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -574,14 +574,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -609,25 +609,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.101.3"
+version = "0.101.4"
 
 [[package]]
 name = "cranelift-control"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "serde",
  "serde_derive",
@@ -665,7 +665,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.0",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -712,7 +712,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -745,7 +745,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -779,7 +779,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -826,7 +826,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.101.3"
+version = "0.101.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2943,7 +2943,7 @@ dependencies = [
 
 [[package]]
 name = "verify-component-adapter"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -2993,7 +2993,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-cap-std-sync"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3015,7 +3015,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-common"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "bitflags 2.3.3",
@@ -3048,7 +3048,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "byte-array-literals",
  "object",
@@ -3077,7 +3077,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-tokio"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3309,14 +3309,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3358,7 +3358,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -3380,7 +3380,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3446,7 +3446,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3462,11 +3462,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "14.0.3"
+version = "14.0.4"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3503,7 +3503,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3541,7 +3541,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3555,7 +3555,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "backtrace",
  "cc",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3648,7 +3648,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "object",
  "once_cell",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "cc",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3717,7 +3717,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3753,7 +3753,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "openvino",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "log",
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "log",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3824,7 +3824,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "heck",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "14.0.3"
+version = "14.0.4"
 
 [[package]]
 name = "wast"
@@ -3895,7 +3895,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3912,7 +3912,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "anyhow",
  "heck",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "14.0.3"
+version = "14.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3980,7 +3980,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -129,7 +129,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "14.0.3"
+version = "14.0.4"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -137,58 +137,58 @@ edition = "2021"
 rust-version = "1.70.0"
 
 [workspace.dependencies]
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=14.0.3" }
-wasmtime = { path = "crates/wasmtime", version = "14.0.3", default-features = false }
-wasmtime-cache = { path = "crates/cache", version = "=14.0.3" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=14.0.3" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=14.0.3" }
-wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=14.0.3" }
-wasmtime-winch = { path = "crates/winch", version = "=14.0.3" }
-wasmtime-environ = { path = "crates/environ", version = "=14.0.3" }
-wasmtime-explorer = { path = "crates/explorer", version = "=14.0.3" }
-wasmtime-fiber = { path = "crates/fiber", version = "=14.0.3" }
-wasmtime-types = { path = "crates/types", version = "14.0.3" }
-wasmtime-jit = { path = "crates/jit", version = "=14.0.3" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=14.0.3" }
-wasmtime-runtime = { path = "crates/runtime", version = "=14.0.3" }
-wasmtime-wast = { path = "crates/wast", version = "=14.0.3" }
-wasmtime-wasi = { path = "crates/wasi", version = "14.0.3", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=14.0.3", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "14.0.3" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "14.0.3" }
-wasmtime-component-util = { path = "crates/component-util", version = "=14.0.3" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=14.0.3" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=14.0.3" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=14.0.3" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=14.0.4" }
+wasmtime = { path = "crates/wasmtime", version = "14.0.4", default-features = false }
+wasmtime-cache = { path = "crates/cache", version = "=14.0.4" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=14.0.4" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=14.0.4" }
+wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=14.0.4" }
+wasmtime-winch = { path = "crates/winch", version = "=14.0.4" }
+wasmtime-environ = { path = "crates/environ", version = "=14.0.4" }
+wasmtime-explorer = { path = "crates/explorer", version = "=14.0.4" }
+wasmtime-fiber = { path = "crates/fiber", version = "=14.0.4" }
+wasmtime-types = { path = "crates/types", version = "14.0.4" }
+wasmtime-jit = { path = "crates/jit", version = "=14.0.4" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=14.0.4" }
+wasmtime-runtime = { path = "crates/runtime", version = "=14.0.4" }
+wasmtime-wast = { path = "crates/wast", version = "=14.0.4" }
+wasmtime-wasi = { path = "crates/wasi", version = "14.0.4", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=14.0.4", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "14.0.4" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "14.0.4" }
+wasmtime-component-util = { path = "crates/component-util", version = "=14.0.4" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=14.0.4" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=14.0.4" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=14.0.4" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=14.0.3", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=14.0.3" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=14.0.3" }
-wasi-common = { path = "crates/wasi-common", version = "=14.0.3" }
-wasi-tokio = { path = "crates/wasi-common/tokio", version = "=14.0.3" }
-wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=14.0.3" }
+wiggle = { path = "crates/wiggle", version = "=14.0.4", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=14.0.4" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=14.0.4" }
+wasi-common = { path = "crates/wasi-common", version = "=14.0.4" }
+wasi-tokio = { path = "crates/wasi-common/tokio", version = "=14.0.4" }
+wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=14.0.4" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=14.0.3" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=14.0.3" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=14.0.4" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=14.0.4" }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.101.3" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.101.3", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.101.3" }
-cranelift-entity = { path = "cranelift/entity", version = "0.101.3" }
-cranelift-native = { path = "cranelift/native", version = "0.101.3" }
-cranelift-module = { path = "cranelift/module", version = "0.101.3" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.101.3" }
-cranelift-reader = { path = "cranelift/reader", version = "0.101.3" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.101.4" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.101.4", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.101.4" }
+cranelift-entity = { path = "cranelift/entity", version = "0.101.4" }
+cranelift-native = { path = "cranelift/native", version = "0.101.4" }
+cranelift-module = { path = "cranelift/module", version = "0.101.4" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.101.4" }
+cranelift-reader = { path = "cranelift/reader", version = "0.101.4" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.101.3" }
-cranelift-jit = { path = "cranelift/jit", version = "0.101.3" }
+cranelift-object = { path = "cranelift/object", version = "0.101.4" }
+cranelift-jit = { path = "cranelift/jit", version = "0.101.4" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.101.3" }
-cranelift-control = { path = "cranelift/control", version = "0.101.3" }
-cranelift = { path = "cranelift/umbrella", version = "0.101.3" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.101.4" }
+cranelift-control = { path = "cranelift/control", version = "0.101.4" }
+cranelift = { path = "cranelift/umbrella", version = "0.101.4" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.12.3" }
+winch-codegen = { path = "winch/codegen", version = "=0.12.4" }
 winch-filetests = { path = "winch/filetests" }
 winch-test-macros = { path = "winch/test-macros" }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,20 @@
 --------------------------------------------------------------------------------
 
+## 14.0.4
+
+Released 2023-11-01
+
+### Fixed
+
+* Using the `--dir` argument combined with a `::`-remapped path no longer prints
+  a warning about compatibility with the old CLI and works with remapping.
+  [#7416](https://github.com/bytecodealliance/wasmtime/pull/7416)
+
+* Consecutive file writes in preview2 have been fixed.
+  [#7394](https://github.com/bytecodealliance/wasmtime/pull/7394)
+
+--------------------------------------------------------------------------------
+
 ## 14.0.3
 
 Released 2023-10-29

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.101.3"
+version = "0.101.4"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.101.3"
+version = "0.101.4"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -16,7 +16,7 @@ edition.workspace = true
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.101.3" }
+cranelift-codegen-shared = { path = "./shared", version = "0.101.4" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -41,8 +41,8 @@ criterion = { version = "0.5.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.101.3" }
-cranelift-isle = { path = "../isle/isle", version = "=0.101.3" }
+cranelift-codegen-meta = { path = "meta", version = "0.101.4" }
+cranelift-isle = { path = "../isle/isle", version = "=0.101.4" }
 
 [features]
 default = ["std", "unwind", "host-arch"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.101.3"
+version = "0.101.4"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -12,4 +12,4 @@ edition.workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.101.3" }
+cranelift-codegen-shared = { path = "../shared", version = "0.101.4" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.101.3"
+version = "0.101.4"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.101.3"
+version = "0.101.4"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.101.3"
+version = "0.101.4"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.101.3"
+version = "0.101.4"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.101.3"
+version = "0.101.4"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.101.3"
+version = "0.101.4"
 
 [dependencies]
 codespan-reporting = { version = "0.11.1", optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.101.3"
+version = "0.101.4"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.101.3"
+version = "0.101.4"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.101.3"
+version = "0.101.4"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.101.3"
+version = "0.101.4"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.101.3"
+version = "0.101.4"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.101.3"
+version = "0.101.4"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.101.3"
+version = "0.101.4"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.101.3"
+version = "0.101.4"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -200,7 +200,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "14.0.3"
+#define WASMTIME_VERSION "14.0.4"
 /**
  * \brief Wasmtime major version number.
  */
@@ -212,7 +212,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 3
+#define WASMTIME_VERSION_PATCH 4
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -21,6 +21,10 @@ audited_as = "0.101.1"
 version = "0.101.3"
 audited_as = "0.101.2"
 
+[[unpublished.cranelift]]
+version = "0.101.4"
+audited_as = "0.101.3"
+
 [[unpublished.cranelift-bforest]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -40,6 +44,10 @@ audited_as = "0.101.1"
 [[unpublished.cranelift-bforest]]
 version = "0.101.3"
 audited_as = "0.101.2"
+
+[[unpublished.cranelift-bforest]]
+version = "0.101.4"
+audited_as = "0.101.3"
 
 [[unpublished.cranelift-codegen]]
 version = "0.100.0"
@@ -61,6 +69,10 @@ audited_as = "0.101.1"
 version = "0.101.3"
 audited_as = "0.101.2"
 
+[[unpublished.cranelift-codegen]]
+version = "0.101.4"
+audited_as = "0.101.3"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -80,6 +92,10 @@ audited_as = "0.101.1"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.101.3"
 audited_as = "0.101.2"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.101.4"
+audited_as = "0.101.3"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.100.0"
@@ -101,6 +117,10 @@ audited_as = "0.101.1"
 version = "0.101.3"
 audited_as = "0.101.2"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.101.4"
+audited_as = "0.101.3"
+
 [[unpublished.cranelift-control]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -120,6 +140,10 @@ audited_as = "0.101.1"
 [[unpublished.cranelift-control]]
 version = "0.101.3"
 audited_as = "0.101.2"
+
+[[unpublished.cranelift-control]]
+version = "0.101.4"
+audited_as = "0.101.3"
 
 [[unpublished.cranelift-entity]]
 version = "0.100.0"
@@ -141,6 +165,10 @@ audited_as = "0.101.1"
 version = "0.101.3"
 audited_as = "0.101.2"
 
+[[unpublished.cranelift-entity]]
+version = "0.101.4"
+audited_as = "0.101.3"
+
 [[unpublished.cranelift-frontend]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -160,6 +188,10 @@ audited_as = "0.101.1"
 [[unpublished.cranelift-frontend]]
 version = "0.101.3"
 audited_as = "0.101.2"
+
+[[unpublished.cranelift-frontend]]
+version = "0.101.4"
+audited_as = "0.101.3"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.100.0"
@@ -181,6 +213,10 @@ audited_as = "0.101.1"
 version = "0.101.3"
 audited_as = "0.101.2"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.101.4"
+audited_as = "0.101.3"
+
 [[unpublished.cranelift-isle]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -200,6 +236,10 @@ audited_as = "0.101.1"
 [[unpublished.cranelift-isle]]
 version = "0.101.3"
 audited_as = "0.101.2"
+
+[[unpublished.cranelift-isle]]
+version = "0.101.4"
+audited_as = "0.101.3"
 
 [[unpublished.cranelift-jit]]
 version = "0.100.0"
@@ -221,6 +261,10 @@ audited_as = "0.101.1"
 version = "0.101.3"
 audited_as = "0.101.2"
 
+[[unpublished.cranelift-jit]]
+version = "0.101.4"
+audited_as = "0.101.3"
+
 [[unpublished.cranelift-module]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -240,6 +284,10 @@ audited_as = "0.101.1"
 [[unpublished.cranelift-module]]
 version = "0.101.3"
 audited_as = "0.101.2"
+
+[[unpublished.cranelift-module]]
+version = "0.101.4"
+audited_as = "0.101.3"
 
 [[unpublished.cranelift-native]]
 version = "0.100.0"
@@ -261,6 +309,10 @@ audited_as = "0.101.1"
 version = "0.101.3"
 audited_as = "0.101.2"
 
+[[unpublished.cranelift-native]]
+version = "0.101.4"
+audited_as = "0.101.3"
+
 [[unpublished.cranelift-object]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -281,6 +333,10 @@ audited_as = "0.101.1"
 version = "0.101.3"
 audited_as = "0.101.2"
 
+[[unpublished.cranelift-object]]
+version = "0.101.4"
+audited_as = "0.101.3"
+
 [[unpublished.cranelift-reader]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -301,6 +357,10 @@ audited_as = "0.101.1"
 version = "0.101.3"
 audited_as = "0.101.2"
 
+[[unpublished.cranelift-reader]]
+version = "0.101.4"
+audited_as = "0.101.3"
+
 [[unpublished.cranelift-serde]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -321,6 +381,10 @@ audited_as = "0.101.1"
 version = "0.101.3"
 audited_as = "0.101.2"
 
+[[unpublished.cranelift-serde]]
+version = "0.101.4"
+audited_as = "0.101.3"
+
 [[unpublished.cranelift-wasm]]
 version = "0.100.0"
 audited_as = "0.98.1"
@@ -341,6 +405,10 @@ audited_as = "0.101.1"
 version = "0.101.3"
 audited_as = "0.101.2"
 
+[[unpublished.cranelift-wasm]]
+version = "0.101.4"
+audited_as = "0.101.3"
+
 [[unpublished.wasi-cap-std-sync]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -360,6 +428,10 @@ audited_as = "14.0.1"
 [[unpublished.wasi-cap-std-sync]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasi-cap-std-sync]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasi-common]]
 version = "13.0.0"
@@ -381,6 +453,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasi-common]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasi-tokio]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -400,6 +476,10 @@ audited_as = "14.0.1"
 [[unpublished.wasi-tokio]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasi-tokio]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime]]
 version = "13.0.0"
@@ -421,6 +501,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -440,6 +524,10 @@ audited_as = "14.0.1"
 [[unpublished.wasmtime-asm-macros]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime-cache]]
 version = "13.0.0"
@@ -461,6 +549,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-cache]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-cli]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -480,6 +572,10 @@ audited_as = "14.0.1"
 [[unpublished.wasmtime-cli]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasmtime-cli]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "13.0.0"
@@ -501,6 +597,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-component-macro]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -520,6 +620,10 @@ audited_as = "14.0.1"
 [[unpublished.wasmtime-component-macro]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasmtime-component-macro]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime-component-util]]
 version = "13.0.0"
@@ -541,6 +645,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-component-util]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-cranelift]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -560,6 +668,10 @@ audited_as = "14.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasmtime-cranelift]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "13.0.0"
@@ -581,6 +693,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-cranelift-shared]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-environ]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -600,6 +716,10 @@ audited_as = "14.0.1"
 [[unpublished.wasmtime-environ]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasmtime-environ]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime-explorer]]
 version = "13.0.0"
@@ -621,6 +741,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-explorer]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-fiber]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -640,6 +764,10 @@ audited_as = "14.0.1"
 [[unpublished.wasmtime-fiber]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasmtime-fiber]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime-jit]]
 version = "13.0.0"
@@ -661,6 +789,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-jit]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-jit-debug]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -680,6 +812,10 @@ audited_as = "14.0.1"
 [[unpublished.wasmtime-jit-debug]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasmtime-jit-debug]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "13.0.0"
@@ -701,6 +837,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-runtime]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -720,6 +860,10 @@ audited_as = "14.0.1"
 [[unpublished.wasmtime-runtime]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasmtime-runtime]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime-types]]
 version = "13.0.0"
@@ -741,6 +885,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-types]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-wasi]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -760,6 +908,10 @@ audited_as = "14.0.1"
 [[unpublished.wasmtime-wasi]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasmtime-wasi]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "13.0.0"
@@ -781,6 +933,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-wasi-http]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-wasi-nn]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -800,6 +956,10 @@ audited_as = "14.0.1"
 [[unpublished.wasmtime-wasi-nn]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasmtime-wasi-nn]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "13.0.0"
@@ -821,6 +981,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-wasi-threads]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-wast]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -841,6 +1005,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-wast]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-winch]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -861,6 +1029,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-winch]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wasmtime-wit-bindgen]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -880,6 +1052,10 @@ audited_as = "14.0.1"
 [[unpublished.wasmtime-wit-bindgen]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wasmtime-wit-bindgen]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "14.0.0"
@@ -897,6 +1073,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wasmtime-wmemcheck]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wiggle]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -917,6 +1097,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wiggle]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wiggle-generate]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -937,6 +1121,10 @@ audited_as = "14.0.1"
 version = "14.0.3"
 audited_as = "14.0.2"
 
+[[unpublished.wiggle-generate]]
+version = "14.0.4"
+audited_as = "14.0.3"
+
 [[unpublished.wiggle-macro]]
 version = "13.0.0"
 audited_as = "11.0.1"
@@ -956,6 +1144,10 @@ audited_as = "14.0.1"
 [[unpublished.wiggle-macro]]
 version = "14.0.3"
 audited_as = "14.0.2"
+
+[[unpublished.wiggle-macro]]
+version = "14.0.4"
+audited_as = "14.0.3"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -980,6 +1172,10 @@ audited_as = "0.12.1"
 [[unpublished.winch-codegen]]
 version = "0.12.3"
 audited_as = "0.12.2"
+
+[[unpublished.winch-codegen]]
+version = "0.12.4"
+audited_as = "0.12.3"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -1186,6 +1382,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.101.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1213,6 +1415,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.101.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.101.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1246,6 +1454,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.101.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1273,6 +1487,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-meta]]
 version = "0.101.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.101.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1306,6 +1526,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.101.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1333,6 +1559,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-control]]
 version = "0.101.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.101.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1366,6 +1598,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.101.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1393,6 +1631,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-frontend]]
 version = "0.101.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.101.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1426,6 +1670,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.101.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1453,6 +1703,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-isle]]
 version = "0.101.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.101.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1486,6 +1742,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.101.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1513,6 +1775,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-module]]
 version = "0.101.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.101.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1546,6 +1814,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.101.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1576,6 +1850,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-object]]
+version = "0.101.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-reader]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1606,6 +1886,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.101.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1636,6 +1922,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.101.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.98.1"
 when = "2023-07-24"
@@ -1663,6 +1955,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.101.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.101.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2031,6 +2329,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-cap-std-sync]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-common]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2061,6 +2365,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasi-tokio]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2088,6 +2398,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasi-tokio]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasi-tokio]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2422,6 +2738,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2449,6 +2771,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2482,6 +2810,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2509,6 +2843,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2542,6 +2882,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2569,6 +2915,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2602,6 +2954,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2629,6 +2987,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2662,6 +3026,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cranelift-shared]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-environ]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2689,6 +3059,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-environ]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-environ]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2722,6 +3098,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-explorer]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-fiber]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2749,6 +3131,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-fiber]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-fiber]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2782,6 +3170,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-debug]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2809,6 +3203,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-debug]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-debug]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2842,6 +3242,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-runtime]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2869,6 +3275,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-runtime]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-runtime]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2902,6 +3314,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-types]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2929,6 +3347,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2962,6 +3386,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-http]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-nn]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -2989,6 +3419,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-nn]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-nn]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -3022,6 +3458,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-threads]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wast]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -3052,6 +3494,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -3082,6 +3530,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-winch]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wit-bindgen]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -3109,6 +3563,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wit-bindgen]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wit-bindgen]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -3133,6 +3593,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -3250,6 +3716,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -3280,6 +3752,12 @@ when = "2023-10-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "14.0.3"
+when = "2023-10-30"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "11.0.1"
 when = "2023-07-24"
@@ -3307,6 +3785,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "14.0.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "14.0.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -3351,6 +3835,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.12.2"
 when = "2023-10-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.12.3"
+when = "2023-10-30"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.12.3"
+version = "0.12.4"
 edition.workspace = true
 
 [dependencies]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 14.0.4, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
