### PR TITLE
winch: Do not use `unconditional_jump` with `br_table`

### DIFF
--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -404,6 +404,13 @@ impl<'a, 'builtins> CodeGenContext<'a, 'builtins> {
         self.reachable = false;
     }
 
+    /// A combination of [Self::pop_abi_results] and [Self::push_abi_results]
+    /// to be used on conditional branches: br_if and br_table.
+    pub fn top_abi_results<M: MacroAssembler>(&mut self, result: &ABIResult, masm: &mut M) {
+        self.pop_abi_results(result, masm);
+        self.push_abi_results(result, masm);
+    }
+
     /// Handles the emission of the ABI result. This function is used at the end
     /// of a block or function to pop the results from the value stack into the
     /// corresponding ABI result representation.

--- a/winch/filetests/filetests/x64/br_table/stack_handling.wat
+++ b/winch/filetests/filetests/x64/br_table/stack_handling.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+(module
+  (func (;0;) (param i32)
+    local.get 0
+    block ;; label = @1
+      i32.const 808727609
+      br_table 0 (;@1;) 1 (;@0;) 0 (;@1;)
+    end
+    drop
+  )
+  (export "main" (func 0))
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   16:	 4153                 	push	r11
+;;   18:	 b839343430           	mov	eax, 0x30343439
+;;   1d:	 b902000000           	mov	ecx, 2
+;;   22:	 39c1                 	cmp	ecx, eax
+;;   24:	 0f42c1               	cmovb	eax, ecx
+;;   27:	 4c8d1d0a000000       	lea	r11, [rip + 0xa]
+;;   2e:	 49630c83             	movsxd	rcx, dword ptr [r11 + rax*4]
+;;   32:	 4901cb               	add	r11, rcx
+;;   35:	 41ffe3               	jmp	r11
+;;   38:	 0c00                 	or	al, 0
+;;   3a:	 0000                 	add	byte ptr [rax], al
+;;   3c:	 1000                 	adc	byte ptr [rax], al
+;;   3e:	 0000                 	add	byte ptr [rax], al
+;;   40:	 0c00                 	or	al, 0
+;;   42:	 0000                 	add	byte ptr [rax], al
+;;   44:	 4883c408             	add	rsp, 8
+;;   48:	 4883c410             	add	rsp, 0x10
+;;   4c:	 5d                   	pop	rbp
+;;   4d:	 c3                   	ret	


### PR DESCRIPTION
This patch fixes how jumps are handled in `br_table`; prior to this change, `br_table` was implemented using
`CodeGenContext::unconditional_jump`; this function ensures, among other invariants that the value stack and stack pointer must be balanced according to the expectation of the target branch. Even though in `br_table` there's branch to a potentially known location, it's impossible be certain at compile time, which branch will be taken; in that regard, `br_table` behaves more like `br_if`. Using `unconditional_jump` resulted in the stack being manipulated multiple times and breaking the other existing invariants around stack balancing.

This commit makes it so that `br_table` doesn't rely on `unconditional_jump` anymore and instead it delegates control flow to the target branch, which will ensure that the value stack and stack pointer are correctly balanced when restoring reachability, very similar to what happens with `br_if`.

This issue was discovered while fuzzing and a file test is included with the test case.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
