### PR TITLE
Validate the status code in outgoing-response

### DIFF
--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -17,7 +17,7 @@ struct T;
 impl bindings::exports::wasi::http::incoming_handler::Guest for T {
     fn handle(_request: IncomingRequest, outparam: ResponseOutparam) {
         let hdrs = bindings::wasi::http::types::Headers::new();
-        let resp = bindings::wasi::http::types::OutgoingResponse::new(200, hdrs);
+        let resp = bindings::wasi::http::types::OutgoingResponse::new(hdrs);
         let body = resp.body().expect("outgoing response");
 
         bindings::wasi::http::types::ResponseOutparam::set(outparam, Ok(resp));

--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -53,7 +53,6 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
             let mut results = stream::iter(results).buffer_unordered(MAX_CONCURRENCY);
 
             let response = OutgoingResponse::new(
-                200,
                 Fields::from_list(&[("content-type".to_string(), b"text/plain".to_vec())]).unwrap(),
             );
 
@@ -79,7 +78,6 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
             // Echo the request body without buffering it.
 
             let response = OutgoingResponse::new(
-                200,
                 Fields::from_list(
                     &headers
                         .into_iter()
@@ -129,7 +127,6 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
                         );
 
                         let response = OutgoingResponse::new(
-                            200,
                             Fields::from_list(
                                 &headers
                                     .into_iter()
@@ -242,7 +239,10 @@ fn method_not_allowed(response_out: ResponseOutparam) {
 }
 
 fn respond(status: u16, response_out: ResponseOutparam) {
-    let response = OutgoingResponse::new(status, Fields::new());
+    let response = OutgoingResponse::new(Fields::new());
+    response
+        .set_status_code(status)
+        .expect("setting status code");
 
     let body = response.body().expect("response should be writable");
 

--- a/crates/test-programs/src/bin/http_outbound_request_response_build.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_response_build.rs
@@ -27,7 +27,7 @@ fn main() {
             "application/text".to_string().into_bytes(),
         )])
         .unwrap();
-        let response = http_types::OutgoingResponse::new(200, headers);
+        let response = http_types::OutgoingResponse::new(headers);
         let outgoing_body = response.body().unwrap();
         let response_body = outgoing_body.write().unwrap();
         response_body

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -279,7 +279,7 @@ pub struct HostIncomingResponse {
 }
 
 pub struct HostOutgoingResponse {
-    pub status: u16,
+    pub status: http::StatusCode,
     pub headers: FieldMap,
     pub body: Option<HyperOutgoingBody>,
 }

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -351,16 +351,18 @@ interface types {
   /// Represents an outgoing HTTP Response.
   resource outgoing-response {
 
-    /// Construct an `outgoing-response`.
+    /// Construct an `outgoing-response`, with a default `status-code` of `200`.
+    /// If a different `status-code` is needed, it must be set via the
+    /// `set-status-code` method.
     ///
-    /// * `status-code` is the HTTP Status Code for the Response.
     /// * `headers` is the HTTP Headers for the Response.
-    constructor(status-code: status-code, headers: headers);
+    constructor(headers: headers);
 
     /// Get the HTTP Status Code for the Response.
     status-code: func() -> status-code;
+
     /// Set the HTTP Status Code for the Response.
-    set-status-code: func(status-code: status-code);
+    set-status-code: func(status-code: status-code) -> result<_, error>;
 
     /// Get the headers associated with the Request.
     ///

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -351,16 +351,18 @@ interface types {
   /// Represents an outgoing HTTP Response.
   resource outgoing-response {
 
-    /// Construct an `outgoing-response`.
+    /// Construct an `outgoing-response`, with a default `status-code` of `200`.
+    /// If a different `status-code` is needed, it must be set via the
+    /// `set-status-code` method.
     ///
-    /// * `status-code` is the HTTP Status Code for the Response.
     /// * `headers` is the HTTP Headers for the Response.
-    constructor(status-code: status-code, headers: headers);
+    constructor(headers: headers);
 
     /// Get the HTTP Status Code for the Response.
     status-code: func() -> status-code;
+
     /// Set the HTTP Status Code for the Response.
-    set-status-code: func(status-code: status-code);
+    set-status-code: func(status-code: status-code) -> result<_, error>;
 
     /// Get the headers associated with the Request.
     ///


### PR DESCRIPTION
Validate the `status-code` given to `outoging-reponse` in wasi-http. This forces two changes to the interface:

* The constructor can no longer take a `status-code` argument, as there's no way to indicate errors from a constructor. The solution here is to default the `status-code` to `200`, and use `outgoing-response.set-status-code` to change it when necessary.
* The `outgoing-response.set-status-code` method has become fallible, allowing us to indicate to the guest when an invalid `status-code` has been given.

Internally, the change to the wasmtime-wasi-http crate is that we're now storing an `http::StatusCode` instead of a raw `u16`.

cc @JakeChampion 
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
