### PR TITLE
Move Subscribe trait's static lifetime tag out.

### DIFF
--- a/crates/wasi/src/preview2/poll.rs
+++ b/crates/wasi/src/preview2/poll.rs
@@ -24,7 +24,7 @@ pub struct Pollable {
 }
 
 #[async_trait::async_trait]
-pub trait Subscribe: Send + Sync + 'static {
+pub trait Subscribe: Send + Sync {
     async fn ready(&mut self);
 }
 
@@ -37,11 +37,11 @@ pub trait Subscribe: Send + Sync + 'static {
 /// deleted while the `pollable` is still alive.
 pub fn subscribe<T>(table: &mut Table, resource: Resource<T>) -> Result<Resource<Pollable>>
 where
-    T: Subscribe,
+    T: Subscribe + 'static,
 {
     fn make_future<'a, T>(stream: &'a mut dyn Any) -> PollableFuture<'a>
     where
-        T: Subscribe,
+        T: Subscribe + 'static,
     {
         stream.downcast_mut::<T>().unwrap().ready()
     }


### PR DESCRIPTION
Static lifetime should not be mandatory.

It's helpful when someone impl this trait outside.

By the way, I have tried to avoid the lifetime's checking, but it was failed...

I think this PR should help me solve the problem, so that I can normally apply for temporary memory from the heap when impl Subscribe this trait.

[Here's the repo](https://github.com/celestia-island/tairitsu/tree/lifetime-test)