### PR TITLE
Fix flakiness in tcp_bind test

### DIFF
--- a/crates/test-programs/src/bin/preview2_tcp_bind.rs
+++ b/crates/test-programs/src/bin/preview2_tcp_bind.rs
@@ -30,7 +30,7 @@ fn test_tcp_bind_specific_port(net: &Network, ip: IpAddress) {
             assert_eq!(bind_addr.ip(), bound_addr.ip());
             assert_eq!(bind_addr.port(), bound_addr.port());
         }
-        Err(ErrorCode::AddressInUse) => {}
+        Err(ErrorCode::AddressInUse | ErrorCode::AccessDenied) => {}
         Err(e) => panic!("error: {e}"),
     }
 }

--- a/crates/test-programs/src/bin/preview2_tcp_bind.rs
+++ b/crates/test-programs/src/bin/preview2_tcp_bind.rs
@@ -30,6 +30,8 @@ fn test_tcp_bind_specific_port(net: &Network, ip: IpAddress) {
             assert_eq!(bind_addr.ip(), bound_addr.ip());
             assert_eq!(bind_addr.port(), bound_addr.port());
         }
+        // Concurrent invocations of this test can yield `AddressInUse` and that
+        // same error can show up on Windows as `AccessDenied`.
         Err(ErrorCode::AddressInUse | ErrorCode::AccessDenied) => {}
         Err(e) => panic!("error: {e}"),
     }


### PR DESCRIPTION
This commit adds another case to handle in the TCP bind test which binds a specific port to handle concurrent invocations of the test.

Closes #7429

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
