### PR TITLE
PCC: Fix several aarch64 check_constant failures

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -1709,6 +1709,9 @@
 (decl pure partial imm_logic_from_u64 (Type u64) ImmLogic)
 (extern constructor imm_logic_from_u64 imm_logic_from_u64)
 
+(decl pure partial imm_size_from_type (Type) u16)
+(extern constructor imm_size_from_type imm_size_from_type)
+
 (decl pure partial imm_logic_from_imm64 (Type Imm64) ImmLogic)
 (extern constructor imm_logic_from_imm64 imm_logic_from_imm64)
 
@@ -2938,9 +2941,10 @@
 ;; we only match when we are zero-extending the value.
 (rule 1 (imm (integral_ty ty) (ImmExtend.Zero) k)
       (if-let n (imm_logic_from_u64 ty k))
+      (if-let m (imm_size_from_type ty))
       (add_range_fact
        (orr_imm ty (zero_reg) n)
-       64 k k))
+       m k k))
 
 (decl load_constant64_full (Type ImmExtend u64) Reg)
 (extern constructor load_constant64_full load_constant64_full)

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -174,6 +174,14 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
         ImmLogic::maybe_from_u64(n, ty)
     }
 
+    fn imm_size_from_type(&mut self, ty: Type) -> Option<u16> {
+        match ty {
+            I32 => Some(32),
+            I64 => Some(64),
+            _ => None,
+        }
+    }
+
     fn imm_logic_from_imm64(&mut self, ty: Type, n: Imm64) -> Option<ImmLogic> {
         let ty = if ty.bits() < 32 { I32 } else { ty };
         self.imm_logic_from_u64(ty, n.bits() as u64)
@@ -395,7 +403,7 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
                         size,
                     });
                     if pcc {
-                        running_value = !(imm16 << shift);
+                        running_value = !(u64::from(imm.bits) << shift);
                         self.lower_ctx.add_range_fact(
                             rd.to_reg(),
                             64,

--- a/cranelift/codegen/src/machinst/pcc.rs
+++ b/cranelift/codegen/src/machinst/pcc.rs
@@ -6,12 +6,7 @@ use crate::trace;
 
 pub(crate) fn get_fact_or_default<I: VCodeInst>(vcode: &VCode<I>, reg: Reg, width: u16) -> Fact {
     trace!(
-        "get_fact_or_default: reg {} -> {:?}",
-        if reg.is_virtual() {
-            format!("v{}", reg.to_virtual_reg().unwrap().index())
-        } else {
-            format!("r{}", reg.to_real_reg().unwrap().hw_enc())
-        },
+        "get_fact_or_default: reg {reg:?} -> {:?}"
         vcode.vreg_fact(reg.into())
     );
     vcode

--- a/cranelift/codegen/src/machinst/pcc.rs
+++ b/cranelift/codegen/src/machinst/pcc.rs
@@ -6,7 +6,7 @@ use crate::trace;
 
 pub(crate) fn get_fact_or_default<I: VCodeInst>(vcode: &VCode<I>, reg: Reg, width: u16) -> Fact {
     trace!(
-        "get_fact_or_default: reg {reg:?} -> {:?}"
+        "get_fact_or_default: reg {reg:?} -> {:?}",
         vcode.vreg_fact(reg.into())
     );
     vcode

--- a/cranelift/codegen/src/machinst/pcc.rs
+++ b/cranelift/codegen/src/machinst/pcc.rs
@@ -6,8 +6,12 @@ use crate::trace;
 
 pub(crate) fn get_fact_or_default<I: VCodeInst>(vcode: &VCode<I>, reg: Reg, width: u16) -> Fact {
     trace!(
-        "get_fact_or_default: reg v{} -> {:?}",
-        reg.to_virtual_reg().unwrap().index(),
+        "get_fact_or_default: reg {} -> {:?}",
+        if reg.is_virtual() {
+            format!("v{}", reg.to_virtual_reg().unwrap().index())
+        } else {
+            format!("r{}", reg.to_real_reg().unwrap().hw_enc())
+        },
         vcode.vreg_fact(reg.into())
     );
     vcode

--- a/cranelift/filetests/filetests/pcc/succeed/const.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/const.clif
@@ -16,3 +16,15 @@ block0:
     v8 ! range(64, 0xffff_0000_0000_ffff, 0xffff_0000_0000_ffff) = iconst.i64 0xffff_0000_0000_ffff
     return
 }
+
+function %f1() -> i32 {
+block0:
+    v0 = iconst.i32 0x10_0010
+    return v0
+}
+
+function %f2() -> i64 {
+block0:
+    v0 = iconst.i64 0x9_ffff_ffff
+    return v0
+}


### PR DESCRIPTION
Hi team, please consider:
This patch fixes several aarch64 check_constant failures:

1. `check_subsume` for `AluRRImmLogic` failed due to the mismatch of fact width

  isle rule for `orr_imm` always generates fact with bit_width 64 regardless of
  immediate type. So when Type is I32, `check_subsume` will be failed.
  This could be reproduced with the simple wasm module [1].

2. `MovN` generates incorrect fact range value when `first_is_inverted` is true

  `running_value` should be calculated as `!(((!imm16) & 0xffff) << shift)` or
  `!(u64::from(imm.bits) << shift)`
  This could be reproduced with the simple wasm module [2].

Added two test cases in cranelift/filetests/filetests/pcc/succeed/const.clif.

Additional fix for `get_fact_or_default`:

  `trace!` treats `reg` as VirtualReg and it will panic when `reg` is RealReg and
  `trace-log` feature is enabled.


[1]:
```wasm
;; test_logic.wat
(module
  (func (export "test_logic") (result i32) (i32.const 0x100010))
)
```
[2]:
```wasm
;; test_const.wat
(module
  (func (export "test_constant") (result i64) (i64.const 0x0009ffffffff))
)
```
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
