### PR TITLE
wasi-http: Make all setters fallible

### DIFF
--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use bindings::wasi::http::types::{
     Fields, IncomingRequest, IncomingResponse, Method, OutgoingBody, OutgoingRequest,
     OutgoingResponse, ResponseOutparam, Scheme,
@@ -174,15 +174,26 @@ async fn double_echo(
     incoming_request: IncomingRequest,
     url: &Url,
 ) -> Result<(impl Future<Output = Result<()>>, IncomingResponse)> {
-    let outgoing_request = OutgoingRequest::new(
-        &Method::Post,
-        Some(url.path()),
-        Some(&match url.scheme() {
+    let outgoing_request = OutgoingRequest::new(Fields::new());
+
+    outgoing_request
+        .set_method(&Method::Post)
+        .context("method")?;
+
+    outgoing_request
+        .set_path_with_query(Some(url.path()))
+        .context("path_with_query")?;
+
+    outgoing_request
+        .set_scheme(Some(&match url.scheme() {
             "http" => Scheme::Http,
             "https" => Scheme::Https,
             scheme => Scheme::Other(scheme.into()),
-        }),
-        Some(&format!(
+        }))
+        .context("scheme")?;
+
+    outgoing_request
+        .set_authority(Some(&format!(
             "{}{}",
             url.host_str().unwrap_or(""),
             if let Some(port) = url.port() {
@@ -190,9 +201,8 @@ async fn double_echo(
             } else {
                 String::new()
             }
-        )),
-        Fields::new(),
-    );
+        )))
+        .context("authority")?;
 
     let mut body = executor::outgoing_body(
         outgoing_request
@@ -252,15 +262,20 @@ fn respond(status: u16, response_out: ResponseOutparam) {
 }
 
 async fn hash(url: &Url) -> Result<String> {
-    let request = OutgoingRequest::new(
-        &Method::Get,
-        Some(url.path()),
-        Some(&match url.scheme() {
+    let request = OutgoingRequest::new(Fields::new());
+
+    request
+        .set_path_with_query(Some(url.path()))
+        .context("path_with_query")?;
+    request
+        .set_scheme(Some(&match url.scheme() {
             "http" => Scheme::Http,
             "https" => Scheme::Https,
             scheme => Scheme::Other(scheme.into()),
-        }),
-        Some(&format!(
+        }))
+        .context("scheme")?;
+    request
+        .set_authority(Some(&format!(
             "{}{}",
             url.host_str().unwrap_or(""),
             if let Some(port) = url.port() {
@@ -268,9 +283,8 @@ async fn hash(url: &Url) -> Result<String> {
             } else {
                 String::new()
             }
-        )),
-        Fields::new(),
-    );
+        )))
+        .context("authority")?;
 
     let response = executor::outgoing_request_send(request).await?;
 

--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Context, Result};
+use anyhow::{anyhow, bail, Result};
 use bindings::wasi::http::types::{
     Fields, IncomingRequest, IncomingResponse, Method, OutgoingBody, OutgoingRequest,
     OutgoingResponse, ResponseOutparam, Scheme,
@@ -178,11 +178,11 @@ async fn double_echo(
 
     outgoing_request
         .set_method(&Method::Post)
-        .context("method")?;
+        .map_err(|()| anyhow!("failed to set method"))?;
 
     outgoing_request
         .set_path_with_query(Some(url.path()))
-        .context("path_with_query")?;
+        .map_err(|()| anyhow!("failed to set path_with_query"))?;
 
     outgoing_request
         .set_scheme(Some(&match url.scheme() {
@@ -190,7 +190,7 @@ async fn double_echo(
             "https" => Scheme::Https,
             scheme => Scheme::Other(scheme.into()),
         }))
-        .context("scheme")?;
+        .map_err(|()| anyhow!("failed to set scheme"))?;
 
     outgoing_request
         .set_authority(Some(&format!(
@@ -202,7 +202,7 @@ async fn double_echo(
                 String::new()
             }
         )))
-        .context("authority")?;
+        .map_err(|()| anyhow!("failed to set authority"))?;
 
     let mut body = executor::outgoing_body(
         outgoing_request
@@ -266,14 +266,14 @@ async fn hash(url: &Url) -> Result<String> {
 
     request
         .set_path_with_query(Some(url.path()))
-        .context("path_with_query")?;
+        .map_err(|()| anyhow!("failed to set path_with_query"))?;
     request
         .set_scheme(Some(&match url.scheme() {
             "http" => Scheme::Http,
             "https" => Scheme::Https,
             scheme => Scheme::Other(scheme.into()),
         }))
-        .context("scheme")?;
+        .map_err(|()| anyhow!("failed to set scheme"))?;
     request
         .set_authority(Some(&format!(
             "{}{}",
@@ -284,7 +284,7 @@ async fn hash(url: &Url) -> Result<String> {
                 String::new()
             }
         )))
-        .context("authority")?;
+        .map_err(|()| anyhow!("failed to set authority"))?;
 
     let response = executor::outgoing_request_send(request).await?;
 

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
@@ -1,10 +1,10 @@
-use test_programs::wasi::http::types::{HeaderError, Headers};
+use test_programs::wasi::http::types;
 
 fn main() {
-    let hdrs = Headers::new();
+    let hdrs = types::Headers::new();
     assert!(matches!(
         hdrs.append(&"malformed header name".to_owned(), &b"ok value".to_vec()),
-        Err(HeaderError::InvalidSyntax)
+        Err(types::ValidationError::InvalidSyntax)
     ));
 
     assert!(matches!(
@@ -14,17 +14,17 @@ fn main() {
 
     assert!(matches!(
         hdrs.append(&"ok-header-name".to_owned(), &b"bad\nvalue".to_vec()),
-        Err(HeaderError::InvalidSyntax)
+        Err(types::ValidationError::InvalidSyntax)
     ));
 
     assert!(matches!(
         hdrs.append(&"Connection".to_owned(), &b"keep-alive".to_vec()),
-        Err(HeaderError::Forbidden)
+        Err(types::ValidationError::Forbidden)
     ));
 
     assert!(matches!(
         hdrs.append(&"Keep-Alive".to_owned(), &b"stuff".to_vec()),
-        Err(HeaderError::Forbidden)
+        Err(types::ValidationError::Forbidden)
     ));
 
     assert!(matches!(
@@ -32,7 +32,7 @@ fn main() {
             &"custom-forbidden-header".to_owned(),
             &b"keep-alive".to_vec()
         ),
-        Err(HeaderError::Forbidden)
+        Err(types::ValidationError::Forbidden)
     ));
 
     assert!(matches!(
@@ -40,21 +40,21 @@ fn main() {
             &"Custom-Forbidden-Header".to_owned(),
             &b"keep-alive".to_vec()
         ),
-        Err(HeaderError::Forbidden)
+        Err(types::ValidationError::Forbidden)
     ));
 
     assert!(matches!(
-        Headers::from_list(&[("bad header".to_owned(), b"value".to_vec())]),
-        Err(HeaderError::InvalidSyntax)
+        types::Headers::from_list(&[("bad header".to_owned(), b"value".to_vec())]),
+        Err(types::ValidationError::InvalidSyntax)
     ));
 
     assert!(matches!(
-        Headers::from_list(&[("custom-forbidden-header".to_owned(), b"value".to_vec())]),
-        Err(HeaderError::Forbidden)
+        types::Headers::from_list(&[("custom-forbidden-header".to_owned(), b"value".to_vec())]),
+        Err(types::ValidationError::Forbidden)
     ));
 
     assert!(matches!(
-        Headers::from_list(&[("ok-header-name".to_owned(), b"bad\nvalue".to_vec())]),
-        Err(HeaderError::InvalidSyntax)
+        types::Headers::from_list(&[("ok-header-name".to_owned(), b"bad\nvalue".to_vec())]),
+        Err(types::ValidationError::InvalidSyntax)
     ));
 }

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
@@ -1,10 +1,10 @@
-use test_programs::wasi::http::types;
+use test_programs::wasi::http::types::{HeaderError, Headers};
 
 fn main() {
-    let hdrs = types::Headers::new();
+    let hdrs = Headers::new();
     assert!(matches!(
         hdrs.append(&"malformed header name".to_owned(), &b"ok value".to_vec()),
-        Err(types::ValidationError::InvalidSyntax)
+        Err(HeaderError::InvalidSyntax)
     ));
 
     assert!(matches!(
@@ -14,17 +14,17 @@ fn main() {
 
     assert!(matches!(
         hdrs.append(&"ok-header-name".to_owned(), &b"bad\nvalue".to_vec()),
-        Err(types::ValidationError::InvalidSyntax)
+        Err(HeaderError::InvalidSyntax)
     ));
 
     assert!(matches!(
         hdrs.append(&"Connection".to_owned(), &b"keep-alive".to_vec()),
-        Err(types::ValidationError::Forbidden)
+        Err(HeaderError::Forbidden)
     ));
 
     assert!(matches!(
         hdrs.append(&"Keep-Alive".to_owned(), &b"stuff".to_vec()),
-        Err(types::ValidationError::Forbidden)
+        Err(HeaderError::Forbidden)
     ));
 
     assert!(matches!(
@@ -32,7 +32,7 @@ fn main() {
             &"custom-forbidden-header".to_owned(),
             &b"keep-alive".to_vec()
         ),
-        Err(types::ValidationError::Forbidden)
+        Err(HeaderError::Forbidden)
     ));
 
     assert!(matches!(
@@ -40,21 +40,21 @@ fn main() {
             &"Custom-Forbidden-Header".to_owned(),
             &b"keep-alive".to_vec()
         ),
-        Err(types::ValidationError::Forbidden)
+        Err(HeaderError::Forbidden)
     ));
 
     assert!(matches!(
-        types::Headers::from_list(&[("bad header".to_owned(), b"value".to_vec())]),
-        Err(types::ValidationError::InvalidSyntax)
+        Headers::from_list(&[("bad header".to_owned(), b"value".to_vec())]),
+        Err(HeaderError::InvalidSyntax)
     ));
 
     assert!(matches!(
-        types::Headers::from_list(&[("custom-forbidden-header".to_owned(), b"value".to_vec())]),
-        Err(types::ValidationError::Forbidden)
+        Headers::from_list(&[("custom-forbidden-header".to_owned(), b"value".to_vec())]),
+        Err(HeaderError::Forbidden)
     ));
 
     assert!(matches!(
-        types::Headers::from_list(&[("ok-header-name".to_owned(), b"bad\nvalue".to_vec())]),
-        Err(types::ValidationError::InvalidSyntax)
+        Headers::from_list(&[("ok-header-name".to_owned(), b"bad\nvalue".to_vec())]),
+        Err(HeaderError::InvalidSyntax)
     ));
 }

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_port.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_port.rs
@@ -1,4 +1,4 @@
-use test_programs::wasi::http::types::{Method, Scheme, ValidationError};
+use test_programs::wasi::http::types::{Method, Scheme};
 
 fn main() {
     let res = test_programs::http::request(
@@ -10,8 +10,5 @@ fn main() {
         None,
     );
 
-    assert!(matches!(
-        res.unwrap_err().downcast(),
-        Ok(ValidationError::InvalidSyntax),
-    ));
+    assert!(res.is_err());
 }

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_port.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_port.rs
@@ -1,4 +1,4 @@
-use test_programs::wasi::http::types::{Method, Scheme};
+use test_programs::wasi::http::types::{Method, Scheme, ValidationError};
 
 fn main() {
     let res = test_programs::http::request(
@@ -10,9 +10,8 @@ fn main() {
         None,
     );
 
-    let error = res.unwrap_err();
-    assert_eq!(
-        error.to_string(),
-        "Error::InvalidUrl(\"invalid port value\")"
-    );
+    assert!(matches!(
+        res.unwrap_err().downcast(),
+        Ok(ValidationError::InvalidSyntax),
+    ));
 }

--- a/crates/test-programs/src/bin/http_outbound_request_response_build.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_response_build.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use test_programs::wasi::http::types as http_types;
 
 fn main() {
@@ -44,53 +43,19 @@ fn main() {
     {
         let req = http_types::OutgoingRequest::new(http_types::Fields::new());
 
-        assert!(matches!(
-            req.set_method(&http_types::Method::Other("invalid method".to_string()))
-                .context("invalid method")
-                .unwrap_err()
-                .downcast::<http_types::ValidationError>(),
-            Ok(http_types::ValidationError::InvalidSyntax)
-        ));
+        assert!(req
+            .set_method(&http_types::Method::Other("invalid method".to_string()))
+            .is_err());
 
-        assert!(matches!(
-            req.set_authority(Some("bad-port:99999"))
-                .context("bad port")
-                .unwrap_err()
-                .downcast::<http_types::ValidationError>(),
-            Ok(http_types::ValidationError::InvalidSyntax)
-        ));
+        assert!(req.set_authority(Some("bad-port:99999")).is_err());
+        assert!(req.set_authority(Some("bad-\nhost")).is_err());
+        assert!(req.set_authority(Some("too-many-ports:80:80:80")).is_err());
 
-        assert!(matches!(
-            req.set_authority(Some("bad-\nhost"))
-                .context("bad hostname")
-                .unwrap_err()
-                .downcast::<http_types::ValidationError>(),
-            Ok(http_types::ValidationError::InvalidSyntax)
-        ));
+        assert!(req
+            .set_scheme(Some(&http_types::Scheme::Other("bad\nscheme".to_string())))
+            .is_err());
 
-        assert!(matches!(
-            req.set_authority(Some("too-many-ports:80:80:80"))
-                .context("too many ports")
-                .unwrap_err()
-                .downcast::<http_types::ValidationError>(),
-            Ok(http_types::ValidationError::InvalidSyntax)
-        ));
-
-        assert!(matches!(
-            req.set_scheme(Some(&http_types::Scheme::Other("bad\nscheme".to_string())))
-                .context("bad scheme")
-                .unwrap_err()
-                .downcast::<http_types::ValidationError>(),
-            Ok(http_types::ValidationError::InvalidSyntax)
-        ));
-
-        assert!(matches!(
-            req.set_path_with_query(Some("/bad\npath"))
-                .context("bad path")
-                .unwrap_err()
-                .downcast::<http_types::ValidationError>(),
-            Ok(http_types::ValidationError::InvalidSyntax)
-        ));
+        assert!(req.set_path_with_query(Some("/bad\npath")).is_err());
     }
 
     println!("Done");

--- a/crates/test-programs/src/bin/http_outbound_request_response_build.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_response_build.rs
@@ -8,13 +8,18 @@ fn main() {
             "application/json".to_string().into_bytes(),
         )])
         .unwrap();
-        let request = http_types::OutgoingRequest::new(
-            &http_types::Method::Get,
-            None,
-            Some(&http_types::Scheme::Https),
-            Some("www.example.com"),
-            headers,
-        );
+        let request = http_types::OutgoingRequest::new(headers);
+
+        request
+            .set_method(&http_types::Method::Get)
+            .expect("setting method");
+        request
+            .set_scheme(Some(&http_types::Scheme::Https))
+            .expect("setting scheme");
+        request
+            .set_authority(Some("www.example.com"))
+            .expect("setting authority");
+
         let outgoing_body = request.body().unwrap();
         let request_body = outgoing_body.write().unwrap();
         request_body

--- a/crates/test-programs/src/http.rs
+++ b/crates/test-programs/src/http.rs
@@ -1,6 +1,6 @@
 use crate::wasi::http::{outgoing_handler, types as http_types};
 use crate::wasi::io::streams;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Result};
 use std::fmt;
 
 pub struct Response {
@@ -54,14 +54,18 @@ pub fn request(
 
     let request = http_types::OutgoingRequest::new(headers);
 
-    request.set_method(&method).context("method")?;
-    request.set_scheme(Some(&scheme)).context("scheme")?;
+    request
+        .set_method(&method)
+        .map_err(|()| anyhow!("failed to set method"))?;
+    request
+        .set_scheme(Some(&scheme))
+        .map_err(|()| anyhow!("failed to set scheme"))?;
     request
         .set_authority(Some(authority))
-        .context("authority")?;
+        .map_err(|()| anyhow!("failed to set authority"))?;
     request
         .set_path_with_query(Some(&path_with_query))
-        .context("path_with_query")?;
+        .map_err(|()| anyhow!("failed to set path_with_query"))?;
 
     let outgoing_body = request
         .body()

--- a/crates/test-programs/src/http.rs
+++ b/crates/test-programs/src/http.rs
@@ -1,6 +1,6 @@
 use crate::wasi::http::{outgoing_handler, types as http_types};
 use crate::wasi::io::streams;
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use std::fmt;
 
 pub struct Response {
@@ -52,13 +52,16 @@ pub fn request(
         .concat(),
     )?;
 
-    let request = http_types::OutgoingRequest::new(
-        &method,
-        Some(path_with_query),
-        Some(&scheme),
-        Some(authority),
-        headers,
-    );
+    let request = http_types::OutgoingRequest::new(headers);
+
+    request.set_method(&method).context("method")?;
+    request.set_scheme(Some(&scheme)).context("scheme")?;
+    request
+        .set_authority(Some(authority))
+        .context("authority")?;
+    request
+        .set_path_with_query(Some(&path_with_query))
+        .context("path_with_query")?;
 
     let outgoing_body = request
         .body()

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -1,5 +1,5 @@
 use crate::bindings::http::types::{
-    self, Error, HeaderError, Headers, Method, Scheme, StatusCode, Trailers,
+    self, Error, Headers, Method, Scheme, StatusCode, Trailers,
 };
 use crate::body::{FinishMessage, HostFutureTrailers};
 use crate::types::{HostIncomingRequest, HostOutgoingResponse};
@@ -85,22 +85,22 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFields for T {
     fn from_list(
         &mut self,
         entries: Vec<(String, Vec<u8>)>,
-    ) -> wasmtime::Result<Result<Resource<HostFields>, HeaderError>> {
+    ) -> wasmtime::Result<Result<Resource<HostFields>, types::ValidationError>> {
         let mut map = hyper::HeaderMap::new();
 
         for (header, value) in entries {
             let header = match hyper::header::HeaderName::from_bytes(header.as_bytes()) {
                 Ok(header) => header,
-                Err(_) => return Ok(Err(HeaderError::InvalidSyntax)),
+                Err(_) => return Ok(Err(types::ValidationError::InvalidSyntax)),
             };
 
             if is_forbidden_header(self, &header) {
-                return Ok(Err(HeaderError::Forbidden));
+                return Ok(Err(types::ValidationError::Forbidden));
             }
 
             let value = match hyper::header::HeaderValue::from_bytes(&value) {
                 Ok(value) => value,
-                Err(_) => return Ok(Err(HeaderError::InvalidSyntax)),
+                Err(_) => return Ok(Err(types::ValidationError::InvalidSyntax)),
             };
 
             map.append(header, value);
@@ -145,21 +145,21 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFields for T {
         fields: Resource<HostFields>,
         name: String,
         byte_values: Vec<Vec<u8>>,
-    ) -> wasmtime::Result<Result<(), HeaderError>> {
+    ) -> wasmtime::Result<Result<(), types::ValidationError>> {
         let header = match hyper::header::HeaderName::from_bytes(name.as_bytes()) {
             Ok(header) => header,
-            Err(_) => return Ok(Err(HeaderError::InvalidSyntax)),
+            Err(_) => return Ok(Err(types::ValidationError::InvalidSyntax)),
         };
 
         if is_forbidden_header(self, &header) {
-            return Ok(Err(HeaderError::Forbidden));
+            return Ok(Err(types::ValidationError::Forbidden));
         }
 
         let mut values = Vec::with_capacity(byte_values.len());
         for value in byte_values {
             match hyper::header::HeaderValue::from_bytes(&value) {
                 Ok(value) => values.push(value),
-                Err(_) => return Ok(Err(HeaderError::InvalidSyntax)),
+                Err(_) => return Ok(Err(types::ValidationError::InvalidSyntax)),
             }
         }
 
@@ -189,19 +189,19 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFields for T {
         fields: Resource<HostFields>,
         name: String,
         value: Vec<u8>,
-    ) -> wasmtime::Result<Result<(), HeaderError>> {
+    ) -> wasmtime::Result<Result<(), types::ValidationError>> {
         let header = match hyper::header::HeaderName::from_bytes(name.as_bytes()) {
             Ok(header) => header,
-            Err(_) => return Ok(Err(HeaderError::InvalidSyntax)),
+            Err(_) => return Ok(Err(types::ValidationError::InvalidSyntax)),
         };
 
         if is_forbidden_header(self, &header) {
-            return Ok(Err(HeaderError::Forbidden));
+            return Ok(Err(types::ValidationError::Forbidden));
         }
 
         let value = match hyper::header::HeaderValue::from_bytes(&value) {
             Ok(value) => value,
-            Err(_) => return Ok(Err(HeaderError::InvalidSyntax)),
+            Err(_) => return Ok(Err(types::ValidationError::InvalidSyntax)),
         };
 
         let m = get_fields_mut(self.table(), &fields)

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -1,17 +1,16 @@
-use crate::bindings::http::types::{self, Error, Headers, Method, Scheme, StatusCode, Trailers};
-use crate::body::{FinishMessage, HostFutureTrailers, HostFutureTrailersState};
-use crate::types::{HostIncomingRequest, HostOutgoingResponse};
-use crate::WasiHttpView;
 use crate::{
-    body::{HostIncomingBody, HostOutgoingBody},
+    bindings::http::types::{self, Error, Headers, Method, Scheme, StatusCode, Trailers},
+    body::{FinishMessage, HostFutureTrailers, HostIncomingBody, HostOutgoingBody},
     types::{
-        FieldMap, HostFields, HostFutureIncomingResponse, HostIncomingResponse,
-        HostOutgoingRequest, HostResponseOutparam,
+        FieldMap, HostFields, HostFutureIncomingResponse, HostIncomingRequest,
+        HostIncomingResponse, HostOutgoingRequest, HostOutgoingResponse, HostResponseOutparam,
     },
+    WasiHttpView,
 };
 use anyhow::Context;
 use hyper::header::HeaderName;
 use std::any::Any;
+use std::str::FromStr;
 use wasmtime::component::Resource;
 use wasmtime_wasi::preview2::{
     bindings::io::streams::{InputStream, OutputStream},

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -37,10 +37,14 @@ interface types {
     unexpected-error(string)
   }
 
-  /// This tyep enumerates the different kinds of errors that may occur when
-  /// setting or appending to a `fields` resource.
-  variant header-error {
+  /// This type enumerates the different kinds of errors that may occur when
+  /// validating arguments to setters.
+  variant validation-error {
+    /// This error indicates that the value given to a setter was syntactically
+    /// invalid.
     invalid-syntax,
+
+    /// This error indicates that a value given to a setter was forbidden.
     forbidden,
   }
 
@@ -75,7 +79,7 @@ interface types {
     /// syntactically invalid, or if a header was forbidden.
     from-list: static func(
       entries: list<tuple<field-key,field-value>>
-    ) -> result<fields, header-error>;
+    ) -> result<fields, validation-error>;
 
     /// Get all of the values corresponding to a key.
     get: func(name: field-key) -> list<field-value>;
@@ -85,7 +89,7 @@ interface types {
     ///
     /// The operation can fail if the name or value arguments are invalid, or if
     /// the name is forbidden.
-    set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
+    set: func(name: field-key, value: list<field-value>) -> result<_, validation-error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
@@ -96,7 +100,7 @@ interface types {
     ///
     /// The operation can fail if the name or value arguments are invalid, or if
     /// the name is forbidden.
-    append: func(name: field-key, value: field-value) -> result<_, header-error>;
+    append: func(name: field-key, value: field-value) -> result<_, validation-error>;
 
 
     /// Retrieve the full set of keys and values in the Fields. Like the

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -37,14 +37,10 @@ interface types {
     unexpected-error(string)
   }
 
-  /// This type enumerates the different kinds of errors that may occur when
-  /// validating arguments to setters.
-  variant validation-error {
-    /// This error indicates that the value given to a setter was syntactically
-    /// invalid.
+  /// This tyep enumerates the different kinds of errors that may occur when
+  /// setting or appending to a `fields` resource.
+  variant header-error {
     invalid-syntax,
-
-    /// This error indicates that a value given to a setter was forbidden.
     forbidden,
   }
 
@@ -79,7 +75,7 @@ interface types {
     /// syntactically invalid, or if a header was forbidden.
     from-list: static func(
       entries: list<tuple<field-key,field-value>>
-    ) -> result<fields, validation-error>;
+    ) -> result<fields, header-error>;
 
     /// Get all of the values corresponding to a key.
     get: func(name: field-key) -> list<field-value>;
@@ -89,7 +85,7 @@ interface types {
     ///
     /// The operation can fail if the name or value arguments are invalid, or if
     /// the name is forbidden.
-    set: func(name: field-key, value: list<field-value>) -> result<_, validation-error>;
+    set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
@@ -100,7 +96,7 @@ interface types {
     ///
     /// The operation can fail if the name or value arguments are invalid, or if
     /// the name is forbidden.
-    append: func(name: field-key, value: field-value) -> result<_, validation-error>;
+    append: func(name: field-key, value: field-value) -> result<_, header-error>;
 
 
     /// Retrieve the full set of keys and values in the Fields. Like the
@@ -177,23 +173,21 @@ interface types {
     /// Get the Method for the Request.
     method: func() -> method;
     /// Set the Method for the Request.
-    set-method: func(method: method) -> result<_, validation-error>;
+    set-method: func(method: method) -> result;
 
     /// Get the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
     path-with-query: func() -> option<string>;
     /// Set the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
-    set-path-with-query: func(
-      path-with-query: option<string>
-    ) -> result<_, validation-error>;
+    set-path-with-query: func( path-with-query: option<string>) -> result;
 
     /// Get the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
     scheme: func() -> option<scheme>;
     /// Set the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
-    set-scheme: func(scheme: option<scheme>) -> result<_, validation-error>;
+    set-scheme: func(scheme: option<scheme>) -> result;
 
     /// Get the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
@@ -202,9 +196,7 @@ interface types {
     /// Set the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
     /// HTTPS schemes always require an authority.
-    set-authority: func(
-      authority: option<string>
-    ) -> result<_, validation-error>;
+    set-authority: func(authority: option<string>) -> result;
 
     /// Get the headers associated with the Request.
     ///
@@ -358,7 +350,7 @@ interface types {
     status-code: func() -> status-code;
 
     /// Set the HTTP Status Code for the Response.
-    set-status-code: func(status-code: status-code) -> result<_, validation-error>;
+    set-status-code: func(status-code: status-code) -> result;
 
     /// Get the headers associated with the Request.
     ///

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -152,17 +152,9 @@ interface types {
   /// Represents an outgoing HTTP Request.
   resource outgoing-request {
 
-    /// Construct a new `outgoing-request`.
+    /// Construct a new `outgoing-request` with a default `method` of `GET`, and
+    /// default values for `path-with-query`, `scheme`, and `authority.
     ///
-    /// * `method` represents the HTTP Method for the Request.
-    /// * `path-with-query` is the combination of the HTTP Path and Query for
-    ///    the Request. When `none`, this represents an empty Path and empty
-    ///    Query.
-    /// * `scheme` is the HTTP Related Scheme for the Request. When `none`,
-    ///    the implementation may choose an appropriate default scheme.
-    /// * `authority` is the HTTP Authority for the Request. A value of `none`
-    ///    may be used with Related Schemes which do not require an Authority.
-    ///    The HTTP and HTTPS schemes always require an authority.
     /// * `headers` is the HTTP Headers for the Request.
     ///
     /// It is possible to construct, or manipulate with the accessor functions
@@ -171,10 +163,6 @@ interface types {
     /// It is the obligation of the `outgoing-handler.handle` implementation
     /// to reject invalid constructions of `outgoing-request`.
     constructor(
-      method: method,
-      path-with-query: option<string>,
-      scheme: option<scheme>,
-      authority: option<string>,
       headers: headers
     );
 
@@ -189,21 +177,23 @@ interface types {
     /// Get the Method for the Request.
     method: func() -> method;
     /// Set the Method for the Request.
-    set-method: func(method: method);
+    set-method: func(method: method) -> result<_, validation-error>;
 
     /// Get the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
     path-with-query: func() -> option<string>;
     /// Set the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
-    set-path-with-query: func(path-with-query: option<string>);
+    set-path-with-query: func(
+      path-with-query: option<string>
+    ) -> result<_, validation-error>;
 
     /// Get the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
     scheme: func() -> option<scheme>;
     /// Set the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
-    set-scheme: func(scheme: option<scheme>);
+    set-scheme: func(scheme: option<scheme>) -> result<_, validation-error>;
 
     /// Get the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
@@ -212,7 +202,9 @@ interface types {
     /// Set the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
     /// HTTPS schemes always require an authority.
-    set-authority: func(authority: option<string>);
+    set-authority: func(
+      authority: option<string>
+    ) -> result<_, validation-error>;
 
     /// Get the headers associated with the Request.
     ///
@@ -366,7 +358,7 @@ interface types {
     status-code: func() -> status-code;
 
     /// Set the HTTP Status Code for the Response.
-    set-status-code: func(status-code: status-code) -> result<_, error>;
+    set-status-code: func(status-code: status-code) -> result<_, validation-error>;
 
     /// Get the headers associated with the Request.
     ///

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -172,21 +172,24 @@ interface types {
 
     /// Get the Method for the Request.
     method: func() -> method;
-    /// Set the Method for the Request.
+    /// Set the Method for the Request. Fails if the string present in a
+    /// `method.other` argument is not a syntactically valid method.
     set-method: func(method: method) -> result;
 
     /// Get the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
     path-with-query: func() -> option<string>;
     /// Set the combination of the HTTP Path and Query for the Request.
-    /// When `none`, this represents an empty Path and empty Query.
-    set-path-with-query: func( path-with-query: option<string>) -> result;
+    /// When `none`, this represents an empty Path and empty Query. Fails is the
+    /// string given is not a syntactically valid path and query uri component.
+    set-path-with-query: func(path-with-query: option<string>) -> result;
 
     /// Get the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
     scheme: func() -> option<scheme>;
     /// Set the HTTP Related Scheme for the Request. When `none`, the
-    /// implementation may choose an appropriate default scheme.
+    /// implementation may choose an appropriate default scheme. Fails if the
+    /// string given is not a syntactically valid uri scheme.
     set-scheme: func(scheme: option<scheme>) -> result;
 
     /// Get the HTTP Authority for the Request. A value of `none` may be used
@@ -195,7 +198,8 @@ interface types {
     authority: func() -> option<string>;
     /// Set the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
-    /// HTTPS schemes always require an authority.
+    /// HTTPS schemes always require an authority. Fails if the string given is
+    /// not a syntactically valid uri authority.
     set-authority: func(authority: option<string>) -> result;
 
     /// Get the headers associated with the Request.
@@ -349,7 +353,8 @@ interface types {
     /// Get the HTTP Status Code for the Response.
     status-code: func() -> status-code;
 
-    /// Set the HTTP Status Code for the Response.
+    /// Set the HTTP Status Code for the Response. Fails if the status-code
+    /// given is not a valid http status code.
     set-status-code: func(status-code: status-code) -> result;
 
     /// Get the headers associated with the Request.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -37,10 +37,14 @@ interface types {
     unexpected-error(string)
   }
 
-  /// This tyep enumerates the different kinds of errors that may occur when
-  /// setting or appending to a `fields` resource.
-  variant header-error {
+  /// This type enumerates the different kinds of errors that may occur when
+  /// validating arguments to setters.
+  variant validation-error {
+    /// This error indicates that the value given to a setter was syntactically
+    /// invalid.
     invalid-syntax,
+
+    /// This error indicates that a value given to a setter was forbidden.
     forbidden,
   }
 
@@ -75,7 +79,7 @@ interface types {
     /// syntactically invalid, or if a header was forbidden.
     from-list: static func(
       entries: list<tuple<field-key,field-value>>
-    ) -> result<fields, header-error>;
+    ) -> result<fields, validation-error>;
 
     /// Get all of the values corresponding to a key.
     get: func(name: field-key) -> list<field-value>;
@@ -85,7 +89,7 @@ interface types {
     ///
     /// The operation can fail if the name or value arguments are invalid, or if
     /// the name is forbidden.
-    set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
+    set: func(name: field-key, value: list<field-value>) -> result<_, validation-error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
@@ -96,7 +100,7 @@ interface types {
     ///
     /// The operation can fail if the name or value arguments are invalid, or if
     /// the name is forbidden.
-    append: func(name: field-key, value: field-value) -> result<_, header-error>;
+    append: func(name: field-key, value: field-value) -> result<_, validation-error>;
 
 
     /// Retrieve the full set of keys and values in the Fields. Like the

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -37,14 +37,10 @@ interface types {
     unexpected-error(string)
   }
 
-  /// This type enumerates the different kinds of errors that may occur when
-  /// validating arguments to setters.
-  variant validation-error {
-    /// This error indicates that the value given to a setter was syntactically
-    /// invalid.
+  /// This tyep enumerates the different kinds of errors that may occur when
+  /// setting or appending to a `fields` resource.
+  variant header-error {
     invalid-syntax,
-
-    /// This error indicates that a value given to a setter was forbidden.
     forbidden,
   }
 
@@ -79,7 +75,7 @@ interface types {
     /// syntactically invalid, or if a header was forbidden.
     from-list: static func(
       entries: list<tuple<field-key,field-value>>
-    ) -> result<fields, validation-error>;
+    ) -> result<fields, header-error>;
 
     /// Get all of the values corresponding to a key.
     get: func(name: field-key) -> list<field-value>;
@@ -89,7 +85,7 @@ interface types {
     ///
     /// The operation can fail if the name or value arguments are invalid, or if
     /// the name is forbidden.
-    set: func(name: field-key, value: list<field-value>) -> result<_, validation-error>;
+    set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
@@ -100,7 +96,7 @@ interface types {
     ///
     /// The operation can fail if the name or value arguments are invalid, or if
     /// the name is forbidden.
-    append: func(name: field-key, value: field-value) -> result<_, validation-error>;
+    append: func(name: field-key, value: field-value) -> result<_, header-error>;
 
 
     /// Retrieve the full set of keys and values in the Fields. Like the
@@ -177,23 +173,21 @@ interface types {
     /// Get the Method for the Request.
     method: func() -> method;
     /// Set the Method for the Request.
-    set-method: func(method: method) -> result<_, validation-error>;
+    set-method: func(method: method) -> result;
 
     /// Get the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
     path-with-query: func() -> option<string>;
     /// Set the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
-    set-path-with-query: func(
-      path-with-query: option<string>
-    ) -> result<_, validation-error>;
+    set-path-with-query: func( path-with-query: option<string>) -> result;
 
     /// Get the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
     scheme: func() -> option<scheme>;
     /// Set the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
-    set-scheme: func(scheme: option<scheme>) -> result<_, validation-error>;
+    set-scheme: func(scheme: option<scheme>) -> result;
 
     /// Get the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
@@ -202,9 +196,7 @@ interface types {
     /// Set the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
     /// HTTPS schemes always require an authority.
-    set-authority: func(
-      authority: option<string>
-    ) -> result<_, validation-error>;
+    set-authority: func(authority: option<string>) -> result;
 
     /// Get the headers associated with the Request.
     ///
@@ -358,7 +350,7 @@ interface types {
     status-code: func() -> status-code;
 
     /// Set the HTTP Status Code for the Response.
-    set-status-code: func(status-code: status-code) -> result<_, validation-error>;
+    set-status-code: func(status-code: status-code) -> result;
 
     /// Get the headers associated with the Request.
     ///

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -152,17 +152,9 @@ interface types {
   /// Represents an outgoing HTTP Request.
   resource outgoing-request {
 
-    /// Construct a new `outgoing-request`.
+    /// Construct a new `outgoing-request` with a default `method` of `GET`, and
+    /// default values for `path-with-query`, `scheme`, and `authority.
     ///
-    /// * `method` represents the HTTP Method for the Request.
-    /// * `path-with-query` is the combination of the HTTP Path and Query for
-    ///    the Request. When `none`, this represents an empty Path and empty
-    ///    Query.
-    /// * `scheme` is the HTTP Related Scheme for the Request. When `none`,
-    ///    the implementation may choose an appropriate default scheme.
-    /// * `authority` is the HTTP Authority for the Request. A value of `none`
-    ///    may be used with Related Schemes which do not require an Authority.
-    ///    The HTTP and HTTPS schemes always require an authority.
     /// * `headers` is the HTTP Headers for the Request.
     ///
     /// It is possible to construct, or manipulate with the accessor functions
@@ -171,10 +163,6 @@ interface types {
     /// It is the obligation of the `outgoing-handler.handle` implementation
     /// to reject invalid constructions of `outgoing-request`.
     constructor(
-      method: method,
-      path-with-query: option<string>,
-      scheme: option<scheme>,
-      authority: option<string>,
       headers: headers
     );
 
@@ -189,21 +177,23 @@ interface types {
     /// Get the Method for the Request.
     method: func() -> method;
     /// Set the Method for the Request.
-    set-method: func(method: method);
+    set-method: func(method: method) -> result<_, validation-error>;
 
     /// Get the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
     path-with-query: func() -> option<string>;
     /// Set the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
-    set-path-with-query: func(path-with-query: option<string>);
+    set-path-with-query: func(
+      path-with-query: option<string>
+    ) -> result<_, validation-error>;
 
     /// Get the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
     scheme: func() -> option<scheme>;
     /// Set the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
-    set-scheme: func(scheme: option<scheme>);
+    set-scheme: func(scheme: option<scheme>) -> result<_, validation-error>;
 
     /// Get the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
@@ -212,7 +202,9 @@ interface types {
     /// Set the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
     /// HTTPS schemes always require an authority.
-    set-authority: func(authority: option<string>);
+    set-authority: func(
+      authority: option<string>
+    ) -> result<_, validation-error>;
 
     /// Get the headers associated with the Request.
     ///
@@ -366,7 +358,7 @@ interface types {
     status-code: func() -> status-code;
 
     /// Set the HTTP Status Code for the Response.
-    set-status-code: func(status-code: status-code) -> result<_, error>;
+    set-status-code: func(status-code: status-code) -> result<_, validation-error>;
 
     /// Get the headers associated with the Request.
     ///

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -172,21 +172,24 @@ interface types {
 
     /// Get the Method for the Request.
     method: func() -> method;
-    /// Set the Method for the Request.
+    /// Set the Method for the Request. Fails if the string present in a
+    /// `method.other` argument is not a syntactically valid method.
     set-method: func(method: method) -> result;
 
     /// Get the combination of the HTTP Path and Query for the Request.
     /// When `none`, this represents an empty Path and empty Query.
     path-with-query: func() -> option<string>;
     /// Set the combination of the HTTP Path and Query for the Request.
-    /// When `none`, this represents an empty Path and empty Query.
-    set-path-with-query: func( path-with-query: option<string>) -> result;
+    /// When `none`, this represents an empty Path and empty Query. Fails is the
+    /// string given is not a syntactically valid path and query uri component.
+    set-path-with-query: func(path-with-query: option<string>) -> result;
 
     /// Get the HTTP Related Scheme for the Request. When `none`, the
     /// implementation may choose an appropriate default scheme.
     scheme: func() -> option<scheme>;
     /// Set the HTTP Related Scheme for the Request. When `none`, the
-    /// implementation may choose an appropriate default scheme.
+    /// implementation may choose an appropriate default scheme. Fails if the
+    /// string given is not a syntactically valid uri scheme.
     set-scheme: func(scheme: option<scheme>) -> result;
 
     /// Get the HTTP Authority for the Request. A value of `none` may be used
@@ -195,7 +198,8 @@ interface types {
     authority: func() -> option<string>;
     /// Set the HTTP Authority for the Request. A value of `none` may be used
     /// with Related Schemes which do not require an Authority. The HTTP and
-    /// HTTPS schemes always require an authority.
+    /// HTTPS schemes always require an authority. Fails if the string given is
+    /// not a syntactically valid uri authority.
     set-authority: func(authority: option<string>) -> result;
 
     /// Get the headers associated with the Request.
@@ -349,7 +353,8 @@ interface types {
     /// Get the HTTP Status Code for the Response.
     status-code: func() -> status-code;
 
-    /// Set the HTTP Status Code for the Response.
+    /// Set the HTTP Status Code for the Response. Fails if the status-code
+    /// given is not a valid http status code.
     set-status-code: func(status-code: status-code) -> result;
 
     /// Get the headers associated with the Request.


### PR DESCRIPTION
Rename the `header-error` variant to `validation-error`, and use that variant as the error value for all setters of `outbound-request` and `outbound-response`. This ensures that we have the opportunity to validate outbound request and response values before they're given to their respective handlers.

Validation for uri components is done by using `http:uri::Builder` with only that value, ensuring that we don't raise an error. Validation for method and scheme is only done for the `Other` cases, and is accomplished by using the fallible parsers for each type from the `http` crate.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
