### PR TITLE
c-api: support disabling mach ports use on macos

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -367,6 +367,17 @@ WASM_API_EXTERN void wasmtime_config_cranelift_flag_enable(wasm_config_t*, const
  */
 WASM_API_EXTERN void wasmtime_config_cranelift_flag_set(wasm_config_t*, const char *key, const char *value);
 
+/**
+ * \brief Configures whether, when on macOS, Mach ports are used for exception handling
+ * instead of traditional Unix-based signal handling.
+ *
+ * This option defaults to true, using Mach ports by default.
+ *
+ * For more information see the Rust documentation at
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.macos_use_mach_ports
+ */
+WASMTIME_CONFIG_PROP(void, macos_use_mach_ports, bool)
+
 
 /**
  * Return the data from a LinearMemory instance.

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -241,6 +241,11 @@ pub unsafe extern "C" fn wasmtime_config_target_set(
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_config_macos_use_mach_ports_set(c: &mut wasm_config_t, enabled: bool) {
+    c.config.macos_use_mach_ports(enabled);
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn wasmtime_config_cranelift_flag_enable(
     c: &mut wasm_config_t,
     flag: *const c_char,


### PR DESCRIPTION
This PR proposes exposing [macos_use_mach_ports](https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.macos_use_mach_ports) engine configuration in the c-api.

As discussed [here](https://github.com/bytecodealliance/wasmtime/issues/6785) host applications that employ fork strategies might benefit from disabling `macos_use_mach_ports` when running on macOS. 
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
