### PR TITLE
wasi-http: Remove extra task when reading bodies

### DIFF
--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -1,8 +1,12 @@
 use crate::{bindings::http::types, types::FieldMap};
 use anyhow::anyhow;
 use bytes::Bytes;
+use http_body::{Body, Frame};
 use http_body_util::combinators::BoxBody;
+use http_body_util::BodyExt;
 use std::future::Future;
+use std::mem;
+use std::task::{Context, Poll};
 use std::{
     pin::Pin,
     sync::{Arc, Mutex},
@@ -10,186 +14,198 @@ use std::{
 };
 use tokio::sync::{mpsc, oneshot};
 use wasmtime_wasi::preview2::{
-    self, AbortOnDropJoinHandle, HostInputStream, HostOutputStream, StreamError, Subscribe,
+    self, poll_noop, AbortOnDropJoinHandle, HostInputStream, HostOutputStream, StreamError,
+    Subscribe,
 };
 
 pub type HyperIncomingBody = BoxBody<Bytes, types::Error>;
 
-/// Holds onto the things needed to construct a [`HostIncomingBody`] until we are ready to build
-/// one. The HostIncomingBody spawns a task that starts consuming the incoming body, and we don't
-/// want to do that unless the user asks to consume the body.
-pub struct HostIncomingBodyBuilder {
-    pub body: HyperIncomingBody,
-    pub worker: Option<Arc<AbortOnDropJoinHandle<Result<(), types::Error>>>>,
-    pub between_bytes_timeout: Duration,
+/// Small wrapper around `BoxBody` which adds a timeout to every frame.
+struct BodyWithTimeout {
+    /// Underlying stream that frames are coming from.
+    inner: HyperIncomingBody,
+    /// Currently active timeout that's reset between frames.
+    timeout: Pin<Box<tokio::time::Sleep>>,
+    /// Whether or not `timeout` needs to be reset on the next call to
+    /// `poll_frame`.
+    reset_sleep: bool,
+    /// Maximal duration between when a frame is first requested and when it's
+    /// allowed to arrive.
+    between_bytes_timeout: Duration,
 }
 
-impl HostIncomingBodyBuilder {
-    /// Consume the state held in the [`HostIncomingBodyBuilder`] to spawn a task that will drive the
-    /// streaming body to completion. Data segments will be communicated out over the
-    /// [`HostIncomingBodyStream`], and a [`HostFutureTrailers`] gives a way to block on/retrieve
-    /// the trailers.
-    pub fn build(mut self) -> HostIncomingBody {
-        let (body_writer, body_receiver) = mpsc::channel(1);
-        let (trailer_writer, trailers) = oneshot::channel();
-
-        let worker = preview2::spawn(async move {
-            loop {
-                let frame = match tokio::time::timeout(
-                    self.between_bytes_timeout,
-                    http_body_util::BodyExt::frame(&mut self.body),
-                )
-                .await
-                {
-                    Ok(None) => break,
-
-                    Ok(Some(Ok(frame))) => frame,
-
-                    Ok(Some(Err(e))) => {
-                        match body_writer.send(Err(e)).await {
-                            Ok(_) => {}
-                            // If the body read end has dropped, then we report this error with the
-                            // trailers. unwrap and rewrap Err because the Ok side of these two Results
-                            // are different.
-                            Err(e) => {
-                                let _ = trailer_writer.send(Err(e.0.unwrap_err()));
-                            }
-                        }
-                        break;
-                    }
-
-                    Err(_) => {
-                        match body_writer
-                            .send(Err(types::Error::TimeoutError(
-                                "data frame timed out".to_string(),
-                            )
-                            .into()))
-                            .await
-                        {
-                            Ok(_) => {}
-                            Err(e) => {
-                                let _ = trailer_writer.send(Err(e.0.unwrap_err()));
-                            }
-                        }
-                        break;
-                    }
-                };
-
-                if frame.is_trailers() {
-                    // We know we're not going to write any more data frames at this point, so we
-                    // explicitly drop the body_writer so that anything waiting on the read end returns
-                    // immediately.
-                    drop(body_writer);
-
-                    let trailers = frame.into_trailers().unwrap();
-
-                    // TODO: this will fail in two cases:
-                    // 1. we've already used the channel once, which should be imposible,
-                    // 2. the read end is closed.
-                    // I'm not sure how to differentiate between these two cases, or really
-                    // if we need to do anything to handle either.
-                    let _ = trailer_writer.send(Ok(trailers));
-
-                    break;
-                }
-
-                assert!(frame.is_data(), "frame wasn't data");
-
-                let data = frame.into_data().unwrap();
-
-                // If the receiver no longer exists, thats ok - in that case we want to keep the
-                // loop running to relieve backpressure, so we get to the trailers.
-                let _ = body_writer.send(Ok(data)).await;
-            }
-
-            // Force the builder's worker to be owned by this task, ensuring that it's kept around
-            // until this task exits.
-            drop(self.worker);
-        });
-
-        HostIncomingBody {
-            worker,
-            stream: Some(HostIncomingBodyStream::new(body_receiver)),
-            trailers,
+impl BodyWithTimeout {
+    fn new(inner: HyperIncomingBody, between_bytes_timeout: Duration) -> BodyWithTimeout {
+        BodyWithTimeout {
+            inner,
+            between_bytes_timeout,
+            reset_sleep: true,
+            timeout: Box::pin(preview2::with_ambient_tokio_runtime(|| {
+                tokio::time::sleep(Duration::new(0, 0))
+            })),
         }
+    }
+}
+
+impl Body for BodyWithTimeout {
+    type Data = Bytes;
+    type Error = types::Error;
+
+    fn poll_frame(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Bytes>, types::Error>>> {
+        let me = Pin::into_inner(self);
+
+        // If the timeout timer needs to be reset, do that now relative to the
+        // current instant. Otherwise test the timeout timer and see if it's
+        // fired yet and if so we've timed out and return an error.
+        if me.reset_sleep {
+            me.timeout
+                .as_mut()
+                .reset(tokio::time::Instant::now() + me.between_bytes_timeout);
+            me.reset_sleep = false;
+        }
+
+        // Register interest in this context on the sleep timer, and if the
+        // sleep elapsed that means that we've timed out.
+        if let Poll::Ready(()) = me.timeout.as_mut().poll(cx) {
+            return Poll::Ready(Some(Err(types::Error::TimeoutError(
+                "frame timed out".to_string(),
+            ))));
+        }
+
+        // Without timeout business now handled check for the frame. If a frame
+        // arrives then the sleep timer will be reset on the next frame.
+        let result = Pin::new(&mut me.inner).poll_frame(cx);
+        me.reset_sleep = result.is_ready();
+        result
     }
 }
 
 pub struct HostIncomingBody {
-    pub worker: AbortOnDropJoinHandle<()>,
-    pub stream: Option<HostIncomingBodyStream>,
-    pub trailers: oneshot::Receiver<Result<hyper::HeaderMap, types::Error>>,
+    body: IncomingBodyState,
+    /// An optional worker task to keep alive while this body is being read.
+    /// This ensures that if the parent of this body is dropped before the body
+    /// then the backing data behind this worker is kept alive.
+    worker: Option<Arc<AbortOnDropJoinHandle<()>>>,
+}
+
+enum IncomingBodyState {
+    /// The body is stored here meaning that within `HostIncomingBody` the
+    /// `take_stream` method can be called for example.
+    Start(BodyWithTimeout),
+
+    /// The body is within a `HostIncomingBodyStream` meaning that it's not
+    /// currently owned here. The body will be sent back over this channel when
+    /// it's done, however.
+    InBodyStream(oneshot::Receiver<StreamEnd>),
+}
+
+/// Message sent when a `HostIncomingBodyStream` is done to the
+/// `HostFutureTrailers` state.
+enum StreamEnd {
+    /// The body wasn't completely read and was dropped early. May still have
+    /// trailers, but requires reading more frames.
+    Remaining(BodyWithTimeout),
+
+    /// Body was completely read and trailers were read. Here are the trailers.
+    /// Note that `None` means that the body finished without trailers.
+    Trailers(Option<FieldMap>),
 }
 
 impl HostIncomingBody {
-    pub fn into_future_trailers(self) -> HostFutureTrailers {
-        HostFutureTrailers {
-            _worker: self.worker,
-            state: HostFutureTrailersState::Waiting(self.trailers),
+    pub fn new(body: HyperIncomingBody, between_bytes_timeout: Duration) -> HostIncomingBody {
+        let body = BodyWithTimeout::new(body, between_bytes_timeout);
+        HostIncomingBody {
+            body: IncomingBodyState::Start(body),
+            worker: None,
         }
+    }
+
+    pub fn retain_worker(&mut self, worker: &Arc<AbortOnDropJoinHandle<()>>) {
+        assert!(self.worker.is_none());
+        self.worker = Some(worker.clone());
+    }
+
+    pub fn take_stream(&mut self) -> Option<HostIncomingBodyStream> {
+        match &mut self.body {
+            IncomingBodyState::Start(_) => {}
+            IncomingBodyState::InBodyStream(_) => return None,
+        }
+        let (tx, rx) = oneshot::channel();
+        let body = match mem::replace(&mut self.body, IncomingBodyState::InBodyStream(rx)) {
+            IncomingBodyState::Start(b) => b,
+            IncomingBodyState::InBodyStream(_) => unreachable!(),
+        };
+        Some(HostIncomingBodyStream {
+            state: IncomingBodyStreamState::Open { body, tx },
+            buffer: Bytes::new(),
+            error: None,
+        })
+    }
+
+    pub fn into_future_trailers(self) -> HostFutureTrailers {
+        HostFutureTrailers::Waiting(self)
     }
 }
 
 pub struct HostIncomingBodyStream {
-    pub open: bool,
-    pub receiver: mpsc::Receiver<Result<Bytes, types::Error>>,
-    pub buffer: Bytes,
-    pub error: Option<anyhow::Error>,
+    state: IncomingBodyStreamState,
+    buffer: Bytes,
+    error: Option<anyhow::Error>,
 }
 
-impl HostIncomingBodyStream {
-    fn new(receiver: mpsc::Receiver<Result<Bytes, types::Error>>) -> Self {
-        Self {
-            open: true,
-            receiver,
-            buffer: Bytes::new(),
-            error: None,
-        }
-    }
+enum IncomingBodyStreamState {
+    /// The body is currently open for reading and present here.
+    ///
+    /// When trailers are read, or when this is dropped, the body is sent along
+    /// `tx`.
+    ///
+    /// This state is transitioned to `Closed` when an error happens, EOF
+    /// happens, or when trailers are read.
+    Open {
+        body: BodyWithTimeout,
+        tx: oneshot::Sender<StreamEnd>,
+    },
+
+    /// This body is closed and no longer available for reading, no more data
+    /// will come.
+    Closed,
 }
 
 #[async_trait::async_trait]
 impl HostInputStream for HostIncomingBodyStream {
     fn read(&mut self, size: usize) -> Result<Bytes, StreamError> {
-        use mpsc::error::TryRecvError;
-
-        if !self.buffer.is_empty() {
-            let len = size.min(self.buffer.len());
-            let chunk = self.buffer.split_to(len);
-            return Ok(chunk);
-        }
-
-        if let Some(e) = self.error.take() {
-            return Err(StreamError::LastOperationFailed(e));
-        }
-
-        if !self.open {
-            return Err(StreamError::Closed);
-        }
-
-        match self.receiver.try_recv() {
-            Ok(Ok(mut bytes)) => {
-                let len = bytes.len().min(size);
-                let chunk = bytes.split_to(len);
-                if !bytes.is_empty() {
-                    self.buffer = bytes;
-                }
-
+        loop {
+            // Handle buffered data/errors if any
+            if !self.buffer.is_empty() {
+                let len = size.min(self.buffer.len());
+                let chunk = self.buffer.split_to(len);
                 return Ok(chunk);
             }
 
-            Ok(Err(e)) => {
-                self.open = false;
-                return Err(StreamError::LastOperationFailed(e.into()));
+            if let Some(e) = self.error.take() {
+                return Err(StreamError::LastOperationFailed(e));
             }
 
-            Err(TryRecvError::Empty) => {
-                return Ok(Bytes::new());
-            }
+            // Extract the body that we're reading from. If present perform a
+            // non-blocking poll to see if a frame is already here. If it is
+            // then turn the loop again to operate on the results. If it's not
+            // here then return an empty buffer as no data is available at this
+            // time.
+            let body = match &mut self.state {
+                IncomingBodyStreamState::Open { body, .. } => body,
+                IncomingBodyStreamState::Closed => return Err(StreamError::Closed),
+            };
 
-            Err(TryRecvError::Disconnected) => {
-                self.open = false;
-                return Err(StreamError::Closed);
+            let future = body.frame();
+            futures::pin_mut!(future);
+            match poll_noop(future) {
+                Some(result) => {
+                    self.record_frame(result);
+                }
+                None => return Ok(Bytes::new()),
             }
         }
     }
@@ -198,56 +214,155 @@ impl HostInputStream for HostIncomingBodyStream {
 #[async_trait::async_trait]
 impl Subscribe for HostIncomingBodyStream {
     async fn ready(&mut self) {
-        if !self.buffer.is_empty() {
+        if !self.buffer.is_empty() || self.error.is_some() {
             return;
         }
 
-        if !self.open {
-            return;
-        }
-
-        match self.receiver.recv().await {
-            Some(Ok(bytes)) => self.buffer = bytes,
-
-            Some(Err(e)) => {
-                self.error = Some(e.into());
-                self.open = false;
-            }
-
-            None => self.open = false,
+        if let IncomingBodyStreamState::Open { body, .. } = &mut self.state {
+            let frame = body.frame().await;
+            self.record_frame(frame);
         }
     }
 }
 
-pub struct HostFutureTrailers {
-    _worker: AbortOnDropJoinHandle<()>,
-    pub state: HostFutureTrailersState,
+impl HostIncomingBodyStream {
+    fn record_frame(&mut self, frame: Option<Result<Frame<Bytes>, types::Error>>) {
+        match frame {
+            Some(Ok(frame)) => match frame.into_data() {
+                // A data frame was received, so queue up the buffered data for
+                // the next `read` call.
+                Ok(bytes) => {
+                    assert!(self.buffer.is_empty());
+                    self.buffer = bytes;
+                }
+
+                // Trailers were received meaning that this was the final frame.
+                // Throw away the body and send the trailers along the
+                // `tx` channel to make them available.
+                Err(trailers) => {
+                    let trailers = trailers.into_trailers().unwrap();
+                    let tx = match mem::replace(&mut self.state, IncomingBodyStreamState::Closed) {
+                        IncomingBodyStreamState::Open { body: _, tx } => tx,
+                        IncomingBodyStreamState::Closed => unreachable!(),
+                    };
+
+                    // NB: ignore send failures here because if this fails then
+                    // no one was interested in the trailers.
+                    let _ = tx.send(StreamEnd::Trailers(Some(trailers)));
+                }
+            },
+
+            // An error was received meaning that the stream is now done.
+            // Destroy the body to terminate the stream while enqueueing the
+            // error to get returned from the next call to `read`.
+            Some(Err(e)) => {
+                self.error = Some(e.into());
+                self.state = IncomingBodyStreamState::Closed;
+            }
+
+            // No more frames are going to be received again, so drop the `body`
+            // and the `tx` channel we'd send the body back onto because it's
+            // not needed as frames are done.
+            None => {
+                self.state = IncomingBodyStreamState::Closed;
+            }
+        }
+    }
 }
 
-pub enum HostFutureTrailersState {
-    Waiting(oneshot::Receiver<Result<hyper::HeaderMap, types::Error>>),
+impl Drop for HostIncomingBodyStream {
+    fn drop(&mut self) {
+        // When a body stream is dropped, for whatever reason, attempt to send
+        // the body back to the `tx` which will provide the trailers if desired.
+        // This isn't necessary if the state is already closed. Additionally,
+        // like `record_frame` above, `send` errors are ignored as they indicate
+        // that the body/trailers aren't actually needed.
+        let prev = mem::replace(&mut self.state, IncomingBodyStreamState::Closed);
+        if let IncomingBodyStreamState::Open { body, tx } = prev {
+            let _ = tx.send(StreamEnd::Remaining(body));
+        }
+    }
+}
+
+pub enum HostFutureTrailers {
+    /// Trailers aren't here yet.
+    ///
+    /// This state represents two similar states:
+    ///
+    /// * The body is here and ready for reading and we're waiting to read
+    ///   trailers. This can happen for example when the actual body wasn't read
+    ///   or if the body was only partially read.
+    ///
+    /// * The body is being read by something else and we're waiting for that to
+    ///   send us the trailers (or the body itself). This state will get entered
+    ///   when the body stream is dropped for example. If the body stream reads
+    ///   the trailers itself it will also send a message over here with the
+    ///   trailers.
+    Waiting(HostIncomingBody),
+
+    /// Trailers are ready and here they are.
+    ///
+    /// Note that `Ok(None)` means that there were no trailers for this request
+    /// while `Ok(Some(_))` means that trailers were found in the request.
     Done(Result<Option<FieldMap>, types::Error>),
 }
 
 #[async_trait::async_trait]
 impl Subscribe for HostFutureTrailers {
     async fn ready(&mut self) {
-        if let HostFutureTrailersState::Waiting(rx) = &mut self.state {
-            let result = match rx.await {
-                Ok(Ok(headers)) => {
-                    if headers.is_empty() {
-                        Ok(None)
-                    } else {
-                        Ok(Some(headers))
+        let body = match self {
+            HostFutureTrailers::Waiting(body) => body,
+            HostFutureTrailers::Done(_) => return,
+        };
+
+        // If the body is itself being read by a body stream then we need to
+        // wait for that to be done.
+        if let IncomingBodyState::InBodyStream(rx) = &mut body.body {
+            match rx.await {
+                // Trailers were read for us and here they are, so store the
+                // result.
+                Ok(StreamEnd::Trailers(t)) => *self = Self::Done(Ok(t)),
+
+                // The body wasn't fully read and was dropped before trailers
+                // were reached. It's up to us now to complete the body.
+                Ok(StreamEnd::Remaining(b)) => body.body = IncomingBodyState::Start(b),
+
+                // Technically this shouldn't be possible as the sender
+                // shouldn't get destroyed without receiving a message. Handle
+                // this just in case though.
+                Err(_) => {
+                    debug_assert!(false, "should be unreachable");
+                    *self = HostFutureTrailers::Done(Err(types::Error::ProtocolError(
+                        "stream hung up before trailers were received".to_string(),
+                    )));
+                }
+            }
+        }
+
+        // Here it should be guaranteed that `InBodyStream` is now gone, so if
+        // we have the body ourselves then read frames until trailers are found.
+        let body = match self {
+            HostFutureTrailers::Waiting(body) => body,
+            HostFutureTrailers::Done(_) => return,
+        };
+        let hyper_body = match &mut body.body {
+            IncomingBodyState::Start(body) => body,
+            IncomingBodyState::InBodyStream(_) => unreachable!(),
+        };
+        let result = loop {
+            match hyper_body.frame().await {
+                None => break Ok(None),
+                Some(Err(e)) => break Err(e),
+                Some(Ok(frame)) => {
+                    // If this frame is a data frame ignore it as we're only
+                    // interested in trailers.
+                    if let Ok(headers) = frame.into_trailers() {
+                        break Ok(Some(headers));
                     }
                 }
-                Ok(Err(e)) => Err(types::Error::ProtocolError(format!("hyper error: {e:?}"))),
-                Err(_) => Err(types::Error::ProtocolError(
-                    "stream hung up before trailers were received".to_string(),
-                )),
-            };
-            self.state = HostFutureTrailersState::Done(result);
-        }
+            }
+        };
+        *self = HostFutureTrailers::Done(result);
     }
 }
 
@@ -266,9 +381,6 @@ pub struct HostOutgoingBody {
 
 impl HostOutgoingBody {
     pub fn new() -> (Self, HyperOutgoingBody) {
-        use http_body_util::BodyExt;
-        use hyper::body::{Body, Frame};
-        use std::task::{Context, Poll};
         use tokio::sync::oneshot::error::RecvError;
         struct BodyImpl {
             body_receiver: mpsc::Receiver<Bytes>,

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -268,7 +268,7 @@ async fn do_wasi_http_hash_all(override_send_request: bool) -> Result<()> {
                 let response = handle(request.into_parts().0).map(|resp| {
                     Ok(IncomingResponseInternal {
                         resp,
-                        worker: Arc::new(preview2::spawn(future::ready(Ok(())))),
+                        worker: Arc::new(preview2::spawn(future::ready(()))),
                         between_bytes_timeout,
                     })
                 });


### PR DESCRIPTION
This commit is in the same spirit as #7461 and is aimed at removing an extra task when interoperating between WebAssembly and Hyper. The intention here is to ensure that when data is ready immediately a context switch between Tokio tasks isn't necessary. I'm still not sure why this context switch would tank performance so much.

The goal of this commit is to remove the Tokio task associated with reading bodies. Currently a task is spawned with two channels coming out: one for frames and one for trailers. Instead the body is now read directly when data frames are read and trailers are managed similarly. The interactions here are somewhat nontrivial due to the management of resources and how the body needs to jump from the body stream object to the trailers object, but it's overall not the worst thing in the world.

Locally on Linux this takes a "hello world" component which starts out by reading its HTTP body and then responds with a string from 6.7k rps locally via `wasmtime serve` to 16.8k rps. This restores the performance of wasi-http to be in-line with the historical SDK that Fermyon offered, for example, that's based on a custom HTTP interface. Note that these performance numbers use #7461 as a baseline.

This commit has a downside, however, that if the incoming body is not being subscribed to actively by the wasm then no activity will happen on the host. This is a function of `poll` isn't being actively watched unless `subscribe`'s result is being actively watched via a wasm call to `wasi:io/poll`. Manual investigation of Hyper shows that this is probably ok for now since bodies are primarily channel-based which seems like the tasks doing the actual I/O are managed elsewhere. In that sense this shouldn't cause any immediate impact, but Hyper's situation in the future could change or my analysis could additionally be wrong. Given the performance benefits here though I'd be tempted to push in favor of this commit and handle "poll in the background" as necessary in the future if needed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
