### PR TITLE
cranelift: Make inline stackprobe unroll sequence valgrind compliant

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -1053,15 +1053,24 @@ fn create_reg_enviroment() -> MachineEnv {
 
 impl Riscv64MachineDeps {
     fn gen_probestack_unroll(insts: &mut SmallInstVec<Inst>, guard_size: u32, probe_count: u32) {
-        insts.reserve(probe_count as usize);
-        for i in 0..probe_count {
-            let offset = (guard_size * (i + 1)) as i64;
+        // When manually unrolling adjust the stack pointer and then write a zero
+        // to the stack at that offset.
+        //
+        // We do this because valgrind expects us to never write beyond the stack
+        // pointer and associated redzone.
+        // See: https://github.com/bytecodealliance/wasmtime/issues/7454
+        for _ in 0..probe_count {
+            insts.extend(Self::gen_sp_reg_adjust(-(guard_size as i32)));
+
             insts.push(Self::gen_store_stack(
-                StackAMode::SPOffset(-offset, I8),
+                StackAMode::SPOffset(0, I8),
                 zero_reg(),
                 I32,
             ));
         }
+
+        // Restore the stack pointer to its original value
+        insts.extend(Self::gen_sp_reg_adjust((guard_size * probe_count) as i32));
     }
 
     fn gen_probestack_loop(

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -718,10 +718,20 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         // Number of probes that we need to perform
         let probe_count = align_to(frame_size, guard_size) / guard_size;
 
+        // Must be a caller-saved register that is not an argument.
+        let tmp = match call_conv {
+            isa::CallConv::Tail => Writable::from_reg(x_reg(1)),
+            _ => Writable::from_reg(x_reg(28)), // t3
+        };
+
         if probe_count <= PROBE_MAX_UNROLL {
-            Self::gen_probestack_unroll(insts, guard_size, probe_count)
+            Self::gen_probestack_unroll(insts, tmp, guard_size, probe_count)
         } else {
-            Self::gen_probestack_loop(insts, call_conv, guard_size, probe_count)
+            insts.push(Inst::StackProbeLoop {
+                guard_size,
+                probe_count,
+                tmp,
+            });
         }
     }
 }
@@ -1052,15 +1062,32 @@ fn create_reg_enviroment() -> MachineEnv {
 }
 
 impl Riscv64MachineDeps {
-    fn gen_probestack_unroll(insts: &mut SmallInstVec<Inst>, guard_size: u32, probe_count: u32) {
+    fn gen_probestack_unroll(
+        insts: &mut SmallInstVec<Inst>,
+        tmp: Writable<Reg>,
+        guard_size: u32,
+        probe_count: u32,
+    ) {
         // When manually unrolling adjust the stack pointer and then write a zero
         // to the stack at that offset.
         //
         // We do this because valgrind expects us to never write beyond the stack
         // pointer and associated redzone.
         // See: https://github.com/bytecodealliance/wasmtime/issues/7454
+
+        // Store the adjust amount in a register upfront, so we don't have to
+        // reload it for each probe. It's worth loading this as a negative and
+        // using an `add` instruction since we have compressed versions of `add`
+        // but not the `sub` instruction.
+        insts.extend(Inst::load_constant_u64(tmp, (-(guard_size as i64)) as u64));
+
         for _ in 0..probe_count {
-            insts.extend(Self::gen_sp_reg_adjust(-(guard_size as i32)));
+            insts.push(Inst::AluRRR {
+                alu_op: AluOPRRR::Add,
+                rd: writable_stack_reg(),
+                rs1: stack_reg(),
+                rs2: tmp.to_reg(),
+            });
 
             insts.push(Self::gen_store_stack(
                 StackAMode::SPOffset(0, I8),
@@ -1071,23 +1098,5 @@ impl Riscv64MachineDeps {
 
         // Restore the stack pointer to its original value
         insts.extend(Self::gen_sp_reg_adjust((guard_size * probe_count) as i32));
-    }
-
-    fn gen_probestack_loop(
-        insts: &mut SmallInstVec<Inst>,
-        call_conv: isa::CallConv,
-        guard_size: u32,
-        probe_count: u32,
-    ) {
-        // Must be a caller-saved register that is not an argument.
-        let tmp = match call_conv {
-            isa::CallConv::Tail => Writable::from_reg(x_reg(1)),
-            _ => Writable::from_reg(x_reg(28)), // t3
-        };
-        insts.push(Inst::StackProbeLoop {
-            guard_size,
-            probe_count,
-            tmp,
-        });
     }
 }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -33,7 +33,7 @@ pub struct X64ABIMachineSpec;
 impl X64ABIMachineSpec {
     fn gen_probestack_unroll(insts: &mut SmallInstVec<Inst>, guard_size: u32, probe_count: u32) {
         insts.reserve(probe_count as usize);
-        for i in 0..probe_count {
+        for _ in 0..probe_count {
             // "Allocate" stack space for the probe by decrementing the stack pointer before
             // the write. This is required to make valgrind happy.
             // See: https://github.com/bytecodealliance/wasmtime/issues/7454

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -34,16 +34,22 @@ impl X64ABIMachineSpec {
     fn gen_probestack_unroll(insts: &mut SmallInstVec<Inst>, guard_size: u32, probe_count: u32) {
         insts.reserve(probe_count as usize);
         for i in 0..probe_count {
-            let offset = (guard_size * (i + 1)) as i64;
+            // "Allocate" stack space for the probe by decrementing the stack pointer before
+            // the write. This is required to make valgrind happy.
+            // See: https://github.com/bytecodealliance/wasmtime/issues/7454
+            insts.extend(Self::gen_sp_reg_adjust(-(guard_size as i32)));
 
             // TODO: It would be nice if we could store the imm 0, but we don't have insts for those
             // so store the stack pointer. Any register will do, since the stack is undefined at this point
             insts.push(Self::gen_store_stack(
-                StackAMode::SPOffset(-offset, I8),
+                StackAMode::SPOffset(0, I8),
                 regs::rsp(),
                 I32,
             ));
         }
+
+        // Restore the stack pointer to its original value
+        insts.extend(Self::gen_sp_reg_adjust((guard_size * probe_count) as i32));
     }
 
     fn gen_probestack_loop(
@@ -523,8 +529,8 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         // Unroll at most n consecutive probes, before falling back to using a loop
         //
         // This was number was picked because the loop version is 38 bytes long. We can fit
-        // 5 inline probes in that space, so unroll if its beneficial in terms of code size.
-        const PROBE_MAX_UNROLL: u32 = 5;
+        // 4 inline probes in that space, so unroll if its beneficial in terms of code size.
+        const PROBE_MAX_UNROLL: u32 = 4;
 
         // Number of probes that we need to perform
         let probe_count = align_to(frame_size, guard_size) / guard_size;

--- a/cranelift/filetests/filetests/isa/aarch64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/inline-probestack.clif
@@ -47,9 +47,13 @@ block0:
 ; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
-;   movn x16, #4095 ; str wzr, [sp, x16, SXTX]
-;   movn x16, #8191 ; str wzr, [sp, x16, SXTX]
-;   movn x16, #12287 ; str wzr, [sp, x16, SXTX]
+;   sub sp, sp, #4096
+;   str wzr, [sp]
+;   sub sp, sp, #4096
+;   str wzr, [sp]
+;   sub sp, sp, #4096
+;   str wzr, [sp]
+;   add sp, sp, #12288
 ;   sub sp, sp, #12288
 ; block0:
 ;   mov x0, sp
@@ -61,14 +65,15 @@ block0:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-;   mov x16, #-0x1000
-;   str wzr, [sp, x16, sxtx]
-;   mov x16, #-0x2000
-;   str wzr, [sp, x16, sxtx]
-;   mov x16, #-0x3000
-;   str wzr, [sp, x16, sxtx]
+;   sub sp, sp, #1, lsl #12
+;   stur wzr, [sp]
+;   sub sp, sp, #1, lsl #12
+;   stur wzr, [sp]
+;   sub sp, sp, #1, lsl #12
+;   stur wzr, [sp]
+;   add sp, sp, #3, lsl #12
 ;   sub sp, sp, #3, lsl #12
-; block1: ; offset 0x24
+; block1: ; offset 0x28
 ;   mov x0, sp
 ;   add sp, sp, #3, lsl #12
 ;   ldp x29, x30, [sp], #0x10

--- a/cranelift/filetests/filetests/isa/riscv64/c-inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/c-inline-probestack.clif
@@ -1,0 +1,166 @@
+test compile precise-output
+set enable_probestack=true
+set probestack_strategy=inline
+; This is the default and is equivalent to a page size of 4096
+set probestack_size_log2=12
+target riscv64 has_c
+
+
+; If the stack size is just one page, we can avoid the stack probe entirely
+function %single_page() -> i64 system_v {
+ss0 = explicit_slot 2048
+
+block0:
+  v1 = stack_addr.i64 ss0
+  return v1
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   addi sp,sp,-2048
+; block0:
+;   load_addr a0,0(nominal_sp)
+;   lui t6,1
+;   addi t6,t6,-2048
+;   add sp,t6,sp
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi16sp sp, -0x10
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
+;   c.mv s0, sp
+;   addi sp, sp, -0x800
+; block1: ; offset 0xc
+;   c.mv a0, sp
+;   c.lui t6, 1
+;   addi t6, t6, -0x800
+;   add sp, t6, sp
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
+;   c.addi16sp sp, 0x10
+;   c.jr ra
+
+function %unrolled() -> i64 system_v {
+ss0 = explicit_slot 12288
+
+block0:
+  v1 = stack_addr.i64 ss0
+  return v1
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   lui t6,-1
+;   add sp,t6,sp
+;   sw zero,0(sp)
+;   lui t6,-1
+;   add sp,t6,sp
+;   sw zero,0(sp)
+;   lui t6,-1
+;   add sp,t6,sp
+;   sw zero,0(sp)
+;   lui t6,3
+;   add sp,t6,sp
+;   lui t6,-3
+;   add sp,t6,sp
+; block0:
+;   load_addr a0,0(nominal_sp)
+;   lui t6,3
+;   add sp,t6,sp
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi16sp sp, -0x10
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
+;   c.mv s0, sp
+;   c.lui t6, 0xfffff
+;   add sp, t6, sp
+;   c.swsp zero, 0(sp)
+;   c.lui t6, 0xfffff
+;   add sp, t6, sp
+;   c.swsp zero, 0(sp)
+;   c.lui t6, 0xfffff
+;   add sp, t6, sp
+;   c.swsp zero, 0(sp)
+;   c.lui t6, 3
+;   add sp, t6, sp
+;   c.lui t6, 0xffffd
+;   add sp, t6, sp
+; block1: ; offset 0x2c
+;   c.mv a0, sp
+;   c.lui t6, 3
+;   add sp, t6, sp
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
+;   c.addi16sp sp, 0x10
+;   c.jr ra
+
+function %large() -> i64 system_v {
+ss0 = explicit_slot 100000
+
+block0:
+  v1 = stack_addr.i64 ss0
+  return v1
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   inline_stack_probe##guard_size=4096 probe_count=25 tmp=t3
+;   lui t6,-24
+;   addi t6,t6,-1696
+;   add sp,t6,sp
+; block0:
+;   load_addr a0,0(nominal_sp)
+;   lui t6,24
+;   addi t6,t6,1696
+;   add sp,t6,sp
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.addi16sp sp, -0x10
+;   c.sdsp ra, 8(sp)
+;   c.sdsp s0, 0(sp)
+;   c.mv s0, sp
+;   c.lui t6, 0x19
+;   c.lui t3, 1
+;   bgeu t3, t6, 0x12
+;   sub t5, sp, t6
+;   sb zero, 0(t5)
+;   sub t6, t6, t3
+;   c.j -0x10
+;   c.lui t6, 0xfffe8
+;   addi t6, t6, -0x6a0
+;   add sp, t6, sp
+; block1: ; offset 0x28
+;   c.mv a0, sp
+;   c.lui t6, 0x18
+;   addi t6, t6, 0x6a0
+;   add sp, t6, sp
+;   c.ldsp ra, 8(sp)
+;   c.ldsp s0, 0(sp)
+;   c.addi16sp sp, 0x10
+;   c.jr ra
+

--- a/cranelift/filetests/filetests/isa/riscv64/c-inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/c-inline-probestack.clif
@@ -61,14 +61,12 @@ block0:
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   lui t6,-1
-;   add sp,t6,sp
+;   lui t3,-1
+;   add sp,sp,t3
 ;   sw zero,0(sp)
-;   lui t6,-1
-;   add sp,t6,sp
+;   add sp,sp,t3
 ;   sw zero,0(sp)
-;   lui t6,-1
-;   add sp,t6,sp
+;   add sp,sp,t3
 ;   sw zero,0(sp)
 ;   lui t6,3
 ;   add sp,t6,sp
@@ -89,20 +87,18 @@ block0:
 ;   c.sdsp ra, 8(sp)
 ;   c.sdsp s0, 0(sp)
 ;   c.mv s0, sp
-;   c.lui t6, 0xfffff
-;   add sp, t6, sp
+;   c.lui t3, 0xfffff
+;   c.add sp, t3
 ;   c.swsp zero, 0(sp)
-;   c.lui t6, 0xfffff
-;   add sp, t6, sp
+;   c.add sp, t3
 ;   c.swsp zero, 0(sp)
-;   c.lui t6, 0xfffff
-;   add sp, t6, sp
+;   c.add sp, t3
 ;   c.swsp zero, 0(sp)
 ;   c.lui t6, 3
 ;   add sp, t6, sp
 ;   c.lui t6, 0xffffd
 ;   add sp, t6, sp
-; block1: ; offset 0x2c
+; block1: ; offset 0x22
 ;   c.mv a0, sp
 ;   c.lui t6, 3
 ;   add sp, t6, sp

--- a/cranelift/filetests/filetests/isa/riscv64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/inline-probestack.clif
@@ -61,14 +61,12 @@ block0:
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   lui t6,-1
-;   add sp,t6,sp
+;   lui t3,-1
+;   add sp,sp,t3
 ;   sw zero,0(sp)
-;   lui t6,-1
-;   add sp,t6,sp
+;   add sp,sp,t3
 ;   sw zero,0(sp)
-;   lui t6,-1
-;   add sp,t6,sp
+;   add sp,sp,t3
 ;   sw zero,0(sp)
 ;   lui t6,3
 ;   add sp,t6,sp
@@ -89,20 +87,18 @@ block0:
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   lui t6, 0xfffff
-;   add sp, t6, sp
+;   lui t3, 0xfffff
+;   add sp, sp, t3
 ;   sw zero, 0(sp)
-;   lui t6, 0xfffff
-;   add sp, t6, sp
+;   add sp, sp, t3
 ;   sw zero, 0(sp)
-;   lui t6, 0xfffff
-;   add sp, t6, sp
+;   add sp, sp, t3
 ;   sw zero, 0(sp)
 ;   lui t6, 3
 ;   add sp, t6, sp
 ;   lui t6, 0xffffd
 ;   add sp, t6, sp
-; block1: ; offset 0x44
+; block1: ; offset 0x3c
 ;   mv a0, sp
 ;   lui t6, 3
 ;   add sp, t6, sp

--- a/cranelift/filetests/filetests/isa/riscv64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/inline-probestack.clif
@@ -1,0 +1,166 @@
+test compile precise-output
+set enable_probestack=true
+set probestack_strategy=inline
+; This is the default and is equivalent to a page size of 4096
+set probestack_size_log2=12
+target riscv64
+
+
+; If the stack size is just one page, we can avoid the stack probe entirely
+function %single_page() -> i64 system_v {
+ss0 = explicit_slot 2048
+
+block0:
+  v1 = stack_addr.i64 ss0
+  return v1
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   addi sp,sp,-2048
+; block0:
+;   load_addr a0,0(nominal_sp)
+;   lui t6,1
+;   addi t6,t6,-2048
+;   add sp,t6,sp
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+;   addi sp, sp, -0x800
+; block1: ; offset 0x14
+;   mv a0, sp
+;   lui t6, 1
+;   addi t6, t6, -0x800
+;   add sp, t6, sp
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %unrolled() -> i64 system_v {
+ss0 = explicit_slot 12288
+
+block0:
+  v1 = stack_addr.i64 ss0
+  return v1
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   lui t6,-1
+;   add sp,t6,sp
+;   sw zero,0(sp)
+;   lui t6,-1
+;   add sp,t6,sp
+;   sw zero,0(sp)
+;   lui t6,-1
+;   add sp,t6,sp
+;   sw zero,0(sp)
+;   lui t6,3
+;   add sp,t6,sp
+;   lui t6,-3
+;   add sp,t6,sp
+; block0:
+;   load_addr a0,0(nominal_sp)
+;   lui t6,3
+;   add sp,t6,sp
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+;   lui t6, 0xfffff
+;   add sp, t6, sp
+;   sw zero, 0(sp)
+;   lui t6, 0xfffff
+;   add sp, t6, sp
+;   sw zero, 0(sp)
+;   lui t6, 0xfffff
+;   add sp, t6, sp
+;   sw zero, 0(sp)
+;   lui t6, 3
+;   add sp, t6, sp
+;   lui t6, 0xffffd
+;   add sp, t6, sp
+; block1: ; offset 0x44
+;   mv a0, sp
+;   lui t6, 3
+;   add sp, t6, sp
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+
+function %large() -> i64 system_v {
+ss0 = explicit_slot 100000
+
+block0:
+  v1 = stack_addr.i64 ss0
+  return v1
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   inline_stack_probe##guard_size=4096 probe_count=25 tmp=t3
+;   lui t6,-24
+;   addi t6,t6,-1696
+;   add sp,t6,sp
+; block0:
+;   load_addr a0,0(nominal_sp)
+;   lui t6,24
+;   addi t6,t6,1696
+;   add sp,t6,sp
+;   ld ra,8(sp)
+;   ld fp,0(sp)
+;   addi sp,sp,16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+;   lui t6, 0x19
+;   lui t3, 1
+;   bgeu t3, t6, 0x14
+;   sub t5, sp, t6
+;   sb zero, 0(t5)
+;   sub t6, t6, t3
+;   j -0x10
+;   lui t6, 0xfffe8
+;   addi t6, t6, -0x6a0
+;   add sp, t6, sp
+; block1: ; offset 0x38
+;   mv a0, sp
+;   lui t6, 0x18
+;   addi t6, t6, 0x6a0
+;   add sp, t6, sp
+;   ld ra, 8(sp)
+;   ld s0, 0(sp)
+;   addi sp, sp, 0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack-large.clif
@@ -50,9 +50,13 @@ block0:
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   movl    %esp, -65536(%rsp)
-;   movl    %esp, -131072(%rsp)
-;   movl    %esp, -196608(%rsp)
+;   subq    %rsp, $65536, %rsp
+;   movl    %esp, 0(%rsp)
+;   subq    %rsp, $65536, %rsp
+;   movl    %esp, 0(%rsp)
+;   subq    %rsp, $65536, %rsp
+;   movl    %esp, 0(%rsp)
+;   addq    %rsp, $196608, %rsp
 ;   subq    %rsp, $196608, %rsp
 ; block0:
 ;   lea     rsp(0 + virtual offset), %rax
@@ -65,11 +69,15 @@ block0:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   movl %esp, -0x10000(%rsp)
-;   movl %esp, -0x20000(%rsp)
-;   movl %esp, -0x30000(%rsp)
+;   subq $0x10000, %rsp
+;   movl %esp, (%rsp)
+;   subq $0x10000, %rsp
+;   movl %esp, (%rsp)
+;   subq $0x10000, %rsp
+;   movl %esp, (%rsp)
+;   addq $0x30000, %rsp
 ;   subq $0x30000, %rsp
-; block1: ; offset 0x20
+; block1: ; offset 0x30
 ;   leaq (%rsp), %rax
 ;   addq $0x30000, %rsp
 ;   movq %rbp, %rsp

--- a/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/x64/inline-probestack.clif
@@ -49,9 +49,13 @@ block0:
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   movl    %esp, -4096(%rsp)
-;   movl    %esp, -8192(%rsp)
-;   movl    %esp, -12288(%rsp)
+;   subq    %rsp, $4096, %rsp
+;   movl    %esp, 0(%rsp)
+;   subq    %rsp, $4096, %rsp
+;   movl    %esp, 0(%rsp)
+;   subq    %rsp, $4096, %rsp
+;   movl    %esp, 0(%rsp)
+;   addq    %rsp, $12288, %rsp
 ;   subq    %rsp, $12288, %rsp
 ; block0:
 ;   lea     rsp(0 + virtual offset), %rax
@@ -64,11 +68,15 @@ block0:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   movl %esp, -0x1000(%rsp)
-;   movl %esp, -0x2000(%rsp)
-;   movl %esp, -0x3000(%rsp)
+;   subq $0x1000, %rsp
+;   movl %esp, (%rsp)
+;   subq $0x1000, %rsp
+;   movl %esp, (%rsp)
+;   subq $0x1000, %rsp
+;   movl %esp, (%rsp)
+;   addq $0x3000, %rsp
 ;   subq $0x3000, %rsp
-; block1: ; offset 0x20
+; block1: ; offset 0x30
 ;   leaq (%rsp), %rax
 ;   addq $0x3000, %rsp
 ;   movq %rbp, %rsp


### PR DESCRIPTION
👋 Hey,

This PR alters our stackprobe unroll sequences to move the stackpointer before writing to the stack. I don't think there was anything wrong with what we were doing before but it makes valgrind really unhappy. (See #7454)

I've tested this with cg_clif on x86, and it now cleanly passes valgrind for the original reported testcase.

Fixes: #7454
prtest:full