### PR TITLE
Downgrade log level on pcc error

### DIFF
--- a/cranelift/codegen/src/ir/pcc.rs
+++ b/cranelift/codegen/src/ir/pcc.rs
@@ -1655,7 +1655,7 @@ pub fn check_vcode_facts<B: LowerBackend + TargetIsa>(
         for inst in vcode.block_insns(block).iter() {
             // Check any output facts on this inst.
             if let Err(e) = backend.check_fact(&ctx, vcode, inst, &mut flow_state) {
-                log::error!("Error checking instruction: {:?}", vcode[inst]);
+                log::info!("Error checking instruction: {:?}", vcode[inst]);
                 return Err(e);
             }
 


### PR DESCRIPTION
Currently `cargo run test filetests` in the `cranelift` directory prints a bunch of `ERROR:` logs for the pcc tests which I'm assuming is expected as they're testing failures. This commit turns down the log level to `info!` so it's suppressed by default in this situation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
