### PR TITLE
Remove unimplemented sockets from preview1 adapter

### DIFF
--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -3,7 +3,6 @@ use crate::bindings::wasi::cli::{
 };
 use crate::bindings::wasi::filesystem::types as filesystem;
 use crate::bindings::wasi::io::streams::{InputStream, OutputStream};
-use crate::bindings::wasi::sockets::tcp;
 use crate::{BlockingMode, BumpArena, File, ImportAlloc, TrappingUnwrap, WasmStr};
 use core::cell::{Cell, OnceCell, UnsafeCell};
 use core::mem::MaybeUninit;
@@ -93,16 +92,12 @@ impl Streams {
     }
 }
 
-#[allow(dead_code)] // until Socket is implemented
 pub enum StreamType {
     /// Streams for implementing stdio.
     Stdio(IsATTY),
 
     /// Streaming data with a file.
     File(File),
-
-    /// Streaming data with a socket connection.
-    Socket(tcp::TcpSocket),
 }
 
 pub enum IsATTY {
@@ -367,18 +362,6 @@ impl Descriptors {
             }) => Ok(file),
             Descriptor::Closed(_) => Err(wasi::ERRNO_BADF),
             _ => Err(error),
-        }
-    }
-
-    #[allow(dead_code)] // until Socket is implemented
-    pub fn get_socket(&self, fd: Fd) -> Result<&tcp::TcpSocket, Errno> {
-        match self.get(fd)? {
-            Descriptor::Streams(Streams {
-                type_: StreamType::Socket(socket),
-                ..
-            }) => Ok(&*socket),
-            Descriptor::Closed(_) => Err(wasi::ERRNO_BADF),
-            _ => Err(wasi::ERRNO_INVAL),
         }
     }
 


### PR DESCRIPTION
This commit removes the usage of wasi:sockets from the preview1 adapter. It's never been implemented but has the side effect of requiring TCP support to be imported into components even though it's never used. This commit removes the stubs in the adapter to get filled in at a later date if necessary.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
