### PR TITLE
riscv64: Instruction selection improvements

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1885,6 +1885,14 @@
 (decl imm12_from_value (Imm12) Value)
 (extractor (imm12_from_value n) (i64_from_iconst (imm12_from_i64 n)))
 
+;; Conceptually the same as `imm12_from_value`, but tries negating the constant
+;; value (first sign-extending to handle narrow widths).
+(decl pure partial imm12_from_negated_value (Value) Imm12)
+(rule
+  (imm12_from_negated_value (has_type ty (iconst n)))
+  (if-let (imm12_from_u64 imm) (i64_as_u64 (i64_neg (i64_sextend_imm64 ty n))))
+  imm)
+
 (decl imm12_from_u64 (Imm12) u64)
 (extern extractor imm12_from_u64 imm12_from_u64)
 

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -377,25 +377,42 @@ impl Inst {
                     alu_op @ (AluOPRRR::And
                     | AluOPRRR::Or
                     | AluOPRRR::Xor
-                    | AluOPRRR::Sub
                     | AluOPRRR::Addw
-                    | AluOPRRR::Subw
                     | AluOPRRR::Mul),
+                rd,
+                rs1,
+                rs2,
+            } if (rd.to_reg() == rs1 || rd.to_reg() == rs2)
+                && reg_is_compressible(rs1)
+                && reg_is_compressible(rs2) =>
+            {
+                let op = match alu_op {
+                    AluOPRRR::And => CaOp::CAnd,
+                    AluOPRRR::Or => CaOp::COr,
+                    AluOPRRR::Xor => CaOp::CXor,
+                    AluOPRRR::Addw => CaOp::CAddw,
+                    AluOPRRR::Mul if has_zcb && has_m => CaOp::CMul,
+                    _ => return None,
+                };
+                // The canonical expansion for these instruction has `rd == rs1`, but
+                // these are all comutative operations, so we can swap the operands.
+                let src = if rd.to_reg() == rs1 { rs2 } else { rs1 };
+
+                sink.put2(encode_ca_type(op, rd, src));
+            }
+
+            // The sub instructions are non comutative, so we can't swap the operands.
+            Inst::AluRRR {
+                alu_op: alu_op @ (AluOPRRR::Sub | AluOPRRR::Subw),
                 rd,
                 rs1,
                 rs2,
             } if rd.to_reg() == rs1 && reg_is_compressible(rs1) && reg_is_compressible(rs2) => {
                 let op = match alu_op {
-                    AluOPRRR::And => CaOp::CAnd,
-                    AluOPRRR::Or => CaOp::COr,
-                    AluOPRRR::Xor => CaOp::CXor,
                     AluOPRRR::Sub => CaOp::CSub,
-                    AluOPRRR::Addw => CaOp::CAddw,
                     AluOPRRR::Subw => CaOp::CSubw,
-                    AluOPRRR::Mul if has_zcb && has_m => CaOp::CMul,
                     _ => return None,
                 };
-
                 sink.put2(encode_ca_type(op, rd, rs2));
             }
 

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -324,107 +324,116 @@
 (rule 2 (lower (has_type $I128 (isub x y)))
   (i128_sub x y))
 
+;; Switch to an `addi` by a negative if we can fit the value in an `imm12`.
+(rule 3 (lower (has_type (ty_int_ref_scalar_64 ty) (isub x y)))
+  (if-let imm12_neg (imm12_from_negated_value y))
+  (alu_rr_imm12 (select_addi ty) x imm12_neg))
+
+(rule 4 (lower (has_type (ty_int_ref_scalar_64 ty) (isub x y)))
+  (if-let imm12_neg (imm12_from_negated_value x))
+  (alu_rr_imm12 (select_addi ty) y imm12_neg))
+
 ;; SIMD Vectors
-(rule 3 (lower (has_type (ty_vec_fits_in_register ty) (isub x y)))
+(rule 5 (lower (has_type (ty_vec_fits_in_register ty) (isub x y)))
   (rv_vsub_vv x y (unmasked) ty))
 
-(rule 4 (lower (has_type (ty_vec_fits_in_register ty) (isub x (splat y))))
+(rule 6 (lower (has_type (ty_vec_fits_in_register ty) (isub x (splat y))))
   (rv_vsub_vx x y (unmasked) ty))
 
-(rule 5 (lower (has_type (ty_vec_fits_in_register ty) (isub x (splat (sextend y @ (value_type sext_ty))))))
+(rule 7 (lower (has_type (ty_vec_fits_in_register ty) (isub x (splat (sextend y @ (value_type sext_ty))))))
   (if-let half_ty (ty_half_width ty))
   (if-let $true (ty_equal (lane_type half_ty) sext_ty))
   (rv_vwsub_wx x y (unmasked) (vstate_mf2 half_ty)))
 
-(rule 5 (lower (has_type (ty_vec_fits_in_register ty) (isub x (splat (uextend y @ (value_type uext_ty))))))
+(rule 7 (lower (has_type (ty_vec_fits_in_register ty) (isub x (splat (uextend y @ (value_type uext_ty))))))
   (if-let half_ty (ty_half_width ty))
   (if-let $true (ty_equal (lane_type half_ty) uext_ty))
   (rv_vwsubu_wx x y (unmasked) (vstate_mf2 half_ty)))
 
-(rule 6 (lower (has_type (ty_vec_fits_in_register ty) (isub (splat x) y)))
+(rule 8 (lower (has_type (ty_vec_fits_in_register ty) (isub (splat x) y)))
   (rv_vrsub_vx y x (unmasked) ty))
 
-(rule 7 (lower (has_type (ty_vec_fits_in_register ty) (isub x y)))
+(rule 9 (lower (has_type (ty_vec_fits_in_register ty) (isub x y)))
   (if-let x_imm (replicated_imm5 x))
   (rv_vrsub_vi y x_imm (unmasked) ty))
 
 
 ;; Signed Widening Low Subtractions
 
-(rule 5 (lower (has_type (ty_vec_fits_in_register _) (isub x (swiden_low y @ (value_type in_ty)))))
+(rule 7 (lower (has_type (ty_vec_fits_in_register _) (isub x (swiden_low y @ (value_type in_ty)))))
   (rv_vwsub_wv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
-                                                           (swiden_low y))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
+                                                            (swiden_low y))))
   (rv_vwsub_vv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
-                                                           (splat (sextend y @ (value_type sext_ty))))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
+                                                            (splat (sextend y @ (value_type sext_ty))))))
   (if-let $true (ty_equal (lane_type in_ty) sext_ty))
   (rv_vwsub_vx x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
 ;; Signed Widening High Subtractions
 ;; These are the same as the low widenings, but we first slide down the inputs.
 
-(rule 5 (lower (has_type (ty_vec_fits_in_register _) (isub x (swiden_high y @ (value_type in_ty)))))
+(rule 7 (lower (has_type (ty_vec_fits_in_register _) (isub x (swiden_high y @ (value_type in_ty)))))
   (rv_vwsub_wv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
-                                                           (swiden_high y))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
+                                                            (swiden_high y))))
   (rv_vwsub_vv (gen_slidedown_half in_ty x) (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
-                                                           (splat (sextend y @ (value_type sext_ty))))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
+                                                            (splat (sextend y @ (value_type sext_ty))))))
   (if-let $true (ty_equal (lane_type in_ty) sext_ty))
   (rv_vwsub_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
 ;; Unsigned Widening Low Subtractions
 
-(rule 5 (lower (has_type (ty_vec_fits_in_register _) (isub x (uwiden_low y @ (value_type in_ty)))))
+(rule 7 (lower (has_type (ty_vec_fits_in_register _) (isub x (uwiden_low y @ (value_type in_ty)))))
   (rv_vwsubu_wv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
-                                                           (uwiden_low y))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
+                                                            (uwiden_low y))))
   (rv_vwsubu_vv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
-                                                           (splat (uextend y @ (value_type uext_ty))))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
+                                                            (splat (uextend y @ (value_type uext_ty))))))
   (if-let $true (ty_equal (lane_type in_ty) uext_ty))
   (rv_vwsubu_vx x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
 ;; Unsigned Widening High Subtractions
 ;; These are the same as the low widenings, but we first slide down the inputs.
 
-(rule 5 (lower (has_type (ty_vec_fits_in_register _) (isub x (uwiden_high y @ (value_type in_ty)))))
+(rule 7 (lower (has_type (ty_vec_fits_in_register _) (isub x (uwiden_high y @ (value_type in_ty)))))
   (rv_vwsubu_wv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
-                                                           (uwiden_high y))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
+                                                            (uwiden_high y))))
   (rv_vwsubu_vv (gen_slidedown_half in_ty x) (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
-                                                           (splat (uextend y @ (value_type uext_ty))))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
+                                                            (splat (uextend y @ (value_type uext_ty))))))
   (if-let $true (ty_equal (lane_type in_ty) uext_ty))
   (rv_vwsubu_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
 ;; Signed Widening Mixed High/Low Subtractions
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
-                                                           (swiden_high y))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
+                                                            (swiden_high y))))
   (rv_vwsub_vv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
-                                                           (swiden_low y))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
+                                                            (swiden_low y))))
   (rv_vwsub_vv (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
 ;; Unsigned Widening Mixed High/Low Subtractions
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
-                                                           (uwiden_high y))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
+                                                            (uwiden_high y))))
   (rv_vwsubu_vv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 8 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
-                                                           (uwiden_low y))))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
+                                                            (uwiden_low y))))
   (rv_vwsubu_vv (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
 

--- a/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/arithmetic.clif
@@ -512,14 +512,12 @@ block0(v0: i32):
 
 ; VCode:
 ; block0:
-;   li a3,-1
-;   subw a0,a0,a3
+;   addiw a0,a0,1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a3, zero, -1
-;   subw a0, a0, a3
+;   addiw a0, a0, 1
 ;   ret
 
 function %f28(i64) -> i64 {
@@ -531,14 +529,12 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   li a3,-1
-;   sub a0,a0,a3
+;   addi a0,a0,1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi a3, zero, -1
-;   sub a0, a0, a3
+;   addi a0, a0, 1
 ;   ret
 
 function %f29(i64) -> i64 {

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -42,15 +42,14 @@
 ;; function u0:0:
 ;; block0:
 ;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   ld a4,8(a2)
-;;   li a0,4
-;;   sub a4,a4,a0
-;;   bgtu a5,a4,taken(label3),not_taken(label1)
+;;   srli a4,a3,32
+;;   ld a3,8(a2)
+;;   addi a3,a3,-4
+;;   bgtu a4,a3,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a0,0(a2)
-;;   add a5,a0,a5
-;;   sw a1,0(a5)
+;;   ld a5,0(a2)
+;;   add a4,a5,a4
+;;   sw a1,0(a4)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -59,16 +58,15 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a5,a3,32
-;;   ld a4,8(a1)
-;;   li a0,4
-;;   sub a4,a4,a0
-;;   bgtu a5,a4,taken(label3),not_taken(label1)
+;;   slli a2,a0,32
+;;   srli a4,a2,32
+;;   ld a3,8(a1)
+;;   addi a3,a3,-4
+;;   bgtu a4,a3,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a0,0(a1)
-;;   add a5,a0,a5
-;;   lw a0,0(a5)
+;;   ld a5,0(a1)
+;;   add a4,a5,a4
+;;   lw a0,0(a4)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,36 +41,34 @@
 
 ;; function u0:0:
 ;; block0:
-;;   slli a3,a0,32
-;;   srli a3,a3,32
+;;   slli a0,a0,32
+;;   srli a3,a0,32
 ;;   ld a4,8(a2)
-;;   li a5,4
-;;   sub a4,a4,a5
+;;   addi a4,a4,-4
 ;;   sltu a4,a4,a3
 ;;   ld a2,0(a2)
 ;;   add a2,a2,a3
-;;   sub a0,zero,a4
-;;   not a3,a0
-;;   and a4,a2,a3
-;;   sw a1,0(a4)
+;;   sub a5,zero,a4
+;;   not a3,a5
+;;   and a3,a2,a3
+;;   sw a1,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret
 ;;
 ;; function u0:1:
 ;; block0:
-;;   slli a2,a0,32
-;;   srli a3,a2,32
-;;   ld a2,8(a1)
-;;   li a4,4
-;;   sub a2,a2,a4
-;;   sltu a2,a2,a3
-;;   ld a4,0(a1)
-;;   add a3,a4,a3
-;;   sub a0,zero,a2
-;;   not a2,a0
-;;   and a4,a3,a2
-;;   lw a0,0(a4)
+;;   slli a0,a0,32
+;;   srli a2,a0,32
+;;   ld a3,8(a1)
+;;   addi a3,a3,-4
+;;   sltu a3,a3,a2
+;;   ld a1,0(a1)
+;;   add a1,a1,a2
+;;   sub a5,zero,a3
+;;   not a2,a5
+;;   and a3,a1,a2
+;;   lw a0,0(a3)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -42,13 +42,12 @@
 ;; function u0:0:
 ;; block0:
 ;;   ld a3,8(a2)
-;;   li a4,4
-;;   sub a3,a3,a4
+;;   addi a3,a3,-4
 ;;   bgtu a0,a3,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a3,0(a2)
-;;   add a3,a3,a0
-;;   sw a1,0(a3)
+;;   ld a2,0(a2)
+;;   add a2,a2,a0
+;;   sw a1,0(a2)
 ;;   j label2
 ;; block2:
 ;;   ret
@@ -58,13 +57,12 @@
 ;; function u0:1:
 ;; block0:
 ;;   ld a2,8(a1)
-;;   li a3,4
-;;   sub a2,a2,a3
+;;   addi a2,a2,-4
 ;;   bgtu a0,a2,taken(label3),not_taken(label1)
 ;; block1:
-;;   ld a3,0(a1)
-;;   add a3,a3,a0
-;;   lw a0,0(a3)
+;;   ld a2,0(a1)
+;;   add a2,a2,a0
+;;   lw a0,0(a2)
 ;;   j label2
 ;; block2:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/cranelift/filetests/filetests/isa/riscv64/wasm/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -41,15 +41,14 @@
 
 ;; function u0:0:
 ;; block0:
-;;   ld a3,8(a2)
-;;   li a4,4
-;;   sub a3,a3,a4
-;;   sltu a3,a3,a0
+;;   ld a5,8(a2)
+;;   addi a5,a5,-4
+;;   sltu a5,a5,a0
 ;;   ld a2,0(a2)
 ;;   add a0,a2,a0
-;;   sub a4,zero,a3
-;;   not a2,a4
-;;   and a2,a0,a2
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a2,a0,a5
 ;;   sw a1,0(a2)
 ;;   j label1
 ;; block1:
@@ -57,16 +56,15 @@
 ;;
 ;; function u0:1:
 ;; block0:
-;;   ld a2,8(a1)
-;;   li a3,4
-;;   sub a2,a2,a3
-;;   sltu a2,a2,a0
+;;   ld a5,8(a1)
+;;   addi a5,a5,-4
+;;   sltu a5,a5,a0
 ;;   ld a1,0(a1)
 ;;   add a0,a1,a0
-;;   sub a4,zero,a2
-;;   not a1,a4
-;;   and a2,a0,a1
-;;   lw a0,0(a2)
+;;   sub a3,zero,a5
+;;   not a5,a3
+;;   and a1,a0,a5
+;;   lw a0,0(a1)
 ;;   j label1
 ;; block1:
 ;;   ret

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -906,3 +906,19 @@ block0(v0: i64):
 ;   c.ld a0, 0x40(a0)
 ;   c.jr ra
 
+function %band_reverse(i64, i64) -> i64 {
+block0(v0: i64, v1: i64):
+    v2 = band v1, v0
+    return v2
+}
+
+; VCode:
+; block0:
+;   and a0,a1,a0
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   c.and a0, a1
+;   c.jr ra
+


### PR DESCRIPTION
👋 Hey,

This PR does two small instruction selection and encoding optimizations.

#### Use `addi` for subs

This is one of the regressions that showed up in #7468. That PR changes `iadd_imm(x, -k)` to `isub(x, iconst(k))`. We can use the same `iadd` instruction for both, but we didn't have a rule to do it.

So we now try to negate an Imm12 and if we are able to do that we emit an `addi` when subtracting.

#### Try to swap registers when encoding compressed instructions for commutative operations

This is pretty much the same as #7471 but for all of the remaining compressed commutative instructions.

It allows us to emit these instructions as compressed more often.
