### PR TITLE
mpk: allow forcing MPK during tests

### DIFF
--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -225,13 +225,6 @@ pub struct PoolingInstanceAllocatorConfig {
 
 impl Default for PoolingInstanceAllocatorConfig {
     fn default() -> PoolingInstanceAllocatorConfig {
-        // When testing, we may choose to start with MPK force-enabled to ensure
-        // we use that functionality.
-        let memory_protection_keys = if std::env::var("WASMTIME_TEST_FORCE_MPK").is_ok() {
-            MpkEnabled::Enable
-        } else {
-            MpkEnabled::Disable
-        };
         PoolingInstanceAllocatorConfig {
             max_unused_warm_slots: 100,
             stack_size: 2 << 20,
@@ -240,7 +233,7 @@ impl Default for PoolingInstanceAllocatorConfig {
             async_stack_keep_resident: 0,
             linear_memory_keep_resident: 0,
             table_keep_resident: 0,
-            memory_protection_keys,
+            memory_protection_keys: MpkEnabled::Disable,
             max_memory_protection_keys: 16,
         }
     }

--- a/crates/runtime/src/instance/allocator/pooling.rs
+++ b/crates/runtime/src/instance/allocator/pooling.rs
@@ -225,6 +225,13 @@ pub struct PoolingInstanceAllocatorConfig {
 
 impl Default for PoolingInstanceAllocatorConfig {
     fn default() -> PoolingInstanceAllocatorConfig {
+        // When testing, we may choose to start with MPK force-enabled to ensure
+        // we use that functionality.
+        let memory_protection_keys = if std::env::var("WASMTIME_TEST_FORCE_MPK").is_ok() {
+            MpkEnabled::Enable
+        } else {
+            MpkEnabled::Disable
+        };
         PoolingInstanceAllocatorConfig {
             max_unused_warm_slots: 100,
             stack_size: 2 << 20,
@@ -233,7 +240,7 @@ impl Default for PoolingInstanceAllocatorConfig {
             async_stack_keep_resident: 0,
             linear_memory_keep_resident: 0,
             table_keep_resident: 0,
-            memory_protection_keys: MpkEnabled::Disable,
+            memory_protection_keys,
             max_memory_protection_keys: 16,
         }
     }

--- a/crates/runtime/src/mpk/enabled.rs
+++ b/crates/runtime/src/mpk/enabled.rs
@@ -152,6 +152,9 @@ mod tests {
     #[test]
     fn check_is_supported() {
         println!("is pku supported = {}", is_supported());
+        if std::env::var("WASMTIME_TEST_FORCE_MPK").is_ok() {
+            assert!(is_supported());
+        }
     }
 
     #[test]

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -92,6 +92,12 @@ pub(crate) fn small_pool_config() -> wasmtime::PoolingAllocationConfig {
     config.total_tables(1);
     config.table_elements(10);
 
+    // When testing, we may choose to start with MPK force-enabled to ensure
+    // we use that functionality.
+    if std::env::var("WASMTIME_TEST_FORCE_MPK").is_ok() {
+        config.memory_protection_keys(wasmtime_runtime::MpkEnabled::Enable);
+    }
+
     #[cfg(feature = "async")]
     config.total_stacks(1);
 

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -7,6 +7,7 @@ use wasmtime::{
     Config, Engine, InstanceAllocationStrategy, PoolingAllocationConfig, Store, Strategy,
 };
 use wasmtime_environ::WASM_PAGE_SIZE;
+use wasmtime_runtime::MpkEnabled;
 use wasmtime_wast::WastContext;
 
 include!(concat!(env!("OUT_DIR"), "/wast_testsuite_tests.rs"));
@@ -133,6 +134,13 @@ fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()>
             .memory_pages(805)
             .max_memories_per_module(if multi_memory { 9 } else { 1 })
             .max_tables_per_module(4);
+
+        // When testing, we may choose to start with MPK force-enabled to ensure
+        // we use that functionality.
+        if std::env::var("WASMTIME_TEST_FORCE_MPK").is_ok() {
+            pool.memory_protection_keys(MpkEnabled::Enable);
+        }
+
         cfg.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
         Some(lock_pooling())
     } else {


### PR DESCRIPTION
For testing on machines on which we know MPK is enabled, we want to be
able to force-enable MPK, ensuring we get coverage of MPK-related code.
This change adds a `WASMTIME_TEST_FORCE_MPK` environment variable which,
when set, sets the pooling allocator configuration to force-enable MPK.
This variable, like the `WASMTIME_TEST_NO_HOG_MEMORY` variable it is
styled from, could be used in CI workflows on which we know MPK should
be available.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
