### PR TITLE
WASI wits: use 0.2.0-rc-2023-11-10

### DIFF
--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -10,9 +10,9 @@ pub mod bindings {
     wasmtime::component::bindgen!({
         path: "wit",
         interfaces: "
-            import wasi:http/incoming-handler@0.2.0-rc-2023-11-05;
-            import wasi:http/outgoing-handler@0.2.0-rc-2023-11-05;
-            import wasi:http/types@0.2.0-rc-2023-11-05;
+            import wasi:http/incoming-handler@0.2.0-rc-2023-11-10;
+            import wasi:http/outgoing-handler@0.2.0-rc-2023-11-10;
+            import wasi:http/types@0.2.0-rc-2023-11-10;
         ",
         tracing: true,
         async: false,

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -20,7 +20,7 @@ use wasmtime_wasi::preview2::{
 impl<T: WasiHttpView> crate::bindings::http::types::Host for T {
     fn http_error_code(
         &mut self,
-        _err: wasmtime::component::Resource<types::StreamError>,
+        _err: wasmtime::component::Resource<types::IoError>,
     ) -> wasmtime::Result<Option<types::ErrorCode>> {
         todo!()
     }

--- a/crates/wasi-http/wit/command-extended.wit
+++ b/crates/wasi-http/wit/command-extended.wit
@@ -1,6 +1,6 @@
 // All of the same imports and exports available in the wasi:cli/command world
 // with addition of HTTP proxy related imports:
 world command-extended {
-  include wasi:cli/command@0.2.0-rc-2023-11-05;
-  import wasi:http/outgoing-handler@0.2.0-rc-2023-11-05;
+  include wasi:cli/command@0.2.0-rc-2023-11-10;
+  import wasi:http/outgoing-handler@0.2.0-rc-2023-11-10;
 }

--- a/crates/wasi-http/wit/deps/cli/command.wit
+++ b/crates/wasi-http/wit/deps/cli/command.wit
@@ -1,4 +1,4 @@
-package wasi:cli@0.2.0-rc-2023-11-05;
+package wasi:cli@0.2.0-rc-2023-11-10;
 
 world command {
   include reactor;

--- a/crates/wasi-http/wit/deps/cli/reactor.wit
+++ b/crates/wasi-http/wit/deps/cli/reactor.wit
@@ -1,22 +1,22 @@
-package wasi:cli@0.2.0-rc-2023-11-05;
+package wasi:cli@0.2.0-rc-2023-11-10;
 
 world reactor {
-  import wasi:clocks/wall-clock@0.2.0-rc-2023-11-05;
-  import wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05;
-  import wasi:filesystem/types@0.2.0-rc-2023-11-05;
-  import wasi:filesystem/preopens@0.2.0-rc-2023-11-05;
-  import wasi:sockets/instance-network@0.2.0-rc-2023-11-05;
-  import wasi:sockets/ip-name-lookup@0.2.0-rc-2023-11-05;
-  import wasi:sockets/network@0.2.0-rc-2023-11-05;
-  import wasi:sockets/tcp-create-socket@0.2.0-rc-2023-11-05;
-  import wasi:sockets/tcp@0.2.0-rc-2023-11-05;
-  import wasi:sockets/udp-create-socket@0.2.0-rc-2023-11-05;
-  import wasi:sockets/udp@0.2.0-rc-2023-11-05;
-  import wasi:random/random@0.2.0-rc-2023-11-05;
-  import wasi:random/insecure@0.2.0-rc-2023-11-05;
-  import wasi:random/insecure-seed@0.2.0-rc-2023-11-05;
-  import wasi:io/poll@0.2.0-rc-2023-11-05;
-  import wasi:io/streams@0.2.0-rc-2023-11-05;
+  import wasi:clocks/wall-clock@0.2.0-rc-2023-11-10;
+  import wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10;
+  import wasi:filesystem/types@0.2.0-rc-2023-11-10;
+  import wasi:filesystem/preopens@0.2.0-rc-2023-11-10;
+  import wasi:sockets/instance-network@0.2.0-rc-2023-11-10;
+  import wasi:sockets/ip-name-lookup@0.2.0-rc-2023-11-10;
+  import wasi:sockets/network@0.2.0-rc-2023-11-10;
+  import wasi:sockets/tcp-create-socket@0.2.0-rc-2023-11-10;
+  import wasi:sockets/tcp@0.2.0-rc-2023-11-10;
+  import wasi:sockets/udp-create-socket@0.2.0-rc-2023-11-10;
+  import wasi:sockets/udp@0.2.0-rc-2023-11-10;
+  import wasi:random/random@0.2.0-rc-2023-11-10;
+  import wasi:random/insecure@0.2.0-rc-2023-11-10;
+  import wasi:random/insecure-seed@0.2.0-rc-2023-11-10;
+  import wasi:io/poll@0.2.0-rc-2023-11-10;
+  import wasi:io/streams@0.2.0-rc-2023-11-10;
 
   import environment;
   import exit;

--- a/crates/wasi-http/wit/deps/cli/stdio.wit
+++ b/crates/wasi-http/wit/deps/cli/stdio.wit
@@ -1,17 +1,17 @@
 interface stdin {
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream};
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream};
 
   get-stdin: func() -> input-stream;
 }
 
 interface stdout {
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{output-stream};
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
 
   get-stdout: func() -> output-stream;
 }
 
 interface stderr {
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{output-stream};
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
 
   get-stderr: func() -> output-stream;
 }

--- a/crates/wasi-http/wit/deps/clocks/monotonic-clock.wit
+++ b/crates/wasi-http/wit/deps/clocks/monotonic-clock.wit
@@ -1,3 +1,4 @@
+package wasi:clocks@0.2.0-rc-2023-11-10;
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
 ///
@@ -9,7 +10,7 @@
 ///
 /// It is intended for measuring elapsed time.
 interface monotonic-clock {
-    use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
+    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from

--- a/crates/wasi-http/wit/deps/clocks/wall-clock.wit
+++ b/crates/wasi-http/wit/deps/clocks/wall-clock.wit
@@ -1,3 +1,4 @@
+package wasi:clocks@0.2.0-rc-2023-11-10;
 /// WASI Wall Clock is a clock API intended to let users query the current
 /// time. The name "wall" makes an analogy to a "clock on the wall", which
 /// is not necessarily monotonic as it may be reset.

--- a/crates/wasi-http/wit/deps/clocks/world.wit
+++ b/crates/wasi-http/wit/deps/clocks/world.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.0-rc-2023-11-05;
+package wasi:clocks@0.2.0-rc-2023-11-10;
 
 world imports {
     import monotonic-clock;

--- a/crates/wasi-http/wit/deps/filesystem/preopens.wit
+++ b/crates/wasi-http/wit/deps/filesystem/preopens.wit
@@ -1,3 +1,5 @@
+package wasi:filesystem@0.2.0-rc-2023-11-10;
+
 interface preopens {
     use types.{descriptor};
 

--- a/crates/wasi-http/wit/deps/filesystem/types.wit
+++ b/crates/wasi-http/wit/deps/filesystem/types.wit
@@ -1,3 +1,4 @@
+package wasi:filesystem@0.2.0-rc-2023-11-10;
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
 /// significant overhead.
@@ -23,8 +24,8 @@
 ///
 /// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
 interface types {
-    use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream, error};
-    use wasi:clocks/wall-clock@0.2.0-rc-2023-11-05.{datetime};
+    use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream, error};
+    use wasi:clocks/wall-clock@0.2.0-rc-2023-11-10.{datetime};
 
     /// File size or length of a region within a file.
     type filesize = u64;

--- a/crates/wasi-http/wit/deps/filesystem/world.wit
+++ b/crates/wasi-http/wit/deps/filesystem/world.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.0-rc-2023-11-05;
+package wasi:filesystem@0.2.0-rc-2023-11-10;
 
 world imports {
     import types;

--- a/crates/wasi-http/wit/deps/http/proxy.wit
+++ b/crates/wasi-http/wit/deps/http/proxy.wit
@@ -1,4 +1,4 @@
-package wasi:http@0.2.0-rc-2023-11-05;
+package wasi:http@0.2.0-rc-2023-11-10;
 
 /// The `wasi:http/proxy` world captures a widely-implementable intersection of
 /// hosts that includes HTTP forward and reverse proxies. Components targeting
@@ -6,20 +6,20 @@ package wasi:http@0.2.0-rc-2023-11-05;
 /// outgoing HTTP requests.
 world proxy {
   /// HTTP proxies have access to time and randomness.
-  import wasi:clocks/wall-clock@0.2.0-rc-2023-11-05;
-  import wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05;
-  import wasi:random/random@0.2.0-rc-2023-11-05;
+  import wasi:clocks/wall-clock@0.2.0-rc-2023-11-10;
+  import wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10;
+  import wasi:random/random@0.2.0-rc-2023-11-10;
 
   /// Proxies have standard output and error streams which are expected to
   /// terminate in a developer-facing console provided by the host.
-  import wasi:cli/stdout@0.2.0-rc-2023-11-05;
-  import wasi:cli/stderr@0.2.0-rc-2023-11-05;
+  import wasi:cli/stdout@0.2.0-rc-2023-11-10;
+  import wasi:cli/stderr@0.2.0-rc-2023-11-10;
 
   /// TODO: this is a temporary workaround until component tooling is able to
   /// gracefully handle the absence of stdin. Hosts must return an eof stream
   /// for this import, which is what wasi-libc + tooling will do automatically
   /// when this import is properly removed.
-  import wasi:cli/stdin@0.2.0-rc-2023-11-05;
+  import wasi:cli/stdin@0.2.0-rc-2023-11-10;
 
   /// This is the default handler to use when user code simply wants to make an
   /// HTTP request (e.g., via `fetch()`).

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -2,9 +2,10 @@
 /// HTTP Requests and Responses, both incoming and outgoing, as well as
 /// their headers, trailers, and bodies.
 interface types {
-  use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05.{duration};
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream, error as stream-error};
-  use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
+  use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10.{duration};
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
+  use wasi:io/error@0.2.0-rc-2023-11-10.{error as io-error};
+  use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
   variant method {
@@ -94,17 +95,18 @@ interface types {
     field-size: option<u32>
   }
 
-  /// Attempts to extract a http-related `error` from the stream `error`
+  /// Attempts to extract a http-related `error` from the wasi:io `error`
   /// provided.
   ///
-  /// Stream operations which return `stream-error::last-operation-failed` have
-  /// a payload with more information about the operation that failed. This
-  /// payload can be passed through to this function to see if there's
-  /// http-related information about the error to return.
+  /// Stream operations which return
+  /// `wasi:io/stream/stream-error::last-operation-failed` have a payload of
+  /// type `wasi:io/error/error` with more information about the operation
+  /// that failed. This payload can be passed through to this function to see
+  /// if there's http-related information about the error to return.
   ///
-  /// Note that this function is fallible because not all stream-related errors
-  /// are http-related errors.
-  http-error-code: func(err: borrow<stream-error>) -> option<error-code>;
+  /// Note that this function is fallible because not all io-errors are
+  /// http-related errors.
+  http-error-code: func(err: borrow<io-error>) -> option<error-code>;
 
   /// This type enumerates the different kinds of errors that may occur when
   /// setting or appending to a `fields` resource.
@@ -134,12 +136,23 @@ interface types {
   /// This following block defines the `fields` resource which corresponds to
   /// HTTP standard Fields. Fields are a common representation used for both
   /// Headers and Trailers.
+  ///
+  /// A `fields` may be mutable or immutable. A `fields` created using the
+  /// constructor, `from-list`, or `clone` will be mutable, but a `fields`
+  /// resource given by other means (including, but not limited to,
+  /// `incoming-request.headers`, `outgoing-request.headers`) might be be
+  /// immutable. In an immutable fields, the `set`, `append`, and `delete`
+  /// operations will fail with `header-error.immutable`.
   resource fields {
 
     /// Construct an empty HTTP Fields.
+    ///
+    /// The resulting `fields` is mutable.
     constructor();
 
     /// Construct an HTTP Fields.
+    ///
+    /// The resulting `fields` is mutable.
     ///
     /// The list represents each key-value pair in the Fields. Keys
     /// which have multiple values are represented by multiple entries in this
@@ -161,14 +174,20 @@ interface types {
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
     set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
     delete: func(name: field-key) -> result<_, header-error>;
 
     /// Append a value for a key. Does not change or delete any existing
     /// values for that key.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
     append: func(name: field-key, value: field-value) -> result<_, header-error>;
 
     /// Retrieve the full set of keys and values in the Fields. Like the
@@ -180,7 +199,8 @@ interface types {
     entries: func() -> list<tuple<field-key,field-value>>;
 
     /// Make a deep copy of the Fields. Equivelant in behavior to calling the
-    /// `fields` constructor on the return value of `entries` 
+    /// `fields` constructor on the return value of `entries`. The resulting
+    /// `fields` is mutable.
     clone: func() -> fields;
   }
 
@@ -205,7 +225,10 @@ interface types {
     /// Returns the authority from the request, if it was present.
     authority: func() -> option<string>;
 
-    /// Returns the `headers` from the request.
+    /// Get the `headers` associated with the request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
     ///
     /// The `headers` returned are a child resource: it must be dropped before
     /// the parent `incoming-request` is dropped. Dropping this
@@ -238,7 +261,7 @@ interface types {
     /// Request.
     ///
     /// Returns success on the first call: the `outgoing-body` resource for
-    /// this `outgoing-response` can be retrieved at most once. Subsequent
+    /// this `outgoing-request` can be retrieved at most once. Subsequent
     /// calls will return error.
     body: func() -> result<outgoing-body>;
 
@@ -275,6 +298,9 @@ interface types {
     set-authority: func(authority: option<string>) -> result;
 
     /// Get the headers associated with the Request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
     ///
     /// This headers resource is a child: it must be dropped before the parent
     /// `outgoing-request` is dropped, or its ownership is transfered to
@@ -348,6 +374,12 @@ interface types {
     status: func() -> status-code;
 
     /// Returns the headers from the incoming response.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `incoming-response` is dropped.
     headers: func() -> headers;
 
     /// Returns the incoming body. May be called at most once. Returns error
@@ -409,6 +441,11 @@ interface types {
     /// as well as any trailers, were received successfully, or that an error
     /// occured receiving them. The optional `trailers` indicates whether or not
     /// trailers were present in the body.
+    ///
+    /// When some `trailers` are returned by this method, the `trailers`
+    /// resource is immutable, and a child. Use of the `set`, `append`, or
+    /// `delete` methods will return an error, and the resource must be
+    /// dropped before the parent `future-trailers` is dropped.
     get: func() -> option<result<option<trailers>, error-code>>;
   }
 
@@ -430,6 +467,9 @@ interface types {
     set-status-code: func(status-code: status-code) -> result;
 
     /// Get the headers associated with the Request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
     ///
     /// This headers resource is a child: it must be dropped before the parent
     /// `outgoing-request` is dropped, or its ownership is transfered to
@@ -477,6 +517,11 @@ interface types {
     /// called to signal that the response is complete. If the `outgoing-body`
     /// is dropped without calling `outgoing-body.finalize`, the implementation
     /// should treat the body as corrupted.
+    ///
+    /// Fails if the body's `outgoing-request` or `outgoing-response` was
+    /// constructed with a Content-Length header, and the contents written
+    /// to the body (via `write`) does not match the value given in the
+    /// Content-Length.
     finish: static func(
       this: outgoing-body,
       trailers: option<trailers>

--- a/crates/wasi-http/wit/deps/io/error.wit
+++ b/crates/wasi-http/wit/deps/io/error.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-05;
+package wasi:io@0.2.0-rc-2023-11-10;
 
 
 interface error {

--- a/crates/wasi-http/wit/deps/io/poll.wit
+++ b/crates/wasi-http/wit/deps/io/poll.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-05;
+package wasi:io@0.2.0-rc-2023-11-10;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.

--- a/crates/wasi-http/wit/deps/io/streams.wit
+++ b/crates/wasi-http/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-05;
+package wasi:io@0.2.0-rc-2023-11-10;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.

--- a/crates/wasi-http/wit/deps/io/world.wit
+++ b/crates/wasi-http/wit/deps/io/world.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-05;
+package wasi:io@0.2.0-rc-2023-11-10;
 
 world imports {
     import streams;

--- a/crates/wasi-http/wit/deps/random/insecure-seed.wit
+++ b/crates/wasi-http/wit/deps/random/insecure-seed.wit
@@ -1,3 +1,4 @@
+package wasi:random@0.2.0-rc-2023-11-10;
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi-http/wit/deps/random/insecure.wit
+++ b/crates/wasi-http/wit/deps/random/insecure.wit
@@ -1,3 +1,4 @@
+package wasi:random@0.2.0-rc-2023-11-10;
 /// The insecure interface for insecure pseudo-random numbers.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi-http/wit/deps/random/random.wit
+++ b/crates/wasi-http/wit/deps/random/random.wit
@@ -1,3 +1,4 @@
+package wasi:random@0.2.0-rc-2023-11-10;
 /// WASI Random is a random data API.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi-http/wit/deps/random/world.wit
+++ b/crates/wasi-http/wit/deps/random/world.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.0-rc-2023-11-05;
+package wasi:random@0.2.0-rc-2023-11-10;
 
 world imports {
     import random;

--- a/crates/wasi-http/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi-http/wit/deps/sockets/ip-name-lookup.wit
@@ -1,6 +1,6 @@
 
 interface ip-name-lookup {
-    use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
+    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
     use network.{network, error-code, ip-address};
 
 

--- a/crates/wasi-http/wit/deps/sockets/tcp.wit
+++ b/crates/wasi-http/wit/deps/sockets/tcp.wit
@@ -1,8 +1,8 @@
 
 interface tcp {
-    use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream};
-    use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
-    use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05.{duration};
+    use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
+    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+    use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10.{duration};
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
     enum shutdown-type {

--- a/crates/wasi-http/wit/deps/sockets/udp.wit
+++ b/crates/wasi-http/wit/deps/sockets/udp.wit
@@ -1,6 +1,6 @@
 
 interface udp {
-    use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
+    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
     /// A received datagram.

--- a/crates/wasi-http/wit/deps/sockets/world.wit
+++ b/crates/wasi-http/wit/deps/sockets/world.wit
@@ -1,4 +1,4 @@
-package wasi:sockets@0.2.0-rc-2023-11-05;
+package wasi:sockets@0.2.0-rc-2023-11-10;
 
 world imports {
     import instance-network;

--- a/crates/wasi-http/wit/test.wit
+++ b/crates/wasi-http/wit/test.wit
@@ -2,21 +2,21 @@ package wasmtime:wasi;
 
 // only used as part of `test-programs`
 world test-reactor {
-  include wasi:cli/reactor@0.2.0-rc-2023-11-05;
+  include wasi:cli/reactor@0.2.0-rc-2023-11-10;
 
   export add-strings: func(s: list<string>) -> u32;
   export get-strings: func() -> list<string>;
 
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{output-stream};
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
 
   export write-strings-to: func(o: output-stream) -> result;
 
-  use wasi:filesystem/types@0.2.0-rc-2023-11-05.{descriptor-stat};
+  use wasi:filesystem/types@0.2.0-rc-2023-11-10.{descriptor-stat};
   export pass-an-imported-record: func(d: descriptor-stat) -> string;
 }
 
 world test-command {
-  include wasi:cli/reactor@0.2.0-rc-2023-11-05;
-  import wasi:http/types@0.2.0-rc-2023-11-05;
-  import wasi:http/outgoing-handler@0.2.0-rc-2023-11-05;
+  include wasi:cli/reactor@0.2.0-rc-2023-11-10;
+  import wasi:http/types@0.2.0-rc-2023-11-10;
+  import wasi:http/outgoing-handler@0.2.0-rc-2023-11-10;
 }

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -181,7 +181,7 @@ impl Descriptors {
         }))
         .trapping_unwrap();
 
-        #[link(wasm_import_module = "wasi:filesystem/preopens@0.2.0-rc-2023-11-05")]
+        #[link(wasm_import_module = "wasi:filesystem/preopens@0.2.0-rc-2023-11-10")]
         #[allow(improper_ctypes)] // FIXME(bytecodealliance/wit-bindgen#684)
         extern "C" {
             #[link_name = "get-directories"]

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -58,7 +58,7 @@ pub mod bindings {
     });
 }
 
-#[export_name = "wasi:cli/run@0.2.0-rc-2023-11-05#run"]
+#[export_name = "wasi:cli/run@0.2.0-rc-2023-11-10#run"]
 #[cfg(feature = "command")]
 pub unsafe extern "C" fn run() -> u32 {
     #[link(wasm_import_module = "__main_module__")]
@@ -1784,7 +1784,7 @@ pub unsafe extern "C" fn poll_oneoff(
             });
         }
 
-        #[link(wasm_import_module = "wasi:io/poll@0.2.0-rc-2023-11-05")]
+        #[link(wasm_import_module = "wasi:io/poll@0.2.0-rc-2023-11-10")]
         #[allow(improper_ctypes)] // FIXME(bytecodealliance/wit-bindgen#684)
         extern "C" {
             #[link_name = "poll"]
@@ -2511,7 +2511,7 @@ impl State {
 
     fn get_environment(&self) -> &[StrTuple] {
         if self.env_vars.get().is_none() {
-            #[link(wasm_import_module = "wasi:cli/environment@0.2.0-rc-2023-11-05")]
+            #[link(wasm_import_module = "wasi:cli/environment@0.2.0-rc-2023-11-10")]
             extern "C" {
                 #[link_name = "get-environment"]
                 fn get_environment_import(rval: *mut StrTupleList);
@@ -2535,7 +2535,7 @@ impl State {
 
     fn get_args(&self) -> &[WasmStr] {
         if self.args.get().is_none() {
-            #[link(wasm_import_module = "wasi:cli/environment@0.2.0-rc-2023-11-05")]
+            #[link(wasm_import_module = "wasi:cli/environment@0.2.0-rc-2023-11-10")]
             extern "C" {
                 #[link_name = "get-arguments"]
                 fn get_args_import(rval: *mut WasmStrList);

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -68,9 +68,9 @@ pub mod bindings {
             wasmtime::component::bindgen!({
                 path: "wit",
                 interfaces: "
-                    import wasi:io/poll@0.2.0-rc-2023-11-05;
-                    import wasi:io/streams@0.2.0-rc-2023-11-05;
-                    import wasi:filesystem/types@0.2.0-rc-2023-11-05;
+                    import wasi:io/poll@0.2.0-rc-2023-11-10;
+                    import wasi:io/streams@0.2.0-rc-2023-11-10;
+                    import wasi:filesystem/types@0.2.0-rc-2023-11-10;
                 ",
                 tracing: true,
                 trappable_error_type: {

--- a/crates/wasi/wit/command-extended.wit
+++ b/crates/wasi/wit/command-extended.wit
@@ -1,6 +1,6 @@
 // All of the same imports and exports available in the wasi:cli/command world
 // with addition of HTTP proxy related imports:
 world command-extended {
-  include wasi:cli/command@0.2.0-rc-2023-11-05;
-  import wasi:http/outgoing-handler@0.2.0-rc-2023-11-05;
+  include wasi:cli/command@0.2.0-rc-2023-11-10;
+  import wasi:http/outgoing-handler@0.2.0-rc-2023-11-10;
 }

--- a/crates/wasi/wit/deps/cli/command.wit
+++ b/crates/wasi/wit/deps/cli/command.wit
@@ -1,4 +1,4 @@
-package wasi:cli@0.2.0-rc-2023-11-05;
+package wasi:cli@0.2.0-rc-2023-11-10;
 
 world command {
   include reactor;

--- a/crates/wasi/wit/deps/cli/reactor.wit
+++ b/crates/wasi/wit/deps/cli/reactor.wit
@@ -1,22 +1,22 @@
-package wasi:cli@0.2.0-rc-2023-11-05;
+package wasi:cli@0.2.0-rc-2023-11-10;
 
 world reactor {
-  import wasi:clocks/wall-clock@0.2.0-rc-2023-11-05;
-  import wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05;
-  import wasi:filesystem/types@0.2.0-rc-2023-11-05;
-  import wasi:filesystem/preopens@0.2.0-rc-2023-11-05;
-  import wasi:sockets/instance-network@0.2.0-rc-2023-11-05;
-  import wasi:sockets/ip-name-lookup@0.2.0-rc-2023-11-05;
-  import wasi:sockets/network@0.2.0-rc-2023-11-05;
-  import wasi:sockets/tcp-create-socket@0.2.0-rc-2023-11-05;
-  import wasi:sockets/tcp@0.2.0-rc-2023-11-05;
-  import wasi:sockets/udp-create-socket@0.2.0-rc-2023-11-05;
-  import wasi:sockets/udp@0.2.0-rc-2023-11-05;
-  import wasi:random/random@0.2.0-rc-2023-11-05;
-  import wasi:random/insecure@0.2.0-rc-2023-11-05;
-  import wasi:random/insecure-seed@0.2.0-rc-2023-11-05;
-  import wasi:io/poll@0.2.0-rc-2023-11-05;
-  import wasi:io/streams@0.2.0-rc-2023-11-05;
+  import wasi:clocks/wall-clock@0.2.0-rc-2023-11-10;
+  import wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10;
+  import wasi:filesystem/types@0.2.0-rc-2023-11-10;
+  import wasi:filesystem/preopens@0.2.0-rc-2023-11-10;
+  import wasi:sockets/instance-network@0.2.0-rc-2023-11-10;
+  import wasi:sockets/ip-name-lookup@0.2.0-rc-2023-11-10;
+  import wasi:sockets/network@0.2.0-rc-2023-11-10;
+  import wasi:sockets/tcp-create-socket@0.2.0-rc-2023-11-10;
+  import wasi:sockets/tcp@0.2.0-rc-2023-11-10;
+  import wasi:sockets/udp-create-socket@0.2.0-rc-2023-11-10;
+  import wasi:sockets/udp@0.2.0-rc-2023-11-10;
+  import wasi:random/random@0.2.0-rc-2023-11-10;
+  import wasi:random/insecure@0.2.0-rc-2023-11-10;
+  import wasi:random/insecure-seed@0.2.0-rc-2023-11-10;
+  import wasi:io/poll@0.2.0-rc-2023-11-10;
+  import wasi:io/streams@0.2.0-rc-2023-11-10;
 
   import environment;
   import exit;

--- a/crates/wasi/wit/deps/cli/stdio.wit
+++ b/crates/wasi/wit/deps/cli/stdio.wit
@@ -1,17 +1,17 @@
 interface stdin {
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream};
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream};
 
   get-stdin: func() -> input-stream;
 }
 
 interface stdout {
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{output-stream};
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
 
   get-stdout: func() -> output-stream;
 }
 
 interface stderr {
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{output-stream};
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
 
   get-stderr: func() -> output-stream;
 }

--- a/crates/wasi/wit/deps/clocks/monotonic-clock.wit
+++ b/crates/wasi/wit/deps/clocks/monotonic-clock.wit
@@ -1,3 +1,4 @@
+package wasi:clocks@0.2.0-rc-2023-11-10;
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
 ///
@@ -9,7 +10,7 @@
 ///
 /// It is intended for measuring elapsed time.
 interface monotonic-clock {
-    use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
+    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from

--- a/crates/wasi/wit/deps/clocks/wall-clock.wit
+++ b/crates/wasi/wit/deps/clocks/wall-clock.wit
@@ -1,3 +1,4 @@
+package wasi:clocks@0.2.0-rc-2023-11-10;
 /// WASI Wall Clock is a clock API intended to let users query the current
 /// time. The name "wall" makes an analogy to a "clock on the wall", which
 /// is not necessarily monotonic as it may be reset.

--- a/crates/wasi/wit/deps/clocks/world.wit
+++ b/crates/wasi/wit/deps/clocks/world.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.0-rc-2023-11-05;
+package wasi:clocks@0.2.0-rc-2023-11-10;
 
 world imports {
     import monotonic-clock;

--- a/crates/wasi/wit/deps/filesystem/preopens.wit
+++ b/crates/wasi/wit/deps/filesystem/preopens.wit
@@ -1,3 +1,5 @@
+package wasi:filesystem@0.2.0-rc-2023-11-10;
+
 interface preopens {
     use types.{descriptor};
 

--- a/crates/wasi/wit/deps/filesystem/types.wit
+++ b/crates/wasi/wit/deps/filesystem/types.wit
@@ -1,3 +1,4 @@
+package wasi:filesystem@0.2.0-rc-2023-11-10;
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
 /// significant overhead.
@@ -23,8 +24,8 @@
 ///
 /// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
 interface types {
-    use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream, error};
-    use wasi:clocks/wall-clock@0.2.0-rc-2023-11-05.{datetime};
+    use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream, error};
+    use wasi:clocks/wall-clock@0.2.0-rc-2023-11-10.{datetime};
 
     /// File size or length of a region within a file.
     type filesize = u64;

--- a/crates/wasi/wit/deps/filesystem/world.wit
+++ b/crates/wasi/wit/deps/filesystem/world.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.0-rc-2023-11-05;
+package wasi:filesystem@0.2.0-rc-2023-11-10;
 
 world imports {
     import types;

--- a/crates/wasi/wit/deps/http/proxy.wit
+++ b/crates/wasi/wit/deps/http/proxy.wit
@@ -1,4 +1,4 @@
-package wasi:http@0.2.0-rc-2023-11-05;
+package wasi:http@0.2.0-rc-2023-11-10;
 
 /// The `wasi:http/proxy` world captures a widely-implementable intersection of
 /// hosts that includes HTTP forward and reverse proxies. Components targeting
@@ -6,20 +6,20 @@ package wasi:http@0.2.0-rc-2023-11-05;
 /// outgoing HTTP requests.
 world proxy {
   /// HTTP proxies have access to time and randomness.
-  import wasi:clocks/wall-clock@0.2.0-rc-2023-11-05;
-  import wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05;
-  import wasi:random/random@0.2.0-rc-2023-11-05;
+  import wasi:clocks/wall-clock@0.2.0-rc-2023-11-10;
+  import wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10;
+  import wasi:random/random@0.2.0-rc-2023-11-10;
 
   /// Proxies have standard output and error streams which are expected to
   /// terminate in a developer-facing console provided by the host.
-  import wasi:cli/stdout@0.2.0-rc-2023-11-05;
-  import wasi:cli/stderr@0.2.0-rc-2023-11-05;
+  import wasi:cli/stdout@0.2.0-rc-2023-11-10;
+  import wasi:cli/stderr@0.2.0-rc-2023-11-10;
 
   /// TODO: this is a temporary workaround until component tooling is able to
   /// gracefully handle the absence of stdin. Hosts must return an eof stream
   /// for this import, which is what wasi-libc + tooling will do automatically
   /// when this import is properly removed.
-  import wasi:cli/stdin@0.2.0-rc-2023-11-05;
+  import wasi:cli/stdin@0.2.0-rc-2023-11-10;
 
   /// This is the default handler to use when user code simply wants to make an
   /// HTTP request (e.g., via `fetch()`).

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -2,9 +2,10 @@
 /// HTTP Requests and Responses, both incoming and outgoing, as well as
 /// their headers, trailers, and bodies.
 interface types {
-  use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05.{duration};
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream, error as stream-error};
-  use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
+  use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10.{duration};
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
+  use wasi:io/error@0.2.0-rc-2023-11-10.{error as io-error};
+  use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
   variant method {
@@ -94,17 +95,18 @@ interface types {
     field-size: option<u32>
   }
 
-  /// Attempts to extract a http-related `error` from the stream `error`
+  /// Attempts to extract a http-related `error` from the wasi:io `error`
   /// provided.
   ///
-  /// Stream operations which return `stream-error::last-operation-failed` have
-  /// a payload with more information about the operation that failed. This
-  /// payload can be passed through to this function to see if there's
-  /// http-related information about the error to return.
+  /// Stream operations which return
+  /// `wasi:io/stream/stream-error::last-operation-failed` have a payload of
+  /// type `wasi:io/error/error` with more information about the operation
+  /// that failed. This payload can be passed through to this function to see
+  /// if there's http-related information about the error to return.
   ///
-  /// Note that this function is fallible because not all stream-related errors
-  /// are http-related errors.
-  http-error-code: func(err: borrow<stream-error>) -> option<error-code>;
+  /// Note that this function is fallible because not all io-errors are
+  /// http-related errors.
+  http-error-code: func(err: borrow<io-error>) -> option<error-code>;
 
   /// This type enumerates the different kinds of errors that may occur when
   /// setting or appending to a `fields` resource.
@@ -134,12 +136,23 @@ interface types {
   /// This following block defines the `fields` resource which corresponds to
   /// HTTP standard Fields. Fields are a common representation used for both
   /// Headers and Trailers.
+  ///
+  /// A `fields` may be mutable or immutable. A `fields` created using the
+  /// constructor, `from-list`, or `clone` will be mutable, but a `fields`
+  /// resource given by other means (including, but not limited to,
+  /// `incoming-request.headers`, `outgoing-request.headers`) might be be
+  /// immutable. In an immutable fields, the `set`, `append`, and `delete`
+  /// operations will fail with `header-error.immutable`.
   resource fields {
 
     /// Construct an empty HTTP Fields.
+    ///
+    /// The resulting `fields` is mutable.
     constructor();
 
     /// Construct an HTTP Fields.
+    ///
+    /// The resulting `fields` is mutable.
     ///
     /// The list represents each key-value pair in the Fields. Keys
     /// which have multiple values are represented by multiple entries in this
@@ -161,14 +174,20 @@ interface types {
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
     set: func(name: field-key, value: list<field-value>) -> result<_, header-error>;
 
     /// Delete all values for a key. Does nothing if no values for the key
     /// exist.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
     delete: func(name: field-key) -> result<_, header-error>;
 
     /// Append a value for a key. Does not change or delete any existing
     /// values for that key.
+    ///
+    /// Fails with `header-error.immutable` if the `fields` are immutable.
     append: func(name: field-key, value: field-value) -> result<_, header-error>;
 
     /// Retrieve the full set of keys and values in the Fields. Like the
@@ -180,7 +199,8 @@ interface types {
     entries: func() -> list<tuple<field-key,field-value>>;
 
     /// Make a deep copy of the Fields. Equivelant in behavior to calling the
-    /// `fields` constructor on the return value of `entries` 
+    /// `fields` constructor on the return value of `entries`. The resulting
+    /// `fields` is mutable.
     clone: func() -> fields;
   }
 
@@ -205,7 +225,10 @@ interface types {
     /// Returns the authority from the request, if it was present.
     authority: func() -> option<string>;
 
-    /// Returns the `headers` from the request.
+    /// Get the `headers` associated with the request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
     ///
     /// The `headers` returned are a child resource: it must be dropped before
     /// the parent `incoming-request` is dropped. Dropping this
@@ -238,7 +261,7 @@ interface types {
     /// Request.
     ///
     /// Returns success on the first call: the `outgoing-body` resource for
-    /// this `outgoing-response` can be retrieved at most once. Subsequent
+    /// this `outgoing-request` can be retrieved at most once. Subsequent
     /// calls will return error.
     body: func() -> result<outgoing-body>;
 
@@ -275,6 +298,9 @@ interface types {
     set-authority: func(authority: option<string>) -> result;
 
     /// Get the headers associated with the Request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
     ///
     /// This headers resource is a child: it must be dropped before the parent
     /// `outgoing-request` is dropped, or its ownership is transfered to
@@ -348,6 +374,12 @@ interface types {
     status: func() -> status-code;
 
     /// Returns the headers from the incoming response.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
+    ///
+    /// This headers resource is a child: it must be dropped before the parent
+    /// `incoming-response` is dropped.
     headers: func() -> headers;
 
     /// Returns the incoming body. May be called at most once. Returns error
@@ -409,6 +441,11 @@ interface types {
     /// as well as any trailers, were received successfully, or that an error
     /// occured receiving them. The optional `trailers` indicates whether or not
     /// trailers were present in the body.
+    ///
+    /// When some `trailers` are returned by this method, the `trailers`
+    /// resource is immutable, and a child. Use of the `set`, `append`, or
+    /// `delete` methods will return an error, and the resource must be
+    /// dropped before the parent `future-trailers` is dropped.
     get: func() -> option<result<option<trailers>, error-code>>;
   }
 
@@ -430,6 +467,9 @@ interface types {
     set-status-code: func(status-code: status-code) -> result;
 
     /// Get the headers associated with the Request.
+    ///
+    /// The returned `headers` resource is immutable: `set`, `append`, and
+    /// `delete` operations will fail with `header-error.immutable`.
     ///
     /// This headers resource is a child: it must be dropped before the parent
     /// `outgoing-request` is dropped, or its ownership is transfered to
@@ -477,6 +517,11 @@ interface types {
     /// called to signal that the response is complete. If the `outgoing-body`
     /// is dropped without calling `outgoing-body.finalize`, the implementation
     /// should treat the body as corrupted.
+    ///
+    /// Fails if the body's `outgoing-request` or `outgoing-response` was
+    /// constructed with a Content-Length header, and the contents written
+    /// to the body (via `write`) does not match the value given in the
+    /// Content-Length.
     finish: static func(
       this: outgoing-body,
       trailers: option<trailers>

--- a/crates/wasi/wit/deps/io/error.wit
+++ b/crates/wasi/wit/deps/io/error.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-05;
+package wasi:io@0.2.0-rc-2023-11-10;
 
 
 interface error {

--- a/crates/wasi/wit/deps/io/poll.wit
+++ b/crates/wasi/wit/deps/io/poll.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-05;
+package wasi:io@0.2.0-rc-2023-11-10;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.

--- a/crates/wasi/wit/deps/io/streams.wit
+++ b/crates/wasi/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-05;
+package wasi:io@0.2.0-rc-2023-11-10;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.

--- a/crates/wasi/wit/deps/io/world.wit
+++ b/crates/wasi/wit/deps/io/world.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-05;
+package wasi:io@0.2.0-rc-2023-11-10;
 
 world imports {
     import streams;

--- a/crates/wasi/wit/deps/random/insecure-seed.wit
+++ b/crates/wasi/wit/deps/random/insecure-seed.wit
@@ -1,3 +1,4 @@
+package wasi:random@0.2.0-rc-2023-11-10;
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi/wit/deps/random/insecure.wit
+++ b/crates/wasi/wit/deps/random/insecure.wit
@@ -1,3 +1,4 @@
+package wasi:random@0.2.0-rc-2023-11-10;
 /// The insecure interface for insecure pseudo-random numbers.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi/wit/deps/random/random.wit
+++ b/crates/wasi/wit/deps/random/random.wit
@@ -1,3 +1,4 @@
+package wasi:random@0.2.0-rc-2023-11-10;
 /// WASI Random is a random data API.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi/wit/deps/random/world.wit
+++ b/crates/wasi/wit/deps/random/world.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.0-rc-2023-11-05;
+package wasi:random@0.2.0-rc-2023-11-10;
 
 world imports {
     import random;

--- a/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
@@ -1,6 +1,6 @@
 
 interface ip-name-lookup {
-    use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
+    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
     use network.{network, error-code, ip-address};
 
 

--- a/crates/wasi/wit/deps/sockets/tcp.wit
+++ b/crates/wasi/wit/deps/sockets/tcp.wit
@@ -1,8 +1,8 @@
 
 interface tcp {
-    use wasi:io/streams@0.2.0-rc-2023-11-05.{input-stream, output-stream};
-    use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
-    use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-05.{duration};
+    use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
+    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+    use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10.{duration};
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
     enum shutdown-type {

--- a/crates/wasi/wit/deps/sockets/udp.wit
+++ b/crates/wasi/wit/deps/sockets/udp.wit
@@ -1,6 +1,6 @@
 
 interface udp {
-    use wasi:io/poll@0.2.0-rc-2023-11-05.{pollable};
+    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
     /// A received datagram.

--- a/crates/wasi/wit/deps/sockets/world.wit
+++ b/crates/wasi/wit/deps/sockets/world.wit
@@ -1,4 +1,4 @@
-package wasi:sockets@0.2.0-rc-2023-11-05;
+package wasi:sockets@0.2.0-rc-2023-11-10;
 
 world imports {
     import instance-network;

--- a/crates/wasi/wit/test.wit
+++ b/crates/wasi/wit/test.wit
@@ -2,21 +2,21 @@ package wasmtime:wasi;
 
 // only used as part of `test-programs`
 world test-reactor {
-  include wasi:cli/reactor@0.2.0-rc-2023-11-05;
+  include wasi:cli/reactor@0.2.0-rc-2023-11-10;
 
   export add-strings: func(s: list<string>) -> u32;
   export get-strings: func() -> list<string>;
 
-  use wasi:io/streams@0.2.0-rc-2023-11-05.{output-stream};
+  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
 
   export write-strings-to: func(o: output-stream) -> result;
 
-  use wasi:filesystem/types@0.2.0-rc-2023-11-05.{descriptor-stat};
+  use wasi:filesystem/types@0.2.0-rc-2023-11-10.{descriptor-stat};
   export pass-an-imported-record: func(d: descriptor-stat) -> string;
 }
 
 world test-command {
-  include wasi:cli/reactor@0.2.0-rc-2023-11-05;
-  import wasi:http/types@0.2.0-rc-2023-11-05;
-  import wasi:http/outgoing-handler@0.2.0-rc-2023-11-05;
+  include wasi:cli/reactor@0.2.0-rc-2023-11-10;
+  import wasi:http/types@0.2.0-rc-2023-11-10;
+  import wasi:http/outgoing-handler@0.2.0-rc-2023-11-10;
 }

--- a/tests/all/cli_tests/component-basic.wat
+++ b/tests/all/cli_tests/component-basic.wat
@@ -7,6 +7,6 @@
   (func $run (result (result))
     (canon lift (core func $i "run")))
 
-  (instance (export (interface "wasi:cli/run@0.2.0-rc-2023-11-05"))
+  (instance (export (interface "wasi:cli/run@0.2.0-rc-2023-11-10"))
     (export "run" (func $run)))
 )


### PR DESCRIPTION
All WASI wits have been synchronized with RCs tagged upstream as 0.2.0-rc-2023-11-10, e.g. https://github.com/WebAssembly/wasi-http/releases/tag/v0.2.0-rc-2023-11-10

Aside from the version number in the wits, there are no interface changes, just doc comment improvements that were made as part of submitting upstream.