### PR TITLE
wasi-sockets: Remove TCP no-delay

### DIFF
--- a/crates/test-programs/src/bin/preview2_tcp_sockopts.rs
+++ b/crates/test-programs/src/bin/preview2_tcp_sockopts.rs
@@ -13,7 +13,6 @@ fn test_tcp_sockopt_defaults(family: IpAddressFamily) {
     }
 
     sock.keep_alive().unwrap(); // Only verify that it has a default value at all, but either value is valid.
-    assert_eq!(sock.no_delay().unwrap(), false);
     assert!(sock.unicast_hop_limit().unwrap() > 0);
     assert!(sock.receive_buffer_size().unwrap() > 0);
     assert!(sock.send_buffer_size().unwrap() > 0);
@@ -32,9 +31,6 @@ fn test_tcp_sockopt_input_ranges(family: IpAddressFamily) {
 
     assert!(matches!(sock.set_keep_alive(true), Ok(_)));
     assert!(matches!(sock.set_keep_alive(false), Ok(_)));
-
-    assert!(matches!(sock.set_no_delay(true), Ok(_)));
-    assert!(matches!(sock.set_no_delay(false), Ok(_)));
 
     assert!(matches!(
         sock.set_unicast_hop_limit(0),
@@ -64,11 +60,6 @@ fn test_tcp_sockopt_readback(family: IpAddressFamily) {
     sock.set_keep_alive(false).unwrap();
     assert_eq!(sock.keep_alive().unwrap(), false);
 
-    sock.set_no_delay(true).unwrap();
-    assert_eq!(sock.no_delay().unwrap(), true);
-    sock.set_no_delay(false).unwrap();
-    assert_eq!(sock.no_delay().unwrap(), false);
-
     sock.set_unicast_hop_limit(42).unwrap();
     assert_eq!(sock.unicast_hop_limit().unwrap(), 42);
 
@@ -93,7 +84,6 @@ fn test_tcp_sockopt_inheritance(net: &Network, family: IpAddressFamily) {
         }
 
         listener.set_keep_alive(!default_keep_alive).unwrap();
-        listener.set_no_delay(true).unwrap();
         listener.set_unicast_hop_limit(42).unwrap();
         listener.set_receive_buffer_size(0x10000).unwrap();
         listener.set_send_buffer_size(0x10000).unwrap();
@@ -113,7 +103,6 @@ fn test_tcp_sockopt_inheritance(net: &Network, family: IpAddressFamily) {
         }
 
         assert_eq!(accepted_client.keep_alive().unwrap(), !default_keep_alive);
-        assert_eq!(accepted_client.no_delay().unwrap(), true);
         assert_eq!(accepted_client.unicast_hop_limit().unwrap(), 42);
         assert_eq!(accepted_client.receive_buffer_size().unwrap(), 0x10000);
         assert_eq!(accepted_client.send_buffer_size().unwrap(), 0x10000);
@@ -122,7 +111,6 @@ fn test_tcp_sockopt_inheritance(net: &Network, family: IpAddressFamily) {
     // Update options on listener to something else:
     {
         listener.set_keep_alive(default_keep_alive).unwrap();
-        listener.set_no_delay(false).unwrap();
         listener.set_unicast_hop_limit(43).unwrap();
         listener.set_receive_buffer_size(0x20000).unwrap();
         listener.set_send_buffer_size(0x20000).unwrap();
@@ -131,7 +119,6 @@ fn test_tcp_sockopt_inheritance(net: &Network, family: IpAddressFamily) {
     // Verify that the already accepted socket was not affected:
     {
         assert_eq!(accepted_client.keep_alive().unwrap(), !default_keep_alive);
-        assert_eq!(accepted_client.no_delay().unwrap(), true);
         assert_eq!(accepted_client.unicast_hop_limit().unwrap(), 42);
         assert_eq!(accepted_client.receive_buffer_size().unwrap(), 0x10000);
         assert_eq!(accepted_client.send_buffer_size().unwrap(), 0x10000);
@@ -150,7 +137,6 @@ fn test_tcp_sockopt_after_listen(net: &Network, family: IpAddressFamily) {
     // Update options while the socket is already listening:
     {
         listener.set_keep_alive(!default_keep_alive).unwrap();
-        listener.set_no_delay(true).unwrap();
         listener.set_unicast_hop_limit(42).unwrap();
         listener.set_receive_buffer_size(0x10000).unwrap();
         listener.set_send_buffer_size(0x10000).unwrap();
@@ -163,7 +149,6 @@ fn test_tcp_sockopt_after_listen(net: &Network, family: IpAddressFamily) {
     // Verify options on accepted socket:
     {
         assert_eq!(accepted_client.keep_alive().unwrap(), !default_keep_alive);
-        assert_eq!(accepted_client.no_delay().unwrap(), true);
         assert_eq!(accepted_client.unicast_hop_limit().unwrap(), 42);
         assert_eq!(accepted_client.receive_buffer_size().unwrap(), 0x10000);
         assert_eq!(accepted_client.send_buffer_size().unwrap(), 0x10000);

--- a/crates/test-programs/src/bin/preview2_tcp_states.rs
+++ b/crates/test-programs/src/bin/preview2_tcp_states.rs
@@ -51,8 +51,6 @@ fn test_tcp_unbound_state_invariants(family: IpAddressFamily) {
     assert!(matches!(sock.set_listen_backlog_size(32), Ok(_)));
     assert!(matches!(sock.keep_alive(), Ok(_)));
     assert!(matches!(sock.set_keep_alive(false), Ok(_)));
-    assert!(matches!(sock.no_delay(), Ok(_)));
-    assert!(matches!(sock.set_no_delay(false), Ok(_)));
     assert!(matches!(sock.unicast_hop_limit(), Ok(_)));
     assert!(matches!(sock.set_unicast_hop_limit(255), Ok(_)));
     assert!(matches!(sock.receive_buffer_size(), Ok(_)));
@@ -111,8 +109,6 @@ fn test_tcp_bound_state_invariants(net: &Network, family: IpAddressFamily) {
     assert!(matches!(sock.set_listen_backlog_size(32), Ok(_)));
     assert!(matches!(sock.keep_alive(), Ok(_)));
     assert!(matches!(sock.set_keep_alive(false), Ok(_)));
-    assert!(matches!(sock.no_delay(), Ok(_)));
-    assert!(matches!(sock.set_no_delay(false), Ok(_)));
     assert!(matches!(sock.unicast_hop_limit(), Ok(_)));
     assert!(matches!(sock.set_unicast_hop_limit(255), Ok(_)));
     assert!(matches!(sock.receive_buffer_size(), Ok(_)));
@@ -178,8 +174,6 @@ fn test_tcp_listening_state_invariants(net: &Network, family: IpAddressFamily) {
     ));
     assert!(matches!(sock.keep_alive(), Ok(_)));
     assert!(matches!(sock.set_keep_alive(false), Ok(_)));
-    assert!(matches!(sock.no_delay(), Ok(_)));
-    assert!(matches!(sock.set_no_delay(false), Ok(_)));
     assert!(matches!(sock.unicast_hop_limit(), Ok(_)));
     assert!(matches!(sock.set_unicast_hop_limit(255), Ok(_)));
     assert!(matches!(sock.receive_buffer_size(), Ok(_)));
@@ -238,8 +232,6 @@ fn test_tcp_connected_state_invariants(net: &Network, family: IpAddressFamily) {
 
     assert!(matches!(sock.keep_alive(), Ok(_)));
     assert!(matches!(sock.set_keep_alive(false), Ok(_)));
-    assert!(matches!(sock.no_delay(), Ok(_)));
-    assert!(matches!(sock.set_no_delay(false), Ok(_)));
     assert!(matches!(sock.unicast_hop_limit(), Ok(_)));
     assert!(matches!(sock.set_unicast_hop_limit(255), Ok(_)));
     assert!(matches!(sock.receive_buffer_size(), Ok(_)));

--- a/crates/wasi-http/wit/deps/sockets/tcp.wit
+++ b/crates/wasi-http/wit/deps/sockets/tcp.wit
@@ -126,7 +126,6 @@ interface tcp {
         /// - `address-family`
         /// - `ipv6-only`
         /// - `keep-alive`
-        /// - `no-delay`
         /// - `unicast-hop-limit`
         /// - `receive-buffer-size`
         /// - `send-buffer-size`
@@ -203,12 +202,6 @@ interface tcp {
         /// Equivalent to the SO_KEEPALIVE socket option.
         keep-alive: func() -> result<bool, error-code>;
         set-keep-alive: func(value: bool) -> result<_, error-code>;
-
-        /// Equivalent to the TCP_NODELAY socket option.
-        ///
-        /// The default value is `false`.
-        no-delay: func() -> result<bool, error-code>;
-        set-no-delay: func(value: bool) -> result<_, error-code>;
 
         /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
         ///

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -438,18 +438,6 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         Ok(sockopt::set_socket_keepalive(socket.tcp_socket(), value)?)
     }
 
-    fn no_delay(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<bool> {
-        let table = self.table();
-        let socket = table.get(&this)?;
-        Ok(sockopt::get_tcp_nodelay(socket.tcp_socket())?)
-    }
-
-    fn set_no_delay(&mut self, this: Resource<tcp::TcpSocket>, value: bool) -> SocketResult<()> {
-        let table = self.table();
-        let socket = table.get(&this)?;
-        Ok(sockopt::set_tcp_nodelay(socket.tcp_socket(), value)?)
-    }
-
     fn unicast_hop_limit(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u8> {
         let table = self.table();
         let socket = table.get(&this)?;

--- a/crates/wasi/wit/deps/sockets/tcp.wit
+++ b/crates/wasi/wit/deps/sockets/tcp.wit
@@ -126,7 +126,6 @@ interface tcp {
         /// - `address-family`
         /// - `ipv6-only`
         /// - `keep-alive`
-        /// - `no-delay`
         /// - `unicast-hop-limit`
         /// - `receive-buffer-size`
         /// - `send-buffer-size`
@@ -203,12 +202,6 @@ interface tcp {
         /// Equivalent to the SO_KEEPALIVE socket option.
         keep-alive: func() -> result<bool, error-code>;
         set-keep-alive: func(value: bool) -> result<_, error-code>;
-
-        /// Equivalent to the TCP_NODELAY socket option.
-        ///
-        /// The default value is `false`.
-        no-delay: func() -> result<bool, error-code>;
-        set-no-delay: func(value: bool) -> result<_, error-code>;
 
         /// Equivalent to the IP_TTL & IPV6_UNICAST_HOPS socket options.
         ///


### PR DESCRIPTION
The semantics of TCP_NODELAY (and TCP_CORK for that matter) and its effects on the output-stream needs to investigated and specified.  I don't expect there to be anything insurmountable. Its just that I haven't had the time to do so yet and I can't promise to have it done before the stabilization Preview2.

So, in order to get wasi-sockets ready for Preview2, it was discussed to temporarily remove `no-delay` and reevaluate its inclusion before Preview3.

Related: https://github.com/bytecodealliance/wasmtime/issues/7013