### PR TITLE
Update the wasm-tools family of crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,7 +2604,7 @@ version = "0.0.0"
 dependencies = [
  "cargo_metadata",
  "heck",
- "wit-component 0.18.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -3067,18 +3067,18 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.36.2"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822b645bf4f2446b949776ffca47e2af60b167209ffb70814ef8779d299cd421"
+checksum = "7b09bc5df933a3dabbdb72ae4b6b71be8ae07f58774d5aa41bd20adcd41a235a"
 dependencies = [
  "leb128",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.10.11"
+version = "0.10.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2167ce53b2faa16a92c6cafd4942cff16c9a4fa0c5a5a0a41131ee4e49fc055f"
+checksum = "3b4a14bbedb07737809c00843d1f2f88ba0b8950c114283e0387e30b1b6ee558"
 dependencies = [
  "anyhow",
  "indexmap 2.0.0",
@@ -3092,9 +3092,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-mutate"
-version = "0.2.40"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49afec9e74f8dd90367c8f9b60440e6b84bdfd46e8ca133dd6a040f296bbc328"
+checksum = "140f2555b7c16b89592a1cd2f2626612c8c3cba9ff3224f87b00e063264b4b38"
 dependencies = [
  "egg",
  "log",
@@ -3106,16 +3106,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-smith"
-version = "0.12.23"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "426255ec37d1127b020492d957b1a48c0828e667ad2693d98af942e276cfbd86"
+checksum = "8ee085568165cd2886137be8ece587fe2f5cabbc0d63e35d8c8afc7daef2e8c2"
 dependencies = [
  "arbitrary",
  "flagset",
  "indexmap 2.0.0",
  "leb128",
  "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -3158,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.116.1"
+version = "0.118.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
+checksum = "ebbb91574de0011ded32b14db12777e7dd5e9ea2f9d7317a1ab51a9495c75924"
 dependencies = [
  "indexmap 2.0.0",
  "semver",
@@ -3177,9 +3176,9 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.2.72"
+version = "0.2.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aff4df0cdf1906ec040e97d78c3fc8fd26d3f8d70adaac81f07f80957b63b54"
+checksum = "61a7a046e6636d25c06a5df00bdc34e02f9e6e0e8a356d738299b961a6126114"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3355,7 +3354,7 @@ dependencies = [
  "wasmtime-wasi-nn",
  "wasmtime-wasi-threads",
  "wasmtime-wast",
- "wast 67.0.1",
+ "wast 69.0.0",
  "wat",
  "windows-sys",
 ]
@@ -3386,7 +3385,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.13.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -3741,7 +3740,7 @@ dependencies = [
  "anyhow",
  "log",
  "wasmtime",
- "wast 67.0.1",
+ "wast 69.0.0",
 ]
 
 [[package]]
@@ -3766,7 +3765,7 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap 2.0.0",
- "wit-parser 0.13.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -3784,9 +3783,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "67.0.1"
+version = "69.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a974d82fac092b5227c1663e16514e7a85f32014e22e6fdcb08b71aec9d3fb1e"
+checksum = "efa51b5ad1391943d1bfad537e50f28fe938199ee76b115be6bae83802cd5185"
 dependencies = [
  "leb128",
  "memchr",
@@ -3796,11 +3795,11 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb220934f92f8551144c0003d1bc57a060674c99139f45ed623fbbf6d9262e7"
+checksum = "74a4c2488d058326466e086a43f5d4ea448241a8d0975e3eb0642c0828be1eb3"
 dependencies = [
- "wast 67.0.1",
+ "wast 69.0.0",
 ]
 
 [[package]]
@@ -3941,6 +3940,7 @@ dependencies = [
  "similar",
  "target-lexicon",
  "toml",
+ "wasmparser",
  "wasmtime-environ",
  "wat",
  "winch-codegen",
@@ -4056,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38726c54a5d7c03cac28a2a8de1006cfe40397ddf6def3f836189033a413bc08"
+checksum = "d0e367a0bdb6b9f6db939a21749dfcd398b62a23f58afa5c44e7de16289dbeba"
 dependencies = [
  "bitflags 2.4.1",
  "wit-bindgen-rust-macro",
@@ -4066,33 +4066,33 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8bf1fddccaff31a1ad57432d8bfb7027a7e552969b6c68d6d8820dcf5c2371f"
+checksum = "147bee3fde39f80da448dc971d3357c34f5810605e0ba59345ebe576002371c8"
 dependencies = [
  "anyhow",
- "wit-component 0.17.0",
- "wit-parser 0.12.2",
+ "wit-component",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.13.2"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7200e565124801e01b7b5ddafc559e1da1b2e1bed5364d669cd1d96fb88722"
+checksum = "3033046c0f9112a67dc6c1e4281347c8d5f1e01d4cafc01321c259d45e3b8e4f"
 dependencies = [
  "anyhow",
  "heck",
  "wasm-metadata",
  "wit-bindgen-core",
- "wit-component 0.17.0",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae33920ad8119fe72cf59eb00f127c0b256a236b9de029a1a10397b1f38bdbd"
+checksum = "f191047320b2c8bd05a5d367a28c7fe0ad409d43153efc8881aa775a652ca112"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4100,14 +4100,14 @@ dependencies = [
  "syn 2.0.29",
  "wit-bindgen-core",
  "wit-bindgen-rust",
- "wit-component 0.17.0",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-component"
-version = "0.17.0"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480cc1a078b305c1b8510f7c455c76cbd008ee49935f3a6c5fd5e937d8d95b1e"
+checksum = "5b8a35a2a9992898c9d27f1664001860595a4bc99d32dd3599d547412e17d7e2"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4119,43 +4119,7 @@ dependencies = [
  "wasm-encoder",
  "wasm-metadata",
  "wasmparser",
- "wit-parser 0.12.2",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d0371ac5e57e42991aa53f0d79e53e53484afbf54777a5347605b0b229b9d"
-dependencies = [
- "anyhow",
- "bitflags 2.4.1",
- "indexmap 2.0.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser 0.13.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43771ee863a16ec4ecf9da0fc65c3bbd4a1235c8e3da5f094b562894843dfa76"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.0.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
+ "wit-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,18 +227,18 @@ io-extras = "0.18.0"
 rustix = "0.38.21"
 is-terminal = "0.4.0"
 # wit-bindgen:
-wit-bindgen = { version = "0.13.1", default-features = false }
+wit-bindgen = { version = "0.15.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = "0.116.0"
-wat = "1.0.79"
-wast = "67.0.1"
-wasmprinter = "0.2.72"
-wasm-encoder = "0.36.2"
-wasm-smith = "0.12.23"
-wasm-mutate = "0.2.40"
+wasmparser = "0.118.0"
+wat = "1.0.81"
+wast = "69.0.0"
+wasmprinter = "0.2.74"
+wasm-encoder = "0.38.0"
+wasm-smith = "0.13.0"
+wasm-mutate = "0.2.42"
 wit-parser = "0.13.0"
-wit-component = "0.18.0"
+wit-component = "0.18.2"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------

--- a/cranelift/filetests/src/test_wasm/env.rs
+++ b/cranelift/filetests/src/test_wasm/env.rs
@@ -236,7 +236,7 @@ impl<'data> ModuleEnvironment<'data> for ModuleEnv {
 }
 
 impl TypeConvert for ModuleEnv {
-    fn lookup_heap_type(&self, _index: TypeIndex) -> WasmHeapType {
+    fn lookup_heap_type(&self, _index: wasmparser::UnpackedIndex) -> WasmHeapType {
         todo!()
     }
 }
@@ -271,7 +271,7 @@ impl<'a> FuncEnv<'a> {
 }
 
 impl TypeConvert for FuncEnv<'_> {
-    fn lookup_heap_type(&self, _index: TypeIndex) -> WasmHeapType {
+    fn lookup_heap_type(&self, _index: wasmparser::UnpackedIndex) -> WasmHeapType {
         todo!()
     }
 }

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -248,7 +248,7 @@ impl<'dummy_environment> DummyFuncEnvironment<'dummy_environment> {
 }
 
 impl<'dummy_environment> TypeConvert for DummyFuncEnvironment<'dummy_environment> {
-    fn lookup_heap_type(&self, _index: TypeIndex) -> WasmHeapType {
+    fn lookup_heap_type(&self, _index: wasmparser::UnpackedIndex) -> WasmHeapType {
         unimplemented!()
     }
 }
@@ -704,7 +704,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
 }
 
 impl TypeConvert for DummyEnvironment {
-    fn lookup_heap_type(&self, _index: TypeIndex) -> WasmHeapType {
+    fn lookup_heap_type(&self, _index: wasmparser::UnpackedIndex) -> WasmHeapType {
         unimplemented!()
     }
 }

--- a/cranelift/wasm/src/translation_utils.rs
+++ b/cranelift/wasm/src/translation_utils.rs
@@ -18,22 +18,14 @@ where
     T: WasmModuleResources,
 {
     return Ok(match ty {
-        wasmparser::BlockType::Empty => {
-            let params: &'static [wasmparser::ValType] = &[];
-            let results: std::vec::Vec<wasmparser::ValType> = vec![];
-            (
-                itertools::Either::Left(params.iter().copied()),
-                itertools::Either::Left(results.into_iter()),
-            )
-        }
-        wasmparser::BlockType::Type(ty) => {
-            let params: &'static [wasmparser::ValType] = &[];
-            let results: std::vec::Vec<wasmparser::ValType> = vec![ty.clone()];
-            (
-                itertools::Either::Left(params.iter().copied()),
-                itertools::Either::Left(results.into_iter()),
-            )
-        }
+        wasmparser::BlockType::Empty => (
+            itertools::Either::Left(std::iter::empty()),
+            itertools::Either::Left(None.into_iter()),
+        ),
+        wasmparser::BlockType::Type(ty) => (
+            itertools::Either::Left(std::iter::empty()),
+            itertools::Either::Left(Some(ty).into_iter()),
+        ),
         wasmparser::BlockType::FuncType(ty_index) => {
             let ty = validator
                 .resources()

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -32,8 +32,8 @@ use wasmparser::{FuncValidatorAllocations, FunctionBody};
 use wasmtime_cranelift_shared::{CompiledFunction, ModuleTextBuilder};
 use wasmtime_environ::{
     AddressMapSection, CacheStore, CompileError, FlagValue, FunctionBodyData, FunctionLoc,
-    ModuleTranslation, ModuleTypes, PtrSize, StackMapInformation, TrapEncodingBuilder, Tunables,
-    VMOffsets, WasmFunctionInfo,
+    ModuleTranslation, ModuleTypesBuilder, PtrSize, StackMapInformation, TrapEncodingBuilder,
+    Tunables, VMOffsets, WasmFunctionInfo,
 };
 
 #[cfg(feature = "component-model")]
@@ -131,7 +131,7 @@ impl wasmtime_environ::Compiler for Compiler {
         translation: &ModuleTranslation<'_>,
         func_index: DefinedFuncIndex,
         input: FunctionBodyData<'_>,
-        types: &ModuleTypes,
+        types: &ModuleTypesBuilder,
     ) -> Result<(WasmFunctionInfo, Box<dyn Any + Send>), CompileError> {
         let isa = &*self.isa;
         let module = &translation.module;
@@ -240,7 +240,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_array_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
-        types: &ModuleTypes,
+        types: &ModuleTypesBuilder,
         def_func_index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError> {
         let func_index = translation.module.func_index(def_func_index);
@@ -308,7 +308,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_native_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
-        types: &ModuleTypes,
+        types: &ModuleTypesBuilder,
         def_func_index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError> {
         let func_index = translation.module.func_index(def_func_index);

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -15,7 +15,7 @@ struct TrampolineCompiler<'a> {
     isa: &'a (dyn TargetIsa + 'static),
     builder: FunctionBuilder<'a>,
     component: &'a Component,
-    types: &'a ComponentTypes,
+    types: &'a ComponentTypesBuilder,
     offsets: VMComponentOffsets<u8>,
     abi: Abi,
     block0: ir::Block,
@@ -34,7 +34,7 @@ impl<'a> TrampolineCompiler<'a> {
         compiler: &'a Compiler,
         func_compiler: &'a mut super::FunctionCompiler<'_>,
         component: &'a Component,
-        types: &'a ComponentTypes,
+        types: &'a ComponentTypesBuilder,
         index: TrampolineIndex,
         abi: Abi,
     ) -> TrampolineCompiler<'a> {
@@ -625,7 +625,7 @@ impl ComponentCompiler for Compiler {
     fn compile_trampoline(
         &self,
         component: &ComponentTranslation,
-        types: &ComponentTypes,
+        types: &ComponentTypesBuilder,
         index: TrampolineIndex,
     ) -> Result<AllCallFunc<Box<dyn Any + Send>>> {
         let compile = |abi: Abi| -> Result<_> {

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -21,8 +21,8 @@ use std::convert::TryFrom;
 use std::mem;
 use wasmparser::Operator;
 use wasmtime_environ::{
-    BuiltinFunctionIndex, MemoryPlan, MemoryStyle, Module, ModuleTranslation, ModuleTypes, PtrSize,
-    TableStyle, Tunables, TypeConvert, VMOffsets, WASM_PAGE_SIZE,
+    BuiltinFunctionIndex, MemoryPlan, MemoryStyle, Module, ModuleTranslation, ModuleTypesBuilder,
+    PtrSize, TableStyle, Tunables, TypeConvert, VMOffsets, WASM_PAGE_SIZE,
 };
 use wasmtime_environ::{FUNCREF_INIT_BIT, FUNCREF_MASK};
 
@@ -112,7 +112,7 @@ wasmtime_environ::foreach_builtin_function!(declare_function_signatures);
 pub struct FuncEnvironment<'module_environment> {
     isa: &'module_environment (dyn TargetIsa + 'module_environment),
     module: &'module_environment Module,
-    types: &'module_environment ModuleTypes,
+    types: &'module_environment ModuleTypesBuilder,
 
     translation: &'module_environment ModuleTranslation<'module_environment>,
 
@@ -169,7 +169,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
     pub fn new(
         isa: &'module_environment (dyn TargetIsa + 'module_environment),
         translation: &'module_environment ModuleTranslation<'module_environment>,
-        types: &'module_environment ModuleTypes,
+        types: &'module_environment ModuleTypesBuilder,
         tunables: &'module_environment Tunables,
         wmemcheck: bool,
     ) -> Self {
@@ -1204,8 +1204,12 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
 }
 
 impl TypeConvert for FuncEnvironment<'_> {
-    fn lookup_heap_type(&self, ty: TypeIndex) -> WasmHeapType {
-        self.module.lookup_heap_type(ty)
+    fn lookup_heap_type(&self, ty: wasmparser::UnpackedIndex) -> WasmHeapType {
+        wasmtime_environ::WasmparserTypeConverter {
+            module: self.module,
+            types: self.types,
+        }
+        .lookup_heap_type(ty)
     }
 }
 

--- a/crates/environ/src/compilation.rs
+++ b/crates/environ/src/compilation.rs
@@ -3,7 +3,7 @@
 
 use crate::{obj, Tunables};
 use crate::{
-    DefinedFuncIndex, FilePos, FuncIndex, FunctionBodyData, ModuleTranslation, ModuleTypes,
+    DefinedFuncIndex, FilePos, FuncIndex, FunctionBodyData, ModuleTranslation, ModuleTypesBuilder,
     PrimaryMap, StackMap, WasmError, WasmFuncType,
 };
 use anyhow::Result;
@@ -179,7 +179,7 @@ pub trait Compiler: Send + Sync {
         translation: &ModuleTranslation<'_>,
         index: DefinedFuncIndex,
         data: FunctionBodyData<'_>,
-        types: &ModuleTypes,
+        types: &ModuleTypesBuilder,
     ) -> Result<(WasmFunctionInfo, Box<dyn Any + Send>), CompileError>;
 
     /// Compile a trampoline for an array-call host function caller calling the
@@ -190,7 +190,7 @@ pub trait Compiler: Send + Sync {
     fn compile_array_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
-        types: &ModuleTypes,
+        types: &ModuleTypesBuilder,
         index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError>;
 
@@ -202,7 +202,7 @@ pub trait Compiler: Send + Sync {
     fn compile_native_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
-        types: &ModuleTypes,
+        types: &ModuleTypesBuilder,
         index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError>;
 

--- a/crates/environ/src/component/compiler.rs
+++ b/crates/environ/src/component/compiler.rs
@@ -1,4 +1,4 @@
-use crate::component::{ComponentTranslation, ComponentTypes, TrampolineIndex};
+use crate::component::{ComponentTranslation, ComponentTypesBuilder, TrampolineIndex};
 use anyhow::Result;
 use serde_derive::{Deserialize, Serialize};
 use std::any::Any;
@@ -41,7 +41,7 @@ pub trait ComponentCompiler: Send + Sync {
     fn compile_trampoline(
         &self,
         component: &ComponentTranslation,
-        types: &ComponentTypes,
+        types: &ComponentTypesBuilder,
         trampoline: TrampolineIndex,
     ) -> Result<AllCallFunc<Box<dyn Any + Send>>>;
 }

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -894,7 +894,7 @@ impl<'a, 'data> Translator<'a, 'data> {
         let id = types.core_function_at(idx);
         let ty = types[id].unwrap_func();
         let ty = self.types.convert_func_type(ty);
-        self.types.module_types_builder().wasm_func_type(ty)
+        self.types.module_types_builder().wasm_func_type(id, ty)
     }
 }
 
@@ -928,7 +928,7 @@ mod pre_inlining {
         }
 
         pub fn module_types_builder(&mut self) -> &mut ModuleTypesBuilder {
-            self.types.module_types_builder()
+            self.types.module_types_builder_mut()
         }
 
         pub fn types(&self) -> &ComponentTypesBuilder {
@@ -943,7 +943,7 @@ mod pre_inlining {
     }
 
     impl TypeConvert for PreInliningComponentTypes<'_> {
-        fn lookup_heap_type(&self, index: TypeIndex) -> WasmHeapType {
+        fn lookup_heap_type(&self, index: wasmparser::UnpackedIndex) -> WasmHeapType {
             self.types.lookup_heap_type(index)
         }
     }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -1049,14 +1049,6 @@ impl Module {
     }
 }
 
-impl TypeConvert for Module {
-    fn lookup_heap_type(&self, index: TypeIndex) -> WasmHeapType {
-        match self.types[index] {
-            ModuleType::Function(i) => WasmHeapType::TypedFunc(i),
-        }
-    }
-}
-
 /// Type information about functions in a wasm module.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct FunctionType {

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -5,8 +5,8 @@ use crate::module::{
 use crate::{
     DataIndex, DefinedFuncIndex, ElemIndex, EntityIndex, EntityType, FuncIndex, GlobalIndex,
     GlobalInit, MemoryIndex, ModuleTypesBuilder, PrimaryMap, SignatureIndex, TableIndex,
-    TableInitialValue, Tunables, TypeConvert, TypeIndex, Unsigned, WasmError, WasmFuncType,
-    WasmHeapType, WasmResult, WasmType,
+    TableInitialValue, Tunables, TypeConvert, TypeIndex, Unsigned, WasmError, WasmHeapType,
+    WasmResult, WasmType, WasmparserTypeConverter,
 };
 use cranelift_entity::packed_option::ReservedValue;
 use std::borrow::Cow;
@@ -14,10 +14,11 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::path::PathBuf;
 use std::sync::Arc;
+use wasmparser::types::{CoreTypeId, Types};
 use wasmparser::{
-    types::Types, CustomSectionReader, DataKind, ElementItems, ElementKind, Encoding, ExternalKind,
-    FuncToValidate, FunctionBody, NameSectionReader, Naming, Operator, Parser, Payload, TypeRef,
-    Validator, ValidatorResources,
+    CompositeType, CustomSectionReader, DataKind, ElementItems, ElementKind, Encoding,
+    ExternalKind, FuncToValidate, FunctionBody, NameSectionReader, Naming, Operator, Parser,
+    Payload, TypeRef, Validator, ValidatorResources,
 };
 
 /// Object containing the standalone environment information.
@@ -237,9 +238,10 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                 self.result.module.types.reserve(num);
                 self.types.reserve_wasm_signatures(num);
 
-                for ty in types.into_iter_err_on_gc_types() {
-                    let ty = self.convert_func_type(&ty?);
-                    self.declare_type_func(ty)?;
+                for i in 0..types.count() {
+                    let types = self.validator.types(0).unwrap();
+                    let ty = types.core_type_at(i);
+                    self.declare_type(ty.unwrap_sub())?;
                 }
             }
 
@@ -791,12 +793,22 @@ and for re-adding support for interface types you can see this issue:
         self.result.module.num_escaped_funcs += 1;
     }
 
-    fn declare_type_func(&mut self, wasm: WasmFuncType) -> WasmResult<()> {
-        let sig_index = self.types.wasm_func_type(wasm);
-        self.result
-            .module
-            .types
-            .push(ModuleType::Function(sig_index));
+    fn declare_type(&mut self, id: CoreTypeId) -> WasmResult<()> {
+        let types = self.validator.types(0).unwrap();
+        let ty = &types[id];
+        assert!(ty.is_final);
+        assert!(ty.supertype_idx.is_none());
+        match &ty.composite_type {
+            CompositeType::Func(ty) => {
+                let wasm = self.convert_func_type(ty);
+                let sig_index = self.types.wasm_func_type(id, wasm);
+                self.result
+                    .module
+                    .types
+                    .push(ModuleType::Function(sig_index));
+            }
+            CompositeType::Array(_) | CompositeType::Struct(_) => unimplemented!(),
+        }
         Ok(())
     }
 
@@ -870,7 +882,11 @@ and for re-adding support for interface types you can see this issue:
 }
 
 impl TypeConvert for ModuleEnvironment<'_, '_> {
-    fn lookup_heap_type(&self, index: TypeIndex) -> WasmHeapType {
-        self.result.module.lookup_heap_type(index)
+    fn lookup_heap_type(&self, index: wasmparser::UnpackedIndex) -> WasmHeapType {
+        WasmparserTypeConverter {
+            types: &self.types,
+            module: &self.result.module,
+        }
+        .lookup_heap_type(index)
     }
 }

--- a/crates/environ/src/module_types.rs
+++ b/crates/environ/src/module_types.rs
@@ -1,7 +1,12 @@
-use crate::{PrimaryMap, SignatureIndex, WasmFuncType};
+use crate::{
+    Module, ModuleType, PrimaryMap, SignatureIndex, TypeConvert, TypeIndex, WasmFuncType,
+    WasmHeapType,
+};
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::ops::Index;
+use wasmparser::types::CoreTypeId;
+use wasmparser::UnpackedIndex;
 
 /// All types used in a core wasm module.
 ///
@@ -38,6 +43,7 @@ impl Index<SignatureIndex> for ModuleTypes {
 pub struct ModuleTypesBuilder {
     types: ModuleTypes,
     interned_func_types: HashMap<WasmFuncType, SignatureIndex>,
+    wasmparser_to_wasmtime: HashMap<CoreTypeId, SignatureIndex>,
 }
 
 impl ModuleTypesBuilder {
@@ -49,7 +55,13 @@ impl ModuleTypesBuilder {
     /// Interns the `sig` specified and returns a unique `SignatureIndex` that
     /// can be looked up within [`ModuleTypes`] to recover the [`WasmFuncType`]
     /// at runtime.
-    pub fn wasm_func_type(&mut self, sig: WasmFuncType) -> SignatureIndex {
+    pub fn wasm_func_type(&mut self, id: CoreTypeId, sig: WasmFuncType) -> SignatureIndex {
+        let sig = self.intern_func_type(sig);
+        self.wasmparser_to_wasmtime.insert(id, sig);
+        sig
+    }
+
+    fn intern_func_type(&mut self, sig: WasmFuncType) -> SignatureIndex {
         if let Some(idx) = self.interned_func_types.get(&sig) {
             return *idx;
         }
@@ -63,6 +75,12 @@ impl ModuleTypesBuilder {
     pub fn finish(self) -> ModuleTypes {
         self.types
     }
+
+    /// Returns an iterator over all the wasm function signatures found within
+    /// this module.
+    pub fn wasm_signatures(&self) -> impl Iterator<Item = (SignatureIndex, &WasmFuncType)> {
+        self.types.wasm_signatures()
+    }
 }
 
 // Forward the indexing impl to the internal `ModuleTypes`
@@ -74,5 +92,29 @@ where
 
     fn index(&self, sig: T) -> &Self::Output {
         &self.types[sig]
+    }
+}
+
+#[allow(missing_docs)]
+pub struct WasmparserTypeConverter<'a> {
+    pub types: &'a ModuleTypesBuilder,
+    pub module: &'a Module,
+}
+
+impl TypeConvert for WasmparserTypeConverter<'_> {
+    fn lookup_heap_type(&self, index: UnpackedIndex) -> WasmHeapType {
+        match index {
+            UnpackedIndex::Id(id) => {
+                let signature = self.types.wasmparser_to_wasmtime[&id];
+                WasmHeapType::TypedFunc(signature)
+            }
+            UnpackedIndex::RecGroup(_) => unreachable!(),
+            UnpackedIndex::Module(i) => {
+                let i = TypeIndex::from_u32(i);
+                match self.module.types[i] {
+                    ModuleType::Function(sig) => WasmHeapType::TypedFunc(sig),
+                }
+            }
+        }
     }
 }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -483,7 +483,7 @@ pub trait TypeConvert {
         match ty {
             wasmparser::HeapType::Func => WasmHeapType::Func,
             wasmparser::HeapType::Extern => WasmHeapType::Extern,
-            wasmparser::HeapType::Concrete(i) => self.lookup_heap_type(TypeIndex::from_u32(i)),
+            wasmparser::HeapType::Concrete(i) => self.lookup_heap_type(i),
 
             wasmparser::HeapType::Any
             | wasmparser::HeapType::None
@@ -500,5 +500,5 @@ pub trait TypeConvert {
 
     /// Converts the specified type index from a heap type into a canonicalized
     /// heap type.
-    fn lookup_heap_type(&self, index: TypeIndex) -> WasmHeapType;
+    fn lookup_heap_type(&self, index: wasmparser::UnpackedIndex) -> WasmHeapType;
 }

--- a/crates/wasmtime/src/compiler.rs
+++ b/crates/wasmtime/src/compiler.rs
@@ -28,7 +28,7 @@ use std::collections::{btree_map, BTreeMap, BTreeSet};
 use std::{any::Any, collections::HashMap};
 use wasmtime_environ::{
     Compiler, DefinedFuncIndex, FuncIndex, FunctionBodyData, ModuleTranslation, ModuleType,
-    ModuleTypes, PrimaryMap, SignatureIndex, StaticModuleIndex, WasmFunctionInfo,
+    ModuleTypesBuilder, PrimaryMap, SignatureIndex, StaticModuleIndex, WasmFunctionInfo,
 };
 use wasmtime_jit::{CompiledFunctionInfo, CompiledModuleInfo};
 
@@ -173,7 +173,7 @@ impl<'a> CompileInputs<'a> {
 
     /// Create the `CompileInputs` for a core Wasm module.
     pub fn for_module(
-        types: &'a ModuleTypes,
+        types: &'a ModuleTypesBuilder,
         translation: &'a ModuleTranslation<'a>,
         functions: PrimaryMap<DefinedFuncIndex, FunctionBodyData<'a>>,
     ) -> Self {
@@ -188,7 +188,7 @@ impl<'a> CompileInputs<'a> {
     /// Create a `CompileInputs` for a component.
     #[cfg(feature = "component-model")]
     pub fn for_component(
-        types: &'a wasmtime_environ::component::ComponentTypes,
+        types: &'a wasmtime_environ::component::ComponentTypesBuilder,
         component: &'a wasmtime_environ::component::ComponentTranslation,
         module_translations: impl IntoIterator<
             Item = (
@@ -200,7 +200,7 @@ impl<'a> CompileInputs<'a> {
     ) -> Self {
         let mut ret = CompileInputs::default();
 
-        ret.collect_inputs_in_translations(types.module_types(), module_translations);
+        ret.collect_inputs_in_translations(types.module_types_builder(), module_translations);
 
         for (idx, trampoline) in component.trampolines.iter() {
             ret.push_input(move |compiler| {
@@ -241,7 +241,7 @@ impl<'a> CompileInputs<'a> {
 
     fn collect_inputs_in_translations(
         &mut self,
-        types: &'a ModuleTypes,
+        types: &'a ModuleTypesBuilder,
         translations: impl IntoIterator<
             Item = (
                 StaticModuleIndex,

--- a/crates/wasmtime/src/component/component.rs
+++ b/crates/wasmtime/src/component/component.rs
@@ -187,7 +187,6 @@ impl Component {
             Translator::new(tunables, &mut validator, &mut types, &scope)
                 .translate(binary)
                 .context("failed to parse WebAssembly module")?;
-        let types = types.finish();
 
         let compile_inputs = CompileInputs::for_component(
             &types,
@@ -198,6 +197,7 @@ impl Component {
             }),
         );
         let unlinked_compile_outputs = compile_inputs.compile(&engine)?;
+        let types = types.finish();
         let (compiled_funcs, function_indices) = unlinked_compile_outputs.pre_link();
 
         let mut object = compiler.object(ObjectKind::Component)?;

--- a/crates/wasmtime/src/module.rs
+++ b/crates/wasmtime/src/module.rs
@@ -415,10 +415,10 @@ impl Module {
             .translate(parser, wasm)
             .context("failed to parse WebAssembly module")?;
         let functions = mem::take(&mut translation.function_body_inputs);
-        let types = types.finish();
 
         let compile_inputs = CompileInputs::for_module(&types, &translation, functions);
         let unlinked_compile_outputs = compile_inputs.compile(engine)?;
+        let types = types.finish();
         let (compiled_funcs, function_indices) = unlinked_compile_outputs.pre_link();
 
         // Emplace all compiled functions into the object file with any other

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -7,7 +7,8 @@ use wasmparser::FuncValidatorAllocations;
 use wasmtime_cranelift_shared::{CompiledFunction, ModuleTextBuilder};
 use wasmtime_environ::{
     CompileError, DefinedFuncIndex, FilePos, FuncIndex, FunctionBodyData, FunctionLoc,
-    ModuleTranslation, ModuleTypes, PrimaryMap, TrapEncodingBuilder, VMOffsets, WasmFunctionInfo,
+    ModuleTranslation, ModuleTypesBuilder, PrimaryMap, TrapEncodingBuilder, VMOffsets,
+    WasmFunctionInfo,
 };
 use winch_codegen::{BuiltinFunctions, TargetIsa, TrampolineKind};
 
@@ -70,7 +71,7 @@ impl wasmtime_environ::Compiler for Compiler {
         translation: &ModuleTranslation<'_>,
         index: DefinedFuncIndex,
         data: FunctionBodyData<'_>,
-        types: &ModuleTypes,
+        types: &ModuleTypesBuilder,
     ) -> Result<(WasmFunctionInfo, Box<dyn Any + Send>), CompileError> {
         let index = translation.module.func_index(index);
         let sig = translation.module.functions[index].signature;
@@ -112,7 +113,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_array_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
-        types: &ModuleTypes,
+        types: &ModuleTypesBuilder,
         index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError> {
         let func_index = translation.module.func_index(index);
@@ -131,7 +132,7 @@ impl wasmtime_environ::Compiler for Compiler {
     fn compile_native_to_wasm_trampoline(
         &self,
         translation: &ModuleTranslation<'_>,
-        types: &ModuleTypes,
+        types: &ModuleTypesBuilder,
         index: DefinedFuncIndex,
     ) -> Result<Box<dyn Any + Send>, CompileError> {
         let func_index = translation.module.func_index(index);

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1182,6 +1182,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasm-encoder]]
+version = "0.38.0"
+when = "2023-11-20"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wasm-metadata]]
 version = "0.10.9"
 when = "2023-10-14"
@@ -1199,6 +1206,13 @@ user-name = "Alex Crichton"
 [[publisher.wasm-metadata]]
 version = "0.10.11"
 when = "2023-11-06"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-metadata]]
+version = "0.10.13"
+when = "2023-11-20"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1224,6 +1238,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasm-mutate]]
+version = "0.2.42"
+when = "2023-11-20"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wasm-smith]]
 version = "0.12.21"
 when = "2023-10-14"
@@ -1241,6 +1262,13 @@ user-name = "Alex Crichton"
 [[publisher.wasm-smith]]
 version = "0.12.23"
 when = "2023-11-06"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasm-smith]]
+version = "0.13.0"
+when = "2023-11-20"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1266,6 +1294,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wasmparser]]
+version = "0.118.0"
+when = "2023-11-20"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wasmprinter]]
 version = "0.2.70"
 when = "2023-10-14"
@@ -1283,6 +1318,13 @@ user-name = "Alex Crichton"
 [[publisher.wasmprinter]]
 version = "0.2.72"
 when = "2023-11-06"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wasmprinter]]
+version = "0.2.74"
+when = "2023-11-20"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1608,6 +1650,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wast]]
+version = "69.0.0"
+when = "2023-11-20"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wat]]
 version = "1.0.77"
 when = "2023-10-14"
@@ -1625,6 +1674,13 @@ user-name = "Alex Crichton"
 [[publisher.wat]]
 version = "1.0.79"
 when = "2023-11-06"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wat]]
+version = "1.0.81"
+when = "2023-11-20"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1775,6 +1831,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wit-bindgen]]
+version = "0.15.0"
+when = "2023-11-27"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wit-bindgen-core]]
 version = "0.13.0"
 when = "2023-10-18"
@@ -1785,6 +1848,13 @@ user-name = "Alex Crichton"
 [[publisher.wit-bindgen-core]]
 version = "0.13.1"
 when = "2023-10-30"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen-core]]
+version = "0.15.0"
+when = "2023-11-27"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1803,6 +1873,13 @@ user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
+[[publisher.wit-bindgen-rust]]
+version = "0.15.0"
+when = "2023-11-27"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.wit-bindgen-rust-macro]]
 version = "0.13.0"
 when = "2023-10-18"
@@ -1813,6 +1890,13 @@ user-name = "Alex Crichton"
 [[publisher.wit-bindgen-rust-macro]]
 version = "0.13.1"
 when = "2023-10-30"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-bindgen-rust-macro]]
+version = "0.15.0"
+when = "2023-11-27"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1834,6 +1918,13 @@ user-name = "Alex Crichton"
 [[publisher.wit-component]]
 version = "0.18.0"
 when = "2023-11-06"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
+[[publisher.wit-component]]
+version = "0.18.2"
+when = "2023-11-20"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"

--- a/winch/codegen/src/frame/mod.rs
+++ b/winch/codegen/src/frame/mod.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use smallvec::SmallVec;
 use std::ops::Range;
 use wasmparser::{BinaryReader, FuncValidator, ValidatorResources};
-use wasmtime_environ::{ModuleTranslation, TypeConvert, WasmType};
+use wasmtime_environ::{TypeConvert, WasmType};
 
 // TODO:
 // SpiderMonkey's implementation uses 16;
@@ -36,7 +36,7 @@ pub(crate) struct DefinedLocals {
 impl DefinedLocals {
     /// Compute the local slots for a Wasm function.
     pub fn new<A: ABI>(
-        translation: &ModuleTranslation<'_>,
+        types: &impl TypeConvert,
         reader: &mut BinaryReader<'_>,
         validator: &mut FuncValidator<ValidatorResources>,
     ) -> Result<Self> {
@@ -51,7 +51,7 @@ impl DefinedLocals {
             let ty = reader.read()?;
             validator.define_locals(position, count, ty)?;
 
-            let ty = translation.module.convert_valtype(ty);
+            let ty = types.convert_valtype(ty);
             for _ in 0..count {
                 let ty_size = <A as ABI>::sizeof(&ty);
                 next_stack = align_to(next_stack, ty_size) + ty_size;

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -17,7 +17,7 @@ use cranelift_codegen::{MachTextSectionBuilder, TextSectionBuilder};
 use masm::MacroAssembler as Aarch64Masm;
 use target_lexicon::Triple;
 use wasmparser::{FuncValidator, FunctionBody, ValidatorResources};
-use wasmtime_environ::{ModuleTranslation, ModuleTypes, VMOffsets, WasmFuncType};
+use wasmtime_environ::{ModuleTranslation, ModuleTypesBuilder, VMOffsets, WasmFuncType};
 
 mod abi;
 mod address;
@@ -87,7 +87,7 @@ impl TargetIsa for Aarch64 {
         sig: &WasmFuncType,
         body: &FunctionBody,
         translation: &ModuleTranslation,
-        types: &ModuleTypes,
+        types: &ModuleTypesBuilder,
         builtins: &mut BuiltinFunctions,
         validator: &mut FuncValidator<ValidatorResources>,
     ) -> Result<MachBufferFinalized<Final>> {
@@ -98,8 +98,8 @@ impl TargetIsa for Aarch64 {
         let stack = Stack::new();
         let abi_sig = abi::Aarch64ABI::sig(sig, &CallingConvention::Default);
 
-        let defined_locals =
-            DefinedLocals::new::<abi::Aarch64ABI>(translation, &mut body, validator)?;
+        let env = FuncEnv::new(&vmoffsets, translation, types);
+        let defined_locals = DefinedLocals::new::<abi::Aarch64ABI>(&env, &mut body, validator)?;
         let frame = Frame::new::<abi::Aarch64ABI>(&abi_sig, &defined_locals)?;
         let gpr = RegBitSet::int(
             ALL_GPR.into(),
@@ -110,7 +110,6 @@ impl TargetIsa for Aarch64 {
         let fpr = RegBitSet::float(0, 0, usize::try_from(MAX_FPR).unwrap());
         let regalloc = RegAlloc::from(gpr, fpr);
         let codegen_context = CodeGenContext::new(regalloc, stack, frame, builtins, &vmoffsets);
-        let env = FuncEnv::new(&vmoffsets, translation, types);
         let mut codegen = CodeGen::new(&mut masm, codegen_context, env, abi_sig);
 
         codegen.emit(&mut body, validator)?;

--- a/winch/codegen/src/isa/mod.rs
+++ b/winch/codegen/src/isa/mod.rs
@@ -10,7 +10,7 @@ use std::{
 };
 use target_lexicon::{Architecture, Triple};
 use wasmparser::{FuncValidator, FunctionBody, ValidatorResources};
-use wasmtime_environ::{ModuleTranslation, ModuleTypes, WasmFuncType};
+use wasmtime_environ::{ModuleTranslation, ModuleTypesBuilder, WasmFuncType};
 
 #[cfg(feature = "x64")]
 pub(crate) mod x64;
@@ -158,7 +158,7 @@ pub trait TargetIsa: Send + Sync {
         sig: &WasmFuncType,
         body: &FunctionBody,
         translation: &ModuleTranslation,
-        types: &ModuleTypes,
+        types: &ModuleTypesBuilder,
         builtins: &mut BuiltinFunctions,
         validator: &mut FuncValidator<ValidatorResources>,
     ) -> Result<MachBufferFinalized<Final>>;

--- a/winch/filetests/Cargo.toml
+++ b/winch/filetests/Cargo.toml
@@ -24,3 +24,4 @@ serde = { workspace = true }
 serde_derive = { workspace = true }
 cranelift-codegen = { workspace = true }
 capstone = { workspace = true }
+wasmparser = { workspace = true }


### PR DESCRIPTION
This commit updates to the latest wasm-tools and `wit-bindgen` to bring the family of crates forward. This update notably includes Nick's work on packed indices in the `wasmparser` crate for validation for the upcoming implementation of GC types. This meant that translation from `wasmparser` types to Wasmtime types now may work with a "type id" instead of just a type index which required plumbing not only Wasmtime's own type information but additionally `wasmparser`'s type information throughout translation.

This required a fair bit of refactoring to get this working but no change in functionality is intended, only a different way of doing everything prior.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
