### PR TITLE
fuzzgen: Allow restricting generated opcodes with env var

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -88,3 +88,15 @@ following steps to reproduce it locally:
    to print the configuration and WebAssembly input used by the test case (see
    uses of  `log_wasm` in the `wasmtime-fuzzing` crate).
 
+## Target specific options
+
+### `cranelift-fuzzgen`
+
+Fuzzgen supports passing the `FUZZGEN_ALLOWED_OPS` environment variable, which when available restricts the instructions that it will generate.
+
+Running `FUZZGEN_ALLOWED_OPS=ineg,ishl cargo fuzz run cranelift-fuzzgen` will run fuzzgen but only generate `ineg` or `ishl` opcodes.
+
+### `cranelift-icache`
+
+The icache target also uses the fuzzgen library, thus also supports the `FUZZGEN_ALLOWED_OPS` enviornment variable as described in the `cranelift-fuzzgen` section above.
+


### PR DESCRIPTION
👋 Hey,

This PR allows users to pass a environment variable to fuzzgen that restricts the instructions that it can generate. Passing `FUZZGEN_ALLOWED_OPS=ineg,ushr` restricts fuzzgen to generate only those two instructions.

Using this allows me to get better fuzzing throughput when testing a specific rule or lowering.