### PR TITLE
Fix memory initialization when offset is negative

### DIFF
--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -607,7 +607,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                             let memory_index = MemoryIndex::from_u32(memory_index);
                             let mut offset_expr_reader = offset_expr.get_binary_reader();
                             let (base, offset) = match offset_expr_reader.read_operator()? {
-                                Operator::I32Const { value } => (None, value as u64),
+                                Operator::I32Const { value } => (None, (value as u32).into()),
                                 Operator::I64Const { value } => (None, value as u64),
                                 Operator::GlobalGet { global_index } => {
                                     (Some(GlobalIndex::from_u32(global_index)), 0)

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -642,3 +642,21 @@ fn shared_memory_wait_notify() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn init_with_negative_segment() -> Result<()> {
+    let engine = Engine::default();
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (memory 65536)
+                (data (i32.const 0x8000_0000) "x")
+            )
+        "#,
+    )?;
+    let mut store = Store::new(&engine, ());
+    Instance::new(&mut store, &module, &[])?;
+    Ok(())
+}


### PR DESCRIPTION
This commit fixes a bug in initializing memory segments of 32-bit memories where if the offset was negative when viewed as a signed integer the offset was incorrectly sign-extended to a 64-bit value instead of zero-extended. This commit replaces an `i32`-to-`u64` cast with an `i32`-to-`u32` cast followed by a `u32`-to-`u64` cast which performs the zero extend.

Closes #7558

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
