### PR TITLE
Add profile flags to cli-flags crate

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -126,6 +126,8 @@ wasmtime_option_group! {
         pub log_to_files: Option<bool>,
         /// Enable coredump generation to this file after a WebAssembly trap.
         pub coredump: Option<String>,
+        /// configure profiler as VTune, JitDump, or PerfMap
+        pub profile: Option<wasmtime::ProfilingStrategy>,
     }
 
     enum Debug {
@@ -405,6 +407,15 @@ impl CommonOptions {
         }
         if let Some(enable) = self.debug.debug_info {
             config.debug_info(enable);
+        }
+        if let Some(wasmtime::ProfilingStrategy::VTune) = self.debug.profile {
+            config.profiler(wasmtime::ProfilingStrategy::VTune);
+        }
+        if let Some(wasmtime::ProfilingStrategy::JitDump) = self.debug.profile {
+            config.profiler(wasmtime::ProfilingStrategy::JitDump);
+        }
+        if let Some(wasmtime::ProfilingStrategy::PerfMap) = self.debug.profile {
+            config.profiler(wasmtime::ProfilingStrategy::PerfMap);
         }
         if self.debug.coredump.is_some() {
             #[cfg(feature = "coredump")]

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -395,7 +395,7 @@ impl WasmtimeOptionValue for wasmtime::ProfilingStrategy {
             "VTune"|"vtune" => Ok(wasmtime::ProfilingStrategy::VTune),
             "JitDump"|"jitdump" => Ok(wasmtime::ProfilingStrategy::JitDump),
             "PerfMap"|"perfmap" => Ok(wasmtime::ProfilingStrategy::PerfMap),
-            other => bail!("unknown compiler `{other}` only `VTune`,`JitDump`, or `PerfMap` are accepted",),
+            other => bail!("unknown profiler `{other}` only `VTune`,`JitDump`, or `PerfMap` are accepted",),
         }
     }
 }

--- a/crates/cli-flags/src/opt.rs
+++ b/crates/cli-flags/src/opt.rs
@@ -387,3 +387,15 @@ impl WasmtimeOptionValue for WasiNnGraph {
         })
     }
 }
+
+impl WasmtimeOptionValue for wasmtime::ProfilingStrategy {
+    const VAL_HELP: &'static str = "=VTune|JitDump|PerfMap";
+    fn parse(val: Option<&str>) -> Result<Self> {
+        match String::parse(val)?.as_str() {
+            "VTune"|"vtune" => Ok(wasmtime::ProfilingStrategy::VTune),
+            "JitDump"|"jitdump" => Ok(wasmtime::ProfilingStrategy::JitDump),
+            "PerfMap"|"perfmap" => Ok(wasmtime::ProfilingStrategy::PerfMap),
+            other => bail!("unknown compiler `{other}` only `VTune`,`JitDump`, or `PerfMap` are accepted",),
+        }
+    }
+}


### PR DESCRIPTION
This change adds profile options like `vtune`, `jitdump` and `perfmap` to cli-flags crate, so that they can be used by `Sightglass` and other benchmarks (via `--engine-flags` for sightglass).
This will enable wasm code visibility via profilers like vtune in sightglass, which was lacking.

I have added these flags to the `Debug` group of options - I can create a separate `Profile` group if needed instead.
