### PR TITLE
winch: Properly handle unconditional jumps

### DIFF
--- a/winch/filetests/filetests/x64/br/br_jump.wat
+++ b/winch/filetests/filetests/x64/br/br_jump.wat
@@ -1,0 +1,30 @@
+;;! target = "x86_64"
+(module
+  (func (;0;) (result i32)
+    (local i32)
+    local.get 0
+    loop ;; label = @1
+      local.get 0
+      block ;; label = @2
+      end
+      br 0 (;@1;)
+    end
+  )
+  (export "" (func 0))
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 48c744240800000000   	
+;; 				mov	qword ptr [rsp + 8], 0
+;;   11:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   16:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   1b:	 4153                 	push	r11
+;;   1d:	 448b5c2414           	mov	r11d, dword ptr [rsp + 0x14]
+;;   22:	 4153                 	push	r11
+;;   24:	 4883c408             	add	rsp, 8
+;;   28:	 e9f0ffffff           	jmp	0x1d
+;;   2d:	 4883c408             	add	rsp, 8
+;;   31:	 4883c410             	add	rsp, 0x10
+;;   35:	 5d                   	pop	rbp
+;;   36:	 c3                   	ret	


### PR DESCRIPTION
This commit improves unconditional jumps by balancing the stack pointer as well as the value stack when the current stack pointer and value stack are greater than the target stack pointer and value stack. The invariant that this changes maintains is that the the value stack should always reflect the the state of the machine stack. The value stack might have excess stack values in a presence of a fallthrough (`br_if` or `br_table`) in which the target branch is not known at compile time; in this situation instructions like `return` or `br` discard any excess values.

The fuzzer discovered the following test case, which triggered several assertions related to unconditional jump handling:

```wat
(module
  (func (;0;) (result i32)
    (local i32)
    local.get 0
    loop ;; label = @1
      local.get 0
      block ;; label = @2
      end
      br 0 (;@1;)
    end
  )
  (export "" (func 0))
)
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
