### PR TITLE
Reset sp_offset when resetting stack in Winch

### DIFF
--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -167,15 +167,19 @@ where
         // `CodeGenContext::reset_stack` only gets called when
         // handling unreachable end or unreachable else, so we only
         // care about freeing any registers in the provided range.
+        let mut bytes_freed = 0;
         context.drop_last(
             context.stack.len() - target_stack_len,
             |regalloc, val| match val {
                 Val::Reg(tr) => regalloc.free(tr.reg),
+                Val::Memory(m) => bytes_freed += m.slot.size,
                 _ => {}
             },
         );
         if masm.sp_offset() > target_sp {
-            masm.free_stack(masm.sp_offset() - target_sp);
+            let bytes = masm.sp_offset() - target_sp;
+            assert!(bytes_freed == bytes);
+            masm.free_stack(bytes);
         }
     }
 

--- a/winch/filetests/filetests/x64/unreachable/with_spilled_local.wat
+++ b/winch/filetests/filetests/x64/unreachable/with_spilled_local.wat
@@ -1,0 +1,24 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "")
+    (local i32)
+    local.get 0
+    block
+    end
+    unreachable
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   16:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   1b:	 4153                 	push	r11
+;;   1d:	 0f0b                 	ud2	
+;;   1f:	 4883c408             	add	rsp, 8
+;;   23:	 4883c410             	add	rsp, 0x10
+;;   27:	 5d                   	pop	rbp
+;;   28:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/with_spilled_local_in_if.wat
+++ b/winch/filetests/filetests/x64/unreachable/with_spilled_local_in_if.wat
@@ -1,0 +1,32 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "")
+    (local i32)
+    local.get 0
+    if
+      local.get 0
+      block
+      end
+      unreachable
+    else
+      nop
+    end
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   16:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   1a:	 85c0                 	test	eax, eax
+;;   1c:	 0f840d000000         	je	0x2f
+;;   22:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   27:	 4153                 	push	r11
+;;   29:	 0f0b                 	ud2	
+;;   2b:	 4883c408             	add	rsp, 8
+;;   2f:	 4883c410             	add	rsp, 0x10
+;;   33:	 5d                   	pop	rbp
+;;   34:	 c3                   	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
This is a fix for a fuzzer testcase triggering an assertion of `sp_offset` not equaling `locals_size` where there was a function which had spilled a local and ended with `unreachable`. I've added a minimal reproduction of the test case as the filetest `with_spilled_local.wat`. While investigating, it looks like something similar happens when `unreachable` is the last instruction in an `if` followed by an `else` (covered by the other filetest added). Having `reset_stack` also reset the `sp_offset` clears up both assertion failures.