### PR TITLE
Fix Winch bug for funcs with params and locals

### DIFF
--- a/winch/codegen/src/frame/mod.rs
+++ b/winch/codegen/src/frame/mod.rs
@@ -108,7 +108,7 @@ impl Frame {
             locals_size,
             vmctx_slot: LocalSlot::i64(vmctx_offset),
             defined_locals_range: DefinedLocalsRange(
-                defined_locals_start..defined_locals.stack_size,
+                defined_locals_start..(defined_locals_start + defined_locals.stack_size),
             ),
         })
     }

--- a/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
@@ -12,13 +12,15 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec10             	sub	rsp, 0x10
 ;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
-;;    c:	 4c893424             	mov	qword ptr [rsp], r14
-;;   10:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
-;;   14:	 b811000000           	mov	eax, 0x11
-;;   19:	 85c9                 	test	ecx, ecx
-;;   1b:	 0f8509000000         	jne	0x2a
-;;   21:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
-;;   25:	 b8ffffffff           	mov	eax, 0xffffffff
-;;   2a:	 4883c410             	add	rsp, 0x10
-;;   2e:	 5d                   	pop	rbp
-;;   2f:	 c3                   	ret	
+;;    c:	 c744240800000000     	mov	dword ptr [rsp + 8], 0
+;;   14:	 4531db               	xor	r11d, r11d
+;;   17:	 4c893424             	mov	qword ptr [rsp], r14
+;;   1b:	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
+;;   1f:	 b811000000           	mov	eax, 0x11
+;;   24:	 85c9                 	test	ecx, ecx
+;;   26:	 0f8509000000         	jne	0x35
+;;   2c:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   30:	 b8ffffffff           	mov	eax, 0xffffffff
+;;   35:	 4883c410             	add	rsp, 0x10
+;;   39:	 5d                   	pop	rbp
+;;   3a:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/for.wat
+++ b/winch/filetests/filetests/x64/loop/for.wat
@@ -19,29 +19,30 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec20             	sub	rsp, 0x20
 ;;    8:	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
-;;    d:	 48c744241000000000   	
-;; 				mov	qword ptr [rsp + 0x10], 0
-;;   16:	 4c893424             	mov	qword ptr [rsp], r14
-;;   1a:	 48c7c001000000       	mov	rax, 1
-;;   21:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
-;;   26:	 48c7c002000000       	mov	rax, 2
-;;   2d:	 4889442408           	mov	qword ptr [rsp + 8], rax
-;;   32:	 488b442418           	mov	rax, qword ptr [rsp + 0x18]
-;;   37:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
-;;   3c:	 4839c1               	cmp	rcx, rax
-;;   3f:	 b900000000           	mov	ecx, 0
-;;   44:	 400f97c1             	seta	cl
-;;   48:	 85c9                 	test	ecx, ecx
-;;   4a:	 0f8526000000         	jne	0x76
-;;   50:	 488b442408           	mov	rax, qword ptr [rsp + 8]
-;;   55:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
-;;   5a:	 480fafc8             	imul	rcx, rax
-;;   5e:	 48894c2410           	mov	qword ptr [rsp + 0x10], rcx
-;;   63:	 488b442408           	mov	rax, qword ptr [rsp + 8]
-;;   68:	 4883c001             	add	rax, 1
-;;   6c:	 4889442408           	mov	qword ptr [rsp + 8], rax
-;;   71:	 e9bcffffff           	jmp	0x32
-;;   76:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
-;;   7b:	 4883c420             	add	rsp, 0x20
-;;   7f:	 5d                   	pop	rbp
-;;   80:	 c3                   	ret	
+;;    d:	 4531db               	xor	r11d, r11d
+;;   10:	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
+;;   15:	 4c895c2408           	mov	qword ptr [rsp + 8], r11
+;;   1a:	 4c893424             	mov	qword ptr [rsp], r14
+;;   1e:	 48c7c001000000       	mov	rax, 1
+;;   25:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   2a:	 48c7c002000000       	mov	rax, 2
+;;   31:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   36:	 488b442418           	mov	rax, qword ptr [rsp + 0x18]
+;;   3b:	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
+;;   40:	 4839c1               	cmp	rcx, rax
+;;   43:	 b900000000           	mov	ecx, 0
+;;   48:	 400f97c1             	seta	cl
+;;   4c:	 85c9                 	test	ecx, ecx
+;;   4e:	 0f8526000000         	jne	0x7a
+;;   54:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   59:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   5e:	 480fafc8             	imul	rcx, rax
+;;   62:	 48894c2410           	mov	qword ptr [rsp + 0x10], rcx
+;;   67:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   6c:	 4883c001             	add	rax, 1
+;;   70:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   75:	 e9bcffffff           	jmp	0x36
+;;   7a:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   7f:	 4883c420             	add	rsp, 0x20
+;;   83:	 5d                   	pop	rbp
+;;   84:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/while.wat
+++ b/winch/filetests/filetests/x64/loop/while.wat
@@ -18,24 +18,26 @@
 ;;    1:	 4889e5               	mov	rbp, rsp
 ;;    4:	 4883ec18             	sub	rsp, 0x18
 ;;    8:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
-;;    d:	 4c893424             	mov	qword ptr [rsp], r14
-;;   11:	 48c7c001000000       	mov	rax, 1
-;;   18:	 4889442408           	mov	qword ptr [rsp + 8], rax
-;;   1d:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
-;;   22:	 4883f800             	cmp	rax, 0
-;;   26:	 b800000000           	mov	eax, 0
-;;   2b:	 400f94c0             	sete	al
-;;   2f:	 85c0                 	test	eax, eax
-;;   31:	 0f8526000000         	jne	0x5d
-;;   37:	 488b442408           	mov	rax, qword ptr [rsp + 8]
-;;   3c:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
-;;   41:	 480fafc8             	imul	rcx, rax
-;;   45:	 48894c2408           	mov	qword ptr [rsp + 8], rcx
-;;   4a:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
-;;   4f:	 4883e801             	sub	rax, 1
-;;   53:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
-;;   58:	 e9c0ffffff           	jmp	0x1d
-;;   5d:	 488b442408           	mov	rax, qword ptr [rsp + 8]
-;;   62:	 4883c418             	add	rsp, 0x18
-;;   66:	 5d                   	pop	rbp
-;;   67:	 c3                   	ret	
+;;    d:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   16:	 4c893424             	mov	qword ptr [rsp], r14
+;;   1a:	 48c7c001000000       	mov	rax, 1
+;;   21:	 4889442408           	mov	qword ptr [rsp + 8], rax
+;;   26:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   2b:	 4883f800             	cmp	rax, 0
+;;   2f:	 b800000000           	mov	eax, 0
+;;   34:	 400f94c0             	sete	al
+;;   38:	 85c0                 	test	eax, eax
+;;   3a:	 0f8526000000         	jne	0x66
+;;   40:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   45:	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
+;;   4a:	 480fafc8             	imul	rcx, rax
+;;   4e:	 48894c2408           	mov	qword ptr [rsp + 8], rcx
+;;   53:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;   58:	 4883e801             	sub	rax, 1
+;;   5c:	 4889442410           	mov	qword ptr [rsp + 0x10], rax
+;;   61:	 e9c0ffffff           	jmp	0x26
+;;   66:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;   6b:	 4883c418             	add	rsp, 0x18
+;;   6f:	 5d                   	pop	rbp
+;;   70:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/table/fill.wat
+++ b/winch/filetests/filetests/x64/table/fill.wat
@@ -49,46 +49,49 @@
 ;;    8:	 897c241c             	mov	dword ptr [rsp + 0x1c], edi
 ;;    c:	 89742418             	mov	dword ptr [rsp + 0x18], esi
 ;;   10:	 89542414             	mov	dword ptr [rsp + 0x14], edx
-;;   14:	 4c89742404           	mov	qword ptr [rsp + 4], r14
-;;   19:	 8b4c2418             	mov	ecx, dword ptr [rsp + 0x18]
-;;   1d:	 4c89f2               	mov	rdx, r14
-;;   20:	 8b5a50               	mov	ebx, dword ptr [rdx + 0x50]
-;;   23:	 39d9                 	cmp	ecx, ebx
-;;   25:	 0f8381000000         	jae	0xac
-;;   2b:	 4189cb               	mov	r11d, ecx
-;;   2e:	 4d6bdb08             	imul	r11, r11, 8
-;;   32:	 488b5248             	mov	rdx, qword ptr [rdx + 0x48]
-;;   36:	 4889d6               	mov	rsi, rdx
-;;   39:	 4c01da               	add	rdx, r11
-;;   3c:	 39d9                 	cmp	ecx, ebx
-;;   3e:	 480f43d6             	cmovae	rdx, rsi
-;;   42:	 488b02               	mov	rax, qword ptr [rdx]
-;;   45:	 4885c0               	test	rax, rax
-;;   48:	 0f8523000000         	jne	0x71
-;;   4e:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
-;;   52:	 498b5b48             	mov	rbx, qword ptr [r11 + 0x48]
-;;   56:	 4156                 	push	r14
-;;   58:	 51                   	push	rcx
-;;   59:	 488b7c2408           	mov	rdi, qword ptr [rsp + 8]
-;;   5e:	 be00000000           	mov	esi, 0
-;;   63:	 8b1424               	mov	edx, dword ptr [rsp]
-;;   66:	 ffd3                 	call	rbx
-;;   68:	 4883c410             	add	rsp, 0x10
-;;   6c:	 e904000000           	jmp	0x75
-;;   71:	 4883e0fe             	and	rax, 0xfffffffffffffffe
-;;   75:	 488944240c           	mov	qword ptr [rsp + 0xc], rax
-;;   7a:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
-;;   7e:	 498b4368             	mov	rax, qword ptr [r11 + 0x68]
-;;   82:	 4156                 	push	r14
-;;   84:	 4883ec08             	sub	rsp, 8
-;;   88:	 488b7c2408           	mov	rdi, qword ptr [rsp + 8]
-;;   8d:	 be01000000           	mov	esi, 1
-;;   92:	 8b54242c             	mov	edx, dword ptr [rsp + 0x2c]
-;;   96:	 488b4c241c           	mov	rcx, qword ptr [rsp + 0x1c]
-;;   9b:	 448b442424           	mov	r8d, dword ptr [rsp + 0x24]
-;;   a0:	 ffd0                 	call	rax
-;;   a2:	 4883c410             	add	rsp, 0x10
-;;   a6:	 4883c420             	add	rsp, 0x20
-;;   aa:	 5d                   	pop	rbp
-;;   ab:	 c3                   	ret	
-;;   ac:	 0f0b                 	ud2	
+;;   14:	 c744241000000000     	mov	dword ptr [rsp + 0x10], 0
+;;   1c:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   25:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   2a:	 8b4c2418             	mov	ecx, dword ptr [rsp + 0x18]
+;;   2e:	 4c89f2               	mov	rdx, r14
+;;   31:	 8b5a50               	mov	ebx, dword ptr [rdx + 0x50]
+;;   34:	 39d9                 	cmp	ecx, ebx
+;;   36:	 0f8381000000         	jae	0xbd
+;;   3c:	 4189cb               	mov	r11d, ecx
+;;   3f:	 4d6bdb08             	imul	r11, r11, 8
+;;   43:	 488b5248             	mov	rdx, qword ptr [rdx + 0x48]
+;;   47:	 4889d6               	mov	rsi, rdx
+;;   4a:	 4c01da               	add	rdx, r11
+;;   4d:	 39d9                 	cmp	ecx, ebx
+;;   4f:	 480f43d6             	cmovae	rdx, rsi
+;;   53:	 488b02               	mov	rax, qword ptr [rdx]
+;;   56:	 4885c0               	test	rax, rax
+;;   59:	 0f8523000000         	jne	0x82
+;;   5f:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
+;;   63:	 498b5b48             	mov	rbx, qword ptr [r11 + 0x48]
+;;   67:	 4156                 	push	r14
+;;   69:	 51                   	push	rcx
+;;   6a:	 488b7c2408           	mov	rdi, qword ptr [rsp + 8]
+;;   6f:	 be00000000           	mov	esi, 0
+;;   74:	 8b1424               	mov	edx, dword ptr [rsp]
+;;   77:	 ffd3                 	call	rbx
+;;   79:	 4883c410             	add	rsp, 0x10
+;;   7d:	 e904000000           	jmp	0x86
+;;   82:	 4883e0fe             	and	rax, 0xfffffffffffffffe
+;;   86:	 488944240c           	mov	qword ptr [rsp + 0xc], rax
+;;   8b:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
+;;   8f:	 498b4368             	mov	rax, qword ptr [r11 + 0x68]
+;;   93:	 4156                 	push	r14
+;;   95:	 4883ec08             	sub	rsp, 8
+;;   99:	 488b7c2408           	mov	rdi, qword ptr [rsp + 8]
+;;   9e:	 be01000000           	mov	esi, 1
+;;   a3:	 8b54242c             	mov	edx, dword ptr [rsp + 0x2c]
+;;   a7:	 488b4c241c           	mov	rcx, qword ptr [rsp + 0x1c]
+;;   ac:	 448b442424           	mov	r8d, dword ptr [rsp + 0x24]
+;;   b1:	 ffd0                 	call	rax
+;;   b3:	 4883c410             	add	rsp, 0x10
+;;   b7:	 4883c420             	add	rsp, 0x20
+;;   bb:	 5d                   	pop	rbp
+;;   bc:	 c3                   	ret	
+;;   bd:	 0f0b                 	ud2	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
I noticed a differential fuzzing failure in Winch when running the following module:

```wat
(module
  (type (;0;) (func (param i64)))
  (func (;0;) (type 0) (param i64)
    (local i32)
    global.get 1
    i32.eqz
    if ;; label = @1
      unreachable
    end
    global.get 1
    i32.const 1
    i32.sub
    global.set 1
    local.get 1
    local.tee 1
    global.get 0
    i32.xor
    global.set 0
  )
  (global (;0;) (mut i32) i32.const 0)
  (global (;1;) (mut i32) i32.const 1000)
  (export "\00\01\00" (func 0))
  (export "" (global 0))
)
```

I was able to narrow a repro case down to:

```wat
(module
  (func (;0;) (param i32) (result i32)
    (local i32)
    local.get 1
  )
  (export "t" (func 0))
)
```

This strongly hinted that there was a potential issue with locals when there is a param present.

In the area of code I have changed, `defined_locals.stack_size` may be an equal or lower value than `defined_locals_start` since `defined_locals_start` is set based on the number and type of parameters and `defined_locals.stack_size` is set based on the number and type of locals but not parameters. The range should be `defined_locals_start` to `defined_locals_start` plus `defined_locals.stack_size`.