### PR TITLE
popcnt should check for sse4.2 support in Winch

### DIFF
--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -773,7 +773,10 @@ impl Assembler {
     }
 
     pub fn popcnt(&mut self, src: Reg, size: OperandSize) {
-        assert!(self.isa_flags.has_popcnt(), "Requires has_popcnt flag");
+        assert!(
+            self.isa_flags.has_popcnt() && self.isa_flags.has_sse42(),
+            "Requires has_popcnt and has_sse42 flags"
+        );
         self.emit(Inst::UnaryRmR {
             size: size.into(),
             op: args::UnaryRmROpcode::Popcnt,

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -799,7 +799,7 @@ impl Masm for MacroAssembler {
 
     fn popcnt(&mut self, context: &mut CodeGenContext, size: OperandSize) {
         let src = context.pop_to_reg(self, None);
-        if self.flags.has_popcnt() {
+        if self.flags.has_popcnt() && self.flags.has_sse42() {
             self.asm.popcnt(src.into(), size);
             context.stack.push(src.into());
         } else {

--- a/winch/filetests/filetests/x64/i32_popcnt/no_sse42.wat
+++ b/winch/filetests/filetests/x64/i32_popcnt/no_sse42.wat
@@ -1,0 +1,33 @@
+;;! target = "x86_64"
+;;! flags = ["has_popcnt"]
+
+(module
+    (func (result i32)
+      i32.const 3
+      i32.popcnt
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b803000000           	mov	eax, 3
+;;   11:	 89c1                 	mov	ecx, eax
+;;   13:	 c1e801               	shr	eax, 1
+;;   16:	 81e055555555         	and	eax, 0x55555555
+;;   1c:	 29c1                 	sub	ecx, eax
+;;   1e:	 89c8                 	mov	eax, ecx
+;;   20:	 41bb33333333         	mov	r11d, 0x33333333
+;;   26:	 4421d8               	and	eax, r11d
+;;   29:	 c1e902               	shr	ecx, 2
+;;   2c:	 4421d9               	and	ecx, r11d
+;;   2f:	 01c1                 	add	ecx, eax
+;;   31:	 89c8                 	mov	eax, ecx
+;;   33:	 c1e804               	shr	eax, 4
+;;   36:	 01c8                 	add	eax, ecx
+;;   38:	 81e00f0f0f0f         	and	eax, 0xf0f0f0f
+;;   3e:	 69c001010101         	imul	eax, eax, 0x1010101
+;;   44:	 c1e818               	shr	eax, 0x18
+;;   47:	 4883c408             	add	rsp, 8
+;;   4b:	 5d                   	pop	rbp
+;;   4c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_popcnt/no_sse42.wat
+++ b/winch/filetests/filetests/x64/i64_popcnt/no_sse42.wat
@@ -1,0 +1,40 @@
+;;! target = "x86_64"
+;;! flags = ["has_popcnt"]
+
+(module
+    (func (result i64)
+      i64.const 3
+      i64.popcnt
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c003000000       	mov	rax, 3
+;;   13:	 4889c1               	mov	rcx, rax
+;;   16:	 48c1e801             	shr	rax, 1
+;;   1a:	 49bb5555555555555555 	
+;; 				movabs	r11, 0x5555555555555555
+;;   24:	 4c21d8               	and	rax, r11
+;;   27:	 4829c1               	sub	rcx, rax
+;;   2a:	 4889c8               	mov	rax, rcx
+;;   2d:	 49bb3333333333333333 	
+;; 				movabs	r11, 0x3333333333333333
+;;   37:	 4c21d8               	and	rax, r11
+;;   3a:	 48c1e902             	shr	rcx, 2
+;;   3e:	 4c21d9               	and	rcx, r11
+;;   41:	 4801c1               	add	rcx, rax
+;;   44:	 4889c8               	mov	rax, rcx
+;;   47:	 48c1e804             	shr	rax, 4
+;;   4b:	 4801c8               	add	rax, rcx
+;;   4e:	 49bb0f0f0f0f0f0f0f0f 	
+;; 				movabs	r11, 0xf0f0f0f0f0f0f0f
+;;   58:	 4c21d8               	and	rax, r11
+;;   5b:	 49bb0101010101010101 	
+;; 				movabs	r11, 0x101010101010101
+;;   65:	 490fafc3             	imul	rax, r11
+;;   69:	 48c1e838             	shr	rax, 0x38
+;;   6d:	 4883c408             	add	rsp, 8
+;;   71:	 5d                   	pop	rbp
+;;   72:	 c3                   	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
I noticed a failure in Winch's fuzzing with the following:

```wat
(module
  (type (;0;) (func (param i64) (result i64)))
  (func (;0;) (type 0) (param i64) (result i64)
    local.get 0
    i64.popcnt
  )
  (export "test" (func 0))
)
```

with a configuration where `has_popcnt` was set to `true` but `has_sse42` was set to `false` with an error message saying:

```
Cannot emit inst 'popcntq %rax, %rax' for target; failed to match ISA requirements: [Popcnt]
```

I was able to reproduce the error message with the two new file tests in this PR.

Adding a check in the macroassember to use the fallback if either flag is missing appears to resolve the issue.