### PR TITLE
Winch: cleanup stack in br_if in non-fallthrough case

### DIFF
--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -24,7 +24,7 @@ pub(crate) enum RemKind {
 }
 
 /// Representation of the stack pointer offset.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug, PartialOrd, Ord)]
 pub struct SPOffset(u32);
 
 impl SPOffset {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1213,8 +1213,6 @@ where
 
             // Emit instructions to balance the stack and jump if not falling
             // through.
-            let current_sp_offset = self.masm.sp_offset();
-            let (_, frame_sp_offset) = frame.base_stack_len_and_sp();
             self.masm.ensure_sp_for_jump(frame_sp_offset);
             self.masm.jmp(*frame.label());
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1189,13 +1189,39 @@ where
             self.context.pop_to_reg(self.masm, None)
         };
 
-        self.masm.branch(
-            IntCmpKind::Ne,
-            top.reg.into(),
-            top.reg.into(),
-            *frame.label(),
-            OperandSize::S32,
-        );
+        // Emit instructions to balance the machine stack if the frame has
+        // a different offset.
+        let current_sp_offset = self.masm.sp_offset();
+        let (_, frame_sp_offset) = frame.base_stack_len_and_sp();
+        if current_sp_offset == frame_sp_offset {
+            self.masm.branch(
+                IntCmpKind::Ne,
+                top.reg.into(),
+                top.reg.into(),
+                *frame.label(),
+                OperandSize::S32,
+            );
+        } else {
+            let br_fallthrough_label = self.masm.get_label();
+            self.masm.branch(
+                IntCmpKind::Eq,
+                top.reg.into(),
+                top.reg.into(),
+                br_fallthrough_label,
+                OperandSize::S32,
+            );
+
+            // Emit instructions to balance the stack and jump if not falling
+            // through.
+            let current_sp_offset = self.masm.sp_offset();
+            let (_, frame_sp_offset) = frame.base_stack_len_and_sp();
+            self.masm.ensure_sp_for_jump(frame_sp_offset);
+            self.masm.jmp(*frame.label());
+
+            // Restore sp_offset to what it was for falling through.
+            self.masm.reset_stack_pointer(current_sp_offset);
+            self.masm.bind(br_fallthrough_label);
+        }
         self.context.free_reg(top);
     }
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -1193,7 +1193,7 @@ where
         // a different offset.
         let current_sp_offset = self.masm.sp_offset();
         let (_, frame_sp_offset) = frame.base_stack_len_and_sp();
-        let (label, cmp, needs_cleanup) = if current_sp_offset.as_u32() > frame_sp_offset.as_u32() {
+        let (label, cmp, needs_cleanup) = if current_sp_offset > frame_sp_offset {
             (self.masm.get_label(), IntCmpKind::Eq, true)
         } else {
             (*frame.label(), IntCmpKind::Ne, false)

--- a/winch/filetests/filetests/x64/br_if/with_machine_stack_entry.wat
+++ b/winch/filetests/filetests/x64/br_if/with_machine_stack_entry.wat
@@ -1,0 +1,42 @@
+;;! target = "x86_64"
+
+(module
+  (func (export "") 
+    call 1
+    call 1
+    br_if 0
+    drop
+  )
+  (func (;1;) (result i32)
+    i32.const 1
+  )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 4883ec08             	sub	rsp, 8
+;;   10:	 e800000000           	call	0x15
+;;   15:	 4883c408             	add	rsp, 8
+;;   19:	 4883ec04             	sub	rsp, 4
+;;   1d:	 890424               	mov	dword ptr [rsp], eax
+;;   20:	 4883ec04             	sub	rsp, 4
+;;   24:	 e800000000           	call	0x29
+;;   29:	 4883c404             	add	rsp, 4
+;;   2d:	 85c0                 	test	eax, eax
+;;   2f:	 0f8409000000         	je	0x3e
+;;   35:	 4883c404             	add	rsp, 4
+;;   39:	 e904000000           	jmp	0x42
+;;   3e:	 4883c404             	add	rsp, 4
+;;   42:	 4883c408             	add	rsp, 8
+;;   46:	 5d                   	pop	rbp
+;;   47:	 c3                   	ret	
+;;
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 b801000000           	mov	eax, 1
+;;   11:	 4883c408             	add	rsp, 8
+;;   15:	 5d                   	pop	rbp
+;;   16:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/call/reg_on_stack.wat
+++ b/winch/filetests/filetests/x64/call/reg_on_stack.wat
@@ -35,8 +35,10 @@
 ;;   56:	 8b0424               	mov	eax, dword ptr [rsp]
 ;;   59:	 4883c404             	add	rsp, 4
 ;;   5d:	 85c9                 	test	ecx, ecx
-;;   5f:	 0f8502000000         	jne	0x67
-;;   65:	 0f0b                 	ud2	
-;;   67:	 4883c410             	add	rsp, 0x10
-;;   6b:	 5d                   	pop	rbp
-;;   6c:	 c3                   	ret	
+;;   5f:	 0f8409000000         	je	0x6e
+;;   65:	 4883c404             	add	rsp, 4
+;;   69:	 e902000000           	jmp	0x70
+;;   6e:	 0f0b                 	ud2	
+;;   70:	 4883c410             	add	rsp, 0x10
+;;   74:	 5d                   	pop	rbp
+;;   75:	 c3                   	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
I discovered that executing the following module compiled with Winch causes a segmentation fault:

```wat
(module
  (func (export "") 
    call 1
    call 1
    br_if 0
    drop
  )
  (func (;1;) (result i32)
    i32.const 1
  )
)
```

The cause appears to be that the code that would increment `rsp` to balance the machine stack is jumped over when the `br_if` path is taken.

What appears to work is, if the frame's `sp_offset` is different than the current `sp_offset`, we invert the existing jump and execute instructions to balance the stack before jumping to the frame's label, and reset the `sp_offset` before continuing with the fallthrough code (falling through in terms of the `br_if`, not the machine code jump). In the case where there is no difference between `sp_offset`s, we can use the existing `jne` machine code emission since we don't need to run any stack balancing instructions.

In terms of machine instructions, we'd be changing

```
sub rsp, 4
test <reg> <reg>
jne end
add rsp, 4
end:
add rsp, 8
pop rbp
ret
```

to

```
sub rsp, 4
test <reg> <reg>
jeq fallthrough
add rsp, 4
jmp end
fallthrough:
add rsp, 4
end:
add rsp, 8
pop rbp
ret
```