### PR TITLE
Raise Http{Request,Response}BodyError when Content-Length doesn't match

### DIFF
--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -1,4 +1,3 @@
-use crate::internal_error;
 use crate::{bindings::http::types, types::FieldMap};
 use anyhow::anyhow;
 use bytes::Bytes;
@@ -381,6 +380,11 @@ impl WrittenState {
         }
     }
 
+    /// The number of bytes that have been written so far.
+    fn written(&self) -> u64 {
+        self.written.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Add `len` to the total number of bytes written. Returns `false` if the new total exceeds
     /// the number of bytes expected to be written.
     fn update(&self, len: usize) -> bool {
@@ -390,22 +394,17 @@ impl WrittenState {
             .fetch_add(len, std::sync::atomic::Ordering::Relaxed);
         old + len <= self.expected
     }
-
-    /// Return a comparison of total bytes written to the number of bytes expected to be written.
-    fn finish(self) -> std::cmp::Ordering {
-        let written = self.written.load(std::sync::atomic::Ordering::Relaxed);
-        written.cmp(&self.expected)
-    }
 }
 
 pub struct HostOutgoingBody {
     pub body_output_stream: Option<Box<dyn HostOutputStream>>,
+    context: StreamContext,
     written: Option<WrittenState>,
     finish_sender: Option<tokio::sync::oneshot::Sender<FinishMessage>>,
 }
 
 impl HostOutgoingBody {
-    pub fn new(size: Option<u64>) -> (Self, HyperOutgoingBody) {
+    pub fn new(context: StreamContext, size: Option<u64>) -> (Self, HyperOutgoingBody) {
         let written = size.map(WrittenState::new);
 
         use tokio::sync::oneshot::error::RecvError;
@@ -460,11 +459,13 @@ impl HostOutgoingBody {
         .boxed();
 
         // TODO: this capacity constant is arbitrary, and should be configurable
-        let output_stream = BodyWriteStream::new(1024 * 1024, body_sender, written.clone());
+        let output_stream =
+            BodyWriteStream::new(context, 1024 * 1024, body_sender, written.clone());
 
         (
             Self {
                 body_output_stream: Some(Box::new(output_stream)),
+                context,
                 written,
                 finish_sender: Some(finish_sender),
             },
@@ -483,17 +484,10 @@ impl HostOutgoingBody {
             .expect("outgoing-body trailer_sender consumed by a non-owning function");
 
         if let Some(w) = self.written {
-            use std::cmp::Ordering;
-            let res = w.finish();
-            if res != Ordering::Equal {
-                let msg = match res {
-                    Ordering::Less => "not enough",
-                    Ordering::Greater => "too much",
-                    Ordering::Equal => unreachable!(),
-                };
-
+            let written = w.written();
+            if written != w.expected {
                 let _ = sender.send(FinishMessage::Abort);
-                return Err(internal_error(format!("{msg} written to body stream")));
+                return Err(self.context.as_body_error(written));
             }
         }
 
@@ -523,8 +517,25 @@ impl HostOutgoingBody {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum StreamContext {
+    Request,
+    Response,
+}
+
+impl StreamContext {
+    /// Construct an http request or response body size error.
+    pub fn as_body_error(&self, size: u64) -> types::ErrorCode {
+        match self {
+            StreamContext::Request => types::ErrorCode::HttpRequestBodySize(Some(size)),
+            StreamContext::Response => types::ErrorCode::HttpResponseBodySize(Some(size)),
+        }
+    }
+}
+
 /// Provides a [`HostOutputStream`] impl from a [`tokio::sync::mpsc::Sender`].
 struct BodyWriteStream {
+    context: StreamContext,
     writer: mpsc::Sender<Bytes>,
     write_budget: usize,
     written: Option<WrittenState>,
@@ -533,6 +544,7 @@ struct BodyWriteStream {
 impl BodyWriteStream {
     /// Create a [`BodyWriteStream`].
     fn new(
+        context: StreamContext,
         write_budget: usize,
         writer: mpsc::Sender<Bytes>,
         written: Option<WrittenState>,
@@ -540,6 +552,7 @@ impl BodyWriteStream {
         // at least one capacity is required to send a message
         assert!(writer.max_capacity() >= 1);
         BodyWriteStream {
+            context,
             writer,
             write_budget,
             written,
@@ -557,9 +570,10 @@ impl HostOutputStream for BodyWriteStream {
             Ok(()) => {
                 if let Some(written) = self.written.as_ref() {
                     if !written.update(len) {
-                        return Err(StreamError::LastOperationFailed(anyhow!(internal_error(
-                            "too much written to output stream".to_owned()
-                        ))));
+                        let total = written.written();
+                        return Err(StreamError::LastOperationFailed(anyhow!(self
+                            .context
+                            .as_body_error(total))));
                     }
                 }
 

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -1,6 +1,6 @@
 use crate::{
     bindings::http::types::{self, Headers, Method, Scheme, StatusCode, Trailers},
-    body::{HostFutureTrailers, HostIncomingBody, HostOutgoingBody},
+    body::{HostFutureTrailers, HostIncomingBody, HostOutgoingBody, StreamContext},
     types::{
         is_forbidden_header, remove_forbidden_headers, FieldMap, HostFields,
         HostFutureIncomingResponse, HostIncomingRequest, HostIncomingResponse, HostOutgoingRequest,
@@ -384,7 +384,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingRequest for T {
             Err(e) => return Ok(Err(e)),
         };
 
-        let (host_body, hyper_body) = HostOutgoingBody::new(size);
+        let (host_body, hyper_body) = HostOutgoingBody::new(StreamContext::Request, size);
 
         req.body = Some(hyper_body);
 
@@ -728,7 +728,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingResponse for T {
             Err(e) => return Ok(Err(e)),
         };
 
-        let (host, body) = HostOutgoingBody::new(size);
+        let (host, body) = HostOutgoingBody::new(StreamContext::Response, size);
 
         resp.body.replace(body);
 


### PR DESCRIPTION
Instead of `InternalError`, raise a more specific request or response body size error when the number of bytes written to the outgoing body doesn't match the expectation set by the `Content-Length` header.

This change does overload the meaning of the `http-{request,response}-body-size` errors, as they were previously defined as meaning specifically that the body was too large, while this PR uses them to mean that the body length didn't match the expected length.

Addresses https://github.com/WebAssembly/wasi-http/issues/83
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
