### PR TITLE
PCC: fully support dynamic and static memories in Wasmtime on x86-64 and aarch64.

### DIFF
--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -45,7 +45,7 @@ cranelift-codegen-meta = { path = "meta", version = "0.102.0" }
 cranelift-isle = { path = "../isle/isle", version = "=0.102.0" }
 
 [features]
-default = ["std", "unwind", "host-arch", "trace-log"]
+default = ["std", "unwind", "host-arch"]
 
 # The "std" feature enables use of libstd. The "core" feature enables use
 # of some minimal std-like replacement libraries. At least one of these two

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -45,7 +45,7 @@ cranelift-codegen-meta = { path = "meta", version = "0.102.0" }
 cranelift-isle = { path = "../isle/isle", version = "=0.102.0" }
 
 [features]
-default = ["std", "unwind", "host-arch"]
+default = ["std", "unwind", "host-arch", "trace-log"]
 
 # The "std" feature enables use of libstd. The "core" feature enables use
 # of some minimal std-like replacement libraries. At least one of these two

--- a/cranelift/codegen/src/ir/mod.rs
+++ b/cranelift/codegen/src/ir/mod.rs
@@ -56,6 +56,7 @@ pub use crate::ir::layout::Layout;
 pub use crate::ir::libcall::{get_probestack_funcref, LibCall};
 pub use crate::ir::memflags::{Endianness, MemFlags};
 pub use crate::ir::memtype::{MemoryTypeData, MemoryTypeField};
+pub use crate::ir::pcc::{BaseExpr, Expr, Fact, FactContext, PccError, PccResult};
 pub use crate::ir::progpoint::ProgramPoint;
 pub use crate::ir::sourceloc::RelSourceLoc;
 pub use crate::ir::sourceloc::SourceLoc;

--- a/cranelift/codegen/src/ir/pcc.rs
+++ b/cranelift/codegen/src/ir/pcc.rs
@@ -267,6 +267,22 @@ impl BaseExpr {
 }
 
 impl Expr {
+    /// Constant value.
+    fn constant(offset: i64) -> Self {
+        Expr {
+            base: BaseExpr::None,
+            offset,
+        }
+    }
+
+    /// The value of a global value.
+    fn global_value(gv: ir::GlobalValue) -> Self {
+        Expr {
+            base: BaseExpr::GlobalValue(gv),
+            offset: 0,
+        }
+    }
+
     /// Is one expression definitely less than or equal to another?
     /// (We can't always know; in such cases, returns `false`.)
     fn le(lhs: &Expr, rhs: &Expr) -> bool {
@@ -427,6 +443,25 @@ impl Fact {
             bit_width,
             min: value,
             max: value,
+        }
+    }
+
+    /// Create a dynamic range fact that points to the base of a dynamic memory.
+    pub fn dynamic_base_ptr(ty: ir::MemoryType) -> Self {
+        Fact::DynamicMem {
+            ty,
+            min: Expr::constant(0),
+            max: Expr::constant(0),
+            nullable: false,
+        }
+    }
+
+    /// Create a fact that specifies the value is exactly the value of a GV.
+    pub fn global_value(bit_width: u16, gv: ir::GlobalValue) -> Self {
+        Fact::DynamicRange {
+            bit_width,
+            min: Expr::global_value(gv),
+            max: Expr::global_value(gv),
         }
     }
 

--- a/cranelift/codegen/src/ir/pcc.rs
+++ b/cranelift/codegen/src/ir/pcc.rs
@@ -47,6 +47,10 @@
 //!
 //! TODO:
 //!
+//! Deployment:
+//! - Add to fuzzing
+//! - Turn on during wasm spec-tests
+//!
 //! More checks:
 //! - Check that facts on `vmctx` GVs are subsumed by the actual facts
 //!   on the vmctx arg in block0 (function arg).

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -2914,16 +2914,22 @@
 ;; are zero-extending the value.
 (rule 3 (imm (integral_ty ty) (ImmExtend.Zero) k)
       (if-let n (move_wide_const_from_u64 ty k))
-      (movz n (operand_size ty)))
+      (add_range_fact
+       (movz n (operand_size ty))
+       64 k k))
 (rule 2 (imm (integral_ty (ty_32_or_64 ty)) (ImmExtend.Zero) k)
       (if-let n (move_wide_const_from_inverted_u64 ty k))
-      (movn n (operand_size ty)))
+      (add_range_fact
+       (movn n (operand_size ty))
+       64 k k))
 
 ;; Weird logical-instruction immediate in ORI using zero register; to simplify,
 ;; we only match when we are zero-extending the value.
 (rule 1 (imm (integral_ty ty) (ImmExtend.Zero) k)
       (if-let n (imm_logic_from_u64 ty k))
-      (orr_imm ty (zero_reg) n))
+      (add_range_fact
+       (orr_imm ty (zero_reg) n)
+       64 k k))
 
 (decl load_constant64_full (Type ImmExtend u64) Reg)
 (extern constructor load_constant64_full load_constant64_full)

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -266,6 +266,7 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
         extend: &generated_code::ImmExtend,
         value: u64,
     ) -> Reg {
+        let pcc = self.backend.flags.enable_pcc();
         let bits = ty.bits();
         let value = if bits < 64 {
             if *extend == generated_code::ImmExtend::Sign {
@@ -295,6 +296,14 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
                     imm: MoveWideConst::maybe_with_shift(!lower_halfword, 0).unwrap(),
                     size,
                 });
+                if pcc {
+                    self.lower_ctx.add_range_fact(
+                        rd.to_reg(),
+                        64,
+                        u64::from(lower_halfword),
+                        u64::from(lower_halfword),
+                    );
+                }
             } else {
                 self.emit(&MInst::MovWide {
                     op: MoveWideOp::MovZ,
@@ -302,6 +311,14 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
                     imm: MoveWideConst::maybe_with_shift(lower_halfword, 0).unwrap(),
                     size,
                 });
+                if pcc {
+                    self.lower_ctx.add_range_fact(
+                        rd.to_reg(),
+                        64,
+                        u64::from(lower_halfword),
+                        u64::from(lower_halfword),
+                    );
+                }
 
                 if upper_halfword != 0 {
                     let tmp = self.temp_writable_reg(I64);
@@ -311,6 +328,10 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
                         imm: MoveWideConst::maybe_with_shift(upper_halfword, 16).unwrap(),
                         size,
                     });
+                    if pcc {
+                        self.lower_ctx
+                            .add_range_fact(tmp.to_reg(), 64, value, value);
+                    }
                     return tmp.to_reg();
                 }
             };
@@ -324,6 +345,10 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
                 imm: MoveWideConst::zero(),
                 size,
             });
+            if pcc {
+                self.lower_ctx
+                    .add_range_fact(rd.to_reg(), 64, u64::MAX, u64::MAX);
+            }
             return rd.to_reg();
         };
 
@@ -347,6 +372,7 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
             .collect();
 
         let mut prev_result = None;
+        let mut running_value: u64 = 0;
         for (i, imm16) in halfwords {
             let shift = i * 16;
             let rd = self.temp_writable_reg(I64);
@@ -354,6 +380,11 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
             if let Some(rn) = prev_result {
                 let imm = MoveWideConst::maybe_with_shift(imm16 as u16, shift).unwrap();
                 self.emit(&MInst::MovK { rd, rn, imm, size });
+                if pcc {
+                    running_value |= imm16 << shift;
+                    self.lower_ctx
+                        .add_range_fact(rd.to_reg(), 64, running_value, running_value);
+                }
             } else {
                 if first_is_inverted {
                     let imm =
@@ -364,6 +395,15 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
                         imm,
                         size,
                     });
+                    if pcc {
+                        running_value = !(imm16 << shift);
+                        self.lower_ctx.add_range_fact(
+                            rd.to_reg(),
+                            64,
+                            running_value,
+                            running_value,
+                        );
+                    }
                 } else {
                     let imm = MoveWideConst::maybe_with_shift(imm16 as u16, shift).unwrap();
                     self.emit(&MInst::MovWide {
@@ -372,6 +412,15 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
                         imm,
                         size,
                     });
+                    if pcc {
+                        running_value = imm16 << shift;
+                        self.lower_ctx.add_range_fact(
+                            rd.to_reg(),
+                            64,
+                            running_value,
+                            running_value,
+                        );
+                    }
                 }
             }
 

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -167,7 +167,7 @@ pub struct VCode<I: VCodeInst> {
     reftyped_vregs: Vec<VReg>,
 
     /// Constants.
-    constants: VCodeConstants,
+    pub(crate) constants: VCodeConstants,
 
     /// Value labels for debuginfo attached to vregs.
     debug_value_labels: Vec<(VReg, InsnIndex, InsnIndex, u32)>,

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -43,8 +43,8 @@
 ;; block0:
 ;;   mov w9, w0
 ;;   ldr x10, [x2, #8]
-;;   movn x11, #4099
-;;   add x10, x10, x11
+;;   movz x11, #4100
+;;   sub x10, x10, x11
 ;;   subs xzr, x9, x10
 ;;   b.hi label3 ; b label1
 ;; block1:
@@ -61,8 +61,8 @@
 ;; block0:
 ;;   mov w9, w0
 ;;   ldr x10, [x1, #8]
-;;   movn x11, #4099
-;;   add x10, x10, x11
+;;   movz x11, #4100
+;;   sub x10, x10, x11
 ;;   subs xzr, x9, x10
 ;;   b.hi label3 ; b label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -43,8 +43,8 @@
 ;; block0:
 ;;   mov w9, w0
 ;;   ldr x10, [x2, #8]
-;;   movn x11, #4096
-;;   add x10, x10, x11
+;;   movz x11, #4097
+;;   sub x10, x10, x11
 ;;   subs xzr, x9, x10
 ;;   b.hi label3 ; b label1
 ;; block1:
@@ -61,8 +61,8 @@
 ;; block0:
 ;;   mov w9, w0
 ;;   ldr x10, [x1, #8]
-;;   movn x11, #4096
-;;   add x10, x10, x11
+;;   movz x11, #4097
+;;   sub x10, x10, x11
 ;;   subs xzr, x9, x10
 ;;   b.hi label3 ; b label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -43,8 +43,8 @@
 ;; block0:
 ;;   mov w12, w0
 ;;   ldr x13, [x2, #8]
-;;   movn x14, #4099
-;;   add x13, x13, x14
+;;   movz x14, #4100
+;;   sub x13, x13, x14
 ;;   ldr x14, [x2]
 ;;   add x14, x14, x0, UXTW
 ;;   add x14, x14, #4096
@@ -61,8 +61,8 @@
 ;; block0:
 ;;   mov w12, w0
 ;;   ldr x13, [x1, #8]
-;;   movn x14, #4099
-;;   add x13, x13, x14
+;;   movz x14, #4100
+;;   sub x13, x13, x14
 ;;   ldr x14, [x1]
 ;;   add x14, x14, x0, UXTW
 ;;   add x14, x14, #4096

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -43,8 +43,8 @@
 ;; block0:
 ;;   mov w12, w0
 ;;   ldr x13, [x2, #8]
-;;   movn x14, #4096
-;;   add x13, x13, x14
+;;   movz x14, #4097
+;;   sub x13, x13, x14
 ;;   ldr x14, [x2]
 ;;   add x14, x14, x0, UXTW
 ;;   add x14, x14, #4096
@@ -61,8 +61,8 @@
 ;; block0:
 ;;   mov w12, w0
 ;;   ldr x13, [x1, #8]
-;;   movn x14, #4096
-;;   add x13, x13, x14
+;;   movz x14, #4097
+;;   sub x13, x13, x14
 ;;   ldr x14, [x1]
 ;;   add x14, x14, x0, UXTW
 ;;   add x14, x14, #4096

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -42,8 +42,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   ldr x8, [x2, #8]
-;;   movn x9, #4099
-;;   add x8, x8, x9
+;;   movz x9, #4100
+;;   sub x8, x8, x9
 ;;   subs xzr, x0, x8
 ;;   b.hi label3 ; b label1
 ;; block1:
@@ -59,8 +59,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   ldr x8, [x1, #8]
-;;   movn x9, #4099
-;;   add x8, x8, x9
+;;   movz x9, #4100
+;;   sub x8, x8, x9
 ;;   subs xzr, x0, x8
 ;;   b.hi label3 ; b label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -42,8 +42,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   ldr x8, [x2, #8]
-;;   movn x9, #4096
-;;   add x8, x8, x9
+;;   movz x9, #4097
+;;   sub x8, x8, x9
 ;;   subs xzr, x0, x8
 ;;   b.hi label3 ; b label1
 ;; block1:
@@ -59,8 +59,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   ldr x8, [x1, #8]
-;;   movn x9, #4096
-;;   add x8, x8, x9
+;;   movz x9, #4097
+;;   sub x8, x8, x9
 ;;   subs xzr, x0, x8
 ;;   b.hi label3 ; b label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -42,8 +42,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   ldr x11, [x2, #8]
-;;   movn x12, #4099
-;;   add x11, x11, x12
+;;   movz x12, #4100
+;;   sub x11, x11, x12
 ;;   ldr x12, [x2]
 ;;   add x12, x12, x0
 ;;   add x12, x12, #4096
@@ -59,8 +59,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   ldr x11, [x1, #8]
-;;   movn x12, #4099
-;;   add x11, x11, x12
+;;   movz x12, #4100
+;;   sub x11, x11, x12
 ;;   ldr x12, [x1]
 ;;   add x12, x12, x0
 ;;   add x12, x12, #4096

--- a/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/aarch64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -42,8 +42,8 @@
 ;; function u0:0:
 ;; block0:
 ;;   ldr x11, [x2, #8]
-;;   movn x12, #4096
-;;   add x11, x11, x12
+;;   movz x12, #4097
+;;   sub x11, x11, x12
 ;;   ldr x12, [x2]
 ;;   add x12, x12, x0
 ;;   add x12, x12, #4096
@@ -59,8 +59,8 @@
 ;; function u0:1:
 ;; block0:
 ;;   ldr x11, [x1, #8]
-;;   movn x12, #4096
-;;   add x11, x11, x12
+;;   movz x12, #4097
+;;   sub x11, x11, x12
 ;;   ldr x12, [x1]
 ;;   add x12, x12, x0
 ;;   add x12, x12, #4096

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -42,14 +42,15 @@
 ;; function u0:0:
 ;; block0:
 ;;   slli a3,a0,32
-;;   srli a4,a3,32
-;;   ld a3,8(a2)
-;;   addi a3,a3,-4
-;;   bgtu a4,a3,taken(label3),not_taken(label1)
+;;   srli a5,a3,32
+;;   ld a4,8(a2)
+;;   li a0,4
+;;   sub a4,a4,a0
+;;   bgtu a5,a4,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a5,0(a2)
-;;   add a4,a5,a4
-;;   sw a1,0(a4)
+;;   ld a0,0(a2)
+;;   add a5,a0,a5
+;;   sw a1,0(a5)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -58,15 +59,16 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a4,a2,32
-;;   ld a3,8(a1)
-;;   addi a3,a3,-4
-;;   bgtu a4,a3,taken(label3),not_taken(label1)
+;;   slli a3,a0,32
+;;   srli a5,a3,32
+;;   ld a4,8(a1)
+;;   li a0,4
+;;   sub a4,a4,a0
+;;   bgtu a5,a4,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a5,0(a1)
-;;   add a4,a5,a4
-;;   lw a0,0(a4)
+;;   ld a0,0(a1)
+;;   add a5,a0,a5
+;;   lw a0,0(a5)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -44,9 +44,9 @@
 ;;   slli a4,a0,32
 ;;   srli a0,a4,32
 ;;   ld a5,8(a2)
-;;   lui a4,-1
-;;   addi a3,a4,-4
-;;   add a5,a5,a3
+;;   lui a4,1
+;;   addi a3,a4,4
+;;   sub a5,a5,a3
 ;;   bgtu a0,a5,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a2,0(a2)
@@ -63,9 +63,9 @@
 ;;   slli a4,a0,32
 ;;   srli a0,a4,32
 ;;   ld a5,8(a1)
-;;   lui a4,-1
-;;   addi a2,a4,-4
-;;   add a5,a5,a2
+;;   lui a4,1
+;;   addi a2,a4,4
+;;   sub a5,a5,a2
 ;;   bgtu a0,a5,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a1,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -44,9 +44,9 @@
 ;;   slli a4,a0,32
 ;;   srli a0,a4,32
 ;;   ld a5,8(a2)
-;;   lui a4,-1
-;;   addi a3,a4,-1
-;;   add a5,a5,a3
+;;   lui a4,1
+;;   addi a3,a4,1
+;;   sub a5,a5,a3
 ;;   bgtu a0,a5,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a2,0(a2)
@@ -63,9 +63,9 @@
 ;;   slli a4,a0,32
 ;;   srli a0,a4,32
 ;;   ld a5,8(a1)
-;;   lui a4,-1
-;;   addi a2,a4,-1
-;;   add a5,a5,a2
+;;   lui a4,1
+;;   addi a2,a4,1
+;;   sub a5,a5,a2
 ;;   bgtu a0,a5,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a1,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,34 +41,36 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a0,a0,32
-;;   srli a3,a0,32
+;;   slli a3,a0,32
+;;   srli a3,a3,32
 ;;   ld a4,8(a2)
-;;   addi a4,a4,-4
+;;   li a5,4
+;;   sub a4,a4,a5
 ;;   sltu a4,a4,a3
 ;;   ld a2,0(a2)
 ;;   add a2,a2,a3
-;;   sub a5,zero,a4
-;;   not a3,a5
-;;   and a3,a2,a3
-;;   sw a1,0(a3)
+;;   sub a0,zero,a4
+;;   not a3,a0
+;;   and a4,a2,a3
+;;   sw a1,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a0,a0,32
-;;   srli a2,a0,32
-;;   ld a3,8(a1)
-;;   addi a3,a3,-4
-;;   sltu a3,a3,a2
-;;   ld a1,0(a1)
-;;   add a1,a1,a2
-;;   sub a5,zero,a3
-;;   not a2,a5
-;;   and a3,a1,a2
-;;   lw a0,0(a3)
+;;   slli a2,a0,32
+;;   srli a3,a2,32
+;;   ld a2,8(a1)
+;;   li a4,4
+;;   sub a2,a2,a4
+;;   sltu a2,a2,a3
+;;   ld a4,0(a1)
+;;   add a3,a4,a3
+;;   sub a0,zero,a2
+;;   not a2,a0
+;;   and a4,a3,a2
+;;   lw a0,0(a4)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -44,9 +44,9 @@
 ;;   slli a4,a0,32
 ;;   srli a0,a4,32
 ;;   ld a5,8(a2)
-;;   lui a4,-1
-;;   addi a3,a4,-4
-;;   add a5,a5,a3
+;;   lui a4,1
+;;   addi a3,a4,4
+;;   sub a5,a5,a3
 ;;   sltu a5,a5,a0
 ;;   ld a2,0(a2)
 ;;   add a0,a2,a0
@@ -65,9 +65,9 @@
 ;;   slli a4,a0,32
 ;;   srli a0,a4,32
 ;;   ld a5,8(a1)
-;;   lui a4,-1
-;;   addi a2,a4,-4
-;;   add a5,a5,a2
+;;   lui a4,1
+;;   addi a2,a4,4
+;;   sub a5,a5,a2
 ;;   sltu a5,a5,a0
 ;;   ld a1,0(a1)
 ;;   add a0,a1,a0

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -44,9 +44,9 @@
 ;;   slli a4,a0,32
 ;;   srli a0,a4,32
 ;;   ld a5,8(a2)
-;;   lui a4,-1
-;;   addi a3,a4,-1
-;;   add a5,a5,a3
+;;   lui a4,1
+;;   addi a3,a4,1
+;;   sub a5,a5,a3
 ;;   sltu a5,a5,a0
 ;;   ld a2,0(a2)
 ;;   add a0,a2,a0
@@ -65,9 +65,9 @@
 ;;   slli a4,a0,32
 ;;   srli a0,a4,32
 ;;   ld a5,8(a1)
-;;   lui a4,-1
-;;   addi a2,a4,-1
-;;   add a5,a5,a2
+;;   lui a4,1
+;;   addi a2,a4,1
+;;   sub a5,a5,a2
 ;;   sltu a5,a5,a0
 ;;   ld a1,0(a1)
 ;;   add a0,a1,a0

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -42,12 +42,13 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a3,8(a2)
-;;   addi a3,a3,-4
+;;   li a4,4
+;;   sub a3,a3,a4
 ;;   bgtu a0,a3,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a2,0(a2)
-;;   add a2,a2,a0
-;;   sw a1,0(a2)
+;;   ld a3,0(a2)
+;;   add a3,a3,a0
+;;   sw a1,0(a3)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -57,12 +58,13 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a2,8(a1)
-;;   addi a2,a2,-4
+;;   li a3,4
+;;   sub a2,a2,a3
 ;;   bgtu a0,a2,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a2,0(a1)
-;;   add a2,a2,a0
-;;   lw a0,0(a2)
+;;   ld a3,0(a1)
+;;   add a3,a3,a0
+;;   lw a0,0(a3)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -42,9 +42,9 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a3,8(a2)
-;;   lui a4,-1
-;;   addi a4,a4,-4
-;;   add a3,a3,a4
+;;   lui a4,1
+;;   addi a4,a4,4
+;;   sub a3,a3,a4
 ;;   bgtu a0,a3,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a4,0(a2)
@@ -59,9 +59,9 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a3,8(a1)
-;;   lui a2,-1
-;;   addi a4,a2,-4
-;;   add a3,a3,a4
+;;   lui a2,1
+;;   addi a4,a2,4
+;;   sub a3,a3,a4
 ;;   bgtu a0,a3,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a4,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -42,9 +42,9 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a3,8(a2)
-;;   lui a4,-1
-;;   addi a4,a4,-1
-;;   add a3,a3,a4
+;;   lui a4,1
+;;   addi a4,a4,1
+;;   sub a3,a3,a4
 ;;   bgtu a0,a3,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a4,0(a2)
@@ -59,9 +59,9 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a3,8(a1)
-;;   lui a2,-1
-;;   addi a4,a2,-1
-;;   add a3,a3,a4
+;;   lui a2,1
+;;   addi a4,a2,1
+;;   sub a3,a3,a4
 ;;   bgtu a0,a3,taken(label3),not_taken(label1)
 ;; block1:
 ;;   ld a4,0(a1)

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,14 +41,15 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a5,8(a2)
-;;   addi a5,a5,-4
-;;   sltu a5,a5,a0
+;;   ld a3,8(a2)
+;;   li a4,4
+;;   sub a3,a3,a4
+;;   sltu a3,a3,a0
 ;;   ld a2,0(a2)
 ;;   add a0,a2,a0
-;;   sub a3,zero,a5
-;;   not a5,a3
-;;   and a2,a0,a5
+;;   sub a4,zero,a3
+;;   not a2,a4
+;;   and a2,a0,a2
 ;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
@@ -56,15 +57,16 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a5,8(a1)
-;;   addi a5,a5,-4
-;;   sltu a5,a5,a0
+;;   ld a2,8(a1)
+;;   li a3,4
+;;   sub a2,a2,a3
+;;   sltu a2,a2,a0
 ;;   ld a1,0(a1)
 ;;   add a0,a1,a0
-;;   sub a3,zero,a5
-;;   not a5,a3
-;;   and a1,a0,a5
-;;   lw a0,0(a1)
+;;   sub a4,zero,a2
+;;   not a1,a4
+;;   and a2,a0,a1
+;;   lw a0,0(a2)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -42,9 +42,9 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a3,8(a2)
-;;   lui a4,-1
-;;   addi a4,a4,-4
-;;   add a3,a3,a4
+;;   lui a4,1
+;;   addi a4,a4,4
+;;   sub a3,a3,a4
 ;;   sltu a3,a3,a0
 ;;   ld a4,0(a2)
 ;;   add a4,a4,a0
@@ -61,9 +61,9 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a3,8(a1)
-;;   lui a2,-1
-;;   addi a4,a2,-4
-;;   add a3,a3,a4
+;;   lui a2,1
+;;   addi a4,a2,4
+;;   sub a3,a3,a4
 ;;   sltu a3,a3,a0
 ;;   ld a4,0(a1)
 ;;   add a4,a4,a0

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -42,9 +42,9 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a3,8(a2)
-;;   lui a4,-1
-;;   addi a4,a4,-1
-;;   add a3,a3,a4
+;;   lui a4,1
+;;   addi a4,a4,1
+;;   sub a3,a3,a4
 ;;   sltu a3,a3,a0
 ;;   ld a4,0(a2)
 ;;   add a4,a4,a0
@@ -61,9 +61,9 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a3,8(a1)
-;;   lui a2,-1
-;;   addi a4,a2,-1
-;;   add a3,a3,a4
+;;   lui a2,1
+;;   addi a4,a2,1
+;;   sub a3,a3,a4
 ;;   sltu a3,a3,a0
 ;;   ld a4,0(a1)
 ;;   add a4,a4,a0

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -44,8 +44,8 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   llgfr %r5, %r2
-;;   lghi %r2, -4
-;;   ag %r2, 8(%r4)
+;;   lg %r2, 8(%r4)
+;;   aghi %r2, -4
 ;;   clgr %r5, %r2
 ;;   jgh label3 ; jg label1
 ;; block1:
@@ -62,9 +62,9 @@
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
 ;;   llgfr %r5, %r2
-;;   lghi %r4, -4
-;;   ag %r4, 8(%r3)
-;;   clgr %r5, %r4
+;;   lg %r2, 8(%r3)
+;;   aghi %r2, -4
+;;   clgr %r5, %r2
 ;;   jgh label3 ; jg label1
 ;; block1:
 ;;   lg %r3, 0(%r3)

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -45,8 +45,8 @@
 ;; block0:
 ;;   lgr %r5, %r4
 ;;   llgfr %r4, %r2
-;;   lghi %r2, -4100
-;;   ag %r2, 8(%r5)
+;;   lg %r2, 8(%r5)
+;;   aghi %r2, -4100
 ;;   clgr %r4, %r2
 ;;   jgh label3 ; jg label1
 ;; block1:
@@ -65,13 +65,12 @@
 ;; block0:
 ;;   lgr %r4, %r3
 ;;   llgfr %r3, %r2
-;;   lghi %r2, -4100
-;;   lgr %r5, %r4
-;;   ag %r2, 8(%r5)
+;;   lg %r2, 8(%r4)
+;;   aghi %r2, -4100
 ;;   clgr %r3, %r2
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   ag %r3, 0(%r5)
+;;   ag %r3, 0(%r4)
 ;;   lghi %r4, 4096
 ;;   lrv %r2, 0(%r4,%r3)
 ;;   jg label2

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -45,8 +45,8 @@
 ;; block0:
 ;;   lgr %r5, %r4
 ;;   llgfr %r4, %r2
-;;   lghi %r2, -4097
-;;   ag %r2, 8(%r5)
+;;   lg %r2, 8(%r5)
+;;   aghi %r2, -4097
 ;;   clgr %r4, %r2
 ;;   jgh label3 ; jg label1
 ;; block1:
@@ -65,13 +65,12 @@
 ;; block0:
 ;;   lgr %r4, %r3
 ;;   llgfr %r3, %r2
-;;   lghi %r2, -4097
-;;   lgr %r5, %r4
-;;   ag %r2, 8(%r5)
+;;   lg %r2, 8(%r4)
+;;   aghi %r2, -4097
 ;;   clgr %r3, %r2
 ;;   jgh label3 ; jg label1
 ;; block1:
-;;   ag %r3, 0(%r5)
+;;   ag %r3, 0(%r4)
 ;;   lghi %r4, 4096
 ;;   llc %r2, 0(%r4,%r3)
 ;;   jg label2

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -56,14 +56,14 @@
 ;; block0:
 ;;   lgr %r5, %r4
 ;;   llgfr %r4, %r2
-;;   lghi %r2, -4
-;;   lgr %r9, %r5
-;;   ag %r2, 8(%r9)
+;;   lgr %r2, %r5
+;;   lg %r5, 8(%r2)
+;;   aghik %r6, %r5, -4
 ;;   lgr %r5, %r4
-;;   ag %r5, 0(%r9)
-;;   lghi %r6, 0
-;;   clgr %r4, %r2
-;;   locgrh %r5, %r6
+;;   ag %r5, 0(%r2)
+;;   lghi %r2, 0
+;;   clgr %r4, %r6
+;;   locgrh %r5, %r2
 ;;   strv %r3, 0(%r5)
 ;;   jg label1
 ;; block1:
@@ -76,13 +76,14 @@
 ;; block0:
 ;;   lgr %r4, %r3
 ;;   llgfr %r3, %r2
-;;   lghi %r2, -4
-;;   ag %r2, 8(%r4)
+;;   lgr %r2, %r4
+;;   lg %r4, 8(%r2)
+;;   aghi %r4, -4
 ;;   lgr %r5, %r3
-;;   ag %r5, 0(%r4)
-;;   lghi %r4, 0
-;;   clgr %r3, %r2
-;;   locgrh %r5, %r4
+;;   ag %r5, 0(%r2)
+;;   lghi %r2, 0
+;;   clgr %r3, %r4
+;;   locgrh %r5, %r2
 ;;   lrv %r2, 0(%r5)
 ;;   jg label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -53,14 +53,14 @@
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   llgfr %r2, %r2
-;;   lghi %r5, -4100
-;;   ag %r5, 8(%r4)
-;;   lgr %r7, %r2
+;;   llgfr %r5, %r2
+;;   lg %r2, 8(%r4)
+;;   aghi %r2, -4100
+;;   lgr %r7, %r5
 ;;   ag %r7, 0(%r4)
 ;;   aghik %r4, %r7, 4096
 ;;   lghi %r7, 0
-;;   clgr %r2, %r5
+;;   clgr %r5, %r2
 ;;   locgrh %r4, %r7
 ;;   strv %r3, 0(%r4)
 ;;   jg label1
@@ -72,16 +72,15 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r3
 ;;   llgfr %r4, %r2
-;;   lghi %r3, -4100
-;;   ag %r3, 8(%r5)
+;;   lg %r5, 8(%r3)
+;;   aghi %r5, -4100
 ;;   lgr %r2, %r4
-;;   ag %r2, 0(%r5)
+;;   ag %r2, 0(%r3)
 ;;   aghi %r2, 4096
-;;   lghi %r5, 0
-;;   clgr %r4, %r3
-;;   locgrh %r2, %r5
+;;   lghi %r3, 0
+;;   clgr %r4, %r5
+;;   locgrh %r2, %r3
 ;;   lrv %r2, 0(%r2)
 ;;   jg label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -53,14 +53,14 @@
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   llgfr %r2, %r2
-;;   lghi %r5, -4097
-;;   ag %r5, 8(%r4)
-;;   lgr %r7, %r2
+;;   llgfr %r5, %r2
+;;   lg %r2, 8(%r4)
+;;   aghi %r2, -4097
+;;   lgr %r7, %r5
 ;;   ag %r7, 0(%r4)
 ;;   aghik %r4, %r7, 4096
 ;;   lghi %r7, 0
-;;   clgr %r2, %r5
+;;   clgr %r5, %r2
 ;;   locgrh %r4, %r7
 ;;   stc %r3, 0(%r4)
 ;;   jg label1
@@ -72,16 +72,15 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r3
 ;;   llgfr %r4, %r2
-;;   lghi %r3, -4097
-;;   ag %r3, 8(%r5)
+;;   lg %r5, 8(%r3)
+;;   aghi %r5, -4097
 ;;   lgr %r2, %r4
-;;   ag %r2, 0(%r5)
+;;   ag %r2, 0(%r3)
 ;;   aghi %r2, 4096
-;;   lghi %r5, 0
-;;   clgr %r4, %r3
-;;   locgrh %r2, %r5
+;;   lghi %r3, 0
+;;   clgr %r4, %r5
+;;   locgrh %r2, %r3
 ;;   llc %r2, 0(%r2)
 ;;   jg label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -43,8 +43,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r5, -4
-;;   ag %r5, 8(%r4)
+;;   lg %r5, 8(%r4)
+;;   aghi %r5, -4
 ;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
@@ -60,8 +60,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r4, -4
-;;   ag %r4, 8(%r3)
+;;   lg %r4, 8(%r3)
+;;   aghi %r4, -4
 ;;   clgr %r2, %r4
 ;;   jgh label3 ; jg label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -43,8 +43,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r5, -4100
-;;   ag %r5, 8(%r4)
+;;   lg %r5, 8(%r4)
+;;   aghi %r5, -4100
 ;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
@@ -61,9 +61,9 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r4, -4100
-;;   ag %r4, 8(%r3)
-;;   clgr %r2, %r4
+;;   lg %r5, 8(%r3)
+;;   aghi %r5, -4100
+;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
 ;;   ag %r2, 0(%r3)

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -43,8 +43,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r5, -4097
-;;   ag %r5, 8(%r4)
+;;   lg %r5, 8(%r4)
+;;   aghi %r5, -4097
 ;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
@@ -61,9 +61,9 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r4, -4097
-;;   ag %r4, 8(%r3)
-;;   clgr %r2, %r4
+;;   lg %r5, 8(%r3)
+;;   aghi %r5, -4097
+;;   clgr %r2, %r5
 ;;   jgh label3 ; jg label1
 ;; block1:
 ;;   ag %r2, 0(%r3)

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -52,9 +52,9 @@
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r5, -4
-;;   ag %r5, 8(%r4)
+;;   lg %r5, 8(%r4)
 ;;   lgr %r8, %r4
+;;   aghi %r5, -4
 ;;   lgr %r4, %r2
 ;;   ag %r4, 0(%r8)
 ;;   lghi %r14, 0
@@ -70,8 +70,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lghi %r5, -4
-;;   ag %r5, 8(%r3)
+;;   lg %r4, 8(%r3)
+;;   aghik %r5, %r4, -4
 ;;   lgr %r4, %r2
 ;;   ag %r4, 0(%r3)
 ;;   lghi %r3, 0

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -54,15 +54,14 @@
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r4
-;;   lghi %r4, -4100
-;;   ag %r4, 8(%r5)
-;;   lgr %r6, %r2
-;;   ag %r6, 0(%r5)
-;;   aghik %r5, %r6, 4096
-;;   lghi %r6, 0
-;;   clgr %r2, %r4
-;;   locgrh %r5, %r6
+;;   lg %r5, 8(%r4)
+;;   aghik %r6, %r5, -4100
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r4)
+;;   aghi %r5, 4096
+;;   lghi %r4, 0
+;;   clgr %r2, %r6
+;;   locgrh %r5, %r4
 ;;   strv %r3, 0(%r5)
 ;;   jg label1
 ;; block1:
@@ -73,16 +72,14 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r4, %r3
-;;   lghi %r3, -4100
-;;   lgr %r5, %r4
-;;   ag %r3, 8(%r5)
-;;   lgr %r4, %r2
-;;   ag %r4, 0(%r5)
-;;   aghik %r5, %r4, 4096
-;;   lghi %r4, 0
-;;   clgr %r2, %r3
-;;   locgrh %r5, %r4
+;;   lg %r4, 8(%r3)
+;;   aghi %r4, -4100
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r3)
+;;   aghi %r5, 4096
+;;   lghi %r3, 0
+;;   clgr %r2, %r4
+;;   locgrh %r5, %r3
 ;;   lrv %r2, 0(%r5)
 ;;   jg label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/s390x/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -54,15 +54,14 @@
 ;;   unwind SaveReg { clobber_offset: 120, reg: p15i }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r5, %r4
-;;   lghi %r4, -4097
-;;   ag %r4, 8(%r5)
-;;   lgr %r6, %r2
-;;   ag %r6, 0(%r5)
-;;   aghik %r5, %r6, 4096
-;;   lghi %r6, 0
-;;   clgr %r2, %r4
-;;   locgrh %r5, %r6
+;;   lg %r5, 8(%r4)
+;;   aghik %r6, %r5, -4097
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r4)
+;;   aghi %r5, 4096
+;;   lghi %r4, 0
+;;   clgr %r2, %r6
+;;   locgrh %r5, %r4
 ;;   stc %r3, 0(%r5)
 ;;   jg label1
 ;; block1:
@@ -73,16 +72,14 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 160, offset_downward_to_clobbers: 0 }
 ;;   unwind StackAlloc { size: 0 }
 ;; block0:
-;;   lgr %r4, %r3
-;;   lghi %r3, -4097
-;;   lgr %r5, %r4
-;;   ag %r3, 8(%r5)
-;;   lgr %r4, %r2
-;;   ag %r4, 0(%r5)
-;;   aghik %r5, %r4, 4096
-;;   lghi %r4, 0
-;;   clgr %r2, %r3
-;;   locgrh %r5, %r4
+;;   lg %r4, 8(%r3)
+;;   aghi %r4, -4097
+;;   lgr %r5, %r2
+;;   ag %r5, 0(%r3)
+;;   aghi %r5, 4096
+;;   lghi %r3, 0
+;;   clgr %r2, %r4
+;;   locgrh %r5, %r3
 ;;   llc %r2, 0(%r5)
 ;;   jg label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -46,8 +46,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r10d
-;;   movabsq $-4, %r9
-;;   addq    %r9, 8(%rdx), %r9
+;;   movq    8(%rdx), %r9
+;;   subq    %r9, $4, %r9
 ;;   cmpq    %r9, %r10
 ;;   jnbe    label3; j label1
 ;; block1:
@@ -68,8 +68,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r10d
-;;   movabsq $-4, %r9
-;;   addq    %r9, 8(%rsi), %r9
+;;   movq    8(%rsi), %r9
+;;   subq    %r9, $4, %r9
 ;;   cmpq    %r9, %r10
 ;;   jnbe    label3; j label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -46,8 +46,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r10d
-;;   movabsq $-4100, %r9
-;;   addq    %r9, 8(%rdx), %r9
+;;   movq    8(%rdx), %r9
+;;   subq    %r9, $4100, %r9
 ;;   cmpq    %r9, %r10
 ;;   jnbe    label3; j label1
 ;; block1:
@@ -68,8 +68,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r10d
-;;   movabsq $-4100, %r9
-;;   addq    %r9, 8(%rsi), %r9
+;;   movq    8(%rsi), %r9
+;;   subq    %r9, $4100, %r9
 ;;   cmpq    %r9, %r10
 ;;   jnbe    label3; j label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -46,8 +46,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r10d
-;;   movabsq $-4097, %r9
-;;   addq    %r9, 8(%rdx), %r9
+;;   movq    8(%rdx), %r9
+;;   subq    %r9, $4097, %r9
 ;;   cmpq    %r9, %r10
 ;;   jnbe    label3; j label1
 ;; block1:
@@ -68,8 +68,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %r10d
-;;   movabsq $-4097, %r9
-;;   addq    %r9, 8(%rsi), %r9
+;;   movq    8(%rsi), %r9
+;;   subq    %r9, $4097, %r9
 ;;   cmpq    %r9, %r10
 ;;   jnbe    label3; j label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -46,8 +46,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %edi
-;;   movabsq $-4, %r11
-;;   addq    %r11, 8(%rdx), %r11
+;;   movq    8(%rdx), %r11
+;;   subq    %r11, $4, %r11
 ;;   movq    %rdi, %r10
 ;;   addq    %r10, 0(%rdx), %r10
 ;;   xorq    %rax, %rax, %rax
@@ -68,11 +68,10 @@
 ;; block0:
 ;;   movq    %rsi, %rax
 ;;   movl    %edi, %esi
-;;   movabsq $-4, %r11
-;;   movq    %rax, %rcx
-;;   addq    %r11, 8(%rcx), %r11
+;;   movq    8(%rax), %r11
+;;   subq    %r11, $4, %r11
 ;;   movq    %rsi, %r10
-;;   addq    %r10, 0(%rcx), %r10
+;;   addq    %r10, 0(%rax), %r10
 ;;   xorq    %rdi, %rdi, %rdi
 ;;   cmpq    %r11, %rsi
 ;;   cmovnbeq %rdi, %r10, %r10

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -46,8 +46,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %edi
-;;   movabsq $-4100, %rax
-;;   addq    %rax, 8(%rdx), %rax
+;;   movq    8(%rdx), %rax
+;;   subq    %rax, $4100, %rax
 ;;   movq    0(%rdx), %rcx
 ;;   lea     4096(%rcx,%rdi,1), %r11
 ;;   xorq    %rcx, %rcx, %rcx
@@ -66,12 +66,11 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rsi, %rax
+;;   movq    %rsi, %r8
 ;;   movl    %edi, %edi
-;;   movabsq $-4100, %rsi
-;;   movq    %rax, %rdx
-;;   addq    %rsi, 8(%rdx), %rsi
-;;   movq    0(%rdx), %rax
+;;   movq    8(%r8), %rsi
+;;   subq    %rsi, $4100, %rsi
+;;   movq    0(%r8), %rax
 ;;   lea     4096(%rax,%rdi,1), %r11
 ;;   xorq    %rax, %rax, %rax
 ;;   cmpq    %rsi, %rdi

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -46,8 +46,8 @@
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
 ;;   movl    %edi, %edi
-;;   movabsq $-4097, %rax
-;;   addq    %rax, 8(%rdx), %rax
+;;   movq    8(%rdx), %rax
+;;   subq    %rax, $4097, %rax
 ;;   movq    0(%rdx), %rcx
 ;;   lea     4096(%rcx,%rdi,1), %r11
 ;;   xorq    %rcx, %rcx, %rcx
@@ -66,12 +66,11 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movq    %rsi, %rax
+;;   movq    %rsi, %r8
 ;;   movl    %edi, %edi
-;;   movabsq $-4097, %rsi
-;;   movq    %rax, %rdx
-;;   addq    %rsi, 8(%rdx), %rsi
-;;   movq    0(%rdx), %rax
+;;   movq    8(%r8), %rsi
+;;   subq    %rsi, $4097, %rsi
+;;   movq    0(%r8), %rax
 ;;   lea     4096(%rax,%rdi,1), %r11
 ;;   xorq    %rax, %rax, %rax
 ;;   cmpq    %rsi, %rdi

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -45,8 +45,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4, %r8
-;;   addq    %r8, 8(%rdx), %r8
+;;   movq    8(%rdx), %r8
+;;   subq    %r8, $4, %r8
 ;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
@@ -66,8 +66,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4, %r8
-;;   addq    %r8, 8(%rsi), %r8
+;;   movq    8(%rsi), %r8
+;;   subq    %r8, $4, %r8
 ;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -45,8 +45,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4100, %r8
-;;   addq    %r8, 8(%rdx), %r8
+;;   movq    8(%rdx), %r8
+;;   subq    %r8, $4100, %r8
 ;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
@@ -66,8 +66,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4100, %r8
-;;   addq    %r8, 8(%rsi), %r8
+;;   movq    8(%rsi), %r8
+;;   subq    %r8, $4100, %r8
 ;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -45,8 +45,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4097, %r8
-;;   addq    %r8, 8(%rdx), %r8
+;;   movq    8(%rdx), %r8
+;;   subq    %r8, $4097, %r8
 ;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:
@@ -66,8 +66,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4097, %r8
-;;   addq    %r8, 8(%rsi), %r8
+;;   movq    8(%rsi), %r8
+;;   subq    %r8, $4097, %r8
 ;;   cmpq    %r8, %rdi
 ;;   jnbe    label3; j label1
 ;; block1:

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -45,8 +45,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4, %r10
-;;   addq    %r10, 8(%rdx), %r10
+;;   movq    8(%rdx), %r10
+;;   subq    %r10, $4, %r10
 ;;   movq    %rdi, %r9
 ;;   addq    %r9, 0(%rdx), %r9
 ;;   xorq    %r11, %r11, %r11
@@ -65,8 +65,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4, %r10
-;;   addq    %r10, 8(%rsi), %r10
+;;   movq    8(%rsi), %r10
+;;   subq    %r10, $4, %r10
 ;;   movq    %rdi, %r9
 ;;   addq    %r9, 0(%rsi), %r9
 ;;   xorq    %r11, %r11, %r11

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -45,8 +45,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4100, %r11
-;;   addq    %r11, 8(%rdx), %r11
+;;   movq    8(%rdx), %r11
+;;   subq    %r11, $4100, %r11
 ;;   movq    0(%rdx), %rax
 ;;   lea     4096(%rax,%rdi,1), %r10
 ;;   xorq    %rax, %rax, %rax
@@ -65,8 +65,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4100, %r11
-;;   addq    %r11, 8(%rsi), %r11
+;;   movq    8(%rsi), %r11
+;;   subq    %r11, $4100, %r11
 ;;   movq    0(%rsi), %rsi
 ;;   lea     4096(%rsi,%rdi,1), %r10
 ;;   xorq    %rsi, %rsi, %rsi

--- a/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/isa/x64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -45,8 +45,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4097, %r11
-;;   addq    %r11, 8(%rdx), %r11
+;;   movq    8(%rdx), %r11
+;;   subq    %r11, $4097, %r11
 ;;   movq    0(%rdx), %rax
 ;;   lea     4096(%rax,%rdi,1), %r10
 ;;   xorq    %rax, %rax, %rax
@@ -65,8 +65,8 @@
 ;;   movq    %rsp, %rbp
 ;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ;; block0:
-;;   movabsq $-4097, %r11
-;;   addq    %r11, 8(%rsi), %r11
+;;   movq    8(%rsi), %r11
+;;   subq    %r11, $4097, %r11
 ;;   movq    0(%rsi), %rsi
 ;;   lea     4096(%rsi,%rdi,1), %r10
 ;;   xorq    %rsi, %rsi, %rsi

--- a/cranelift/filetests/filetests/pcc/succeed/const.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/const.clif
@@ -1,0 +1,18 @@
+test compile
+set enable_pcc=true
+target aarch64
+target x86_64
+
+function %f0() {
+block0:
+    v0 ! range(64, 0, 0) = iconst.i64 0
+    v1 ! range(64, 1, 1) = iconst.i64 1
+    v2 ! range(64, 0xfff, 0xfff) = iconst.i64 0xfff
+    v3 ! range(64, 0x10000, 0x10000) = iconst.i64 0x10000
+    v4 ! range(64, 0xffffc, 0xffffc) = iconst.i64 0xffffc
+    v5 ! range(64, 0x1_0000_0000, 0x1_0000_0000) = iconst.i64 0x1_0000_0000
+    v6 ! range(64, 0x1_0000_0000_0000, 0x1_0000_0000_0000) = iconst.i64 0x1_0000_0000_0000
+    v7 ! range(64, 0xffff_0000_0000_0000, 0xffff_0000_0000_0000) = iconst.i64 0xffff_0000_0000_0000
+    v8 ! range(64, 0xffff_0000_0000_ffff, 0xffff_0000_0000_ffff) = iconst.i64 0xffff_0000_0000_ffff
+    return
+}

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -47,12 +47,13 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4
-;; @0040                               v6 = icmp ugt v3, v5
-;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v3
-;; @0040                               store little heap v1, v8
+;; @0040                               v5 = iconst.i64 4
+;; @0040                               v6 = isub v4, v5  ; v5 = 4
+;; @0040                               v7 = icmp ugt v3, v6
+;; @0040                               trapnz v7, heap_oob
+;; @0040                               v8 = global_value.i64 gv2
+;; @0040                               v9 = iadd v8, v3
+;; @0040                               store little heap v1, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -67,13 +68,14 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0048                               v3 = uextend.i64 v0
 ;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd_imm v4, -4
-;; @0048                               v6 = icmp ugt v3, v5
-;; @0048                               trapnz v6, heap_oob
-;; @0048                               v7 = global_value.i64 gv2
-;; @0048                               v8 = iadd v7, v3
-;; @0048                               v9 = load.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @0048                               v5 = iconst.i64 4
+;; @0048                               v6 = isub v4, v5  ; v5 = 4
+;; @0048                               v7 = icmp ugt v3, v6
+;; @0048                               trapnz v7, heap_oob
+;; @0048                               v8 = global_value.i64 gv2
+;; @0048                               v9 = iadd v8, v3
+;; @0048                               v10 = load.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -47,14 +47,15 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4100
-;; @0040                               v6 = icmp ugt v3, v5
-;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v3
-;; @0040                               v9 = iconst.i64 4096
-;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               store little heap v1, v10
+;; @0040                               v5 = iconst.i64 4100
+;; @0040                               v6 = isub v4, v5  ; v5 = 4100
+;; @0040                               v7 = icmp ugt v3, v6
+;; @0040                               trapnz v7, heap_oob
+;; @0040                               v8 = global_value.i64 gv2
+;; @0040                               v9 = iadd v8, v3
+;; @0040                               v10 = iconst.i64 4096
+;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0040                               store little heap v1, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -69,15 +70,16 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
 ;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd_imm v4, -4100
-;; @0049                               v6 = icmp ugt v3, v5
-;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv2
-;; @0049                               v8 = iadd v7, v3
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = load.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @0049                               v5 = iconst.i64 4100
+;; @0049                               v6 = isub v4, v5  ; v5 = 4100
+;; @0049                               v7 = icmp ugt v3, v6
+;; @0049                               trapnz v7, heap_oob
+;; @0049                               v8 = global_value.i64 gv2
+;; @0049                               v9 = iadd v8, v3
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = load.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -47,14 +47,15 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4097
-;; @0040                               v6 = icmp ugt v3, v5
-;; @0040                               trapnz v6, heap_oob
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v3
-;; @0040                               v9 = iconst.i64 4096
-;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               istore8 little heap v1, v10
+;; @0040                               v5 = iconst.i64 4097
+;; @0040                               v6 = isub v4, v5  ; v5 = 4097
+;; @0040                               v7 = icmp ugt v3, v6
+;; @0040                               trapnz v7, heap_oob
+;; @0040                               v8 = global_value.i64 gv2
+;; @0040                               v9 = iadd v8, v3
+;; @0040                               v10 = iconst.i64 4096
+;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0040                               istore8 little heap v1, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -69,15 +70,16 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
 ;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd_imm v4, -4097
-;; @0049                               v6 = icmp ugt v3, v5
-;; @0049                               trapnz v6, heap_oob
-;; @0049                               v7 = global_value.i64 gv2
-;; @0049                               v8 = iadd v7, v3
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = uload8.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @0049                               v5 = iconst.i64 4097
+;; @0049                               v6 = isub v4, v5  ; v5 = 4097
+;; @0049                               v7 = icmp ugt v3, v6
+;; @0049                               trapnz v7, heap_oob
+;; @0049                               v8 = global_value.i64 gv2
+;; @0049                               v9 = iadd v8, v3
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = uload8.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -47,13 +47,14 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4
-;; @0040                               v6 = icmp ugt v3, v5
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v3
-;; @0040                               v9 = iconst.i64 0
-;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0040                               store little heap v1, v10
+;; @0040                               v5 = iconst.i64 4
+;; @0040                               v6 = isub v4, v5  ; v5 = 4
+;; @0040                               v7 = icmp ugt v3, v6
+;; @0040                               v8 = global_value.i64 gv2
+;; @0040                               v9 = iadd v8, v3
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
+;; @0040                               store little heap v1, v11
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -68,14 +69,15 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0048                               v3 = uextend.i64 v0
 ;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd_imm v4, -4
-;; @0048                               v6 = icmp ugt v3, v5
-;; @0048                               v7 = global_value.i64 gv2
-;; @0048                               v8 = iadd v7, v3
-;; @0048                               v9 = iconst.i64 0
-;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
-;; @0048                               v11 = load.i32 little heap v10
-;; @004b                               jump block1(v11)
+;; @0048                               v5 = iconst.i64 4
+;; @0048                               v6 = isub v4, v5  ; v5 = 4
+;; @0048                               v7 = icmp ugt v3, v6
+;; @0048                               v8 = global_value.i64 gv2
+;; @0048                               v9 = iadd v8, v3
+;; @0048                               v10 = iconst.i64 0
+;; @0048                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
+;; @0048                               v12 = load.i32 little heap v11
+;; @004b                               jump block1(v12)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -47,15 +47,16 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4100
-;; @0040                               v6 = icmp ugt v3, v5
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v3
-;; @0040                               v9 = iconst.i64 4096
-;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               v11 = iconst.i64 0
-;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               store little heap v1, v12
+;; @0040                               v5 = iconst.i64 4100
+;; @0040                               v6 = isub v4, v5  ; v5 = 4100
+;; @0040                               v7 = icmp ugt v3, v6
+;; @0040                               v8 = global_value.i64 gv2
+;; @0040                               v9 = iadd v8, v3
+;; @0040                               v10 = iconst.i64 4096
+;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0040                               v12 = iconst.i64 0
+;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0040                               store little heap v1, v13
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -70,16 +71,17 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
 ;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd_imm v4, -4100
-;; @0049                               v6 = icmp ugt v3, v5
-;; @0049                               v7 = global_value.i64 gv2
-;; @0049                               v8 = iadd v7, v3
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = iconst.i64 0
-;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = load.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @0049                               v5 = iconst.i64 4100
+;; @0049                               v6 = isub v4, v5  ; v5 = 4100
+;; @0049                               v7 = icmp ugt v3, v6
+;; @0049                               v8 = global_value.i64 gv2
+;; @0049                               v9 = iadd v8, v3
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = iconst.i64 0
+;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0049                               v14 = load.i32 little heap v13
+;; @004d                               jump block1(v14)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -47,15 +47,16 @@
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
 ;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd_imm v4, -4097
-;; @0040                               v6 = icmp ugt v3, v5
-;; @0040                               v7 = global_value.i64 gv2
-;; @0040                               v8 = iadd v7, v3
-;; @0040                               v9 = iconst.i64 4096
-;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0040                               v11 = iconst.i64 0
-;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0040                               istore8 little heap v1, v12
+;; @0040                               v5 = iconst.i64 4097
+;; @0040                               v6 = isub v4, v5  ; v5 = 4097
+;; @0040                               v7 = icmp ugt v3, v6
+;; @0040                               v8 = global_value.i64 gv2
+;; @0040                               v9 = iadd v8, v3
+;; @0040                               v10 = iconst.i64 4096
+;; @0040                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0040                               v12 = iconst.i64 0
+;; @0040                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0040                               istore8 little heap v1, v13
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -70,16 +71,17 @@
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
 ;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd_imm v4, -4097
-;; @0049                               v6 = icmp ugt v3, v5
-;; @0049                               v7 = global_value.i64 gv2
-;; @0049                               v8 = iadd v7, v3
-;; @0049                               v9 = iconst.i64 4096
-;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
-;; @0049                               v11 = iconst.i64 0
-;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
-;; @0049                               v13 = uload8.i32 little heap v12
-;; @004d                               jump block1(v13)
+;; @0049                               v5 = iconst.i64 4097
+;; @0049                               v6 = isub v4, v5  ; v5 = 4097
+;; @0049                               v7 = icmp ugt v3, v6
+;; @0049                               v8 = global_value.i64 gv2
+;; @0049                               v9 = iadd v8, v3
+;; @0049                               v10 = iconst.i64 4096
+;; @0049                               v11 = iadd v9, v10  ; v10 = 4096
+;; @0049                               v12 = iconst.i64 0
+;; @0049                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
+;; @0049                               v14 = uload8.i32 little heap v13
+;; @004d                               jump block1(v14)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -46,12 +46,13 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4
-;; @0040                               v5 = icmp ugt v0, v4
-;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v0
-;; @0040                               store little heap v1, v7
+;; @0040                               v4 = iconst.i64 4
+;; @0040                               v5 = isub v3, v4  ; v4 = 4
+;; @0040                               v6 = icmp ugt v0, v5
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv2
+;; @0040                               v8 = iadd v7, v0
+;; @0040                               store little heap v1, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -65,13 +66,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0048                               v3 = global_value.i64 gv1
-;; @0048                               v4 = iadd_imm v3, -4
-;; @0048                               v5 = icmp ugt v0, v4
-;; @0048                               trapnz v5, heap_oob
-;; @0048                               v6 = global_value.i64 gv2
-;; @0048                               v7 = iadd v6, v0
-;; @0048                               v8 = load.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @0048                               v4 = iconst.i64 4
+;; @0048                               v5 = isub v3, v4  ; v4 = 4
+;; @0048                               v6 = icmp ugt v0, v5
+;; @0048                               trapnz v6, heap_oob
+;; @0048                               v7 = global_value.i64 gv2
+;; @0048                               v8 = iadd v7, v0
+;; @0048                               v9 = load.i32 little heap v8
+;; @004b                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -46,14 +46,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4100
-;; @0040                               v5 = icmp ugt v0, v4
-;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v0
-;; @0040                               v8 = iconst.i64 4096
-;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               store little heap v1, v9
+;; @0040                               v4 = iconst.i64 4100
+;; @0040                               v5 = isub v3, v4  ; v4 = 4100
+;; @0040                               v6 = icmp ugt v0, v5
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv2
+;; @0040                               v8 = iadd v7, v0
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               store little heap v1, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -67,15 +68,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0049                               v3 = global_value.i64 gv1
-;; @0049                               v4 = iadd_imm v3, -4100
-;; @0049                               v5 = icmp ugt v0, v4
-;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv2
-;; @0049                               v7 = iadd v6, v0
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = load.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @0049                               v4 = iconst.i64 4100
+;; @0049                               v5 = isub v3, v4  ; v4 = 4100
+;; @0049                               v6 = icmp ugt v0, v5
+;; @0049                               trapnz v6, heap_oob
+;; @0049                               v7 = global_value.i64 gv2
+;; @0049                               v8 = iadd v7, v0
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = load.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -46,14 +46,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4097
-;; @0040                               v5 = icmp ugt v0, v4
-;; @0040                               trapnz v5, heap_oob
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v0
-;; @0040                               v8 = iconst.i64 4096
-;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               istore8 little heap v1, v9
+;; @0040                               v4 = iconst.i64 4097
+;; @0040                               v5 = isub v3, v4  ; v4 = 4097
+;; @0040                               v6 = icmp ugt v0, v5
+;; @0040                               trapnz v6, heap_oob
+;; @0040                               v7 = global_value.i64 gv2
+;; @0040                               v8 = iadd v7, v0
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               istore8 little heap v1, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -67,15 +68,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0049                               v3 = global_value.i64 gv1
-;; @0049                               v4 = iadd_imm v3, -4097
-;; @0049                               v5 = icmp ugt v0, v4
-;; @0049                               trapnz v5, heap_oob
-;; @0049                               v6 = global_value.i64 gv2
-;; @0049                               v7 = iadd v6, v0
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = uload8.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @0049                               v4 = iconst.i64 4097
+;; @0049                               v5 = isub v3, v4  ; v4 = 4097
+;; @0049                               v6 = icmp ugt v0, v5
+;; @0049                               trapnz v6, heap_oob
+;; @0049                               v7 = global_value.i64 gv2
+;; @0049                               v8 = iadd v7, v0
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = uload8.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -46,13 +46,14 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4
-;; @0040                               v5 = icmp ugt v0, v4
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v0
-;; @0040                               v8 = iconst.i64 0
-;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0040                               store little heap v1, v9
+;; @0040                               v4 = iconst.i64 4
+;; @0040                               v5 = isub v3, v4  ; v4 = 4
+;; @0040                               v6 = icmp ugt v0, v5
+;; @0040                               v7 = global_value.i64 gv2
+;; @0040                               v8 = iadd v7, v0
+;; @0040                               v9 = iconst.i64 0
+;; @0040                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
+;; @0040                               store little heap v1, v10
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -66,14 +67,15 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0048                               v3 = global_value.i64 gv1
-;; @0048                               v4 = iadd_imm v3, -4
-;; @0048                               v5 = icmp ugt v0, v4
-;; @0048                               v6 = global_value.i64 gv2
-;; @0048                               v7 = iadd v6, v0
-;; @0048                               v8 = iconst.i64 0
-;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
-;; @0048                               v10 = load.i32 little heap v9
-;; @004b                               jump block1(v10)
+;; @0048                               v4 = iconst.i64 4
+;; @0048                               v5 = isub v3, v4  ; v4 = 4
+;; @0048                               v6 = icmp ugt v0, v5
+;; @0048                               v7 = global_value.i64 gv2
+;; @0048                               v8 = iadd v7, v0
+;; @0048                               v9 = iconst.i64 0
+;; @0048                               v10 = select_spectre_guard v6, v9, v8  ; v9 = 0
+;; @0048                               v11 = load.i32 little heap v10
+;; @004b                               jump block1(v11)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -46,15 +46,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4100
-;; @0040                               v5 = icmp ugt v0, v4
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v0
-;; @0040                               v8 = iconst.i64 4096
-;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               v10 = iconst.i64 0
-;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               store little heap v1, v11
+;; @0040                               v4 = iconst.i64 4100
+;; @0040                               v5 = isub v3, v4  ; v4 = 4100
+;; @0040                               v6 = icmp ugt v0, v5
+;; @0040                               v7 = global_value.i64 gv2
+;; @0040                               v8 = iadd v7, v0
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               v11 = iconst.i64 0
+;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0040                               store little heap v1, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -68,16 +69,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0049                               v3 = global_value.i64 gv1
-;; @0049                               v4 = iadd_imm v3, -4100
-;; @0049                               v5 = icmp ugt v0, v4
-;; @0049                               v6 = global_value.i64 gv2
-;; @0049                               v7 = iadd v6, v0
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = iconst.i64 0
-;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = load.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @0049                               v4 = iconst.i64 4100
+;; @0049                               v5 = isub v3, v4  ; v4 = 4100
+;; @0049                               v6 = icmp ugt v0, v5
+;; @0049                               v7 = global_value.i64 gv2
+;; @0049                               v8 = iadd v7, v0
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = iconst.i64 0
+;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0049                               v13 = load.i32 little heap v12
+;; @004d                               jump block1(v13)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -46,15 +46,16 @@
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
 ;; @0040                               v3 = global_value.i64 gv1
-;; @0040                               v4 = iadd_imm v3, -4097
-;; @0040                               v5 = icmp ugt v0, v4
-;; @0040                               v6 = global_value.i64 gv2
-;; @0040                               v7 = iadd v6, v0
-;; @0040                               v8 = iconst.i64 4096
-;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0040                               v10 = iconst.i64 0
-;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0040                               istore8 little heap v1, v11
+;; @0040                               v4 = iconst.i64 4097
+;; @0040                               v5 = isub v3, v4  ; v4 = 4097
+;; @0040                               v6 = icmp ugt v0, v5
+;; @0040                               v7 = global_value.i64 gv2
+;; @0040                               v8 = iadd v7, v0
+;; @0040                               v9 = iconst.i64 4096
+;; @0040                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0040                               v11 = iconst.i64 0
+;; @0040                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0040                               istore8 little heap v1, v12
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -68,16 +69,17 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64):
 ;; @0049                               v3 = global_value.i64 gv1
-;; @0049                               v4 = iadd_imm v3, -4097
-;; @0049                               v5 = icmp ugt v0, v4
-;; @0049                               v6 = global_value.i64 gv2
-;; @0049                               v7 = iadd v6, v0
-;; @0049                               v8 = iconst.i64 4096
-;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
-;; @0049                               v10 = iconst.i64 0
-;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
-;; @0049                               v12 = uload8.i32 little heap v11
-;; @004d                               jump block1(v12)
+;; @0049                               v4 = iconst.i64 4097
+;; @0049                               v5 = isub v3, v4  ; v4 = 4097
+;; @0049                               v6 = icmp ugt v0, v5
+;; @0049                               v7 = global_value.i64 gv2
+;; @0049                               v8 = iadd v7, v0
+;; @0049                               v9 = iconst.i64 4096
+;; @0049                               v10 = iadd v8, v9  ; v9 = 4096
+;; @0049                               v11 = iconst.i64 0
+;; @0049                               v12 = select_spectre_guard v6, v11, v10  ; v11 = 0
+;; @0049                               v13 = uload8.i32 little heap v12
+;; @004d                               jump block1(v13)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -43,11 +43,12 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = icmp_imm ugt v3, 0x0fff_fffc
-;; @0040                               trapnz v4, heap_oob
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = iadd v5, v3
-;; @0040                               store little heap v1, v6
+;; @0040                               v4 = iconst.i64 0x0fff_fffc
+;; @0040                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_fffc
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv1
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               store little heap v1, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -60,12 +61,13 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0048                               v3 = uextend.i64 v0
-;; @0048                               v4 = icmp_imm ugt v3, 0x0fff_fffc
-;; @0048                               trapnz v4, heap_oob
-;; @0048                               v5 = global_value.i64 gv1
-;; @0048                               v6 = iadd v5, v3
-;; @0048                               v7 = load.i32 little heap v6
-;; @004b                               jump block1(v7)
+;; @0048                               v4 = iconst.i64 0x0fff_fffc
+;; @0048                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_fffc
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = global_value.i64 gv1
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = load.i32 little heap v7
+;; @004b                               jump block1(v8)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -43,13 +43,14 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = icmp_imm ugt v3, 0x0fff_effc
-;; @0040                               trapnz v4, heap_oob
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = iadd v5, v3
-;; @0040                               v7 = iconst.i64 4096
-;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               store little heap v1, v8
+;; @0040                               v4 = iconst.i64 0x0fff_effc
+;; @0040                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_effc
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv1
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               store little heap v1, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -62,14 +63,15 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
-;; @0049                               v4 = icmp_imm ugt v3, 0x0fff_effc
-;; @0049                               trapnz v4, heap_oob
-;; @0049                               v5 = global_value.i64 gv1
-;; @0049                               v6 = iadd v5, v3
-;; @0049                               v7 = iconst.i64 4096
-;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = load.i32 little heap v8
-;; @004d                               jump block1(v9)
+;; @0049                               v4 = iconst.i64 0x0fff_effc
+;; @0049                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_effc
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = global_value.i64 gv1
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = load.i32 little heap v9
+;; @004d                               jump block1(v10)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -43,11 +43,12 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = icmp_imm ugt v3, 0x0fff_ffff
-;; @0040                               trapnz v4, heap_oob
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = iadd v5, v3
-;; @0040                               istore8 little heap v1, v6
+;; @0040                               v4 = iconst.i64 0x0fff_ffff
+;; @0040                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_ffff
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv1
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               istore8 little heap v1, v7
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -60,12 +61,13 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0048                               v3 = uextend.i64 v0
-;; @0048                               v4 = icmp_imm ugt v3, 0x0fff_ffff
-;; @0048                               trapnz v4, heap_oob
-;; @0048                               v5 = global_value.i64 gv1
-;; @0048                               v6 = iadd v5, v3
-;; @0048                               v7 = uload8.i32 little heap v6
-;; @004b                               jump block1(v7)
+;; @0048                               v4 = iconst.i64 0x0fff_ffff
+;; @0048                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_ffff
+;; @0048                               trapnz v5, heap_oob
+;; @0048                               v6 = global_value.i64 gv1
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = uload8.i32 little heap v7
+;; @004b                               jump block1(v8)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -43,13 +43,14 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = icmp_imm ugt v3, 0x0fff_efff
-;; @0040                               trapnz v4, heap_oob
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = iadd v5, v3
-;; @0040                               v7 = iconst.i64 4096
-;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               istore8 little heap v1, v8
+;; @0040                               v4 = iconst.i64 0x0fff_efff
+;; @0040                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_efff
+;; @0040                               trapnz v5, heap_oob
+;; @0040                               v6 = global_value.i64 gv1
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               istore8 little heap v1, v9
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -62,14 +63,15 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
-;; @0049                               v4 = icmp_imm ugt v3, 0x0fff_efff
-;; @0049                               trapnz v4, heap_oob
-;; @0049                               v5 = global_value.i64 gv1
-;; @0049                               v6 = iadd v5, v3
-;; @0049                               v7 = iconst.i64 4096
-;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = uload8.i32 little heap v8
-;; @004d                               jump block1(v9)
+;; @0049                               v4 = iconst.i64 0x0fff_efff
+;; @0049                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_efff
+;; @0049                               trapnz v5, heap_oob
+;; @0049                               v6 = global_value.i64 gv1
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = uload8.i32 little heap v9
+;; @004d                               jump block1(v10)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -43,12 +43,13 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = icmp_imm ugt v3, 0x0fff_fffc
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = iadd v5, v3
-;; @0040                               v7 = iconst.i64 0
-;; @0040                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
-;; @0040                               store little heap v1, v8
+;; @0040                               v4 = iconst.i64 0x0fff_fffc
+;; @0040                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_fffc
+;; @0040                               v6 = global_value.i64 gv1
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0040                               store little heap v1, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -61,13 +62,14 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0048                               v3 = uextend.i64 v0
-;; @0048                               v4 = icmp_imm ugt v3, 0x0fff_fffc
-;; @0048                               v5 = global_value.i64 gv1
-;; @0048                               v6 = iadd v5, v3
-;; @0048                               v7 = iconst.i64 0
-;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
-;; @0048                               v9 = load.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @0048                               v4 = iconst.i64 0x0fff_fffc
+;; @0048                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_fffc
+;; @0048                               v6 = global_value.i64 gv1
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = load.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -43,14 +43,15 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = icmp_imm ugt v3, 0x0fff_effc
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = iadd v5, v3
-;; @0040                               v7 = iconst.i64 4096
-;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               v9 = iconst.i64 0
-;; @0040                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
-;; @0040                               store little heap v1, v10
+;; @0040                               v4 = iconst.i64 0x0fff_effc
+;; @0040                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_effc
+;; @0040                               v6 = global_value.i64 gv1
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               store little heap v1, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -63,15 +64,16 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
-;; @0049                               v4 = icmp_imm ugt v3, 0x0fff_effc
-;; @0049                               v5 = global_value.i64 gv1
-;; @0049                               v6 = iadd v5, v3
-;; @0049                               v7 = iconst.i64 4096
-;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = iconst.i64 0
-;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
-;; @0049                               v11 = load.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @0049                               v4 = iconst.i64 0x0fff_effc
+;; @0049                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_effc
+;; @0049                               v6 = global_value.i64 gv1
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = load.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -43,12 +43,13 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = icmp_imm ugt v3, 0x0fff_ffff
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = iadd v5, v3
-;; @0040                               v7 = iconst.i64 0
-;; @0040                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
-;; @0040                               istore8 little heap v1, v8
+;; @0040                               v4 = iconst.i64 0x0fff_ffff
+;; @0040                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_ffff
+;; @0040                               v6 = global_value.i64 gv1
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               v8 = iconst.i64 0
+;; @0040                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0040                               istore8 little heap v1, v9
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -61,13 +62,14 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0048                               v3 = uextend.i64 v0
-;; @0048                               v4 = icmp_imm ugt v3, 0x0fff_ffff
-;; @0048                               v5 = global_value.i64 gv1
-;; @0048                               v6 = iadd v5, v3
-;; @0048                               v7 = iconst.i64 0
-;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
-;; @0048                               v9 = uload8.i32 little heap v8
-;; @004b                               jump block1(v9)
+;; @0048                               v4 = iconst.i64 0x0fff_ffff
+;; @0048                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_ffff
+;; @0048                               v6 = global_value.i64 gv1
+;; @0048                               v7 = iadd v6, v3
+;; @0048                               v8 = iconst.i64 0
+;; @0048                               v9 = select_spectre_guard v5, v8, v7  ; v8 = 0
+;; @0048                               v10 = uload8.i32 little heap v9
+;; @004b                               jump block1(v10)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -43,14 +43,15 @@
 ;;
 ;;                                 block0(v0: i32, v1: i32, v2: i64):
 ;; @0040                               v3 = uextend.i64 v0
-;; @0040                               v4 = icmp_imm ugt v3, 0x0fff_efff
-;; @0040                               v5 = global_value.i64 gv1
-;; @0040                               v6 = iadd v5, v3
-;; @0040                               v7 = iconst.i64 4096
-;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0040                               v9 = iconst.i64 0
-;; @0040                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
-;; @0040                               istore8 little heap v1, v10
+;; @0040                               v4 = iconst.i64 0x0fff_efff
+;; @0040                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_efff
+;; @0040                               v6 = global_value.i64 gv1
+;; @0040                               v7 = iadd v6, v3
+;; @0040                               v8 = iconst.i64 4096
+;; @0040                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0040                               v10 = iconst.i64 0
+;; @0040                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0040                               istore8 little heap v1, v11
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -63,15 +64,16 @@
 ;;
 ;;                                 block0(v0: i32, v1: i64):
 ;; @0049                               v3 = uextend.i64 v0
-;; @0049                               v4 = icmp_imm ugt v3, 0x0fff_efff
-;; @0049                               v5 = global_value.i64 gv1
-;; @0049                               v6 = iadd v5, v3
-;; @0049                               v7 = iconst.i64 4096
-;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
-;; @0049                               v9 = iconst.i64 0
-;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
-;; @0049                               v11 = uload8.i32 little heap v10
-;; @004d                               jump block1(v11)
+;; @0049                               v4 = iconst.i64 0x0fff_efff
+;; @0049                               v5 = icmp ugt v3, v4  ; v4 = 0x0fff_efff
+;; @0049                               v6 = global_value.i64 gv1
+;; @0049                               v7 = iadd v6, v3
+;; @0049                               v8 = iconst.i64 4096
+;; @0049                               v9 = iadd v7, v8  ; v8 = 4096
+;; @0049                               v10 = iconst.i64 0
+;; @0049                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
+;; @0049                               v12 = uload8.i32 little heap v11
+;; @004d                               jump block1(v12)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -42,11 +42,12 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_fffc
-;; @0040                               trapnz v3, heap_oob
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               store little heap v1, v5
+;; @0040                               v3 = iconst.i64 0x0fff_fffc
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_fffc
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               store little heap v1, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -58,12 +59,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0048                               v3 = icmp_imm ugt v0, 0x0fff_fffc
-;; @0048                               trapnz v3, heap_oob
-;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd v4, v0
-;; @0048                               v6 = load.i32 little heap v5
-;; @004b                               jump block1(v6)
+;; @0048                               v3 = iconst.i64 0x0fff_fffc
+;; @0048                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_fffc
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = global_value.i64 gv1
+;; @0048                               v6 = iadd v5, v0
+;; @0048                               v7 = load.i32 little heap v6
+;; @004b                               jump block1(v7)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -42,13 +42,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_effc
-;; @0040                               trapnz v3, heap_oob
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 4096
-;; @0040                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0040                               store little heap v1, v7
+;; @0040                               v3 = iconst.i64 0x0fff_effc
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_effc
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               store little heap v1, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -60,14 +61,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0049                               v3 = icmp_imm ugt v0, 0x0fff_effc
-;; @0049                               trapnz v3, heap_oob
-;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd v4, v0
-;; @0049                               v6 = iconst.i64 4096
-;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0049                               v8 = load.i32 little heap v7
-;; @004d                               jump block1(v8)
+;; @0049                               v3 = iconst.i64 0x0fff_effc
+;; @0049                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_effc
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = global_value.i64 gv1
+;; @0049                               v6 = iadd v5, v0
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = load.i32 little heap v8
+;; @004d                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -42,11 +42,12 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_ffff
-;; @0040                               trapnz v3, heap_oob
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               istore8 little heap v1, v5
+;; @0040                               v3 = iconst.i64 0x0fff_ffff
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_ffff
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               istore8 little heap v1, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -58,12 +59,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0048                               v3 = icmp_imm ugt v0, 0x0fff_ffff
-;; @0048                               trapnz v3, heap_oob
-;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd v4, v0
-;; @0048                               v6 = uload8.i32 little heap v5
-;; @004b                               jump block1(v6)
+;; @0048                               v3 = iconst.i64 0x0fff_ffff
+;; @0048                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_ffff
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = global_value.i64 gv1
+;; @0048                               v6 = iadd v5, v0
+;; @0048                               v7 = uload8.i32 little heap v6
+;; @004b                               jump block1(v7)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -42,13 +42,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_efff
-;; @0040                               trapnz v3, heap_oob
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 4096
-;; @0040                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0040                               istore8 little heap v1, v7
+;; @0040                               v3 = iconst.i64 0x0fff_efff
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_efff
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               istore8 little heap v1, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -60,14 +61,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0049                               v3 = icmp_imm ugt v0, 0x0fff_efff
-;; @0049                               trapnz v3, heap_oob
-;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd v4, v0
-;; @0049                               v6 = iconst.i64 4096
-;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0049                               v8 = uload8.i32 little heap v7
-;; @004d                               jump block1(v8)
+;; @0049                               v3 = iconst.i64 0x0fff_efff
+;; @0049                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_efff
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = global_value.i64 gv1
+;; @0049                               v6 = iadd v5, v0
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = uload8.i32 little heap v8
+;; @004d                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -42,12 +42,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_fffc
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 0
-;; @0040                               v7 = select_spectre_guard v3, v6, v5  ; v6 = 0
-;; @0040                               store little heap v1, v7
+;; @0040                               v3 = iconst.i64 0x0fff_fffc
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_fffc
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 0
+;; @0040                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0040                               store little heap v1, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -59,13 +60,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0048                               v3 = icmp_imm ugt v0, 0x0fff_fffc
-;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd v4, v0
-;; @0048                               v6 = iconst.i64 0
-;; @0048                               v7 = select_spectre_guard v3, v6, v5  ; v6 = 0
-;; @0048                               v8 = load.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @0048                               v3 = iconst.i64 0x0fff_fffc
+;; @0048                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_fffc
+;; @0048                               v5 = global_value.i64 gv1
+;; @0048                               v6 = iadd v5, v0
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0048                               v9 = load.i32 little heap v8
+;; @004b                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -42,14 +42,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_effc
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 4096
-;; @0040                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0040                               v8 = iconst.i64 0
-;; @0040                               v9 = select_spectre_guard v3, v8, v7  ; v8 = 0
-;; @0040                               store little heap v1, v9
+;; @0040                               v3 = iconst.i64 0x0fff_effc
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_effc
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               v9 = iconst.i64 0
+;; @0040                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0040                               store little heap v1, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -61,15 +62,16 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0049                               v3 = icmp_imm ugt v0, 0x0fff_effc
-;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd v4, v0
-;; @0049                               v6 = iconst.i64 4096
-;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0049                               v8 = iconst.i64 0
-;; @0049                               v9 = select_spectre_guard v3, v8, v7  ; v8 = 0
-;; @0049                               v10 = load.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @0049                               v3 = iconst.i64 0x0fff_effc
+;; @0049                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_effc
+;; @0049                               v5 = global_value.i64 gv1
+;; @0049                               v6 = iadd v5, v0
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = iconst.i64 0
+;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0049                               v11 = load.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -42,12 +42,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_ffff
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 0
-;; @0040                               v7 = select_spectre_guard v3, v6, v5  ; v6 = 0
-;; @0040                               istore8 little heap v1, v7
+;; @0040                               v3 = iconst.i64 0x0fff_ffff
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_ffff
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 0
+;; @0040                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0040                               istore8 little heap v1, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -59,13 +60,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0048                               v3 = icmp_imm ugt v0, 0x0fff_ffff
-;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd v4, v0
-;; @0048                               v6 = iconst.i64 0
-;; @0048                               v7 = select_spectre_guard v3, v6, v5  ; v6 = 0
-;; @0048                               v8 = uload8.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @0048                               v3 = iconst.i64 0x0fff_ffff
+;; @0048                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_ffff
+;; @0048                               v5 = global_value.i64 gv1
+;; @0048                               v6 = iadd v5, v0
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0048                               v9 = uload8.i32 little heap v8
+;; @004b                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -42,14 +42,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_efff
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 4096
-;; @0040                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0040                               v8 = iconst.i64 0
-;; @0040                               v9 = select_spectre_guard v3, v8, v7  ; v8 = 0
-;; @0040                               istore8 little heap v1, v9
+;; @0040                               v3 = iconst.i64 0x0fff_efff
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_efff
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               v9 = iconst.i64 0
+;; @0040                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0040                               istore8 little heap v1, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -61,15 +62,16 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0049                               v3 = icmp_imm ugt v0, 0x0fff_efff
-;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd v4, v0
-;; @0049                               v6 = iconst.i64 4096
-;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0049                               v8 = iconst.i64 0
-;; @0049                               v9 = select_spectre_guard v3, v8, v7  ; v8 = 0
-;; @0049                               v10 = uload8.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @0049                               v3 = iconst.i64 0x0fff_efff
+;; @0049                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_efff
+;; @0049                               v5 = global_value.i64 gv1
+;; @0049                               v6 = iadd v5, v0
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = iconst.i64 0
+;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0049                               v11 = uload8.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -42,11 +42,12 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_fffc
-;; @0040                               trapnz v3, heap_oob
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               store little heap v1, v5
+;; @0040                               v3 = iconst.i64 0x0fff_fffc
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_fffc
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               store little heap v1, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -58,12 +59,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0048                               v3 = icmp_imm ugt v0, 0x0fff_fffc
-;; @0048                               trapnz v3, heap_oob
-;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd v4, v0
-;; @0048                               v6 = load.i32 little heap v5
-;; @004b                               jump block1(v6)
+;; @0048                               v3 = iconst.i64 0x0fff_fffc
+;; @0048                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_fffc
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = global_value.i64 gv1
+;; @0048                               v6 = iadd v5, v0
+;; @0048                               v7 = load.i32 little heap v6
+;; @004b                               jump block1(v7)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -42,13 +42,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_effc
-;; @0040                               trapnz v3, heap_oob
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 4096
-;; @0040                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0040                               store little heap v1, v7
+;; @0040                               v3 = iconst.i64 0x0fff_effc
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_effc
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               store little heap v1, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -60,14 +61,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0049                               v3 = icmp_imm ugt v0, 0x0fff_effc
-;; @0049                               trapnz v3, heap_oob
-;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd v4, v0
-;; @0049                               v6 = iconst.i64 4096
-;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0049                               v8 = load.i32 little heap v7
-;; @004d                               jump block1(v8)
+;; @0049                               v3 = iconst.i64 0x0fff_effc
+;; @0049                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_effc
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = global_value.i64 gv1
+;; @0049                               v6 = iadd v5, v0
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = load.i32 little heap v8
+;; @004d                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -42,11 +42,12 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_ffff
-;; @0040                               trapnz v3, heap_oob
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               istore8 little heap v1, v5
+;; @0040                               v3 = iconst.i64 0x0fff_ffff
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_ffff
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               istore8 little heap v1, v6
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -58,12 +59,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0048                               v3 = icmp_imm ugt v0, 0x0fff_ffff
-;; @0048                               trapnz v3, heap_oob
-;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd v4, v0
-;; @0048                               v6 = uload8.i32 little heap v5
-;; @004b                               jump block1(v6)
+;; @0048                               v3 = iconst.i64 0x0fff_ffff
+;; @0048                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_ffff
+;; @0048                               trapnz v4, heap_oob
+;; @0048                               v5 = global_value.i64 gv1
+;; @0048                               v6 = iadd v5, v0
+;; @0048                               v7 = uload8.i32 little heap v6
+;; @004b                               jump block1(v7)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -42,13 +42,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_efff
-;; @0040                               trapnz v3, heap_oob
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 4096
-;; @0040                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0040                               istore8 little heap v1, v7
+;; @0040                               v3 = iconst.i64 0x0fff_efff
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_efff
+;; @0040                               trapnz v4, heap_oob
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               istore8 little heap v1, v8
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -60,14 +61,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0049                               v3 = icmp_imm ugt v0, 0x0fff_efff
-;; @0049                               trapnz v3, heap_oob
-;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd v4, v0
-;; @0049                               v6 = iconst.i64 4096
-;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0049                               v8 = uload8.i32 little heap v7
-;; @004d                               jump block1(v8)
+;; @0049                               v3 = iconst.i64 0x0fff_efff
+;; @0049                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_efff
+;; @0049                               trapnz v4, heap_oob
+;; @0049                               v5 = global_value.i64 gv1
+;; @0049                               v6 = iadd v5, v0
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = uload8.i32 little heap v8
+;; @004d                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -42,12 +42,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_fffc
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 0
-;; @0040                               v7 = select_spectre_guard v3, v6, v5  ; v6 = 0
-;; @0040                               store little heap v1, v7
+;; @0040                               v3 = iconst.i64 0x0fff_fffc
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_fffc
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 0
+;; @0040                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0040                               store little heap v1, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -59,13 +60,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0048                               v3 = icmp_imm ugt v0, 0x0fff_fffc
-;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd v4, v0
-;; @0048                               v6 = iconst.i64 0
-;; @0048                               v7 = select_spectre_guard v3, v6, v5  ; v6 = 0
-;; @0048                               v8 = load.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @0048                               v3 = iconst.i64 0x0fff_fffc
+;; @0048                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_fffc
+;; @0048                               v5 = global_value.i64 gv1
+;; @0048                               v6 = iadd v5, v0
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0048                               v9 = load.i32 little heap v8
+;; @004b                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -42,14 +42,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_effc
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 4096
-;; @0040                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0040                               v8 = iconst.i64 0
-;; @0040                               v9 = select_spectre_guard v3, v8, v7  ; v8 = 0
-;; @0040                               store little heap v1, v9
+;; @0040                               v3 = iconst.i64 0x0fff_effc
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_effc
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               v9 = iconst.i64 0
+;; @0040                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0040                               store little heap v1, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -61,15 +62,16 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0049                               v3 = icmp_imm ugt v0, 0x0fff_effc
-;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd v4, v0
-;; @0049                               v6 = iconst.i64 4096
-;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0049                               v8 = iconst.i64 0
-;; @0049                               v9 = select_spectre_guard v3, v8, v7  ; v8 = 0
-;; @0049                               v10 = load.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @0049                               v3 = iconst.i64 0x0fff_effc
+;; @0049                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_effc
+;; @0049                               v5 = global_value.i64 gv1
+;; @0049                               v6 = iadd v5, v0
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = iconst.i64 0
+;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0049                               v11 = load.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -42,12 +42,13 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_ffff
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 0
-;; @0040                               v7 = select_spectre_guard v3, v6, v5  ; v6 = 0
-;; @0040                               istore8 little heap v1, v7
+;; @0040                               v3 = iconst.i64 0x0fff_ffff
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_ffff
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 0
+;; @0040                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0040                               istore8 little heap v1, v8
 ;; @0043                               jump block1
 ;;
 ;;                                 block1:
@@ -59,13 +60,14 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0048                               v3 = icmp_imm ugt v0, 0x0fff_ffff
-;; @0048                               v4 = global_value.i64 gv1
-;; @0048                               v5 = iadd v4, v0
-;; @0048                               v6 = iconst.i64 0
-;; @0048                               v7 = select_spectre_guard v3, v6, v5  ; v6 = 0
-;; @0048                               v8 = uload8.i32 little heap v7
-;; @004b                               jump block1(v8)
+;; @0048                               v3 = iconst.i64 0x0fff_ffff
+;; @0048                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_ffff
+;; @0048                               v5 = global_value.i64 gv1
+;; @0048                               v6 = iadd v5, v0
+;; @0048                               v7 = iconst.i64 0
+;; @0048                               v8 = select_spectre_guard v4, v7, v6  ; v7 = 0
+;; @0048                               v9 = uload8.i32 little heap v8
+;; @004b                               jump block1(v9)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004b                               return v2

--- a/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/cranelift/filetests/filetests/wasm/load-store/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -42,14 +42,15 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i32, v2: i64):
-;; @0040                               v3 = icmp_imm ugt v0, 0x0fff_efff
-;; @0040                               v4 = global_value.i64 gv1
-;; @0040                               v5 = iadd v4, v0
-;; @0040                               v6 = iconst.i64 4096
-;; @0040                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0040                               v8 = iconst.i64 0
-;; @0040                               v9 = select_spectre_guard v3, v8, v7  ; v8 = 0
-;; @0040                               istore8 little heap v1, v9
+;; @0040                               v3 = iconst.i64 0x0fff_efff
+;; @0040                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_efff
+;; @0040                               v5 = global_value.i64 gv1
+;; @0040                               v6 = iadd v5, v0
+;; @0040                               v7 = iconst.i64 4096
+;; @0040                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0040                               v9 = iconst.i64 0
+;; @0040                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0040                               istore8 little heap v1, v10
 ;; @0044                               jump block1
 ;;
 ;;                                 block1:
@@ -61,15 +62,16 @@
 ;;     gv1 = load.i64 notrap aligned readonly gv0
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;; @0049                               v3 = icmp_imm ugt v0, 0x0fff_efff
-;; @0049                               v4 = global_value.i64 gv1
-;; @0049                               v5 = iadd v4, v0
-;; @0049                               v6 = iconst.i64 4096
-;; @0049                               v7 = iadd v5, v6  ; v6 = 4096
-;; @0049                               v8 = iconst.i64 0
-;; @0049                               v9 = select_spectre_guard v3, v8, v7  ; v8 = 0
-;; @0049                               v10 = uload8.i32 little heap v9
-;; @004d                               jump block1(v10)
+;; @0049                               v3 = iconst.i64 0x0fff_efff
+;; @0049                               v4 = icmp ugt v0, v3  ; v3 = 0x0fff_efff
+;; @0049                               v5 = global_value.i64 gv1
+;; @0049                               v6 = iadd v5, v0
+;; @0049                               v7 = iconst.i64 4096
+;; @0049                               v8 = iadd v6, v7  ; v7 = 4096
+;; @0049                               v9 = iconst.i64 0
+;; @0049                               v10 = select_spectre_guard v4, v9, v8  ; v9 = 0
+;; @0049                               v11 = uload8.i32 little heap v10
+;; @004d                               jump block1(v11)
 ;;
 ;;                                 block1(v2: i32):
 ;; @004d                               return v2

--- a/cranelift/wasm/src/code_translator/bounds_checks.rs
+++ b/cranelift/wasm/src/code_translator/bounds_checks.rs
@@ -23,8 +23,8 @@ use super::Reachability;
 use crate::{FuncEnvironment, HeapData, HeapStyle};
 use cranelift_codegen::{
     cursor::{Cursor, FuncCursor},
-    ir::pcc::Fact,
     ir::{self, condcodes::IntCC, InstBuilder, RelSourceLoc},
+    ir::{Expr, Fact},
 };
 use cranelift_frontend::FunctionBuilder;
 use wasmtime_types::WasmResult;
@@ -49,6 +49,8 @@ pub fn bounds_check_and_compute_addr<Env>(
 where
     Env: FuncEnvironment + ?Sized,
 {
+    let pointer_bit_width = u16::try_from(env.pointer_type().bits()).unwrap();
+    let orig_index = index;
     let index = cast_index_to_pointer_ty(
         index,
         heap.index_type,
@@ -59,6 +61,50 @@ where
     let offset_and_size = offset_plus_size(offset, access_size);
     let spectre_mitigations_enabled = env.heap_access_spectre_mitigation();
     let pcc = env.proof_carrying_code();
+
+    let make_compare = |builder: &mut FunctionBuilder, compare_kind, lhs, lhs_off, rhs, rhs_off| {
+        let result = builder.ins().icmp(compare_kind, lhs, rhs);
+        if pcc {
+            // Name the original value as a def of the SSA value;
+            // if the value was extended, name that as well with a
+            // dynamic range, overwriting the basic full-range
+            // fact that we previously put on the uextend.
+            builder.func.dfg.facts[orig_index] = Some(Fact::Def { value: orig_index });
+            if index != orig_index {
+                builder.func.dfg.facts[index] = Some(Fact::value(pointer_bit_width, orig_index));
+            }
+
+            // Create a fact on the LHS that is a "trivial symbolic
+            // fact": v1 has range v1+LHS_off..=v1+LHS_off
+            builder.func.dfg.facts[lhs] =
+                Some(Fact::value_offset(pointer_bit_width, orig_index, lhs_off));
+            // If the RHS is a symbolic value (v1 or gv1), we can
+            // emit a Compare fact.
+            if let Some(rhs) = builder.func.dfg.facts[rhs]
+                .as_ref()
+                .and_then(|f| f.as_symbol())
+            {
+                builder.func.dfg.facts[result] = Some(Fact::Compare {
+                    kind: compare_kind,
+                    lhs: Expr::offset(&Expr::value(orig_index), lhs_off).unwrap(),
+                    rhs: Expr::offset(rhs, rhs_off).unwrap(),
+                });
+            }
+            // Likewise, if the RHS is a constant, we can emit a
+            // Compare fact.
+            if let Some(k) = builder.func.dfg.facts[rhs]
+                .as_ref()
+                .and_then(|f| f.as_const(pointer_bit_width))
+            {
+                builder.func.dfg.facts[result] = Some(Fact::Compare {
+                    kind: compare_kind,
+                    lhs: Expr::offset(&Expr::value(orig_index), lhs_off).unwrap(),
+                    rhs: Expr::constant((k as i64).checked_add(rhs_off).unwrap()),
+                });
+            }
+        }
+        result
+    };
 
     // We need to emit code that will trap (or compute an address that will trap
     // when accessed) if
@@ -86,19 +132,25 @@ where
         //
         //            index + 1 > bound
         //        ==> index >= bound
-        HeapStyle::Dynamic { .. } if offset_and_size == 1 => {
+        HeapStyle::Dynamic { bound_gv } if offset_and_size == 1 => {
             let bound = get_dynamic_heap_bound(builder, env, heap);
-            let oob = builder
-                .ins()
-                .icmp(IntCC::UnsignedGreaterThanOrEqual, index, bound);
+            let oob = make_compare(
+                builder,
+                IntCC::UnsignedGreaterThanOrEqual,
+                index,
+                0,
+                bound,
+                0,
+            );
             Reachable(explicit_check_oob_condition_and_compute_addr(
                 &mut builder.cursor(),
                 heap,
                 env.pointer_type(),
                 index,
                 offset,
+                access_size,
                 spectre_mitigations_enabled,
-                pcc,
+                AddrPcc::dynamic(heap.memory_type, bound_gv),
                 oob,
             ))
         }
@@ -128,17 +180,18 @@ where
         //    offset immediates -- which is a common code pattern when accessing
         //    multiple fields in the same struct that is in linear memory --
         //    will all emit the same `index > bound` check, which we can GVN.
-        HeapStyle::Dynamic { .. } if offset_and_size <= heap.offset_guard_size => {
+        HeapStyle::Dynamic { bound_gv } if offset_and_size <= heap.offset_guard_size => {
             let bound = get_dynamic_heap_bound(builder, env, heap);
-            let oob = builder.ins().icmp(IntCC::UnsignedGreaterThan, index, bound);
+            let oob = make_compare(builder, IntCC::UnsignedGreaterThan, index, 0, bound, 0);
             Reachable(explicit_check_oob_condition_and_compute_addr(
                 &mut builder.cursor(),
                 heap,
                 env.pointer_type(),
                 index,
                 offset,
+                access_size,
                 spectre_mitigations_enabled,
-                pcc,
+                AddrPcc::dynamic(heap.memory_type, bound_gv),
                 oob,
             ))
         }
@@ -150,20 +203,39 @@ where
         //
         //            index + offset + access_size > bound
         //        ==> index > bound - (offset + access_size)
-        HeapStyle::Dynamic { .. } if offset_and_size <= heap.min_size.into() => {
+        HeapStyle::Dynamic { bound_gv } if offset_and_size <= heap.min_size.into() => {
             let bound = get_dynamic_heap_bound(builder, env, heap);
-            let adjusted_bound = builder.ins().iadd_imm(bound, -(offset_and_size as i64));
-            let oob = builder
-                .ins()
-                .icmp(IntCC::UnsignedGreaterThan, index, adjusted_bound);
+            let adjustment = offset_and_size as i64;
+            let adjustment_value = builder.ins().iconst(env.pointer_type(), adjustment);
+            if pcc {
+                builder.func.dfg.facts[adjustment_value] =
+                    Some(Fact::constant(pointer_bit_width, offset_and_size));
+            }
+            let adjusted_bound = builder.ins().isub(bound, adjustment_value);
+            if pcc {
+                builder.func.dfg.facts[adjusted_bound] = Some(Fact::global_value_offset(
+                    pointer_bit_width,
+                    bound_gv,
+                    -adjustment,
+                ));
+            }
+            let oob = make_compare(
+                builder,
+                IntCC::UnsignedGreaterThan,
+                index,
+                0,
+                adjusted_bound,
+                adjustment,
+            );
             Reachable(explicit_check_oob_condition_and_compute_addr(
                 &mut builder.cursor(),
                 heap,
                 env.pointer_type(),
                 index,
                 offset,
+                access_size,
                 spectre_mitigations_enabled,
-                pcc,
+                AddrPcc::dynamic(heap.memory_type, bound_gv),
                 oob,
             ))
         }
@@ -173,27 +245,44 @@ where
         //        index + offset + access_size > bound
         //
         //    And we have to handle the overflow case in the left-hand side.
-        HeapStyle::Dynamic { .. } => {
+        HeapStyle::Dynamic { bound_gv } => {
             let access_size_val = builder
                 .ins()
                 .iconst(env.pointer_type(), offset_and_size as i64);
+            if pcc {
+                builder.func.dfg.facts[access_size_val] =
+                    Some(Fact::constant(pointer_bit_width, offset_and_size));
+            }
             let adjusted_index = builder.ins().uadd_overflow_trap(
                 index,
                 access_size_val,
                 ir::TrapCode::HeapOutOfBounds,
             );
+            if pcc {
+                builder.func.dfg.facts[adjusted_index] = Some(Fact::value_offset(
+                    pointer_bit_width,
+                    index,
+                    offset_and_size as i64,
+                ));
+            }
             let bound = get_dynamic_heap_bound(builder, env, heap);
-            let oob = builder
-                .ins()
-                .icmp(IntCC::UnsignedGreaterThan, adjusted_index, bound);
+            let oob = make_compare(
+                builder,
+                IntCC::UnsignedGreaterThan,
+                adjusted_index,
+                offset_and_size as i64,
+                bound,
+                0,
+            );
             Reachable(explicit_check_oob_condition_and_compute_addr(
                 &mut builder.cursor(),
                 heap,
                 env.pointer_type(),
                 index,
                 offset,
+                access_size,
                 spectre_mitigations_enabled,
-                pcc,
+                AddrPcc::dynamic(heap.memory_type, bound_gv),
                 oob,
             ))
         }
@@ -261,7 +350,10 @@ where
                 env.pointer_type(),
                 index,
                 offset,
-                pcc,
+                AddrPcc::static32(
+                    heap.memory_type,
+                    u64::from(bound) + u64::from(heap.offset_guard_size),
+                ),
             ))
         }
 
@@ -280,18 +372,30 @@ where
             // NB: this subtraction cannot wrap because we didn't hit the first
             // special case.
             let adjusted_bound = u64::from(bound) - offset_and_size;
-            let oob =
-                builder
-                    .ins()
-                    .icmp_imm(IntCC::UnsignedGreaterThan, index, adjusted_bound as i64);
+            let adjusted_bound_value = builder
+                .ins()
+                .iconst(env.pointer_type(), adjusted_bound as i64);
+            if pcc {
+                builder.func.dfg.facts[adjusted_bound_value] =
+                    Some(Fact::constant(pointer_bit_width, adjusted_bound));
+            }
+            let oob = make_compare(
+                builder,
+                IntCC::UnsignedGreaterThan,
+                index,
+                0,
+                adjusted_bound_value,
+                0,
+            );
             Reachable(explicit_check_oob_condition_and_compute_addr(
                 &mut builder.cursor(),
                 heap,
                 env.pointer_type(),
                 index,
                 offset,
+                access_size,
                 spectre_mitigations_enabled,
-                pcc,
+                AddrPcc::static32(heap.memory_type, u64::from(bound)),
                 oob,
             ))
         }
@@ -387,6 +491,38 @@ fn cast_index_to_pointer_ty(
     extended_index
 }
 
+/// Which facts do we want to emit for proof-carrying code, if any, on
+/// address computations?
+#[derive(Clone, Copy, Debug)]
+enum AddrPcc {
+    None,
+    /// A 32-bit static memory with the given size.
+    Static32(ir::MemoryType, u64),
+    /// Dynamic bounds-check, with actual memory size (the `GlobalValue`)
+    /// expressed symbolically.
+    Dynamic(ir::MemoryType, ir::GlobalValue),
+}
+impl AddrPcc {
+    fn is_some(&self) -> bool {
+        match self {
+            AddrPcc::None => false,
+            _ => true,
+        }
+    }
+    fn static32(memory_type: Option<ir::MemoryType>, size: u64) -> Self {
+        match memory_type {
+            Some(ty) => AddrPcc::Static32(ty, size),
+            None => AddrPcc::None,
+        }
+    }
+    fn dynamic(memory_type: Option<ir::MemoryType>, bound: ir::GlobalValue) -> Self {
+        match memory_type {
+            Some(ty) => AddrPcc::Dynamic(ty, bound),
+            None => AddrPcc::None,
+        }
+    }
+}
+
 /// Emit explicit checks on the given out-of-bounds condition for the Wasm
 /// address and return the native address.
 ///
@@ -398,10 +534,11 @@ fn explicit_check_oob_condition_and_compute_addr(
     addr_ty: ir::Type,
     index: ir::Value,
     offset: u32,
+    access_size: u8,
     // Whether Spectre mitigations are enabled for heap accesses.
     spectre_mitigations_enabled: bool,
     // Whether we're emitting PCC facts.
-    pcc: bool,
+    pcc: AddrPcc,
     // The `i8` boolean value that is non-zero when the heap access is out of
     // bounds (and therefore we should trap) and is zero when the heap access is
     // in bounds (and therefore we can proceed).
@@ -417,24 +554,40 @@ fn explicit_check_oob_condition_and_compute_addr(
     if spectre_mitigations_enabled {
         let null = pos.ins().iconst(addr_ty, 0);
         addr = pos.ins().select_spectre_guard(oob_condition, null, addr);
+
+        match pcc {
+            AddrPcc::None => {}
+            AddrPcc::Static32(ty, size) => {
+                pos.func.dfg.facts[null] =
+                    Some(Fact::constant(u16::try_from(addr_ty.bits()).unwrap(), 0));
+                pos.func.dfg.facts[addr] = Some(Fact::Mem {
+                    ty,
+                    min_offset: 0,
+                    max_offset: size - u64::from(access_size),
+                    nullable: true,
+                });
+            }
+            AddrPcc::Dynamic(ty, gv) => {
+                pos.func.dfg.facts[null] =
+                    Some(Fact::constant(u16::try_from(addr_ty.bits()).unwrap(), 0));
+                pos.func.dfg.facts[addr] = Some(Fact::DynamicMem {
+                    ty,
+                    min: Expr::constant(0),
+                    max: Expr::offset(
+                        &Expr::global_value(gv),
+                        i64::try_from(heap.offset_guard_size)
+                            .unwrap()
+                            .checked_sub(i64::from(access_size))
+                            .unwrap(),
+                    )
+                    .unwrap(),
+                    nullable: true,
+                });
+            }
+        }
     }
 
     addr
-}
-
-fn add_fact<F: Fn(ir::MemoryType) -> Fact>(
-    pos: &mut FuncCursor,
-    pcc_memtype: Option<ir::MemoryType>,
-    value: ir::Value,
-    make_fact: F,
-) {
-    if let Some(ty) = pcc_memtype {
-        assert!(
-            pos.func.dfg.facts[value].is_none(),
-            "Overwriting a fact is invalid"
-        );
-        pos.func.dfg.facts[value] = Some(make_fact(ty));
-    }
 }
 
 /// Emit code for the native address computation of a Wasm address,
@@ -449,39 +602,53 @@ fn compute_addr(
     addr_ty: ir::Type,
     index: ir::Value,
     offset: u32,
-    pcc: bool,
+    pcc: AddrPcc,
 ) -> ir::Value {
     debug_assert_eq!(pos.func.dfg.value_type(index), addr_ty);
 
     let heap_base = pos.ins().global_value(addr_ty, heap.base);
 
-    let pcc_memtype = if pcc {
-        Some(
-            heap.memory_type
-                .expect("A memory type is required when PCC is enabled"),
-        )
-    } else {
-        None
-    };
-
-    add_fact(pos, pcc_memtype, heap_base, |ty| Fact::Mem {
-        ty,
-        min_offset: 0,
-        max_offset: 0,
-    });
+    match pcc {
+        AddrPcc::None => {}
+        AddrPcc::Static32(ty, _size) => {
+            pos.func.dfg.facts[heap_base] = Some(Fact::Mem {
+                ty,
+                min_offset: 0,
+                max_offset: 0,
+                nullable: false,
+            });
+        }
+        AddrPcc::Dynamic(ty, _limit) => {
+            pos.func.dfg.facts[heap_base] = Some(Fact::dynamic_base_ptr(ty));
+        }
+    }
 
     let base_and_index = pos.ins().iadd(heap_base, index);
 
-    add_fact(pos, pcc_memtype, base_and_index, |ty| {
-        // TODO: handle memory64 as well. For now we assert that we
-        // have a 32-bit `heap.index_type`.
-        assert_eq!(heap.index_type, ir::types::I32);
-        Fact::Mem {
-            ty,
-            min_offset: 0,
-            max_offset: u64::from(u32::MAX),
+    match pcc {
+        AddrPcc::None => {}
+        AddrPcc::Static32(ty, _) | AddrPcc::Dynamic(ty, _) => {
+            if let Some(idx) = pos.func.dfg.facts[index]
+                .as_ref()
+                .and_then(|f| f.as_symbol())
+                .cloned()
+            {
+                pos.func.dfg.facts[base_and_index] = Some(Fact::DynamicMem {
+                    ty,
+                    min: idx.clone(),
+                    max: idx,
+                    nullable: false,
+                });
+            } else {
+                pos.func.dfg.facts[base_and_index] = Some(Fact::Mem {
+                    ty,
+                    min_offset: 0,
+                    max_offset: u64::from(u32::MAX),
+                    nullable: false,
+                });
+            }
         }
-    });
+    }
 
     if offset == 0 {
         base_and_index
@@ -491,19 +658,46 @@ fn compute_addr(
         // potentially are letting speculative execution read the whole first
         // 4GiB of memory.
         let offset_val = pos.ins().iconst(addr_ty, i64::from(offset));
-        add_fact(pos, pcc_memtype, offset_val, |_| {
-            Fact::constant(u16::try_from(addr_ty.bits()).unwrap(), u64::from(offset))
-        });
+
+        if pcc.is_some() {
+            pos.func.dfg.facts[offset_val] = Some(Fact::constant(
+                u16::try_from(addr_ty.bits()).unwrap(),
+                u64::from(offset),
+            ));
+        }
+
         let result = pos.ins().iadd(base_and_index, offset_val);
-        add_fact(pos, pcc_memtype, result, |ty| Fact::Mem {
-            ty,
-            min_offset: u64::from(offset),
-            // Safety: can't overflow -- two u32s summed in a
-            // 64-bit add. TODO: when memory64 is supported here,
-            // `u32::MAX` is no longer true, and we'll need to
-            // handle overflow here.
-            max_offset: u64::from(u32::MAX) + u64::from(offset),
-        });
+
+        match pcc {
+            AddrPcc::None => {}
+            AddrPcc::Static32(ty, _) | AddrPcc::Dynamic(ty, _) => {
+                if let Some(idx) = pos.func.dfg.facts[index]
+                    .as_ref()
+                    .and_then(|f| f.as_symbol())
+                {
+                    pos.func.dfg.facts[result] = Some(Fact::DynamicMem {
+                        ty,
+                        min: idx.clone(),
+                        // Safety: adding an offset to an expression with
+                        // zero offset -- add cannot wrap, so `unwrap()`
+                        // cannot fail.
+                        max: Expr::offset(idx, i64::from(offset)).unwrap(),
+                        nullable: false,
+                    });
+                } else {
+                    pos.func.dfg.facts[result] = Some(Fact::Mem {
+                        ty,
+                        min_offset: u64::from(offset),
+                        // Safety: can't overflow -- two u32s summed in a
+                        // 64-bit add. TODO: when memory64 is supported here,
+                        // `u32::MAX` is no longer true, and we'll need to
+                        // handle overflow here.
+                        max_offset: u64::from(u32::MAX) + u64::from(offset),
+                        nullable: false,
+                    });
+                }
+            }
+        }
         result
     }
 }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -9,7 +9,6 @@ use cranelift_codegen::ir::{
     AbiParam, ArgumentPurpose, Function, InstBuilder, MemFlags, Signature, UserFuncName, Value,
 };
 use cranelift_codegen::isa::{self, CallConv, TargetFrontendConfig, TargetIsa};
-use cranelift_entity::SecondaryMap;
 use cranelift_entity::{EntityRef, PrimaryMap};
 use cranelift_frontend::FunctionBuilder;
 use cranelift_frontend::Variable;
@@ -127,10 +126,6 @@ pub struct FuncEnvironment<'module_environment> {
     /// using PCC.
     pcc_vmctx_memtype: Option<ir::MemoryType>,
 
-    /// The PCC memory type describing the data for each memory, if
-    /// we're using PCC.
-    pcc_memory_memtypes: SecondaryMap<MemoryIndex, Option<ir::MemoryType>>,
-
     /// Caches of signatures for builtin functions.
     builtin_function_signatures: BuiltinFunctionSignatures,
 
@@ -199,7 +194,6 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             heaps: PrimaryMap::default(),
             vmctx: None,
             pcc_vmctx_memtype: None,
-            pcc_memory_memtypes: SecondaryMap::new(),
             builtin_function_signatures,
             offsets: VMOffsets::new(isa.pointer_bytes(), &translation.module),
             tunables,
@@ -225,59 +219,13 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         self.vmctx.unwrap_or_else(|| {
             let vmctx = func.create_global_value(ir::GlobalValueData::VMContext);
             if self.isa.flags().enable_pcc() {
-                let mut fields = vec![];
-                for (memory_idx, plan) in &self.module.memory_plans {
-                    // For now, we only do PCC on defined, owned (non-shared), static, 32-bit memories (whew!).
-                    if plan.memory.shared || plan.memory.memory64 {
-                        continue;
-                    }
-                    let static_bound_wasm_pages = match &plan.style {
-                        MemoryStyle::Dynamic { .. } => continue,
-                        MemoryStyle::Static { bound } => *bound,
-                    };
-                    let static_bound = static_bound_wasm_pages.checked_mul(0x1_0000).unwrap();
-                    let def_memory_idx = match self.module.defined_memory_index(memory_idx) {
-                        Some(i) => i,
-                        None => continue,
-                    };
-                    let owned_memory_idx = self.module.owned_memory_index(def_memory_idx);
-
-                    let base_field_offset = self
-                        .offsets
-                        .vmctx_vmmemory_definition_base(owned_memory_idx);
-                    // Create a new "blob" memory type to represent the pointed-to memory.
-                    let data_mt = func.create_memory_type(ir::MemoryTypeData::Memory {
-                        size: static_bound
-                            .checked_add(plan.offset_guard_size)
-                            .expect("Memory plan has overflowing size plus guard"),
-                    });
-
-                    self.pcc_memory_memtypes[memory_idx] = Some(data_mt);
-
-                    fields.push(ir::MemoryTypeField {
-                        offset: u64::from(base_field_offset),
-                        ty: self.isa.pointer_type(),
-                        // Read-only field from the PoV of PCC checks:
-                        // don't allow stores to this field. (Even if
-                        // it is a dynamic memory whose base can
-                        // change, that update happens inside the
-                        // runtime, not in generated code.)
-                        readonly: true,
-                        fact: Some(Fact::Mem {
-                            ty: data_mt,
-                            min_offset: 0,
-                            max_offset: 0,
-                        }),
-                    });
-                }
-                let size = fields
-                    .iter()
-                    .map(|field| field.offset + u64::from(self.isa.pointer_type().bytes()))
-                    .max()
-                    .unwrap_or(0);
-
-                let vmctx_memtype =
-                    func.create_memory_type(ir::MemoryTypeData::Struct { size, fields });
+                // Create a placeholder memtype for the vmctx; we'll
+                // add fields to it as we lazily create HeapData
+                // structs and global values.
+                let vmctx_memtype = func.create_memory_type(ir::MemoryTypeData::Struct {
+                    size: 0,
+                    fields: vec![],
+                });
 
                 self.pcc_vmctx_memtype = Some(vmctx_memtype);
                 func.global_value_facts[vmctx] = Some(Fact::Mem {
@@ -286,6 +234,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
                     max_offset: 0,
                 });
             }
+
             self.vmctx = Some(vmctx);
             vmctx
         })
@@ -1844,7 +1793,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             .maximum
             .and_then(|max| max.checked_mul(u64::from(WASM_PAGE_SIZE)));
 
-        let (ptr, base_offset, current_length_offset) = {
+        let (ptr, base_offset, current_length_offset, ptr_memtype) = {
             let vmctx = self.vmctx(func);
             if let Some(def_index) = self.module.defined_memory_index(index) {
                 if is_shared {
@@ -1862,7 +1811,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                     let base_offset = i32::from(self.offsets.ptr.vmmemory_definition_base());
                     let current_length_offset =
                         i32::from(self.offsets.ptr.vmmemory_definition_current_length());
-                    (memory, base_offset, current_length_offset)
+                    (memory, base_offset, current_length_offset, None)
                 } else {
                     let owned_index = self.module.owned_memory_index(def_index);
                     let owned_base_offset =
@@ -1872,7 +1821,12 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                         .vmctx_vmmemory_definition_current_length(owned_index);
                     let current_base_offset = i32::try_from(owned_base_offset).unwrap();
                     let current_length_offset = i32::try_from(owned_length_offset).unwrap();
-                    (vmctx, current_base_offset, current_length_offset)
+                    (
+                        vmctx,
+                        current_base_offset,
+                        current_length_offset,
+                        self.pcc_vmctx_memtype,
+                    )
                 }
             } else {
                 let from_offset = self.offsets.vmctx_vmmemory_import_from(index);
@@ -1885,46 +1839,92 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                 let base_offset = i32::from(self.offsets.ptr.vmmemory_definition_base());
                 let current_length_offset =
                     i32::from(self.offsets.ptr.vmmemory_definition_current_length());
-                (memory, base_offset, current_length_offset)
+                (memory, base_offset, current_length_offset, None)
             }
         };
 
         // If we have a declared maximum, we can make this a "static" heap, which is
         // allocated up front and never moved.
-        let (offset_guard_size, heap_style, readonly_base) = match self.module.memory_plans[index] {
-            MemoryPlan {
-                style: MemoryStyle::Dynamic { .. },
-                offset_guard_size,
-                pre_guard_size: _,
-                memory: _,
-            } => {
-                let heap_bound = func.create_global_value(ir::GlobalValueData::Load {
-                    base: ptr,
-                    offset: Offset32::new(current_length_offset),
-                    global_type: pointer_type,
-                    flags: MemFlags::trusted(),
-                });
-                (
+        let (offset_guard_size, heap_style, readonly_base, base_fact, memory_type) =
+            match self.module.memory_plans[index] {
+                MemoryPlan {
+                    style: MemoryStyle::Dynamic { .. },
                     offset_guard_size,
-                    HeapStyle::Dynamic {
-                        bound_gv: heap_bound,
-                    },
-                    false,
-                )
-            }
-            MemoryPlan {
-                style: MemoryStyle::Static { bound },
-                offset_guard_size,
-                pre_guard_size: _,
-                memory: _,
-            } => (
-                offset_guard_size,
-                HeapStyle::Static {
-                    bound: u64::from(bound) * u64::from(WASM_PAGE_SIZE),
-                },
-                true,
-            ),
-        };
+                    pre_guard_size: _,
+                    memory: _,
+                } => {
+                    let heap_bound = func.create_global_value(ir::GlobalValueData::Load {
+                        base: ptr,
+                        offset: Offset32::new(current_length_offset),
+                        global_type: pointer_type,
+                        flags: MemFlags::trusted(),
+                    });
+                    (
+                        offset_guard_size,
+                        HeapStyle::Dynamic {
+                            bound_gv: heap_bound,
+                        },
+                        false,
+                        None,
+                        None,
+                    )
+                }
+                MemoryPlan {
+                    style: MemoryStyle::Static { bound: bound_pages },
+                    offset_guard_size,
+                    pre_guard_size: _,
+                    memory: _,
+                } => {
+                    let bound_bytes = u64::from(bound_pages) * u64::from(WASM_PAGE_SIZE);
+                    let (base_fact, data_mt) = if let Some(ptr_memtype) = ptr_memtype {
+                        // Create a memtype representing the untyped memory region.
+                        let data_mt = func.create_memory_type(ir::MemoryTypeData::Memory {
+                            size: bound_bytes
+                                .checked_add(offset_guard_size)
+                                .expect("Memory plan has overflowing size plus guard"),
+                        });
+                        // This fact applies to any pointer to the start of the memory.
+                        let base_fact = Fact::Mem {
+                            ty: data_mt,
+                            min_offset: 0,
+                            max_offset: 0,
+                        };
+                        // Create a field in the vmctx for the base pointer.
+                        match &mut func.memory_types[ptr_memtype] {
+                            ir::MemoryTypeData::Struct { size, fields } => {
+                                let offset = u64::try_from(base_offset).unwrap();
+                                fields.push(ir::MemoryTypeField {
+                                    offset,
+                                    ty: self.isa.pointer_type(),
+                                    // Read-only field from the PoV of PCC checks:
+                                    // don't allow stores to this field. (Even if
+                                    // it is a dynamic memory whose base can
+                                    // change, that update happens inside the
+                                    // runtime, not in generated code.)
+                                    readonly: true,
+                                    fact: Some(base_fact.clone()),
+                                });
+                                *size = std::cmp::max(
+                                    *size,
+                                    offset + u64::from(self.isa.pointer_type().bytes()),
+                                );
+                            }
+                            _ => {}
+                        }
+                        // Apply a fact to the base pointer.
+                        (Some(base_fact), Some(data_mt))
+                    } else {
+                        (None, None)
+                    };
+                    (
+                        offset_guard_size,
+                        HeapStyle::Static { bound: bound_bytes },
+                        true,
+                        base_fact,
+                        data_mt,
+                    )
+                }
+            };
 
         let mut flags = MemFlags::trusted().with_checked();
         if readonly_base {
@@ -1936,14 +1936,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             global_type: pointer_type,
             flags,
         });
-        let memory_type = self.pcc_memory_memtypes[index];
-        if let Some(ty) = memory_type {
-            func.global_value_facts[heap_base] = Some(Fact::Mem {
-                ty,
-                min_offset: 0,
-                max_offset: 0,
-            });
-        }
+        func.global_value_facts[heap_base] = base_fact;
 
         Ok(self.heaps.push(HeapData {
             base: heap_base,
@@ -2554,6 +2547,16 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     ) -> WasmResult<()> {
         if self.tunables.consume_fuel && state.reachable() {
             self.fuel_function_exit(builder);
+        }
+        if let Some(pcc_vmctx_memtype) = self.pcc_vmctx_memtype {
+            // Sort the fields by offset in the struct definition for
+            // vmctx, now that we've completed it.
+            match &mut builder.func.memory_types[pcc_vmctx_memtype] {
+                ir::MemoryTypeData::Struct { fields, .. } => {
+                    fields.sort_by_key(|f| f.offset);
+                }
+                _ => {}
+            }
         }
         Ok(())
     }

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -232,6 +232,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
                     ty: vmctx_memtype,
                     min_offset: 0,
                     max_offset: 0,
+                    nullable: false,
                 });
             }
 
@@ -1942,6 +1943,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                             ty: data_mt,
                             min_offset: 0,
                             max_offset: 0,
+                            nullable: false,
                         };
                         // Create a field in the vmctx for the base pointer.
                         match &mut func.memory_types[ptr_memtype] {

--- a/tests/pcc_memory.rs
+++ b/tests/pcc_memory.rs
@@ -34,7 +34,11 @@ fn test_build() {
         for static_memory_maximum_size in [0, 64 * KIB, 1 * MIB, 4 * GIB, 6 * GIB] {
             for guard_size in [0, 64 * KIB, 2 * GIB] {
                 log::trace!("test:\n{}\n", test);
-                log::trace!("static {:x} guard {:x}", static_memory_maximum_size, guard_size);
+                log::trace!(
+                    "static {:x} guard {:x}",
+                    static_memory_maximum_size,
+                    guard_size
+                );
                 let mut cfg = Config::new();
                 cfg.static_memory_maximum_size(static_memory_maximum_size);
                 cfg.static_memory_guard_size(guard_size);

--- a/tests/pcc_memory.rs
+++ b/tests/pcc_memory.rs
@@ -1,0 +1,50 @@
+//! Tests for proof-carrying-code-based validation of memory accesses
+//! in Wasmtime/Cranelift-compiled Wasm, with various combinations of
+//! memory settings.
+
+use wasmtime::*;
+
+const TEST1: &'static str = r#"
+(module
+ (memory 1 1)
+ (func (param i32) (result i32)
+  local.get 0
+  i32.load
+  i32.load offset=0x10000))
+"#;
+
+const TEST2: &'static str = r#"
+(module
+ (memory 10 20)
+ (func (param i32) (result i32)
+  local.get 0
+  i32.load
+  i32.load offset=0x10000))
+"#;
+
+#[test]
+#[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+fn test_build() {
+    let _ = env_logger::try_init();
+    const KIB: u64 = 1024;
+    const MIB: u64 = 1024 * KIB;
+    const GIB: u64 = 1024 * MIB;
+
+    for test in [TEST1, TEST2] {
+        for static_memory_maximum_size in [0, 64 * KIB, 1 * MIB, 4 * GIB, 6 * GIB] {
+            for guard_size in [0, 64 * KIB, 2 * GIB] {
+                log::trace!("test:\n{}\n", test);
+                log::trace!("static {:x} guard {:x}", static_memory_maximum_size, guard_size);
+                let mut cfg = Config::new();
+                cfg.static_memory_maximum_size(static_memory_maximum_size);
+                cfg.static_memory_guard_size(guard_size);
+                cfg.dynamic_memory_guard_size(guard_size);
+                cfg.cranelift_pcc(true);
+                let engine = Engine::new(&cfg).unwrap();
+
+                let _module =
+                    Module::new(&engine, test).expect("compilation with PCC should succeed");
+            }
+        }
+    }
+}

--- a/tests/pcc_memory.rs
+++ b/tests/pcc_memory.rs
@@ -2,176 +2,178 @@
 //! in Wasmtime/Cranelift-compiled Wasm, with various combinations of
 //! memory settings.
 
-use wasmtime::*;
-
-const TESTS: &'static [&'static str] = &[
-    r#"
-(module
- (memory 1 1)
- (func (param i32)
-  local.get 0
-  i32.load8_u
-  drop))
-    "#,
-    r#"
-(module
- (memory 1 1)
- (func (param i32)
-  local.get 0
-  i32.load8_u offset=0x10000
-  drop))
-    "#,
-    r#"
-(module
- (memory 1 1)
- (func (param i32)
-  local.get 0
-  i32.load16_u
-  drop))
-    "#,
-    r#"
-(module
- (memory 1 1)
- (func (param i32)
-  local.get 0
-  i32.load16_u offset=0x10000
-  drop))
-    "#,
-    r#"
-(module
- (memory 1 1)
- (func (param i32)
-  local.get 0
-  i32.load
-  drop))
-    "#,
-    r#"
-(module
- (memory 1 1)
- (func (param i32)
-  local.get 0
-  i32.load offset=0x10000
-  drop))
-    "#,
-    r#"
-(module
- (memory 1 1)
- (func (param i32)
-  local.get 0
-  i64.load
-  drop))
-    "#,
-    r#"
-(module
- (memory 1 1)
- (func (param i32)
-  local.get 0
-  i64.load offset=0x10000
-  drop))
-    "#,
-    r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load8_u
-  drop))
-    "#,
-    r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load8_u offset=0x10000
-  drop))
-    "#,
-    r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load16_u
-  drop))
-    "#,
-    r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load16_u offset=0x10000
-  drop))
-    "#,
-    r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load
-  drop))
-    "#,
-    r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load offset=0x10000
-  drop))
-    "#,
-    r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i64.load
-  drop))
-    "#,
-    r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i64.load offset=0x10000
-  drop))
-    "#,
-];
-
-#[test]
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
-fn test_build() {
-    let _ = env_logger::try_init();
-    const KIB: u64 = 1024;
-    const MIB: u64 = 1024 * KIB;
-    const GIB: u64 = 1024 * MIB;
+mod pcc_memory_tests {
+    use wasmtime::*;
 
-    for &test in TESTS {
-        for static_memory_maximum_size in [0, 64 * KIB, 1 * MIB, 4 * GIB, 6 * GIB] {
-            for guard_size in [0, 64 * KIB, 2 * GIB] {
-                for enable_spectre in [true /* not yet supported by PCC: false */] {
-                    for _memory_bits in [32 /* not yet supported by PCC: 64 */] {
-                        log::trace!("test:\n{}\n", test);
-                        log::trace!(
-                            "static {:x} guard {:x}",
-                            static_memory_maximum_size,
-                            guard_size
-                        );
-                        let mut cfg = Config::new();
-                        cfg.static_memory_maximum_size(static_memory_maximum_size);
-                        cfg.static_memory_guard_size(guard_size);
-                        cfg.dynamic_memory_guard_size(guard_size);
-                        cfg.cranelift_pcc(true);
-                        unsafe {
-                            cfg.cranelift_flag_set(
-                                "enable_heap_access_spectre_mitigation",
-                                &enable_spectre.to_string(),
+    const TESTS: &'static [&'static str] = &[
+        r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i32.load8_u
+  drop))
+    "#,
+        r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i32.load8_u offset=0x10000
+  drop))
+    "#,
+        r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i32.load16_u
+  drop))
+    "#,
+        r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i32.load16_u offset=0x10000
+  drop))
+    "#,
+        r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i32.load
+  drop))
+    "#,
+        r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i32.load offset=0x10000
+  drop))
+    "#,
+        r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i64.load
+  drop))
+    "#,
+        r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i64.load offset=0x10000
+  drop))
+    "#,
+        r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i32.load8_u
+  drop))
+    "#,
+        r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i32.load8_u offset=0x10000
+  drop))
+    "#,
+        r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i32.load16_u
+  drop))
+    "#,
+        r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i32.load16_u offset=0x10000
+  drop))
+    "#,
+        r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i32.load
+  drop))
+    "#,
+        r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i32.load offset=0x10000
+  drop))
+    "#,
+        r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i64.load
+  drop))
+    "#,
+        r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i64.load offset=0x10000
+  drop))
+    "#,
+    ];
+
+    #[test]
+    fn test_build() {
+        let _ = env_logger::try_init();
+        const KIB: u64 = 1024;
+        const MIB: u64 = 1024 * KIB;
+        const GIB: u64 = 1024 * MIB;
+
+        for &test in TESTS {
+            for static_memory_maximum_size in [0, 64 * KIB, 1 * MIB, 4 * GIB, 6 * GIB] {
+                for guard_size in [0, 64 * KIB, 2 * GIB] {
+                    for enable_spectre in [true /* not yet supported by PCC: false */] {
+                        for _memory_bits in [32 /* not yet supported by PCC: 64 */] {
+                            log::trace!("test:\n{}\n", test);
+                            log::trace!(
+                                "static {:x} guard {:x}",
+                                static_memory_maximum_size,
+                                guard_size
                             );
+                            let mut cfg = Config::new();
+                            cfg.static_memory_maximum_size(static_memory_maximum_size);
+                            cfg.static_memory_guard_size(guard_size);
+                            cfg.dynamic_memory_guard_size(guard_size);
+                            cfg.cranelift_pcc(true);
+                            unsafe {
+                                cfg.cranelift_flag_set(
+                                    "enable_heap_access_spectre_mitigation",
+                                    &enable_spectre.to_string(),
+                                );
+                            }
+                            // TODO: substitute memory32/memory64 into
+                            // test module.
+
+                            let engine = Engine::new(&cfg).unwrap();
+
+                            let _module = Module::new(&engine, test)
+                                .expect("compilation with PCC should succeed");
                         }
-                        // TODO: substitute memory32/memory64 into
-                        // test module.
-
-                        let engine = Engine::new(&cfg).unwrap();
-
-                        let _module = Module::new(&engine, test)
-                            .expect("compilation with PCC should succeed");
                     }
                 }
             }

--- a/tests/pcc_memory.rs
+++ b/tests/pcc_memory.rs
@@ -138,6 +138,7 @@ mod pcc_memory_tests {
     ];
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn test_build() {
         let _ = env_logger::try_init();
         const KIB: u64 = 1024;

--- a/tests/pcc_memory.rs
+++ b/tests/pcc_memory.rs
@@ -4,23 +4,136 @@
 
 use wasmtime::*;
 
-const TEST1: &'static str = r#"
+const TESTS: &'static [&'static str] = &[
+    r#"
 (module
  (memory 1 1)
- (func (param i32) (result i32)
+ (func (param i32)
+  local.get 0
+  i32.load8_u
+  drop))
+    "#,
+    r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i32.load8_u offset=0x10000
+  drop))
+    "#,
+    r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i32.load16_u
+  drop))
+    "#,
+    r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i32.load16_u offset=0x10000
+  drop))
+    "#,
+    r#"
+(module
+ (memory 1 1)
+ (func (param i32)
   local.get 0
   i32.load
-  i32.load offset=0x10000))
-"#;
-
-const TEST2: &'static str = r#"
+  drop))
+    "#,
+    r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i32.load offset=0x10000
+  drop))
+    "#,
+    r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i64.load
+  drop))
+    "#,
+    r#"
+(module
+ (memory 1 1)
+ (func (param i32)
+  local.get 0
+  i64.load offset=0x10000
+  drop))
+    "#,
+    r#"
 (module
  (memory 10 20)
- (func (param i32) (result i32)
+ (func (param i32)
+  local.get 0
+  i32.load8_u
+  drop))
+    "#,
+    r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i32.load8_u offset=0x10000
+  drop))
+    "#,
+    r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i32.load16_u
+  drop))
+    "#,
+    r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i32.load16_u offset=0x10000
+  drop))
+    "#,
+    r#"
+(module
+ (memory 10 20)
+ (func (param i32)
   local.get 0
   i32.load
-  i32.load offset=0x10000))
-"#;
+  drop))
+    "#,
+    r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i32.load offset=0x10000
+  drop))
+    "#,
+    r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i64.load
+  drop))
+    "#,
+    r#"
+(module
+ (memory 10 20)
+ (func (param i32)
+  local.get 0
+  i64.load offset=0x10000
+  drop))
+    "#,
+];
 
 #[test]
 #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
@@ -30,24 +143,37 @@ fn test_build() {
     const MIB: u64 = 1024 * KIB;
     const GIB: u64 = 1024 * MIB;
 
-    for test in [TEST1, TEST2] {
+    for &test in TESTS {
         for static_memory_maximum_size in [0, 64 * KIB, 1 * MIB, 4 * GIB, 6 * GIB] {
             for guard_size in [0, 64 * KIB, 2 * GIB] {
-                log::trace!("test:\n{}\n", test);
-                log::trace!(
-                    "static {:x} guard {:x}",
-                    static_memory_maximum_size,
-                    guard_size
-                );
-                let mut cfg = Config::new();
-                cfg.static_memory_maximum_size(static_memory_maximum_size);
-                cfg.static_memory_guard_size(guard_size);
-                cfg.dynamic_memory_guard_size(guard_size);
-                cfg.cranelift_pcc(true);
-                let engine = Engine::new(&cfg).unwrap();
+                for enable_spectre in [true /* not yet supported by PCC: false */] {
+                    for _memory_bits in [32 /* not yet supported by PCC: 64 */] {
+                        log::trace!("test:\n{}\n", test);
+                        log::trace!(
+                            "static {:x} guard {:x}",
+                            static_memory_maximum_size,
+                            guard_size
+                        );
+                        let mut cfg = Config::new();
+                        cfg.static_memory_maximum_size(static_memory_maximum_size);
+                        cfg.static_memory_guard_size(guard_size);
+                        cfg.dynamic_memory_guard_size(guard_size);
+                        cfg.cranelift_pcc(true);
+                        unsafe {
+                            cfg.cranelift_flag_set(
+                                "enable_heap_access_spectre_mitigation",
+                                &enable_spectre.to_string(),
+                            );
+                        }
+                        // TODO: substitute memory32/memory64 into
+                        // test module.
 
-                let _module =
-                    Module::new(&engine, test).expect("compilation with PCC should succeed");
+                        let engine = Engine::new(&cfg).unwrap();
+
+                        let _module = Module::new(&engine, test)
+                            .expect("compilation with PCC should succeed");
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This PR completes the work to add proof-carrying-code validation to Wasm heap accesses in Wasmtime, for all bounds-check cases (dynamic and static, covering the 4 and 3 cases of the former and latter respectively), on x86-64 and aarch64.

The PR includes an integration test at the top level (`tests/pcc_memory.rs`) that compiles a Wasm module with PCC enabled under a range of memory configurations. Ideally we'd use the existing Wasm filetest infrastructure for this; but it has its own Wasm environment definitions and PCC hasn't been plumbed through those (this would also mean we'd be testing a slightly different path of at least the memory-type setup than production Wasmtime).

The test expectations change slightly because this PR had to change `iadd_imm(x, -k)` to `isub(x, iconst(k))` in the generated bounds-checking code. Some of the backends (riscv64, s390x) seem to match iadd-of-negative better than isub-of-positive; but that's an orthogonal isel issue and can be fixed up.

I hope to add fuzzing to exercise this further, but we at least have (theoretical) functional completeness with this PR. Hence, I think this fixes #6090.

Followup work on PCC could include use of PCC annotations to verify table accesses as well, and a strong-enforcing mode that disallows all non-`checked` memory accesses (so we have to audit and allowlist constant pools and ABI code and the like, and ensure all lowered Wasm ops are covered). However I don't think this additional assurance level is necessary to turn on and benefit from Wasm-memory-bounds-checking PCC.

The first half of this PR was

Co-authored-by: Nick Fitzgerald <fitzgen@gmail.com>