### PR TITLE
Use scratch XMM register for spilling floats in Winch

### DIFF
--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -89,8 +89,11 @@ pub(crate) trait ABI {
         Self::word_bits() / 8
     }
 
-    /// Returns the designated scratch register.
+    /// Returns the designated general purpose scratch register.
     fn scratch_reg() -> Reg;
+
+    /// Returns the designated floating point scratch register.
+    fn float_scratch_reg() -> Reg;
 
     /// Returns the frame pointer register.
     fn fp_reg() -> Reg;

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -454,7 +454,11 @@ impl<'a, 'builtins> CodeGenContext<'a, 'builtins> {
             Val::Local(local) => {
                 let slot = frame.get_local(local.index).expect("valid local at slot");
                 let addr = masm.local_address(&slot);
-                let scratch = <M::ABI as ABI>::scratch_reg();
+                let scratch = match slot.ty {
+                    WasmType::I32 | WasmType::I64 => <M::ABI as ABI>::scratch_reg(),
+                    WasmType::F32 | WasmType::F64 => <M::ABI as ABI>::float_scratch_reg(),
+                    WasmType::V128 | WasmType::Ref(_) => unimplemented!(),
+                };
                 masm.load(addr, scratch, slot.ty.into());
                 let stack_slot = masm.push(scratch, slot.ty.into());
                 *v = Val::mem(slot.ty, stack_slot);

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -111,6 +111,10 @@ impl ABI for Aarch64ABI {
         regs::scratch()
     }
 
+    fn float_scratch_reg() -> Reg {
+        todo!()
+    }
+
     fn sp_reg() -> Reg {
         todo!()
     }

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -157,6 +157,10 @@ impl ABI for X64ABI {
         regs::scratch()
     }
 
+    fn float_scratch_reg() -> Reg {
+        regs::scratch_xmm()
+    }
+
     fn fp_reg() -> Reg {
         regs::rbp()
     }

--- a/winch/filetests/filetests/x64/block/with_local_float.wat
+++ b/winch/filetests/filetests/x64/block/with_local_float.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "") (param f32) (result f32)
+    local.get 0
+    block
+    end
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;    e:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   13:	 f3440f107c240c       	movss	xmm15, dword ptr [rsp + 0xc]
+;;   1a:	 4883ec04             	sub	rsp, 4
+;;   1e:	 f3440f113c24         	movss	dword ptr [rsp], xmm15
+;;   24:	 f30f100424           	movss	xmm0, dword ptr [rsp]
+;;   29:	 4883c404             	add	rsp, 4
+;;   2d:	 4883c410             	add	rsp, 0x10
+;;   31:	 5d                   	pop	rbp
+;;   32:	 c3                   	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
I observed an assertion failure of `assertion failed: self.sp_offset == locals_size` in the `epilogue` function when there's a float on the value stack and a spill is triggered when using Winch. When we spill, we use the scratch register which results in 8 bytes being allocated on the stack and when we pop the float to return that value, we only free 4 bytes because it's a float. This changes the spilling behaviour to use a floating point scratch register instead so we increment the stack by the same amount we will decrement it by when popping the function result.