### PR TITLE
wasi-http: Migrate to more descriptive error variant

### DIFF
--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -451,7 +451,7 @@ mod executor {
 
     pub fn outgoing_request_send(
         request: OutgoingRequest,
-    ) -> impl Future<Output = Result<IncomingResponse, types::Error>> {
+    ) -> impl Future<Output = Result<IncomingResponse, types::ErrorCode>> {
         future::poll_fn({
             let response = outgoing_handler::handle(request, None);
 

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_dnsname.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_dnsname.rs
@@ -1,4 +1,4 @@
-use test_programs::wasi::http::types::{Method, Scheme};
+use test_programs::wasi::http::types::{ErrorCode, Method, Scheme};
 
 fn main() {
     let res = test_programs::http::request(
@@ -10,9 +10,10 @@ fn main() {
         None,
     );
 
-    let error = res.unwrap_err().to_string();
-    assert!(
-        error.starts_with("Error::InvalidUrl(\""),
-        "bad error: {error}"
-    );
+    assert!(matches!(
+        res.unwrap_err()
+            .downcast::<ErrorCode>()
+            .expect("expected a wasi-http ErrorCode"),
+        ErrorCode::DnsError(_)
+    ));
 }

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_dnsname.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_dnsname.rs
@@ -15,7 +15,7 @@ fn main() {
         matches!(
             e.downcast_ref::<ErrorCode>()
                 .expect("expected a wasi-http ErrorCode"),
-            ErrorCode::DnsError(_)
+            ErrorCode::DnsError(_) | ErrorCode::ConnectionRefused,
         ),
         "Unexpected error: {e:#?}"
     );

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_dnsname.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_dnsname.rs
@@ -10,10 +10,13 @@ fn main() {
         None,
     );
 
-    assert!(matches!(
-        res.unwrap_err()
-            .downcast::<ErrorCode>()
-            .expect("expected a wasi-http ErrorCode"),
-        ErrorCode::DnsError(_)
-    ));
+    let e = res.unwrap_err();
+    assert!(
+        matches!(
+            e.downcast_ref::<ErrorCode>()
+                .expect("expected a wasi-http ErrorCode"),
+            ErrorCode::DnsError(_)
+        ),
+        "Unexpected error: {e:#?}"
+    );
 }

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_version.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_version.rs
@@ -1,17 +1,14 @@
-use test_programs::wasi::http::types::{Method, Scheme};
+use test_programs::wasi::http::types::{ErrorCode, Method, Scheme};
 
 fn main() {
     let addr = std::env::var("HTTP_SERVER").unwrap();
     let res =
         test_programs::http::request(Method::Connect, Scheme::Http, &addr, "/", None, Some(&[]));
 
-    let error = res.unwrap_err().to_string();
-    if !error.starts_with("Error::ProtocolError(\"") {
-        panic!(
-            r#"assertion failed: `(left == right)`
-      left: `"{error}"`,
-      right: `"Error::ProtocolError(\"invalid HTTP version parsed\")"`
-            or `"Error::ProtocolError(\"operation was canceled\")"`)"#
-        )
-    }
+    assert!(matches!(
+        res.unwrap_err()
+            .downcast::<ErrorCode>()
+            .expect("expected a wasi-http ErrorCode"),
+        ErrorCode::HttpProtocolError,
+    ));
 }

--- a/crates/test-programs/src/bin/http_outbound_request_unknown_method.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_unknown_method.rs
@@ -1,4 +1,4 @@
-use test_programs::wasi::http::types::{Method, Scheme};
+use test_programs::wasi::http::types::{ErrorCode, HttpRequestErrorPayload, Method, Scheme};
 
 fn main() {
     let res = test_programs::http::request(
@@ -10,9 +10,13 @@ fn main() {
         None,
     );
 
-    let error = res.unwrap_err();
-    assert_eq!(
-        error.to_string(),
-        "Error::InvalidUrl(\"unknown method OTHER\")"
-    );
+    assert!(matches!(
+        res.unwrap_err()
+            .downcast::<ErrorCode>()
+            .expect("expected a wasi-http ErrorCode"),
+        ErrorCode::HttpRequestError(HttpRequestErrorPayload {
+            status_code: 405,
+            ..
+        }),
+    ));
 }

--- a/crates/test-programs/src/bin/http_outbound_request_unknown_method.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_unknown_method.rs
@@ -15,7 +15,7 @@ fn main() {
             .downcast::<ErrorCode>()
             .expect("expected a wasi-http ErrorCode"),
         ErrorCode::HttpRequestError(HttpRequestErrorPayload {
-            status_code: 405,
+            status_code: Some(405),
             ..
         }),
     ));

--- a/crates/test-programs/src/bin/http_outbound_request_unknown_method.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_unknown_method.rs
@@ -1,4 +1,4 @@
-use test_programs::wasi::http::types::{ErrorCode, HttpRequestErrorPayload, Method, Scheme};
+use test_programs::wasi::http::types::{ErrorCode, Method, Scheme};
 
 fn main() {
     let res = test_programs::http::request(
@@ -14,9 +14,6 @@ fn main() {
         res.unwrap_err()
             .downcast::<ErrorCode>()
             .expect("expected a wasi-http ErrorCode"),
-        ErrorCode::HttpRequestError(HttpRequestErrorPayload {
-            status_code: Some(405),
-            ..
-        }),
+        ErrorCode::HttpProtocolError,
     ));
 }

--- a/crates/test-programs/src/bin/http_outbound_request_unknown_method.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_unknown_method.rs
@@ -1,8 +1,8 @@
-use test_programs::wasi::http::types::{ErrorCode, Method, Scheme};
+use test_programs::wasi::http::types::{Method, Scheme};
 
 fn main() {
     let res = test_programs::http::request(
-        Method::Other("OTHER".to_owned()),
+        Method::Other("bad\nmethod".to_owned()),
         Scheme::Http,
         "localhost:3000",
         "/",
@@ -10,10 +10,6 @@ fn main() {
         None,
     );
 
-    assert!(matches!(
-        res.unwrap_err()
-            .downcast::<ErrorCode>()
-            .expect("expected a wasi-http ErrorCode"),
-        ErrorCode::HttpProtocolError,
-    ));
+    // This error arises from input validation in the `set_method` function on `OutgoingRequest`.
+    assert_eq!(res.unwrap_err().to_string(), "failed to set method");
 }

--- a/crates/test-programs/src/bin/http_outbound_request_unsupported_scheme.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_unsupported_scheme.rs
@@ -1,4 +1,4 @@
-use test_programs::wasi::http::types::{Method, Scheme};
+use test_programs::wasi::http::types::{ErrorCode, HttpRequestErrorPayload, Method, Scheme};
 
 fn main() {
     let res = test_programs::http::request(
@@ -10,9 +10,13 @@ fn main() {
         None,
     );
 
-    let error = res.unwrap_err();
-    assert_eq!(
-        error.to_string(),
-        "Error::InvalidUrl(\"unsupported scheme WS\")"
-    );
+    assert!(matches!(
+        res.unwrap_err()
+            .downcast::<ErrorCode>()
+            .expect("expected a wasi-http ErrorCode"),
+        ErrorCode::HttpRequestError(HttpRequestErrorPayload {
+            status_code: 400,
+            ..
+        }),
+    ));
 }

--- a/crates/test-programs/src/bin/http_outbound_request_unsupported_scheme.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_unsupported_scheme.rs
@@ -1,4 +1,4 @@
-use test_programs::wasi::http::types::{ErrorCode, HttpRequestErrorPayload, Method, Scheme};
+use test_programs::wasi::http::types::{ErrorCode, Method, Scheme};
 
 fn main() {
     let res = test_programs::http::request(
@@ -14,9 +14,6 @@ fn main() {
         res.unwrap_err()
             .downcast::<ErrorCode>()
             .expect("expected a wasi-http ErrorCode"),
-        ErrorCode::HttpRequestError(HttpRequestErrorPayload {
-            status_code: Some(400),
-            ..
-        }),
+        ErrorCode::HttpProtocolError,
     ));
 }

--- a/crates/test-programs/src/bin/http_outbound_request_unsupported_scheme.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_unsupported_scheme.rs
@@ -15,7 +15,7 @@ fn main() {
             .downcast::<ErrorCode>()
             .expect("expected a wasi-http ErrorCode"),
         ErrorCode::HttpRequestError(HttpRequestErrorPayload {
-            status_code: 400,
+            status_code: Some(400),
             ..
         }),
     ));

--- a/crates/test-programs/src/http.rs
+++ b/crates/test-programs/src/http.rs
@@ -113,19 +113,16 @@ pub fn request(
     http_types::OutgoingBody::finish(outgoing_body, None);
 
     let incoming_response = match future_response.get() {
-        Some(result) => result.map_err(|_| anyhow!("incoming response errored"))?,
+        Some(result) => result.map_err(|()| anyhow!("response already taken"))?,
         None => {
             let pollable = future_response.subscribe();
             pollable.block();
             future_response
                 .get()
                 .expect("incoming response available")
-                .map_err(|_| anyhow!("incoming response errored"))?
+                .map_err(|()| anyhow!("response already taken"))?
         }
-    }
-    // TODO: maybe anything that appears in the Result<_, E> position should impl
-    // Error? anyway, just use its Debug here:
-    .map_err(|e| anyhow!("{e:?}"))?;
+    }?;
 
     drop(future_response);
 

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -37,64 +37,21 @@ pub mod bindings {
     pub use wasi::http;
 }
 
-impl From<wasmtime_wasi::preview2::TableError> for crate::bindings::http::types::Error {
-    fn from(err: wasmtime_wasi::preview2::TableError) -> Self {
-        Self::UnexpectedError(err.to_string())
-    }
+pub(crate) fn dns_error(rcode: String, info_code: u16) -> bindings::http::types::ErrorCode {
+    bindings::http::types::ErrorCode::DnsError(bindings::http::types::DnsErrorPayload {
+        rcode,
+        info_code,
+    })
 }
 
-impl From<anyhow::Error> for crate::bindings::http::types::Error {
-    fn from(err: anyhow::Error) -> Self {
-        Self::UnexpectedError(err.to_string())
-    }
-}
-
-impl From<std::io::Error> for crate::bindings::http::types::Error {
-    fn from(err: std::io::Error) -> Self {
-        let message = err.to_string();
-        match err.kind() {
-            std::io::ErrorKind::InvalidInput => Self::InvalidUrl(message),
-            std::io::ErrorKind::AddrNotAvailable => Self::InvalidUrl(message),
-            _ => {
-                if message.starts_with("failed to lookup address information") {
-                    Self::InvalidUrl("invalid dnsname".to_string())
-                } else {
-                    Self::ProtocolError(message)
-                }
-            }
-        }
-    }
-}
-
-impl From<hyper::Error> for crate::bindings::http::types::Error {
-    fn from(err: hyper::Error) -> Self {
-        let message = err.message().to_string();
-        if err.is_timeout() {
-            Self::TimeoutError(message)
-        } else if err.is_parse_status() || err.is_user() {
-            Self::InvalidUrl(message)
-        } else if err.is_body_write_aborted()
-            || err.is_canceled()
-            || err.is_closed()
-            || err.is_incomplete_message()
-            || err.is_parse()
-        {
-            Self::ProtocolError(message)
-        } else {
-            Self::UnexpectedError(message)
-        }
-    }
-}
-
-impl From<tokio::time::error::Elapsed> for crate::bindings::http::types::Error {
-    fn from(err: tokio::time::error::Elapsed) -> Self {
-        Self::TimeoutError(err.to_string())
-    }
-}
-
-#[cfg(not(any(target_arch = "riscv64", target_arch = "s390x")))]
-impl From<rustls::client::InvalidDnsNameError> for crate::bindings::http::types::Error {
-    fn from(_err: rustls::client::InvalidDnsNameError) -> Self {
-        Self::InvalidUrl("invalid dnsname".to_string())
-    }
+pub(crate) fn http_request_error(
+    status_code: u16,
+    status_phrase: String,
+) -> bindings::http::types::ErrorCode {
+    bindings::http::types::ErrorCode::HttpRequestError(
+        bindings::http::types::HttpRequestErrorPayload {
+            status_code,
+            status_phrase,
+        },
+    )
 }

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -39,8 +39,8 @@ pub mod bindings {
 
 pub(crate) fn dns_error(rcode: String, info_code: u16) -> bindings::http::types::ErrorCode {
     bindings::http::types::ErrorCode::DnsError(bindings::http::types::DnsErrorPayload {
-        rcode,
-        info_code,
+        rcode: Some(rcode),
+        info_code: Some(info_code),
     })
 }
 
@@ -50,8 +50,8 @@ pub(crate) fn http_request_error(
 ) -> bindings::http::types::ErrorCode {
     bindings::http::types::ErrorCode::HttpRequestError(
         bindings::http::types::HttpRequestErrorPayload {
-            status_code,
-            status_phrase,
+            status_code: Some(status_code),
+            status_phrase: Some(status_phrase),
         },
     )
 }

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -43,15 +43,3 @@ pub(crate) fn dns_error(rcode: String, info_code: u16) -> bindings::http::types:
         info_code: Some(info_code),
     })
 }
-
-pub(crate) fn http_request_error(
-    status_code: u16,
-    status_phrase: String,
-) -> bindings::http::types::ErrorCode {
-    bindings::http::types::ErrorCode::HttpRequestError(
-        bindings::http::types::HttpRequestErrorPayload {
-            status_code: Some(status_code),
-            status_phrase: Some(status_phrase),
-        },
-    )
-}

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -131,8 +131,8 @@ async fn handler(
     let (mut sender, worker) = if use_tls {
         #[cfg(any(target_arch = "riscv64", target_arch = "s390x"))]
         {
-            return Err(crate::bindings::http::types::ErrorCode::UnexpectedError(
-                "unsupported architecture for SSL".to_string(),
+            return Err(crate::bindings::http::types::ErrorCode::InternalError(
+                Some("unsupported architecture for SSL".to_string()),
             ));
         }
 

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -4,6 +4,7 @@
 use crate::{
     bindings::http::types::{self, Method, Scheme},
     body::{HostIncomingBody, HyperIncomingBody, HyperOutgoingBody},
+    dns_error,
 };
 use http_body_util::BodyExt;
 use hyper::header::HeaderName;
@@ -50,7 +51,7 @@ pub trait WasiHttpView: Send {
     fn new_response_outparam(
         &mut self,
         result: tokio::sync::oneshot::Sender<
-            Result<hyper::Response<HyperOutgoingBody>, types::Error>,
+            Result<hyper::Response<HyperOutgoingBody>, types::ErrorCode>,
         >,
     ) -> wasmtime::Result<Resource<HostResponseOutparam>> {
         let id = self.table().push(HostResponseOutparam { result })?;
@@ -108,15 +109,29 @@ async fn handler(
     first_byte_timeout: Duration,
     request: http::Request<HyperOutgoingBody>,
     between_bytes_timeout: Duration,
-) -> Result<IncomingResponseInternal, types::Error> {
+) -> Result<IncomingResponseInternal, types::ErrorCode> {
     let tcp_stream = TcpStream::connect(authority.clone())
         .await
-        .map_err(invalid_url)?;
+        .map_err(|e| match e.kind() {
+            std::io::ErrorKind::AddrNotAvailable => {
+                dns_error("address not available".to_string(), 0)
+            }
+
+            _ => {
+                if e.to_string()
+                    .starts_with("failed to lookup address information")
+                {
+                    dns_error("address not available".to_string(), 0)
+                } else {
+                    types::ErrorCode::ConnectionRefused
+                }
+            }
+        })?;
 
     let (mut sender, worker) = if use_tls {
         #[cfg(any(target_arch = "riscv64", target_arch = "s390x"))]
         {
-            return Err(crate::bindings::http::types::Error::UnexpectedError(
+            return Err(crate::bindings::http::types::ErrorCode::UnexpectedError(
                 "unsupported architecture for SSL".to_string(),
             ));
         }
@@ -141,18 +156,20 @@ async fn handler(
             let connector = tokio_rustls::TlsConnector::from(std::sync::Arc::new(config));
             let mut parts = authority.split(":");
             let host = parts.next().unwrap_or(&authority);
-            let domain = rustls::ServerName::try_from(host)?;
+            let domain = rustls::ServerName::try_from(host)
+                .map_err(|_| dns_error("invalid dns name".to_string(), 0))?;
             let stream = connector
                 .connect(domain, tcp_stream)
                 .await
-                .map_err(|e| crate::bindings::http::types::Error::ProtocolError(e.to_string()))?;
+                .map_err(|_| types::ErrorCode::TlsProtocolError)?;
 
             let (sender, conn) = timeout(
                 connect_timeout,
                 hyper::client::conn::http1::handshake(stream),
             )
             .await
-            .map_err(|_| timeout_error("connection"))??;
+            .map_err(|_| types::ErrorCode::ConnectionTimeout)?
+            .map_err(|_| types::ErrorCode::ConnectionTimeout)?;
 
             let worker = preview2::spawn(async move {
                 match conn.await {
@@ -172,7 +189,8 @@ async fn handler(
             hyper::client::conn::http1::handshake(tcp_stream),
         )
         .await
-        .map_err(|_| timeout_error("connection"))??;
+        .map_err(|_| types::ErrorCode::ConnectionTimeout)?
+        .map_err(|_| types::ErrorCode::HttpProtocolError)?;
 
         let worker = preview2::spawn(async move {
             match conn.await {
@@ -187,9 +205,12 @@ async fn handler(
 
     let resp = timeout(first_byte_timeout, sender.send_request(request))
         .await
-        .map_err(|_| timeout_error("first byte"))?
-        .map_err(hyper_protocol_error)?
-        .map(|body| body.map_err(|e| e.into()).boxed());
+        .map_err(|_| types::ErrorCode::ConnectionReadTimeout)?
+        .map_err(|_| types::ErrorCode::HttpProtocolError)?
+        .map(|body| {
+            body.map_err(|_| types::ErrorCode::HttpProtocolError)
+                .boxed()
+        });
 
     Ok(IncomingResponseInternal {
         resp,
@@ -197,25 +218,6 @@ async fn handler(
         between_bytes_timeout,
     })
 }
-
-pub fn timeout_error(kind: &str) -> types::Error {
-    types::Error::TimeoutError(format!("{kind} timed out"))
-}
-
-pub fn http_protocol_error(e: http::Error) -> types::Error {
-    types::Error::ProtocolError(e.to_string())
-}
-
-pub fn hyper_protocol_error(e: hyper::Error) -> types::Error {
-    types::Error::ProtocolError(e.to_string())
-}
-
-fn invalid_url(e: std::io::Error) -> types::Error {
-    // TODO: DNS errors show up as a Custom io error, what subset of errors should we consider for
-    // InvalidUrl here?
-    types::Error::InvalidUrl(e.to_string())
-}
-
 impl From<http::Method> for types::Method {
     fn from(method: http::Method) -> Self {
         if method == http::Method::GET {
@@ -268,7 +270,7 @@ pub struct HostIncomingRequest {
 
 pub struct HostResponseOutparam {
     pub result:
-        tokio::sync::oneshot::Sender<Result<hyper::Response<HyperOutgoingBody>, types::Error>>,
+        tokio::sync::oneshot::Sender<Result<hyper::Response<HyperOutgoingBody>, types::ErrorCode>>,
 }
 
 pub struct HostOutgoingRequest {
@@ -347,11 +349,11 @@ pub struct IncomingResponseInternal {
 }
 
 type FutureIncomingResponseHandle =
-    AbortOnDropJoinHandle<anyhow::Result<Result<IncomingResponseInternal, types::Error>>>;
+    AbortOnDropJoinHandle<anyhow::Result<Result<IncomingResponseInternal, types::ErrorCode>>>;
 
 pub enum HostFutureIncomingResponse {
     Pending(FutureIncomingResponseHandle),
-    Ready(anyhow::Result<Result<IncomingResponseInternal, types::Error>>),
+    Ready(anyhow::Result<Result<IncomingResponseInternal, types::ErrorCode>>),
     Consumed,
 }
 
@@ -364,7 +366,9 @@ impl HostFutureIncomingResponse {
         matches!(self, Self::Ready(_))
     }
 
-    pub fn unwrap_ready(self) -> anyhow::Result<Result<IncomingResponseInternal, types::Error>> {
+    pub fn unwrap_ready(
+        self,
+    ) -> anyhow::Result<Result<IncomingResponseInternal, types::ErrorCode>> {
         match self {
             Self::Ready(res) => res,
             Self::Pending(_) | Self::Consumed => {

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bindings::http::types::{self, Error, Headers, Method, Scheme, StatusCode, Trailers},
+    bindings::http::types::{self, Headers, Method, Scheme, StatusCode, Trailers},
     body::{FinishMessage, HostFutureTrailers, HostIncomingBody, HostOutgoingBody},
     types::{
         FieldMap, HostFields, HostFutureIncomingResponse, HostIncomingRequest,
@@ -17,7 +17,14 @@ use wasmtime_wasi::preview2::{
     Pollable, Table,
 };
 
-impl<T: WasiHttpView> crate::bindings::http::types::Host for T {}
+impl<T: WasiHttpView> crate::bindings::http::types::Host for T {
+    fn http_error(
+        &mut self,
+        _err: wasmtime::component::Resource<types::StreamError>,
+    ) -> wasmtime::Result<Option<types::ErrorCode>> {
+        todo!()
+    }
+}
 
 /// Take ownership of the underlying [`FieldMap`] associated with this fields resource. If the
 /// fields resource references another fields, the returned [`FieldMap`] will be cloned.
@@ -525,7 +532,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostResponseOutparam for T {
     fn set(
         &mut self,
         id: Resource<HostResponseOutparam>,
-        resp: Result<Resource<HostOutgoingResponse>, Error>,
+        resp: Result<Resource<HostOutgoingResponse>, types::ErrorCode>,
     ) -> wasmtime::Result<()> {
         let val = match resp {
             Ok(resp) => Ok(self.table().delete(resp)?.try_into()?),
@@ -620,7 +627,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFutureTrailers for T {
     fn get(
         &mut self,
         id: Resource<HostFutureTrailers>,
-    ) -> wasmtime::Result<Option<Result<Option<Resource<Trailers>>, Error>>> {
+    ) -> wasmtime::Result<Option<Result<Option<Resource<Trailers>>, types::ErrorCode>>> {
         let trailers = self.table().get_mut(&id)?;
         match trailers {
             HostFutureTrailers::Waiting(_) => return Ok(None),
@@ -773,7 +780,9 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFutureIncomingResponse f
     fn get(
         &mut self,
         id: Resource<HostFutureIncomingResponse>,
-    ) -> wasmtime::Result<Option<Result<Result<Resource<HostIncomingResponse>, Error>, ()>>> {
+    ) -> wasmtime::Result<
+        Option<Result<Result<Resource<HostIncomingResponse>, types::ErrorCode>, ()>>,
+    > {
         let resp = self.table().get_mut(&id)?;
 
         match resp {
@@ -786,7 +795,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFutureIncomingResponse f
             match std::mem::replace(resp, HostFutureIncomingResponse::Consumed).unwrap_ready() {
                 Err(e) => {
                     // Trapping if it's not possible to downcast to an wasi-http error
-                    let e = e.downcast::<Error>()?;
+                    let e = e.downcast::<types::ErrorCode>()?;
                     return Ok(Some(Ok(Err(e))));
                 }
 

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -18,7 +18,7 @@ use wasmtime_wasi::preview2::{
 };
 
 impl<T: WasiHttpView> crate::bindings::http::types::Host for T {
-    fn http_error(
+    fn http_error_code(
         &mut self,
         _err: wasmtime::component::Resource<types::StreamError>,
     ) -> wasmtime::Result<Option<types::ErrorCode>> {

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -15,7 +15,7 @@ use wasmtime_wasi::preview2::{
     self, pipe::MemoryOutputPipe, Table, WasiCtx, WasiCtxBuilder, WasiView,
 };
 use wasmtime_wasi_http::{
-    bindings::http::types::Error,
+    bindings::http::types::ErrorCode,
     body::HyperIncomingBody,
     types::{self, HostFutureIncomingResponse, IncomingResponseInternal, OutgoingRequest},
     WasiHttpCtx, WasiHttpView,
@@ -128,7 +128,7 @@ async fn run_wasi_http(
     component_filename: &str,
     req: hyper::Request<HyperIncomingBody>,
     send_request: Option<RequestSender>,
-) -> anyhow::Result<Result<hyper::Response<Collected<Bytes>>, Error>> {
+) -> anyhow::Result<Result<hyper::Response<Collected<Bytes>>, ErrorCode>> {
     let stdout = MemoryOutputPipe::new(4096);
     let stderr = MemoryOutputPipe::new(4096);
     let table = Table::new();
@@ -457,7 +457,7 @@ async fn do_wasi_http_echo(uri: &str, url_header: Option<&str>) -> Result<()> {
 
     let request = request.body(BoxBody::new(StreamBody::new(stream::iter(
         body.chunks(16 * 1024)
-            .map(|chunk| Ok::<_, Error>(Frame::data(Bytes::copy_from_slice(chunk))))
+            .map(|chunk| Ok::<_, ErrorCode>(Frame::data(Bytes::copy_from_slice(chunk))))
             .collect::<Vec<_>>(),
     ))))?;
 

--- a/crates/wasi-http/wit/deps/http/handler.wit
+++ b/crates/wasi-http/wit/deps/http/handler.wit
@@ -22,7 +22,9 @@ interface incoming-handler {
 /// This interface defines a handler of outgoing HTTP Requests. It should be
 /// imported by components which wish to make HTTP Requests.
 interface outgoing-handler {
-  use types.{outgoing-request, request-options, future-incoming-response, error};
+  use types.{
+    outgoing-request, request-options, future-incoming-response, error-code
+  };
 
   /// This function is invoked with an outgoing HTTP Request, and it returns
   /// a resource `future-incoming-response` which represents an HTTP Response
@@ -37,5 +39,5 @@ interface outgoing-handler {
   handle: func(
     request: outgoing-request,
     options: option<request-options>
-  ) -> result<future-incoming-response, error>;
+  ) -> result<future-incoming-response, error-code>;
 }

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -45,8 +45,12 @@ interface types {
     TLS-protocol-error,
     TLS-certificate-error,
     TLS-alert-received(TLS-alert-received-payload),
-    HTTP-request-error(HTTP-request-error-payload),
     HTTP-request-denied,
+    HTTP-request-length-required,
+    HTTP-request-content-too-large,
+    HTTP-request-URI-too-long,
+    HTTP-request-header-section-size(option<u32>),
+    HTTP-request-header-size(option<field-size-payload>),
     HTTP-response-incomplete,
     HTTP-response-header-section-size(option<u32>),
     HTTP-response-header-size(field-size-payload),
@@ -74,12 +78,6 @@ interface types {
   record TLS-alert-received-payload {
     alert-ID: option<u8>,
     alert-message: option<string>
-  }
-
-  /// Defines the case payload type for `HTTP-request-error` above:
-  record HTTP-request-error-payload {
-    status-code: option<u16>,
-    status-phrase: option<string>
   }
 
   /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -27,7 +27,7 @@ interface types {
     other(string)
   }
 
-  /// The cases of this variant correspond to the IANA HTTP Proxy Error Types:
+  /// These cases are inspired by the IANA HTTP Proxy Error Types:
   ///   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
   variant error-code {
     DNS-timeout,
@@ -47,14 +47,18 @@ interface types {
     TLS-alert-received(TLS-alert-received-payload),
     HTTP-request-denied,
     HTTP-request-length-required,
-    HTTP-request-content-too-large,
+    HTTP-request-body-size(option<u64>),
+    HTTP-request-method-invalid,
+    HTTP-request-URI-invalid,
     HTTP-request-URI-too-long,
     HTTP-request-header-section-size(option<u32>),
     HTTP-request-header-size(option<field-size-payload>),
+    HTTP-request-trailer-section-size(option<u32>),
+    HTTP-request-trailer-size(field-size-payload),
     HTTP-response-incomplete,
     HTTP-response-header-section-size(option<u32>),
     HTTP-response-header-size(field-size-payload),
-    HTTP-response-body-size(option<u32>),
+    HTTP-response-body-size(option<u64>),
     HTTP-response-trailer-section-size(option<u32>),
     HTTP-response-trailer-size(field-size-payload),
     HTTP-response-transfer-coding(option<string>),
@@ -62,10 +66,14 @@ interface types {
     HTTP-response-timeout,
     HTTP-upgrade-failed,
     HTTP-protocol-error,
-    proxy-internal-response,
-    proxy-internal-error,
-    proxy-configuration-error,
-    proxy-loop-detected
+    loop-detected,
+    configuration-error,
+    /// This is a catch-all error for anything that doesn't fit cleanly into a
+    /// more specific case. It also includes an optional string for an
+    /// unstructured description of the error. Users should not depend on the
+    /// string for diagnosing errors, as it's not required to be consistent
+    /// between implementations.
+    internal-error(option<string>)
   }
 
   /// Defines the case payload type for `DNS-error` above:
@@ -76,7 +84,7 @@ interface types {
 
   /// Defines the case payload type for `TLS-alert-received` above:
   record TLS-alert-received-payload {
-    alert-ID: option<u8>,
+    alert-id: option<u8>,
     alert-message: option<string>
   }
 
@@ -84,14 +92,6 @@ interface types {
   record field-size-payload {
     field-name: option<string>,
     field-size: option<u32>
-  }
-
-  /// This tyep enumerates the different kinds of errors that may occur when
-  /// setting or appending to a `fields` resource.
-  variant header-error {
-    invalid-syntax,
-    forbidden,
-    immutable
   }
 
   /// Attempts to extract a http-related `error` from the stream `error`
@@ -104,13 +104,23 @@ interface types {
   ///
   /// Note that this function is fallible because not all stream-related errors
   /// are http-related errors.
-  http-error: func(err: borrow<stream-error>) -> option<error-code>;
+  http-error-code: func(err: borrow<stream-error>) -> option<error-code>;
 
-  /// This tyep enumerates the different kinds of errors that may occur when
+  /// This type enumerates the different kinds of errors that may occur when
   /// setting or appending to a `fields` resource.
   variant header-error {
+    /// This error indicates that a `field-key` or `field-value` was
+    /// syntactically invalid when used with an operation that sets headers in a
+    /// `fields`.
     invalid-syntax,
+
+    /// This error indicates that a forbidden `field-key` was used when trying
+    /// to set a header in a `fields`.
     forbidden,
+
+    /// This error indicates that the operation on the `fields` was not
+    /// permitted because the fields are immutable.
+    immutable,
   }
 
   /// Field keys are always strings.
@@ -151,21 +161,14 @@ interface types {
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.
-    ///
-    /// The operation can fail if the name or value arguments are invalid, or if
-    /// the name is forbidden.
     set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
-    /// exist. Returns and error if the `field-key` is syntactically invalid, or
-    /// if the `field-key` is forbidden.
+    /// exist.
     delete: func(name: field-key) -> result<_, header-error>;
 
     /// Append a value for a key. Does not change or delete any existing
     /// values for that key.
-    ///
-    /// The operation can fail if the name or value arguments are invalid, or if
-    /// the name is forbidden.
     append: func(name: field-key, value: field-value) -> result<_, header-error>;
 
     /// Retrieve the full set of keys and values in the Fields. Like the
@@ -218,7 +221,7 @@ interface types {
   resource outgoing-request {
 
     /// Construct a new `outgoing-request` with a default `method` of `GET`, and
-    /// default values for `path-with-query`, `scheme`, and `authority.
+    /// `none` values for `path-with-query`, `scheme`, and `authority`.
     ///
     /// * `headers` is the HTTP Headers for the Request.
     ///

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -27,8 +27,8 @@ interface types {
     other(string)
   }
 
-  // The cases of this variant correspond to the IANA HTTP Proxy Error Types:
-  //   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
+  /// The cases of this variant correspond to the IANA HTTP Proxy Error Types:
+  ///   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
   variant error-code {
     DNS-timeout,
     DNS-error(DNS-error-payload),
@@ -48,13 +48,13 @@ interface types {
     HTTP-request-error(HTTP-request-error-payload),
     HTTP-request-denied,
     HTTP-response-incomplete,
-    HTTP-response-header-section-size(u32),
+    HTTP-response-header-section-size(option<u32>),
     HTTP-response-header-size(field-size-payload),
-    HTTP-response-body-size(u32),
-    HTTP-response-trailer-section-size(u32),
+    HTTP-response-body-size(option<u32>),
+    HTTP-response-trailer-section-size(option<u32>),
     HTTP-response-trailer-size(field-size-payload),
-    HTTP-response-transfer-coding(string),
-    HTTP-response-content-coding(string),
+    HTTP-response-transfer-coding(option<string>),
+    HTTP-response-content-coding(option<string>),
     HTTP-response-timeout,
     HTTP-upgrade-failed,
     HTTP-protocol-error,
@@ -64,28 +64,28 @@ interface types {
     proxy-loop-detected
   }
 
-  // Defines the case payload type for `DNS-error` above:
+  /// Defines the case payload type for `DNS-error` above:
   record DNS-error-payload {
-    rcode: string,
-    info-code: u16
+    rcode: option<string>,
+    info-code: option<u16>
   }
 
-  // Defines the case payload type for `TLS-alert-received` above:
+  /// Defines the case payload type for `TLS-alert-received` above:
   record TLS-alert-received-payload {
-    alert-ID: u8,
-    alert-message: string
+    alert-ID: option<u8>,
+    alert-message: option<string>
   }
 
-  // Defines the case payload type for `HTTP-request-error` above:
+  /// Defines the case payload type for `HTTP-request-error` above:
   record HTTP-request-error-payload {
-    status-code: u16,
-    status-phrase: string
+    status-code: option<u16>,
+    status-phrase: option<string>
   }
 
-  // Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
+  /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
   record field-size-payload {
-    field-name: string,
-    field-size: u32
+    field-name: option<string>,
+    field-size: option<u32>
   }
 
   /// This tyep enumerates the different kinds of errors that may occur when
@@ -107,6 +107,13 @@ interface types {
   /// Note that this function is fallible because not all stream-related errors
   /// are http-related errors.
   http-error: func(err: borrow<stream-error>) -> option<error-code>;
+
+  /// This tyep enumerates the different kinds of errors that may occur when
+  /// setting or appending to a `fields` resource.
+  variant header-error {
+    invalid-syntax,
+    forbidden,
+  }
 
   /// Field keys are always strings.
   type field-key = string;

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -3,7 +3,7 @@
 /// their headers, trailers, and bodies.
 interface types {
   use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05.{duration};
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream};
+  use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream, error as stream-error};
   use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
@@ -27,14 +27,65 @@ interface types {
     other(string)
   }
 
-  /// TODO: perhaps better align with HTTP semantics?
-  /// This type enumerates the different kinds of errors that may occur when
-  /// initially returning a response.
-  variant error {
-    invalid-url(string),
-    timeout-error(string),
-    protocol-error(string),
-    unexpected-error(string)
+  // The cases of this variant correspond to the IANA HTTP Proxy Error Types:
+  //   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
+  variant error-code {
+    DNS-timeout,
+    DNS-error(DNS-error-payload),
+    destination-not-found,
+    destination-unavailable,
+    destination-IP-prohibited,
+    destination-IP-unroutable,
+    connection-refused,
+    connection-terminated,
+    connection-timeout,
+    connection-read-timeout,
+    connection-write-timeout,
+    connection-limit-reached,
+    TLS-protocol-error,
+    TLS-certificate-error,
+    TLS-alert-received(TLS-alert-received-payload),
+    HTTP-request-error(HTTP-request-error-payload),
+    HTTP-request-denied,
+    HTTP-response-incomplete,
+    HTTP-response-header-section-size(u32),
+    HTTP-response-header-size(field-size-payload),
+    HTTP-response-body-size(u32),
+    HTTP-response-trailer-section-size(u32),
+    HTTP-response-trailer-size(field-size-payload),
+    HTTP-response-transfer-coding(string),
+    HTTP-response-content-coding(string),
+    HTTP-response-timeout,
+    HTTP-upgrade-failed,
+    HTTP-protocol-error,
+    proxy-internal-response,
+    proxy-internal-error,
+    proxy-configuration-error,
+    proxy-loop-detected
+  }
+
+  // Defines the case payload type for `DNS-error` above:
+  record DNS-error-payload {
+    rcode: string,
+    info-code: u16
+  }
+
+  // Defines the case payload type for `TLS-alert-received` above:
+  record TLS-alert-received-payload {
+    alert-ID: u8,
+    alert-message: string
+  }
+
+  // Defines the case payload type for `HTTP-request-error` above:
+  record HTTP-request-error-payload {
+    status-code: u16,
+    status-phrase: string
+  }
+
+  // Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
+  record field-size-payload {
+    field-name: string,
+    field-size: u32
   }
 
   /// This tyep enumerates the different kinds of errors that may occur when
@@ -44,6 +95,18 @@ interface types {
     forbidden,
     immutable
   }
+
+  /// Attempts to extract a http-related `error` from the stream `error`
+  /// provided.
+  ///
+  /// Stream operations which return `stream-error::last-operation-failed` have
+  /// a payload with more information about the operation that failed. This
+  /// payload can be passed through to this function to see if there's
+  /// http-related information about the error to return.
+  ///
+  /// Note that this function is fallible because not all stream-related errors
+  /// are http-related errors.
+  http-error: func(err: borrow<stream-error>) -> option<error-code>;
 
   /// Field keys are always strings.
   type field-key = string;
@@ -263,7 +326,7 @@ interface types {
     /// implementation determine how to respond with an HTTP error response.
     set: static func(
       param: response-outparam,
-      response: result<outgoing-response, error>,
+      response: result<outgoing-response, error-code>,
     );
   }
 
@@ -338,7 +401,7 @@ interface types {
     /// as well as any trailers, were received successfully, or that an error
     /// occured receiving them. The optional `trailers` indicates whether or not
     /// trailers were present in the body.
-    get: func() -> option<result<option<trailers>, error>>;
+    get: func() -> option<result<option<trailers>, error-code>>;
   }
 
   /// Represents an outgoing HTTP Response.
@@ -434,7 +497,7 @@ interface types {
     /// occured. Errors may also occur while consuming the response body,
     /// but those will be reported by the `incoming-body` and its
     /// `output-stream` child.
-    get: func() -> option<result<result<incoming-response, error>>>;
+    get: func() -> option<result<result<incoming-response, error-code>>>;
 
   }
 }

--- a/crates/wasi/wit/deps/http/handler.wit
+++ b/crates/wasi/wit/deps/http/handler.wit
@@ -22,7 +22,9 @@ interface incoming-handler {
 /// This interface defines a handler of outgoing HTTP Requests. It should be
 /// imported by components which wish to make HTTP Requests.
 interface outgoing-handler {
-  use types.{outgoing-request, request-options, future-incoming-response, error};
+  use types.{
+    outgoing-request, request-options, future-incoming-response, error-code
+  };
 
   /// This function is invoked with an outgoing HTTP Request, and it returns
   /// a resource `future-incoming-response` which represents an HTTP Response
@@ -37,5 +39,5 @@ interface outgoing-handler {
   handle: func(
     request: outgoing-request,
     options: option<request-options>
-  ) -> result<future-incoming-response, error>;
+  ) -> result<future-incoming-response, error-code>;
 }

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -45,8 +45,12 @@ interface types {
     TLS-protocol-error,
     TLS-certificate-error,
     TLS-alert-received(TLS-alert-received-payload),
-    HTTP-request-error(HTTP-request-error-payload),
     HTTP-request-denied,
+    HTTP-request-length-required,
+    HTTP-request-content-too-large,
+    HTTP-request-URI-too-long,
+    HTTP-request-header-section-size(option<u32>),
+    HTTP-request-header-size(option<field-size-payload>),
     HTTP-response-incomplete,
     HTTP-response-header-section-size(option<u32>),
     HTTP-response-header-size(field-size-payload),
@@ -74,12 +78,6 @@ interface types {
   record TLS-alert-received-payload {
     alert-ID: option<u8>,
     alert-message: option<string>
-  }
-
-  /// Defines the case payload type for `HTTP-request-error` above:
-  record HTTP-request-error-payload {
-    status-code: option<u16>,
-    status-phrase: option<string>
   }
 
   /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -27,7 +27,7 @@ interface types {
     other(string)
   }
 
-  /// The cases of this variant correspond to the IANA HTTP Proxy Error Types:
+  /// These cases are inspired by the IANA HTTP Proxy Error Types:
   ///   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
   variant error-code {
     DNS-timeout,
@@ -47,14 +47,18 @@ interface types {
     TLS-alert-received(TLS-alert-received-payload),
     HTTP-request-denied,
     HTTP-request-length-required,
-    HTTP-request-content-too-large,
+    HTTP-request-body-size(option<u64>),
+    HTTP-request-method-invalid,
+    HTTP-request-URI-invalid,
     HTTP-request-URI-too-long,
     HTTP-request-header-section-size(option<u32>),
     HTTP-request-header-size(option<field-size-payload>),
+    HTTP-request-trailer-section-size(option<u32>),
+    HTTP-request-trailer-size(field-size-payload),
     HTTP-response-incomplete,
     HTTP-response-header-section-size(option<u32>),
     HTTP-response-header-size(field-size-payload),
-    HTTP-response-body-size(option<u32>),
+    HTTP-response-body-size(option<u64>),
     HTTP-response-trailer-section-size(option<u32>),
     HTTP-response-trailer-size(field-size-payload),
     HTTP-response-transfer-coding(option<string>),
@@ -62,10 +66,14 @@ interface types {
     HTTP-response-timeout,
     HTTP-upgrade-failed,
     HTTP-protocol-error,
-    proxy-internal-response,
-    proxy-internal-error,
-    proxy-configuration-error,
-    proxy-loop-detected
+    loop-detected,
+    configuration-error,
+    /// This is a catch-all error for anything that doesn't fit cleanly into a
+    /// more specific case. It also includes an optional string for an
+    /// unstructured description of the error. Users should not depend on the
+    /// string for diagnosing errors, as it's not required to be consistent
+    /// between implementations.
+    internal-error(option<string>)
   }
 
   /// Defines the case payload type for `DNS-error` above:
@@ -76,7 +84,7 @@ interface types {
 
   /// Defines the case payload type for `TLS-alert-received` above:
   record TLS-alert-received-payload {
-    alert-ID: option<u8>,
+    alert-id: option<u8>,
     alert-message: option<string>
   }
 
@@ -84,14 +92,6 @@ interface types {
   record field-size-payload {
     field-name: option<string>,
     field-size: option<u32>
-  }
-
-  /// This tyep enumerates the different kinds of errors that may occur when
-  /// setting or appending to a `fields` resource.
-  variant header-error {
-    invalid-syntax,
-    forbidden,
-    immutable
   }
 
   /// Attempts to extract a http-related `error` from the stream `error`
@@ -104,13 +104,23 @@ interface types {
   ///
   /// Note that this function is fallible because not all stream-related errors
   /// are http-related errors.
-  http-error: func(err: borrow<stream-error>) -> option<error-code>;
+  http-error-code: func(err: borrow<stream-error>) -> option<error-code>;
 
-  /// This tyep enumerates the different kinds of errors that may occur when
+  /// This type enumerates the different kinds of errors that may occur when
   /// setting or appending to a `fields` resource.
   variant header-error {
+    /// This error indicates that a `field-key` or `field-value` was
+    /// syntactically invalid when used with an operation that sets headers in a
+    /// `fields`.
     invalid-syntax,
+
+    /// This error indicates that a forbidden `field-key` was used when trying
+    /// to set a header in a `fields`.
     forbidden,
+
+    /// This error indicates that the operation on the `fields` was not
+    /// permitted because the fields are immutable.
+    immutable,
   }
 
   /// Field keys are always strings.
@@ -151,21 +161,14 @@ interface types {
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.
-    ///
-    /// The operation can fail if the name or value arguments are invalid, or if
-    /// the name is forbidden.
     set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
-    /// exist. Returns and error if the `field-key` is syntactically invalid, or
-    /// if the `field-key` is forbidden.
+    /// exist.
     delete: func(name: field-key) -> result<_, header-error>;
 
     /// Append a value for a key. Does not change or delete any existing
     /// values for that key.
-    ///
-    /// The operation can fail if the name or value arguments are invalid, or if
-    /// the name is forbidden.
     append: func(name: field-key, value: field-value) -> result<_, header-error>;
 
     /// Retrieve the full set of keys and values in the Fields. Like the
@@ -218,7 +221,7 @@ interface types {
   resource outgoing-request {
 
     /// Construct a new `outgoing-request` with a default `method` of `GET`, and
-    /// default values for `path-with-query`, `scheme`, and `authority.
+    /// `none` values for `path-with-query`, `scheme`, and `authority`.
     ///
     /// * `headers` is the HTTP Headers for the Request.
     ///

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -27,8 +27,8 @@ interface types {
     other(string)
   }
 
-  // The cases of this variant correspond to the IANA HTTP Proxy Error Types:
-  //   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
+  /// The cases of this variant correspond to the IANA HTTP Proxy Error Types:
+  ///   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
   variant error-code {
     DNS-timeout,
     DNS-error(DNS-error-payload),
@@ -48,13 +48,13 @@ interface types {
     HTTP-request-error(HTTP-request-error-payload),
     HTTP-request-denied,
     HTTP-response-incomplete,
-    HTTP-response-header-section-size(u32),
+    HTTP-response-header-section-size(option<u32>),
     HTTP-response-header-size(field-size-payload),
-    HTTP-response-body-size(u32),
-    HTTP-response-trailer-section-size(u32),
+    HTTP-response-body-size(option<u32>),
+    HTTP-response-trailer-section-size(option<u32>),
     HTTP-response-trailer-size(field-size-payload),
-    HTTP-response-transfer-coding(string),
-    HTTP-response-content-coding(string),
+    HTTP-response-transfer-coding(option<string>),
+    HTTP-response-content-coding(option<string>),
     HTTP-response-timeout,
     HTTP-upgrade-failed,
     HTTP-protocol-error,
@@ -64,28 +64,28 @@ interface types {
     proxy-loop-detected
   }
 
-  // Defines the case payload type for `DNS-error` above:
+  /// Defines the case payload type for `DNS-error` above:
   record DNS-error-payload {
-    rcode: string,
-    info-code: u16
+    rcode: option<string>,
+    info-code: option<u16>
   }
 
-  // Defines the case payload type for `TLS-alert-received` above:
+  /// Defines the case payload type for `TLS-alert-received` above:
   record TLS-alert-received-payload {
-    alert-ID: u8,
-    alert-message: string
+    alert-ID: option<u8>,
+    alert-message: option<string>
   }
 
-  // Defines the case payload type for `HTTP-request-error` above:
+  /// Defines the case payload type for `HTTP-request-error` above:
   record HTTP-request-error-payload {
-    status-code: u16,
-    status-phrase: string
+    status-code: option<u16>,
+    status-phrase: option<string>
   }
 
-  // Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
+  /// Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
   record field-size-payload {
-    field-name: string,
-    field-size: u32
+    field-name: option<string>,
+    field-size: option<u32>
   }
 
   /// This tyep enumerates the different kinds of errors that may occur when
@@ -107,6 +107,13 @@ interface types {
   /// Note that this function is fallible because not all stream-related errors
   /// are http-related errors.
   http-error: func(err: borrow<stream-error>) -> option<error-code>;
+
+  /// This tyep enumerates the different kinds of errors that may occur when
+  /// setting or appending to a `fields` resource.
+  variant header-error {
+    invalid-syntax,
+    forbidden,
+  }
 
   /// Field keys are always strings.
   type field-key = string;

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -3,7 +3,7 @@
 /// their headers, trailers, and bodies.
 interface types {
   use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05.{duration};
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream};
+  use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream, error as stream-error};
   use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
@@ -27,14 +27,65 @@ interface types {
     other(string)
   }
 
-  /// TODO: perhaps better align with HTTP semantics?
-  /// This type enumerates the different kinds of errors that may occur when
-  /// initially returning a response.
-  variant error {
-    invalid-url(string),
-    timeout-error(string),
-    protocol-error(string),
-    unexpected-error(string)
+  // The cases of this variant correspond to the IANA HTTP Proxy Error Types:
+  //   https://www.iana.org/assignments/http-proxy-status/http-proxy-status.xhtml#table-http-proxy-error-types
+  variant error-code {
+    DNS-timeout,
+    DNS-error(DNS-error-payload),
+    destination-not-found,
+    destination-unavailable,
+    destination-IP-prohibited,
+    destination-IP-unroutable,
+    connection-refused,
+    connection-terminated,
+    connection-timeout,
+    connection-read-timeout,
+    connection-write-timeout,
+    connection-limit-reached,
+    TLS-protocol-error,
+    TLS-certificate-error,
+    TLS-alert-received(TLS-alert-received-payload),
+    HTTP-request-error(HTTP-request-error-payload),
+    HTTP-request-denied,
+    HTTP-response-incomplete,
+    HTTP-response-header-section-size(u32),
+    HTTP-response-header-size(field-size-payload),
+    HTTP-response-body-size(u32),
+    HTTP-response-trailer-section-size(u32),
+    HTTP-response-trailer-size(field-size-payload),
+    HTTP-response-transfer-coding(string),
+    HTTP-response-content-coding(string),
+    HTTP-response-timeout,
+    HTTP-upgrade-failed,
+    HTTP-protocol-error,
+    proxy-internal-response,
+    proxy-internal-error,
+    proxy-configuration-error,
+    proxy-loop-detected
+  }
+
+  // Defines the case payload type for `DNS-error` above:
+  record DNS-error-payload {
+    rcode: string,
+    info-code: u16
+  }
+
+  // Defines the case payload type for `TLS-alert-received` above:
+  record TLS-alert-received-payload {
+    alert-ID: u8,
+    alert-message: string
+  }
+
+  // Defines the case payload type for `HTTP-request-error` above:
+  record HTTP-request-error-payload {
+    status-code: u16,
+    status-phrase: string
+  }
+
+  // Defines the case payload type for `HTTP-response-{header,trailer}-size` above:
+  record field-size-payload {
+    field-name: string,
+    field-size: u32
   }
 
   /// This tyep enumerates the different kinds of errors that may occur when
@@ -44,6 +95,18 @@ interface types {
     forbidden,
     immutable
   }
+
+  /// Attempts to extract a http-related `error` from the stream `error`
+  /// provided.
+  ///
+  /// Stream operations which return `stream-error::last-operation-failed` have
+  /// a payload with more information about the operation that failed. This
+  /// payload can be passed through to this function to see if there's
+  /// http-related information about the error to return.
+  ///
+  /// Note that this function is fallible because not all stream-related errors
+  /// are http-related errors.
+  http-error: func(err: borrow<stream-error>) -> option<error-code>;
 
   /// Field keys are always strings.
   type field-key = string;
@@ -263,7 +326,7 @@ interface types {
     /// implementation determine how to respond with an HTTP error response.
     set: static func(
       param: response-outparam,
-      response: result<outgoing-response, error>,
+      response: result<outgoing-response, error-code>,
     );
   }
 
@@ -338,7 +401,7 @@ interface types {
     /// as well as any trailers, were received successfully, or that an error
     /// occured receiving them. The optional `trailers` indicates whether or not
     /// trailers were present in the body.
-    get: func() -> option<result<option<trailers>, error>>;
+    get: func() -> option<result<option<trailers>, error-code>>;
   }
 
   /// Represents an outgoing HTTP Response.
@@ -434,7 +497,7 @@ interface types {
     /// occured. Errors may also occur while consuming the response body,
     /// but those will be reported by the `incoming-body` and its
     /// `output-stream` child.
-    get: func() -> option<result<result<incoming-response, error>>>;
+    get: func() -> option<result<result<incoming-response, error-code>>>;
 
   }
 }

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -372,15 +372,15 @@ impl hyper::service::Service<Request> for ProxyHandler {
                     } else if err.is_parse_status() || err.is_user() {
                         http_types::ErrorCode::HttpRequestError(
                             http_types::HttpRequestErrorPayload {
-                                status_code: 400,
-                                status_phrase: "".to_string(),
+                                status_code: Some(400),
+                                status_phrase: Some("".to_string()),
                             },
                         )
                     } else if err.is_parse_too_large() {
                         http_types::ErrorCode::HttpRequestError(
                             http_types::HttpRequestErrorPayload {
-                                status_code: 413,
-                                status_phrase: "".to_string(),
+                                status_code: Some(413),
+                                status_phrase: Some("".to_string()),
                             },
                         )
                     } else {

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -14,7 +14,9 @@ use wasmtime::{Engine, Store, StoreLimits};
 use wasmtime_wasi::preview2::{
     self, StreamError, StreamResult, Table, WasiCtx, WasiCtxBuilder, WasiView,
 };
-use wasmtime_wasi_http::{body::HyperOutgoingBody, WasiHttpCtx, WasiHttpView};
+use wasmtime_wasi_http::{
+    bindings::http::types as http_types, body::HyperOutgoingBody, WasiHttpCtx, WasiHttpView,
+};
 
 #[cfg(feature = "wasi-nn")]
 use wasmtime_wasi_nn::WasiNnCtx;
@@ -363,9 +365,30 @@ impl hyper::service::Service<Request> for ProxyHandler {
 
             let mut store = inner.cmd.new_store(&inner.engine, req_id)?;
 
-            let req = store
-                .data_mut()
-                .new_incoming_request(req.map(|body| body.map_err(|e| e.into()).boxed()))?;
+            let req = store.data_mut().new_incoming_request(req.map(|body| {
+                body.map_err(|err| {
+                    if err.is_timeout() {
+                        http_types::ErrorCode::HttpResponseTimeout
+                    } else if err.is_parse_status() || err.is_user() {
+                        http_types::ErrorCode::HttpRequestError(
+                            http_types::HttpRequestErrorPayload {
+                                status_code: 400,
+                                status_phrase: "".to_string(),
+                            },
+                        )
+                    } else if err.is_parse_too_large() {
+                        http_types::ErrorCode::HttpRequestError(
+                            http_types::HttpRequestErrorPayload {
+                                status_code: 413,
+                                status_phrase: "".to_string(),
+                            },
+                        )
+                    } else {
+                        http_types::ErrorCode::HttpProtocolError
+                    }
+                })
+                .boxed()
+            }))?;
 
             let out = store.data_mut().new_response_outparam(sender)?;
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -369,10 +369,8 @@ impl hyper::service::Service<Request> for ProxyHandler {
                 body.map_err(|err| {
                     if err.is_timeout() {
                         http_types::ErrorCode::HttpResponseTimeout
-                    } else if err.is_parse_too_large() {
-                        http_types::ErrorCode::HttpRequestContentTooLarge
                     } else {
-                        http_types::ErrorCode::HttpProtocolError
+                        http_types::ErrorCode::InternalError(Some(err.message().to_string()))
                     }
                 })
                 .boxed()

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -369,20 +369,8 @@ impl hyper::service::Service<Request> for ProxyHandler {
                 body.map_err(|err| {
                     if err.is_timeout() {
                         http_types::ErrorCode::HttpResponseTimeout
-                    } else if err.is_parse_status() || err.is_user() {
-                        http_types::ErrorCode::HttpRequestError(
-                            http_types::HttpRequestErrorPayload {
-                                status_code: Some(400),
-                                status_phrase: Some("".to_string()),
-                            },
-                        )
                     } else if err.is_parse_too_large() {
-                        http_types::ErrorCode::HttpRequestError(
-                            http_types::HttpRequestErrorPayload {
-                                status_code: Some(413),
-                                status_phrase: Some("".to_string()),
-                            },
-                        )
+                        http_types::ErrorCode::HttpRequestContentTooLarge
                     } else {
                         http_types::ErrorCode::HttpProtocolError
                     }


### PR DESCRIPTION
Integrate the more descriptive error variant present in https://github.com/WebAssembly/wasi-http/pull/52. This PR attempts to port the existing errors we raise directly to the new variant.

Fixes #7248 
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
