### PR TITLE
Change http `consume` methods to statically consume

### DIFF
--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -92,8 +92,7 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
 
             ResponseOutparam::set(response_out, Ok(response));
 
-            let mut stream =
-                executor::incoming_body(request.consume().expect("request should be readable"));
+            let mut stream = executor::incoming_body(IncomingRequest::consume(request));
 
             while let Some(chunk) = stream.next().await {
                 match chunk {
@@ -122,9 +121,8 @@ async fn handle_request(request: IncomingRequest, response_out: ResponseOutparam
             }) {
                 match double_echo(request, &url).await {
                     Ok((request_copy, response)) => {
-                        let mut stream = executor::incoming_body(
-                            response.consume().expect("response should be consumable"),
-                        );
+                        let mut stream =
+                            executor::incoming_body(IncomingResponse::consume(response));
 
                         let response = OutgoingResponse::new(
                             Fields::from_list(
@@ -202,11 +200,7 @@ async fn double_echo(
 
     let response = executor::outgoing_request_send(outgoing_request);
 
-    let mut stream = executor::incoming_body(
-        incoming_request
-            .consume()
-            .expect("request should be consumable"),
-    );
+    let mut stream = executor::incoming_body(IncomingRequest::consume(incoming_request));
 
     let copy = async move {
         while let Some(chunk) = stream.next().await {
@@ -280,8 +274,7 @@ async fn hash(url: &Url) -> Result<String> {
         bail!("unexpected status: {status}");
     }
 
-    let mut body =
-        executor::incoming_body(response.consume().expect("response should be readable"));
+    let mut body = executor::incoming_body(IncomingResponse::consume(response));
 
     use sha2::Digest;
     let mut hasher = sha2::Sha256::new();

--- a/crates/test-programs/src/http.rs
+++ b/crates/test-programs/src/http.rs
@@ -128,11 +128,7 @@ pub fn request(
     let headers = headers_handle.entries();
     drop(headers_handle);
 
-    let incoming_body = incoming_response
-        .consume()
-        .map_err(|()| anyhow!("incoming response has no body stream"))?;
-
-    drop(incoming_response);
+    let incoming_body = http_types::IncomingResponse::consume(incoming_response);
 
     let input_stream = incoming_body.stream().unwrap();
     let input_stream_pollable = input_stream.subscribe();

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -42,10 +42,7 @@ pub trait WasiHttpView: Send {
             // TODO: this needs to be plumbed through
             between_bytes_timeout: std::time::Duration::from_millis(600 * 1000),
         };
-        Ok(self.table().push(HostIncomingRequest {
-            parts,
-            body: Some(body),
-        })?)
+        Ok(self.table().push(HostIncomingRequest { parts, body })?)
     }
 
     fn new_response_outparam(
@@ -257,7 +254,7 @@ impl TryInto<http::Method> for types::Method {
 
 pub struct HostIncomingRequest {
     pub parts: http::request::Parts,
-    pub body: Option<HostIncomingBodyBuilder>,
+    pub body: HostIncomingBodyBuilder,
 }
 
 pub struct HostResponseOutparam {
@@ -284,7 +281,7 @@ pub struct HostRequestOptions {
 pub struct HostIncomingResponse {
     pub status: u16,
     pub headers: FieldMap,
-    pub body: Option<HostIncomingBodyBuilder>,
+    pub body: HostIncomingBodyBuilder,
     pub worker: Arc<AbortOnDropJoinHandle<Result<(), types::Error>>>,
 }
 

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -100,7 +100,7 @@ interface types {
 
 
     /// Retrieve the full set of keys and values in the Fields. Like the
-    /// constructor, the list represents each key-value pair. 
+    /// constructor, the list represents each key-value pair.
     ///
     /// The outer list represents each key-value pair in the Fields. Keys
     /// which have multiple values are represented by multiple entries in this
@@ -108,7 +108,7 @@ interface types {
     entries: func() -> list<tuple<field-key,field-value>>;
 
     /// Make a deep copy of the Fields. Equivelant in behavior to calling the
-    /// `fields` constructor on the return value of `entries` 
+    /// `fields` constructor on the return value of `entries`
     clone: func() -> fields;
   }
 
@@ -140,9 +140,8 @@ interface types {
     /// `incoming-request` before all children are dropped will trap.
     headers: func() -> headers;
 
-    /// Gives the `incoming-body` associated with this request. Will only
-    /// return success at most once, and subsequent calls will return error.
-    consume: func() -> result<incoming-body>;
+    /// Gives the `incoming-body` associated with this request.
+    consume: static func(r: incoming-request) -> incoming-body;
   }
 
   /// Represents an outgoing HTTP Request.
@@ -286,9 +285,8 @@ interface types {
     /// Returns the headers from the incoming response.
     headers: func() -> headers;
 
-    /// Returns the incoming body. May be called at most once. Returns error
-    /// if called additional times.
-    consume: func() -> result<incoming-body>;
+    /// Returns the incoming body.
+    consume: static func(r: incoming-response) -> incoming-body;
   }
 
   /// Represents an incoming HTTP Request or Response's Body.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -100,7 +100,7 @@ interface types {
 
 
     /// Retrieve the full set of keys and values in the Fields. Like the
-    /// constructor, the list represents each key-value pair. 
+    /// constructor, the list represents each key-value pair.
     ///
     /// The outer list represents each key-value pair in the Fields. Keys
     /// which have multiple values are represented by multiple entries in this
@@ -108,7 +108,7 @@ interface types {
     entries: func() -> list<tuple<field-key,field-value>>;
 
     /// Make a deep copy of the Fields. Equivelant in behavior to calling the
-    /// `fields` constructor on the return value of `entries` 
+    /// `fields` constructor on the return value of `entries`
     clone: func() -> fields;
   }
 
@@ -140,9 +140,8 @@ interface types {
     /// `incoming-request` before all children are dropped will trap.
     headers: func() -> headers;
 
-    /// Gives the `incoming-body` associated with this request. Will only
-    /// return success at most once, and subsequent calls will return error.
-    consume: func() -> result<incoming-body>;
+    /// Gives the `incoming-body` associated with this request.
+    consume: static func(r: incoming-request) -> incoming-body;
   }
 
   /// Represents an outgoing HTTP Request.
@@ -286,9 +285,8 @@ interface types {
     /// Returns the headers from the incoming response.
     headers: func() -> headers;
 
-    /// Returns the incoming body. May be called at most once. Returns error
-    /// if called additional times.
-    consume: func() -> result<incoming-body>;
+    /// Returns the incoming body.
+    consume: static func(r: incoming-response) -> incoming-body;
   }
 
   /// Represents an incoming HTTP Request or Response's Body.


### PR DESCRIPTION
Currently these take `borrow<_>` arguments but semantically only work once, so instead switch them to `static` methods which take ownership of the input.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
