### PR TITLE
ci: log CPU details when testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -475,7 +475,10 @@ jobs:
     # to CPU-specific features.
     - name: CPU information
       run: lscpu
-      if: matrix.os != 'windows-latest'
+      if: matrix.os == 'ubuntu-latest'
+    - name: CPU information
+      run: sysctl hw
+      if: matrix.os == 'macos-latest'
     - name: CPU information
       run: wmic cpu list /format:list
       shell: pwsh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -473,7 +473,13 @@ jobs:
 
     # Record some CPU details; this is helpful information if tests fail due
     # to CPU-specific features.
-    - run: lscpu
+    - name: CPU information
+      run: lscpu
+      if: matrix.os != 'windows-latest'
+    - name: CPU information
+      run: wmic cpu list /format:list
+      shell: pwsh
+      if: matrix.os == 'windows-latest'
 
     # Build and test all features
     - run: ./ci/run-tests.sh --locked

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -471,6 +471,10 @@ jobs:
       run: |
         diff -ru crates/wasi/wit crates/wasi-http/wit
 
+    # Record some CPU details; this is helpful information if tests fail due
+    # to CPU-specific features.
+    - run: lscpu
+
     # Build and test all features
     - run: ./ci/run-tests.sh --locked
       env:


### PR DESCRIPTION
When testing, there are certain CPU-dependent features that influence Cranelift's codegen (e.g., availability of AVX512 instructions). This additional CI step logs the current CPU information to aid in troubleshooting, such as the MPK-related troubleshooting over in #7445. Also, if we let this run in CI for a while, we may be able to run queries on the logs to determine how often jobs run on servers with certain features enabled.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
