### PR TITLE
docs: clarify definition in Introduction

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,7 +1,7 @@
 # Introduction
 
 [Wasmtime][github] is a standalone optimizing runtime for [WebAssembly],
-[the Component Model], and [WASI] by the [Bytecode Alliance][BA] project. It runs
+[the Component Model], and [WASI] by the [Bytecode Alliance][BA]. It runs
 WebAssembly code [outside of the Web], and can be used both as a command-line
 utility or as a library embedded in a larger application. Wasmtime strives to be
 a highly configurable and embeddable runtime to run on any scale of application.

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -1,7 +1,7 @@
 # Introduction
 
-[Wasmtime][github] is a [Bytecode Alliance][BA] project that is a standalone
-optimizing runtime for [WebAssembly], [the Component Model], and [WASI]. It runs
+[Wasmtime][github] is a standalone optimizing runtime for [WebAssembly],
+[the Component Model], and [WASI] by the [Bytecode Alliance][BA] project. It runs
 WebAssembly code [outside of the Web], and can be used both as a command-line
 utility or as a library embedded in a larger application. Wasmtime strives to be
 a highly configurable and embeddable runtime to run on any scale of application.


### PR DESCRIPTION
Clarify the definition of the project in the Introduction. A direct "X is a Z" is clearer than a "X is a Y that is a Z" where Y is some superset of Z.