### PR TITLE
mpk: temporarily disable to avoid CI failures

### DIFF
--- a/crates/runtime/src/mpk/pkru.rs
+++ b/crates/runtime/src/mpk/pkru.rs
@@ -56,6 +56,11 @@ pub fn write(pkru: u32) {
 /// Check the `ECX.PKU` flag (bit 3) of the `07h` `CPUID` leaf; see the
 /// Intel Software Development Manual, vol 3a, section 2.7.
 pub fn has_cpuid_bit_set() -> bool {
+    // TODO: disable MPK support until the following issue is resolved:
+    // https://github.com/bytecodealliance/wasmtime/issues/7445
+    if true {
+        return false;
+    }
     let result = unsafe { std::arch::x86_64::__cpuid(0x07) };
     (result.ecx & 0b100) != 0
 }


### PR DESCRIPTION
GitHub CI runners are showing some strange behavior: on certain runners (unknown which ones), the CPUID bits claim that MPK is supported, but running any MPK code (e.g., `RDPKRU`) causes a `SIGILL` crash. This change disables MPK until #7445 is resolved.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
