### PR TITLE
c-api: support yielding in wasmtime_store_epoch_deadline_callback

### DIFF
--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -200,11 +200,11 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_context_set_wasi(wasmtime_context_t *
  */
 WASM_API_EXTERN void wasmtime_context_set_epoch_deadline(wasmtime_context_t *context, uint64_t ticks_beyond_current);
 
-// \brief An enum for the behavior before extending the epoch deadline.
+/// \brief An enum for the behavior before extending the epoch deadline.
 typedef uint8_t wasmtime_update_deadline_kind_t;
-// \brief Directly continue to updating the deadline and executing WebAssembly.
+/// \brief Directly continue to updating the deadline and executing WebAssembly.
 #define WASMTIME_UPDATE_DEADLINE_CONTINUE 0
-// \brief Yield control (via async support) then update the deadline.
+/// \brief Yield control (via async support) then update the deadline.
 #define WASMTIME_UPDATE_DEADLINE_YIELD    1
 
 /**

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -200,19 +200,44 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_context_set_wasi(wasmtime_context_t *
  */
 WASM_API_EXTERN void wasmtime_context_set_epoch_deadline(wasmtime_context_t *context, uint64_t ticks_beyond_current);
 
+// \brief An enum for the behavior before extending the epoch deadline.
+typedef uint8_t wasmtime_update_deadline_kind_t;
+// \brief Directly continue to updating the deadline and executing WebAssembly.
+#define WASMTIME_UPDATE_DEADLINE_CONTINUE 0
+// \brief Yield control (via async support) then update the deadline.
+#define WASMTIME_UPDATE_DEADLINE_YIELD    1
+
 /**
  * \brief Configures epoch deadline callback to C function.
  *
  * This function configures a store-local callback function that will be
  * called when the running WebAssembly function has exceeded its epoch
- * deadline. That function can return a #wasmtime_error_t to terminate
- * the function, or set the delta argument and return NULL to update the
- * epoch deadline and resume function execution.
+ * deadline. That function can:
+ * - return a #wasmtime_error_t to terminate the function
+ * - set the delta argument and return NULL to update the
+ *   epoch deadline delta and resume function execution.
+ * - set the delta argument, update the epoch deadline, 
+ *   set update_kind to WASMTIME_UPDATE_DEADLINE_YIELD,
+ *   and return NULL to yield (via async support) and 
+ *   resume function execution.
+ *
+ * To use WASMTIME_UPDATE_DEADLINE_YIELD async support must be enabled 
+ * for this store.
  *
  * See also #wasmtime_config_epoch_interruption_set and
  * #wasmtime_context_set_epoch_deadline.
  */
-WASM_API_EXTERN void wasmtime_store_epoch_deadline_callback(wasmtime_store_t *store, wasmtime_error_t* (*func)(wasmtime_context_t*, void*, uint64_t*), void *data);
+WASM_API_EXTERN void wasmtime_store_epoch_deadline_callback(
+    wasmtime_store_t *store, 
+    wasmtime_error_t* (*func)(
+      wasmtime_context_t* context, 
+      void* data, 
+      uint64_t* epoch_deadline_delta, 
+      wasmtime_update_deadline_kind_t* update_kind
+    ), 
+    void *data,
+    void (*finalizer)(void*)
+);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/crates/c-api/src/async.rs
+++ b/crates/c-api/src/async.rs
@@ -15,8 +15,7 @@ use wasmtime::{
 use crate::{
     bad_utf8, handle_result, to_str, translate_args, wasm_config_t, wasm_functype_t, wasm_trap_t,
     wasmtime_caller_t, wasmtime_error_t, wasmtime_instance_pre_t, wasmtime_linker_t,
-    wasmtime_module_t, wasmtime_val_t, wasmtime_val_union, CStoreContextMut, CallbackDataPtr,
-    WASMTIME_I32,
+    wasmtime_module_t, wasmtime_val_t, wasmtime_val_union, CStoreContextMut, WASMTIME_I32,
 };
 
 #[no_mangle]
@@ -87,6 +86,17 @@ impl Future for wasmtime_async_continuation_t {
         }
     }
 }
+
+/// Internal structure to add Send/Sync to a c_void member.
+///
+/// This is useful in closures that need to capture some C data.
+#[derive(Debug)]
+struct CallbackDataPtr {
+    pub ptr: *mut std::ffi::c_void,
+}
+
+unsafe impl Send for CallbackDataPtr {}
+unsafe impl Sync for CallbackDataPtr {}
 
 pub type wasmtime_func_async_continuation_callback_t = extern "C" fn(*mut c_void) -> bool;
 

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -114,14 +114,3 @@ unsafe fn slice_from_raw_parts_mut<'a, T>(ptr: *mut T, len: usize) -> &'a mut [T
         std::slice::from_raw_parts_mut(ptr, len)
     }
 }
-
-/// Internal structure to add Send/Sync to a c_void member.
-///
-/// This is useful in closures that need to capture some C data.
-#[derive(Debug)]
-struct CallbackDataPtr {
-    pub ptr: *mut std::ffi::c_void,
-}
-
-unsafe impl Send for CallbackDataPtr {}
-unsafe impl Sync for CallbackDataPtr {}

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -114,3 +114,14 @@ unsafe fn slice_from_raw_parts_mut<'a, T>(ptr: *mut T, len: usize) -> &'a mut [T
         std::slice::from_raw_parts_mut(ptr, len)
     }
 }
+
+/// Internal structure to add Send/Sync to a c_void member.
+///
+/// This is useful in closures that need to capture some C data.
+#[derive(Debug)]
+struct CallbackDataPtr {
+    pub ptr: *mut std::ffi::c_void,
+}
+
+unsafe impl Send for CallbackDataPtr {}
+unsafe impl Sync for CallbackDataPtr {}

--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -106,20 +106,9 @@ pub extern "C" fn wasmtime_store_new(
     })
 }
 
-// Internal structure to add Send/Sync to the c_void member.
-#[derive(Debug)]
-pub struct CallbackDataPtr {
-    pub ptr: *mut c_void,
-}
-
-impl CallbackDataPtr {
-    fn as_mut_ptr(&self) -> *mut c_void {
-        self.ptr
-    }
-}
-
-unsafe impl Send for CallbackDataPtr {}
-unsafe impl Sync for CallbackDataPtr {}
+pub type wasmtime_update_deadline_kind_t = u8;
+pub const WASMTIME_UPDATE_DEADLINE_CONTINUE: wasmtime_update_deadline_kind_t = 0;
+pub const WASMTIME_UPDATE_DEADLINE_YIELD: wasmtime_update_deadline_kind_t = 1;
 
 #[no_mangle]
 pub extern "C" fn wasmtime_store_epoch_deadline_callback(
@@ -128,22 +117,31 @@ pub extern "C" fn wasmtime_store_epoch_deadline_callback(
         CStoreContextMut<'_>,
         *mut c_void,
         *mut u64,
+        *mut wasmtime_update_deadline_kind_t,
     ) -> Option<Box<wasmtime_error_t>>,
     data: *mut c_void,
+    finalizer: Option<extern "C" fn(*mut c_void)>,
 ) {
-    let sendable = CallbackDataPtr { ptr: data };
+    let foreign = crate::ForeignData { data, finalizer };
     store.store.epoch_deadline_callback(move |mut store_ctx| {
+        let _ = &foreign; // Move foreign into this closure
         let mut delta: u64 = 0;
+        let mut kind = WASMTIME_UPDATE_DEADLINE_CONTINUE;
         let result = (func)(
             store_ctx.as_context_mut(),
-            sendable.as_mut_ptr(),
+            foreign.data,
             &mut delta as *mut u64,
+            &mut kind as *mut wasmtime_update_deadline_kind_t,
         );
         match result {
             Some(err) => Err(wasmtime::Error::from(<wasmtime_error_t as Into<
                 anyhow::Error,
             >>::into(*err))),
-            None => Ok(UpdateDeadline::Continue(delta)),
+            None if kind == WASMTIME_UPDATE_DEADLINE_CONTINUE => {
+                Ok(UpdateDeadline::Continue(delta))
+            }
+            None if kind == WASMTIME_UPDATE_DEADLINE_YIELD => Ok(UpdateDeadline::Yield(delta)),
+            _ => panic!("unknown wasmtime_update_deadline_kind_t: {}", kind),
         }
     });
 }

--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -140,6 +140,7 @@ pub extern "C" fn wasmtime_store_epoch_deadline_callback(
             None if kind == WASMTIME_UPDATE_DEADLINE_CONTINUE => {
                 Ok(UpdateDeadline::Continue(delta))
             }
+            #[cfg(feature = "async")]
             None if kind == WASMTIME_UPDATE_DEADLINE_YIELD => Ok(UpdateDeadline::Yield(delta)),
             _ => panic!("unknown wasmtime_update_deadline_kind_t: {}", kind),
         }


### PR DESCRIPTION
Allow supporting yielding in the epoch callback in addition to continuing, additionally support a finalizer, as that is the "standard" approach to the C API. Happy to take suggestion on API alternatives.
