### PR TITLE
[15.0.0] wasi-filesystem: delete access modes

### DIFF
--- a/crates/wasi-http/wit/deps/filesystem/types.wit
+++ b/crates/wasi-http/wit/deps/filesystem/types.wit
@@ -142,29 +142,6 @@ interface types {
         truncate,
     }
 
-    /// Permissions mode used by `open-at`, `change-file-permissions-at`, and
-    /// similar.
-    flags modes {
-        /// True if the resource is considered readable by the containing
-        /// filesystem.
-        readable,
-        /// True if the resource is considered writable by the containing
-        /// filesystem.
-        writable,
-        /// True if the resource is considered executable by the containing
-        /// filesystem. This does not apply to directories.
-        executable,
-    }
-
-    /// Access type used by `access-at`.
-    variant access-type {
-        /// Test for readability, writeability, or executability.
-        access(modes),
-
-        /// Test whether the path exists.
-        exists,
-    }
-
     /// Number of hard links to an inode.
     type link-count = u64;
 
@@ -538,8 +515,6 @@ interface types {
             open-flags: open-flags,
             /// Flags to use for the resulting descriptor.
             %flags: descriptor-flags,
-            /// Permissions to use when creating a new file.
-            modes: modes
         ) -> result<descriptor, error-code>;
 
         /// Read the contents of a symbolic link.
@@ -588,25 +563,6 @@ interface types {
             new-path: string,
         ) -> result<_, error-code>;
 
-        /// Check accessibility of a filesystem path.
-        ///
-        /// Check whether the given filesystem path names an object which is
-        /// readable, writable, or executable, or whether it exists.
-        ///
-        /// This does not a guarantee that subsequent accesses will succeed, as
-        /// filesystem permissions may be modified asynchronously by external
-        /// entities.
-        ///
-        /// Note: This is similar to `faccessat` with the `AT_EACCESS` flag in POSIX.
-        access-at: func(
-            /// Flags determining the method of how the path is resolved.
-            path-flags: path-flags,
-            /// The relative path to check.
-            path: string,
-            /// The type of check to perform.
-            %type: access-type
-        ) -> result<_, error-code>;
-
         /// Unlink a filesystem object that is not a directory.
         ///
         /// Return `error-code::is-directory` if the path refers to a directory.
@@ -614,40 +570,6 @@ interface types {
         unlink-file-at: func(
             /// The relative path to a file to unlink.
             path: string,
-        ) -> result<_, error-code>;
-
-        /// Change the permissions of a filesystem object that is not a directory.
-        ///
-        /// Note that the ultimate meanings of these permissions is
-        /// filesystem-specific.
-        ///
-        /// Note: This is similar to `fchmodat` in POSIX.
-        change-file-permissions-at: func(
-            /// Flags determining the method of how the path is resolved.
-            path-flags: path-flags,
-            /// The relative path to operate on.
-            path: string,
-            /// The new permissions for the filesystem object.
-            modes: modes,
-        ) -> result<_, error-code>;
-
-        /// Change the permissions of a directory.
-        ///
-        /// Note that the ultimate meanings of these permissions is
-        /// filesystem-specific.
-        ///
-        /// Unlike in POSIX, the `executable` flag is not reinterpreted as a "search"
-        /// flag. `read` on a directory implies readability and searchability, and
-        /// `execute` is not valid for directories.
-        ///
-        /// Note: This is similar to `fchmodat` in POSIX.
-        change-directory-permissions-at: func(
-            /// Flags determining the method of how the path is resolved.
-            path-flags: path-flags,
-            /// The relative path to operate on.
-            path: string,
-            /// The new permissions for the directory.
-            modes: modes,
         ) -> result<_, error-code>;
 
         /// Test whether two descriptors refer to the same filesystem object.

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -1456,7 +1456,6 @@ pub unsafe extern "C" fn path_open(
     let at_flags = at_flags_from_lookupflags(dirflags);
     let o_flags = o_flags_from_oflags(oflags);
     let flags = descriptor_flags_from_flags(fs_rights_base, fdflags);
-    let mode = filesystem::Modes::READABLE | filesystem::Modes::WRITABLE;
     let append = fdflags & wasi::FDFLAGS_APPEND == wasi::FDFLAGS_APPEND;
 
     State::with(|state| {
@@ -1464,7 +1463,7 @@ pub unsafe extern "C" fn path_open(
             .descriptors()
             .get_dir(fd)?
             .fd
-            .open_at(at_flags, path, o_flags, flags, mode)?;
+            .open_at(at_flags, path, o_flags, flags)?;
         let descriptor_type = result.get_type()?;
         let desc = Descriptor::Streams(Streams {
             input: OnceCell::new(),

--- a/crates/wasi/src/preview2/host/filesystem.rs
+++ b/crates/wasi/src/preview2/host/filesystem.rs
@@ -487,9 +487,6 @@ impl<T: WasiView> HostDescriptor for T {
         path: String,
         oflags: types::OpenFlags,
         flags: types::DescriptorFlags,
-        // TODO: These are the permissions to use when creating a new file.
-        // Not implemented yet.
-        _mode: types::Modes,
     ) -> FsResult<Resource<types::Descriptor>> {
         use cap_fs_ext::{FollowSymlinks, OpenOptionsFollowExt, OpenOptionsMaybeDirExt};
         use system_interface::fs::{FdFlags, GetSetFdFlags};
@@ -696,36 +693,6 @@ impl<T: WasiView> HostDescriptor for T {
         }
         Ok(d.spawn_blocking(move |d| d.remove_file_or_symlink(&path))
             .await?)
-    }
-
-    async fn access_at(
-        &mut self,
-        _fd: Resource<types::Descriptor>,
-        _path_flags: types::PathFlags,
-        _path: String,
-        _access: types::AccessType,
-    ) -> FsResult<()> {
-        todo!("filesystem access_at is not implemented")
-    }
-
-    async fn change_file_permissions_at(
-        &mut self,
-        _fd: Resource<types::Descriptor>,
-        _path_flags: types::PathFlags,
-        _path: String,
-        _mode: types::Modes,
-    ) -> FsResult<()> {
-        todo!("filesystem change_file_permissions_at is not implemented")
-    }
-
-    async fn change_directory_permissions_at(
-        &mut self,
-        _fd: Resource<types::Descriptor>,
-        _path_flags: types::PathFlags,
-        _path: String,
-        _mode: types::Modes,
-    ) -> FsResult<()> {
-        todo!("filesystem change_directory_permissions_at is not implemented")
     }
 
     fn read_via_stream(

--- a/crates/wasi/src/preview2/host/filesystem/sync.rs
+++ b/crates/wasi/src/preview2/host/filesystem/sync.rs
@@ -175,7 +175,6 @@ impl<T: async_filesystem::HostDescriptor> sync_filesystem::HostDescriptor for T 
         path: String,
         oflags: sync_filesystem::OpenFlags,
         flags: sync_filesystem::DescriptorFlags,
-        mode: sync_filesystem::Modes,
     ) -> FsResult<Resource<sync_filesystem::Descriptor>> {
         in_tokio(async {
             async_filesystem::HostDescriptor::open_at(
@@ -185,7 +184,6 @@ impl<T: async_filesystem::HostDescriptor> sync_filesystem::HostDescriptor for T 
                 path,
                 oflags.into(),
                 flags.into(),
-                mode.into(),
             )
             .await
         })
@@ -242,63 +240,6 @@ impl<T: async_filesystem::HostDescriptor> sync_filesystem::HostDescriptor for T 
         path: String,
     ) -> FsResult<()> {
         in_tokio(async { async_filesystem::HostDescriptor::unlink_file_at(self, fd, path).await })
-    }
-
-    fn access_at(
-        &mut self,
-        fd: Resource<sync_filesystem::Descriptor>,
-        path_flags: sync_filesystem::PathFlags,
-        path: String,
-        access: sync_filesystem::AccessType,
-    ) -> FsResult<()> {
-        in_tokio(async {
-            async_filesystem::HostDescriptor::access_at(
-                self,
-                fd,
-                path_flags.into(),
-                path,
-                access.into(),
-            )
-            .await
-        })
-    }
-
-    fn change_file_permissions_at(
-        &mut self,
-        fd: Resource<sync_filesystem::Descriptor>,
-        path_flags: sync_filesystem::PathFlags,
-        path: String,
-        mode: sync_filesystem::Modes,
-    ) -> FsResult<()> {
-        in_tokio(async {
-            async_filesystem::HostDescriptor::change_file_permissions_at(
-                self,
-                fd,
-                path_flags.into(),
-                path,
-                mode.into(),
-            )
-            .await
-        })
-    }
-
-    fn change_directory_permissions_at(
-        &mut self,
-        fd: Resource<sync_filesystem::Descriptor>,
-        path_flags: sync_filesystem::PathFlags,
-        path: String,
-        mode: sync_filesystem::Modes,
-    ) -> FsResult<()> {
-        in_tokio(async {
-            async_filesystem::HostDescriptor::change_directory_permissions_at(
-                self,
-                fd,
-                path_flags.into(),
-                path,
-                mode.into(),
-            )
-            .await
-        })
     }
 
     fn read_via_stream(
@@ -564,30 +505,6 @@ impl From<sync_filesystem::DescriptorFlags> for async_filesystem::DescriptorFlag
             out |= Self::MUTATE_DIRECTORY;
         }
         out
-    }
-}
-impl From<sync_filesystem::Modes> for async_filesystem::Modes {
-    fn from(other: sync_filesystem::Modes) -> Self {
-        let mut out = Self::empty();
-        if other.contains(sync_filesystem::Modes::READABLE) {
-            out |= Self::READABLE;
-        }
-        if other.contains(sync_filesystem::Modes::WRITABLE) {
-            out |= Self::WRITABLE;
-        }
-        if other.contains(sync_filesystem::Modes::EXECUTABLE) {
-            out |= Self::EXECUTABLE;
-        }
-        out
-    }
-}
-impl From<sync_filesystem::AccessType> for async_filesystem::AccessType {
-    fn from(other: sync_filesystem::AccessType) -> Self {
-        use sync_filesystem::AccessType;
-        match other {
-            AccessType::Access(modes) => Self::Access(modes.into()),
-            AccessType::Exists => Self::Exists,
-        }
     }
 }
 impl From<async_filesystem::MetadataHashValue> for sync_filesystem::MetadataHashValue {

--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -1893,14 +1893,7 @@ impl<
         };
         drop(t);
         let fd = self
-            .open_at(
-                dirfd,
-                dirflags.into(),
-                path,
-                oflags.into(),
-                flags,
-                filesystem::Modes::READABLE | filesystem::Modes::WRITABLE,
-            )
+            .open_at(dirfd, dirflags.into(), path, oflags.into(), flags)
             .await
             .map_err(|e| {
                 e.try_into()

--- a/crates/wasi/wit/deps/filesystem/types.wit
+++ b/crates/wasi/wit/deps/filesystem/types.wit
@@ -142,29 +142,6 @@ interface types {
         truncate,
     }
 
-    /// Permissions mode used by `open-at`, `change-file-permissions-at`, and
-    /// similar.
-    flags modes {
-        /// True if the resource is considered readable by the containing
-        /// filesystem.
-        readable,
-        /// True if the resource is considered writable by the containing
-        /// filesystem.
-        writable,
-        /// True if the resource is considered executable by the containing
-        /// filesystem. This does not apply to directories.
-        executable,
-    }
-
-    /// Access type used by `access-at`.
-    variant access-type {
-        /// Test for readability, writeability, or executability.
-        access(modes),
-
-        /// Test whether the path exists.
-        exists,
-    }
-
     /// Number of hard links to an inode.
     type link-count = u64;
 
@@ -538,8 +515,6 @@ interface types {
             open-flags: open-flags,
             /// Flags to use for the resulting descriptor.
             %flags: descriptor-flags,
-            /// Permissions to use when creating a new file.
-            modes: modes
         ) -> result<descriptor, error-code>;
 
         /// Read the contents of a symbolic link.
@@ -588,25 +563,6 @@ interface types {
             new-path: string,
         ) -> result<_, error-code>;
 
-        /// Check accessibility of a filesystem path.
-        ///
-        /// Check whether the given filesystem path names an object which is
-        /// readable, writable, or executable, or whether it exists.
-        ///
-        /// This does not a guarantee that subsequent accesses will succeed, as
-        /// filesystem permissions may be modified asynchronously by external
-        /// entities.
-        ///
-        /// Note: This is similar to `faccessat` with the `AT_EACCESS` flag in POSIX.
-        access-at: func(
-            /// Flags determining the method of how the path is resolved.
-            path-flags: path-flags,
-            /// The relative path to check.
-            path: string,
-            /// The type of check to perform.
-            %type: access-type
-        ) -> result<_, error-code>;
-
         /// Unlink a filesystem object that is not a directory.
         ///
         /// Return `error-code::is-directory` if the path refers to a directory.
@@ -614,40 +570,6 @@ interface types {
         unlink-file-at: func(
             /// The relative path to a file to unlink.
             path: string,
-        ) -> result<_, error-code>;
-
-        /// Change the permissions of a filesystem object that is not a directory.
-        ///
-        /// Note that the ultimate meanings of these permissions is
-        /// filesystem-specific.
-        ///
-        /// Note: This is similar to `fchmodat` in POSIX.
-        change-file-permissions-at: func(
-            /// Flags determining the method of how the path is resolved.
-            path-flags: path-flags,
-            /// The relative path to operate on.
-            path: string,
-            /// The new permissions for the filesystem object.
-            modes: modes,
-        ) -> result<_, error-code>;
-
-        /// Change the permissions of a directory.
-        ///
-        /// Note that the ultimate meanings of these permissions is
-        /// filesystem-specific.
-        ///
-        /// Unlike in POSIX, the `executable` flag is not reinterpreted as a "search"
-        /// flag. `read` on a directory implies readability and searchability, and
-        /// `execute` is not valid for directories.
-        ///
-        /// Note: This is similar to `fchmodat` in POSIX.
-        change-directory-permissions-at: func(
-            /// Flags determining the method of how the path is resolved.
-            path-flags: path-flags,
-            /// The relative path to operate on.
-            path: string,
-            /// The new permissions for the directory.
-            modes: modes,
         ) -> result<_, error-code>;
 
         /// Test whether two descriptors refer to the same filesystem object.


### PR DESCRIPTION
This is a backport of #7510