### PR TITLE
winch: Properly derive a scratch register for arg assignment

### DIFF
--- a/tests/misc_testsuite/winch/call.wast
+++ b/tests/misc_testsuite/winch/call.wast
@@ -144,6 +144,13 @@
     (block (result i32) (i32.const 2) (call $const-i32) (br_table 0 0))
   )
 
+  (func $return-from-long-argument-list-helper (param f32 i32 i32 f64 f32 f32 f32 f64 f32 i32 i32 f32 f64 i64 i64 i32 i64 i64 f32 i64 i64 i64 i32 f32 f32 f32 f64 f32 i32 i64 f32 f64 f64 f32 i32 f32 f32 f64 i64 f64 i32 i64 f32 f64 i32 i32 i32 i64 f64 i32 i64 i64 f64 f64 f64 f64 f64 f64 i32 f32 f64 f64 i32 i64 f32 f32 f32 i32 f64 f64 f64 f64 f64 f32 i64 i64 i32 i32 i32 f32 f64 i32 i64 f32 f32 f32 i32 i32 f32 f64 i64 f32 f64 f32 f32 f32 i32 f32 i64 i32) (result i32)
+    (local.get 99)
+  )
+
+  (func (export "return-from-long-argument-list") (param i32) (result i32)
+    (call $return-from-long-argument-list-helper (f32.const 0) (i32.const 0) (i32.const 0) (f64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (f64.const 0) (f32.const 0) (i32.const 0) (i32.const 0) (f32.const 0) (f64.const 0) (i64.const 0) (i64.const 0) (i32.const 0) (i64.const 0) (i64.const 0) (f32.const 0) (i64.const 0) (i64.const 0) (i64.const 0) (i32.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (f64.const 0) (f32.const 0) (i32.const 0) (i64.const 0) (f32.const 0) (f64.const 0) (f64.const 0) (f32.const 0) (i32.const 0) (f32.const 0) (f32.const 0) (f64.const 0) (i64.const 0) (f64.const 0) (i32.const 0) (i64.const 0) (f32.const 0) (f64.const 0) (i32.const 0) (i32.const 0) (i32.const 0) (i64.const 0) (f64.const 0) (i32.const 0) (i64.const 0) (i64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (i32.const 0) (f32.const 0) (f64.const 0) (f64.const 0) (i32.const 0) (i64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (i32.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f64.const 0) (f32.const 0) (i64.const 0) (i64.const 0) (i32.const 0) (i32.const 0) (i32.const 0) (f32.const 0) (f64.const 0) (i32.const 0) (i64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (i32.const 0) (i32.const 0) (f32.const 0) (f64.const 0) (i64.const 0) (f32.const 0) (f64.const 0) (f32.const 0) (f32.const 0) (f32.const 0) (i32.const 0) (f32.const 0) (i64.const 0) (local.get 0))
+  )
 )
 
 (assert_return (invoke "type-i32") (i32.const 0x132))
@@ -193,3 +200,4 @@
 
 (assert_return (invoke "as-br_table-first") (i32.const 0x132))
 (assert_return (invoke "as-br_table-last") (i32.const 2))
+(assert_return (invoke "return-from-long-argument-list" (i32.const 42)) (i32.const 42))

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -95,6 +95,15 @@ pub(crate) trait ABI {
     /// Returns the designated floating point scratch register.
     fn float_scratch_reg() -> Reg;
 
+    /// Returns the designated scratch register for the given [WasmType].
+    fn scratch_for(ty: &WasmType) -> Reg {
+        match ty {
+            WasmType::I32 | WasmType::I64 => Self::scratch_reg(),
+            WasmType::F32 | WasmType::F64 => Self::float_scratch_reg(),
+            _ => unimplemented!(),
+        }
+    }
+
     /// Returns the frame pointer register.
     fn fp_reg() -> Reg;
 

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -454,11 +454,7 @@ impl<'a, 'builtins> CodeGenContext<'a, 'builtins> {
             Val::Local(local) => {
                 let slot = frame.get_local(local.index).expect("valid local at slot");
                 let addr = masm.local_address(&slot);
-                let scratch = match slot.ty {
-                    WasmType::I32 | WasmType::I64 => <M::ABI as ABI>::scratch_reg(),
-                    WasmType::F32 | WasmType::F64 => <M::ABI as ABI>::float_scratch_reg(),
-                    WasmType::V128 | WasmType::Ref(_) => unimplemented!(),
-                };
+                let scratch = <M::ABI as ABI>::scratch_for(&slot.ty);
                 masm.load(addr, scratch, slot.ty.into());
                 let stack_slot = masm.push(scratch, slot.ty.into());
                 *v = Val::mem(slot.ty, stack_slot);


### PR DESCRIPTION
This commit properly derives a scratch register for a particular WebAssembly type. The included spec test uncovered that the previous implementation used a int scratch register to assign float stack arguments, which resulted in a panic.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
