### PR TITLE
wasmtime: Fix RISC-V build when using clang

### DIFF
--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -8,9 +8,9 @@
 #define platform_longjmp(buf, arg) longjmp(buf, arg)
 typedef jmp_buf platform_jmp_buf;
 
-#elif defined(__clang__) && (defined(__aarch64__) || defined(__s390x__))
+#elif defined(__clang__) && (defined(__aarch64__) || defined(__s390x__) || defined(__riscv))
 
-// Clang on aarch64 and s390x doesn't support `__builtin_setjmp`, so use
+// Clang on aarch64, s390x and riscv doesn't support `__builtin_setjmp`, so use
 //`sigsetjmp` from libc.
 //
 // Note that `sigsetjmp` and `siglongjmp` are used here where possible to


### PR DESCRIPTION
👋 Hey,

As reported in [zulip](https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime/topic/Building.20for.20RISCV64.20no.20longer.20working/near/402189028), it looks like clang does not expose `__builtin_{set,long}jmp` for some platforms. This was a known issue previously for AArch64 and S390X, but it looks like it also affects RISC-V.