### PR TITLE
mpk: fix CPUID bit check

### DIFF
--- a/crates/runtime/src/mpk/pkru.rs
+++ b/crates/runtime/src/mpk/pkru.rs
@@ -53,12 +53,13 @@ pub fn write(pkru: u32) {
     }
 }
 
-/// Check the `ECX.PKU` flag (bit 3) of the `07h` `CPUID` leaf; see the Intel
-/// Software Development Manual, vol 3a, section 2.7. This flag is only set on
-/// Intel CPUs, so this function also checks the `CPUID` vendor string.
+/// Check the `ECX.PKU` flag (bit 3, zero-based) of the `07h` `CPUID` leaf; see
+/// the Intel Software Development Manual, vol 3a, section 2.7. This flag is
+/// only set on Intel CPUs, so this function also checks the `CPUID` vendor
+/// string.
 pub fn has_cpuid_bit_set() -> bool {
     let result = unsafe { std::arch::x86_64::__cpuid(0x07) };
-    is_intel_cpu() && (result.ecx & 0b100) != 0
+    is_intel_cpu() && (result.ecx & 0b1000) != 0
 }
 
 /// Check the `CPUID` vendor string for `GenuineIntel`; see the Intel Software


### PR DESCRIPTION
This bug was discovered when testing with QEMU: the documentation states
that "bit 3" should be checked but this is a 0-based bit. The check
previously performed a 1-based "bit 3" check, which tests the UMIP
feature. This change switches to use the correct bit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
