### PR TITLE
ISLE: Allow callers to pass in storage for multi returns

### DIFF
--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -12,13 +12,13 @@ use crate::ir::{
     Block, DataFlowGraph, Function, Inst, InstructionData, Type, Value, ValueDef, ValueListPool,
 };
 use crate::loop_analysis::LoopAnalysis;
-use crate::opts::generated_code::ContextIter;
 use crate::opts::IsleContext;
 use crate::scoped_hash_map::{Entry as ScopedEntry, ScopedHashMap};
 use crate::trace;
 use crate::unionfind::UnionFind;
 use cranelift_entity::packed_option::ReservedValue;
 use cranelift_entity::SecondaryMap;
+use smallvec::SmallVec;
 use std::hash::Hasher;
 
 mod cost;
@@ -69,6 +69,9 @@ pub struct EgraphPass<'a> {
     eclasses: UnionFind<Value>,
 }
 
+// The maximum number of rewrites we will take from a single call into ISLE.
+const MATCHES_LIMIT: usize = 5;
+
 /// Context passed through node insertion and optimization.
 pub(crate) struct OptimizeCtx<'opt, 'analysis>
 where
@@ -87,6 +90,7 @@ where
     // Held locally during optimization of one node (recursively):
     pub(crate) rewrite_depth: usize,
     pub(crate) subsume_values: FxHashSet<Value>,
+    optimized_values: SmallVec<[Value; MATCHES_LIMIT]>,
 }
 
 /// For passing to `insert_pure_enode`. Sometimes the enode already
@@ -213,6 +217,7 @@ where
         // A pure node always has exactly one result.
         let orig_value = self.func.dfg.first_result(inst);
 
+        let mut optimized_values = std::mem::take(&mut self.optimized_values);
         let mut isle_ctx = IsleContext { ctx: self };
 
         // Limit rewrite depth. When we apply optimization rules, they
@@ -239,26 +244,26 @@ where
         // values produced as equivalents to this value.
         trace!("Calling into ISLE with original value {}", orig_value);
         isle_ctx.ctx.stats.rewrite_rule_invoked += 1;
-        let mut optimized_values =
-            crate::opts::generated_code::constructor_simplify(&mut isle_ctx, orig_value);
-        trace!(
-            "  -> returned from ISLE, optimized values's size hint = {:?}",
-            optimized_values.size_hint()
+        debug_assert!(optimized_values.is_empty());
+        crate::opts::generated_code::constructor_simplify(
+            &mut isle_ctx,
+            orig_value,
+            &mut optimized_values,
         );
+        trace!(
+            "  -> returned from ISLE, generated {} optimized values",
+            optimized_values.len()
+        );
+        if optimized_values.len() > MATCHES_LIMIT {
+            trace!("Reached maximum matches limit; too many optimized values, ignoring rest.");
+            optimized_values.truncate(MATCHES_LIMIT);
+        }
 
         // Create a union of all new values with the original (or
         // maybe just one new value marked as "subsuming" the
         // original, if present.)
-        let mut i = 0;
         let mut union_value = orig_value;
-        while let Some(optimized_value) = optimized_values.next(&mut isle_ctx) {
-            i += 1;
-            const MATCHES_LIMIT: u32 = 5;
-            if i > MATCHES_LIMIT {
-                trace!("Reached maximum matches limit; too many optimized values, ignoring rest.");
-                break;
-            }
-
+        for optimized_value in optimized_values.drain(..) {
             trace!(
                 "Returned from ISLE for {}, got {:?}",
                 orig_value,
@@ -304,6 +309,9 @@ where
         }
 
         isle_ctx.ctx.rewrite_depth -= 1;
+
+        debug_assert!(isle_ctx.ctx.optimized_values.is_empty());
+        isle_ctx.ctx.optimized_values = optimized_values;
 
         union_value
     }
@@ -550,6 +558,7 @@ impl<'a> EgraphPass<'a> {
                             stats: &mut self.stats,
                             alias_analysis: self.alias_analysis,
                             alias_analysis_state: &mut alias_analysis_state,
+                            optimized_values: Default::default(),
                         };
 
                         if is_pure_for_egraph(ctx.func, inst) {

--- a/cranelift/isle/isle/isle_examples/link/multi_constructor_main.rs
+++ b/cranelift/isle/isle/isle_examples/link/multi_constructor_main.rs
@@ -1,15 +1,15 @@
 mod multi_constructor;
-
-pub(crate) type ConstructorVec<T> = Vec<T>;
+use multi_constructor::{ContextIter, IntoContextIter};
 
 struct Context;
 
+#[derive(Default)]
 struct It {
     i: u32,
     limit: u32,
 }
 
-impl multi_constructor::ContextIter for It {
+impl ContextIter for It {
     type Context = Context;
     type Output = u32;
     fn next(&mut self, _ctx: &mut Self::Context) -> Option<u32> {
@@ -23,15 +23,25 @@ impl multi_constructor::ContextIter for It {
     }
 }
 
+impl IntoContextIter for It {
+    type Context = Context;
+    type Output = u32;
+    type IntoIter = It;
+    fn into_context_iter(self) -> It {
+        self
+    }
+}
+
 impl multi_constructor::Context for Context {
-    type etor_C_iter = It;
-    fn etor_C(&mut self, value: u32) -> It {
-        It { i: 0, limit: value }
+    type etor_C_returns = It;
+    fn etor_C(&mut self, value: u32, returns: &mut It) {
+        returns.i = 0;
+        returns.limit = value;
     }
 
-    type ctor_B_iter = multi_constructor::ContextIterWrapper<u32, std::vec::IntoIter<u32>, Context>;
-    fn ctor_B(&mut self, value: u32) -> Self::ctor_B_iter {
-        (0..value).rev().collect::<Vec<_>>().into_iter().into()
+    type ctor_B_returns = multi_constructor::ContextIterWrapper<Vec<u32>, Context>;
+    fn ctor_B(&mut self, value: u32, returns: &mut Self::ctor_B_returns) {
+        returns.extend((0..value).rev());
     }
 }
 
@@ -55,16 +65,21 @@ impl<'a, Item, I: multi_constructor::ContextIter<Output = Item, Context = Contex
 
 fn main() {
     let mut ctx = Context;
-    let l1 = multi_constructor::constructor_A(&mut ctx, 10);
-    let l2 = multi_constructor::constructor_D(&mut ctx, 5);
+
+    let mut l1 = multi_constructor::ContextIterWrapper::<Vec<_>, _>::default();
+    multi_constructor::constructor_A(&mut ctx, 10, &mut l1);
+
+    let mut l2 = multi_constructor::ContextIterWrapper::<Vec<_>, _>::default();
+    multi_constructor::constructor_D(&mut ctx, 5, &mut l2);
+
     let l1 = IterWithContext {
         ctx: &mut ctx,
-        it: l1,
+        it: l1.into_context_iter(),
     }
     .collect::<Vec<_>>();
     let l2 = IterWithContext {
         ctx: &mut ctx,
-        it: l2,
+        it: l2.into_context_iter(),
     }
     .collect::<Vec<_>>();
     println!("l1 = {:?} l2 = {:?}", l1, l2);

--- a/cranelift/isle/isle/isle_examples/link/multi_extractor_main.rs
+++ b/cranelift/isle/isle/isle_examples/link/multi_extractor_main.rs
@@ -1,8 +1,6 @@
 mod multi_extractor;
 
-use multi_extractor::ContextIter;
-
-pub(crate) type ConstructorVec<T> = Vec<T>;
+use multi_extractor::{ContextIter, IntoContextIter};
 
 #[derive(Clone)]
 pub enum A {
@@ -10,12 +8,13 @@ pub enum A {
     C,
 }
 
+#[derive(Default)]
 struct It {
     i: u32,
     arg: u32,
 }
 
-impl multi_extractor::ContextIter for It {
+impl ContextIter for It {
     type Context = Context;
     type Output = (A, u32);
     fn next(&mut self, _ctx: &mut Self::Context) -> Option<Self::Output> {
@@ -34,17 +33,29 @@ impl multi_extractor::ContextIter for It {
     }
 }
 
+impl IntoContextIter for It {
+    type Context = Context;
+    type IntoIter = It;
+    type Output = (A, u32);
+    fn into_context_iter(self) -> It {
+        self
+    }
+}
+
 struct Context;
 impl multi_extractor::Context for Context {
-    type e1_etor_iter = It;
-    fn e1_etor(&mut self, arg0: u32) -> It {
-        It { i: 0, arg: arg0 }
+    type e1_etor_returns = It;
+    fn e1_etor(&mut self, arg0: u32, returns: &mut It) {
+        returns.i = 0;
+        returns.arg = arg0;
     }
 }
 
 fn main() {
     let mut ctx = Context;
-    let x = multi_extractor::constructor_Rule(&mut ctx, 0xf0).next(&mut ctx);
-    let y = multi_extractor::constructor_Rule(&mut ctx, 0).next(&mut ctx);
+    let mut x = vec![];
+    multi_extractor::constructor_Rule(&mut ctx, 0xf0, &mut x);
+    let mut y = vec![];
+    multi_extractor::constructor_Rule(&mut ctx, 0, &mut y);
     println!("x = {:?} y = {:?}", x, y);
 }

--- a/cranelift/isle/isle/src/codegen.rs
+++ b/cranelift/isle/isle/src/codegen.rs
@@ -154,7 +154,7 @@ impl<'a> Codegen<'a> {
         if sig.ret_kind == ReturnKind::Iterator {
             writeln!(
                 code,
-                "{indent}type {name}_iter: ContextIter<Context = Self, Output = {output}>;",
+                "{indent}type {name}_returns: Default + IntoContextIter<Context = Self, Output = {output}>;",
                 indent = indent,
                 name = sig.func_name,
                 output = ret_tuple,
@@ -165,7 +165,7 @@ impl<'a> Codegen<'a> {
         let ret_ty = match sig.ret_kind {
             ReturnKind::Plain => ret_tuple,
             ReturnKind::Option => format!("Option<{}>", ret_tuple),
-            ReturnKind::Iterator => format!("Self::{}_iter", sig.func_name),
+            ReturnKind::Iterator => format!("()"),
         };
 
         writeln!(
@@ -178,6 +178,11 @@ impl<'a> Codegen<'a> {
                 .iter()
                 .enumerate()
                 .map(|(i, &ty)| format!("arg{}: {}", i, self.type_name(ty, /* by_ref = */ true)))
+                .chain(if sig.ret_kind == ReturnKind::Iterator {
+                    Some(format!("returns: &mut Self::{}_returns", sig.func_name))
+                } else {
+                    None
+                })
                 .collect::<Vec<_>>()
                 .join(", "),
             ret_ty = ret_ty,
@@ -217,35 +222,77 @@ impl<'a> Codegen<'a> {
         writeln!(
             code,
             r#"
-           pub trait ContextIter {{
-               type Context;
-               type Output;
-               fn next(&mut self, ctx: &mut Self::Context) -> Option<Self::Output>;
-               fn size_hint(&self) -> (usize, Option<usize>) {{ (0, None) }}
-           }}
+pub trait ContextIter {{
+    type Context;
+    type Output;
+    fn next(&mut self, ctx: &mut Self::Context) -> Option<Self::Output>;
+    fn size_hint(&self) -> (usize, Option<usize>) {{ (0, None) }}
+}}
 
-           pub struct ContextIterWrapper<Item, I: Iterator < Item = Item>, C: Context> {{
-               iter: I,
-               _ctx: PhantomData<C>,
-           }}
-           impl<Item, I: Iterator<Item = Item>, C: Context> From<I> for ContextIterWrapper<Item, I, C> {{
-               fn from(iter: I) -> Self {{
-                   Self {{ iter, _ctx: PhantomData }}
-               }}
-           }}
-           impl<Item, I: Iterator<Item = Item>, C: Context> ContextIter for ContextIterWrapper<Item, I, C> {{
-               type Context = C;
-               type Output = Item;
-               fn next(&mut self, _ctx: &mut Self::Context) -> Option<Self::Output> {{
-                   self.iter.next()
-               }}
-               fn size_hint(&self) -> (usize, Option<usize>) {{
-                   self.iter.size_hint()
-               }}
-           }}
+pub trait IntoContextIter {{
+    type Context;
+    type Output;
+    type IntoIter: ContextIter<Context = Self::Context, Output = Self::Output>;
+    fn into_context_iter(self) -> Self::IntoIter;
+}}
+
+pub struct ContextIterWrapper<I, C> {{
+    iter: I,
+    _ctx: std::marker::PhantomData<C>,
+}}
+impl<I: Default, C> Default for ContextIterWrapper<I, C> {{
+    fn default() -> Self {{
+        ContextIterWrapper {{
+            iter: I::default(),
+            _ctx: std::marker::PhantomData
+        }}
+    }}
+}}
+impl<I, C> std::ops::Deref for ContextIterWrapper<I, C> {{
+    type Target = I;
+    fn deref(&self) -> &I {{
+        &self.iter
+    }}
+}}
+impl<I, C> std::ops::DerefMut for ContextIterWrapper<I, C> {{
+    fn deref_mut(&mut self) -> &mut I {{
+        &mut self.iter
+    }}
+}}
+impl<I: Iterator, C: Context> From<I> for ContextIterWrapper<I, C> {{
+    fn from(iter: I) -> Self {{
+        Self {{ iter, _ctx: std::marker::PhantomData }}
+    }}
+}}
+impl<I: Iterator, C: Context> ContextIter for ContextIterWrapper<I, C> {{
+    type Context = C;
+    type Output = I::Item;
+    fn next(&mut self, _ctx: &mut Self::Context) -> Option<Self::Output> {{
+        self.iter.next()
+    }}
+    fn size_hint(&self) -> (usize, Option<usize>) {{
+        self.iter.size_hint()
+    }}
+}}
+impl<I: IntoIterator, C: Context> IntoContextIter for ContextIterWrapper<I, C> {{
+    type Context = C;
+    type Output = I::Item;
+    type IntoIter = ContextIterWrapper<I::IntoIter, C>;
+    fn into_context_iter(self) -> Self::IntoIter {{
+        ContextIterWrapper {{
+            iter: self.iter.into_iter(),
+            _ctx: std::marker::PhantomData
+        }}
+    }}
+}}
+impl<T, E: Extend<T>, C> Extend<T> for ContextIterWrapper<E, C> {{
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {{
+        self.iter.extend(iter);
+    }}
+}}
            "#,
         )
-            .unwrap();
+        .unwrap();
     }
 
     fn generate_internal_types(&self, code: &mut String) {
@@ -353,13 +400,20 @@ impl<'a> Codegen<'a> {
                 writeln!(ctx.out, ",")?;
             }
 
-            write!(ctx.out, "{}) -> ", &ctx.indent)?;
             let (_, ret) = self.ty(sig.ret_tys[0]);
             let ret = &self.typeenv.syms[ret.index()];
+
+            if let ReturnKind::Iterator = sig.ret_kind {
+                writeln!(
+                    ctx.out,
+                    "{}    returns: &mut impl Extend<{}>,",
+                    &ctx.indent, ret
+                )?;
+            }
+
+            write!(ctx.out, "{}) -> ", &ctx.indent)?;
             match sig.ret_kind {
-                ReturnKind::Iterator => {
-                    write!(ctx.out, "impl ContextIter<Context = C, Output = {}>", ret)?
-                }
+                ReturnKind::Iterator => write!(ctx.out, "()")?,
                 ReturnKind::Option => write!(ctx.out, "Option<{}>", ret)?,
                 ReturnKind::Plain => write!(ctx.out, "{}", ret)?,
             };
@@ -367,21 +421,13 @@ impl<'a> Codegen<'a> {
             let scope = ctx.enter_scope();
             ctx.begin_block()?;
 
-            if sig.ret_kind == ReturnKind::Iterator {
-                writeln!(
-                    ctx.out,
-                    "{}let mut returns = ConstructorVec::new();",
-                    &ctx.indent
-                )?;
-            }
-
             self.emit_block(&mut ctx, &root, sig.ret_kind)?;
 
             match (sig.ret_kind, root.steps.last()) {
                     (ReturnKind::Iterator, _) => {
                         writeln!(
                             ctx.out,
-                            "{}return ContextIterWrapper::from(returns.into_iter());",
+                            "{}return;",
                             &ctx.indent
                         )?;
                     }
@@ -440,7 +486,47 @@ impl<'a> Codegen<'a> {
 
         for case in block.steps.iter() {
             for &expr in case.bind_order.iter() {
-                write!(ctx.out, "{}let v{} = ", &ctx.indent, expr.index())?;
+                let iter_return = match &ctx.ruleset.bindings[expr.index()] {
+                    Binding::Extractor { term, .. } => {
+                        let termdata = &self.termenv.terms[term.index()];
+                        let sig = termdata.extractor_sig(self.typeenv).unwrap();
+                        if sig.ret_kind == ReturnKind::Iterator {
+                            if termdata.has_external_extractor() {
+                                Some(format!("C::{}_returns", sig.func_name))
+                            } else {
+                                Some(format!("ContextIterWrapper::<ConstructorVec<_>, _>"))
+                            }
+                        } else {
+                            None
+                        }
+                    }
+                    Binding::Constructor { term, .. } => {
+                        let termdata = &self.termenv.terms[term.index()];
+                        let sig = termdata.constructor_sig(self.typeenv).unwrap();
+                        if sig.ret_kind == ReturnKind::Iterator {
+                            if termdata.has_external_constructor() {
+                                Some(format!("C::{}_returns", sig.func_name))
+                            } else {
+                                Some(format!("ContextIterWrapper::<ConstructorVec<_>, _>"))
+                            }
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                };
+                if let Some(ty) = iter_return {
+                    writeln!(
+                        ctx.out,
+                        "{}let mut v{} = {}::default();",
+                        &ctx.indent,
+                        expr.index(),
+                        ty
+                    )?;
+                    write!(ctx.out, "{}", &ctx.indent)?;
+                } else {
+                    write!(ctx.out, "{}let v{} = ", &ctx.indent, expr.index())?;
+                }
                 self.emit_expr(ctx, expr)?;
                 writeln!(ctx.out, ";")?;
                 ctx.is_bound.insert(expr);
@@ -507,9 +593,15 @@ impl<'a> Codegen<'a> {
                         _ => unreachable!("Loop from a non-Iterator"),
                     };
                     let scope = ctx.enter_scope();
-                    write!(ctx.out, "{}let mut v{} = ", &ctx.indent, source.index())?;
-                    self.emit_expr(ctx, *source)?;
-                    writeln!(ctx.out, ";")?;
+
+                    writeln!(
+                        ctx.out,
+                        "{}let mut v{} = v{}.into_context_iter();",
+                        &ctx.indent,
+                        source.index(),
+                        source.index(),
+                    )?;
+
                     write!(
                         ctx.out,
                         "{}while let Some(v{}) = v{}.next(ctx)",
@@ -534,7 +626,7 @@ impl<'a> Codegen<'a> {
                     match ret_kind {
                         ReturnKind::Plain => write!(ctx.out, "return ")?,
                         ReturnKind::Option => write!(ctx.out, "return Some(")?,
-                        ReturnKind::Iterator => write!(ctx.out, "returns.push(")?,
+                        ReturnKind::Iterator => write!(ctx.out, "returns.extend(Some(")?,
                     }
                     self.emit_expr(ctx, result)?;
                     if ctx.is_ref.contains(&result) {
@@ -542,7 +634,8 @@ impl<'a> Codegen<'a> {
                     }
                     match ret_kind {
                         ReturnKind::Plain => writeln!(ctx.out, ";")?,
-                        ReturnKind::Option | ReturnKind::Iterator => writeln!(ctx.out, ");")?,
+                        ReturnKind::Option => writeln!(ctx.out, ");")?,
+                        ReturnKind::Iterator => writeln!(ctx.out, "));")?,
                     }
                 }
             }
@@ -560,6 +653,7 @@ impl<'a> Codegen<'a> {
         let mut call =
             |term: TermId,
              parameters: &[BindingId],
+
              get_sig: fn(&Term, &TypeEnv) -> Option<ExternalSig>| {
                 let termdata = &self.termenv.terms[term.index()];
                 let sig = get_sig(termdata, self.typeenv).unwrap();
@@ -583,6 +677,9 @@ impl<'a> Codegen<'a> {
                     write!(ctx.out, "{}", before)?;
                     self.emit_expr(ctx, parameter)?;
                     write!(ctx.out, "{}", after)?;
+                }
+                if let ReturnKind::Iterator = sig.ret_kind {
+                    write!(ctx.out, ", &mut v{}", result.index())?;
                 }
                 write!(ctx.out, ")")
             };


### PR DESCRIPTION
This allows callers to reuse storage and avoid allocations.

Internal constructors calling internal constructors won't reuse storage (at
least for now) but it is an option for the user code that is calling into ISLE.

Part of #7500
