### PR TITLE
wasi-http: Implement http-error-code, and centralize error conversions

### DIFF
--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -17,6 +17,7 @@ pub mod bindings {
         tracing: true,
         async: false,
         with: {
+            "wasi:io/error": wasmtime_wasi::preview2::bindings::io::error,
             "wasi:io/streams": wasmtime_wasi::preview2::bindings::io::streams,
             "wasi:io/poll": wasmtime_wasi::preview2::bindings::io::poll,
 

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -20,9 +20,10 @@ use wasmtime_wasi::preview2::{
 impl<T: WasiHttpView> crate::bindings::http::types::Host for T {
     fn http_error_code(
         &mut self,
-        _err: wasmtime::component::Resource<types::IoError>,
+        err: wasmtime::component::Resource<types::IoError>,
     ) -> wasmtime::Result<Option<types::ErrorCode>> {
-        todo!()
+        let e = self.table().get(&err)?;
+        Ok(e.downcast_ref::<types::ErrorCode>().cloned())
     }
 }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -15,7 +15,8 @@ use wasmtime_wasi::preview2::{
     self, StreamError, StreamResult, Table, WasiCtx, WasiCtxBuilder, WasiView,
 };
 use wasmtime_wasi_http::{
-    bindings::http::types as http_types, body::HyperOutgoingBody, WasiHttpCtx, WasiHttpView,
+    bindings::http::types as http_types, body::HyperOutgoingBody, hyper_response_error,
+    WasiHttpCtx, WasiHttpView,
 };
 
 #[cfg(feature = "wasi-nn")]
@@ -365,16 +366,9 @@ impl hyper::service::Service<Request> for ProxyHandler {
 
             let mut store = inner.cmd.new_store(&inner.engine, req_id)?;
 
-            let req = store.data_mut().new_incoming_request(req.map(|body| {
-                body.map_err(|err| {
-                    if err.is_timeout() {
-                        http_types::ErrorCode::HttpResponseTimeout
-                    } else {
-                        http_types::ErrorCode::InternalError(Some(err.message().to_string()))
-                    }
-                })
-                .boxed()
-            }))?;
+            let req = store
+                .data_mut()
+                .new_incoming_request(req.map(|body| body.map_err(hyper_response_error).boxed()))?;
 
             let out = store.data_mut().new_response_outparam(sender)?;
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -15,8 +15,7 @@ use wasmtime_wasi::preview2::{
     self, StreamError, StreamResult, Table, WasiCtx, WasiCtxBuilder, WasiView,
 };
 use wasmtime_wasi_http::{
-    bindings::http::types as http_types, body::HyperOutgoingBody, hyper_response_error,
-    WasiHttpCtx, WasiHttpView,
+    body::HyperOutgoingBody, hyper_response_error, WasiHttpCtx, WasiHttpView,
 };
 
 #[cfg(feature = "wasi-nn")]


### PR DESCRIPTION
Implement the body of `http-error-code`, and add a test that shows its use when writing too much. This functionality was missing from #7434.

Additionally, add some functions in wasi-http for converting from hyper::Error and http::Error to the new `ErrorCode` variant. These functions log the error received as a warning, and return the translated error to the guest.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
