### PR TITLE
preview1: Update semantics of seeking on appending files

### DIFF
--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -1428,6 +1428,7 @@ impl<
                 position,
             }) if t.view.table().get(fd)?.is_file() => {
                 let fd = fd.borrowed();
+                let fd2 = fd.borrowed();
                 let blocking_mode = *blocking_mode;
                 let position = position.clone();
                 let append = *append;
@@ -1452,7 +1453,10 @@ impl<
                     (stream, pos)
                 };
                 let n = blocking_mode.write(self, stream, &buf).await?;
-                if !append {
+                if append {
+                    let len = self.stat(fd2).await?;
+                    position.store(len.size, Ordering::Relaxed);
+                } else {
                     let pos = pos.checked_add(n as u64).ok_or(types::Errno::Overflow)?;
                     position.store(pos, Ordering::Relaxed);
                 }


### PR DESCRIPTION
This commit updates the semantics of `fd_{seek,tell}` on preview1 to match native Unix when used with appending files. On Unix `write` claims to always update the file position pointer to the end of the file, so this commit implements that instead of the previous logic of ignoring the position update for appending files. This currently requires an extra roundtrip via `stat` to figure out the size of the file, but for now that seems to be the best that can be done.

Closes #7583

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
