### PR TITLE
Add #[inline] to some trivial methods

### DIFF
--- a/crates/jit/src/code_memory.rs
+++ b/crates/jit/src/code_memory.rs
@@ -149,22 +149,26 @@ impl CodeMemory {
     }
 
     /// Returns a reference to the underlying `MmapVec` this memory owns.
+    #[inline]
     pub fn mmap(&self) -> &MmapVec {
         &self.mmap
     }
 
     /// Returns the contents of the text section of the ELF executable this
     /// represents.
+    #[inline]
     pub fn text(&self) -> &[u8] {
         &self.mmap[self.text.clone()]
     }
 
     /// Returns the contents of the `ELF_WASMTIME_DWARF` section.
+    #[inline]
     pub fn dwarf(&self) -> &[u8] {
         &self.mmap[self.dwarf.clone()]
     }
 
     /// Returns the data in the `ELF_NAME_DATA` section.
+    #[inline]
     pub fn func_name_data(&self) -> &[u8] {
         &self.mmap[self.func_name_data.clone()]
     }
@@ -174,24 +178,28 @@ impl CodeMemory {
     ///
     /// This is used for initialization of memories and all data ranges stored
     /// in a `Module` are relative to the slice returned here.
+    #[inline]
     pub fn wasm_data(&self) -> &[u8] {
         &self.mmap[self.wasm_data.clone()]
     }
 
     /// Returns the encoded address map section used to pass to
     /// `wasmtime_environ::lookup_file_pos`.
+    #[inline]
     pub fn address_map_data(&self) -> &[u8] {
         &self.mmap[self.address_map_data.clone()]
     }
 
     /// Returns the contents of the `ELF_WASMTIME_INFO` section, or an empty
     /// slice if it wasn't found.
+    #[inline]
     pub fn wasmtime_info(&self) -> &[u8] {
         &self.mmap[self.info_data.clone()]
     }
 
     /// Returns the contents of the `ELF_WASMTIME_TRAPS` section, or an empty
     /// slice if it wasn't found.
+    #[inline]
     pub fn trap_data(&self) -> &[u8] {
         &self.mmap[self.trap_data.clone()]
     }

--- a/crates/runtime/src/mmap.rs
+++ b/crates/runtime/src/mmap.rs
@@ -146,11 +146,13 @@ impl Mmap {
     }
 
     /// Return the allocated memory as a pointer to u8.
+    #[inline]
     pub fn as_ptr(&self) -> *const u8 {
         self.sys.as_ptr()
     }
 
     /// Return the allocated memory as a mutable pointer to u8.
+    #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.sys.as_mut_ptr()
     }
@@ -159,6 +161,7 @@ impl Mmap {
     ///
     /// This is the byte length of this entire mapping which includes both
     /// addressible and non-addressible memory.
+    #[inline]
     pub fn len(&self) -> usize {
         self.sys.len()
     }

--- a/crates/runtime/src/mmap/unix.rs
+++ b/crates/runtime/src/mmap/unix.rs
@@ -84,14 +84,17 @@ impl Mmap {
         Ok(())
     }
 
+    #[inline]
     pub fn as_ptr(&self) -> *const u8 {
         self.memory.as_ptr() as *const u8
     }
 
+    #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.memory.as_ptr().cast()
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         unsafe { (*self.memory.as_ptr()).len() }
     }

--- a/crates/runtime/src/mmap/windows.rs
+++ b/crates/runtime/src/mmap/windows.rs
@@ -147,14 +147,17 @@ impl Mmap {
         Ok(())
     }
 
+    #[inline]
     pub fn as_ptr(&self) -> *const u8 {
         self.memory.as_ptr() as *const u8
     }
 
+    #[inline]
     pub fn as_mut_ptr(&mut self) -> *mut u8 {
         self.memory.as_ptr().cast()
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         unsafe { (*self.memory.as_ptr()).len() }
     }


### PR DESCRIPTION
I was seeing these show up in profiles and while inlining them didn't help it helped reduce the noise a bit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
