### PR TITLE
mpk: reenable MPK support with vendor string check

### DIFF
--- a/crates/runtime/src/mpk/pkru.rs
+++ b/crates/runtime/src/mpk/pkru.rs
@@ -67,10 +67,10 @@ pub fn is_intel_cpu() -> bool {
     // To read the CPU vendor string, we pass 0 in EAX and read 12 ASCII bytes
     // from EBX, EDX, and ECX (in that order).
     let result = unsafe { std::arch::x86_64::__cpuid(0) };
-    // Then we check if the string matches "GenuineIntel".
-    result.ebx == 0x756e6547 /* "Genu" */
-        && result.edx == 0x49656e69 /* "ineI" */
-        && result.ecx == 0x6c65746e /* "ntel" */
+    // Then we check if the vendor string matches "GenuineIntel".
+    result.ebx == u32::from_le_bytes(*b"Genu")
+        && result.edx == u32::from_le_bytes(*b"ineI")
+        && result.ecx == u32::from_le_bytes(*b"ntel")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In #7446 I disabled MPK support temporarily due to failures in CI runs. Looking into this further in #7445, I discovered that it is due to how `has_cpuid_bit_set` works on different x86 machines: Intel's `CPUID` instruction reports support for MPK in a certain leaf bit, AMD does it some other (unknown?) way. The CI problem boiled down to occasional runs on AMD machines that would fail with `SIGILL` because the AMD machine reported that it had MPK support when it really did not. This change fixes the issue by first checking if the CPU vendor string is `GenuineIntel` before inspecting the MPK `CPUID` leaf bit.

Closes #7445.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
