### PR TITLE
Wasmtime: omit ANSI color sequences in logging when not a terminal.

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -356,12 +356,10 @@ impl CommonOptions {
         } else {
             use std::io::IsTerminal;
             use tracing_subscriber::{EnvFilter, FmtSubscriber};
-            let mut b = FmtSubscriber::builder()
+            let b = FmtSubscriber::builder()
                 .with_writer(std::io::stderr)
-                .with_env_filter(EnvFilter::from_env("WASMTIME_LOG"));
-            if std::io::stderr().is_terminal() {
-                b = b.with_ansi(true);
-            }
+                .with_env_filter(EnvFilter::from_env("WASMTIME_LOG"))
+                .with_ansi(std::io::stderr().is_terminal());
             b.init();
         }
         #[cfg(not(feature = "logging"))]


### PR DESCRIPTION
In #7239 we added a `tracing-log` subscriber that prints logs to stderr if enabled with an environment variable. It included logic to add ANSI color sequences when stderr is a terminal, for legibility. Unfortunately it seems that while this logic *enabled* colors on a terminal, it did not *disable* colors on a non-terminal; so redirects of stderr to a file would result in ANSI color sequences being captured in that file. Specifically, the builder seems not to default to no-color; so rather than enable-or-nothing, we should explicitly enable or disable always.

Fixes #7435.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
