### PR TITLE
winch: Solidify unreachable code handling

### DIFF
--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -486,4 +486,12 @@ impl ControlStackFrame {
     pub fn as_target_results(&self) -> Option<&ABIResultsData> {
         self.results()
     }
+
+    /// Returns true if the current frame is [ControlStackFrame::If].
+    pub fn is_if(&self) -> bool {
+        match self {
+            Self::If { .. } => true,
+            _ => false,
+        }
+    }
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -663,4 +663,17 @@ pub(crate) trait MacroAssembler {
 
     /// Trap if the source register is zero.
     fn trapz(&mut self, src: Reg, code: TrapCode);
+
+    /// Ensures that the stack pointer is correctly positioned before an unconditional
+    /// jump according to the requirements of the destination target.
+    fn ensure_sp_for_jump(&mut self, target: SPOffset) {
+        let bytes = self
+            .sp_offset()
+            .as_u32()
+            .checked_sub(target.as_u32())
+            .unwrap_or(0);
+        if bytes > 0 {
+            self.free_stack(bytes);
+        }
+    }
 }

--- a/winch/codegen/src/stack.rs
+++ b/winch/codegen/src/stack.rs
@@ -372,6 +372,18 @@ impl Stack {
     pub fn inner_mut(&mut self) -> &mut VecDeque<Val> {
         &mut self.inner
     }
+
+    /// Calculates the size of, in bytes, of the top n [Memory] entries
+    /// in the value stack.
+    pub fn sizeof(&self, top: usize) -> u32 {
+        self.peekn(top).fold(0, |acc, v| {
+            if v.is_mem() {
+                acc + v.unwrap_mem().slot.size
+            } else {
+                acc
+            }
+        })
+    }
 }
 
 #[cfg(test)]

--- a/winch/filetests/filetests/x64/br/br_jump.wat
+++ b/winch/filetests/filetests/x64/br/br_jump.wat
@@ -26,7 +26,6 @@
 ;;   2b:	 44891c24             	mov	dword ptr [rsp], r11d
 ;;   2f:	 4883c404             	add	rsp, 4
 ;;   33:	 e9eaffffff           	jmp	0x22
-;;   38:	 4883c404             	add	rsp, 4
-;;   3c:	 4883c410             	add	rsp, 0x10
-;;   40:	 5d                   	pop	rbp
-;;   41:	 c3                   	ret	
+;;   38:	 4883c410             	add	rsp, 0x10
+;;   3c:	 5d                   	pop	rbp
+;;   3d:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/if/reachability.wat
+++ b/winch/filetests/filetests/x64/if/reachability.wat
@@ -1,0 +1,37 @@
+;;! target = "x86_64"
+(module
+  (func (;0;) (param i32) (result i32)
+    local.get 0
+    local.get 0
+    if (result i32)
+      i32.const 1
+        return
+      else
+        i32.const 2
+      end
+      i32.sub
+  )
+  (export "main" (func 0))
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec10             	sub	rsp, 0x10
+;;    8:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;    c:	 4c893424             	mov	qword ptr [rsp], r14
+;;   10:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;   14:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;   19:	 4883ec04             	sub	rsp, 4
+;;   1d:	 44891c24             	mov	dword ptr [rsp], r11d
+;;   21:	 85c0                 	test	eax, eax
+;;   23:	 0f840e000000         	je	0x37
+;;   29:	 b801000000           	mov	eax, 1
+;;   2e:	 4883c404             	add	rsp, 4
+;;   32:	 e910000000           	jmp	0x47
+;;   37:	 b802000000           	mov	eax, 2
+;;   3c:	 8b0c24               	mov	ecx, dword ptr [rsp]
+;;   3f:	 4883c404             	add	rsp, 4
+;;   43:	 29c1                 	sub	ecx, eax
+;;   45:	 89c8                 	mov	eax, ecx
+;;   47:	 4883c410             	add	rsp, 0x10
+;;   4b:	 5d                   	pop	rbp
+;;   4c:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/loop/cont_inner.wat
+++ b/winch/filetests/filetests/x64/loop/cont_inner.wat
@@ -21,7 +21,6 @@
 ;;   23:	 4883ec04             	sub	rsp, 4
 ;;   27:	 44891c24             	mov	dword ptr [rsp], r11d
 ;;   2b:	 e9fbffffff           	jmp	0x2b
-;;   30:	 4883c404             	add	rsp, 4
-;;   34:	 4883c410             	add	rsp, 0x10
-;;   38:	 5d                   	pop	rbp
-;;   39:	 c3                   	ret	
+;;   30:	 4883c410             	add	rsp, 0x10
+;;   34:	 5d                   	pop	rbp
+;;   35:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/with_spilled_local.wat
+++ b/winch/filetests/filetests/x64/unreachable/with_spilled_local.wat
@@ -19,7 +19,6 @@
 ;;   1a:	 4883ec04             	sub	rsp, 4
 ;;   1e:	 44891c24             	mov	dword ptr [rsp], r11d
 ;;   22:	 0f0b                 	ud2	
-;;   24:	 4883c404             	add	rsp, 4
-;;   28:	 4883c410             	add	rsp, 0x10
-;;   2c:	 5d                   	pop	rbp
-;;   2d:	 c3                   	ret	
+;;   24:	 4883c410             	add	rsp, 0x10
+;;   28:	 5d                   	pop	rbp
+;;   29:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/unreachable/with_spilled_local_in_if.wat
+++ b/winch/filetests/filetests/x64/unreachable/with_spilled_local_in_if.wat
@@ -22,12 +22,11 @@
 ;;   11:	 4c893424             	mov	qword ptr [rsp], r14
 ;;   15:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;   19:	 85c0                 	test	eax, eax
-;;   1b:	 0f8413000000         	je	0x34
+;;   1b:	 0f840f000000         	je	0x30
 ;;   21:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;   26:	 4883ec04             	sub	rsp, 4
 ;;   2a:	 44891c24             	mov	dword ptr [rsp], r11d
 ;;   2e:	 0f0b                 	ud2	
-;;   30:	 4883c404             	add	rsp, 4
-;;   34:	 4883c410             	add	rsp, 0x10
-;;   38:	 5d                   	pop	rbp
-;;   39:	 c3                   	ret	
+;;   30:	 4883c410             	add	rsp, 0x10
+;;   34:	 5d                   	pop	rbp
+;;   35:	 c3                   	ret	


### PR DESCRIPTION
This commit solidifies the approach for unreachable code handling in control flow.

Prior to this change, at unconditional jump sites, the compiler would reset the machine stack as well as the value stack. Even though this appoach might seem natural at first, it actually broke several of the invariants that must be met at the end of each contol block, this was specially noticeable with programs that conditionally entered in an unreachable state, like for example

```wat
(module
  (func (;0;) (param i32) (result i32)
    local.get 0
    local.get 0
    if (result i32)
      i32.const 1
      return
    else
      i32.const 2
    end
    i32.sub
  )
  (export "main" (func 0))
)
```

The approach followed in this commit ensures that all the invariants are met and introduces more guardrails around those invariants. In short, instead of resetting the value stack at unconditional jump sites, the value stack handling is deferred until the reachability analysis restores the reachability of the code generation process, ensuring that the value stack contains the exact amount of values expected by the frame where reachability is restored. Given that unconditional jumps reset the machine stack, when the reachability of the code generation process is restored, the SP offset is also restored which should match the size of the value stack.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
