### PR TITLE
iOS target support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -316,6 +316,10 @@ jobs:
     - run: cargo install --root ${{ runner.tool_cache }}/cargo-ndk --version ${{ env.CARGO_NDK_VERSION }} cargo-ndk
     - run: cargo ndk -t arm64-v8a check -p wasmtime
 
+    # Check whether `wasmtime` cross-compiles to aarch64-apple-ios
+    - run: rustup target add aarch64-apple-ios
+    - run: cargo check -p wasmtime --target aarch64-apple-ios
+
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}
       if: failure() && github.event_name != 'pull_request'

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -115,7 +115,7 @@ pub fn infer_native_flags(isa_builder: &mut dyn Configurable) -> Result<(), &'st
             isa_builder.enable("has_pauth").unwrap();
         }
 
-        if cfg!(target_os = "macos") {
+        if cfg!(any(target_os = "macos", target_os = "ios")) {
             // Pointer authentication is always available on Apple Silicon.
             isa_builder.enable("sign_return_address").unwrap();
             // macOS enforces the use of the B key for return addresses.
@@ -167,7 +167,10 @@ mod tests {
                 .finish(settings::Flags::new(flag_builder))
                 .unwrap();
 
-            if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+            if cfg!(all(
+                any(target_os = "macos", target_os = "ios"),
+                target_arch = "aarch64"
+            )) {
                 assert_eq!(isa.default_call_conv(), CallConv::AppleAarch64);
             } else if cfg!(any(unix, target_os = "nebulet")) {
                 assert_eq!(isa.default_call_conv(), CallConv::SystemV);

--- a/crates/asm-macros/src/lib.rs
+++ b/crates/asm-macros/src/lib.rs
@@ -7,7 +7,7 @@
 //! should be visible to Rust but not visible externally outside of a `*.so`.
 
 cfg_if::cfg_if! {
-    if #[cfg(target_os = "macos")] {
+    if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         #[macro_export]
         macro_rules! asm_func {
             ($name:expr, $body:expr $(, $($args:tt)*)?) => {

--- a/crates/fiber/src/lib.rs
+++ b/crates/fiber/src/lib.rs
@@ -269,7 +269,7 @@ mod tests {
                 // TODO: apparently windows unwind routines don't unwind through fibers, so this will always fail. Is there a way we can fix that?
                 || cfg!(windows)
                 // TODO: the system libunwind is broken (#2808)
-                || cfg!(all(target_os = "macos", target_arch = "aarch64"))
+                || cfg!(all(any(target_os = "macos", target_os = "ios"), target_arch = "aarch64"))
             );
         }
 

--- a/crates/fiber/src/unix/aarch64.rs
+++ b/crates/fiber/src/unix/aarch64.rs
@@ -22,7 +22,7 @@ use super::wasmtime_fiber_start;
 use wasmtime_asm_macros::asm_func;
 
 cfg_if::cfg_if! {
-    if #[cfg(target_os = "macos")] {
+    if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         macro_rules! paci1716 { () => ("pacib1716\n"); }
         macro_rules! pacisp { () => ("pacibsp\n"); }
         macro_rules! autisp { () => ("autibsp\n"); }

--- a/crates/jit-icache-coherence/Cargo.toml
+++ b/crates/jit-icache-coherence/Cargo.toml
@@ -19,7 +19,7 @@ features = [
     "Win32_System_Diagnostics_Debug",
 ]
 
-[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "android"))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "ios", target_os = "freebsd", target_os = "android"))'.dependencies]
 libc = "0.2.42"
 
 [features]

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -30,7 +30,7 @@ encoding_rs = { version = "0.8.31", optional = true }
 sptr = "0.3.2"
 wasm-encoder = { workspace = true }
 
-[target.'cfg(target_os = "macos")'.dependencies]
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
 mach = "0.3.2"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -80,7 +80,7 @@ cfg_if::cfg_if! {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 mod macos;
 
 pub use sys::SignalHandler;
@@ -93,7 +93,7 @@ pub use sys::SignalHandler;
 static mut IS_WASM_PC: fn(usize) -> bool = |_| false;
 
 /// Whether or not macOS is using mach ports.
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "ios"))]
 static mut MACOS_USE_MACH_PORTS: bool = false;
 
 /// This function is required to be called before any WebAssembly is entered.
@@ -118,7 +118,7 @@ pub fn init_traps(is_wasm_pc: fn(usize) -> bool, macos_use_mach_ports: bool) {
 
     INIT.call_once(|| unsafe {
         IS_WASM_PC = is_wasm_pc;
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         if macos_use_mach_ports {
             MACOS_USE_MACH_PORTS = macos_use_mach_ports;
             return macos::platform_init();
@@ -126,7 +126,7 @@ pub fn init_traps(is_wasm_pc: fn(usize) -> bool, macos_use_mach_ports: bool) {
         sys::platform_init();
     });
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     unsafe {
         assert_eq!(
             MACOS_USE_MACH_PORTS, macos_use_mach_ports,
@@ -136,7 +136,7 @@ pub fn init_traps(is_wasm_pc: fn(usize) -> bool, macos_use_mach_ports: bool) {
 }
 
 fn lazy_per_thread_init() {
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     unsafe {
         if MACOS_USE_MACH_PORTS {
             return macos::lazy_per_thread_init();
@@ -489,7 +489,7 @@ impl CallThreadState {
     ///   instance, and the trap handler should quickly return.
     /// * a different pointer - a jmp_buf buffer to longjmp to, meaning that
     ///   the wasm trap was succesfully handled.
-    #[cfg_attr(target_os = "macos", allow(dead_code))] // macOS is more raw and doesn't use this
+    #[cfg_attr(any(target_os = "macos", target_os = "ios"), allow(dead_code))] // macOS is more raw and doesn't use this
     fn take_jmp_buf_if_trap(
         &self,
         pc: *const u8,

--- a/crates/test-programs/artifacts/src/lib.rs
+++ b/crates/test-programs/artifacts/src/lib.rs
@@ -19,7 +19,7 @@ pub fn wasi_tests_environment() -> &'static [(&'static str, &'static str)] {
             ("NO_FDFLAGS_SYNC_SUPPORT", "1"),
         ]
     }
-    #[cfg(all(unix, not(target_os = "macos")))]
+    #[cfg(all(unix, all(not(target_os = "macos"), not(target_os = "ios"))))]
     {
         &[
             ("ERRNO_MODE_UNIX", "1"),
@@ -27,7 +27,7 @@ pub fn wasi_tests_environment() -> &'static [(&'static str, &'static str)] {
             ("NO_FDFLAGS_SYNC_SUPPORT", "1"),
         ]
     }
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     {
         &[
             ("ERRNO_MODE_MACOS", "1"),

--- a/crates/wasi/src/preview2/host/network.rs
+++ b/crates/wasi/src/preview2/host/network.rs
@@ -365,7 +365,7 @@ pub(crate) mod util {
     pub fn udp_disconnect<Fd: AsFd>(sockfd: Fd) -> rustix::io::Result<()> {
         match rustix::net::connect_unspec(sockfd) {
             // BSD platforms return an error even if the UDP socket was disconnected successfully.
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
             Err(Errno::INVAL | Errno::AFNOSUPPORT) => Ok(()),
             r => r,
         }

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -245,7 +245,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
             util::tcp_accept(listener, Blocking::No)
         })?;
 
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             // Manually inherit socket options from listener. We only have to
             // do this on platforms that don't already do this automatically
@@ -442,7 +442,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
             }
         }
 
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             socket.hop_limit = Some(value);
         }
@@ -469,7 +469,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
 
         util::set_socket_recv_buffer_size(socket.tcp_socket(), value)?;
 
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             socket.receive_buffer_size = Some(value);
         }
@@ -496,7 +496,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
 
         util::set_socket_send_buffer_size(socket.tcp_socket(), value)?;
 
-        #[cfg(target_os = "macos")]
+        #[cfg(any(target_os = "macos", target_os = "ios"))]
         {
             socket.send_buffer_size = Some(value);
         }

--- a/crates/wasi/src/preview2/tcp.rs
+++ b/crates/wasi/src/preview2/tcp.rs
@@ -65,13 +65,13 @@ pub struct TcpSocket {
     pub(crate) family: SocketAddressFamily,
 
     /// The manually configured buffer size. `None` means: no preference, use system default.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     pub(crate) receive_buffer_size: Option<usize>,
     /// The manually configured buffer size. `None` means: no preference, use system default.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     pub(crate) send_buffer_size: Option<usize>,
     /// The manually configured TTL. `None` means: no preference, use system default.
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
     pub(crate) hop_limit: Option<u8>,
 }
 
@@ -295,11 +295,11 @@ impl TcpSocket {
             tcp_state: TcpState::Default,
             listen_backlog_size: None,
             family,
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
             receive_buffer_size: None,
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
             send_buffer_size: None,
-            #[cfg(target_os = "macos")]
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
             hop_limit: None,
         })
     }

--- a/tests/all/custom_signal_handler.rs
+++ b/tests/all/custom_signal_handler.rs
@@ -1,6 +1,6 @@
 #[cfg(any(
     target_os = "linux",
-    all(target_os = "macos", feature = "posix-signals-on-macos")
+    all(any(target_os = "macos", target_os = "ios"), feature = "posix-signals-on-macos")
 ))]
 #[cfg(not(miri))]
 mod tests {

--- a/tests/all/debug/lldb.rs
+++ b/tests/all/debug/lldb.rs
@@ -12,7 +12,7 @@ fn lldb_with_script(args: &[&str], script: &str) -> Result<String> {
     let mut cmd = Command::new(&lldb_path);
 
     cmd.arg("--batch");
-    if cfg!(target_os = "macos") {
+    if cfg!(any(target_os = "macos", target_os = "ios")) {
         cmd.args(&["-o", "settings set plugin.jit-loader.gdb.enable on"]);
     }
     let mut script_file = NamedTempFile::new()?;
@@ -60,7 +60,7 @@ fn check_lldb_output(output: &str, directives: &str) -> Result<()> {
 #[test]
 #[ignore]
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "ios"),
     target_pointer_width = "64"
 ))]
 pub fn test_debug_dwarf_lldb() -> Result<()> {
@@ -101,7 +101,7 @@ check: exited with status
 #[test]
 #[ignore]
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "ios"),
     target_pointer_width = "64"
 ))]
 pub fn test_debug_dwarf5_lldb() -> Result<()> {
@@ -142,7 +142,7 @@ check: exited with status
 #[test]
 #[ignore]
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "ios"),
     target_pointer_width = "64"
 ))]
 pub fn test_debug_dwarf_ref() -> Result<()> {
@@ -176,7 +176,7 @@ check: resuming
 #[test]
 #[ignore]
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "ios"),
     target_pointer_width = "64"
 ))]
 pub fn test_debug_inst_offsets_are_correct_when_branches_are_removed() -> Result<()> {
@@ -203,7 +203,7 @@ check: exited with status
 #[test]
 #[ignore]
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "ios"),
     target_pointer_width = "64"
 ))]
 pub fn test_spilled_frame_base_is_accessible() -> Result<()> {

--- a/tests/all/debug/simulate.rs
+++ b/tests/all/debug/simulate.rs
@@ -27,7 +27,7 @@ fn check_wat(wat: &str) -> Result<()> {
 #[test]
 #[ignore]
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "ios"),
     target_pointer_width = "64"
 ))]
 fn test_debug_dwarf_simulate_simple_x86_64() -> Result<()> {
@@ -58,7 +58,7 @@ fn test_debug_dwarf_simulate_simple_x86_64() -> Result<()> {
 #[test]
 #[ignore]
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "ios"),
     target_pointer_width = "64"
 ))]
 fn test_debug_dwarf_simulate_with_imports_x86_64() -> Result<()> {
@@ -79,7 +79,7 @@ fn test_debug_dwarf_simulate_with_imports_x86_64() -> Result<()> {
 #[test]
 #[ignore]
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "ios"),
     target_pointer_width = "64"
 ))]
 fn test_debug_dwarf_simulate_with_invalid_name_x86_64() -> Result<()> {

--- a/tests/all/debug/translate.rs
+++ b/tests/all/debug/translate.rs
@@ -46,7 +46,7 @@ fn check_line_program(wasm_path: &str, directives: &str) -> Result<()> {
 #[test]
 #[ignore]
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "ios"),
     target_pointer_width = "64"
 ))]
 fn test_debug_dwarf_translate_dead_code() -> Result<()> {
@@ -70,7 +70,7 @@ check:      DW_AT_name	("baz")
 #[test]
 #[ignore]
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "ios"),
     target_pointer_width = "64"
 ))]
 fn test_debug_dwarf_translate() -> Result<()> {
@@ -103,7 +103,7 @@ check:        DW_AT_decl_line	(10)
 #[test]
 #[ignore]
 #[cfg(all(
-    any(target_os = "linux", target_os = "macos"),
+    any(target_os = "linux", target_os = "macos", target_os = "ios"),
     target_pointer_width = "64"
 ))]
 fn test_debug_dwarf5_translate() -> Result<()> {


### PR DESCRIPTION
As discussed with @alexcrichton on zulip, there appears to be some interest in supporting iOS as a platform. This PR makes the necessary changes for `wasmtime` to build when targeting `aarch64-apple-ios`. 

A few notes about this PR:
* Although it is now possible to compile `wasmtime` for the iOS target, being able to run `*.cwasm` modules is not yet possible. From what @alexcrichton explained to me it appears there would be some additional work would be needed
to postprocess a `*.cwasm` file into a linkable object files before this can be used in an iOS application. I would be interested in taking on this future work however my understanding of what this would involve is still very limited and I would need help sketching this out in detail.
* I haven't yet tested anything beyond making sure that the cargo check passes. If there are any suggestions of what might be useful to test at this stage before merging this I'd be happy to add in CI tests or do any manual testing deemed appropriate.
* With limited knowledge about the differences between iOS and macOS I am assuming that macOS is identical to iOS for the purposes of this PR, e.g. I have no idea if the whole mach ports vs signals makes sense for iOS.  
* I made the minimal set of changes to get the code compiling, before merging the PR it might make sense to rename certain things e.g. it might make sense to rename the `macos` module in the runtime crate to `apple` or similar. 

As this is the first time contributing, please let me know if this PR makes sense or would need any changes to align with the contributing guidelines for this project.
