### PR TITLE
winch: Materialize latent locals when setting them

### DIFF
--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -350,13 +350,7 @@ where
     pub fn emit_set_local(&mut self, index: u32) -> TypedReg {
         // Materialize any references to the same local index that are in the
         // value stack by spilling.
-        let stack_contains_latent_local = self
-            .context
-            .stack
-            .iter()
-            .skip(1) // top-most element is popped below.
-            .any(|v| v.is_local_at_index(index));
-        if stack_contains_latent_local {
+        if self.context.stack.contains_latent_local(index) {
             self.context.spill(self.masm);
         }
         let src = self.context.pop_to_reg(self.masm, None);

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -292,7 +292,7 @@ pub enum RoundingMode {
 
 pub(crate) trait MacroAssembler {
     /// The addressing mode.
-    type Address: Copy;
+    type Address: Copy + Debug;
 
     /// The pointer representation of the target ISA,
     /// used to access information from [`VMOffsets`].

--- a/winch/codegen/src/stack.rs
+++ b/winch/codegen/src/stack.rs
@@ -155,6 +155,14 @@ impl Val {
         }
     }
 
+    /// Check whether the value is local with a particular index.
+    pub fn is_local_at_index(&self, index: u32) -> bool {
+        match *self {
+            Self::Local(Local { index: i, .. }) if i == index => true,
+            _ => false,
+        }
+    }
+
     /// Get the register representation of the value.
     ///
     /// # Panics
@@ -273,6 +281,11 @@ impl Stack {
 
         let partition = len - n;
         self.inner.range(partition..)
+    }
+
+    /// Returns an iterator of the stack in top-most to bottom-most order.
+    pub fn iter(&self) -> impl Iterator<Item = &Val> + '_ {
+        self.inner.iter().rev()
     }
 
     /// Pops the top element of the stack, if any.

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -912,7 +912,6 @@ where
         }
     }
 
-    // TODO: verify the case where the target local is on the stack.
     fn visit_local_set(&mut self, index: u32) {
         let src = self.emit_set_local(index);
         self.context.free_reg(src);

--- a/winch/filetests/filetests/x64/local/latent.wat
+++ b/winch/filetests/filetests/x64/local/latent.wat
@@ -1,0 +1,22 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "") (param i32) (result i32)
+    local.get 0
+    i32.const 1
+    local.set 0
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   16:	 4153                 	push	r11
+;;   18:	 b801000000           	mov	eax, 1
+;;   1d:	 89442414             	mov	dword ptr [rsp + 0x14], eax
+;;   21:	 58                   	pop	rax
+;;   22:	 4883c410             	add	rsp, 0x10
+;;   26:	 5d                   	pop	rbp
+;;   27:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/local/materialized.wat
+++ b/winch/filetests/filetests/x64/local/materialized.wat
@@ -1,0 +1,18 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "") (param i32) (result i32)
+    local.get 0
+    local.tee 0
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c89742404           	mov	qword ptr [rsp + 4], r14
+;;   11:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   15:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;   19:	 4883c410             	add	rsp, 0x10
+;;   1d:	 5d                   	pop	rbp
+;;   1e:	 c3                   	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Winch has a bug where when setting or teeing a local, and that local is in the value stack but not at the top of the value stack, the local on the stack will pop with an incorrect value because the value of the local is determined lazily (that is, when it's needed). To address that, we can detect if the value stack contains a reference to the local that is not the top-most element, and spill registers and locals into memory if it does, which will materialize the value in the local before the value of the local is changed.