### PR TITLE
riscv64: use `vadd.vi` for small immediate vector subtraction

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1937,8 +1937,8 @@
 ;; Like imm5_from_value, but first negates the `Value`.
 (decl pure partial imm5_from_negated_value (Value) Imm5)
 (rule (imm5_from_negated_value (has_type ty (iconst n)))
-(if-let (imm5_from_i64 imm) (i64_neg (i64_sextend_imm64 ty n)))
-imm)
+  (if-let (imm5_from_i64 imm) (i64_neg (i64_sextend_imm64 ty n)))
+  imm)
 
 ;; Constructor that matches a `Value` equivalent to a replicated Imm5 on all lanes.
 (decl pure partial replicated_imm5 (Value) Imm5)

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1934,6 +1934,12 @@
 (decl imm5_from_value (Imm5) Value)
 (extractor (imm5_from_value n) (i64_from_iconst (imm5_from_i64 n)))
 
+;; Like imm5_from_value, but first negates the `Value`.
+(decl pure partial imm5_from_negated_value (Value) Imm5)
+(rule (imm5_from_negated_value (has_type ty (iconst n)))
+(if-let (imm5_from_i64 imm) (i64_neg (i64_sextend_imm64 ty n)))
+imm)
+
 ;; Constructor that matches a `Value` equivalent to a replicated Imm5 on all lanes.
 (decl pure partial replicated_imm5 (Value) Imm5)
 (rule (replicated_imm5 (splat (imm5_from_value n))) n)
@@ -1943,6 +1949,19 @@
   (if-let (u32_replicated_u16 n16) n32)
   (if-let (u16_replicated_u8 n8) n16)
   (if-let n (i8_to_imm5 (u8_as_i8 n8)))
+  n)
+
+;; Like replicated_imm5, but first negates the `Value`.
+(decl pure partial negated_replicated_imm5 (Value) Imm5)
+(rule (negated_replicated_imm5 (splat n))
+  (if-let imm5 (imm5_from_negated_value n))
+  imm5)
+(rule (negated_replicated_imm5 (vconst (u128_from_constant n128)))
+  (if-let (u128_replicated_u64 n64) n128)
+  (if-let (u64_replicated_u32 n32) n64)
+  (if-let (u32_replicated_u16 n16) n32)
+  (if-let (u16_replicated_u8 n8) n16)
+  (if-let n (i8_to_imm5 (i8_neg (u8_as_i8 n8))))
   n)
 
 ;; UImm5 Helpers

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -350,6 +350,10 @@
   (rv_vrsub_vx y x (unmasked) ty))
 
 (rule 8 (lower (has_type (ty_vec_fits_in_register ty) (isub x y)))
+  (if-let imm5_neg (negated_replicated_imm5 y))
+  (rv_vadd_vi x imm5_neg (unmasked) ty))
+
+(rule 9 (lower (has_type (ty_vec_fits_in_register ty) (isub x y)))
   (if-let x_imm (replicated_imm5 x))
   (rv_vrsub_vi y x_imm (unmasked) ty))
 
@@ -359,11 +363,11 @@
 (rule 6 (lower (has_type (ty_vec_fits_in_register _) (isub x (swiden_low y @ (value_type in_ty)))))
   (rv_vwsub_wv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
                                                            (swiden_low y))))
   (rv_vwsub_vv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
                                                            (splat (sextend y @ (value_type sext_ty))))))
   (if-let $true (ty_equal (lane_type in_ty) sext_ty))
   (rv_vwsub_vx x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
@@ -374,11 +378,11 @@
 (rule 6 (lower (has_type (ty_vec_fits_in_register _) (isub x (swiden_high y @ (value_type in_ty)))))
   (rv_vwsub_wv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
                                                            (swiden_high y))))
   (rv_vwsub_vv (gen_slidedown_half in_ty x) (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
                                                            (splat (sextend y @ (value_type sext_ty))))))
   (if-let $true (ty_equal (lane_type in_ty) sext_ty))
   (rv_vwsub_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
@@ -388,11 +392,11 @@
 (rule 6 (lower (has_type (ty_vec_fits_in_register _) (isub x (uwiden_low y @ (value_type in_ty)))))
   (rv_vwsubu_wv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
                                                            (uwiden_low y))))
   (rv_vwsubu_vv x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
                                                            (splat (uextend y @ (value_type uext_ty))))))
   (if-let $true (ty_equal (lane_type in_ty) uext_ty))
   (rv_vwsubu_vx x y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
@@ -403,32 +407,32 @@
 (rule 6 (lower (has_type (ty_vec_fits_in_register _) (isub x (uwiden_high y @ (value_type in_ty)))))
   (rv_vwsubu_wv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
                                                            (uwiden_high y))))
   (rv_vwsubu_vv (gen_slidedown_half in_ty x) (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
                                                            (splat (uextend y @ (value_type uext_ty))))))
   (if-let $true (ty_equal (lane_type in_ty) uext_ty))
   (rv_vwsubu_vx (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
 ;; Signed Widening Mixed High/Low Subtractions
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_low x @ (value_type in_ty))
                                                            (swiden_high y))))
   (rv_vwsub_vv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (swiden_high x @ (value_type in_ty))
                                                            (swiden_low y))))
   (rv_vwsub_vv (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
 ;; Unsigned Widening Mixed High/Low Subtractions
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_low x @ (value_type in_ty))
                                                            (uwiden_high y))))
   (rv_vwsubu_vv x (gen_slidedown_half in_ty y) (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 
-(rule 9 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
+(rule 10 (lower (has_type (ty_vec_fits_in_register _) (isub (uwiden_high x @ (value_type in_ty))
                                                            (uwiden_low y))))
   (rv_vwsubu_vv (gen_slidedown_half in_ty x) y (unmasked) (vstate_mf2 (ty_half_lanes in_ty))))
 

--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -54,6 +54,11 @@ macro_rules! isle_common_prelude_methods {
         }
 
         #[inline]
+        fn i8_neg(&mut self, x: i8) -> i8 {
+            x.wrapping_neg()
+        }
+
+        #[inline]
         fn u64_add(&mut self, x: u64, y: u64) -> u64 {
             x.wrapping_add(y)
         }

--- a/cranelift/codegen/src/prelude.isle
+++ b/cranelift/codegen/src/prelude.isle
@@ -106,6 +106,9 @@
 (decl pure i64_neg (i64) i64)
 (extern constructor i64_neg i64_neg)
 
+(decl pure i8_neg (i8) i8)
+(extern constructor i8_neg i8_neg)
+
 (decl u128_as_u64 (u64) u128)
 (extern extractor u128_as_u64 u128_as_u64)
 

--- a/cranelift/filetests/filetests/isa/riscv64/simd-isub-splat.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/simd-isub-splat.clif
@@ -334,9 +334,8 @@ block0(v0: i8x16):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   li a5,5
-;   vsub.vx v13,v9,a5 #avl=16, #vtype=(e8, m1, ta, ma)
-;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vadd.vi v12,v9,-5 #avl=16, #vtype=(e8, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -352,9 +351,8 @@ block0(v0: i8x16):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   addi a5, zero, 5
-;   .byte 0xd7, 0xc6, 0x97, 0x0a
-;   .byte 0xa7, 0x06, 0x05, 0x02
+;   .byte 0x57, 0xb6, 0x9d, 0x02
+;   .byte 0x27, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -418,9 +416,8 @@ block0(v0: i32x4):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   li a5,15
-;   vsub.vx v13,v9,a5 #avl=4, #vtype=(e32, m1, ta, ma)
-;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vadd.vi v12,v9,-15 #avl=4, #vtype=(e32, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -436,11 +433,10 @@ block0(v0: i32x4):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   addi a5, zero, 0xf
 ;   .byte 0x57, 0x70, 0x02, 0xcd
-;   .byte 0xd7, 0xc6, 0x97, 0x0a
+;   .byte 0x57, 0xb6, 0x98, 0x02
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x06, 0x05, 0x02
+;   .byte 0x27, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -461,9 +457,8 @@ block0(v0: i64x2):
 ;   mv fp,sp
 ; block0:
 ;   vle8.v v9,16(fp) #avl=16, #vtype=(e8, m1, ta, ma)
-;   li a5,-5
-;   vsub.vx v13,v9,a5 #avl=2, #vtype=(e64, m1, ta, ma)
-;   vse8.v v13,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
+;   vadd.vi v12,v9,5 #avl=2, #vtype=(e64, m1, ta, ma)
+;   vse8.v v12,0(a0) #avl=16, #vtype=(e8, m1, ta, ma)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -479,11 +474,10 @@ block0(v0: i64x2):
 ;   .byte 0x57, 0x70, 0x08, 0xcc
 ;   addi t6, s0, 0x10
 ;   .byte 0x87, 0x84, 0x0f, 0x02
-;   addi a5, zero, -5
 ;   .byte 0x57, 0x70, 0x81, 0xcd
-;   .byte 0xd7, 0xc6, 0x97, 0x0a
+;   .byte 0x57, 0xb6, 0x92, 0x02
 ;   .byte 0x57, 0x70, 0x08, 0xcc
-;   .byte 0xa7, 0x06, 0x05, 0x02
+;   .byte 0x27, 0x06, 0x05, 0x02
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10


### PR DESCRIPTION
this PR implements the change requested in #7481. Since riscv64 doesn't have a `vsub.vi` instruction, this optimization removes a load when the immediate fits in an Imm5.

