### PR TITLE
Configure workspace lints, enable running some Clippy lints on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -316,6 +316,10 @@ jobs:
     - run: cargo install --root ${{ runner.tool_cache }}/cargo-ndk --version ${{ env.CARGO_NDK_VERSION }} cargo-ndk
     - run: cargo ndk -t arm64-v8a check -p wasmtime
 
+    # Run clippy configuration
+    - run: rustup component add clippy
+    - run: cargo clippy --workspace
+
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}
       if: failure() && github.event_name != 'pull_request'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4181,7 +4181,6 @@ version = "0.9.1"
 dependencies = [
  "anyhow",
  "log",
- "rayon",
  "thiserror",
  "wast 35.0.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,9 @@ trivial_numeric_casts = 'warn'
 unstable_features = 'warn'
 unused_import_braces = 'warn'
 
+[workspace.lints.clippy]
+all = 'allow'
+
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
 wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=16.0.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ rust-version = "1.72.0"
 [workspace.lints.rust]
 unused_extern_crates = 'warn'
 trivial_numeric_casts = 'warn'
+unstable_features = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ rust-version = "1.72.0"
 
 [workspace.lints.rust]
 unused_extern_crates = 'deny'
+trivial_numeric_casts = 'deny'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,8 +135,8 @@ edition = "2021"
 rust-version = "1.72.0"
 
 [workspace.lints.rust]
-unused_extern_crates = 'deny'
-trivial_numeric_casts = 'deny'
+unused_extern_crates = 'warn'
+trivial_numeric_casts = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ rust-version = "1.72.0"
 unused_extern_crates = 'warn'
 trivial_numeric_casts = 'warn'
 unstable_features = 'warn'
+unused_import_braces = 'warn'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,12 +135,16 @@ edition = "2021"
 rust-version = "1.72.0"
 
 [workspace.lints.rust]
+# Turn on some lints which are otherwise allow-by-default in rustc.
 unused_extern_crates = 'warn'
 trivial_numeric_casts = 'warn'
 unstable_features = 'warn'
 unused_import_braces = 'warn'
 
 [workspace.lints.clippy]
+# The default set of lints in Clippy is viewed as "too noisy" right now so
+# they're all turned off by default. Selective lints are then enabled below as
+# necessary.
 all = 'allow'
 
 [workspace.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,8 @@ edition = "2021"
 # current stable release of Rust minus 2.
 rust-version = "1.72.0"
 
+[workspace.lints.rust]
+unused_extern_crates = 'deny'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ edition.workspace = true
 default-run = "wasmtime"
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 doctest = false
 
@@ -119,6 +122,7 @@ members = [
 ]
 exclude = [
   'crates/wasi-common/WASI/tools/witx-cli',
+  'crates/wasi-common/WASI/tools/witx',
   'docs/rust_wasi_markdown_parser',
 ]
 
@@ -129,6 +133,7 @@ edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
 rust-version = "1.72.0"
+
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }

--- a/cranelift/Cargo.toml
+++ b/cranelift/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 publish = false
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "clif-util"
 path = "src/clif-util.rs"

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -11,5 +11,8 @@ readme = "README.md"
 keywords = ["btree", "forest", "set", "map"]
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 cranelift-entity = { workspace = true }

--- a/cranelift/bforest/src/lib.rs
+++ b/cranelift/bforest/src/lib.rs
@@ -13,7 +13,7 @@
 //! - Empty trees have a very small 32-bit footprint.
 //! - All the trees in a forest can be cleared in constant time.
 
-#![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
+#![deny(missing_docs, trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 #![no_std]
 

--- a/cranelift/bforest/src/lib.rs
+++ b/cranelift/bforest/src/lib.rs
@@ -13,7 +13,7 @@
 //! - Empty trees have a very small 32-bit footprint.
 //! - All the trees in a forest can be cleared in constant time.
 
-#![deny(missing_docs, trivial_numeric_casts)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 #![no_std]
 

--- a/cranelift/bforest/src/lib.rs
+++ b/cranelift/bforest/src/lib.rs
@@ -14,7 +14,6 @@
 //! - All the trees in a forest can be cleared in constant time.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 #![no_std]
 
 #[cfg(test)]

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -12,6 +12,9 @@ keywords = ["compile", "compiler", "jit"]
 build = "build.rs"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 rustdoc-args = [ "--document-private-items" ]
 

--- a/cranelift/codegen/shared/src/lib.rs
+++ b/cranelift/codegen/shared/src/lib.rs
@@ -2,7 +2,6 @@
 //! `cranelift-codegen-meta` libraries.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 
 pub mod constant_hash;
 pub mod constants;

--- a/cranelift/codegen/shared/src/lib.rs
+++ b/cranelift/codegen/shared/src/lib.rs
@@ -1,7 +1,7 @@
 //! This library contains code that is common to both the `cranelift-codegen` and
 //! `cranelift-codegen-meta` libraries.
 
-#![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
+#![deny(missing_docs, trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
 

--- a/cranelift/codegen/shared/src/lib.rs
+++ b/cranelift/codegen/shared/src/lib.rs
@@ -3,7 +3,6 @@
 
 #![deny(missing_docs)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "std", deny(unstable_features))]
 
 pub mod constant_hash;
 pub mod constants;

--- a/cranelift/codegen/shared/src/lib.rs
+++ b/cranelift/codegen/shared/src/lib.rs
@@ -1,7 +1,7 @@
 //! This library contains code that is common to both the `cranelift-codegen` and
 //! `cranelift-codegen-meta` libraries.
 
-#![deny(missing_docs, trivial_numeric_casts)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
 

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -1,5 +1,5 @@
 //! Cranelift code generation library.
-#![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
+#![deny(missing_docs, trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -1,5 +1,5 @@
 //! Cranelift code generation library.
-#![deny(missing_docs, trivial_numeric_casts)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -1,6 +1,5 @@
 //! Cranelift code generation library.
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 #![no_std]
 // Various bits and pieces of this crate might only be used for one platform or
 // another, but it's not really too useful to learn about that all the time. On

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -1,7 +1,6 @@
 //! Cranelift code generation library.
 #![deny(missing_docs)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]
 // Various bits and pieces of this crate might only be used for one platform or
 // another, but it's not really too useful to learn about that all the time. On

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 keywords = ["entity", "set", "map"]
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 serde = { version = "1.0.188", optional = true }
 serde_derive = { version = "1.0.188", optional = true }

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -30,7 +30,6 @@
 //!   `Vec`.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 #![no_std]
 
 extern crate alloc;

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -29,7 +29,7 @@
 //!   references allocated from an associated memory pool. It has a much smaller footprint than
 //!   `Vec`.
 
-#![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
+#![deny(missing_docs, trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 #![no_std]
 

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -29,7 +29,7 @@
 //!   references allocated from an associated memory pool. It has a much smaller footprint than
 //!   `Vec`.
 
-#![deny(missing_docs, trivial_numeric_casts)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 #![no_std]
 

--- a/cranelift/entity/src/lib.rs
+++ b/cranelift/entity/src/lib.rs
@@ -202,6 +202,7 @@ mod map;
 mod primary;
 mod set;
 mod sparse;
+mod unsigned;
 
 pub use self::boxed_slice::BoxedSlice;
 pub use self::iter::{Iter, IterMut};
@@ -211,6 +212,7 @@ pub use self::map::SecondaryMap;
 pub use self::primary::PrimaryMap;
 pub use self::set::EntitySet;
 pub use self::sparse::{SparseMap, SparseMapValue, SparseSet};
+pub use self::unsigned::Unsigned;
 
 /// A collection of tests to ensure that use of the different `entity_impl!` forms will generate
 /// `EntityRef` implementations that behave the same way.

--- a/cranelift/entity/src/unsigned.rs
+++ b/cranelift/entity/src/unsigned.rs
@@ -1,0 +1,71 @@
+/// Helper trait used to add `unsigned()` methods to primitive signed integer
+/// types.
+///
+/// The purpose of this trait is to signal the intent that the sign bit of a
+/// signed integer is intended to be discarded and the value is instead
+/// understood to be a "bag of bits" where the conversion to an unsigned number
+/// is intended to be lossless. This can be used for example when converting a
+/// signed integer into a larger width with zero-extension.
+pub trait Unsigned {
+    /// The unsigned integer for this type which has the same width.
+    type Unsigned;
+
+    /// View this signed integer as an unsigned integer of the same width.
+    ///
+    /// All bits are preserved.
+    fn unsigned(self) -> Self::Unsigned;
+}
+
+impl Unsigned for i8 {
+    type Unsigned = u8;
+
+    #[inline]
+    fn unsigned(self) -> u8 {
+        self as u8
+    }
+}
+
+impl Unsigned for i16 {
+    type Unsigned = u16;
+
+    #[inline]
+    fn unsigned(self) -> u16 {
+        self as u16
+    }
+}
+
+impl Unsigned for i32 {
+    type Unsigned = u32;
+
+    #[inline]
+    fn unsigned(self) -> u32 {
+        self as u32
+    }
+}
+
+impl Unsigned for i64 {
+    type Unsigned = u64;
+
+    #[inline]
+    fn unsigned(self) -> u64 {
+        self as u64
+    }
+}
+
+impl Unsigned for i128 {
+    type Unsigned = u128;
+
+    #[inline]
+    fn unsigned(self) -> u128 {
+        self as u128
+    }
+}
+
+impl Unsigned for isize {
+    type Unsigned = usize;
+
+    #[inline]
+    fn unsigned(self) -> usize {
+        self as usize
+    }
+}

--- a/cranelift/filetests/Cargo.toml
+++ b/cranelift/filetests/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 publish = false
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 cranelift-codegen = { workspace = true, features = ["disas"] }
 cranelift-frontend = { workspace = true }

--- a/cranelift/filetests/src/lib.rs
+++ b/cranelift/filetests/src/lib.rs
@@ -4,7 +4,6 @@
 //! available filetest commands.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 
 pub use crate::function_runner::TestFileCompiler;
 use crate::runner::TestRunner;

--- a/cranelift/filetests/src/lib.rs
+++ b/cranelift/filetests/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate contains the main test driver as well as implementations of the
 //! available filetest commands.
 
-#![deny(missing_docs, unstable_features)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 
 pub use crate::function_runner::TestFileCompiler;

--- a/cranelift/filetests/src/lib.rs
+++ b/cranelift/filetests/src/lib.rs
@@ -3,12 +3,7 @@
 //! This crate contains the main test driver as well as implementations of the
 //! available filetest commands.
 
-#![deny(
-    missing_docs,
-    trivial_numeric_casts,
-    unused_extern_crates,
-    unstable_features
-)]
+#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
 #![warn(unused_import_braces)]
 
 pub use crate::function_runner::TestFileCompiler;

--- a/cranelift/filetests/src/lib.rs
+++ b/cranelift/filetests/src/lib.rs
@@ -3,7 +3,7 @@
 //! This crate contains the main test driver as well as implementations of the
 //! available filetest commands.
 
-#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
+#![deny(missing_docs, unstable_features)]
 #![warn(unused_import_braces)]
 
 pub use crate::function_runner::TestFileCompiler;

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 cranelift-codegen = { workspace = true }
 target-lexicon = { workspace = true }

--- a/cranelift/frontend/src/lib.rs
+++ b/cranelift/frontend/src/lib.rs
@@ -160,7 +160,7 @@
 //! }
 //! ```
 
-#![deny(missing_docs, trivial_numeric_casts)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]

--- a/cranelift/frontend/src/lib.rs
+++ b/cranelift/frontend/src/lib.rs
@@ -161,7 +161,6 @@
 //! ```
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 #![no_std]
 
 #[allow(unused_imports)] // #[macro_use] is required for no_std

--- a/cranelift/frontend/src/lib.rs
+++ b/cranelift/frontend/src/lib.rs
@@ -162,7 +162,6 @@
 
 #![deny(missing_docs)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]
 
 #[allow(unused_imports)] // #[macro_use] is required for no_std

--- a/cranelift/frontend/src/lib.rs
+++ b/cranelift/frontend/src/lib.rs
@@ -160,7 +160,7 @@
 //! }
 //! ```
 
-#![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
+#![deny(missing_docs, trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]

--- a/cranelift/fuzzgen/Cargo.toml
+++ b/cranelift/fuzzgen/Cargo.toml
@@ -9,6 +9,8 @@ readme = "README.md"
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
 
 [dependencies]
 cranelift = { workspace = true }

--- a/cranelift/fuzzgen/src/function_generator.rs
+++ b/cranelift/fuzzgen/src/function_generator.rs
@@ -1401,7 +1401,7 @@ where
             DataValue::I8(i) => builder.ins().iconst(ty, i as u8 as i64),
             DataValue::I16(i) => builder.ins().iconst(ty, i as u16 as i64),
             DataValue::I32(i) => builder.ins().iconst(ty, i as u32 as i64),
-            DataValue::I64(i) => builder.ins().iconst(ty, i as i64),
+            DataValue::I64(i) => builder.ins().iconst(ty, i),
             DataValue::I128(i) => {
                 let hi = builder.ins().iconst(I64, (i >> 64) as i64);
                 let lo = builder.ins().iconst(I64, i as i64);

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -10,6 +10,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 cranelift-codegen = { workspace = true }
 cranelift-entity = { workspace = true }

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -1075,7 +1075,7 @@ where
             let overflow = if is_signed {
                 x < (min as i128) || x > (max as i128)
             } else {
-                x < 0 || (x as u128) > (max as u128)
+                x < 0 || (x as u128) > max
             };
             // bounds check
             if overflow {
@@ -1102,7 +1102,7 @@ where
                         x
                     } else {
                         let x = if x < 0 { 0 } else { x };
-                        let x = u128::min(x as u128, max as u128);
+                        let x = u128::min(x as u128, max);
                         x as i128
                     };
 

--- a/cranelift/interpreter/src/value.rs
+++ b/cranelift/interpreter/src/value.rs
@@ -1,6 +1,8 @@
 //! The [DataValueExt] trait is an extension trait for [DataValue]. It provides a lot of functions
 //! used by the rest of the interpreter.
 
+#![allow(trivial_numeric_casts)]
+
 use core::convert::TryFrom;
 use core::fmt::{self, Display, Formatter};
 use cranelift_codegen::data_value::{DataValue, DataValueCastFailure};

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -8,6 +8,9 @@ readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
 version = "0.103.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 codespan-reporting = { version = "0.11.1", optional = true }
 log = { workspace = true, optional = true }

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 cranelift-module = { workspace = true }
 cranelift-native = { workspace = true }

--- a/cranelift/jit/src/lib.rs
+++ b/cranelift/jit/src/lib.rs
@@ -3,12 +3,7 @@
 //! There is an [example project](https://github.com/bytecodealliance/cranelift-jit-demo/)
 //! which shows how to use some of the features of `cranelift_jit`.
 
-#![deny(
-    missing_docs,
-    trivial_numeric_casts,
-    unstable_features,
-    unreachable_pub
-)]
+#![deny(missing_docs, unstable_features, unreachable_pub)]
 #![warn(unused_import_braces)]
 
 mod backend;

--- a/cranelift/jit/src/lib.rs
+++ b/cranelift/jit/src/lib.rs
@@ -6,7 +6,6 @@
 #![deny(
     missing_docs,
     trivial_numeric_casts,
-    unused_extern_crates,
     unstable_features,
     unreachable_pub
 )]

--- a/cranelift/jit/src/lib.rs
+++ b/cranelift/jit/src/lib.rs
@@ -3,7 +3,7 @@
 //! There is an [example project](https://github.com/bytecodealliance/cranelift-jit-demo/)
 //! which shows how to use some of the features of `cranelift_jit`.
 
-#![deny(missing_docs, unstable_features, unreachable_pub)]
+#![deny(missing_docs, unreachable_pub)]
 #![warn(unused_import_braces)]
 
 mod backend;

--- a/cranelift/jit/src/lib.rs
+++ b/cranelift/jit/src/lib.rs
@@ -4,7 +4,6 @@
 //! which shows how to use some of the features of `cranelift_jit`.
 
 #![deny(missing_docs, unreachable_pub)]
-#![warn(unused_import_braces)]
 
 mod backend;
 mod compiled_blob;

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -10,6 +10,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 cranelift-codegen = { workspace = true }
 cranelift-control = { workspace = true }

--- a/cranelift/module/src/lib.rs
+++ b/cranelift/module/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![deny(missing_docs)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]
 
 #[cfg(not(feature = "std"))]

--- a/cranelift/module/src/lib.rs
+++ b/cranelift/module/src/lib.rs
@@ -1,7 +1,6 @@
 //! Top-level lib.rs for `cranelift_module`.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 #![no_std]
 
 #[cfg(not(feature = "std"))]

--- a/cranelift/module/src/lib.rs
+++ b/cranelift/module/src/lib.rs
@@ -1,6 +1,6 @@
 //! Top-level lib.rs for `cranelift_module`.
 
-#![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
+#![deny(missing_docs, trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]

--- a/cranelift/module/src/lib.rs
+++ b/cranelift/module/src/lib.rs
@@ -1,6 +1,6 @@
 //! Top-level lib.rs for `cranelift_module`.
 
-#![deny(missing_docs, trivial_numeric_casts)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -1,7 +1,7 @@
 //! Performs autodetection of the host for the purposes of running
 //! Cranelift to generate code to run on the same machine.
 
-#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
+#![deny(missing_docs, unstable_features)]
 #![warn(unused_import_braces)]
 
 use cranelift_codegen::isa;

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -2,7 +2,6 @@
 //! Cranelift to generate code to run on the same machine.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 
 use cranelift_codegen::isa;
 use cranelift_codegen::settings::Configurable;

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -1,12 +1,7 @@
 //! Performs autodetection of the host for the purposes of running
 //! Cranelift to generate code to run on the same machine.
 
-#![deny(
-    missing_docs,
-    trivial_numeric_casts,
-    unused_extern_crates,
-    unstable_features
-)]
+#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
 #![warn(unused_import_braces)]
 
 use cranelift_codegen::isa;

--- a/cranelift/native/src/lib.rs
+++ b/cranelift/native/src/lib.rs
@@ -1,7 +1,7 @@
 //! Performs autodetection of the host for the purposes of running
 //! Cranelift to generate code to run on the same machine.
 
-#![deny(missing_docs, unstable_features)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 
 use cranelift_codegen::isa;

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 readme = "README.md"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 cranelift-module = { workspace = true }
 cranelift-codegen = { workspace = true, features = ["std"] }

--- a/cranelift/object/src/lib.rs
+++ b/cranelift/object/src/lib.rs
@@ -3,7 +3,6 @@
 //! This re-exports `object` so you don't have to explicitly keep the versions in sync.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 
 mod backend;
 

--- a/cranelift/object/src/lib.rs
+++ b/cranelift/object/src/lib.rs
@@ -2,12 +2,7 @@
 //!
 //! This re-exports `object` so you don't have to explicitly keep the versions in sync.
 
-#![deny(
-    missing_docs,
-    trivial_numeric_casts,
-    unused_extern_crates,
-    unstable_features
-)]
+#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
 #![warn(unused_import_braces)]
 
 mod backend;

--- a/cranelift/object/src/lib.rs
+++ b/cranelift/object/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This re-exports `object` so you don't have to explicitly keep the versions in sync.
 
-#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
+#![deny(missing_docs, unstable_features)]
 #![warn(unused_import_braces)]
 
 mod backend;

--- a/cranelift/object/src/lib.rs
+++ b/cranelift/object/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This re-exports `object` so you don't have to explicitly keep the versions in sync.
 
-#![deny(missing_docs, unstable_features)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 
 mod backend;

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -9,6 +9,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow.workspace = true
 cranelift-codegen = { workspace = true }

--- a/cranelift/reader/src/lib.rs
+++ b/cranelift/reader/src/lib.rs
@@ -3,7 +3,7 @@
 //! The `cranelift_reader` library supports reading .clif files. This functionality is needed for
 //! testing Cranelift, but is not essential for a JIT compiler.
 
-#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
+#![deny(missing_docs, unstable_features)]
 #![warn(unused_import_braces)]
 
 pub use crate::error::{Location, ParseError, ParseResult};

--- a/cranelift/reader/src/lib.rs
+++ b/cranelift/reader/src/lib.rs
@@ -3,12 +3,7 @@
 //! The `cranelift_reader` library supports reading .clif files. This functionality is needed for
 //! testing Cranelift, but is not essential for a JIT compiler.
 
-#![deny(
-    missing_docs,
-    trivial_numeric_casts,
-    unused_extern_crates,
-    unstable_features
-)]
+#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
 #![warn(unused_import_braces)]
 
 pub use crate::error::{Location, ParseError, ParseResult};

--- a/cranelift/reader/src/lib.rs
+++ b/cranelift/reader/src/lib.rs
@@ -3,7 +3,7 @@
 //! The `cranelift_reader` library supports reading .clif files. This functionality is needed for
 //! testing Cranelift, but is not essential for a JIT compiler.
 
-#![deny(missing_docs, unstable_features)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 
 pub use crate::error::{Location, ParseError, ParseResult};

--- a/cranelift/reader/src/lib.rs
+++ b/cranelift/reader/src/lib.rs
@@ -4,7 +4,6 @@
 //! testing Cranelift, but is not essential for a JIT compiler.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 
 pub use crate::error::{Location, ParseError, ParseResult};
 pub use crate::isaspec::{parse_option, parse_options, IsaSpec, ParseOptionError};

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 keywords = ["webassembly", "serde"]
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "clif-json"
 path = "src/clif-json.rs"

--- a/cranelift/serde/src/clif-json.rs
+++ b/cranelift/serde/src/clif-json.rs
@@ -1,6 +1,6 @@
 //! Utility for `cranelift_serde`.
 
-#![deny(missing_docs, unstable_features)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 
 use clap::Parser;

--- a/cranelift/serde/src/clif-json.rs
+++ b/cranelift/serde/src/clif-json.rs
@@ -1,6 +1,6 @@
 //! Utility for `cranelift_serde`.
 
-#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
+#![deny(missing_docs, unstable_features)]
 #![warn(unused_import_braces)]
 
 use clap::Parser;

--- a/cranelift/serde/src/clif-json.rs
+++ b/cranelift/serde/src/clif-json.rs
@@ -1,7 +1,6 @@
 //! Utility for `cranelift_serde`.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 
 use clap::Parser;
 use cranelift_codegen::ir::Function;

--- a/cranelift/serde/src/clif-json.rs
+++ b/cranelift/serde/src/clif-json.rs
@@ -1,11 +1,6 @@
 //! Utility for `cranelift_serde`.
 
-#![deny(
-    missing_docs,
-    trivial_numeric_casts,
-    unused_extern_crates,
-    unstable_features
-)]
+#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
 #![warn(unused_import_braces)]
 
 use clap::Parser;

--- a/cranelift/src/clif-util.rs
+++ b/cranelift/src/clif-util.rs
@@ -1,5 +1,3 @@
-#![warn(unused_import_braces)]
-
 use clap::Parser;
 use std::path::PathBuf;
 

--- a/cranelift/src/clif-util.rs
+++ b/cranelift/src/clif-util.rs
@@ -1,5 +1,5 @@
 #![deny(trivial_numeric_casts)]
-#![warn(unused_import_braces, unstable_features, unused_extern_crates)]
+#![warn(unused_import_braces, unstable_features)]
 
 use clap::Parser;
 use std::path::PathBuf;

--- a/cranelift/src/clif-util.rs
+++ b/cranelift/src/clif-util.rs
@@ -1,4 +1,3 @@
-#![deny(trivial_numeric_casts)]
 #![warn(unused_import_braces, unstable_features)]
 
 use clap::Parser;

--- a/cranelift/src/clif-util.rs
+++ b/cranelift/src/clif-util.rs
@@ -1,4 +1,4 @@
-#![warn(unused_import_braces, unstable_features)]
+#![warn(unused_import_braces)]
 
 use clap::Parser;
 use std::path::PathBuf;

--- a/cranelift/umbrella/src/lib.rs
+++ b/cranelift/umbrella/src/lib.rs
@@ -1,6 +1,6 @@
 //! Cranelift umbrella crate, providing a convenient one-line dependency.
 
-#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
+#![deny(missing_docs, unstable_features)]
 #![warn(unused_import_braces)]
 #![no_std]
 

--- a/cranelift/umbrella/src/lib.rs
+++ b/cranelift/umbrella/src/lib.rs
@@ -1,11 +1,6 @@
 //! Cranelift umbrella crate, providing a convenient one-line dependency.
 
-#![deny(
-    missing_docs,
-    trivial_numeric_casts,
-    unused_extern_crates,
-    unstable_features
-)]
+#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
 #![warn(unused_import_braces)]
 #![no_std]
 

--- a/cranelift/umbrella/src/lib.rs
+++ b/cranelift/umbrella/src/lib.rs
@@ -1,6 +1,6 @@
 //! Cranelift umbrella crate, providing a convenient one-line dependency.
 
-#![deny(missing_docs, unstable_features)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 #![no_std]
 

--- a/cranelift/umbrella/src/lib.rs
+++ b/cranelift/umbrella/src/lib.rs
@@ -1,7 +1,6 @@
 //! Cranelift umbrella crate, providing a convenient one-line dependency.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 #![no_std]
 
 /// Provide these crates, renamed to reduce stutter.

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 keywords = ["webassembly", "wasm"]
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 wasmparser = { workspace = true }
 cranelift-codegen = { workspace = true }

--- a/cranelift/wasm/src/lib.rs
+++ b/cranelift/wasm/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! The main function of this module is [`translate_module`](fn.translate_module.html).
 
-#![deny(missing_docs, trivial_numeric_casts)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]

--- a/cranelift/wasm/src/lib.rs
+++ b/cranelift/wasm/src/lib.rs
@@ -11,7 +11,6 @@
 
 #![deny(missing_docs)]
 #![warn(unused_import_braces)]
-#![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]
 
 #[cfg(not(feature = "std"))]

--- a/cranelift/wasm/src/lib.rs
+++ b/cranelift/wasm/src/lib.rs
@@ -10,7 +10,6 @@
 //! The main function of this module is [`translate_module`](fn.translate_module.html).
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 #![no_std]
 
 #[cfg(not(feature = "std"))]

--- a/cranelift/wasm/src/lib.rs
+++ b/cranelift/wasm/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! The main function of this module is [`translate_module`](fn.translate_module.html).
 
-#![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
+#![deny(missing_docs, trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 #![cfg_attr(feature = "std", deny(unstable_features))]
 #![no_std]

--- a/crates/bench-api/Cargo.toml
+++ b/crates/bench-api/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [lib]
 name = "wasmtime_bench_api"
 crate-type = ["cdylib"]

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [lib]
 name = "wamstime_c_api"
 doc = false

--- a/crates/c-api/macros/Cargo.toml
+++ b/crates/c-api/macros/Cargo.toml
@@ -6,6 +6,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 test = false

--- a/crates/c-api/macros/src/lib.rs
+++ b/crates/c-api/macros/src/lib.rs
@@ -3,8 +3,6 @@
 //! These are intended to mirror the macros in the `wasm.h` header file and
 //! largely facilitate the `declare_ref` macro.
 
-extern crate proc_macro;
-
 use proc_macro2::{Ident, TokenStream, TokenTree};
 use quote::quote;
 

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-cache/"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 base64 = "0.21.0"

--- a/crates/cli-flags/Cargo.toml
+++ b/crates/cli-flags/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-cache/"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -1,6 +1,6 @@
 //! Contains the common Wasmtime command line interface (CLI) flags.
 
-#![deny(trivial_numeric_casts, unstable_features)]
+#![deny(unstable_features)]
 #![warn(unused_import_braces)]
 
 use anyhow::Result;

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -1,7 +1,5 @@
 //! Contains the common Wasmtime command line interface (CLI) flags.
 
-#![warn(unused_import_braces)]
-
 use anyhow::Result;
 use clap::Parser;
 use std::time::Duration;

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -1,6 +1,6 @@
 //! Contains the common Wasmtime command line interface (CLI) flags.
 
-#![deny(trivial_numeric_casts, unused_extern_crates, unstable_features)]
+#![deny(trivial_numeric_casts, unstable_features)]
 #![warn(unused_import_braces)]
 
 use anyhow::Result;

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -1,6 +1,5 @@
 //! Contains the common Wasmtime command line interface (CLI) flags.
 
-#![deny(unstable_features)]
 #![warn(unused_import_braces)]
 
 use anyhow::Result;

--- a/crates/component-macro/Cargo.toml
+++ b/crates/component-macro/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 test = false

--- a/crates/component-macro/test-helpers/Cargo.toml
+++ b/crates/component-macro/test-helpers/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 publish = false
 license = "Apache-2.0 WITH LLVM-exception"
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 test = false

--- a/crates/cranelift-shared/Cargo.toml
+++ b/crates/cranelift-shared/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-cranelift-shared/"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 wasmtime-environ = { workspace = true }

--- a/crates/cranelift/Cargo.toml
+++ b/crates/cranelift/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 log = { workspace = true }

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -1,3 +1,5 @@
+#![allow(trivial_numeric_casts)]
+
 use super::address_transform::AddressTransform;
 use crate::debug::ModuleMemoryOffset;
 use anyhow::{Context, Error, Result};

--- a/crates/cranelift/src/debug/transform/simulate.rs
+++ b/crates/cranelift/src/debug/transform/simulate.rs
@@ -70,7 +70,7 @@ fn generate_line_info(
             out_program.row().address_offset = address_offset;
             out_program.row().op_index = 0;
             out_program.row().file = file_index;
-            let wasm_offset = w.code_section_offset + addr_map.wasm as u64;
+            let wasm_offset = w.code_section_offset + addr_map.wasm;
             out_program.row().line = wasm_offset;
             out_program.row().column = 0;
             out_program.row().discriminator = 1;
@@ -363,7 +363,7 @@ pub fn generate_simulated_dwarf(
         );
         die.set(
             gimli::DW_AT_high_pc,
-            write::AttributeValue::Udata((end - start) as u64),
+            write::AttributeValue::Udata(end - start),
         );
 
         let func_index = imported_func_count + (index as u32);
@@ -383,7 +383,7 @@ pub fn generate_simulated_dwarf(
         );
 
         let f_start = map.addresses[0].wasm;
-        let wasm_offset = di.wasm_file.code_section_offset + f_start as u64;
+        let wasm_offset = di.wasm_file.code_section_offset + f_start;
         die.set(
             gimli::DW_AT_decl_file,
             write::AttributeValue::Udata(wasm_offset),

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -10,6 +10,9 @@ categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 cranelift-entity = { workspace = true }

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -3,7 +3,7 @@
 //! the translation the base addresses of regions of memory that will hold the globals, tables and
 //! linear memories.
 
-#![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
+#![deny(missing_docs, trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 
 mod address_map;

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -4,7 +4,6 @@
 //! linear memories.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 
 mod address_map;
 mod builtin;

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -4,6 +4,7 @@
 //! linear memories.
 
 #![deny(missing_docs)]
+#![warn(clippy::cast_sign_loss)]
 
 mod address_map;
 mod builtin;

--- a/crates/environ/src/lib.rs
+++ b/crates/environ/src/lib.rs
@@ -3,7 +3,7 @@
 //! the translation the base addresses of regions of memory that will hold the globals, tables and
 //! linear memories.
 
-#![deny(missing_docs, trivial_numeric_casts)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 
 mod address_map;

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -5,8 +5,8 @@ use crate::module::{
 use crate::{
     DataIndex, DefinedFuncIndex, ElemIndex, EntityIndex, EntityType, FuncIndex, GlobalIndex,
     GlobalInit, MemoryIndex, ModuleTypesBuilder, PrimaryMap, SignatureIndex, TableIndex,
-    TableInitialValue, Tunables, TypeConvert, TypeIndex, WasmError, WasmFuncType, WasmHeapType,
-    WasmResult, WasmType,
+    TableInitialValue, Tunables, TypeConvert, TypeIndex, Unsigned, WasmError, WasmFuncType,
+    WasmHeapType, WasmResult, WasmType,
 };
 use cranelift_entity::packed_option::ReservedValue;
 use std::borrow::Cow;
@@ -487,7 +487,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                             let table_index = TableIndex::from_u32(table_index.unwrap_or(0));
                             let mut offset_expr_reader = offset_expr.get_binary_reader();
                             let (base, offset) = match offset_expr_reader.read_operator()? {
-                                Operator::I32Const { value } => (None, value as u32),
+                                Operator::I32Const { value } => (None, value.unsigned()),
                                 Operator::GlobalGet { global_index } => {
                                     (Some(GlobalIndex::from_u32(global_index)), 0)
                                 }
@@ -607,8 +607,8 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                             let memory_index = MemoryIndex::from_u32(memory_index);
                             let mut offset_expr_reader = offset_expr.get_binary_reader();
                             let (base, offset) = match offset_expr_reader.read_operator()? {
-                                Operator::I32Const { value } => (None, (value as u32).into()),
-                                Operator::I64Const { value } => (None, value as u64),
+                                Operator::I32Const { value } => (None, value.unsigned().into()),
+                                Operator::I64Const { value } => (None, value.unsigned()),
                                 Operator::GlobalGet { global_index } => {
                                     (Some(GlobalIndex::from_u32(global_index)), 0)
                                 }

--- a/crates/explorer/Cargo.toml
+++ b/crates/explorer/Cargo.toml
@@ -8,6 +8,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 capstone = { workspace = true }

--- a/crates/fiber/Cargo.toml
+++ b/crates/fiber/Cargo.toml
@@ -7,6 +7,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 cfg-if = { workspace = true }

--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -130,14 +130,14 @@ impl FiberStack {
                 assert!(
                     start_ptr.align_offset(page_size) == 0,
                     "expected fiber stack end ({}) to be page aligned ({})",
-                    range.start as usize,
+                    range.start,
                     page_size
                 );
                 let end_ptr = range.end as *const u8;
                 assert!(
                     end_ptr.align_offset(page_size) == 0,
                     "expected fiber stack start ({}) to be page aligned ({})",
-                    range.end as usize,
+                    range.end,
                     page_size
                 );
                 range

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 version = "0.0.0"
 license = "Apache-2.0 WITH LLVM-exception"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }

--- a/crates/fuzzing/src/generators/table_ops.rs
+++ b/crates/fuzzing/src/generators/table_ops.rs
@@ -112,7 +112,7 @@ impl TableOps {
 
         func.instruction(&Instruction::Loop(wasm_encoder::BlockType::Empty));
         for op in &self.ops {
-            op.insert(&mut func, self.num_params as u32);
+            op.insert(&mut func, self.num_params);
         }
         func.instruction(&Instruction::Br(0));
         func.instruction(&Instruction::End);

--- a/crates/fuzzing/src/oracles/diff_v8.rs
+++ b/crates/fuzzing/src/oracles/diff_v8.rs
@@ -297,7 +297,7 @@ fn get_diff_value(
     scope: &mut v8::HandleScope<'_>,
 ) -> DiffValue {
     match ty {
-        DiffValueType::I32 => DiffValue::I32(val.to_int32(scope).unwrap().value() as i32),
+        DiffValueType::I32 => DiffValue::I32(val.to_int32(scope).unwrap().value()),
         DiffValueType::I64 => {
             let (val, todo) = val.to_big_int(scope).unwrap().i64_value();
             assert!(todo);

--- a/crates/fuzzing/wasm-spec-interpreter/Cargo.toml
+++ b/crates/fuzzing/wasm-spec-interpreter/Cargo.toml
@@ -7,6 +7,9 @@ publish = false
 edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 
+[lints]
+workspace = true
+
 # Until https://gitlab.com/ocaml-rust/ocaml-boxroot/-/issues/1 is resolved and
 # this crate can use the `without-ocamlopt` feature to avoid build failures, it
 # is better to only build the OCaml dependencies when fuzzing (see the

--- a/crates/jit-debug/Cargo.toml
+++ b/crates/jit-debug/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 once_cell = { workspace = true, optional = true }
 object = { workspace = true, optional = true }

--- a/crates/jit-icache-coherence/Cargo.toml
+++ b/crates/jit-icache-coherence/Cargo.toml
@@ -8,6 +8,9 @@ license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 cfg-if = { workspace = true }
 

--- a/crates/jit/Cargo.toml
+++ b/crates/jit/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["webassembly", "wasm"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 wasmtime-environ = { workspace = true }
 wasmtime-jit-debug = { workspace = true, features = [

--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -1,6 +1,6 @@
 //! JIT-style runtime for WebAssembly using Cranelift.
 
-#![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
+#![deny(missing_docs, trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 
 mod code_memory;

--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -1,6 +1,6 @@
 //! JIT-style runtime for WebAssembly using Cranelift.
 
-#![deny(missing_docs, trivial_numeric_casts)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 
 mod code_memory;

--- a/crates/jit/src/lib.rs
+++ b/crates/jit/src/lib.rs
@@ -1,7 +1,6 @@
 //! JIT-style runtime for WebAssembly using Cranelift.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 
 mod code_memory;
 mod debug;

--- a/crates/misc/component-fuzz-util/Cargo.toml
+++ b/crates/misc/component-fuzz-util/Cargo.toml
@@ -6,6 +6,9 @@ version = "0.0.0"
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 arbitrary = { workspace = true, features = ["derive"] }

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["webassembly", "wasm"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 wasmtime-wmemcheck = { workspace = true }
 wasmtime-asm-macros = { workspace = true }

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,6 +1,6 @@
 //! Runtime library support for Wasmtime.
 
-#![deny(missing_docs, trivial_numeric_casts)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 
 use anyhow::{Error, Result};

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,6 +1,6 @@
 //! Runtime library support for Wasmtime.
 
-#![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
+#![deny(missing_docs, trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 
 use anyhow::{Error, Result};

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,7 +1,6 @@
 //! Runtime library support for Wasmtime.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 
 use anyhow::{Error, Result};
 use std::fmt;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -1,6 +1,7 @@
 //! Runtime library support for Wasmtime.
 
 #![deny(missing_docs)]
+#![warn(clippy::cast_sign_loss)]
 
 use anyhow::{Error, Result};
 use std::fmt;
@@ -240,7 +241,7 @@ pub fn page_size() -> usize {
 
     #[cfg(unix)]
     fn get_page_size() -> usize {
-        unsafe { libc::sysconf(libc::_SC_PAGESIZE) as usize }
+        unsafe { libc::sysconf(libc::_SC_PAGESIZE).try_into().unwrap() }
     }
 }
 

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -66,7 +66,7 @@ use std::mem;
 use std::ptr::{self, NonNull};
 use std::time::{Duration, Instant};
 use wasmtime_environ::{
-    DataIndex, ElemIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, Trap,
+    DataIndex, ElemIndex, FuncIndex, GlobalIndex, MemoryIndex, TableIndex, Trap, Unsigned,
 };
 #[cfg(feature = "wmemcheck")]
 use wasmtime_wmemcheck::AccessError::{
@@ -233,7 +233,7 @@ unsafe fn table_grow(
     };
     Ok(match instance.table_grow(table_index, delta, element)? {
         Some(r) => r,
-        None => -1_i32 as u32,
+        None => (-1_i32).unsigned(),
     })
 }
 

--- a/crates/runtime/src/traphandlers/macos.rs
+++ b/crates/runtime/src/traphandlers/macos.rs
@@ -31,7 +31,7 @@
 //! function declarations. Many bits and pieces are copied or translated from
 //! the SpiderMonkey implementation and it should pass all the tests!
 
-#![allow(non_snake_case)]
+#![allow(non_snake_case, clippy::cast_sign_loss)]
 
 use crate::traphandlers::{tls, wasmtime_longjmp};
 use mach::exception_types::*;

--- a/crates/runtime/src/traphandlers/unix.rs
+++ b/crates/runtime/src/traphandlers/unix.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::cast_sign_loss)] // platforms too fiddly to worry about this
+
 use crate::traphandlers::{tls, wasmtime_longjmp};
 use std::cell::RefCell;
 use std::io;

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -12,7 +12,7 @@ use std::ptr::NonNull;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::u32;
 pub use vm_host_func_context::{VMArrayCallHostFuncContext, VMNativeCallHostFuncContext};
-use wasmtime_environ::{DefinedMemoryIndex, VMCONTEXT_MAGIC};
+use wasmtime_environ::{DefinedMemoryIndex, Unsigned, VMCONTEXT_MAGIC};
 
 /// A function pointer that exposes the array calling convention.
 ///
@@ -1038,7 +1038,7 @@ impl ValRaw {
         // `wasmtime` crate. Otherwise though all `ValRaw` constructors are
         // otherwise constrained to guarantee that the initial 64-bits are
         // always initialized.
-        ValRaw::u64((i as u32).into())
+        ValRaw::u64(i.unsigned().into())
     }
 
     /// Creates a WebAssembly `i64` value
@@ -1112,13 +1112,13 @@ impl ValRaw {
     /// Gets the WebAssembly `i32` value
     #[inline]
     pub fn get_u32(&self) -> u32 {
-        self.get_i32() as u32
+        self.get_i32().unsigned()
     }
 
     /// Gets the WebAssembly `i64` value
     #[inline]
     pub fn get_u64(&self) -> u64 {
-        self.get_i64() as u64
+        self.get_i64().unsigned()
     }
 
     /// Gets the WebAssembly `f32` value

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 publish = false
 license = "Apache-2.0 WITH LLVM-exception"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 wasi = "0.11.0"

--- a/crates/test-programs/artifacts/Cargo.toml
+++ b/crates/test-programs/artifacts/Cargo.toml
@@ -6,6 +6,9 @@ edition.workspace = true
 publish = false
 license = "Apache-2.0 WITH LLVM-exception"
 
+[lints]
+workspace = true
+
 [build-dependencies]
 heck = { workspace = true }
 wit-component = { workspace = true }

--- a/crates/test-programs/src/bin/preview1_stdio_isatty.rs
+++ b/crates/test-programs/src/bin/preview1_stdio_isatty.rs
@@ -1,19 +1,7 @@
 unsafe fn test_stdio_isatty() {
-    assert_eq!(
-        libc::isatty(libc::STDIN_FILENO as std::os::raw::c_int),
-        1,
-        "stdin is a tty"
-    );
-    assert_eq!(
-        libc::isatty(libc::STDOUT_FILENO as std::os::raw::c_int),
-        1,
-        "stdout is a tty"
-    );
-    assert_eq!(
-        libc::isatty(libc::STDERR_FILENO as std::os::raw::c_int),
-        1,
-        "stderr is a tty"
-    );
+    assert_eq!(libc::isatty(libc::STDIN_FILENO), 1, "stdin is a tty");
+    assert_eq!(libc::isatty(libc::STDOUT_FILENO), 1, "stdout is a tty");
+    assert_eq!(libc::isatty(libc::STDERR_FILENO), 1, "stderr is a tty");
 }
 
 fn main() {

--- a/crates/test-programs/src/bin/preview1_stdio_not_isatty.rs
+++ b/crates/test-programs/src/bin/preview1_stdio_not_isatty.rs
@@ -1,19 +1,7 @@
 unsafe fn test_stdio_not_isatty() {
-    assert_eq!(
-        libc::isatty(libc::STDIN_FILENO as std::os::raw::c_int),
-        0,
-        "stdin is not a tty"
-    );
-    assert_eq!(
-        libc::isatty(libc::STDOUT_FILENO as std::os::raw::c_int),
-        0,
-        "stdout is not a tty"
-    );
-    assert_eq!(
-        libc::isatty(libc::STDERR_FILENO as std::os::raw::c_int),
-        0,
-        "stderr is not a tty"
-    );
+    assert_eq!(libc::isatty(libc::STDIN_FILENO), 0, "stdin is not a tty");
+    assert_eq!(libc::isatty(libc::STDOUT_FILENO), 0, "stdout is not a tty");
+    assert_eq!(libc::isatty(libc::STDERR_FILENO), 0, "stderr is not a tty");
 }
 
 fn main() {

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -17,6 +17,9 @@ build = "build.rs"
 # on this crate, allowing other crates to use the same witx files.
 links = "wasi-common-19"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/wasi-common/cap-std-sync/Cargo.toml
+++ b/crates/wasi-common/cap-std-sync/Cargo.toml
@@ -11,6 +11,9 @@ readme = "README.md"
 edition.workspace = true
 include = ["src/**/*", "README.md", "LICENSE" ]
 
+[lints]
+workspace = true
+
 [dependencies]
 wasi-common = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -50,6 +50,9 @@
 //! `WasiCtx::builder(...)` function. The
 //! `wasi_cap_std_sync::WasiCtxBuilder::new()` function uses this public
 //! interface to plug in its own implementations of each of these resources.
+
+#![warn(clippy::cast_sign_loss)]
+
 pub mod clocks;
 mod ctx;
 pub mod dir;

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -554,7 +554,9 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
         let whence = match whence {
             types::Whence::Cur => SeekFrom::Current(offset),
             types::Whence::End => SeekFrom::End(offset),
-            types::Whence::Set => SeekFrom::Start(offset as u64),
+            types::Whence::Set => {
+                SeekFrom::Start(offset.try_into().map_err(|_| Error::invalid_argument())?)
+            }
         };
         let newoffset = self
             .table()

--- a/crates/wasi-common/tokio/Cargo.toml
+++ b/crates/wasi-common/tokio/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true
 include = ["src/**/*", "LICENSE" ]
 
+[lints]
+workspace = true
+
 [dependencies]
 wasi-common = { workspace = true }
 wasi-cap-std-sync = { workspace = true }

--- a/crates/wasi-http/Cargo.toml
+++ b/crates/wasi-http/Cargo.toml
@@ -7,6 +7,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 license = "Apache-2.0 WITH LLVM-exception"
 description = "Experimental HTTP library for WebAssembly in Wasmtime"
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -909,7 +909,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         ms: Option<types::Duration>,
     ) -> wasmtime::Result<Result<(), ()>> {
         self.table().get_mut(&opts)?.connect_timeout =
-            ms.map(|ms| std::time::Duration::from_millis(ms as u64));
+            ms.map(|ms| std::time::Duration::from_millis(ms));
         Ok(Ok(()))
     }
 
@@ -936,7 +936,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         ms: Option<types::Duration>,
     ) -> wasmtime::Result<Result<(), ()>> {
         self.table().get_mut(&opts)?.first_byte_timeout =
-            ms.map(|ms| std::time::Duration::from_millis(ms as u64));
+            ms.map(|ms| std::time::Duration::from_millis(ms));
         Ok(Ok(()))
     }
 
@@ -963,7 +963,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostRequestOptions for T {
         ms: Option<types::Duration>,
     ) -> wasmtime::Result<Result<(), ()>> {
         self.table().get_mut(&opts)?.between_bytes_timeout =
-            ms.map(|ms| std::time::Duration::from_millis(ms as u64));
+            ms.map(|ms| std::time::Duration::from_millis(ms));
         Ok(Ok(()))
     }
 

--- a/crates/wasi-nn/Cargo.toml
+++ b/crates/wasi-nn/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 # These dependencies are necessary for the WITX-generation macros to work:
 anyhow = { workspace = true }

--- a/crates/wasi-preview1-component-adapter/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/Cargo.toml
@@ -5,6 +5,9 @@ authors.workspace = true
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 wasi = { version = "0.11.0", default-features = false }
 wit-bindgen = { workspace = true, default-features = false, features = ["macros"] }

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -316,7 +316,7 @@ impl Descriptors {
         // First, ensure from_fd is in bounds:
         let _ = self.get(from_fd)?;
         // Expand table until to_fd is in bounds as well:
-        while self.table_len.get() as u32 <= to_fd as u32 {
+        while self.table_len.get() as u32 <= to_fd {
             self.push_closed()?;
         }
         // Then, close from_fd and put its contents into to_fd:

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -815,7 +815,7 @@ pub unsafe extern "C" fn fd_prestat_dir_name(fd: Fd, path: *mut u8, path_max_len
     State::with(|state| {
         let ds = state.descriptors();
         if let Some(preopen) = ds.get_preopen(fd) {
-            if preopen.path.len > path_max_len as usize {
+            if preopen.path.len > path_max_len {
                 Err(ERRNO_NAMETOOLONG)
             } else {
                 ptr::copy_nonoverlapping(preopen.path.ptr, path, preopen.path.len);
@@ -1247,7 +1247,7 @@ pub unsafe extern "C" fn fd_tell(fd: Fd, offset: *mut Filesize) -> Errno {
     State::with(|state| {
         let ds = state.descriptors();
         let file = ds.get_seekable_file(fd)?;
-        *offset = file.position.get() as Filesize;
+        *offset = file.position.get();
         Ok(())
     })
 }

--- a/crates/wasi-preview1-component-adapter/verify/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/verify/Cargo.toml
@@ -5,6 +5,9 @@ edition.workspace = true
 authors.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 wasmparser = { workspace = true }
 wat = { workspace = true }

--- a/crates/wasi-threads/Cargo.toml
+++ b/crates/wasi-threads/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 log = { workspace = true }

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -10,7 +10,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 edition.workspace = true
 include = ["src/**/*", "README.md", "LICENSE", "build.rs", "witx/*", "wit/**/*"]
-build = "build.rs"
+
+[lints]
+workspace = true
 
 [dependencies]
 wasmtime = { workspace = true }

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -7,6 +7,8 @@
 //! Individual snapshots are available through
 //! `wasmtime_wasi::snapshots::preview_{0, 1}::Wasi::new(&Store, Rc<RefCell<WasiCtx>>)`.
 
+#![warn(clippy::cast_sign_loss)]
+
 #[cfg(feature = "preview2")]
 pub mod preview2;
 

--- a/crates/wasi/src/preview2/host/io.rs
+++ b/crates/wasi/src/preview2/host/io.rs
@@ -186,7 +186,7 @@ impl<T: WasiView> streams::HostInputStream for T {
             InputStream::Host(s) => s.read(len)?,
             InputStream::File(s) => s.read(len).await?,
         };
-        debug_assert!(bytes.len() <= len as usize);
+        debug_assert!(bytes.len() <= len);
         Ok(bytes.into())
     }
 

--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -1565,7 +1565,9 @@ impl<
         let position = position.clone();
         drop(t);
         let pos = match whence {
-            types::Whence::Set if offset >= 0 => offset as _,
+            types::Whence::Set if offset >= 0 => {
+                offset.try_into().map_err(|_| types::Errno::Inval)?
+            }
             types::Whence::Cur => position
                 .load(Ordering::Relaxed)
                 .checked_add_signed(offset)

--- a/crates/wasi/src/preview2/stream.rs
+++ b/crates/wasi/src/preview2/stream.rs
@@ -143,7 +143,7 @@ pub trait HostOutputStream: Subscribe {
     fn write_zeroes(&mut self, nelem: usize) -> StreamResult<()> {
         // TODO: We could optimize this to not allocate one big zeroed buffer, and instead write
         // repeatedly from a 'static buffer of zeros.
-        let bs = Bytes::from_iter(core::iter::repeat(0 as u8).take(nelem));
+        let bs = Bytes::from_iter(core::iter::repeat(0).take(nelem));
         self.write(bs)?;
         Ok(())
     }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 edition.workspace = true
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 rustdoc-args = ["--cfg", "nightlydoc"]
 # Docs.rs will use the `component-model` feature for documentation;

--- a/crates/wasmtime/src/component/func/typed.rs
+++ b/crates/wasmtime/src/component/func/typed.rs
@@ -715,6 +715,7 @@ macro_rules! integers {
 
         unsafe impl Lower for $primitive {
             #[inline]
+            #[allow(trivial_numeric_casts)]
             fn lower<T>(
                 &self,
                 _cx: &mut LowerContext<'_, T>,
@@ -779,6 +780,7 @@ macro_rules! integers {
 
         unsafe impl Lift for $primitive {
             #[inline]
+            #[allow(trivial_numeric_casts)]
             fn lift(_cx: &mut LiftContext<'_>, ty: InterfaceType, src: &Self::Lower) -> Result<Self> {
                 debug_assert!(matches!(ty, InterfaceType::$ty));
                 Ok(src.$get() as $primitive)

--- a/crates/wast/Cargo.toml
+++ b/crates/wast/Cargo.toml
@@ -9,6 +9,9 @@ keywords = ["webassembly", "wasm"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 wasmtime = { workspace = true, features = ['cranelift', 'wat'] }

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -1,6 +1,6 @@
 //! Implementation of the WAST text format for wasmtime.
 
-#![deny(missing_docs, trivial_numeric_casts)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 #![deny(unstable_features)]
 

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -1,7 +1,6 @@
 //! Implementation of the WAST text format for wasmtime.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 
 #[cfg(feature = "component-model")]
 mod component;

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![deny(missing_docs)]
 #![warn(unused_import_braces)]
-#![deny(unstable_features)]
 
 #[cfg(feature = "component-model")]
 mod component;

--- a/crates/wast/src/lib.rs
+++ b/crates/wast/src/lib.rs
@@ -1,6 +1,6 @@
 //! Implementation of the WAST text format for wasmtime.
 
-#![deny(missing_docs, trivial_numeric_casts, unused_extern_crates)]
+#![deny(missing_docs, trivial_numeric_casts)]
 #![warn(unused_import_braces)]
 #![deny(unstable_features)]
 

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -10,6 +10,9 @@ keywords = ["webassembly", "wasm"]
 repository = "https://github.com/bytecodealliance/wasmtime"
 include = ["src/**/*", "README.md", "LICENSE"]
 
+[lints]
+workspace = true
+
 [dependencies]
 thiserror = { workspace = true }
 witx = { path = "../wasi-common/WASI/tools/witx", version = "0.9.1", optional = true }

--- a/crates/wiggle/generate/Cargo.toml
+++ b/crates/wiggle/generate/Cargo.toml
@@ -11,7 +11,8 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 readme = "README.md"
 include = ["src/**/*", "README.md", "LICENSE"]
 
-[lib]
+[lints]
+workspace = true
 
 [dependencies]
 witx = { version = "0.9.1", path = "../../wasi-common/WASI/tools/witx" }

--- a/crates/wiggle/generate/src/types/handle.rs
+++ b/crates/wiggle/generate/src/types/handle.rs
@@ -7,7 +7,7 @@ use witx::Layout;
 pub(super) fn define_handle(name: &witx::Id, h: &witx::HandleDatatype) -> TokenStream {
     let ident = names::type_(name);
     let size = h.mem_size_align().size as u32;
-    let align = h.mem_size_align().align as usize;
+    let align = h.mem_size_align().align;
     quote! {
         #[repr(transparent)]
         #[derive(Copy, Clone, Debug, ::std::hash::Hash, Eq, PartialEq)]

--- a/crates/wiggle/generate/src/types/record.rs
+++ b/crates/wiggle/generate/src/types/record.rs
@@ -8,7 +8,7 @@ use witx::Layout;
 pub(super) fn define_struct(name: &witx::Id, s: &witx::RecordDatatype) -> TokenStream {
     let ident = names::type_(name);
     let size = s.mem_size_align().size as u32;
-    let align = s.mem_size_align().align as usize;
+    let align = s.mem_size_align().align;
 
     let member_names = s.members.iter().map(|m| names::struct_member(&m.name));
     let member_decls = s.members.iter().map(|m| {

--- a/crates/wiggle/generate/src/types/variant.rs
+++ b/crates/wiggle/generate/src/types/variant.rs
@@ -12,7 +12,7 @@ pub(super) fn define_variant(
 ) -> TokenStream {
     let ident = names::type_(name);
     let size = v.mem_size_align().size as u32;
-    let align = v.mem_size_align().align as usize;
+    let align = v.mem_size_align().align;
     let contents_offset = v.payload_offset() as u32;
 
     let lifetime = quote!('a);

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -21,7 +21,7 @@ mod error;
 mod guest_type;
 mod region;
 
-pub extern crate tracing;
+pub use tracing;
 
 pub use error::GuestError;
 pub use guest_type::{GuestErrorType, GuestType, GuestTypeTransparent};

--- a/crates/wiggle/test-helpers/Cargo.toml
+++ b/crates/wiggle/test-helpers/Cargo.toml
@@ -11,6 +11,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 include = ["src/**/*", "LICENSE"]
 publish = false
 
+[lints]
+workspace = true
+
 [dependencies]
 proptest = "1.0.0"
 wiggle = { path = "..", features = ["tracing_log"] }

--- a/crates/winch/Cargo.toml
+++ b/crates/winch/Cargo.toml
@@ -7,6 +7,9 @@ edition.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
 
+[lints]
+workspace = true
+
 [dependencies]
 winch-codegen = { workspace = true }
 target-lexicon = { workspace = true }

--- a/crates/wit-bindgen/Cargo.toml
+++ b/crates/wit-bindgen/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-wit-bindgen/"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = { workspace = true }
 heck = { workspace = true }

--- a/crates/wmemcheck/Cargo.toml
+++ b/crates/wmemcheck/Cargo.toml
@@ -8,4 +8,5 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 documentation = "https://docs.rs/wasmtime-cranelift/"
 edition.workspace = true
 
-[dependencies]
+[lints]
+workspace = true

--- a/examples/fib-debug/wasm/Cargo.toml
+++ b/examples/fib-debug/wasm/Cargo.toml
@@ -5,6 +5,9 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 publish = false
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib"]
 path = "fib.rs"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.0.0"
 edition.workspace = true
 publish = false
 
+[lints]
+workspace = true
+
 [package.metadata]
 cargo-fuzz = true
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 //! This crate implements the Wasmtime command line tools.
 
 #![deny(missing_docs)]
-#![warn(unused_import_braces)]
 
 pub mod commands;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate implements the Wasmtime command line tools.
 
-#![deny(missing_docs, unstable_features)]
+#![deny(missing_docs)]
 #![warn(unused_import_braces)]
 
 pub mod commands;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate implements the Wasmtime command line tools.
 
-#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
+#![deny(missing_docs, unstable_features)]
 #![warn(unused_import_braces)]
 
 pub mod commands;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,7 @@
 //!
 //! This crate implements the Wasmtime command line tools.
 
-#![deny(
-    missing_docs,
-    trivial_numeric_casts,
-    unused_extern_crates,
-    unstable_features
-)]
+#![deny(missing_docs, trivial_numeric_casts, unstable_features)]
 #![warn(unused_import_braces)]
 
 pub mod commands;

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -409,8 +409,7 @@ impl ResourceLimiter for MemoryContext {
         // Check if the desired exceeds a maximum (either from Wasm or from the host)
         assert!(desired < maximum.unwrap_or(usize::MAX));
 
-        assert_eq!(current as usize, self.wasm_memory_used);
-        let desired = desired as usize;
+        assert_eq!(current, self.wasm_memory_used);
 
         if desired + self.host_memory_used > self.memory_limit {
             self.limit_exceeded = true;
@@ -524,8 +523,7 @@ impl ResourceLimiterAsync for MemoryContext {
         // Check if the desired exceeds a maximum (either from Wasm or from the host)
         assert!(desired < maximum.unwrap_or(usize::MAX));
 
-        assert_eq!(current as usize, self.wasm_memory_used);
-        let desired = desired as usize;
+        assert_eq!(current, self.wasm_memory_used);
 
         if desired + self.host_memory_used > self.memory_limit {
             self.limit_exceeded = true;

--- a/tests/all/memory_creator.rs
+++ b/tests/all/memory_creator.rs
@@ -77,7 +77,7 @@ mod not_for_windows {
         }
 
         fn wasm_accessible(&self) -> Range<usize> {
-            let base = self.mem as usize;
+            let base = self.mem;
             let end = base + self.size;
             base..end
         }

--- a/winch/Cargo.toml
+++ b/winch/Cargo.toml
@@ -7,6 +7,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 publish = false
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [[bin]]
 name = "winch-tools"
 path = "src/main.rs"

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -7,6 +7,9 @@ repository = "https://github.com/bytecodealliance/wasmtime"
 version = "0.14.0"
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 wasmparser = { workspace = true }
 smallvec = { workspace = true }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -191,7 +191,7 @@ impl Masm for MacroAssembler {
                 };
 
                 let scratch = regs::scratch();
-                self.asm.load_constant(imm as u64, scratch);
+                self.asm.load_constant(imm, scratch);
                 self.asm.mov_rr(scratch, rd, size);
             }
             (RegImm::Reg(rs), rd) => {

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -332,7 +332,7 @@ impl Masm for MacroAssembler {
             },
             (RegImm::Imm(imm), dst) => match imm {
                 I::I32(v) => self.asm.mov_ir(v as u64, dst, size),
-                I::I64(v) => self.asm.mov_ir(v as u64, dst, size),
+                I::I64(v) => self.asm.mov_ir(v, dst, size),
                 I::F32(v) => {
                     let addr = self.asm.add_constant(v.to_le_bytes().as_slice());
                     self.asm.xmm_mov_mr(&addr, dst, size);

--- a/winch/filetests/Cargo.toml
+++ b/winch/filetests/Cargo.toml
@@ -8,6 +8,9 @@ version = "0.0.0"
 publish = false
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 winch-test-macros = {workspace = true}
 target-lexicon = { workspace = true }

--- a/winch/test-macros/Cargo.toml
+++ b/winch/test-macros/Cargo.toml
@@ -8,6 +8,9 @@ version = "0.0.0"
 publish = false
 edition.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 test = false

--- a/winch/test-macros/src/lib.rs
+++ b/winch/test-macros/src/lib.rs
@@ -1,5 +1,3 @@
-extern crate proc_macro;
-
 use std::path::Path;
 
 use glob::glob;


### PR DESCRIPTION
This PR is a series of commits building up to the ability to selectively enable clippy lints to prevent issues such as https://github.com/bytecodealliance/wasmtime/issues/7558 from occurring. The root cause of the issue is the behavior of casting a smaller integer to a larger integer and switching signs. For example casting an i8 to a u32. I certainly don't remember whether this is a zero-extend or a sign-extend, and I suspect that I'm not alone. Ideally I was looking for a lint to help weed these out on CI. 

Unfortunately rustc does not have a lint for this. Clippy, however, has a somewhat similar lint called `cast_sign_loss`. Empowered with Rust's 1.74 release and Cargo's addition of a `[lints]` configuration for workspaces, I realized this seemed like a reasonable time to kick the tires. Historically Wasmtime hasn't enabled Clippy because it's too noisy by default and it's too cumbersome to turn it off for all crates. With `[lints]` however it's a single line to turn off all clippy for the entire workspace, which felt like a much better balance to me at least.

First configuring `[lints]` as well as `[workspace.lints]` helped moved some lint configuration for various crates into one location. Afterwards all clippy lints were then disabled and then `cargo clippy` was added to CI. It turns out that `cast_sign_loss` is still too noisy for our purposes to enable for the whole workspace, but it can be selectively enabled for a few crates in question which do at least much of the casting for values at runtime.

This is intended to be somewhat of a trial run to see if we can make running Clippy in CI useful. I'm sure Clippy has other useful lints for helping to catch issues as well as helping with stylistic things for contributors. For now everything is left disabled but if desired selective lints can be enabled as necessary.