### PR TITLE
wasi-http: Make child fields immutable

### DIFF
--- a/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_header.rs
@@ -1,4 +1,4 @@
-use test_programs::wasi::http::types::{HeaderError, Headers};
+use test_programs::wasi::http::types::{HeaderError, Headers, OutgoingRequest};
 
 fn main() {
     let hdrs = Headers::new();
@@ -56,5 +56,23 @@ fn main() {
     assert!(matches!(
         Headers::from_list(&[("ok-header-name".to_owned(), b"bad\nvalue".to_vec())]),
         Err(HeaderError::InvalidSyntax)
+    ));
+
+    let req = OutgoingRequest::new(hdrs);
+    let hdrs = req.headers();
+
+    assert!(matches!(
+        hdrs.set(&"Content-Length".to_owned(), &[b"10".to_vec()]),
+        Err(HeaderError::Immutable),
+    ));
+
+    assert!(matches!(
+        hdrs.append(&"Content-Length".to_owned(), &b"10".to_vec()),
+        Err(HeaderError::Immutable),
+    ));
+
+    assert!(matches!(
+        hdrs.delete(&"Content-Length".to_owned()),
+        Err(HeaderError::Immutable),
     ));
 }

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -323,6 +323,18 @@ impl TryFrom<HostOutgoingResponse> for hyper::Response<HyperOutgoingBody> {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FieldMapMutability {
+    Mutable,
+    Immutable,
+}
+
+impl FieldMapMutability {
+    pub fn is_immutable(&self) -> bool {
+        *self == Self::Immutable
+    }
+}
+
 pub type FieldMap = hyper::HeaderMap;
 
 pub enum HostFields {
@@ -333,6 +345,9 @@ pub enum HostFields {
         // always be registered as a child of the entry with the `parent` id. This ensures that the
         // entry will always exist while this `HostFields::Ref` entry exists in the table, thus we
         // don't need to account for failure when fetching the fields ref from the parent.
+        //
+        // NOTE: references are always considered immutable -- the only way to modify fields is to
+        // create an owned version first.
         get_fields: for<'a> fn(elem: &'a mut (dyn Any + 'static)) -> &'a mut FieldMap,
     },
     Owned {

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -323,18 +323,6 @@ impl TryFrom<HostOutgoingResponse> for hyper::Response<HyperOutgoingBody> {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum FieldMapMutability {
-    Mutable,
-    Immutable,
-}
-
-impl FieldMapMutability {
-    pub fn is_immutable(&self) -> bool {
-        *self == Self::Immutable
-    }
-}
-
 pub type FieldMap = hyper::HeaderMap;
 
 pub enum HostFields {

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -333,9 +333,6 @@ pub enum HostFields {
         // always be registered as a child of the entry with the `parent` id. This ensures that the
         // entry will always exist while this `HostFields::Ref` entry exists in the table, thus we
         // don't need to account for failure when fetching the fields ref from the parent.
-        //
-        // NOTE: references are always considered immutable -- the only way to modify fields is to
-        // create an owned version first.
         get_fields: for<'a> fn(elem: &'a mut (dyn Any + 'static)) -> &'a mut FieldMap,
     },
     Owned {

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -42,6 +42,7 @@ interface types {
   variant header-error {
     invalid-syntax,
     forbidden,
+    immutable
   }
 
   /// Field keys are always strings.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -42,6 +42,7 @@ interface types {
   variant header-error {
     invalid-syntax,
     forbidden,
+    immutable
   }
 
   /// Field keys are always strings.


### PR DESCRIPTION
This PR adds a new case to the `header-error` variant, `immutable`, which indicates that an operation that would modify the `fields` value has failed because that `fields` is immutable. All `fields` returned by getter methods on any of the request/response types are considered immutable, while `fields` that have been created directly through the use of the `fields` constructor are considered mutable until ownership is passed to an outgoing request or response.

This change paves the way to runtime validation of the `Content-Length` header, ensuring that it's safe to check the value provided when an outgoing request or response is created.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
