### PR TITLE
wasi: noent error for dangling symlink

### DIFF
--- a/crates/test-programs/src/bin/preview1_dangling_symlink.rs
+++ b/crates/test-programs/src/bin/preview1_dangling_symlink.rs
@@ -11,14 +11,16 @@ unsafe fn test_dangling_symlink(dir_fd: wasi::Fd) {
             wasi::path_open(dir_fd, 0, "symlink", wasi::OFLAGS_DIRECTORY, 0, 0, 0)
                 .expect_err("opening a dangling symlink as a directory"),
             wasi::ERRNO_NOTDIR,
-            wasi::ERRNO_LOOP
+            wasi::ERRNO_LOOP,
+            wasi::ERRNO_NOENT
         );
 
         // Try to open it as a file with O_NOFOLLOW.
         assert_errno!(
             wasi::path_open(dir_fd, 0, "symlink", 0, 0, 0, 0)
                 .expect_err("opening a dangling symlink as a file"),
-            wasi::ERRNO_LOOP
+            wasi::ERRNO_LOOP,
+            wasi::ERRNO_NOENT
         );
 
         // Clean up.


### PR DESCRIPTION
Updates the dangling symlink error test case to support `ENOENT` as a valid error code.

This was the default when applying this operation in Node.js. We can also patch the implementation to throw the right code as well depending what the expected behaviour would be.