### PR TITLE
wasi-http: Remove a debugging eprintln

### DIFF
--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -77,10 +77,10 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
             uri = uri.path_and_query(path);
         }
 
-        builder = builder.uri(uri.build().map_err(|e| {
-            eprintln!("uri build error: {e:#?}");
-            types::ErrorCode::HttpRequestUriInvalid
-        })?);
+        builder = builder.uri(
+            uri.build()
+                .map_err(|_| types::ErrorCode::HttpRequestUriInvalid)?,
+        );
 
         for (k, v) in req.headers.iter() {
             builder = builder.header(k, v);


### PR DESCRIPTION
Remove an `eprintln!` that should have been removed before #7434 merged.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
