### PR TITLE
Get addr of local after popping from reg

### DIFF
--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -345,12 +345,14 @@ where
     }
 
     /// Pops the value at the stack top and assigns it to the local at
-    ///
     /// the given index, returning the typed register holding the
     /// source value.
-    pub fn emit_set_local(&mut self, addr: M::Address, size: OperandSize) -> TypedReg {
+    pub fn emit_set_local(&mut self, index: u32) -> TypedReg {
         let src = self.context.pop_to_reg(self.masm, None);
-        self.masm.store(RegImm::reg(src.reg), addr, size);
+        // Need to get address of local after `pop_to_reg` since `pop_to_reg`
+        // may change the local's offset from the SP.
+        let (ty, addr) = self.context.frame.get_local_address(index, self.masm);
+        self.masm.store(RegImm::reg(src.reg), addr, ty.into());
 
         src
     }

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -350,7 +350,8 @@ where
     pub fn emit_set_local(&mut self, index: u32) -> TypedReg {
         let src = self.context.pop_to_reg(self.masm, None);
         // Need to get address of local after `pop_to_reg` since `pop_to_reg`
-        // may change the local's offset from the SP.
+        // will pop the machine stack causing an incorrect address to be
+        // calculated.
         let (ty, addr) = self.context.frame.get_local_address(index, self.masm);
         self.masm.store(RegImm::reg(src.reg), addr, ty.into());
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -914,8 +914,7 @@ where
 
     // TODO: verify the case where the target local is on the stack.
     fn visit_local_set(&mut self, index: u32) {
-        let (ty, slot) = self.context.frame.get_local_address(index, self.masm);
-        let src = self.emit_set_local(slot, ty.into());
+        let src = self.emit_set_local(index);
         self.context.free_reg(src);
     }
 
@@ -1247,8 +1246,7 @@ where
     }
 
     fn visit_local_tee(&mut self, index: u32) {
-        let (ty, slot) = self.context.frame.get_local_address(index, self.masm);
-        let typed_reg = self.emit_set_local(slot, ty.into());
+        let typed_reg = self.emit_set_local(index);
         self.context.stack.push(typed_reg.into());
     }
 

--- a/winch/filetests/filetests/x64/block/get_and_set.wat
+++ b/winch/filetests/filetests/x64/block/get_and_set.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "") (param i32)
+    local.get 0
+    block
+    end
+    local.set 0
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   16:	 4153                 	push	r11
+;;   18:	 58                   	pop	rax
+;;   19:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1d:	 4883c410             	add	rsp, 0x10
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/block/get_and_tee.wat
+++ b/winch/filetests/filetests/x64/block/get_and_tee.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "") (param i32) (result i32)
+    local.get 0
+    block
+    end
+    local.tee 0
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   16:	 4153                 	push	r11
+;;   18:	 58                   	pop	rax
+;;   19:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   1d:	 4883c410             	add	rsp, 0x10
+;;   21:	 5d                   	pop	rbp
+;;   22:	 c3                   	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
I observed in Winch that the offset from the stack pointer for locals written to with `local.set` and `local.tee` are slightly wrong when they are writing to a local that had been spilled by a prior operation. The cause appears to be that we get the address of the local (that is, the offset from the stack pointer) before invoking `self.context.pop_to_reg` and then use that address to perform the store operation. `self.context.pop_to_reg` may change the value of the stack pointer if the value on top of the stack is in memory. So the previously calculated stack pointer offset of the local may not be correct when storing a value into that address. This change has us calculate the address of the local (that is, the offset from the stack pointer) after invoking `self.context.pop_to_reg` to avoid that problem.