### PR TITLE
ISLE: Build in maximum limit for multi constructor returns

### DIFF
--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -23,7 +23,16 @@ pub type Range = (usize, usize);
 pub type ValueArray2 = [Value; 2];
 pub type ValueArray3 = [Value; 3];
 
-pub type ConstructorVec<T> = SmallVec<[T; 8]>;
+const MAX_ISLE_RETURNS: usize = 8;
+
+pub type ConstructorVec<T> = SmallVec<[T; MAX_ISLE_RETURNS]>;
+
+impl<T: smallvec::Array> generated_code::Length for SmallVec<T> {
+    #[inline]
+    fn len(&self) -> usize {
+        SmallVec::len(self)
+    }
+}
 
 pub(crate) mod generated_code;
 use generated_code::{ContextIter, IntoContextIter};

--- a/cranelift/isle/isle/isle_examples/link/multi_constructor_main.rs
+++ b/cranelift/isle/isle/isle_examples/link/multi_constructor_main.rs
@@ -3,6 +3,8 @@ use multi_constructor::{ContextIter, IntoContextIter};
 
 struct Context;
 
+const MAX_ISLE_RETURNS: usize = 100;
+
 #[derive(Default)]
 struct It {
     i: u32,

--- a/cranelift/isle/isle/isle_examples/link/multi_extractor_main.rs
+++ b/cranelift/isle/isle/isle_examples/link/multi_extractor_main.rs
@@ -2,6 +2,8 @@ mod multi_extractor;
 
 use multi_extractor::{ContextIter, IntoContextIter};
 
+const MAX_ISLE_RETURNS: usize = 100;
+
 #[derive(Clone)]
 pub enum A {
     B,


### PR DESCRIPTION
Allows users to avoid runaway rules that match too much stuff.

No statistically significant speed up to compilation on sightglass, but good to have as a safeguard anyways.

Fixes #7500

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
