### PR TITLE
 Fix some text-format related features 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -343,7 +343,7 @@ component-model = [
   "wasmtime-wast/component-model",
   "wasmtime-cli-flags/component-model"
 ]
-wat = ["dep:wat"]
+wat = ["dep:wat", "wasmtime/wat"]
 cache = ["dep:wasmtime-cache", "wasmtime-cli-flags/cache"]
 parallel-compilation = ["wasmtime-cli-flags/parallel-compilation"]
 logging = ["wasmtime-cli-flags/logging"]

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-wasmtime = { workspace = true, features = ['cranelift'] }
+wasmtime = { workspace = true, features = ['cranelift', 'wat'] }
 wast = { workspace = true }
 log = { workspace = true }
 


### PR DESCRIPTION
* Enable `wasmtime/wat` when the `wat` feature is enabled on the CLI
* Additionally always enable the `wasmtime/wat` feature for the
  `wasmtime-wast` crate since the text format is used by some tests.

