### PR TITLE
riscv64: Find more oportunities to encode a compressed add

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -336,8 +336,8 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             insts.push(Inst::AluRRR {
                 alu_op: AluOPRRR::Add,
                 rd: writable_stack_reg(),
-                rs1: tmp.to_reg(),
-                rs2: stack_reg(),
+                rs1: stack_reg(),
+                rs2: tmp.to_reg(),
             });
         }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -345,8 +345,16 @@ impl Inst {
                 rd,
                 rs1,
                 rs2,
-            } if rd.to_reg() == rs1 && rs1 != zero_reg() && rs2 != zero_reg() => {
-                sink.put2(encode_cr_type(CrOp::CAdd, rd, rs2));
+            } if (rd.to_reg() == rs1 || rd.to_reg() == rs2)
+                && rs1 != zero_reg()
+                && rs2 != zero_reg() =>
+            {
+                // Technically `c.add rd, rs` expands to `add rd, rd, rs`, but we can
+                // also swap rs1 with rs2 and we get an equivalent instruction. i.e we
+                // can also compress `add rd, rs, rd` into `c.add rd, rs`.
+                let src = if rd.to_reg() == rs1 { rs2 } else { rs1 };
+
+                sink.put2(encode_cr_type(CrOp::CAdd, rd, src));
             }
 
             // C.MV

--- a/cranelift/filetests/filetests/isa/riscv64/c-inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/c-inline-probestack.clif
@@ -25,7 +25,7 @@ block0:
 ;   load_addr a0,0(nominal_sp)
 ;   lui t6,1
 ;   addi t6,t6,-2048
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -42,7 +42,7 @@ block0:
 ;   c.mv a0, sp
 ;   c.lui t6, 1
 ;   addi t6, t6, -0x800
-;   add sp, t6, sp
+;   c.add sp, t6
 ;   c.ldsp ra, 8(sp)
 ;   c.ldsp s0, 0(sp)
 ;   c.addi16sp sp, 0x10
@@ -69,13 +69,13 @@ block0:
 ;   add sp,sp,t3
 ;   sw zero,0(sp)
 ;   lui t6,3
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   lui t6,-3
-;   add sp,t6,sp
+;   add sp,sp,t6
 ; block0:
 ;   load_addr a0,0(nominal_sp)
 ;   lui t6,3
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -95,13 +95,13 @@ block0:
 ;   c.add sp, t3
 ;   c.swsp zero, 0(sp)
 ;   c.lui t6, 3
-;   add sp, t6, sp
+;   c.add sp, t6
 ;   c.lui t6, 0xffffd
-;   add sp, t6, sp
-; block1: ; offset 0x22
+;   c.add sp, t6
+; block1: ; offset 0x1e
 ;   c.mv a0, sp
 ;   c.lui t6, 3
-;   add sp, t6, sp
+;   c.add sp, t6
 ;   c.ldsp ra, 8(sp)
 ;   c.ldsp s0, 0(sp)
 ;   c.addi16sp sp, 0x10
@@ -123,12 +123,12 @@ block0:
 ;   inline_stack_probe##guard_size=4096 probe_count=25 tmp=t3
 ;   lui t6,-24
 ;   addi t6,t6,-1696
-;   add sp,t6,sp
+;   add sp,sp,t6
 ; block0:
 ;   load_addr a0,0(nominal_sp)
 ;   lui t6,24
 ;   addi t6,t6,1696
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -149,12 +149,12 @@ block0:
 ;   c.j -0x10
 ;   c.lui t6, 0xfffe8
 ;   addi t6, t6, -0x6a0
-;   add sp, t6, sp
-; block1: ; offset 0x28
+;   c.add sp, t6
+; block1: ; offset 0x26
 ;   c.mv a0, sp
 ;   c.lui t6, 0x18
 ;   addi t6, t6, 0x6a0
-;   add sp, t6, sp
+;   c.add sp, t6
 ;   c.ldsp ra, 8(sp)
 ;   c.ldsp s0, 0(sp)
 ;   c.addi16sp sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/inline-probestack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/inline-probestack.clif
@@ -25,7 +25,7 @@ block0:
 ;   load_addr a0,0(nominal_sp)
 ;   lui t6,1
 ;   addi t6,t6,-2048
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -42,7 +42,7 @@ block0:
 ;   mv a0, sp
 ;   lui t6, 1
 ;   addi t6, t6, -0x800
-;   add sp, t6, sp
+;   add sp, sp, t6
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -69,13 +69,13 @@ block0:
 ;   add sp,sp,t3
 ;   sw zero,0(sp)
 ;   lui t6,3
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   lui t6,-3
-;   add sp,t6,sp
+;   add sp,sp,t6
 ; block0:
 ;   load_addr a0,0(nominal_sp)
 ;   lui t6,3
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -95,13 +95,13 @@ block0:
 ;   add sp, sp, t3
 ;   sw zero, 0(sp)
 ;   lui t6, 3
-;   add sp, t6, sp
+;   add sp, sp, t6
 ;   lui t6, 0xffffd
-;   add sp, t6, sp
+;   add sp, sp, t6
 ; block1: ; offset 0x3c
 ;   mv a0, sp
 ;   lui t6, 3
-;   add sp, t6, sp
+;   add sp, sp, t6
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -123,12 +123,12 @@ block0:
 ;   inline_stack_probe##guard_size=4096 probe_count=25 tmp=t3
 ;   lui t6,-24
 ;   addi t6,t6,-1696
-;   add sp,t6,sp
+;   add sp,sp,t6
 ; block0:
 ;   load_addr a0,0(nominal_sp)
 ;   lui t6,24
 ;   addi t6,t6,1696
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -149,12 +149,12 @@ block0:
 ;   j -0x10
 ;   lui t6, 0xfffe8
 ;   addi t6, t6, -0x6a0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ; block1: ; offset 0x38
 ;   mv a0, sp
 ;   lui t6, 0x18
 ;   addi t6, t6, 0x6a0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
@@ -195,11 +195,11 @@ block0(v0: i64):
 ;   call %Probestack
 ;   lui t6,-98
 ;   addi t6,t6,1408
-;   add sp,t6,sp
+;   add sp,sp,t6
 ; block0:
 ;   lui t6,98
 ;   addi t6,t6,-1408
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -224,11 +224,11 @@ block0(v0: i64):
 ;   jalr ra
 ;   lui t6, 0xfff9e
 ;   addi t6, t6, 0x580
-;   add sp, t6, sp
+;   add sp, sp, t6
 ; block1: ; offset 0x48
 ;   lui t6, 0x62
 ;   addi t6, t6, -0x580
-;   add sp, t6, sp
+;   add sp, sp, t6
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -307,11 +307,11 @@ block0(v0: i64):
 ;   call %Probestack
 ;   lui t6,-98
 ;   addi t6,t6,1408
-;   add sp,t6,sp
+;   add sp,sp,t6
 ; block0:
 ;   lui t6,98
 ;   addi t6,t6,-1408
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -338,11 +338,11 @@ block0(v0: i64):
 ;   jalr ra
 ;   lui t6, 0xfff9e
 ;   addi t6, t6, 0x580
-;   add sp, t6, sp
+;   add sp, sp, t6
 ; block1: ; offset 0x50
 ;   lui t6, 0x62
 ;   addi t6, t6, -0x580
-;   add sp, t6, sp
+;   add sp, sp, t6
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/stack.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack.clif
@@ -59,12 +59,12 @@ block0:
 ;   call %Probestack
 ;   lui t6,-24
 ;   addi t6,t6,-1712
-;   add sp,t6,sp
+;   add sp,sp,t6
 ; block0:
 ;   load_addr a0,0(nominal_sp)
 ;   lui t6,24
 ;   addi t6,t6,1712
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -82,12 +82,12 @@ block0:
 ;   jalr ra
 ;   lui t6, 0xfffe8
 ;   addi t6, t6, -0x6b0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ; block1: ; offset 0x2c
 ;   mv a0, sp
 ;   lui t6, 0x18
 ;   addi t6, t6, 0x6b0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -149,12 +149,12 @@ block0:
 ;   call %Probestack
 ;   lui t6,-24
 ;   addi t6,t6,-1712
-;   add sp,t6,sp
+;   add sp,sp,t6
 ; block0:
 ;   ld a0,0(nominal_sp)
 ;   lui t6,24
 ;   addi t6,t6,1712
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -172,12 +172,12 @@ block0:
 ;   jalr ra
 ;   lui t6, 0xfffe8
 ;   addi t6, t6, -0x6b0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ; block1: ; offset 0x2c
 ;   ld a0, 0(sp)
 ;   lui t6, 0x18
 ;   addi t6, t6, 0x6b0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -239,12 +239,12 @@ block0(v0: i64):
 ;   call %Probestack
 ;   lui t6,-24
 ;   addi t6,t6,-1712
-;   add sp,t6,sp
+;   add sp,sp,t6
 ; block0:
 ;   sd a0,0(nominal_sp)
 ;   lui t6,24
 ;   addi t6,t6,1712
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -262,12 +262,12 @@ block0(v0: i64):
 ;   jalr ra
 ;   lui t6, 0xfffe8
 ;   addi t6, t6, -0x6b0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ; block1: ; offset 0x2c
 ;   sd a0, 0(sp)
 ;   lui t6, 0x18
 ;   addi t6, t6, 0x6b0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -933,13 +933,13 @@ block0(v0: i128):
 ;   call %Probestack
 ;   lui t6,-24
 ;   addi t6,t6,-1712
-;   add sp,t6,sp
+;   add sp,sp,t6
 ; block0:
 ;   sd a0,0(nominal_sp)
 ;   sd a1,8(nominal_sp)
 ;   lui t6,24
 ;   addi t6,t6,1712
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -957,13 +957,13 @@ block0(v0: i128):
 ;   jalr ra
 ;   lui t6, 0xfffe8
 ;   addi t6, t6, -0x6b0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ; block1: ; offset 0x2c
 ;   sd a0, 0(sp)
 ;   sd a1, 8(sp)
 ;   lui t6, 0x18
 ;   addi t6, t6, 0x6b0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -1067,13 +1067,13 @@ block0:
 ;   call %Probestack
 ;   lui t6,-24
 ;   addi t6,t6,-1712
-;   add sp,t6,sp
+;   add sp,sp,t6
 ; block0:
 ;   ld a0,0(nominal_sp)
 ;   ld a1,8(nominal_sp)
 ;   lui t6,24
 ;   addi t6,t6,1712
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -1091,13 +1091,13 @@ block0:
 ;   jalr ra
 ;   lui t6, 0xfffe8
 ;   addi t6, t6, -0x6b0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ; block1: ; offset 0x2c
 ;   ld a0, 0(sp)
 ;   ld a1, 8(sp)
 ;   lui t6, 0x18
 ;   addi t6, t6, 0x6b0
-;   add sp, t6, sp
+;   add sp, sp, t6
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -463,7 +463,7 @@ block0:
 ;   mv a0,a5
 ;   lui t6,1
 ;   addi t6,t6,-2048
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -489,7 +489,7 @@ block0:
 ;   c.mv a0, a5
 ;   c.lui t6, 1
 ;   addi t6, t6, -0x800
-;   add sp, t6, sp
+;   c.add sp, t6
 ;   c.ldsp ra, 8(sp)
 ;   c.ldsp s0, 0(sp)
 ;   c.addi16sp sp, 0x10
@@ -515,7 +515,7 @@ block0:
 ;   load_addr a1,0(nominal_sp)
 ;   lui t6,1
 ;   addi t6,t6,-2048
-;   add sp,t6,sp
+;   add sp,sp,t6
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -533,7 +533,7 @@ block0:
 ;   c.mv a1, sp
 ;   c.lui t6, 1
 ;   addi t6, t6, -0x800
-;   add sp, t6, sp
+;   c.add sp, t6
 ;   c.ldsp ra, 8(sp)
 ;   c.ldsp s0, 0(sp)
 ;   c.addi16sp sp, 0x10


### PR DESCRIPTION
👋 Hey,

This is a small RISC-V specific follow up to #7470. I noticed that we don't always compress the adjust sp instruction when we could do so.

In the cases where we have build a constant in a temporary register and then `add` it to the `sp`, we encode the registers in a way that was preventing the compressed instruction from being emitted. Currently we only compress an `add` if the destination register is the same as the first source register. This is the canonical expansion of `c.add`.

This PR does two things. 
* I've switched the add instruction to have the stack pointer as the first register. i.e. `add sp, t?, sp` -> `add sp, sp, t?`. This allows us to compress that instruction with the current emit code.
* I've updated the emit code to recognize this pattern and flip the source register when emitting the compressed add. This in theory should allow us to emit this instruction more frequently.

Theoretically we only need the second step to solve this, but I've decided to also change `adjust_sp` since its the canonical representation, and at least to me is visually neater having sp as the first source register.

This is built on top of #7470, but only the last two commits belong to this PR.