### PR TITLE
Fix parsing f32/f64 CLI arguments as floats

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -504,8 +504,8 @@ impl RunCommand {
                 // parses base-10 representations.
                 ValType::I32 => Val::I32(val.parse()?),
                 ValType::I64 => Val::I64(val.parse()?),
-                ValType::F32 => Val::F32(val.parse()?),
-                ValType::F64 => Val::F64(val.parse()?),
+                ValType::F32 => Val::F32(val.parse::<f32>()?.to_bits()),
+                ValType::F64 => Val::F64(val.parse::<f64>()?.to_bits()),
                 t => bail!("unsupported argument type {:?}", t),
             });
         }

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1176,6 +1176,25 @@ warning: this CLI invocation of Wasmtime is going to break in the future -- for
     Ok(())
 }
 
+#[test]
+fn float_args() -> Result<()> {
+    let result = run_wasmtime(&[
+        "--invoke",
+        "echo_f32",
+        "tests/all/cli_tests/simple.wat",
+        "1.0",
+    ])?;
+    assert_eq!(result, "1\n");
+    let result = run_wasmtime(&[
+        "--invoke",
+        "echo_f64",
+        "tests/all/cli_tests/simple.wat",
+        "1.1",
+    ])?;
+    assert_eq!(result, "1.1\n");
+    Ok(())
+}
+
 mod test_programs {
     use super::{get_wasmtime_command, run_wasmtime};
     use anyhow::Result;

--- a/tests/all/cli_tests/simple.wat
+++ b/tests/all/cli_tests/simple.wat
@@ -4,4 +4,6 @@
     )
     (func (export "get_f32") (result f32) f32.const 100)
     (func (export "get_f64") (result f64) f64.const 100)
+    (func (export "echo_f32") (param f32) (result f32) local.get 0)
+    (func (export "echo_f64") (param f64) (result f64) local.get 0)
 )


### PR DESCRIPTION
Type inference wasn't enough for this situation since floats are stored as `u32` and `u64` while they're at rest to avoid modification.

Closes #7401

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
