### PR TITLE
Print the error from the wasi-http incoming-handler to stderr

### DIFF
--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -382,7 +382,7 @@ impl hyper::service::Service<Request> for ProxyHandler {
                 return Err(e);
             }
 
-            Ok::<_, anyhow::Error>(())
+            Ok(())
         });
 
         Box::pin(async move {

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -378,7 +378,7 @@ impl hyper::service::Service<Request> for ProxyHandler {
                 .call_handle(store, req, out)
                 .await
             {
-                eprint!("{:?}\n", e);
+                log::error!("[{req_id}] :: {:#?}", e);
                 return Err(e);
             }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -373,10 +373,14 @@ impl hyper::service::Service<Request> for ProxyHandler {
                 wasmtime_wasi_http::proxy::Proxy::instantiate_pre(&mut store, &inner.instance_pre)
                     .await?;
 
-            proxy
+            if let Err(e) = proxy
                 .wasi_http_incoming_handler()
                 .call_handle(store, req, out)
-                .await?;
+                .await
+            {
+                eprint!("{:?}\n", e);
+                return Err(e);
+            }
 
             Ok::<_, anyhow::Error>(())
         });


### PR DESCRIPTION
Prior to this change, the error was never printed out, making it a challenge to figure out what caused the error

