### PR TITLE
Fix writes being flushed to stdio

### DIFF
--- a/crates/test-programs/src/bin/cli_stdio_write_flushes.rs
+++ b/crates/test-programs/src/bin/cli_stdio_write_flushes.rs
@@ -1,0 +1,10 @@
+use std::io::Write;
+
+fn main() {
+    print!("> ");
+    std::io::stdout().flush();
+
+    let mut s = String::new();
+    std::io::stdin().read_line(&mut s).unwrap();
+    assert!(s.is_empty());
+}

--- a/crates/test-programs/src/bin/cli_stdio_write_flushes.rs
+++ b/crates/test-programs/src/bin/cli_stdio_write_flushes.rs
@@ -2,7 +2,7 @@ use std::io::Write;
 
 fn main() {
     print!("> ");
-    std::io::stdout().flush();
+    std::io::stdout().flush().unwrap();
 
     let mut s = String::new();
     std::io::stdin().read_line(&mut s).unwrap();


### PR DESCRIPTION
This commit fixes an accidental issue with writing to stdout with the `wasi-common` implementation where writes were line-buffered by the Rust standard library rather than being flushed out immediately as WASI semantics required.

Closes #7437

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
