### PR TITLE
wasi-http: Validate Content-Length when present

### DIFF
--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -42,7 +42,8 @@ impl bindings::exports::wasi::http::incoming_handler::Guest for T {
             .expect("writing response");
 
         drop(out);
-        bindings::wasi::http::types::OutgoingBody::finish(body, None);
+        bindings::wasi::http::types::OutgoingBody::finish(body, None)
+            .expect("outgoing-body.finish");
     }
 }
 

--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -258,7 +258,7 @@ fn respond(status: u16, response_out: ResponseOutparam) {
 
     ResponseOutparam::set(response_out, Ok(response));
 
-    OutgoingBody::finish(body, None);
+    OutgoingBody::finish(body, None).expect("outgoing-body.finish");
 }
 
 async fn hash(url: &Url) -> Result<String> {
@@ -390,7 +390,7 @@ mod executor {
             fn drop(&mut self) {
                 if let Some((stream, body)) = self.0.take() {
                     drop(stream);
-                    OutgoingBody::finish(body, None);
+                    OutgoingBody::finish(body, None).expect("outgoing-body.finish");
                 }
             }
         }

--- a/crates/test-programs/src/bin/http_outbound_request_content_length.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_content_length.rs
@@ -1,0 +1,92 @@
+use test_programs::wasi::http::types as http_types;
+
+fn make_request() -> http_types::OutgoingRequest {
+    let request = http_types::OutgoingRequest::new(
+        http_types::Headers::from_list(&[("Content-Length".to_string(), b"11".to_vec())]).unwrap(),
+    );
+
+    request
+        .set_method(&http_types::Method::Post)
+        .expect("setting method");
+    request
+        .set_scheme(Some(&http_types::Scheme::Http))
+        .expect("setting scheme");
+    let addr = std::env::var("HTTP_SERVER").unwrap();
+    request
+        .set_authority(Some(&addr))
+        .expect("setting authority");
+    request
+        .set_path_with_query(Some("/"))
+        .expect("setting path with query");
+
+    request
+}
+
+fn main() {
+    {
+        println!("writing enough");
+        let request = make_request();
+        let outgoing_body = request.body().unwrap();
+
+        {
+            let request_body = outgoing_body.write().unwrap();
+            request_body
+                .blocking_write_and_flush("long enough".as_bytes())
+                .unwrap();
+        }
+
+        http_types::OutgoingBody::finish(outgoing_body, None).expect("enough written")
+    }
+
+    {
+        println!("writing too little");
+        let request = make_request();
+        let outgoing_body = request.body().unwrap();
+
+        {
+            let request_body = outgoing_body.write().unwrap();
+            request_body
+                .blocking_write_and_flush("msg".as_bytes())
+                .unwrap();
+        }
+
+        let e =
+            http_types::OutgoingBody::finish(outgoing_body, None).expect_err("finish should fail");
+
+        assert!(
+            matches!(
+                &e,
+                http_types::ErrorCode::InternalError(Some(s))
+                  if s == "not enough written to body stream",
+            ),
+            "unexpected error: {e:#?}"
+        );
+    }
+
+    {
+        println!("writing too much");
+        let request = make_request();
+        let outgoing_body = request.body().unwrap();
+
+        {
+            let request_body = outgoing_body.write().unwrap();
+            request_body
+                .blocking_write_and_flush("more than 11 bytes".as_bytes())
+                .expect_err("write should fail");
+
+            // TODO: show how to use http-error-code to unwrap this error
+        }
+
+        let e =
+            http_types::OutgoingBody::finish(outgoing_body, None).expect_err("finish should fail");
+
+        assert!(
+            matches!(
+                &e,
+                http_types::ErrorCode::InternalError(Some(s))
+                  if s == "too much written to body stream",
+            ),
+            "unexpected error: {e:#?}"
+        );
+    }
+}

--- a/crates/test-programs/src/http.rs
+++ b/crates/test-programs/src/http.rs
@@ -110,7 +110,7 @@ pub fn request(
 
     let future_response = outgoing_handler::handle(request, None)?;
 
-    http_types::OutgoingBody::finish(outgoing_body, None);
+    http_types::OutgoingBody::finish(outgoing_body, None)?;
 
     let incoming_response = match future_response.get() {
         Some(result) => result.map_err(|()| anyhow!("response already taken"))?,

--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -482,8 +482,6 @@ impl HostOutgoingBody {
             .take()
             .expect("outgoing-body trailer_sender consumed by a non-owning function");
 
-        // TODO: does sending guarantee that the message was received, or could it be queued to
-        // receive?
         if let Some(w) = self.written {
             use std::cmp::Ordering;
             let res = w.finish();

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -43,3 +43,7 @@ pub(crate) fn dns_error(rcode: String, info_code: u16) -> bindings::http::types:
         info_code: Some(info_code),
     })
 }
+
+pub(crate) fn internal_error(msg: String) -> bindings::http::types::ErrorCode {
+    bindings::http::types::ErrorCode::InternalError(Some(msg))
+}

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -845,7 +845,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingBody for T {
         &mut self,
         id: Resource<HostOutgoingBody>,
         ts: Option<Resource<Trailers>>,
-    ) -> wasmtime::Result<()> {
+    ) -> wasmtime::Result<Result<(), types::Error>> {
         let mut body = self.table().delete(id)?;
 
         let sender = body
@@ -862,7 +862,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingBody for T {
         // Ignoring failure: receiver died sending body, but we can't report that here.
         let _ = sender.send(message.into());
 
-        Ok(())
+        Ok(Ok(()))
     }
 
     fn drop(&mut self, id: Resource<HostOutgoingBody>) -> wasmtime::Result<()> {

--- a/crates/wasi-http/tests/all/async_.rs
+++ b/crates/wasi-http/tests/all/async_.rs
@@ -84,3 +84,9 @@ async fn http_outbound_request_response_build() -> Result<()> {
     let server = Server::http1()?;
     run(HTTP_OUTBOUND_REQUEST_RESPONSE_BUILD_COMPONENT, &server).await
 }
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn http_outbound_request_content_length() -> Result<()> {
+    let server = Server::http1()?;
+    run(HTTP_OUTBOUND_REQUEST_CONTENT_LENGTH_COMPONENT, &server).await
+}

--- a/crates/wasi-http/tests/all/sync.rs
+++ b/crates/wasi-http/tests/all/sync.rs
@@ -83,3 +83,9 @@ fn http_outbound_request_response_build() -> Result<()> {
     let server = Server::http1()?;
     run(HTTP_OUTBOUND_REQUEST_RESPONSE_BUILD_COMPONENT, &server)
 }
+
+#[test_log::test]
+fn http_outbound_request_content_length() -> Result<()> {
+    let server = Server::http1()?;
+    run(HTTP_OUTBOUND_REQUEST_CONTENT_LENGTH_COMPONENT, &server)
+}

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -477,7 +477,10 @@ interface types {
     /// called to signal that the response is complete. If the `outgoing-body`
     /// is dropped without calling `outgoing-body.finalize`, the implementation
     /// should treat the body as corrupted.
-    finish: static func(this: outgoing-body, trailers: option<trailers>);
+    finish: static func(
+      this: outgoing-body,
+      trailers: option<trailers>
+    ) -> result<_, error>;
   }
 
   /// Represents a future which may eventaully return an incoming HTTP

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -480,7 +480,7 @@ interface types {
     finish: static func(
       this: outgoing-body,
       trailers: option<trailers>
-    ) -> result<_, error>;
+    ) -> result<_, error-code>;
   }
 
   /// Represents a future which may eventaully return an incoming HTTP

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -477,7 +477,10 @@ interface types {
     /// called to signal that the response is complete. If the `outgoing-body`
     /// is dropped without calling `outgoing-body.finalize`, the implementation
     /// should treat the body as corrupted.
-    finish: static func(this: outgoing-body, trailers: option<trailers>);
+    finish: static func(
+      this: outgoing-body,
+      trailers: option<trailers>
+    ) -> result<_, error>;
   }
 
   /// Represents a future which may eventaully return an incoming HTTP

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -480,7 +480,7 @@ interface types {
     finish: static func(
       this: outgoing-body,
       trailers: option<trailers>
-    ) -> result<_, error>;
+    ) -> result<_, error-code>;
   }
 
   /// Represents a future which may eventaully return an incoming HTTP


### PR DESCRIPTION
Make use of immutable header state to track how much has been written to an output-body stream, ensuring that we write exactly as much as was mentioned in the `Content-Length` header.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
