### PR TITLE
cranelift: Enable fuzzing with PCC enabled

### DIFF
--- a/cranelift/codegen/src/result.rs
+++ b/cranelift/codegen/src/result.rs
@@ -77,6 +77,9 @@ impl std::fmt::Display for CodegenError {
             #[cfg(feature = "unwind")]
             CodegenError::RegisterMappingError(_0) => write!(f, "Register mapping error"),
             CodegenError::Regalloc(errors) => write!(f, "Regalloc validation errors: {:?}", errors),
+
+            // NOTE: if this is changed, please update the `is_pcc_error` function defined in
+            // `wasmtime/crates/fuzzing/src/oracles.rs`
             CodegenError::Pcc(e) => write!(f, "Proof-carrying-code validation error: {:?}", e),
         }
     }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -169,7 +169,8 @@ impl Config {
                 self.wasmtime.memory_guaranteed_dense_image_size,
             ))
             .allocation_strategy(self.wasmtime.strategy.to_wasmtime())
-            .generate_address_map(self.wasmtime.generate_address_map);
+            .generate_address_map(self.wasmtime.generate_address_map)
+            .cranelift_pcc(self.wasmtime.pcc);
 
         if !self.module_config.config.simd_enabled {
             cfg.wasm_relaxed_simd(false);
@@ -404,6 +405,9 @@ pub struct WasmtimeConfig {
     native_unwind_info: bool,
     /// Configuration for the compiler to use.
     pub compiler_strategy: CompilerStrategy,
+
+    /// Whether or not fuzzing should enable PCC.
+    pcc: bool,
 }
 
 impl WasmtimeConfig {

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -250,8 +250,20 @@ fn compile_module(
     config: &generators::Config,
 ) -> Option<Module> {
     log_wasm(bytes);
+
+    fn is_pcc_error(e: &anyhow::Error) -> bool {
+        // NOTE: please keep this predicate in sync with the display format of CodegenError,
+        // defined in `wasmtime/cranelift/codegen/src/result.rs`
+        e.to_string().to_lowercase().contains("proof-carrying-code")
+    }
+
     match config.compile(engine, bytes) {
         Ok(module) => Some(module),
+
+        Err(e) if is_pcc_error(&e) => {
+            panic!("pcc error in input: {e:#?}");
+        }
+
         Err(_) if !known_valid => None,
         Err(e) => {
             if let generators::InstanceAllocationStrategy::Pooling(c) = &config.wasmtime.strategy {


### PR DESCRIPTION
- Configure PCC when fuzzing
- Ensure that we panic for pcc errors in the instantiate fuzz target

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
