### PR TITLE
Replace the preview2 table's HashMap storage with a Vec

### DIFF
--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -276,13 +276,10 @@ impl Table {
     ) -> impl Iterator<Item = (Result<&'a mut dyn Any, TableError>, T)> {
         map.into_iter().map(move |(k, v)| {
             let item = self
-                .entries
-                .get_mut(k as usize)
-                .and_then(Entry::occupied_mut)
+                .occupied_mut(k)
                 .map(|e| Box::as_mut(&mut e.entry))
                 // Safety: extending the lifetime of the mutable reference.
-                .map(|item| unsafe { &mut *(item as *mut dyn Any) })
-                .ok_or(TableError::NotPresent);
+                .map(|item| unsafe { &mut *(item as *mut dyn Any) });
             (item, v)
         })
     }

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -127,7 +127,7 @@ impl Table {
         res
     }
 
-    /// Free an entry in the table, returning its entry. Add the entry to the free list.
+    /// Free an entry in the table, returning its [`TableEntry`]. Add the index to the free list.
     fn free_entry(&mut self, ix: usize) -> TableEntry {
         let entry = match std::mem::replace(
             &mut self.entries[ix],

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -115,16 +115,16 @@ impl Table {
 
     /// Pop an index off of the free list, if it's not empty.
     fn pop_free_list(&mut self) -> Option<usize> {
-        let res = self.free_head;
-        if let Some(ix) = res {
+        if let Some(ix) = self.free_head {
             // Advance free_head to the next entry if one is available.
             match &self.entries[ix] {
                 Entry::Free { next } => self.free_head = *next,
                 Entry::Occupied { .. } => unreachable!(),
             }
+            Some(ix)
+        } else {
+            None
         }
-
-        res
     }
 
     /// Free an entry in the table, returning its [`TableEntry`]. Add the index to the free list.

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -95,7 +95,7 @@ impl Table {
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
-        assert!(capacity > 2);
+        assert!(capacity > 3);
 
         let mut entries = Vec::with_capacity(capacity);
 
@@ -103,6 +103,7 @@ impl Table {
         // indicies are still valid ways to access stdio, they are deliberately left empty.
         // Once we have a full implementation of resources, this confusion should hopefully be
         // impossible :)
+        entries.push(Entry::Free { next: None });
         entries.push(Entry::Free { next: None });
         entries.push(Entry::Free { next: None });
 

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -95,20 +95,8 @@ impl Table {
     }
 
     pub fn with_capacity(capacity: usize) -> Self {
-        assert!(capacity > 3);
-
-        let mut entries = Vec::with_capacity(capacity);
-
-        // 0, 1 and 2 are formerly (preview 1) for stdio. To prevent users from assuming these
-        // indicies are still valid ways to access stdio, they are deliberately left empty.
-        // Once we have a full implementation of resources, this confusion should hopefully be
-        // impossible :)
-        entries.push(Entry::Free { next: None });
-        entries.push(Entry::Free { next: None });
-        entries.push(Entry::Free { next: None });
-
         Table {
-            entries,
+            entries: Vec::with_capacity(capacity),
             free_head: None,
             free_tail: None,
         }

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -95,6 +95,14 @@ impl Table {
         }
     }
 
+    /// Create an empty table with at least the specified capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Table {
+            entries: Vec::with_capacity(capacity),
+            free_head: None,
+        }
+    }
+
     /// Inserts a new value `T` into this table, returning a corresponding
     /// `Resource<T>` which can be used to refer to it after it was inserted.
     pub fn push<T>(&mut self, entry: T) -> Result<Resource<T>, TableError>

--- a/crates/wasi/src/preview2/table.rs
+++ b/crates/wasi/src/preview2/table.rs
@@ -222,19 +222,11 @@ impl Table {
         T: Send + Sync + 'static,
         U: 'static,
     {
-        let idx = self.push_child_(Box::new(entry), parent.rep())?;
-        Ok(Resource::new_own(idx))
-    }
-
-    fn push_child_(
-        &mut self,
-        entry: Box<dyn Any + Send + Sync>,
-        parent: u32,
-    ) -> Result<u32, TableError> {
+        let parent = parent.rep();
         self.occupied(parent)?;
-        let child = self.push_(TableEntry::new(entry, Some(parent)))?;
+        let child = self.push_(TableEntry::new(Box::new(entry), Some(parent)))?;
         self.occupied_mut(parent)?.add_child(child);
-        Ok(child)
+        Ok(Resource::new_own(child))
     }
 
     /// Get an immutable reference to a resource of a given type at a given


### PR DESCRIPTION
Fix the TODO in preview2's table implementation about performance of key generation once the index space has wrapped; instead of incrementing a u32, store resources in a vector and keep a free queue in the empty slots.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
