### PR TITLE
add clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,2 @@
+---
+BasedOnStyle: WebKit

--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,0 @@
----
-BasedOnStyle: WebKit
-BreakBeforeBraces: Attach

--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,3 @@
 ---
 BasedOnStyle: WebKit
+BreakBeforeBraces: Attach

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,7 +56,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
   # Check Code style quickly by running `clang-format` over all the C/C++ code
-  rustfmt:
+  clangformat:
     name: Clang format
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,22 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
+  # Check Code style quickly by running `clang-format` over all the C/C++ code
+  rustfmt:
+    name: Clang format
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - run: git ls-files '*.h' '*.c' '*.cpp' | xargs clang-format-15 --dry-run --Werror --verbose
+
+    # common logic to cancel the entire run if this job fails
+    - run: gh run cancel ${{ github.run_id }}
+      if: failure() && github.event_name != 'pull_request'
+      env:
+        GH_TOKEN: ${{ github.token }}
+
   # Lint dependency graph for security advisories, duplicate versions, and
   # incompatible licences
   cargo_deny:

--- a/crates/c-api/include/doc-wasm.h
+++ b/crates/c-api/include/doc-wasm.h
@@ -1,3 +1,5 @@
+/* clang-format off */
+
 /**
  * \file wasm.h
  *
@@ -211,8 +213,8 @@
  * initialized and after this function is called you are then responsible for
  * ensuring #wasm_byte_vec_delete is called.
  *
- * \fn void wasm_byte_vec_new(wasm_byte_vec_t *out, size_t, wasm_byte_t
- * const[]); \brief Copies the specified data into a new byte vector.
+ * \fn void wasm_byte_vec_new(wasm_byte_vec_t *out, size_t, wasm_byte_t const[]);
+ * \brief Copies the specified data into a new byte vector.
  *
  * This function will copy the provided data into this byte vector. The byte
  * vector should not be previously initialized and the caller is responsible for
@@ -269,13 +271,13 @@
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_valtype_vec_new(wasm_valtype_vec_t *out, size_t, wasm_valtype_t
- * *const[]); \brief Creates a vector with the provided contents.
+ * \fn void wasm_valtype_vec_new(wasm_valtype_vec_t *out, size_t, wasm_valtype_t *const[]);
+ * \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_valtype_vec_copy(wasm_valtype_vec_t *out, const
- * wasm_valtype_vec_t *) \brief Copies one vector to another
+ * \fn void wasm_valtype_vec_copy(wasm_valtype_vec_t *out, const wasm_valtype_vec_t *)
+ * \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -330,19 +332,18 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_functype_vec_new_uninitialized(wasm_functype_vec_t *out,
- * size_t); \brief Creates a vector with the given capacity.
+ * \fn void wasm_functype_vec_new_uninitialized(wasm_functype_vec_t *out, size_t);
+ * \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_functype_vec_new(wasm_functype_vec_t *out, size_t,
- * wasm_functype_t *const[]); \brief Creates a vector with the provided
- * contents.
+ * \fn void wasm_functype_vec_new(wasm_functype_vec_t *out, size_t, wasm_functype_t *const[]);
+ * \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_functype_vec_copy(wasm_functype_vec_t *out, const
- * wasm_functype_vec_t *) \brief Copies one vector to another
+ * \fn void wasm_functype_vec_copy(wasm_functype_vec_t *out, const wasm_functype_vec_t *)
+ * \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -356,9 +357,9 @@
  *
  * The caller is responsible for deleting the returned value.
  *
- * \fn wasm_functype_t* wasm_functype_new(wasm_valtype_vec_t *params,
- * wasm_valtype_vec_t *results); \brief Creates a new function type with the
- * provided parameter and result types.
+ * \fn wasm_functype_t* wasm_functype_new(wasm_valtype_vec_t *params, wasm_valtype_vec_t *results);
+ * \brief Creates a new function type with the provided parameter and result
+ * types.
  *
  * This function takes ownership of the `params` and `results` arguments.
  *
@@ -404,19 +405,18 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_globaltype_vec_new_uninitialized(wasm_globaltype_vec_t *out,
- * size_t); \brief Creates a vector with the given capacity.
+ * \fn void wasm_globaltype_vec_new_uninitialized(wasm_globaltype_vec_t *out, size_t);
+ * \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_globaltype_vec_new(wasm_globaltype_vec_t *out, size_t,
- * wasm_globaltype_t *const[]); \brief Creates a vector with the provided
- * contents.
+ * \fn void wasm_globaltype_vec_new(wasm_globaltype_vec_t *out, size_t, wasm_globaltype_t *const[]);
+ * \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_globaltype_vec_copy(wasm_globaltype_vec_t *out, const
- * wasm_globaltype_vec_t *) \brief Copies one vector to another
+ * \fn void wasm_globaltype_vec_copy(wasm_globaltype_vec_t *out, const wasm_globaltype_vec_t *)
+ * \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -430,8 +430,8 @@
  *
  * The caller is responsible for deleting the returned value.
  *
- * \fn wasm_globaltype_t* wasm_globaltype_new(wasm_valtype_t *,
- * wasm_mutability_t) \brief Creates a new global type.
+ * \fn wasm_globaltype_t* wasm_globaltype_new(wasm_valtype_t *, wasm_mutability_t)
+ * \brief Creates a new global type.
  *
  * This function takes ownership of the #wasm_valtype_t argument.
  *
@@ -479,19 +479,18 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_tabletype_vec_new_uninitialized(wasm_tabletype_vec_t *out,
- * size_t); \brief Creates a vector with the given capacity.
+ * \fn void wasm_tabletype_vec_new_uninitialized(wasm_tabletype_vec_t *out, size_t);
+ * \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_tabletype_vec_new(wasm_tabletype_vec_t *out, size_t,
- * wasm_tabletype_t *const[]); \brief Creates a vector with the provided
- * contents.
+ * \fn void wasm_tabletype_vec_new(wasm_tabletype_vec_t *out, size_t, wasm_tabletype_t *const[]);
+ * \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_tabletype_vec_copy(wasm_tabletype_vec_t *out, const
- * wasm_tabletype_vec_t *) \brief Copies one vector to another
+ * \fn void wasm_tabletype_vec_copy(wasm_tabletype_vec_t *out, const wasm_tabletype_vec_t *)
+ * \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -505,8 +504,8 @@
  *
  * The caller is responsible for deleting the returned value.
  *
- * \fn wasm_tabletype_t* wasm_tabletype_new(wasm_valtype_t *, const
- * wasm_limits_t *)h \brief Creates a new table type.
+ * \fn wasm_tabletype_t* wasm_tabletype_new(wasm_valtype_t *, const wasm_limits_t *)h
+ * \brief Creates a new table type.
  *
  * This function takes ownership of the #wasm_valtype_t argument, but does not
  * take ownership of the #wasm_limits_t.
@@ -566,19 +565,18 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_memorytype_vec_new_uninitialized(wasm_memorytype_vec_t *out,
- * size_t); \brief Creates a vector with the given capacity.
+ * \fn void wasm_memorytype_vec_new_uninitialized(wasm_memorytype_vec_t *out, size_t);
+ * \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_memorytype_vec_new(wasm_memorytype_vec_t *out, size_t,
- * wasm_memorytype_t *const[]); \brief Creates a vector with the provided
- * contents.
+ * \fn void wasm_memorytype_vec_new(wasm_memorytype_vec_t *out, size_t, wasm_memorytype_t *const[]);
+ * \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_memorytype_vec_copy(wasm_memorytype_vec_t *out, const
- * wasm_memorytype_vec_t *) \brief Copies one vector to another
+ * \fn void wasm_memorytype_vec_copy(wasm_memorytype_vec_t *out, const wasm_memorytype_vec_t *)
+ * \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -642,19 +640,18 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_externtype_vec_new_uninitialized(wasm_externtype_vec_t *out,
- * size_t); \brief Creates a vector with the given capacity.
+ * \fn void wasm_externtype_vec_new_uninitialized(wasm_externtype_vec_t *out, size_t);
+ * \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_externtype_vec_new(wasm_externtype_vec_t *out, size_t,
- * wasm_externtype_t *const[]); \brief Creates a vector with the provided
- * contents.
+ * \fn void wasm_externtype_vec_new(wasm_externtype_vec_t *out, size_t, wasm_externtype_t *const[]);
+ * \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_externtype_vec_copy(wasm_externtype_vec_t *out, const
- * wasm_externtype_vec_t *) \brief Copies one vector to another
+ * \fn void wasm_externtype_vec_copy(wasm_externtype_vec_t *out, const wasm_externtype_vec_t *)
+ * \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -705,29 +702,26 @@
  * The returned value is owned by the #wasm_memorytype_t argument and should not
  * be deleted.
  *
- * \fn const wasm_externtype_t* wasm_functype_as_externtype_const(const
- * wasm_functype_t *) \brief Converts a #wasm_functype_t to a #wasm_externtype_t
+ * \fn const wasm_externtype_t* wasm_functype_as_externtype_const(const wasm_functype_t *)
+ * \brief Converts a #wasm_functype_t to a #wasm_externtype_t
  *
  * The returned value is owned by the #wasm_functype_t argument and should not
  * be deleted.
  *
- * \fn const wasm_externtype_t* wasm_tabletype_as_externtype_const(const
- * wasm_tabletype_t *) \brief Converts a #wasm_tabletype_t to a
- * #wasm_externtype_t
+ * \fn const wasm_externtype_t* wasm_tabletype_as_externtype_const(const wasm_tabletype_t *)
+ * \brief Converts a #wasm_tabletype_t to a #wasm_externtype_t
  *
  * The returned value is owned by the #wasm_tabletype_t argument and should not
  * be deleted.
  *
- * \fn const wasm_externtype_t* wasm_globaltype_as_externtype_const(const
- * wasm_globaltype_t *) \brief Converts a #wasm_globaltype_t to a
- * #wasm_externtype_t
+ * \fn const wasm_externtype_t* wasm_globaltype_as_externtype_const(const wasm_globaltype_t *)
+ * \brief Converts a #wasm_globaltype_t to a #wasm_externtype_t
  *
  * The returned value is owned by the #wasm_globaltype_t argument and should not
  * be deleted.
  *
- * \fn const wasm_externtype_t* wasm_memorytype_as_externtype_const(const
- * wasm_memorytype_t *) \brief Converts a #wasm_memorytype_t to a
- * #wasm_externtype_t
+ * \fn const wasm_externtype_t* wasm_memorytype_as_externtype_const(const wasm_memorytype_t *)
+ * \brief Converts a #wasm_memorytype_t to a #wasm_externtype_t
  *
  * The returned value is owned by the #wasm_memorytype_t argument and should not
  * be deleted.
@@ -760,33 +754,29 @@
  * be deleted. Returns `NULL` if the provided argument is not a
  * #wasm_globaltype_t.
  *
- * \fn const wasm_functype_t* wasm_externtype_as_functype_const(const
- * wasm_externtype_t *) \brief Attempts to convert a #wasm_externtype_t to a
- * #wasm_functype_t
+ * \fn const wasm_functype_t* wasm_externtype_as_functype_const(const wasm_externtype_t *)
+ * \brief Attempts to convert a #wasm_externtype_t to a #wasm_functype_t
  *
  * The returned value is owned by the #wasm_functype_t argument and should not
  * be deleted. Returns `NULL` if the provided argument is not a
  * #wasm_functype_t.
  *
- * \fn const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const
- * wasm_externtype_t *) \brief Attempts to convert a #wasm_externtype_t to a
- * #wasm_tabletype_t
+ * \fn const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const wasm_externtype_t *)
+ * \brief Attempts to convert a #wasm_externtype_t to a #wasm_tabletype_t
  *
  * The returned value is owned by the #wasm_tabletype_t argument and should not
  * be deleted. Returns `NULL` if the provided argument is not a
  * #wasm_tabletype_t.
  *
- * \fn const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const
- * wasm_externtype_t *) \brief Attempts to convert a #wasm_externtype_t to a
- * #wasm_memorytype_t
+ * \fn const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const wasm_externtype_t *)
+ * \brief Attempts to convert a #wasm_externtype_t to a #wasm_memorytype_t
  *
  * The returned value is owned by the #wasm_memorytype_t argument and should not
  * be deleted. Returns `NULL` if the provided argument is not a
  * #wasm_memorytype_t.
  *
- * \fn const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const
- * wasm_externtype_t *) \brief Attempts to convert a #wasm_externtype_t to a
- * #wasm_globaltype_t
+ * \fn const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const wasm_externtype_t *)
+ * \brief Attempts to convert a #wasm_externtype_t to a #wasm_globaltype_t
  *
  * The returned value is owned by the #wasm_globaltype_t argument and should not
  * be deleted. Returns `NULL` if the provided argument is not a
@@ -820,19 +810,18 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_importtype_vec_new_uninitialized(wasm_importtype_vec_t *out,
- * size_t); \brief Creates a vector with the given capacity.
+ * \fn void wasm_importtype_vec_new_uninitialized(wasm_importtype_vec_t *out, size_t);
+ * \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_importtype_vec_new(wasm_importtype_vec_t *out, size_t,
- * wasm_importtype_t *const[]); \brief Creates a vector with the provided
- * contents.
+ * \fn void wasm_importtype_vec_new(wasm_importtype_vec_t *out, size_t, wasm_importtype_t *const[]);
+ * \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_importtype_vec_copy(wasm_importtype_vec_t *out, const
- * wasm_importtype_vec_t *) \brief Copies one vector to another
+ * \fn void wasm_importtype_vec_copy(wasm_importtype_vec_t *out, const wasm_importtype_vec_t *)
+ * \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -846,8 +835,8 @@
  *
  * The caller is responsible for deleting the returned value.
  *
- * \fn wasm_importtype_t* wasm_importtype_new(wasm_name_t *module, wasm_name_t
- * *name, wasm_externtype_t *) \brief Creates a new import type.
+ * \fn wasm_importtype_t* wasm_importtype_new(wasm_name_t *module, wasm_name_t *name, wasm_externtype_t *)
+ * \brief Creates a new import type.
  *
  * This function takes ownership of the `module`, `name`, and
  * #wasm_externtype_t arguments. The caller is responsible for deleting the
@@ -902,19 +891,18 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_exporttype_vec_new_uninitialized(wasm_exporttype_vec_t *out,
- * size_t); \brief Creates a vector with the given capacity.
+ * \fn void wasm_exporttype_vec_new_uninitialized(wasm_exporttype_vec_t *out, size_t);
+ * \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_exporttype_vec_new(wasm_exporttype_vec_t *out, size_t,
- * wasm_exporttype_t *const[]); \brief Creates a vector with the provided
- * contents.
+ * \fn void wasm_exporttype_vec_new(wasm_exporttype_vec_t *out, size_t, wasm_exporttype_t *const[]);
+ * \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_exporttype_vec_copy(wasm_exporttype_vec_t *out, const
- * wasm_exporttype_vec_t *) \brief Copies one vector to another
+ * \fn void wasm_exporttype_vec_copy(wasm_exporttype_vec_t *out, const wasm_exporttype_vec_t *)
+ * \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -928,8 +916,8 @@
  *
  * The caller is responsible for deleting the returned value.
  *
- * \fn wasm_exporttype_t* wasm_exporttype_new(wasm_name_t *name,
- * wasm_externtype_t *) \brief Creates a new export type.
+ * \fn wasm_exporttype_t* wasm_exporttype_new(wasm_name_t *name, wasm_externtype_t *)
+ * \brief Creates a new export type.
  *
  * This function takes ownership of the `name` and
  * #wasm_externtype_t arguments. The caller is responsible for deleting the
@@ -1065,9 +1053,8 @@
  * \fn void wasm_ref_set_host_info(wasm_ref_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_ref_set_host_info_with_finalizer(wasm_ref_t *, void *,
- * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
- * called.
+ * \fn void wasm_ref_set_host_info_with_finalizer(wasm_ref_t *, void *, void(*)(void*));
+ * \brief Unimplemented in Wasmtime, aborts the process if called.
  */
 
 /**
@@ -1102,8 +1089,8 @@
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_frame_vec_new(wasm_frame_vec_t *out, size_t, wasm_frame_t
- * *const[]); \brief Creates a vector with the provided contents.
+ * \fn void wasm_frame_vec_new(wasm_frame_vec_t *out, size_t, wasm_frame_t *const[]);
+ * \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
@@ -1162,9 +1149,8 @@
  * \fn void wasm_trap_set_host_info(wasm_trap_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_trap_set_host_info_with_finalizer(wasm_trap_t *, void *,
- * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
- * called.
+ * \fn void wasm_trap_set_host_info_with_finalizer(wasm_trap_t *, void *, void(*)(void*));
+ * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
  * \fn wasm_ref_t *wasm_trap_as_ref(wasm_trap_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1236,9 +1222,8 @@
  * \fn void wasm_foreign_set_host_info(wasm_foreign_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_foreign_set_host_info_with_finalizer(wasm_foreign_t *, void *,
- * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
- * called.
+ * \fn void wasm_foreign_set_host_info_with_finalizer(wasm_foreign_t *, void *, void(*)(void*));
+ * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
  * \fn wasm_ref_t *wasm_foreign_as_ref(wasm_foreign_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1291,9 +1276,8 @@
  * \fn void wasm_module_set_host_info(wasm_module_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_module_set_host_info_with_finalizer(wasm_module_t *, void *,
- * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
- * called.
+ * \fn void wasm_module_set_host_info_with_finalizer(wasm_module_t *, void *, void(*)(void*));
+ * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
  * \fn wasm_ref_t *wasm_module_as_ref(wasm_module_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1322,9 +1306,8 @@
  * This function does not take ownership of the argument, but the caller is
  * expected to deallocate the returned #wasm_shared_module_t.
  *
- * \fn wasm_module_t *wasm_module_obtain(wasm_store_t *, const
- * wasm_shared_module_t *); \brief Attempts to create a #wasm_module_t from the
- * shareable module.
+ * \fn wasm_module_t *wasm_module_obtain(wasm_store_t *, const wasm_shared_module_t *);
+ * \brief Attempts to create a #wasm_module_t from the shareable module.
  *
  * > Note that this API is not necessary in Wasmtime because #wasm_module_t can
  * > be shared across threads. This is implemented for compatibility, however.
@@ -1335,8 +1318,8 @@
  * This function may fail if the engines associated with the #wasm_store_t or
  * #wasm_shared_module_t are different.
  *
- * \fn wasm_module_t *wasm_module_new(wasm_store_t *, const wasm_byte_vec_t
- * *binary) \brief Compiles a raw WebAssembly binary to a #wasm_module_t.
+ * \fn wasm_module_t *wasm_module_new(wasm_store_t *, const wasm_byte_vec_t *binary)
+ * \brief Compiles a raw WebAssembly binary to a #wasm_module_t.
  *
  * This function will validate and compile the provided binary. The returned
  * #wasm_module_t is ready for instantiation after this call returns.
@@ -1354,8 +1337,8 @@
  * `binary` is a valid WebAssembly binary according to the configuration of the
  * #wasm_store_t provided.
  *
- * \fn void wasm_module_imports(const wasm_module_t *, wasm_importtype_vec_t
- * *out); \brief Returns the list of imports that this module expects.
+ * \fn void wasm_module_imports(const wasm_module_t *, wasm_importtype_vec_t *out);
+ * \brief Returns the list of imports that this module expects.
  *
  * The list of imports returned are the types of items expected to be passed to
  * #wasm_instance_new. You can use #wasm_importtype_type to learn about the
@@ -1365,8 +1348,8 @@
  * `out` is passed to the caller. Note that `out` is treated as uninitialized
  * when passed to this function.
  *
- * \fn void wasm_module_exports(const wasm_module_t *, wasm_exporttype_vec_t
- * *out); \brief Returns the list of exports that this module provides.
+ * \fn void wasm_module_exports(const wasm_module_t *, wasm_exporttype_vec_t *out);
+ * \brief Returns the list of exports that this module provides.
  *
  * The list of exports returned are in the same order as the items returned by
  * #wasm_instance_exports.
@@ -1382,8 +1365,8 @@
  * deallocate the `out` vector. The byte vector can later be deserialized
  * through #wasm_module_deserialize.
  *
- * \fn wasm_module_t *wasm_module_deserialize(wasm_store_t *, const
- * wasm_byte_vec_t *); \brief Deserializes a previously-serialized module.
+ * \fn wasm_module_t *wasm_module_deserialize(wasm_store_t *, const wasm_byte_vec_t *);
+ * \brief Deserializes a previously-serialized module.
  *
  * The input bytes must have been created from a previous call to
  * #wasm_module_serialize.
@@ -1438,9 +1421,8 @@
  * \fn void wasm_func_set_host_info(wasm_func_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_func_set_host_info_with_finalizer(wasm_func_t *, void *,
- * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
- * called.
+ * \fn void wasm_func_set_host_info_with_finalizer(wasm_func_t *, void *, void(*)(void*));
+ * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
  * \fn wasm_ref_t *wasm_func_as_ref(wasm_func_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1457,9 +1439,8 @@
  * \fn wasm_ref_as_func_const(const wasm_ref_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn wasm_func_t *wasm_func_new(wasm_store_t *, const wasm_functype_t *,
- * wasm_func_callback_t); \brief Creates a new WebAssembly function with host
- * functionality.
+ * \fn wasm_func_t *wasm_func_new(wasm_store_t *, const wasm_functype_t *, wasm_func_callback_t);
+ * \brief Creates a new WebAssembly function with host functionality.
  *
  * This function creates a new #wasm_func_t from a host-provided function. The
  * host provided function must implement the type signature matching the
@@ -1499,9 +1480,8 @@
  * \fn size_t wasm_func_result_arity(const wasm_func_t *);
  * \brief Returns the number of results returned by this function.
  *
- * \fn wasm_trap_t *wasm_func_call(const wasm_func_t *, const wasm_val_vec_t
- * *args, wasm_val_vec_t *results); \brief Calls the provided function with the
- * arguments given.
+* \fn wasm_trap_t *wasm_func_call(const wasm_func_t *, const wasm_val_vec_t *args, wasm_val_vec_t *results);
+ * \brief Calls the provided function with the arguments given.
  *
  * This function is used to call WebAssembly from the host. The parameter array
  * provided must be valid for #wasm_func_param_arity number of arguments, and
@@ -1547,9 +1527,8 @@
  * \fn void wasm_global_set_host_info(wasm_global_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_global_set_host_info_with_finalizer(wasm_global_t *, void *,
- * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
- * called.
+ * \fn void wasm_global_set_host_info_with_finalizer(wasm_global_t *, void *, void(*)(void*));
+ * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
  * \fn wasm_ref_t *wasm_global_as_ref(wasm_global_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1566,8 +1545,8 @@
  * \fn wasm_ref_as_global_const(const wasm_ref_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn wasm_global_t *wasm_global_new(wasm_store_t *, const wasm_globaltype_t *,
- * const wasm_val_t *); \brief Creates a new WebAssembly global.
+ * \fn wasm_global_t *wasm_global_new(wasm_store_t *, const wasm_globaltype_t *, const wasm_val_t *);
+ * \brief Creates a new WebAssembly global.
  *
  * This function is used to create a wasm global from the host, typically to
  * provide as the import of a module. The type of the global is specified along
@@ -1630,9 +1609,8 @@
  * \fn void wasm_table_set_host_info(wasm_table_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_table_set_host_info_with_finalizer(wasm_table_t *, void *,
- * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
- * called.
+ * \fn void wasm_table_set_host_info_with_finalizer(wasm_table_t *, void *, void(*)(void*));
+ * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
  * \fn wasm_ref_t *wasm_table_as_ref(wasm_table_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1649,8 +1627,8 @@
  * \fn wasm_ref_as_table_const(const wasm_ref_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn wasm_table_t *wasm_table_new(wasm_store_t *, const wasm_tabletype_t *,
- * wasm_ref_t *init); \brief Creates a new WebAssembly table.
+ * \fn wasm_table_t *wasm_table_new(wasm_store_t *, const wasm_tabletype_t *, wasm_ref_t *init);
+ * \brief Creates a new WebAssembly table.
  *
  * Creates a new host-defined table of values. This table has the type provided
  * and is filled with the provided initial value (which can be `NULL`).
@@ -1665,16 +1643,16 @@
  *
  * The caller is expected to deallocate the returned #wasm_tabletype_t.
  *
- * \fn wasm_ref_t *wasm_table_get(const wasm_table_t *, wasm_table_size_t
- * index); \brief Gets an element from this table.
+ * \fn wasm_ref_t *wasm_table_get(const wasm_table_t *, wasm_table_size_t index);
+ * \brief Gets an element from this table.
  *
  * Attempts to get a value at an index in this table. This function returns
  * `NULL` if the index is out of bounds.
  *
  * Gives ownership of the resulting `wasm_ref_t*`.
  *
- * \fn void wasm_table_set(wasm_table_t *, wasm_table_size_t index, wasm_ref_t
- * *); \brief Sets an element in this table.
+ * \fn void wasm_table_set(wasm_table_t *, wasm_table_size_t index, wasm_ref_t *);
+ * \brief Sets an element in this table.
  *
  * Attempts to set a value at an index in this table. This function does nothing
  * in erroneous situations such as:
@@ -1688,8 +1666,8 @@
  * \fn wasm_table_size_t wasm_table_size(const wasm_table_t *);
  * \brief Gets the current size, in elements, of this table.
  *
- * \fn bool wasm_table_grow(wasm_table_t *, wasm_table_size_t delta, wasm_ref_t
- * *init); \brief Attempts to grow this table by `delta` elements.
+ * \fn bool wasm_table_grow(wasm_table_t *, wasm_table_size_t delta, wasm_ref_t *init);
+ * \brief Attempts to grow this table by `delta` elements.
  *
  * This function will grow the table by `delta` elements, initializing all new
  * elements to the `init` value provided.
@@ -1731,9 +1709,8 @@
  * \fn void wasm_memory_set_host_info(wasm_memory_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_memory_set_host_info_with_finalizer(wasm_memory_t *, void *,
- * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
- * called.
+ * \fn void wasm_memory_set_host_info_with_finalizer(wasm_memory_t *, void *, void(*)(void*));
+ * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
  * \fn wasm_ref_t *wasm_memory_as_ref(wasm_memory_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1750,8 +1727,8 @@
  * \fn wasm_ref_as_memory_const(const wasm_ref_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn wasm_memory_t *wasm_memory_new(wasm_store_t *, const wasm_memorytype_t
- * *); \brief Creates a new WebAssembly memory.
+ * \fn wasm_memory_t *wasm_memory_new(wasm_store_t *, const wasm_memorytype_t *);
+ * \brief Creates a new WebAssembly memory.
  *
  * \fn wasm_memorytype_t *wasm_memory_type(const wasm_memory_t *);
  * \brief Returns the type of this memory.
@@ -1811,13 +1788,13 @@
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_extern_vec_new(wasm_extern_vec_t *out, size_t, wasm_extern_t
- * *const[]); \brief Creates a vector with the provided contents.
+ * \fn void wasm_extern_vec_new(wasm_extern_vec_t *out, size_t, wasm_extern_t *const[]);
+ * \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_extern_vec_copy(wasm_extern_vec_t *out, const wasm_extern_vec_t
- * *) \brief Copies one vector to another
+ * \fn void wasm_extern_vec_copy(wasm_extern_vec_t *out, const wasm_extern_vec_t *)
+ * \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -1840,9 +1817,8 @@
  * \fn void wasm_extern_set_host_info(wasm_extern_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_extern_set_host_info_with_finalizer(wasm_extern_t *, void *,
- * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
- * called.
+ * \fn void wasm_extern_set_host_info_with_finalizer(wasm_extern_t *, void *, void(*)(void*));
+ * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
  * \fn wasm_ref_t *wasm_extern_as_ref(wasm_extern_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1950,8 +1926,7 @@
  * should not delete the returned value, and it only lives as long as the
  * #wasm_extern_t argument.
  *
- * If the #wasm_extern_t argument isn't a #wasm_memory_t then `NULL` is
- * returned.
+ * If the #wasm_extern_t argument isn't a #wasm_memory_t then `NULL` is returned.
  *
  * \fn wasm_global_t *wasm_extern_as_global(wasm_extern_t *);
  * \brief Converts a #wasm_extern_t to #wasm_global_t.
@@ -1960,8 +1935,7 @@
  * should not delete the returned value, and it only lives as long as the
  * #wasm_extern_t argument.
  *
- * If the #wasm_extern_t argument isn't a #wasm_global_t then `NULL` is
- * returned.
+ * If the #wasm_extern_t argument isn't a #wasm_global_t then `NULL` is returned.
  *
  * \fn const wasm_func_t *wasm_extern_as_func_const(const wasm_extern_t *);
  * \brief Converts a #wasm_extern_t to #wasm_func_t.
@@ -1988,8 +1962,7 @@
  * should not delete the returned value, and it only lives as long as the
  * #wasm_extern_t argument.
  *
- * If the #wasm_extern_t argument isn't a #wasm_memory_t then `NULL` is
- * returned.
+ * If the #wasm_extern_t argument isn't a #wasm_memory_t then `NULL` is returned.
  *
  * \fn const wasm_global_t *wasm_extern_as_global_const(const wasm_extern_t *);
  * \brief Converts a #wasm_extern_t to #wasm_global_t.
@@ -1998,8 +1971,7 @@
  * should not delete the returned value, and it only lives as long as the
  * #wasm_extern_t argument.
  *
- * If the #wasm_extern_t argument isn't a #wasm_global_t then `NULL` is
- * returned.
+ * If the #wasm_extern_t argument isn't a #wasm_global_t then `NULL` is returned.
  */
 
 /**
@@ -2026,9 +1998,8 @@
  * \fn void wasm_instance_set_host_info(wasm_instance_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_instance_set_host_info_with_finalizer(wasm_instance_t *, void
- * *, void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
- * called.
+ * \fn void wasm_instance_set_host_info_with_finalizer(wasm_instance_t *, void *, void(*)(void*));
+ * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
  * \fn wasm_ref_t *wasm_instance_as_ref(wasm_instance_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -2045,9 +2016,8 @@
  * \fn wasm_ref_as_instance_const(const wasm_ref_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn wasm_instance_t *wasm_instance_new(wasm_store_t *, const wasm_module_t *,
- * const wasm_extern_vec_t *, wasm_trap_t **); \brief Instantiates a module with
- * the provided imports.
+ * \fn wasm_instance_t *wasm_instance_new(wasm_store_t *, const wasm_module_t *, const wasm_extern_vec_t *, wasm_trap_t **);
+ * \brief Instantiates a module with the provided imports.
  *
  * This function will instantiate the provided #wasm_module_t into the provided
  * #wasm_store_t. The `imports` specified are used to satisfy the imports of the
@@ -2065,8 +2035,8 @@
  * This function does not take ownership of any of its arguments, and the
  * returned #wasm_instance_t and #wasm_trap_t are owned by the caller.
  *
- * \fn void wasm_instance_exports(const wasm_instance_t *, wasm_extern_vec_t
- * *out); \brief Returns the exports of an instance.
+ * \fn void wasm_instance_exports(const wasm_instance_t *, wasm_extern_vec_t *out);
+ * \brief Returns the exports of an instance.
  *
  * This function returns a list of #wasm_extern_t values, which will be owned by
  * the caller, which are exported from the instance. The `out` list will have

--- a/crates/c-api/include/doc-wasm.h
+++ b/crates/c-api/include/doc-wasm.h
@@ -211,8 +211,8 @@
  * initialized and after this function is called you are then responsible for
  * ensuring #wasm_byte_vec_delete is called.
  *
- * \fn void wasm_byte_vec_new(wasm_byte_vec_t *out, size_t, wasm_byte_t const[]);
- * \brief Copies the specified data into a new byte vector.
+ * \fn void wasm_byte_vec_new(wasm_byte_vec_t *out, size_t, wasm_byte_t
+ * const[]); \brief Copies the specified data into a new byte vector.
  *
  * This function will copy the provided data into this byte vector. The byte
  * vector should not be previously initialized and the caller is responsible for
@@ -269,13 +269,13 @@
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_valtype_vec_new(wasm_valtype_vec_t *out, size_t, wasm_valtype_t *const[]);
- * \brief Creates a vector with the provided contents.
+ * \fn void wasm_valtype_vec_new(wasm_valtype_vec_t *out, size_t, wasm_valtype_t
+ * *const[]); \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_valtype_vec_copy(wasm_valtype_vec_t *out, const wasm_valtype_vec_t *)
- * \brief Copies one vector to another
+ * \fn void wasm_valtype_vec_copy(wasm_valtype_vec_t *out, const
+ * wasm_valtype_vec_t *) \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -330,18 +330,19 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_functype_vec_new_uninitialized(wasm_functype_vec_t *out, size_t);
- * \brief Creates a vector with the given capacity.
+ * \fn void wasm_functype_vec_new_uninitialized(wasm_functype_vec_t *out,
+ * size_t); \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_functype_vec_new(wasm_functype_vec_t *out, size_t, wasm_functype_t *const[]);
- * \brief Creates a vector with the provided contents.
+ * \fn void wasm_functype_vec_new(wasm_functype_vec_t *out, size_t,
+ * wasm_functype_t *const[]); \brief Creates a vector with the provided
+ * contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_functype_vec_copy(wasm_functype_vec_t *out, const wasm_functype_vec_t *)
- * \brief Copies one vector to another
+ * \fn void wasm_functype_vec_copy(wasm_functype_vec_t *out, const
+ * wasm_functype_vec_t *) \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -355,9 +356,9 @@
  *
  * The caller is responsible for deleting the returned value.
  *
- * \fn wasm_functype_t* wasm_functype_new(wasm_valtype_vec_t *params, wasm_valtype_vec_t *results);
- * \brief Creates a new function type with the provided parameter and result
- * types.
+ * \fn wasm_functype_t* wasm_functype_new(wasm_valtype_vec_t *params,
+ * wasm_valtype_vec_t *results); \brief Creates a new function type with the
+ * provided parameter and result types.
  *
  * This function takes ownership of the `params` and `results` arguments.
  *
@@ -403,18 +404,19 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_globaltype_vec_new_uninitialized(wasm_globaltype_vec_t *out, size_t);
- * \brief Creates a vector with the given capacity.
+ * \fn void wasm_globaltype_vec_new_uninitialized(wasm_globaltype_vec_t *out,
+ * size_t); \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_globaltype_vec_new(wasm_globaltype_vec_t *out, size_t, wasm_globaltype_t *const[]);
- * \brief Creates a vector with the provided contents.
+ * \fn void wasm_globaltype_vec_new(wasm_globaltype_vec_t *out, size_t,
+ * wasm_globaltype_t *const[]); \brief Creates a vector with the provided
+ * contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_globaltype_vec_copy(wasm_globaltype_vec_t *out, const wasm_globaltype_vec_t *)
- * \brief Copies one vector to another
+ * \fn void wasm_globaltype_vec_copy(wasm_globaltype_vec_t *out, const
+ * wasm_globaltype_vec_t *) \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -428,8 +430,8 @@
  *
  * The caller is responsible for deleting the returned value.
  *
- * \fn wasm_globaltype_t* wasm_globaltype_new(wasm_valtype_t *, wasm_mutability_t)
- * \brief Creates a new global type.
+ * \fn wasm_globaltype_t* wasm_globaltype_new(wasm_valtype_t *,
+ * wasm_mutability_t) \brief Creates a new global type.
  *
  * This function takes ownership of the #wasm_valtype_t argument.
  *
@@ -477,18 +479,19 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_tabletype_vec_new_uninitialized(wasm_tabletype_vec_t *out, size_t);
- * \brief Creates a vector with the given capacity.
+ * \fn void wasm_tabletype_vec_new_uninitialized(wasm_tabletype_vec_t *out,
+ * size_t); \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_tabletype_vec_new(wasm_tabletype_vec_t *out, size_t, wasm_tabletype_t *const[]);
- * \brief Creates a vector with the provided contents.
+ * \fn void wasm_tabletype_vec_new(wasm_tabletype_vec_t *out, size_t,
+ * wasm_tabletype_t *const[]); \brief Creates a vector with the provided
+ * contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_tabletype_vec_copy(wasm_tabletype_vec_t *out, const wasm_tabletype_vec_t *)
- * \brief Copies one vector to another
+ * \fn void wasm_tabletype_vec_copy(wasm_tabletype_vec_t *out, const
+ * wasm_tabletype_vec_t *) \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -502,8 +505,8 @@
  *
  * The caller is responsible for deleting the returned value.
  *
- * \fn wasm_tabletype_t* wasm_tabletype_new(wasm_valtype_t *, const wasm_limits_t *)h
- * \brief Creates a new table type.
+ * \fn wasm_tabletype_t* wasm_tabletype_new(wasm_valtype_t *, const
+ * wasm_limits_t *)h \brief Creates a new table type.
  *
  * This function takes ownership of the #wasm_valtype_t argument, but does not
  * take ownership of the #wasm_limits_t.
@@ -563,18 +566,19 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_memorytype_vec_new_uninitialized(wasm_memorytype_vec_t *out, size_t);
- * \brief Creates a vector with the given capacity.
+ * \fn void wasm_memorytype_vec_new_uninitialized(wasm_memorytype_vec_t *out,
+ * size_t); \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_memorytype_vec_new(wasm_memorytype_vec_t *out, size_t, wasm_memorytype_t *const[]);
- * \brief Creates a vector with the provided contents.
+ * \fn void wasm_memorytype_vec_new(wasm_memorytype_vec_t *out, size_t,
+ * wasm_memorytype_t *const[]); \brief Creates a vector with the provided
+ * contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_memorytype_vec_copy(wasm_memorytype_vec_t *out, const wasm_memorytype_vec_t *)
- * \brief Copies one vector to another
+ * \fn void wasm_memorytype_vec_copy(wasm_memorytype_vec_t *out, const
+ * wasm_memorytype_vec_t *) \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -638,18 +642,19 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_externtype_vec_new_uninitialized(wasm_externtype_vec_t *out, size_t);
- * \brief Creates a vector with the given capacity.
+ * \fn void wasm_externtype_vec_new_uninitialized(wasm_externtype_vec_t *out,
+ * size_t); \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_externtype_vec_new(wasm_externtype_vec_t *out, size_t, wasm_externtype_t *const[]);
- * \brief Creates a vector with the provided contents.
+ * \fn void wasm_externtype_vec_new(wasm_externtype_vec_t *out, size_t,
+ * wasm_externtype_t *const[]); \brief Creates a vector with the provided
+ * contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_externtype_vec_copy(wasm_externtype_vec_t *out, const wasm_externtype_vec_t *)
- * \brief Copies one vector to another
+ * \fn void wasm_externtype_vec_copy(wasm_externtype_vec_t *out, const
+ * wasm_externtype_vec_t *) \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -700,26 +705,29 @@
  * The returned value is owned by the #wasm_memorytype_t argument and should not
  * be deleted.
  *
- * \fn const wasm_externtype_t* wasm_functype_as_externtype_const(const wasm_functype_t *)
- * \brief Converts a #wasm_functype_t to a #wasm_externtype_t
+ * \fn const wasm_externtype_t* wasm_functype_as_externtype_const(const
+ * wasm_functype_t *) \brief Converts a #wasm_functype_t to a #wasm_externtype_t
  *
  * The returned value is owned by the #wasm_functype_t argument and should not
  * be deleted.
  *
- * \fn const wasm_externtype_t* wasm_tabletype_as_externtype_const(const wasm_tabletype_t *)
- * \brief Converts a #wasm_tabletype_t to a #wasm_externtype_t
+ * \fn const wasm_externtype_t* wasm_tabletype_as_externtype_const(const
+ * wasm_tabletype_t *) \brief Converts a #wasm_tabletype_t to a
+ * #wasm_externtype_t
  *
  * The returned value is owned by the #wasm_tabletype_t argument and should not
  * be deleted.
  *
- * \fn const wasm_externtype_t* wasm_globaltype_as_externtype_const(const wasm_globaltype_t *)
- * \brief Converts a #wasm_globaltype_t to a #wasm_externtype_t
+ * \fn const wasm_externtype_t* wasm_globaltype_as_externtype_const(const
+ * wasm_globaltype_t *) \brief Converts a #wasm_globaltype_t to a
+ * #wasm_externtype_t
  *
  * The returned value is owned by the #wasm_globaltype_t argument and should not
  * be deleted.
  *
- * \fn const wasm_externtype_t* wasm_memorytype_as_externtype_const(const wasm_memorytype_t *)
- * \brief Converts a #wasm_memorytype_t to a #wasm_externtype_t
+ * \fn const wasm_externtype_t* wasm_memorytype_as_externtype_const(const
+ * wasm_memorytype_t *) \brief Converts a #wasm_memorytype_t to a
+ * #wasm_externtype_t
  *
  * The returned value is owned by the #wasm_memorytype_t argument and should not
  * be deleted.
@@ -752,29 +760,33 @@
  * be deleted. Returns `NULL` if the provided argument is not a
  * #wasm_globaltype_t.
  *
- * \fn const wasm_functype_t* wasm_externtype_as_functype_const(const wasm_externtype_t *)
- * \brief Attempts to convert a #wasm_externtype_t to a #wasm_functype_t
+ * \fn const wasm_functype_t* wasm_externtype_as_functype_const(const
+ * wasm_externtype_t *) \brief Attempts to convert a #wasm_externtype_t to a
+ * #wasm_functype_t
  *
  * The returned value is owned by the #wasm_functype_t argument and should not
  * be deleted. Returns `NULL` if the provided argument is not a
  * #wasm_functype_t.
  *
- * \fn const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const wasm_externtype_t *)
- * \brief Attempts to convert a #wasm_externtype_t to a #wasm_tabletype_t
+ * \fn const wasm_tabletype_t* wasm_externtype_as_tabletype_const(const
+ * wasm_externtype_t *) \brief Attempts to convert a #wasm_externtype_t to a
+ * #wasm_tabletype_t
  *
  * The returned value is owned by the #wasm_tabletype_t argument and should not
  * be deleted. Returns `NULL` if the provided argument is not a
  * #wasm_tabletype_t.
  *
- * \fn const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const wasm_externtype_t *)
- * \brief Attempts to convert a #wasm_externtype_t to a #wasm_memorytype_t
+ * \fn const wasm_memorytype_t* wasm_externtype_as_memorytype_const(const
+ * wasm_externtype_t *) \brief Attempts to convert a #wasm_externtype_t to a
+ * #wasm_memorytype_t
  *
  * The returned value is owned by the #wasm_memorytype_t argument and should not
  * be deleted. Returns `NULL` if the provided argument is not a
  * #wasm_memorytype_t.
  *
- * \fn const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const wasm_externtype_t *)
- * \brief Attempts to convert a #wasm_externtype_t to a #wasm_globaltype_t
+ * \fn const wasm_globaltype_t* wasm_externtype_as_globaltype_const(const
+ * wasm_externtype_t *) \brief Attempts to convert a #wasm_externtype_t to a
+ * #wasm_globaltype_t
  *
  * The returned value is owned by the #wasm_globaltype_t argument and should not
  * be deleted. Returns `NULL` if the provided argument is not a
@@ -808,18 +820,19 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_importtype_vec_new_uninitialized(wasm_importtype_vec_t *out, size_t);
- * \brief Creates a vector with the given capacity.
+ * \fn void wasm_importtype_vec_new_uninitialized(wasm_importtype_vec_t *out,
+ * size_t); \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_importtype_vec_new(wasm_importtype_vec_t *out, size_t, wasm_importtype_t *const[]);
- * \brief Creates a vector with the provided contents.
+ * \fn void wasm_importtype_vec_new(wasm_importtype_vec_t *out, size_t,
+ * wasm_importtype_t *const[]); \brief Creates a vector with the provided
+ * contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_importtype_vec_copy(wasm_importtype_vec_t *out, const wasm_importtype_vec_t *)
- * \brief Copies one vector to another
+ * \fn void wasm_importtype_vec_copy(wasm_importtype_vec_t *out, const
+ * wasm_importtype_vec_t *) \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -833,8 +846,8 @@
  *
  * The caller is responsible for deleting the returned value.
  *
- * \fn wasm_importtype_t* wasm_importtype_new(wasm_name_t *module, wasm_name_t *name, wasm_externtype_t *)
- * \brief Creates a new import type.
+ * \fn wasm_importtype_t* wasm_importtype_new(wasm_name_t *module, wasm_name_t
+ * *name, wasm_externtype_t *) \brief Creates a new import type.
  *
  * This function takes ownership of the `module`, `name`, and
  * #wasm_externtype_t arguments. The caller is responsible for deleting the
@@ -889,18 +902,19 @@
  *
  * See #wasm_byte_vec_new_empty for more information.
  *
- * \fn void wasm_exporttype_vec_new_uninitialized(wasm_exporttype_vec_t *out, size_t);
- * \brief Creates a vector with the given capacity.
+ * \fn void wasm_exporttype_vec_new_uninitialized(wasm_exporttype_vec_t *out,
+ * size_t); \brief Creates a vector with the given capacity.
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_exporttype_vec_new(wasm_exporttype_vec_t *out, size_t, wasm_exporttype_t *const[]);
- * \brief Creates a vector with the provided contents.
+ * \fn void wasm_exporttype_vec_new(wasm_exporttype_vec_t *out, size_t,
+ * wasm_exporttype_t *const[]); \brief Creates a vector with the provided
+ * contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_exporttype_vec_copy(wasm_exporttype_vec_t *out, const wasm_exporttype_vec_t *)
- * \brief Copies one vector to another
+ * \fn void wasm_exporttype_vec_copy(wasm_exporttype_vec_t *out, const
+ * wasm_exporttype_vec_t *) \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -914,8 +928,8 @@
  *
  * The caller is responsible for deleting the returned value.
  *
- * \fn wasm_exporttype_t* wasm_exporttype_new(wasm_name_t *name, wasm_externtype_t *)
- * \brief Creates a new export type.
+ * \fn wasm_exporttype_t* wasm_exporttype_new(wasm_name_t *name,
+ * wasm_externtype_t *) \brief Creates a new export type.
  *
  * This function takes ownership of the `name` and
  * #wasm_externtype_t arguments. The caller is responsible for deleting the
@@ -1051,8 +1065,9 @@
  * \fn void wasm_ref_set_host_info(wasm_ref_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_ref_set_host_info_with_finalizer(wasm_ref_t *, void *, void(*)(void*));
- * \brief Unimplemented in Wasmtime, aborts the process if called.
+ * \fn void wasm_ref_set_host_info_with_finalizer(wasm_ref_t *, void *,
+ * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
+ * called.
  */
 
 /**
@@ -1087,8 +1102,8 @@
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_frame_vec_new(wasm_frame_vec_t *out, size_t, wasm_frame_t *const[]);
- * \brief Creates a vector with the provided contents.
+ * \fn void wasm_frame_vec_new(wasm_frame_vec_t *out, size_t, wasm_frame_t
+ * *const[]); \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
@@ -1147,8 +1162,9 @@
  * \fn void wasm_trap_set_host_info(wasm_trap_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_trap_set_host_info_with_finalizer(wasm_trap_t *, void *, void(*)(void*));
- * \brief Unimplemented in Wasmtime, aborts the process if called.
+ * \fn void wasm_trap_set_host_info_with_finalizer(wasm_trap_t *, void *,
+ * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
+ * called.
  *
  * \fn wasm_ref_t *wasm_trap_as_ref(wasm_trap_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1220,8 +1236,9 @@
  * \fn void wasm_foreign_set_host_info(wasm_foreign_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_foreign_set_host_info_with_finalizer(wasm_foreign_t *, void *, void(*)(void*));
- * \brief Unimplemented in Wasmtime, aborts the process if called.
+ * \fn void wasm_foreign_set_host_info_with_finalizer(wasm_foreign_t *, void *,
+ * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
+ * called.
  *
  * \fn wasm_ref_t *wasm_foreign_as_ref(wasm_foreign_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1274,8 +1291,9 @@
  * \fn void wasm_module_set_host_info(wasm_module_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_module_set_host_info_with_finalizer(wasm_module_t *, void *, void(*)(void*));
- * \brief Unimplemented in Wasmtime, aborts the process if called.
+ * \fn void wasm_module_set_host_info_with_finalizer(wasm_module_t *, void *,
+ * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
+ * called.
  *
  * \fn wasm_ref_t *wasm_module_as_ref(wasm_module_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1304,8 +1322,9 @@
  * This function does not take ownership of the argument, but the caller is
  * expected to deallocate the returned #wasm_shared_module_t.
  *
- * \fn wasm_module_t *wasm_module_obtain(wasm_store_t *, const wasm_shared_module_t *);
- * \brief Attempts to create a #wasm_module_t from the shareable module.
+ * \fn wasm_module_t *wasm_module_obtain(wasm_store_t *, const
+ * wasm_shared_module_t *); \brief Attempts to create a #wasm_module_t from the
+ * shareable module.
  *
  * > Note that this API is not necessary in Wasmtime because #wasm_module_t can
  * > be shared across threads. This is implemented for compatibility, however.
@@ -1316,8 +1335,8 @@
  * This function may fail if the engines associated with the #wasm_store_t or
  * #wasm_shared_module_t are different.
  *
- * \fn wasm_module_t *wasm_module_new(wasm_store_t *, const wasm_byte_vec_t *binary)
- * \brief Compiles a raw WebAssembly binary to a #wasm_module_t.
+ * \fn wasm_module_t *wasm_module_new(wasm_store_t *, const wasm_byte_vec_t
+ * *binary) \brief Compiles a raw WebAssembly binary to a #wasm_module_t.
  *
  * This function will validate and compile the provided binary. The returned
  * #wasm_module_t is ready for instantiation after this call returns.
@@ -1335,8 +1354,8 @@
  * `binary` is a valid WebAssembly binary according to the configuration of the
  * #wasm_store_t provided.
  *
- * \fn void wasm_module_imports(const wasm_module_t *, wasm_importtype_vec_t *out);
- * \brief Returns the list of imports that this module expects.
+ * \fn void wasm_module_imports(const wasm_module_t *, wasm_importtype_vec_t
+ * *out); \brief Returns the list of imports that this module expects.
  *
  * The list of imports returned are the types of items expected to be passed to
  * #wasm_instance_new. You can use #wasm_importtype_type to learn about the
@@ -1346,8 +1365,8 @@
  * `out` is passed to the caller. Note that `out` is treated as uninitialized
  * when passed to this function.
  *
- * \fn void wasm_module_exports(const wasm_module_t *, wasm_exporttype_vec_t *out);
- * \brief Returns the list of exports that this module provides.
+ * \fn void wasm_module_exports(const wasm_module_t *, wasm_exporttype_vec_t
+ * *out); \brief Returns the list of exports that this module provides.
  *
  * The list of exports returned are in the same order as the items returned by
  * #wasm_instance_exports.
@@ -1363,8 +1382,8 @@
  * deallocate the `out` vector. The byte vector can later be deserialized
  * through #wasm_module_deserialize.
  *
- * \fn wasm_module_t *wasm_module_deserialize(wasm_store_t *, const wasm_byte_vec_t *);
- * \brief Deserializes a previously-serialized module.
+ * \fn wasm_module_t *wasm_module_deserialize(wasm_store_t *, const
+ * wasm_byte_vec_t *); \brief Deserializes a previously-serialized module.
  *
  * The input bytes must have been created from a previous call to
  * #wasm_module_serialize.
@@ -1419,8 +1438,9 @@
  * \fn void wasm_func_set_host_info(wasm_func_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_func_set_host_info_with_finalizer(wasm_func_t *, void *, void(*)(void*));
- * \brief Unimplemented in Wasmtime, aborts the process if called.
+ * \fn void wasm_func_set_host_info_with_finalizer(wasm_func_t *, void *,
+ * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
+ * called.
  *
  * \fn wasm_ref_t *wasm_func_as_ref(wasm_func_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1437,8 +1457,9 @@
  * \fn wasm_ref_as_func_const(const wasm_ref_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn wasm_func_t *wasm_func_new(wasm_store_t *, const wasm_functype_t *, wasm_func_callback_t);
- * \brief Creates a new WebAssembly function with host functionality.
+ * \fn wasm_func_t *wasm_func_new(wasm_store_t *, const wasm_functype_t *,
+ * wasm_func_callback_t); \brief Creates a new WebAssembly function with host
+ * functionality.
  *
  * This function creates a new #wasm_func_t from a host-provided function. The
  * host provided function must implement the type signature matching the
@@ -1478,8 +1499,9 @@
  * \fn size_t wasm_func_result_arity(const wasm_func_t *);
  * \brief Returns the number of results returned by this function.
  *
- * \fn wasm_trap_t *wasm_func_call(const wasm_func_t *, const wasm_val_vec_t *args, wasm_val_vec_t *results);
- * \brief Calls the provided function with the arguments given.
+ * \fn wasm_trap_t *wasm_func_call(const wasm_func_t *, const wasm_val_vec_t
+ * *args, wasm_val_vec_t *results); \brief Calls the provided function with the
+ * arguments given.
  *
  * This function is used to call WebAssembly from the host. The parameter array
  * provided must be valid for #wasm_func_param_arity number of arguments, and
@@ -1525,8 +1547,9 @@
  * \fn void wasm_global_set_host_info(wasm_global_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_global_set_host_info_with_finalizer(wasm_global_t *, void *, void(*)(void*));
- * \brief Unimplemented in Wasmtime, aborts the process if called.
+ * \fn void wasm_global_set_host_info_with_finalizer(wasm_global_t *, void *,
+ * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
+ * called.
  *
  * \fn wasm_ref_t *wasm_global_as_ref(wasm_global_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1543,8 +1566,8 @@
  * \fn wasm_ref_as_global_const(const wasm_ref_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn wasm_global_t *wasm_global_new(wasm_store_t *, const wasm_globaltype_t *, const wasm_val_t *);
- * \brief Creates a new WebAssembly global.
+ * \fn wasm_global_t *wasm_global_new(wasm_store_t *, const wasm_globaltype_t *,
+ * const wasm_val_t *); \brief Creates a new WebAssembly global.
  *
  * This function is used to create a wasm global from the host, typically to
  * provide as the import of a module. The type of the global is specified along
@@ -1607,8 +1630,9 @@
  * \fn void wasm_table_set_host_info(wasm_table_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_table_set_host_info_with_finalizer(wasm_table_t *, void *, void(*)(void*));
- * \brief Unimplemented in Wasmtime, aborts the process if called.
+ * \fn void wasm_table_set_host_info_with_finalizer(wasm_table_t *, void *,
+ * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
+ * called.
  *
  * \fn wasm_ref_t *wasm_table_as_ref(wasm_table_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1625,8 +1649,8 @@
  * \fn wasm_ref_as_table_const(const wasm_ref_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn wasm_table_t *wasm_table_new(wasm_store_t *, const wasm_tabletype_t *, wasm_ref_t *init);
- * \brief Creates a new WebAssembly table.
+ * \fn wasm_table_t *wasm_table_new(wasm_store_t *, const wasm_tabletype_t *,
+ * wasm_ref_t *init); \brief Creates a new WebAssembly table.
  *
  * Creates a new host-defined table of values. This table has the type provided
  * and is filled with the provided initial value (which can be `NULL`).
@@ -1641,16 +1665,16 @@
  *
  * The caller is expected to deallocate the returned #wasm_tabletype_t.
  *
- * \fn wasm_ref_t *wasm_table_get(const wasm_table_t *, wasm_table_size_t index);
- * \brief Gets an element from this table.
+ * \fn wasm_ref_t *wasm_table_get(const wasm_table_t *, wasm_table_size_t
+ * index); \brief Gets an element from this table.
  *
  * Attempts to get a value at an index in this table. This function returns
  * `NULL` if the index is out of bounds.
  *
  * Gives ownership of the resulting `wasm_ref_t*`.
  *
- * \fn void wasm_table_set(wasm_table_t *, wasm_table_size_t index, wasm_ref_t *);
- * \brief Sets an element in this table.
+ * \fn void wasm_table_set(wasm_table_t *, wasm_table_size_t index, wasm_ref_t
+ * *); \brief Sets an element in this table.
  *
  * Attempts to set a value at an index in this table. This function does nothing
  * in erroneous situations such as:
@@ -1664,8 +1688,8 @@
  * \fn wasm_table_size_t wasm_table_size(const wasm_table_t *);
  * \brief Gets the current size, in elements, of this table.
  *
- * \fn bool wasm_table_grow(wasm_table_t *, wasm_table_size_t delta, wasm_ref_t *init);
- * \brief Attempts to grow this table by `delta` elements.
+ * \fn bool wasm_table_grow(wasm_table_t *, wasm_table_size_t delta, wasm_ref_t
+ * *init); \brief Attempts to grow this table by `delta` elements.
  *
  * This function will grow the table by `delta` elements, initializing all new
  * elements to the `init` value provided.
@@ -1707,8 +1731,9 @@
  * \fn void wasm_memory_set_host_info(wasm_memory_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_memory_set_host_info_with_finalizer(wasm_memory_t *, void *, void(*)(void*));
- * \brief Unimplemented in Wasmtime, aborts the process if called.
+ * \fn void wasm_memory_set_host_info_with_finalizer(wasm_memory_t *, void *,
+ * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
+ * called.
  *
  * \fn wasm_ref_t *wasm_memory_as_ref(wasm_memory_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1725,8 +1750,8 @@
  * \fn wasm_ref_as_memory_const(const wasm_ref_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn wasm_memory_t *wasm_memory_new(wasm_store_t *, const wasm_memorytype_t *);
- * \brief Creates a new WebAssembly memory.
+ * \fn wasm_memory_t *wasm_memory_new(wasm_store_t *, const wasm_memorytype_t
+ * *); \brief Creates a new WebAssembly memory.
  *
  * \fn wasm_memorytype_t *wasm_memory_type(const wasm_memory_t *);
  * \brief Returns the type of this memory.
@@ -1786,13 +1811,13 @@
  *
  * See #wasm_byte_vec_new_uninitialized for more information.
  *
- * \fn void wasm_extern_vec_new(wasm_extern_vec_t *out, size_t, wasm_extern_t *const[]);
- * \brief Creates a vector with the provided contents.
+ * \fn void wasm_extern_vec_new(wasm_extern_vec_t *out, size_t, wasm_extern_t
+ * *const[]); \brief Creates a vector with the provided contents.
  *
  * See #wasm_byte_vec_new for more information.
  *
- * \fn void wasm_extern_vec_copy(wasm_extern_vec_t *out, const wasm_extern_vec_t *)
- * \brief Copies one vector to another
+ * \fn void wasm_extern_vec_copy(wasm_extern_vec_t *out, const wasm_extern_vec_t
+ * *) \brief Copies one vector to another
  *
  * See #wasm_byte_vec_copy for more information.
  *
@@ -1815,8 +1840,9 @@
  * \fn void wasm_extern_set_host_info(wasm_extern_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_extern_set_host_info_with_finalizer(wasm_extern_t *, void *, void(*)(void*));
- * \brief Unimplemented in Wasmtime, aborts the process if called.
+ * \fn void wasm_extern_set_host_info_with_finalizer(wasm_extern_t *, void *,
+ * void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
+ * called.
  *
  * \fn wasm_ref_t *wasm_extern_as_ref(wasm_extern_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -1924,7 +1950,8 @@
  * should not delete the returned value, and it only lives as long as the
  * #wasm_extern_t argument.
  *
- * If the #wasm_extern_t argument isn't a #wasm_memory_t then `NULL` is returned.
+ * If the #wasm_extern_t argument isn't a #wasm_memory_t then `NULL` is
+ * returned.
  *
  * \fn wasm_global_t *wasm_extern_as_global(wasm_extern_t *);
  * \brief Converts a #wasm_extern_t to #wasm_global_t.
@@ -1933,7 +1960,8 @@
  * should not delete the returned value, and it only lives as long as the
  * #wasm_extern_t argument.
  *
- * If the #wasm_extern_t argument isn't a #wasm_global_t then `NULL` is returned.
+ * If the #wasm_extern_t argument isn't a #wasm_global_t then `NULL` is
+ * returned.
  *
  * \fn const wasm_func_t *wasm_extern_as_func_const(const wasm_extern_t *);
  * \brief Converts a #wasm_extern_t to #wasm_func_t.
@@ -1960,7 +1988,8 @@
  * should not delete the returned value, and it only lives as long as the
  * #wasm_extern_t argument.
  *
- * If the #wasm_extern_t argument isn't a #wasm_memory_t then `NULL` is returned.
+ * If the #wasm_extern_t argument isn't a #wasm_memory_t then `NULL` is
+ * returned.
  *
  * \fn const wasm_global_t *wasm_extern_as_global_const(const wasm_extern_t *);
  * \brief Converts a #wasm_extern_t to #wasm_global_t.
@@ -1969,7 +1998,8 @@
  * should not delete the returned value, and it only lives as long as the
  * #wasm_extern_t argument.
  *
- * If the #wasm_extern_t argument isn't a #wasm_global_t then `NULL` is returned.
+ * If the #wasm_extern_t argument isn't a #wasm_global_t then `NULL` is
+ * returned.
  */
 
 /**
@@ -1996,8 +2026,9 @@
  * \fn void wasm_instance_set_host_info(wasm_instance_t *, void *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn void wasm_instance_set_host_info_with_finalizer(wasm_instance_t *, void *, void(*)(void*));
- * \brief Unimplemented in Wasmtime, aborts the process if called.
+ * \fn void wasm_instance_set_host_info_with_finalizer(wasm_instance_t *, void
+ * *, void(*)(void*)); \brief Unimplemented in Wasmtime, aborts the process if
+ * called.
  *
  * \fn wasm_ref_t *wasm_instance_as_ref(wasm_instance_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
@@ -2014,8 +2045,9 @@
  * \fn wasm_ref_as_instance_const(const wasm_ref_t *);
  * \brief Unimplemented in Wasmtime, aborts the process if called.
  *
- * \fn wasm_instance_t *wasm_instance_new(wasm_store_t *, const wasm_module_t *, const wasm_extern_vec_t *, wasm_trap_t **);
- * \brief Instantiates a module with the provided imports.
+ * \fn wasm_instance_t *wasm_instance_new(wasm_store_t *, const wasm_module_t *,
+ * const wasm_extern_vec_t *, wasm_trap_t **); \brief Instantiates a module with
+ * the provided imports.
  *
  * This function will instantiate the provided #wasm_module_t into the provided
  * #wasm_store_t. The `imports` specified are used to satisfy the imports of the
@@ -2033,8 +2065,8 @@
  * This function does not take ownership of any of its arguments, and the
  * returned #wasm_instance_t and #wasm_trap_t are owned by the caller.
  *
- * \fn void wasm_instance_exports(const wasm_instance_t *, wasm_extern_vec_t *out);
- * \brief Returns the exports of an instance.
+ * \fn void wasm_instance_exports(const wasm_instance_t *, wasm_extern_vec_t
+ * *out); \brief Returns the exports of an instance.
  *
  * This function returns a list of #wasm_extern_t values, which will be owned by
  * the caller, which are exported from the instance. The `out` list will have

--- a/crates/c-api/include/doc-wasm.h
+++ b/crates/c-api/include/doc-wasm.h
@@ -1478,7 +1478,7 @@
  * \fn size_t wasm_func_result_arity(const wasm_func_t *);
  * \brief Returns the number of results returned by this function.
  *
-* \fn wasm_trap_t *wasm_func_call(const wasm_func_t *, const wasm_val_vec_t *args, wasm_val_vec_t *results);
+ * \fn wasm_trap_t *wasm_func_call(const wasm_func_t *, const wasm_val_vec_t *args, wasm_val_vec_t *results);
  * \brief Calls the provided function with the arguments given.
  *
  * This function is used to call WebAssembly from the host. The parameter array

--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -24,9 +24,9 @@ extern "C" {
 
 #define own
 
-#define WASI_DECLARE_OWN(name)                      \
-    typedef struct wasi_##name##_t wasi_##name##_t; \
-    WASI_API_EXTERN void wasi_##name##_delete(own wasi_##name##_t*);
+#define WASI_DECLARE_OWN(name)                                                 \
+  typedef struct wasi_##name##_t wasi_##name##_t;                              \
+  WASI_API_EXTERN void wasi_##name##_delete(own wasi_##name##_t *);
 
 /**
  * \typedef wasi_config_t
@@ -45,7 +45,7 @@ WASI_DECLARE_OWN(config)
  *
  * The caller is expected to deallocate the returned configuration
  */
-WASI_API_EXTERN own wasi_config_t* wasi_config_new();
+WASI_API_EXTERN own wasi_config_t *wasi_config_new();
 
 /**
  * \brief Sets the argv list for this configuration object.
@@ -56,13 +56,14 @@ WASI_API_EXTERN own wasi_config_t* wasi_config_new();
  * The arguments are copied into the `config` object as part of this function
  * call, so the `argv` pointer only needs to stay alive for this function call.
  */
-WASI_API_EXTERN void wasi_config_set_argv(wasi_config_t* config, int argc, const char* argv[]);
+WASI_API_EXTERN void wasi_config_set_argv(wasi_config_t *config, int argc,
+                                          const char *argv[]);
 
 /**
  * \brief Indicates that the argv list should be inherited from this process's
  * argv list.
  */
-WASI_API_EXTERN void wasi_config_inherit_argv(wasi_config_t* config);
+WASI_API_EXTERN void wasi_config_inherit_argv(wasi_config_t *config);
 
 /**
  * \brief Sets the list of environment variables available to the WASI instance.
@@ -76,13 +77,15 @@ WASI_API_EXTERN void wasi_config_inherit_argv(wasi_config_t* config);
  * call, so the `names` and `values` pointers only need to stay alive for this
  * function call.
  */
-WASI_API_EXTERN void wasi_config_set_env(wasi_config_t* config, int envc, const char* names[], const char* values[]);
+WASI_API_EXTERN void wasi_config_set_env(wasi_config_t *config, int envc,
+                                         const char *names[],
+                                         const char *values[]);
 
 /**
  * \brief Indicates that the entire environment of the calling process should be
  * inherited by this WASI configuration.
  */
-WASI_API_EXTERN void wasi_config_inherit_env(wasi_config_t* config);
+WASI_API_EXTERN void wasi_config_inherit_env(wasi_config_t *config);
 
 /**
  * \brief Configures standard input to be taken from the specified file.
@@ -93,23 +96,26 @@ WASI_API_EXTERN void wasi_config_inherit_env(wasi_config_t* config);
  * If the stdin location does not exist or it cannot be opened for reading then
  * `false` is returned. Otherwise `true` is returned.
  */
-WASI_API_EXTERN bool wasi_config_set_stdin_file(wasi_config_t* config, const char* path);
+WASI_API_EXTERN bool wasi_config_set_stdin_file(wasi_config_t *config,
+                                                const char *path);
 
 /**
- * \brief Configures standard input to be taken from the specified #wasm_byte_vec_t.
+ * \brief Configures standard input to be taken from the specified
+ * #wasm_byte_vec_t.
  *
  * By default WASI programs have no stdin, but this configures the specified
  * bytes to be used as stdin for this configuration.
  *
  * This function takes ownership of the `binary` argument.
  */
-WASI_API_EXTERN void wasi_config_set_stdin_bytes(wasi_config_t* config, wasm_byte_vec_t* binary);
+WASI_API_EXTERN void wasi_config_set_stdin_bytes(wasi_config_t *config,
+                                                 wasm_byte_vec_t *binary);
 
 /**
  * \brief Configures this process's own stdin stream to be used as stdin for
  * this WASI configuration.
  */
-WASI_API_EXTERN void wasi_config_inherit_stdin(wasi_config_t* config);
+WASI_API_EXTERN void wasi_config_inherit_stdin(wasi_config_t *config);
 
 /**
  * \brief Configures standard output to be written to the specified file.
@@ -120,13 +126,14 @@ WASI_API_EXTERN void wasi_config_inherit_stdin(wasi_config_t* config);
  * If the stdout location could not be opened for writing then `false` is
  * returned. Otherwise `true` is returned.
  */
-WASI_API_EXTERN bool wasi_config_set_stdout_file(wasi_config_t* config, const char* path);
+WASI_API_EXTERN bool wasi_config_set_stdout_file(wasi_config_t *config,
+                                                 const char *path);
 
 /**
  * \brief Configures this process's own stdout stream to be used as stdout for
  * this WASI configuration.
  */
-WASI_API_EXTERN void wasi_config_inherit_stdout(wasi_config_t* config);
+WASI_API_EXTERN void wasi_config_inherit_stdout(wasi_config_t *config);
 
 /**
  * \brief Configures standard output to be written to the specified file.
@@ -137,25 +144,29 @@ WASI_API_EXTERN void wasi_config_inherit_stdout(wasi_config_t* config);
  * If the stderr location could not be opened for writing then `false` is
  * returned. Otherwise `true` is returned.
  */
-WASI_API_EXTERN bool wasi_config_set_stderr_file(wasi_config_t* config, const char* path);
+WASI_API_EXTERN bool wasi_config_set_stderr_file(wasi_config_t *config,
+                                                 const char *path);
 
 /**
  * \brief Configures this process's own stderr stream to be used as stderr for
  * this WASI configuration.
  */
-WASI_API_EXTERN void wasi_config_inherit_stderr(wasi_config_t* config);
+WASI_API_EXTERN void wasi_config_inherit_stderr(wasi_config_t *config);
 
 /**
  * \brief Configures a "preopened directory" to be available to WASI APIs.
  *
  * By default WASI programs do not have access to anything on the filesystem.
  * This API can be used to grant WASI programs access to a directory on the
- * filesystem, but only that directory (its whole contents but nothing above it).
+ * filesystem, but only that directory (its whole contents but nothing above
+ * it).
  *
  * The `path` argument here is a path name on the host filesystem, and
  * `guest_path` is the name by which it will be known in wasm.
  */
-WASI_API_EXTERN bool wasi_config_preopen_dir(wasi_config_t* config, const char* path, const char* guest_path);
+WASI_API_EXTERN bool wasi_config_preopen_dir(wasi_config_t *config,
+                                             const char *path,
+                                             const char *guest_path);
 
 /**
  * \brief Configures a "preopened" listen socket to be available to WASI APIs.
@@ -168,7 +179,9 @@ WASI_API_EXTERN bool wasi_config_preopen_dir(wasi_config_t* config, const char* 
  * known in WASM and the host_port is the IP address and port (e.g.
  * "127.0.0.1:8080") requested to listen on.
  */
-WASI_API_EXTERN bool wasi_config_preopen_socket(wasi_config_t* config, uint32_t fd_num, const char* host_port);
+WASI_API_EXTERN bool wasi_config_preopen_socket(wasi_config_t *config,
+                                                uint32_t fd_num,
+                                                const char *host_port);
 
 #undef own
 

--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -7,8 +7,8 @@
 #ifndef WASI_H
 #define WASI_H
 
-#include <stdint.h>
 #include "wasm.h"
+#include <stdint.h>
 
 #ifndef WASI_API_EXTERN
 #ifdef _WIN32
@@ -24,9 +24,9 @@ extern "C" {
 
 #define own
 
-#define WASI_DECLARE_OWN(name) \
-  typedef struct wasi_##name##_t wasi_##name##_t; \
-  WASI_API_EXTERN void wasi_##name##_delete(own wasi_##name##_t*);
+#define WASI_DECLARE_OWN(name)                      \
+    typedef struct wasi_##name##_t wasi_##name##_t; \
+    WASI_API_EXTERN void wasi_##name##_delete(own wasi_##name##_t*);
 
 /**
  * \typedef wasi_config_t
@@ -173,7 +173,7 @@ WASI_API_EXTERN bool wasi_config_preopen_socket(wasi_config_t* config, uint32_t 
 #undef own
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
-#endif  // #ifdef WASI_H
+#endif // #ifdef WASI_H

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -57,7 +57,8 @@
  *
  * * Linux - `-lpthread -ldl -lm`
  * * macOS - no extra flags needed
- * * Windows - `ws2_32.lib advapi32.lib userenv.lib ntdll.lib shell32.lib ole32.lib bcrypt.lib`
+ * * Windows - `ws2_32.lib advapi32.lib userenv.lib ntdll.lib shell32.lib
+ * ole32.lib bcrypt.lib`
  *
  * ## Building from Source
  *
@@ -225,11 +226,10 @@ extern "C" {
 /**
  * \brief Converts from the text format of WebAssembly to to the binary format.
  *
- * \param wat this it the input pointer with the WebAssembly Text Format inside of
- *   it. This will be parsed and converted to the binary format.
- * \param wat_len this it the length of `wat`, in bytes.
- * \param ret if the conversion is successful, this byte vector is filled in with
- *   the WebAssembly binary format.
+ * \param wat this it the input pointer with the WebAssembly Text Format inside
+ * of it. This will be parsed and converted to the binary format. \param wat_len
+ * this it the length of `wat`, in bytes. \param ret if the conversion is
+ * successful, this byte vector is filled in with the WebAssembly binary format.
  *
  * \return a non-null error if parsing fails, or returns `NULL`. If parsing
  * fails then `ret` isn't touched.
@@ -237,10 +237,8 @@ extern "C" {
  * This function does not take ownership of `wat`, and the caller is expected to
  * deallocate the returned #wasmtime_error_t and #wasm_byte_vec_t.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_wat2wasm(
-    const char* wat,
-    size_t wat_len,
-    wasm_byte_vec_t* ret);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_wat2wasm(const char *wat, size_t wat_len, wasm_byte_vec_t *ret);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -238,13 +238,12 @@ extern "C" {
  * deallocate the returned #wasmtime_error_t and #wasm_byte_vec_t.
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_wat2wasm(
-    const char *wat,
+    const char* wat,
     size_t wat_len,
-    wasm_byte_vec_t *ret
-);
+    wasm_byte_vec_t* ret);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_API_H

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -181,6 +181,7 @@
 #define WASMTIME_API_H
 
 #include <wasi.h>
+// clang-format off
 // IWYU pragma: begin_exports
 #include <wasmtime/config.h>
 #include <wasmtime/engine.h>
@@ -198,6 +199,7 @@
 #include <wasmtime/val.h>
 #include <wasmtime/async.h>
 // IWYU pragma: end_exports
+// clang-format on
 
 /**
  * \brief Wasmtime version string.

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -227,9 +227,10 @@ extern "C" {
  * \brief Converts from the text format of WebAssembly to to the binary format.
  *
  * \param wat this it the input pointer with the WebAssembly Text Format inside
- * of it. This will be parsed and converted to the binary format. \param wat_len
- * this it the length of `wat`, in bytes. \param ret if the conversion is
- * successful, this byte vector is filled in with the WebAssembly binary format.
+ *        of it. This will be parsed and converted to the binary format.
+ * \param wat_len this it the length of `wat`, in bytes.
+ * \param ret if the conversion is successful, this byte vector is filled in
+ *        with the WebAssembly binary format.
  *
  * \return a non-null error if parsing fails, or returns `NULL`. If parsing
  * fails then `ret` isn't touched.

--- a/crates/c-api/include/wasmtime/async.h
+++ b/crates/c-api/include/wasmtime/async.h
@@ -6,23 +6,27 @@
  * Async functionality in Wasmtime is well documented here:
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.async_support
  *
- * All WebAssembly executes synchronously, but an async support enables the Wasm code
- * be executed on a seperate stack, so it can be paused and resumed. There are three
- * mechanisms for yielding control from wasm to the caller: fuel, epochs, and async host functions.
+ * All WebAssembly executes synchronously, but an async support enables the Wasm
+ * code be executed on a seperate stack, so it can be paused and resumed. There
+ * are three mechanisms for yielding control from wasm to the caller: fuel,
+ * epochs, and async host functions.
  *
- * When WebAssembly is executed, a #wasmtime_call_future_t is returned. This struct represents the
- * state of the execution and each call to #wasmtime_call_future_poll will execute the WebAssembly
- * code on a seperate stack until the function returns or yields control back to the caller.
+ * When WebAssembly is executed, a #wasmtime_call_future_t is returned. This
+ * struct represents the state of the execution and each call to
+ * #wasmtime_call_future_poll will execute the WebAssembly code on a seperate
+ * stack until the function returns or yields control back to the caller.
  *
- * It's expected these futures are pulled in a loop until completed, at which point the future
- * should be deleted. Functions that return a #wasmtime_call_future_t are special in that all
- * parameters to that function should not be modified in any way and must be kept alive until
- * the future is deleted. This includes concurrent calls for a single store - another function
- * on a store should not be called while there is a #wasmtime_call_future_t alive.
+ * It's expected these futures are pulled in a loop until completed, at which
+ * point the future should be deleted. Functions that return a
+ * #wasmtime_call_future_t are special in that all parameters to that function
+ * should not be modified in any way and must be kept alive until the future is
+ * deleted. This includes concurrent calls for a single store - another function
+ * on a store should not be called while there is a #wasmtime_call_future_t
+ * alive.
  *
- * As for asynchronous host calls - the reverse contract is upheld. Wasmtime will keep all parameters
- * to the function alive and unmodified until the #wasmtime_func_async_continuation_callback_t returns
- * true.
+ * As for asynchronous host calls - the reverse contract is upheld. Wasmtime
+ * will keep all parameters to the function alive and unmodified until the
+ * #wasmtime_func_async_continuation_callback_t returns true.
  *
  */
 
@@ -41,11 +45,13 @@ extern "C" {
 #endif
 
 /**
- * \brief Whether or not to enable support for asynchronous functions in Wasmtime.
+ * \brief Whether or not to enable support for asynchronous functions in
+ * Wasmtime.
  *
  * When enabled, the config can optionally define host functions with async.
- * Instances created and functions called with this Config must be called through their asynchronous APIs, however.
- * For example using wasmtime_func_call will panic when used with this config.
+ * Instances created and functions called with this Config must be called
+ * through their asynchronous APIs, however. For example using
+ * wasmtime_func_call will panic when used with this config.
  *
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.async_support
@@ -55,13 +61,15 @@ WASMTIME_CONFIG_PROP(void, async_support, bool)
 /**
  * \brief Configures the size of the stacks used for asynchronous execution.
  *
- * This setting configures the size of the stacks that are allocated for asynchronous execution.
+ * This setting configures the size of the stacks that are allocated for
+ * asynchronous execution.
  *
  * The value cannot be less than max_wasm_stack.
  *
- * The amount of stack space guaranteed for host functions is async_stack_size - max_wasm_stack, so take care
- * not to set these two values close to one another; doing so may cause host functions to overflow the stack
- * and abort the process.
+ * The amount of stack space guaranteed for host functions is async_stack_size -
+ * max_wasm_stack, so take care not to set these two values close to one
+ * another; doing so may cause host functions to overflow the stack and abort
+ * the process.
  *
  * By default this option is 2 MiB.
  *
@@ -86,22 +94,23 @@ WASMTIME_CONFIG_PROP(void, async_stack_size, uint64_t)
  * \param interval the amount of fuel at which to yield. A value of 0 will
  *        disable yielding.
  */
-WASM_API_EXTERN wasmtime_error_t*
-wasmtime_context_fuel_async_yield_interval(wasmtime_context_t* context,
-    uint64_t interval);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_context_fuel_async_yield_interval(wasmtime_context_t *context,
+                                           uint64_t interval);
 
 /**
- * \brief Configures epoch-deadline expiration to yield to the async caller and the update the deadline.
+ * \brief Configures epoch-deadline expiration to yield to the async caller and
+ * the update the deadline.
  *
- * This is only suitable with use of a store associated with an async config because
- * only then are futures used and yields are possible.
+ * This is only suitable with use of a store associated with an async config
+ * because only then are futures used and yields are possible.
  *
  * See the Rust documentation for more:
  * https://docs.wasmtime.dev/api/wasmtime/struct.Store.html#method.epoch_deadline_async_yield_and_update
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_context_epoch_deadline_async_yield_and_update(
-    wasmtime_context_t* context,
-    uint64_t delta);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_context_epoch_deadline_async_yield_and_update(
+    wasmtime_context_t *context, uint64_t delta);
 
 /**
  * The callback to determine a continuation's current state.
@@ -109,18 +118,18 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_context_epoch_deadline_async_yield_an
  * Return true if the host call has completed, otherwise false will
  * continue to yield WebAssembly execution.
  */
-typedef bool (*wasmtime_func_async_continuation_callback_t)(void* env);
+typedef bool (*wasmtime_func_async_continuation_callback_t)(void *env);
 
 /**
  * A continuation for the current state of the host function's execution.
  */
 typedef struct wasmtime_async_continuation_t {
-    /// Callback for if the async function has completed.
-    wasmtime_func_async_continuation_callback_t callback;
-    /// User-provided argument to pass to the callback.
-    void* env;
-    /// A finalizer for the user-provided *env
-    void (*finalizer)(void*);
+  /// Callback for if the async function has completed.
+  wasmtime_func_async_continuation_callback_t callback;
+  /// User-provided argument to pass to the callback.
+  void *env;
+  /// A finalizer for the user-provided *env
+  void (*finalizer)(void *);
 } wasmtime_async_continuation_t;
 
 /**
@@ -131,144 +140,137 @@ typedef struct wasmtime_async_continuation_t {
  * All the arguments to this function will be kept alive until the continuation
  * returns that it has errored or has completed.
  *
- * \param env user-provided argument passed to #wasmtime_linker_define_async_func
- * \param caller a temporary object that can only be used during this function
- * call. Used to acquire #wasmtime_context_t or caller's state
- * \param args the arguments provided to this function invocation
- * \param nargs how many arguments are provided
- * \param results where to write the results of this function
- * \param nresults how many results must be produced
- * \param trap_ret if assigned a not `NULL` value then the called function will
- *        trap with the returned error. Note that ownership of trap is transferred
- *        to wasmtime.
- * \param continuation_ret the returned continuation that determines when the
- *        async function has completed executing.
+ * \param env user-provided argument passed to
+ * #wasmtime_linker_define_async_func \param caller a temporary object that can
+ * only be used during this function call. Used to acquire #wasmtime_context_t
+ * or caller's state \param args the arguments provided to this function
+ * invocation \param nargs how many arguments are provided \param results where
+ * to write the results of this function \param nresults how many results must
+ * be produced \param trap_ret if assigned a not `NULL` value then the called
+ * function will trap with the returned error. Note that ownership of trap is
+ * transferred to wasmtime. \param continuation_ret the returned continuation
+ * that determines when the async function has completed executing.
  *
  * Only supported for async stores.
  *
  * See #wasmtime_func_callback_t for more information.
  */
 typedef void (*wasmtime_func_async_callback_t)(
-    void* env,
-    wasmtime_caller_t* caller,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    wasmtime_val_t* results,
-    size_t nresults,
-    wasm_trap_t** trap_ret,
-    wasmtime_async_continuation_t* continuation_ret);
+    void *env, wasmtime_caller_t *caller, const wasmtime_val_t *args,
+    size_t nargs, wasmtime_val_t *results, size_t nresults,
+    wasm_trap_t **trap_ret, wasmtime_async_continuation_t *continuation_ret);
 
 /**
  * \brief The structure representing a asynchronously running function.
  *
- * This structure is always owned by the caller and must be deleted using #wasmtime_call_future_delete.
+ * This structure is always owned by the caller and must be deleted using
+ * #wasmtime_call_future_delete.
  *
- * Functions that return this type require that the parameters to the function are unmodified until
- * this future is destroyed.
+ * Functions that return this type require that the parameters to the function
+ * are unmodified until this future is destroyed.
  */
 typedef struct wasmtime_call_future wasmtime_call_future_t;
 
 /**
  * \brief Executes WebAssembly in the function.
  *
- * Returns true if the function call has completed. After this function returns true, it should *not* be
- * called again for a given future.
+ * Returns true if the function call has completed. After this function returns
+ * true, it should *not* be called again for a given future.
  *
- * This function returns false if execution has yielded either due to being out of fuel
- * (see wasmtime_context_fuel_async_yield_interval), or the epoch has been incremented enough
- * (see wasmtime_context_epoch_deadline_async_yield_and_update). The function may also return false if
- * asynchronous host functions have been called, which then calling this  function will call the
- * continuation from the async host function.
+ * This function returns false if execution has yielded either due to being out
+ * of fuel (see wasmtime_context_fuel_async_yield_interval), or the epoch has
+ * been incremented enough (see
+ * wasmtime_context_epoch_deadline_async_yield_and_update). The function may
+ * also return false if asynchronous host functions have been called, which then
+ * calling this  function will call the continuation from the async host
+ * function.
  *
  * For more see the information at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#asynchronous-wasm
  *
  */
-WASM_API_EXTERN bool wasmtime_call_future_poll(wasmtime_call_future_t* future);
+WASM_API_EXTERN bool wasmtime_call_future_poll(wasmtime_call_future_t *future);
 
 /**
  * /brief Frees the underlying memory for a future.
  *
- * All wasmtime_call_future_t are owned by the caller and should be deleted using this function.
+ * All wasmtime_call_future_t are owned by the caller and should be deleted
+ * using this function.
  */
-WASM_API_EXTERN void wasmtime_call_future_delete(wasmtime_call_future_t* future);
+WASM_API_EXTERN void
+wasmtime_call_future_delete(wasmtime_call_future_t *future);
 
 /**
- * \brief Invokes this function with the params given, returning the results asynchronously.
+ * \brief Invokes this function with the params given, returning the results
+ * asynchronously.
  *
- * This function is the same as wasmtime_func_call except that it is asynchronous.
- * This is only compatible with stores associated with an asynchronous config.
+ * This function is the same as wasmtime_func_call except that it is
+ * asynchronous. This is only compatible with stores associated with an
+ * asynchronous config.
  *
- * The result is a future that is owned by the caller and must be deleted via #wasmtime_call_future_delete.
+ * The result is a future that is owned by the caller and must be deleted via
+ * #wasmtime_call_future_delete.
  *
- * The `args` and `results` pointers may be `NULL` if the corresponding length is zero.
- * The `trap_ret` and `error_ret` pointers may *not* be `NULL`.
+ * The `args` and `results` pointers may be `NULL` if the corresponding length
+ * is zero. The `trap_ret` and `error_ret` pointers may *not* be `NULL`.
  *
- * Does not take ownership of #wasmtime_val_t arguments or #wasmtime_val_t results,
- * and all parameters to this function must be kept alive and not modified until the
- * returned #wasmtime_call_future_t is deleted. This includes the context and store
- * parameters. Only a single future can be alive for a given store at a single time
- * (meaning only call this function after the previous call's future was deleted).
+ * Does not take ownership of #wasmtime_val_t arguments or #wasmtime_val_t
+ * results, and all parameters to this function must be kept alive and not
+ * modified until the returned #wasmtime_call_future_t is deleted. This includes
+ * the context and store parameters. Only a single future can be alive for a
+ * given store at a single time (meaning only call this function after the
+ * previous call's future was deleted).
  *
  * See the header documentation for for more information.
  *
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Func.html#method.call_async
  */
-WASM_API_EXTERN wasmtime_call_future_t* wasmtime_func_call_async(
-    wasmtime_context_t* context,
-    const wasmtime_func_t* func,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    wasmtime_val_t* results,
-    size_t nresults,
-    wasm_trap_t** trap_ret,
-    wasmtime_error_t** error_ret);
+WASM_API_EXTERN wasmtime_call_future_t *wasmtime_func_call_async(
+    wasmtime_context_t *context, const wasmtime_func_t *func,
+    const wasmtime_val_t *args, size_t nargs, wasmtime_val_t *results,
+    size_t nresults, wasm_trap_t **trap_ret, wasmtime_error_t **error_ret);
 
 /**
  * \brief Defines a new async function in this linker.
  *
- * This function behaves similar to #wasmtime_linker_define_func, except it supports async
- * callbacks.
+ * This function behaves similar to #wasmtime_linker_define_func, except it
+ * supports async callbacks.
  *
  * The callback `cb` will be invoked on another stack (fiber for Windows).
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_async_func(
-    wasmtime_linker_t* linker,
-    const char* module,
-    size_t module_len,
-    const char* name,
-    size_t name_len,
-    const wasm_functype_t* ty,
-    wasmtime_func_async_callback_t cb,
-    void* data,
-    void (*finalizer)(void*));
+WASM_API_EXTERN wasmtime_error_t *wasmtime_linker_define_async_func(
+    wasmtime_linker_t *linker, const char *module, size_t module_len,
+    const char *name, size_t name_len, const wasm_functype_t *ty,
+    wasmtime_func_async_callback_t cb, void *data, void (*finalizer)(void *));
 
 /**
- * \brief Instantiates a #wasm_module_t with the items defined in this linker for an async store.
+ * \brief Instantiates a #wasm_module_t with the items defined in this linker
+ * for an async store.
  *
  * This is the same as #wasmtime_linker_instantiate but used for async stores
- * (which requires functions are called asynchronously). The returning #wasmtime_call_future_t
- * must be polled using #wasmtime_call_future_poll, and is owned and must be deleted using #wasmtime_call_future_delete.
+ * (which requires functions are called asynchronously). The returning
+ * #wasmtime_call_future_t must be polled using #wasmtime_call_future_poll, and
+ * is owned and must be deleted using #wasmtime_call_future_delete.
  *
- * The `trap_ret` and `error_ret` pointers may *not* be `NULL` and the returned memory is owned by the caller.
+ * The `trap_ret` and `error_ret` pointers may *not* be `NULL` and the returned
+ * memory is owned by the caller.
  *
- * All arguments to this function must outlive the returned future and be unmodified until the future is deleted.
+ * All arguments to this function must outlive the returned future and be
+ * unmodified until the future is deleted.
  */
-WASM_API_EXTERN wasmtime_call_future_t* wasmtime_linker_instantiate_async(
-    const wasmtime_linker_t* linker,
-    wasmtime_context_t* store,
-    const wasmtime_module_t* module,
-    wasmtime_instance_t* instance,
-    wasm_trap_t** trap_ret,
-    wasmtime_error_t** error_ret);
+WASM_API_EXTERN wasmtime_call_future_t *wasmtime_linker_instantiate_async(
+    const wasmtime_linker_t *linker, wasmtime_context_t *store,
+    const wasmtime_module_t *module, wasmtime_instance_t *instance,
+    wasm_trap_t **trap_ret, wasmtime_error_t **error_ret);
 
 /**
  * \brief Instantiates instance within the given store.
  *
  * This will also run the function's startup function, if there is one.
  *
- * For more information on async instantiation see #wasmtime_linker_instantiate_async.
+ * For more information on async instantiation see
+ * #wasmtime_linker_instantiate_async.
  *
  * \param instance_pre the pre-initialized instance
  * \param store the store in which to create the instance
@@ -276,16 +278,16 @@ WASM_API_EXTERN wasmtime_call_future_t* wasmtime_linker_instantiate_async(
  * \param trap_ret where to store the returned trap
  * \param error_ret where to store the returned trap
  *
- * The `trap_ret` and `error_ret` pointers may *not* be `NULL` and the returned memory is owned by the caller.
+ * The `trap_ret` and `error_ret` pointers may *not* be `NULL` and the returned
+ * memory is owned by the caller.
  *
- * All arguments to this function must outlive the returned future and be unmodified until the future is deleted.
+ * All arguments to this function must outlive the returned future and be
+ * unmodified until the future is deleted.
  */
-WASM_API_EXTERN wasmtime_call_future_t* wasmtime_instance_pre_instantiate_async(
-    const wasmtime_instance_pre_t* instance_pre,
-    wasmtime_context_t* store,
-    wasmtime_instance_t* instance,
-    wasm_trap_t** trap_ret,
-    wasmtime_error_t** error_ret);
+WASM_API_EXTERN wasmtime_call_future_t *wasmtime_instance_pre_instantiate_async(
+    const wasmtime_instance_pre_t *instance_pre, wasmtime_context_t *store,
+    wasmtime_instance_t *instance, wasm_trap_t **trap_ret,
+    wasmtime_error_t **error_ret);
 
 /**
  * A callback to get the top of the stack address and the length of the stack,
@@ -294,9 +296,8 @@ WASM_API_EXTERN wasmtime_call_future_t* wasmtime_instance_pre_instantiate_async(
  * For more information about the parameters see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/trait.StackMemory.html
  */
-typedef uint8_t* (*wasmtime_stack_memory_get_callback_t)(
-    void* env,
-    size_t* out_len);
+typedef uint8_t *(*wasmtime_stack_memory_get_callback_t)(void *env,
+                                                         size_t *out_len);
 
 /**
  * A Stack instance created from a #wasmtime_new_stack_memory_callback_t.
@@ -305,29 +306,27 @@ typedef uint8_t* (*wasmtime_stack_memory_get_callback_t)(
  * https://docs.wasmtime.dev/api/wasmtime/trait.StackMemory.html
  */
 typedef struct {
-    /// User provided value to be passed to get_memory and grow_memory
-    void* env;
-    /// Callback to get the memory and size of this LinearMemory
-    wasmtime_stack_memory_get_callback_t get_stack_memory;
-    /// An optional finalizer for env
-    void (*finalizer)(void*);
+  /// User provided value to be passed to get_memory and grow_memory
+  void *env;
+  /// Callback to get the memory and size of this LinearMemory
+  wasmtime_stack_memory_get_callback_t get_stack_memory;
+  /// An optional finalizer for env
+  void (*finalizer)(void *);
 } wasmtime_stack_memory_t;
 
 /**
  * A callback to create a new StackMemory from the specified parameters.
  *
- * The result should be written to `stack_ret` and wasmtime will own the values written
- * into that struct.
+ * The result should be written to `stack_ret` and wasmtime will own the values
+ * written into that struct.
  *
  * This callback must be thread-safe.
  *
  * For more information about the parameters see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/trait.StackCreator.html#tymethod.new_stack
  */
-typedef wasmtime_error_t* (*wasmtime_new_stack_memory_callback_t)(
-    void* env,
-    size_t size,
-    wasmtime_stack_memory_t* stack_ret);
+typedef wasmtime_error_t *(*wasmtime_new_stack_memory_callback_t)(
+    void *env, size_t size, wasmtime_stack_memory_t *stack_ret);
 
 /**
  * A representation of custom stack creator.
@@ -336,29 +335,29 @@ typedef wasmtime_error_t* (*wasmtime_new_stack_memory_callback_t)(
  * https://docs.wasmtime.dev/api/wasmtime/trait.StackCreator.html
  */
 typedef struct {
-    /// User provided value to be passed to new_stack
-    void* env;
-    /// The callback to create a new stack, must be thread safe
-    wasmtime_new_stack_memory_callback_t new_stack;
-    /// An optional finalizer for env.
-    void (*finalizer)(void*);
+  /// User provided value to be passed to new_stack
+  void *env;
+  /// The callback to create a new stack, must be thread safe
+  wasmtime_new_stack_memory_callback_t new_stack;
+  /// An optional finalizer for env.
+  void (*finalizer)(void *);
 } wasmtime_stack_creator_t;
 
 /**
  * Sets a custom stack creator.
  *
- * Custom memory creators are used when creating creating async instance stacks for
- * the on-demand instance allocation strategy.
+ * Custom memory creators are used when creating creating async instance stacks
+ * for the on-demand instance allocation strategy.
  *
- * The config does **not** take ownership of the #wasmtime_stack_creator_t passed in, but
- * instead copies all the values in the struct.
+ * The config does **not** take ownership of the #wasmtime_stack_creator_t
+ * passed in, but instead copies all the values in the struct.
  *
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.with_host_stack
  */
-WASM_API_EXTERN void wasmtime_config_host_stack_creator_set(
-    wasm_config_t*,
-    wasmtime_stack_creator_t*);
+WASM_API_EXTERN void
+wasmtime_config_host_stack_creator_set(wasm_config_t *,
+                                       wasmtime_stack_creator_t *);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/async.h
+++ b/crates/c-api/include/wasmtime/async.h
@@ -14,8 +14,8 @@
  * state of the execution and each call to #wasmtime_call_future_poll will execute the WebAssembly
  * code on a seperate stack until the function returns or yields control back to the caller.
  *
- * It's expected these futures are pulled in a loop until completed, at which point the future 
- * should be deleted. Functions that return a #wasmtime_call_future_t are special in that all 
+ * It's expected these futures are pulled in a loop until completed, at which point the future
+ * should be deleted. Functions that return a #wasmtime_call_future_t are special in that all
  * parameters to that function should not be modified in any way and must be kept alive until
  * the future is deleted. This includes concurrent calls for a single store - another function
  * on a store should not be called while there is a #wasmtime_call_future_t alive.
@@ -30,11 +30,11 @@
 #define WASMTIME_ASYNC_H
 
 #include <wasm.h>
-#include <wasmtime/error.h>
 #include <wasmtime/config.h>
-#include <wasmtime/store.h>
+#include <wasmtime/error.h>
 #include <wasmtime/func.h>
 #include <wasmtime/linker.h>
+#include <wasmtime/store.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -43,7 +43,7 @@ extern "C" {
 /**
  * \brief Whether or not to enable support for asynchronous functions in Wasmtime.
  *
- * When enabled, the config can optionally define host functions with async. 
+ * When enabled, the config can optionally define host functions with async.
  * Instances created and functions called with this Config must be called through their asynchronous APIs, however.
  * For example using wasmtime_func_call will panic when used with this config.
  *
@@ -55,12 +55,12 @@ WASMTIME_CONFIG_PROP(void, async_support, bool)
 /**
  * \brief Configures the size of the stacks used for asynchronous execution.
  *
- * This setting configures the size of the stacks that are allocated for asynchronous execution. 
+ * This setting configures the size of the stacks that are allocated for asynchronous execution.
  *
  * The value cannot be less than max_wasm_stack.
  *
  * The amount of stack space guaranteed for host functions is async_stack_size - max_wasm_stack, so take care
- * not to set these two values close to one another; doing so may cause host functions to overflow the stack 
+ * not to set these two values close to one another; doing so may cause host functions to overflow the stack
  * and abort the process.
  *
  * By default this option is 2 MiB.
@@ -87,8 +87,8 @@ WASMTIME_CONFIG_PROP(void, async_stack_size, uint64_t)
  *        disable yielding.
  */
 WASM_API_EXTERN wasmtime_error_t*
-wasmtime_context_fuel_async_yield_interval(wasmtime_context_t *context,
-                                           uint64_t interval);
+wasmtime_context_fuel_async_yield_interval(wasmtime_context_t* context,
+    uint64_t interval);
 
 /**
  * \brief Configures epoch-deadline expiration to yield to the async caller and the update the deadline.
@@ -100,33 +100,33 @@ wasmtime_context_fuel_async_yield_interval(wasmtime_context_t *context,
  * https://docs.wasmtime.dev/api/wasmtime/struct.Store.html#method.epoch_deadline_async_yield_and_update
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_context_epoch_deadline_async_yield_and_update(
-    wasmtime_context_t *context,
+    wasmtime_context_t* context,
     uint64_t delta);
 
 /**
  * The callback to determine a continuation's current state.
  *
- * Return true if the host call has completed, otherwise false will 
+ * Return true if the host call has completed, otherwise false will
  * continue to yield WebAssembly execution.
  */
-typedef bool (*wasmtime_func_async_continuation_callback_t)(void *env);
+typedef bool (*wasmtime_func_async_continuation_callback_t)(void* env);
 
 /**
  * A continuation for the current state of the host function's execution.
  */
 typedef struct wasmtime_async_continuation_t {
-  /// Callback for if the async function has completed.
-  wasmtime_func_async_continuation_callback_t callback;
-  /// User-provided argument to pass to the callback.
-  void *env;
-  /// A finalizer for the user-provided *env
-  void (*finalizer)(void *);
+    /// Callback for if the async function has completed.
+    wasmtime_func_async_continuation_callback_t callback;
+    /// User-provided argument to pass to the callback.
+    void* env;
+    /// A finalizer for the user-provided *env
+    void (*finalizer)(void*);
 } wasmtime_async_continuation_t;
 
 /**
  * \brief Callback signature for #wasmtime_linker_define_async_func.
  *
- * This is a host function that returns a continuation to be called later. 
+ * This is a host function that returns a continuation to be called later.
  *
  * All the arguments to this function will be kept alive until the continuation
  * returns that it has errored or has completed.
@@ -141,7 +141,7 @@ typedef struct wasmtime_async_continuation_t {
  * \param trap_ret if assigned a not `NULL` value then the called function will
  *        trap with the returned error. Note that ownership of trap is transferred
  *        to wasmtime.
- * \param continuation_ret the returned continuation that determines when the 
+ * \param continuation_ret the returned continuation that determines when the
  *        async function has completed executing.
  *
  * Only supported for async stores.
@@ -149,21 +149,21 @@ typedef struct wasmtime_async_continuation_t {
  * See #wasmtime_func_callback_t for more information.
  */
 typedef void (*wasmtime_func_async_callback_t)(
-    void *env,
-    wasmtime_caller_t *caller, 
-    const wasmtime_val_t *args,
-    size_t nargs, 
-    wasmtime_val_t *results,
+    void* env,
+    wasmtime_caller_t* caller,
+    const wasmtime_val_t* args,
+    size_t nargs,
+    wasmtime_val_t* results,
     size_t nresults,
     wasm_trap_t** trap_ret,
-    wasmtime_async_continuation_t * continuation_ret);
+    wasmtime_async_continuation_t* continuation_ret);
 
 /**
  * \brief The structure representing a asynchronously running function.
  *
  * This structure is always owned by the caller and must be deleted using #wasmtime_call_future_delete.
  *
- * Functions that return this type require that the parameters to the function are unmodified until 
+ * Functions that return this type require that the parameters to the function are unmodified until
  * this future is destroyed.
  */
 typedef struct wasmtime_call_future wasmtime_call_future_t;
@@ -171,27 +171,27 @@ typedef struct wasmtime_call_future wasmtime_call_future_t;
 /**
  * \brief Executes WebAssembly in the function.
  *
- * Returns true if the function call has completed. After this function returns true, it should *not* be 
+ * Returns true if the function call has completed. After this function returns true, it should *not* be
  * called again for a given future.
  *
- * This function returns false if execution has yielded either due to being out of fuel 
- * (see wasmtime_context_fuel_async_yield_interval), or the epoch has been incremented enough 
- * (see wasmtime_context_epoch_deadline_async_yield_and_update). The function may also return false if 
- * asynchronous host functions have been called, which then calling this  function will call the 
+ * This function returns false if execution has yielded either due to being out of fuel
+ * (see wasmtime_context_fuel_async_yield_interval), or the epoch has been incremented enough
+ * (see wasmtime_context_epoch_deadline_async_yield_and_update). The function may also return false if
+ * asynchronous host functions have been called, which then calling this  function will call the
  * continuation from the async host function.
  *
  * For more see the information at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#asynchronous-wasm
  *
  */
-WASM_API_EXTERN bool wasmtime_call_future_poll(wasmtime_call_future_t *future);
+WASM_API_EXTERN bool wasmtime_call_future_poll(wasmtime_call_future_t* future);
 
 /**
  * /brief Frees the underlying memory for a future.
  *
  * All wasmtime_call_future_t are owned by the caller and should be deleted using this function.
  */
-WASM_API_EXTERN void wasmtime_call_future_delete(wasmtime_call_future_t *future);
+WASM_API_EXTERN void wasmtime_call_future_delete(wasmtime_call_future_t* future);
 
 /**
  * \brief Invokes this function with the params given, returning the results asynchronously.
@@ -199,7 +199,7 @@ WASM_API_EXTERN void wasmtime_call_future_delete(wasmtime_call_future_t *future)
  * This function is the same as wasmtime_func_call except that it is asynchronous.
  * This is only compatible with stores associated with an asynchronous config.
  *
- * The result is a future that is owned by the caller and must be deleted via #wasmtime_call_future_delete. 
+ * The result is a future that is owned by the caller and must be deleted via #wasmtime_call_future_delete.
  *
  * The `args` and `results` pointers may be `NULL` if the corresponding length is zero.
  * The `trap_ret` and `error_ret` pointers may *not* be `NULL`.
@@ -207,7 +207,7 @@ WASM_API_EXTERN void wasmtime_call_future_delete(wasmtime_call_future_t *future)
  * Does not take ownership of #wasmtime_val_t arguments or #wasmtime_val_t results,
  * and all parameters to this function must be kept alive and not modified until the
  * returned #wasmtime_call_future_t is deleted. This includes the context and store
- * parameters. Only a single future can be alive for a given store at a single time 
+ * parameters. Only a single future can be alive for a given store at a single time
  * (meaning only call this function after the previous call's future was deleted).
  *
  * See the header documentation for for more information.
@@ -216,11 +216,11 @@ WASM_API_EXTERN void wasmtime_call_future_delete(wasmtime_call_future_t *future)
  * https://docs.wasmtime.dev/api/wasmtime/struct.Func.html#method.call_async
  */
 WASM_API_EXTERN wasmtime_call_future_t* wasmtime_func_call_async(
-    wasmtime_context_t *context,
-    const wasmtime_func_t *func,
-    const wasmtime_val_t *args,
+    wasmtime_context_t* context,
+    const wasmtime_func_t* func,
+    const wasmtime_val_t* args,
     size_t nargs,
-    wasmtime_val_t *results,
+    wasmtime_val_t* results,
     size_t nresults,
     wasm_trap_t** trap_ret,
     wasmtime_error_t** error_ret);
@@ -233,33 +233,33 @@ WASM_API_EXTERN wasmtime_call_future_t* wasmtime_func_call_async(
  *
  * The callback `cb` will be invoked on another stack (fiber for Windows).
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_linker_define_async_func(
-    wasmtime_linker_t *linker,
-    const char *module,
+WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_async_func(
+    wasmtime_linker_t* linker,
+    const char* module,
     size_t module_len,
-    const char *name,
+    const char* name,
     size_t name_len,
-    const wasm_functype_t *ty,
+    const wasm_functype_t* ty,
     wasmtime_func_async_callback_t cb,
-    void *data,
-    void (*finalizer)(void *));
+    void* data,
+    void (*finalizer)(void*));
 
 /**
  * \brief Instantiates a #wasm_module_t with the items defined in this linker for an async store.
  *
- * This is the same as #wasmtime_linker_instantiate but used for async stores 
- * (which requires functions are called asynchronously). The returning #wasmtime_call_future_t 
+ * This is the same as #wasmtime_linker_instantiate but used for async stores
+ * (which requires functions are called asynchronously). The returning #wasmtime_call_future_t
  * must be polled using #wasmtime_call_future_poll, and is owned and must be deleted using #wasmtime_call_future_delete.
  *
  * The `trap_ret` and `error_ret` pointers may *not* be `NULL` and the returned memory is owned by the caller.
  *
  * All arguments to this function must outlive the returned future and be unmodified until the future is deleted.
  */
-WASM_API_EXTERN wasmtime_call_future_t *wasmtime_linker_instantiate_async(
-    const wasmtime_linker_t *linker,
-    wasmtime_context_t *store,
-    const wasmtime_module_t *module,
-    wasmtime_instance_t *instance,
+WASM_API_EXTERN wasmtime_call_future_t* wasmtime_linker_instantiate_async(
+    const wasmtime_linker_t* linker,
+    wasmtime_context_t* store,
+    const wasmtime_module_t* module,
+    wasmtime_instance_t* instance,
     wasm_trap_t** trap_ret,
     wasmtime_error_t** error_ret);
 
@@ -280,10 +280,10 @@ WASM_API_EXTERN wasmtime_call_future_t *wasmtime_linker_instantiate_async(
  *
  * All arguments to this function must outlive the returned future and be unmodified until the future is deleted.
  */
-WASM_API_EXTERN wasmtime_call_future_t *wasmtime_instance_pre_instantiate_async(
+WASM_API_EXTERN wasmtime_call_future_t* wasmtime_instance_pre_instantiate_async(
     const wasmtime_instance_pre_t* instance_pre,
-    wasmtime_context_t *store,
-    wasmtime_instance_t *instance,
+    wasmtime_context_t* store,
+    wasmtime_instance_t* instance,
     wasm_trap_t** trap_ret,
     wasmtime_error_t** error_ret);
 
@@ -294,9 +294,9 @@ WASM_API_EXTERN wasmtime_call_future_t *wasmtime_instance_pre_instantiate_async(
  * For more information about the parameters see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/trait.StackMemory.html
  */
-typedef uint8_t *(*wasmtime_stack_memory_get_callback_t)(
-    void *env,
-    size_t *out_len);
+typedef uint8_t* (*wasmtime_stack_memory_get_callback_t)(
+    void* env,
+    size_t* out_len);
 
 /**
  * A Stack instance created from a #wasmtime_new_stack_memory_callback_t.
@@ -305,18 +305,18 @@ typedef uint8_t *(*wasmtime_stack_memory_get_callback_t)(
  * https://docs.wasmtime.dev/api/wasmtime/trait.StackMemory.html
  */
 typedef struct {
-  /// User provided value to be passed to get_memory and grow_memory
-  void *env;
-  /// Callback to get the memory and size of this LinearMemory
-  wasmtime_stack_memory_get_callback_t get_stack_memory;
-  /// An optional finalizer for env
-  void (*finalizer)(void*);
+    /// User provided value to be passed to get_memory and grow_memory
+    void* env;
+    /// Callback to get the memory and size of this LinearMemory
+    wasmtime_stack_memory_get_callback_t get_stack_memory;
+    /// An optional finalizer for env
+    void (*finalizer)(void*);
 } wasmtime_stack_memory_t;
 
 /**
  * A callback to create a new StackMemory from the specified parameters.
  *
- * The result should be written to `stack_ret` and wasmtime will own the values written 
+ * The result should be written to `stack_ret` and wasmtime will own the values written
  * into that struct.
  *
  * This callback must be thread-safe.
@@ -324,10 +324,10 @@ typedef struct {
  * For more information about the parameters see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/trait.StackCreator.html#tymethod.new_stack
  */
-typedef wasmtime_error_t *(*wasmtime_new_stack_memory_callback_t)(
-    void *env,
+typedef wasmtime_error_t* (*wasmtime_new_stack_memory_callback_t)(
+    void* env,
     size_t size,
-    wasmtime_stack_memory_t *stack_ret);
+    wasmtime_stack_memory_t* stack_ret);
 
 /**
  * A representation of custom stack creator.
@@ -336,12 +336,12 @@ typedef wasmtime_error_t *(*wasmtime_new_stack_memory_callback_t)(
  * https://docs.wasmtime.dev/api/wasmtime/trait.StackCreator.html
  */
 typedef struct {
-  /// User provided value to be passed to new_stack
-  void* env;
-  /// The callback to create a new stack, must be thread safe
-  wasmtime_new_stack_memory_callback_t new_stack;
-  /// An optional finalizer for env.
-  void (*finalizer)(void*);
+    /// User provided value to be passed to new_stack
+    void* env;
+    /// The callback to create a new stack, must be thread safe
+    wasmtime_new_stack_memory_callback_t new_stack;
+    /// An optional finalizer for env.
+    void (*finalizer)(void*);
 } wasmtime_stack_creator_t;
 
 /**
@@ -350,7 +350,7 @@ typedef struct {
  * Custom memory creators are used when creating creating async instance stacks for
  * the on-demand instance allocation strategy.
  *
- * The config does **not** take ownership of the #wasmtime_stack_creator_t passed in, but 
+ * The config does **not** take ownership of the #wasmtime_stack_creator_t passed in, but
  * instead copies all the values in the struct.
  *
  * For more information see the Rust documentation at
@@ -360,10 +360,8 @@ WASM_API_EXTERN void wasmtime_config_host_stack_creator_set(
     wasm_config_t*,
     wasmtime_stack_creator_t*);
 
-
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_ASYNC_H
-

--- a/crates/c-api/include/wasmtime/async.h
+++ b/crates/c-api/include/wasmtime/async.h
@@ -145,8 +145,8 @@ typedef struct wasmtime_async_continuation_t {
  * \param caller a temporary object that can only be used during this function
  *        call. Used to acquire #wasmtime_context_t or caller's state
  * \param args the arguments provided to this function invocation
- * \param nargs how many arguments are provided \param results where to write
- *        the results of this function
+ * \param nargs how many arguments are provided
+ * \param results where to write the results of this function
  * \param nresults how many results must be produced
  * \param trap_ret if assigned a not `NULL` value then the called
  *        function will trap with the returned error. Note that ownership of

--- a/crates/c-api/include/wasmtime/async.h
+++ b/crates/c-api/include/wasmtime/async.h
@@ -141,15 +141,18 @@ typedef struct wasmtime_async_continuation_t {
  * returns that it has errored or has completed.
  *
  * \param env user-provided argument passed to
- * #wasmtime_linker_define_async_func \param caller a temporary object that can
- * only be used during this function call. Used to acquire #wasmtime_context_t
- * or caller's state \param args the arguments provided to this function
- * invocation \param nargs how many arguments are provided \param results where
- * to write the results of this function \param nresults how many results must
- * be produced \param trap_ret if assigned a not `NULL` value then the called
- * function will trap with the returned error. Note that ownership of trap is
- * transferred to wasmtime. \param continuation_ret the returned continuation
- * that determines when the async function has completed executing.
+ *        #wasmtime_linker_define_async_func
+ * \param caller a temporary object that can only be used during this function
+ *        call. Used to acquire #wasmtime_context_t or caller's state
+ * \param args the arguments provided to this function invocation
+ * \param nargs how many arguments are provided \param results where to write
+ *        the results of this function
+ * \param nresults how many results must be produced
+ * \param trap_ret if assigned a not `NULL` value then the called
+ *        function will trap with the returned error. Note that ownership of
+ *        trap is transferred to wasmtime.
+ * \param continuation_ret the returned continuation
+ *        that determines when the async function has completed executing.
  *
  * Only supported for async stores.
  *

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -26,13 +26,13 @@ typedef uint8_t wasmtime_strategy_t;
  * The default value is #WASMTIME_STRATEGY_AUTO.
  */
 enum wasmtime_strategy_enum { // Strategy
-    /// Automatically picks the compilation backend, currently always defaulting
-    /// to Cranelift.
-    WASMTIME_STRATEGY_AUTO,
+  /// Automatically picks the compilation backend, currently always defaulting
+  /// to Cranelift.
+  WASMTIME_STRATEGY_AUTO,
 
-    /// Indicates that Wasmtime will unconditionally use Cranelift to compile
-    /// WebAssembly code.
-    WASMTIME_STRATEGY_CRANELIFT,
+  /// Indicates that Wasmtime will unconditionally use Cranelift to compile
+  /// WebAssembly code.
+  WASMTIME_STRATEGY_CRANELIFT,
 };
 
 /**
@@ -48,13 +48,13 @@ typedef uint8_t wasmtime_opt_level_t;
  * The default value is #WASMTIME_OPT_LEVEL_SPEED.
  */
 enum wasmtime_opt_level_enum { // OptLevel
-    /// Generated code will not be optimized at all.
-    WASMTIME_OPT_LEVEL_NONE,
-    /// Generated code will be optimized purely for speed.
-    WASMTIME_OPT_LEVEL_SPEED,
-    /// Generated code will be optimized, but some speed optimizations are
-    /// disabled if they cause the generated code to be significantly larger.
-    WASMTIME_OPT_LEVEL_SPEED_AND_SIZE,
+  /// Generated code will not be optimized at all.
+  WASMTIME_OPT_LEVEL_NONE,
+  /// Generated code will be optimized purely for speed.
+  WASMTIME_OPT_LEVEL_SPEED,
+  /// Generated code will be optimized, but some speed optimizations are
+  /// disabled if they cause the generated code to be significantly larger.
+  WASMTIME_OPT_LEVEL_SPEED_AND_SIZE,
 };
 
 /**
@@ -70,24 +70,24 @@ typedef uint8_t wasmtime_profiling_strategy_t;
  * The default is #WASMTIME_PROFILING_STRATEGY_NONE.
  */
 enum wasmtime_profiling_strategy_enum { // ProfilingStrategy
-    /// No profiling is enabled at runtime.
-    WASMTIME_PROFILING_STRATEGY_NONE,
-    /// Linux's "jitdump" support in `perf` is enabled and when Wasmtime is run
-    /// under `perf` necessary calls will be made to profile generated JIT code.
-    WASMTIME_PROFILING_STRATEGY_JITDUMP,
-    /// Support for VTune will be enabled and the VTune runtime will be informed,
-    /// at runtime, about JIT code.
-    ///
-    /// Note that this isn't always enabled at build time.
-    WASMTIME_PROFILING_STRATEGY_VTUNE,
-    /// Linux's simple "perfmap" support in `perf` is enabled and when Wasmtime is
-    /// run under `perf` necessary calls will be made to profile generated JIT
-    /// code.
-    WASMTIME_PROFILING_STRATEGY_PERFMAP,
+  /// No profiling is enabled at runtime.
+  WASMTIME_PROFILING_STRATEGY_NONE,
+  /// Linux's "jitdump" support in `perf` is enabled and when Wasmtime is run
+  /// under `perf` necessary calls will be made to profile generated JIT code.
+  WASMTIME_PROFILING_STRATEGY_JITDUMP,
+  /// Support for VTune will be enabled and the VTune runtime will be informed,
+  /// at runtime, about JIT code.
+  ///
+  /// Note that this isn't always enabled at build time.
+  WASMTIME_PROFILING_STRATEGY_VTUNE,
+  /// Linux's simple "perfmap" support in `perf` is enabled and when Wasmtime is
+  /// run under `perf` necessary calls will be made to profile generated JIT
+  /// code.
+  WASMTIME_PROFILING_STRATEGY_PERFMAP,
 };
 
-#define WASMTIME_CONFIG_PROP(ret, name, ty) \
-    WASM_API_EXTERN ret wasmtime_config_##name##_set(wasm_config_t*, ty);
+#define WASMTIME_CONFIG_PROP(ret, name, ty)                                    \
+  WASM_API_EXTERN ret wasmtime_config_##name##_set(wasm_config_t *, ty);
 
 /**
  * \brief Configures whether DWARF debug information is constructed at runtime
@@ -221,7 +221,8 @@ WASMTIME_CONFIG_PROP(void, wasm_memory64, bool)
 WASMTIME_CONFIG_PROP(void, strategy, wasmtime_strategy_t)
 
 /**
- * \brief Configure whether wasmtime should compile a module using multiple threads.
+ * \brief Configure whether wasmtime should compile a module using multiple
+ * threads.
  *
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.parallel_compilation.
@@ -239,13 +240,15 @@ WASMTIME_CONFIG_PROP(void, parallel_compilation, bool)
 WASMTIME_CONFIG_PROP(void, cranelift_debug_verifier, bool)
 
 /**
- * \brief Configures whether Cranelift should perform a NaN-canonicalization pass.
+ * \brief Configures whether Cranelift should perform a NaN-canonicalization
+ * pass.
  *
  * When Cranelift is used as a code generation backend this will configure
  * it to replace NaNs with a single canonical value. This is useful for users
  * requiring entirely deterministic WebAssembly computation.
  *
- * This is not required by the WebAssembly spec, so it is not enabled by default.
+ * This is not required by the WebAssembly spec, so it is not enabled by
+ * default.
  *
  * The default value for this is `false`
  */
@@ -300,7 +303,8 @@ WASMTIME_CONFIG_PROP(void, static_memory_guard_size, uint64_t)
 WASMTIME_CONFIG_PROP(void, dynamic_memory_guard_size, uint64_t)
 
 /**
- * \brief Configures the size, in bytes, of the extra virtual memory space reserved after a “dynamic” memory for growing into.
+ * \brief Configures the size, in bytes, of the extra virtual memory space
+ * reserved after a “dynamic” memory for growing into.
  *
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.dynamic_memory_reserved_for_growth
@@ -308,7 +312,8 @@ WASMTIME_CONFIG_PROP(void, dynamic_memory_guard_size, uint64_t)
 WASMTIME_CONFIG_PROP(void, dynamic_memory_reserved_for_growth, uint64_t)
 
 /**
- * \brief Configures whether to generate native unwind information (e.g. .eh_frame on Linux).
+ * \brief Configures whether to generate native unwind information (e.g.
+ * .eh_frame on Linux).
  *
  * This option defaults to true.
  *
@@ -329,7 +334,8 @@ WASMTIME_CONFIG_PROP(void, native_unwind_info, bool)
  * An error is returned if the cache configuration could not be loaded or if the
  * cache could not be enabled.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_config_cache_config_load(wasm_config_t*, const char*);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_config_cache_config_load(wasm_config_t *, const char *);
 
 /**
  * \brief Configures the target triple that this configuration will produce
@@ -343,7 +349,7 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_config_cache_config_load(wasm_config_
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.config
  */
-WASMTIME_CONFIG_PROP(wasmtime_error_t*, target, const char*)
+WASMTIME_CONFIG_PROP(wasmtime_error_t *, target, const char *)
 
 /**
  * \brief Enables a target-specific flag in Cranelift.
@@ -354,7 +360,8 @@ WASMTIME_CONFIG_PROP(wasmtime_error_t*, target, const char*)
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.cranelift_flag_enable
  */
-WASM_API_EXTERN void wasmtime_config_cranelift_flag_enable(wasm_config_t*, const char*);
+WASM_API_EXTERN void wasmtime_config_cranelift_flag_enable(wasm_config_t *,
+                                                           const char *);
 
 /**
  * \brief Sets a target-specific flag in Cranelift to the specified value.
@@ -365,11 +372,13 @@ WASM_API_EXTERN void wasmtime_config_cranelift_flag_enable(wasm_config_t*, const
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.cranelift_flag_set
  */
-WASM_API_EXTERN void wasmtime_config_cranelift_flag_set(wasm_config_t*, const char* key, const char* value);
+WASM_API_EXTERN void wasmtime_config_cranelift_flag_set(wasm_config_t *,
+                                                        const char *key,
+                                                        const char *value);
 
 /**
- * \brief Configures whether, when on macOS, Mach ports are used for exception handling
- * instead of traditional Unix-based signal handling.
+ * \brief Configures whether, when on macOS, Mach ports are used for exception
+ * handling instead of traditional Unix-based signal handling.
  *
  * This option defaults to true, using Mach ports by default.
  *
@@ -381,16 +390,14 @@ WASMTIME_CONFIG_PROP(void, macos_use_mach_ports, bool)
 /**
  * Return the data from a LinearMemory instance.
  *
- * The size in bytes as well as the maximum number of bytes that can be allocated should be
- * returned as well.
+ * The size in bytes as well as the maximum number of bytes that can be
+ * allocated should be returned as well.
  *
  * For more information about see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/trait.LinearMemory.html
  */
-typedef uint8_t* (*wasmtime_memory_get_callback_t)(
-    void* env,
-    size_t* byte_size,
-    size_t* maximum_byte_size);
+typedef uint8_t *(*wasmtime_memory_get_callback_t)(void *env, size_t *byte_size,
+                                                   size_t *maximum_byte_size);
 
 /**
  * Grow the memory to the `new_size` in bytes.
@@ -398,9 +405,8 @@ typedef uint8_t* (*wasmtime_memory_get_callback_t)(
  * For more information about the parameters see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/trait.LinearMemory.html#tymethod.grow_to
  */
-typedef wasmtime_error_t* (*wasmtime_memory_grow_callback_t)(
-    void* env,
-    size_t new_size);
+typedef wasmtime_error_t *(*wasmtime_memory_grow_callback_t)(void *env,
+                                                             size_t new_size);
 
 /**
  * A LinearMemory instance created from a #wasmtime_new_memory_callback_t.
@@ -409,75 +415,76 @@ typedef wasmtime_error_t* (*wasmtime_memory_grow_callback_t)(
  * https://docs.wasmtime.dev/api/wasmtime/trait.LinearMemory.html
  */
 typedef struct wasmtime_linear_memory {
-    /// User provided value to be passed to get_memory and grow_memory
-    void* env;
-    /// Callback to get the memory and size of this LinearMemory
-    wasmtime_memory_get_callback_t get_memory;
-    /// Callback to request growing the memory
-    wasmtime_memory_grow_callback_t grow_memory;
-    /// An optional finalizer for env
-    void (*finalizer)(void*);
+  /// User provided value to be passed to get_memory and grow_memory
+  void *env;
+  /// Callback to get the memory and size of this LinearMemory
+  wasmtime_memory_get_callback_t get_memory;
+  /// Callback to request growing the memory
+  wasmtime_memory_grow_callback_t grow_memory;
+  /// An optional finalizer for env
+  void (*finalizer)(void *);
 } wasmtime_linear_memory_t;
 
 /**
  * A callback to create a new LinearMemory from the specified parameters.
  *
- * The result should be written to `memory_ret` and wasmtime will own the values written
- * into that struct.
+ * The result should be written to `memory_ret` and wasmtime will own the values
+ * written into that struct.
  *
  * This callback must be thread-safe.
  *
  * For more information about the parameters see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/trait.MemoryCreator.html#tymethod.new_memory
  */
-typedef wasmtime_error_t* (*wasmtime_new_memory_callback_t)(
-    void* env,
-    const wasm_memorytype_t* ty,
-    size_t minimum,
-    size_t maximum,
-    size_t reserved_size_in_bytes,
-    size_t guard_size_in_bytes,
-    wasmtime_linear_memory_t* memory_ret);
+typedef wasmtime_error_t *(*wasmtime_new_memory_callback_t)(
+    void *env, const wasm_memorytype_t *ty, size_t minimum, size_t maximum,
+    size_t reserved_size_in_bytes, size_t guard_size_in_bytes,
+    wasmtime_linear_memory_t *memory_ret);
 
 /**
- * A representation of custom memory creator and methods for an instance of LinearMemory.
+ * A representation of custom memory creator and methods for an instance of
+ * LinearMemory.
  *
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/trait.MemoryCreator.html
  */
 typedef struct wasmtime_memory_creator {
-    /// User provided value to be passed to new_memory
-    void* env;
-    /// The callback to create new memory, must be thread safe
-    wasmtime_new_memory_callback_t new_memory;
-    /// An optional finalizer for env.
-    void (*finalizer)(void*);
+  /// User provided value to be passed to new_memory
+  void *env;
+  /// The callback to create new memory, must be thread safe
+  wasmtime_new_memory_callback_t new_memory;
+  /// An optional finalizer for env.
+  void (*finalizer)(void *);
 } wasmtime_memory_creator_t;
 
 /**
  * Sets a custom memory creator.
  *
- * Custom memory creators are used when creating host Memory objects or when creating instance
- * linear memories for the on-demand instance allocation strategy.
+ * Custom memory creators are used when creating host Memory objects or when
+ * creating instance linear memories for the on-demand instance allocation
+ * strategy.
  *
- * The config does **not** take ownership of the #wasmtime_memory_creator_t passed in, but
- * instead copies all the values in the struct.
+ * The config does **not** take ownership of the #wasmtime_memory_creator_t
+ * passed in, but instead copies all the values in the struct.
  *
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.with_host_memory
  */
-WASM_API_EXTERN void wasmtime_config_host_memory_creator_set(
-    wasm_config_t*,
-    wasmtime_memory_creator_t*);
+WASM_API_EXTERN void
+wasmtime_config_host_memory_creator_set(wasm_config_t *,
+                                        wasmtime_memory_creator_t *);
 
 /**
- * \brief Configures whether copy-on-write memory-mapped data is used to initialize a linear memory.
+ * \brief Configures whether copy-on-write memory-mapped data is used to
+ * initialize a linear memory.
  *
- * Initializing linear memory via a copy-on-write mapping can drastically improve instantiation costs
- * of a WebAssembly module because copying memory is deferred. Additionally if a page of memory is
- * only ever read from WebAssembly and never written too then the same underlying page of data will
- * be reused between all instantiations of a module meaning that if a module is instantiated many
- * times this can lower the overall memory required needed to run that module.
+ * Initializing linear memory via a copy-on-write mapping can drastically
+ * improve instantiation costs of a WebAssembly module because copying memory is
+ * deferred. Additionally if a page of memory is only ever read from WebAssembly
+ * and never written too then the same underlying page of data will be reused
+ * between all instantiations of a module meaning that if a module is
+ * instantiated many times this can lower the overall memory required needed to
+ * run that module.
  *
  * This option defaults to true.
  *

--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -26,13 +26,13 @@ typedef uint8_t wasmtime_strategy_t;
  * The default value is #WASMTIME_STRATEGY_AUTO.
  */
 enum wasmtime_strategy_enum { // Strategy
-  /// Automatically picks the compilation backend, currently always defaulting
-  /// to Cranelift.
-  WASMTIME_STRATEGY_AUTO,
+    /// Automatically picks the compilation backend, currently always defaulting
+    /// to Cranelift.
+    WASMTIME_STRATEGY_AUTO,
 
-  /// Indicates that Wasmtime will unconditionally use Cranelift to compile
-  /// WebAssembly code.
-  WASMTIME_STRATEGY_CRANELIFT,
+    /// Indicates that Wasmtime will unconditionally use Cranelift to compile
+    /// WebAssembly code.
+    WASMTIME_STRATEGY_CRANELIFT,
 };
 
 /**
@@ -48,13 +48,13 @@ typedef uint8_t wasmtime_opt_level_t;
  * The default value is #WASMTIME_OPT_LEVEL_SPEED.
  */
 enum wasmtime_opt_level_enum { // OptLevel
-  /// Generated code will not be optimized at all.
-  WASMTIME_OPT_LEVEL_NONE,
-  /// Generated code will be optimized purely for speed.
-  WASMTIME_OPT_LEVEL_SPEED,
-  /// Generated code will be optimized, but some speed optimizations are
-  /// disabled if they cause the generated code to be significantly larger.
-  WASMTIME_OPT_LEVEL_SPEED_AND_SIZE,
+    /// Generated code will not be optimized at all.
+    WASMTIME_OPT_LEVEL_NONE,
+    /// Generated code will be optimized purely for speed.
+    WASMTIME_OPT_LEVEL_SPEED,
+    /// Generated code will be optimized, but some speed optimizations are
+    /// disabled if they cause the generated code to be significantly larger.
+    WASMTIME_OPT_LEVEL_SPEED_AND_SIZE,
 };
 
 /**
@@ -70,20 +70,20 @@ typedef uint8_t wasmtime_profiling_strategy_t;
  * The default is #WASMTIME_PROFILING_STRATEGY_NONE.
  */
 enum wasmtime_profiling_strategy_enum { // ProfilingStrategy
-  /// No profiling is enabled at runtime.
-  WASMTIME_PROFILING_STRATEGY_NONE,
-  /// Linux's "jitdump" support in `perf` is enabled and when Wasmtime is run
-  /// under `perf` necessary calls will be made to profile generated JIT code.
-  WASMTIME_PROFILING_STRATEGY_JITDUMP,
-  /// Support for VTune will be enabled and the VTune runtime will be informed,
-  /// at runtime, about JIT code.
-  ///
-  /// Note that this isn't always enabled at build time.
-  WASMTIME_PROFILING_STRATEGY_VTUNE,
-  /// Linux's simple "perfmap" support in `perf` is enabled and when Wasmtime is
-  /// run under `perf` necessary calls will be made to profile generated JIT
-  /// code.
-  WASMTIME_PROFILING_STRATEGY_PERFMAP,
+    /// No profiling is enabled at runtime.
+    WASMTIME_PROFILING_STRATEGY_NONE,
+    /// Linux's "jitdump" support in `perf` is enabled and when Wasmtime is run
+    /// under `perf` necessary calls will be made to profile generated JIT code.
+    WASMTIME_PROFILING_STRATEGY_JITDUMP,
+    /// Support for VTune will be enabled and the VTune runtime will be informed,
+    /// at runtime, about JIT code.
+    ///
+    /// Note that this isn't always enabled at build time.
+    WASMTIME_PROFILING_STRATEGY_VTUNE,
+    /// Linux's simple "perfmap" support in `perf` is enabled and when Wasmtime is
+    /// run under `perf` necessary calls will be made to profile generated JIT
+    /// code.
+    WASMTIME_PROFILING_STRATEGY_PERFMAP,
 };
 
 #define WASMTIME_CONFIG_PROP(ret, name, ty) \
@@ -365,7 +365,7 @@ WASM_API_EXTERN void wasmtime_config_cranelift_flag_enable(wasm_config_t*, const
  * For more information see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/struct.Config.html#method.cranelift_flag_set
  */
-WASM_API_EXTERN void wasmtime_config_cranelift_flag_set(wasm_config_t*, const char *key, const char *value);
+WASM_API_EXTERN void wasmtime_config_cranelift_flag_set(wasm_config_t*, const char* key, const char* value);
 
 /**
  * \brief Configures whether, when on macOS, Mach ports are used for exception handling
@@ -378,7 +378,6 @@ WASM_API_EXTERN void wasmtime_config_cranelift_flag_set(wasm_config_t*, const ch
  */
 WASMTIME_CONFIG_PROP(void, macos_use_mach_ports, bool)
 
-
 /**
  * Return the data from a LinearMemory instance.
  *
@@ -388,10 +387,10 @@ WASMTIME_CONFIG_PROP(void, macos_use_mach_ports, bool)
  * For more information about see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/trait.LinearMemory.html
  */
-typedef uint8_t *(*wasmtime_memory_get_callback_t)(
-    void *env,
-    size_t *byte_size,
-    size_t *maximum_byte_size);
+typedef uint8_t* (*wasmtime_memory_get_callback_t)(
+    void* env,
+    size_t* byte_size,
+    size_t* maximum_byte_size);
 
 /**
  * Grow the memory to the `new_size` in bytes.
@@ -399,8 +398,8 @@ typedef uint8_t *(*wasmtime_memory_get_callback_t)(
  * For more information about the parameters see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/trait.LinearMemory.html#tymethod.grow_to
  */
-typedef wasmtime_error_t *(*wasmtime_memory_grow_callback_t)(
-    void *env,
+typedef wasmtime_error_t* (*wasmtime_memory_grow_callback_t)(
+    void* env,
     size_t new_size);
 
 /**
@@ -410,14 +409,14 @@ typedef wasmtime_error_t *(*wasmtime_memory_grow_callback_t)(
  * https://docs.wasmtime.dev/api/wasmtime/trait.LinearMemory.html
  */
 typedef struct wasmtime_linear_memory {
-  /// User provided value to be passed to get_memory and grow_memory
-  void *env;
-  /// Callback to get the memory and size of this LinearMemory
-  wasmtime_memory_get_callback_t get_memory;
-  /// Callback to request growing the memory
-  wasmtime_memory_grow_callback_t grow_memory;
-  /// An optional finalizer for env
-  void (*finalizer)(void*);
+    /// User provided value to be passed to get_memory and grow_memory
+    void* env;
+    /// Callback to get the memory and size of this LinearMemory
+    wasmtime_memory_get_callback_t get_memory;
+    /// Callback to request growing the memory
+    wasmtime_memory_grow_callback_t grow_memory;
+    /// An optional finalizer for env
+    void (*finalizer)(void*);
 } wasmtime_linear_memory_t;
 
 /**
@@ -431,14 +430,14 @@ typedef struct wasmtime_linear_memory {
  * For more information about the parameters see the Rust documentation at
  * https://docs.wasmtime.dev/api/wasmtime/trait.MemoryCreator.html#tymethod.new_memory
  */
-typedef wasmtime_error_t *(*wasmtime_new_memory_callback_t)(
-    void *env,
-    const wasm_memorytype_t *ty,
+typedef wasmtime_error_t* (*wasmtime_new_memory_callback_t)(
+    void* env,
+    const wasm_memorytype_t* ty,
     size_t minimum,
     size_t maximum,
     size_t reserved_size_in_bytes,
     size_t guard_size_in_bytes,
-    wasmtime_linear_memory_t *memory_ret);
+    wasmtime_linear_memory_t* memory_ret);
 
 /**
  * A representation of custom memory creator and methods for an instance of LinearMemory.
@@ -447,12 +446,12 @@ typedef wasmtime_error_t *(*wasmtime_new_memory_callback_t)(
  * https://docs.wasmtime.dev/api/wasmtime/trait.MemoryCreator.html
  */
 typedef struct wasmtime_memory_creator {
-  /// User provided value to be passed to new_memory
-  void* env;
-  /// The callback to create new memory, must be thread safe
-  wasmtime_new_memory_callback_t new_memory;
-  /// An optional finalizer for env.
-  void (*finalizer)(void*);
+    /// User provided value to be passed to new_memory
+    void* env;
+    /// The callback to create new memory, must be thread safe
+    wasmtime_new_memory_callback_t new_memory;
+    /// An optional finalizer for env.
+    void (*finalizer)(void*);
 } wasmtime_memory_creator_t;
 
 /**
@@ -488,8 +487,7 @@ WASM_API_EXTERN void wasmtime_config_host_memory_creator_set(
 WASMTIME_CONFIG_PROP(void, memory_init_cow, bool)
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_CONFIG_H
-

--- a/crates/c-api/include/wasmtime/engine.h
+++ b/crates/c-api/include/wasmtime/engine.h
@@ -25,7 +25,7 @@ extern "C" {
  *
  * See also #wasmtime_config_epoch_interruption_set.
  */
-WASM_API_EXTERN void wasmtime_engine_increment_epoch(wasm_engine_t* engine);
+WASM_API_EXTERN void wasmtime_engine_increment_epoch(wasm_engine_t *engine);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/engine.h
+++ b/crates/c-api/include/wasmtime/engine.h
@@ -25,12 +25,10 @@ extern "C" {
  *
  * See also #wasmtime_config_epoch_interruption_set.
  */
-WASM_API_EXTERN void wasmtime_engine_increment_epoch(wasm_engine_t *engine);
+WASM_API_EXTERN void wasmtime_engine_increment_epoch(wasm_engine_t* engine);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_ENGINE_H
-
-

--- a/crates/c-api/include/wasmtime/error.h
+++ b/crates/c-api/include/wasmtime/error.h
@@ -33,12 +33,12 @@ typedef struct wasmtime_error wasmtime_error_t;
 /**
  * \brief Creates a new error with the provided message.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_error_new(const char*);
+WASM_API_EXTERN wasmtime_error_t* wasmtime_error_new(const char*);
 
 /**
  * \brief Deletes an error.
  */
-WASM_API_EXTERN void wasmtime_error_delete(wasmtime_error_t *error);
+WASM_API_EXTERN void wasmtime_error_delete(wasmtime_error_t* error);
 
 /**
  * \brief Returns the string description of this error.
@@ -49,9 +49,8 @@ WASM_API_EXTERN void wasmtime_error_delete(wasmtime_error_t *error);
  * for deallocating it with #wasm_byte_vec_delete afterwards.
  */
 WASM_API_EXTERN void wasmtime_error_message(
-    const wasmtime_error_t *error,
-    wasm_name_t *message
-);
+    const wasmtime_error_t* error,
+    wasm_name_t* message);
 
 /**
  * \brief Attempts to extract a WASI-specific exit status from this error.
@@ -60,7 +59,7 @@ WASM_API_EXTERN void wasmtime_error_message(
  * If `true` is returned then the exit status is returned through the `status`
  * pointer. If `false` is returned then this is not a wasi exit trap.
  */
-WASM_API_EXTERN bool wasmtime_error_exit_status(const wasmtime_error_t*, int *status);
+WASM_API_EXTERN bool wasmtime_error_exit_status(const wasmtime_error_t*, int* status);
 
 /**
  * \brief Attempts to extract a WebAssembly trace from this error.
@@ -69,10 +68,10 @@ WASM_API_EXTERN bool wasmtime_error_exit_status(const wasmtime_error_t*, int *st
  * as input. The `out` argument will be filled in with the wasm trace, if
  * present.
  */
-WASM_API_EXTERN void wasmtime_error_wasm_trace(const wasmtime_error_t*, wasm_frame_vec_t *out);
+WASM_API_EXTERN void wasmtime_error_wasm_trace(const wasmtime_error_t*, wasm_frame_vec_t* out);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_ERROR_H

--- a/crates/c-api/include/wasmtime/error.h
+++ b/crates/c-api/include/wasmtime/error.h
@@ -33,12 +33,12 @@ typedef struct wasmtime_error wasmtime_error_t;
 /**
  * \brief Creates a new error with the provided message.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_error_new(const char*);
+WASM_API_EXTERN wasmtime_error_t *wasmtime_error_new(const char *);
 
 /**
  * \brief Deletes an error.
  */
-WASM_API_EXTERN void wasmtime_error_delete(wasmtime_error_t* error);
+WASM_API_EXTERN void wasmtime_error_delete(wasmtime_error_t *error);
 
 /**
  * \brief Returns the string description of this error.
@@ -48,9 +48,8 @@ WASM_API_EXTERN void wasmtime_error_delete(wasmtime_error_t* error);
  * uninitialized before this function is called and the caller is responsible
  * for deallocating it with #wasm_byte_vec_delete afterwards.
  */
-WASM_API_EXTERN void wasmtime_error_message(
-    const wasmtime_error_t* error,
-    wasm_name_t* message);
+WASM_API_EXTERN void wasmtime_error_message(const wasmtime_error_t *error,
+                                            wasm_name_t *message);
 
 /**
  * \brief Attempts to extract a WASI-specific exit status from this error.
@@ -59,7 +58,8 @@ WASM_API_EXTERN void wasmtime_error_message(
  * If `true` is returned then the exit status is returned through the `status`
  * pointer. If `false` is returned then this is not a wasi exit trap.
  */
-WASM_API_EXTERN bool wasmtime_error_exit_status(const wasmtime_error_t*, int* status);
+WASM_API_EXTERN bool wasmtime_error_exit_status(const wasmtime_error_t *,
+                                                int *status);
 
 /**
  * \brief Attempts to extract a WebAssembly trace from this error.
@@ -68,7 +68,8 @@ WASM_API_EXTERN bool wasmtime_error_exit_status(const wasmtime_error_t*, int* st
  * as input. The `out` argument will be filled in with the wasm trace, if
  * present.
  */
-WASM_API_EXTERN void wasmtime_error_wasm_trace(const wasmtime_error_t*, wasm_frame_vec_t* out);
+WASM_API_EXTERN void wasmtime_error_wasm_trace(const wasmtime_error_t *,
+                                               wasm_frame_vec_t *out);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/extern.h
+++ b/crates/c-api/include/wasmtime/extern.h
@@ -22,10 +22,10 @@ extern "C" {
 /// is passed to the wrong store then it may trigger an assertion to abort the
 /// process.
 typedef struct wasmtime_func {
-    /// Internal identifier of what store this belongs to, never zero.
-    uint64_t store_id;
-    /// Internal index within the store.
-    size_t index;
+  /// Internal identifier of what store this belongs to, never zero.
+  uint64_t store_id;
+  /// Internal index within the store.
+  size_t index;
 } wasmtime_func_t;
 
 /// \brief Representation of a table in Wasmtime.
@@ -36,10 +36,10 @@ typedef struct wasmtime_func {
 /// is passed to the wrong store then it may trigger an assertion to abort the
 /// process.
 typedef struct wasmtime_table {
-    /// Internal identifier of what store this belongs to, never zero.
-    uint64_t store_id;
-    /// Internal index within the store.
-    size_t index;
+  /// Internal identifier of what store this belongs to, never zero.
+  uint64_t store_id;
+  /// Internal index within the store.
+  size_t index;
 } wasmtime_table_t;
 
 /// \brief Representation of a memory in Wasmtime.
@@ -50,10 +50,10 @@ typedef struct wasmtime_table {
 /// is passed to the wrong store then it may trigger an assertion to abort the
 /// process.
 typedef struct wasmtime_memory {
-    /// Internal identifier of what store this belongs to, never zero.
-    uint64_t store_id;
-    /// Internal index within the store.
-    size_t index;
+  /// Internal identifier of what store this belongs to, never zero.
+  uint64_t store_id;
+  /// Internal index within the store.
+  size_t index;
 } wasmtime_memory_t;
 
 /// \brief Representation of a global in Wasmtime.
@@ -64,10 +64,10 @@ typedef struct wasmtime_memory {
 /// is passed to the wrong store then it may trigger an assertion to abort the
 /// process.
 typedef struct wasmtime_global {
-    /// Internal identifier of what store this belongs to, never zero.
-    uint64_t store_id;
-    /// Internal index within the store.
-    size_t index;
+  /// Internal identifier of what store this belongs to, never zero.
+  uint64_t store_id;
+  /// Internal index within the store.
+  size_t index;
 } wasmtime_global_t;
 
 /// \brief Discriminant of #wasmtime_extern_t
@@ -97,14 +97,14 @@ typedef uint8_t wasmtime_extern_kind_t;
  * various kinds of items an extern wasm item can be.
  */
 typedef union wasmtime_extern_union {
-    /// Field used if #wasmtime_extern_t::kind is #WASMTIME_EXTERN_FUNC
-    wasmtime_func_t func;
-    /// Field used if #wasmtime_extern_t::kind is #WASMTIME_EXTERN_GLOBAL
-    wasmtime_global_t global;
-    /// Field used if #wasmtime_extern_t::kind is #WASMTIME_EXTERN_TABLE
-    wasmtime_table_t table;
-    /// Field used if #wasmtime_extern_t::kind is #WASMTIME_EXTERN_MEMORY
-    wasmtime_memory_t memory;
+  /// Field used if #wasmtime_extern_t::kind is #WASMTIME_EXTERN_FUNC
+  wasmtime_func_t func;
+  /// Field used if #wasmtime_extern_t::kind is #WASMTIME_EXTERN_GLOBAL
+  wasmtime_global_t global;
+  /// Field used if #wasmtime_extern_t::kind is #WASMTIME_EXTERN_TABLE
+  wasmtime_table_t table;
+  /// Field used if #wasmtime_extern_t::kind is #WASMTIME_EXTERN_MEMORY
+  wasmtime_memory_t memory;
 } wasmtime_extern_union_t;
 
 /**
@@ -121,21 +121,22 @@ typedef union wasmtime_extern_union {
  * deallocate the value.
  */
 typedef struct wasmtime_extern {
-    /// Discriminant of which field of #of is valid.
-    wasmtime_extern_kind_t kind;
-    /// Container for the extern item's value.
-    wasmtime_extern_union_t of;
+  /// Discriminant of which field of #of is valid.
+  wasmtime_extern_kind_t kind;
+  /// Container for the extern item's value.
+  wasmtime_extern_union_t of;
 } wasmtime_extern_t;
 
 /// \brief Deletes a #wasmtime_extern_t.
-void wasmtime_extern_delete(wasmtime_extern_t* val);
+void wasmtime_extern_delete(wasmtime_extern_t *val);
 
 /// \brief Returns the type of the #wasmtime_extern_t defined within the given
 /// store.
 ///
 /// Does not take ownership of `context` or `val`, but the returned
 /// #wasm_externtype_t is an owned value that needs to be deleted.
-wasm_externtype_t* wasmtime_extern_type(wasmtime_context_t* context, wasmtime_extern_t* val);
+wasm_externtype_t *wasmtime_extern_type(wasmtime_context_t *context,
+                                        wasmtime_extern_t *val);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/extern.h
+++ b/crates/c-api/include/wasmtime/extern.h
@@ -22,10 +22,10 @@ extern "C" {
 /// is passed to the wrong store then it may trigger an assertion to abort the
 /// process.
 typedef struct wasmtime_func {
-  /// Internal identifier of what store this belongs to, never zero.
-  uint64_t store_id;
-  /// Internal index within the store.
-  size_t index;
+    /// Internal identifier of what store this belongs to, never zero.
+    uint64_t store_id;
+    /// Internal index within the store.
+    size_t index;
 } wasmtime_func_t;
 
 /// \brief Representation of a table in Wasmtime.
@@ -36,10 +36,10 @@ typedef struct wasmtime_func {
 /// is passed to the wrong store then it may trigger an assertion to abort the
 /// process.
 typedef struct wasmtime_table {
-  /// Internal identifier of what store this belongs to, never zero.
-  uint64_t store_id;
-  /// Internal index within the store.
-  size_t index;
+    /// Internal identifier of what store this belongs to, never zero.
+    uint64_t store_id;
+    /// Internal index within the store.
+    size_t index;
 } wasmtime_table_t;
 
 /// \brief Representation of a memory in Wasmtime.
@@ -50,10 +50,10 @@ typedef struct wasmtime_table {
 /// is passed to the wrong store then it may trigger an assertion to abort the
 /// process.
 typedef struct wasmtime_memory {
-  /// Internal identifier of what store this belongs to, never zero.
-  uint64_t store_id;
-  /// Internal index within the store.
-  size_t index;
+    /// Internal identifier of what store this belongs to, never zero.
+    uint64_t store_id;
+    /// Internal index within the store.
+    size_t index;
 } wasmtime_memory_t;
 
 /// \brief Representation of a global in Wasmtime.
@@ -64,10 +64,10 @@ typedef struct wasmtime_memory {
 /// is passed to the wrong store then it may trigger an assertion to abort the
 /// process.
 typedef struct wasmtime_global {
-  /// Internal identifier of what store this belongs to, never zero.
-  uint64_t store_id;
-  /// Internal index within the store.
-  size_t index;
+    /// Internal identifier of what store this belongs to, never zero.
+    uint64_t store_id;
+    /// Internal index within the store.
+    size_t index;
 } wasmtime_global_t;
 
 /// \brief Discriminant of #wasmtime_extern_t
@@ -128,18 +128,17 @@ typedef struct wasmtime_extern {
 } wasmtime_extern_t;
 
 /// \brief Deletes a #wasmtime_extern_t.
-void wasmtime_extern_delete(wasmtime_extern_t *val);
+void wasmtime_extern_delete(wasmtime_extern_t* val);
 
 /// \brief Returns the type of the #wasmtime_extern_t defined within the given
 /// store.
 ///
 /// Does not take ownership of `context` or `val`, but the returned
 /// #wasm_externtype_t is an owned value that needs to be deleted.
-wasm_externtype_t *wasmtime_extern_type(wasmtime_context_t *context, wasmtime_extern_t *val);
+wasm_externtype_t* wasmtime_extern_type(wasmtime_context_t* context, wasmtime_extern_t* val);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_EXTERN_H
-

--- a/crates/c-api/include/wasmtime/func.h
+++ b/crates/c-api/include/wasmtime/func.h
@@ -54,13 +54,9 @@ typedef struct wasmtime_caller wasmtime_caller_t;
  * should be raised in WebAssembly. It's expected that in this case the caller
  * relinquishes ownership of the trap and it is passed back to the engine.
  */
-typedef wasm_trap_t* (*wasmtime_func_callback_t)(
-    void* env,
-    wasmtime_caller_t* caller,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    wasmtime_val_t* results,
-    size_t nresults);
+typedef wasm_trap_t *(*wasmtime_func_callback_t)(
+    void *env, wasmtime_caller_t *caller, const wasmtime_val_t *args,
+    size_t nargs, wasmtime_val_t *results, size_t nresults);
 
 /**
  * \brief Creates a new host-defined function.
@@ -78,13 +74,11 @@ typedef wasm_trap_t* (*wasmtime_func_callback_t)(
  *
  * The returned function can only be used with the specified `store`.
  */
-WASM_API_EXTERN void wasmtime_func_new(
-    wasmtime_context_t* store,
-    const wasm_functype_t* type,
-    wasmtime_func_callback_t callback,
-    void* env,
-    void (*finalizer)(void*),
-    wasmtime_func_t* ret);
+WASM_API_EXTERN void wasmtime_func_new(wasmtime_context_t *store,
+                                       const wasm_functype_t *type,
+                                       wasmtime_func_callback_t callback,
+                                       void *env, void (*finalizer)(void *),
+                                       wasmtime_func_t *ret);
 
 /**
  * \brief Callback signature for #wasmtime_func_new_unchecked.
@@ -119,10 +113,8 @@ WASM_API_EXTERN void wasmtime_func_new(
  * array. Results are also written starting at index 0, which will overwrite
  * the arguments.
  */
-typedef wasm_trap_t* (*wasmtime_func_unchecked_callback_t)(
-    void* env,
-    wasmtime_caller_t* caller,
-    wasmtime_val_raw_t* args_and_results,
+typedef wasm_trap_t *(*wasmtime_func_unchecked_callback_t)(
+    void *env, wasmtime_caller_t *caller, wasmtime_val_raw_t *args_and_results,
     size_t num_args_and_results);
 
 /**
@@ -150,21 +142,18 @@ typedef wasm_trap_t* (*wasmtime_func_unchecked_callback_t)(
  * existence).
  */
 WASM_API_EXTERN void wasmtime_func_new_unchecked(
-    wasmtime_context_t* store,
-    const wasm_functype_t* type,
-    wasmtime_func_unchecked_callback_t callback,
-    void* env,
-    void (*finalizer)(void*),
-    wasmtime_func_t* ret);
+    wasmtime_context_t *store, const wasm_functype_t *type,
+    wasmtime_func_unchecked_callback_t callback, void *env,
+    void (*finalizer)(void *), wasmtime_func_t *ret);
 
 /**
  * \brief Returns the type of the function specified
  *
  * The returned #wasm_functype_t is owned by the caller.
  */
-WASM_API_EXTERN wasm_functype_t* wasmtime_func_type(
-    const wasmtime_context_t* store,
-    const wasmtime_func_t* func);
+WASM_API_EXTERN wasm_functype_t *
+wasmtime_func_type(const wasmtime_context_t *store,
+                   const wasmtime_func_t *func);
 
 /**
  * \brief Call a WebAssembly function.
@@ -201,14 +190,11 @@ WASM_API_EXTERN wasm_functype_t* wasmtime_func_type(
  * Does not take ownership of #wasmtime_val_t arguments. Gives ownership of
  * #wasmtime_val_t results.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_func_call(
-    wasmtime_context_t* store,
-    const wasmtime_func_t* func,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    wasmtime_val_t* results,
-    size_t nresults,
-    wasm_trap_t** trap);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_func_call(wasmtime_context_t *store, const wasmtime_func_t *func,
+                   const wasmtime_val_t *args, size_t nargs,
+                   wasmtime_val_t *results, size_t nresults,
+                   wasm_trap_t **trap);
 
 /**
  * \brief Call a WebAssembly function in an "unchecked" fashion.
@@ -239,12 +225,11 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_func_call(
  * faster than that function, but the tradeoff is that embeddings must uphold
  * more invariants rather than relying on Wasmtime to check them for you.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_func_call_unchecked(
-    wasmtime_context_t* store,
-    const wasmtime_func_t* func,
-    wasmtime_val_raw_t* args_and_results,
-    size_t args_and_results_len,
-    wasm_trap_t** trap);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_func_call_unchecked(wasmtime_context_t *store,
+                             const wasmtime_func_t *func,
+                             wasmtime_val_raw_t *args_and_results,
+                             size_t args_and_results_len, wasm_trap_t **trap);
 
 /**
  * \brief Loads a #wasmtime_extern_t from the caller's context
@@ -264,16 +249,16 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_func_call_unchecked(
  * Returns a nonzero value if the export was found, or 0 if the export wasn't
  * found. If the export wasn't found then `item` isn't written to.
  */
-WASM_API_EXTERN bool wasmtime_caller_export_get(
-    wasmtime_caller_t* caller,
-    const char* name,
-    size_t name_len,
-    wasmtime_extern_t* item);
+WASM_API_EXTERN bool wasmtime_caller_export_get(wasmtime_caller_t *caller,
+                                                const char *name,
+                                                size_t name_len,
+                                                wasmtime_extern_t *item);
 
 /**
  * \brief Returns the store context of the caller object.
  */
-WASM_API_EXTERN wasmtime_context_t* wasmtime_caller_context(wasmtime_caller_t* caller);
+WASM_API_EXTERN wasmtime_context_t *
+wasmtime_caller_context(wasmtime_caller_t *caller);
 
 /**
  * \brief Converts a `raw` nonzero `funcref` value from #wasmtime_val_raw_t
@@ -288,18 +273,15 @@ WASM_API_EXTERN wasmtime_context_t* wasmtime_caller_context(wasmtime_caller_t* c
  * #wasmtime_context_t that they were produced from. Providing arbitrary values
  * to `raw` here or cross-context values with `context` is UB.
  */
-WASM_API_EXTERN void wasmtime_func_from_raw(
-    wasmtime_context_t* context,
-    void* raw,
-    wasmtime_func_t* ret);
+WASM_API_EXTERN void wasmtime_func_from_raw(wasmtime_context_t *context,
+                                            void *raw, wasmtime_func_t *ret);
 
 /**
  * \brief Converts a `func`  which belongs to `context` into a `usize`
  * parameter that is suitable for insertion into a #wasmtime_val_raw_t.
  */
-WASM_API_EXTERN void* wasmtime_func_to_raw(
-    wasmtime_context_t* context,
-    const wasmtime_func_t* func);
+WASM_API_EXTERN void *wasmtime_func_to_raw(wasmtime_context_t *context,
+                                           const wasmtime_func_t *func);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/func.h
+++ b/crates/c-api/include/wasmtime/func.h
@@ -8,9 +8,9 @@
 #define WASMTIME_FUNC_H
 
 #include <wasm.h>
-#include <wasmtime/val.h>
-#include <wasmtime/store.h>
 #include <wasmtime/extern.h>
+#include <wasmtime/store.h>
+#include <wasmtime/val.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -55,11 +55,11 @@ typedef struct wasmtime_caller wasmtime_caller_t;
  * relinquishes ownership of the trap and it is passed back to the engine.
  */
 typedef wasm_trap_t* (*wasmtime_func_callback_t)(
-    void *env,
+    void* env,
     wasmtime_caller_t* caller,
-    const wasmtime_val_t *args,
+    const wasmtime_val_t* args,
     size_t nargs,
-    wasmtime_val_t *results,
+    wasmtime_val_t* results,
     size_t nresults);
 
 /**
@@ -79,13 +79,12 @@ typedef wasm_trap_t* (*wasmtime_func_callback_t)(
  * The returned function can only be used with the specified `store`.
  */
 WASM_API_EXTERN void wasmtime_func_new(
-  wasmtime_context_t *store,
-  const wasm_functype_t* type,
-  wasmtime_func_callback_t callback,
-  void *env,
-  void (*finalizer)(void*),
-  wasmtime_func_t *ret
-);
+    wasmtime_context_t* store,
+    const wasm_functype_t* type,
+    wasmtime_func_callback_t callback,
+    void* env,
+    void (*finalizer)(void*),
+    wasmtime_func_t* ret);
 
 /**
  * \brief Callback signature for #wasmtime_func_new_unchecked.
@@ -121,9 +120,9 @@ WASM_API_EXTERN void wasmtime_func_new(
  * the arguments.
  */
 typedef wasm_trap_t* (*wasmtime_func_unchecked_callback_t)(
-    void *env,
+    void* env,
     wasmtime_caller_t* caller,
-    wasmtime_val_raw_t *args_and_results,
+    wasmtime_val_raw_t* args_and_results,
     size_t num_args_and_results);
 
 /**
@@ -151,13 +150,12 @@ typedef wasm_trap_t* (*wasmtime_func_unchecked_callback_t)(
  * existence).
  */
 WASM_API_EXTERN void wasmtime_func_new_unchecked(
-  wasmtime_context_t *store,
-  const wasm_functype_t* type,
-  wasmtime_func_unchecked_callback_t callback,
-  void *env,
-  void (*finalizer)(void*),
-  wasmtime_func_t *ret
-);
+    wasmtime_context_t* store,
+    const wasm_functype_t* type,
+    wasmtime_func_unchecked_callback_t callback,
+    void* env,
+    void (*finalizer)(void*),
+    wasmtime_func_t* ret);
 
 /**
  * \brief Returns the type of the function specified
@@ -165,9 +163,8 @@ WASM_API_EXTERN void wasmtime_func_new_unchecked(
  * The returned #wasm_functype_t is owned by the caller.
  */
 WASM_API_EXTERN wasm_functype_t* wasmtime_func_type(
-    const wasmtime_context_t *store,
-    const wasmtime_func_t *func
-);
+    const wasmtime_context_t* store,
+    const wasmtime_func_t* func);
 
 /**
  * \brief Call a WebAssembly function.
@@ -204,15 +201,14 @@ WASM_API_EXTERN wasm_functype_t* wasmtime_func_type(
  * Does not take ownership of #wasmtime_val_t arguments. Gives ownership of
  * #wasmtime_val_t results.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_func_call(
-    wasmtime_context_t *store,
-    const wasmtime_func_t *func,
-    const wasmtime_val_t *args,
+WASM_API_EXTERN wasmtime_error_t* wasmtime_func_call(
+    wasmtime_context_t* store,
+    const wasmtime_func_t* func,
+    const wasmtime_val_t* args,
     size_t nargs,
-    wasmtime_val_t *results,
+    wasmtime_val_t* results,
     size_t nresults,
-    wasm_trap_t **trap
-);
+    wasm_trap_t** trap);
 
 /**
  * \brief Call a WebAssembly function in an "unchecked" fashion.
@@ -243,13 +239,12 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_func_call(
  * faster than that function, but the tradeoff is that embeddings must uphold
  * more invariants rather than relying on Wasmtime to check them for you.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_func_call_unchecked(
-    wasmtime_context_t *store,
-    const wasmtime_func_t *func,
-    wasmtime_val_raw_t *args_and_results,
+WASM_API_EXTERN wasmtime_error_t* wasmtime_func_call_unchecked(
+    wasmtime_context_t* store,
+    const wasmtime_func_t* func,
+    wasmtime_val_raw_t* args_and_results,
     size_t args_and_results_len,
-    wasm_trap_t **trap
-);
+    wasm_trap_t** trap);
 
 /**
  * \brief Loads a #wasmtime_extern_t from the caller's context
@@ -270,11 +265,10 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_func_call_unchecked(
  * found. If the export wasn't found then `item` isn't written to.
  */
 WASM_API_EXTERN bool wasmtime_caller_export_get(
-    wasmtime_caller_t *caller,
-    const char *name,
+    wasmtime_caller_t* caller,
+    const char* name,
     size_t name_len,
-    wasmtime_extern_t *item
-);
+    wasmtime_extern_t* item);
 
 /**
  * \brief Returns the store context of the caller object.
@@ -296,19 +290,19 @@ WASM_API_EXTERN wasmtime_context_t* wasmtime_caller_context(wasmtime_caller_t* c
  */
 WASM_API_EXTERN void wasmtime_func_from_raw(
     wasmtime_context_t* context,
-    void *raw,
-    wasmtime_func_t *ret);
+    void* raw,
+    wasmtime_func_t* ret);
 
 /**
  * \brief Converts a `func`  which belongs to `context` into a `usize`
  * parameter that is suitable for insertion into a #wasmtime_val_raw_t.
  */
-WASM_API_EXTERN void *wasmtime_func_to_raw(
+WASM_API_EXTERN void* wasmtime_func_to_raw(
     wasmtime_context_t* context,
-    const wasmtime_func_t *func);
+    const wasmtime_func_t* func);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_FUNC_H

--- a/crates/c-api/include/wasmtime/global.h
+++ b/crates/c-api/include/wasmtime/global.h
@@ -33,12 +33,11 @@ extern "C" {
  * This function does not take ownership of any of its arguments but error is
  * owned by the caller.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_global_new(
-    wasmtime_context_t *store,
-    const wasm_globaltype_t *type,
-    const wasmtime_val_t *val,
-    wasmtime_global_t *ret
-);
+WASM_API_EXTERN wasmtime_error_t* wasmtime_global_new(
+    wasmtime_context_t* store,
+    const wasm_globaltype_t* type,
+    const wasmtime_val_t* val,
+    wasmtime_global_t* ret);
 
 /**
  * \brief Returns the wasm type of the specified global.
@@ -46,9 +45,8 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_global_new(
  * The returned #wasm_globaltype_t is owned by the caller.
  */
 WASM_API_EXTERN wasm_globaltype_t* wasmtime_global_type(
-    const wasmtime_context_t *store,
-    const wasmtime_global_t *global
-);
+    const wasmtime_context_t* store,
+    const wasmtime_global_t* global);
 
 /**
  * \brief Get the value of the specified global.
@@ -61,10 +59,9 @@ WASM_API_EXTERN wasm_globaltype_t* wasmtime_global_type(
  * #wasmtime_val_delete may need to be called on the value.
  */
 WASM_API_EXTERN void wasmtime_global_get(
-    wasmtime_context_t *store,
-    const wasmtime_global_t *global,
-    wasmtime_val_t *out
-);
+    wasmtime_context_t* store,
+    const wasmtime_global_t* global,
+    wasmtime_val_t* out);
 
 /**
  * \brief Sets a global to a new value.
@@ -78,14 +75,13 @@ WASM_API_EXTERN void wasmtime_global_get(
  *
  * THis does not take ownership of any argument but returns ownership of the error.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_global_set(
-    wasmtime_context_t *store,
-    const wasmtime_global_t *global,
-    const wasmtime_val_t *val
-);
+WASM_API_EXTERN wasmtime_error_t* wasmtime_global_set(
+    wasmtime_context_t* store,
+    const wasmtime_global_t* global,
+    const wasmtime_val_t* val);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_GLOBAL_H

--- a/crates/c-api/include/wasmtime/global.h
+++ b/crates/c-api/include/wasmtime/global.h
@@ -33,20 +33,18 @@ extern "C" {
  * This function does not take ownership of any of its arguments but error is
  * owned by the caller.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_global_new(
-    wasmtime_context_t* store,
-    const wasm_globaltype_t* type,
-    const wasmtime_val_t* val,
-    wasmtime_global_t* ret);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_global_new(wasmtime_context_t *store, const wasm_globaltype_t *type,
+                    const wasmtime_val_t *val, wasmtime_global_t *ret);
 
 /**
  * \brief Returns the wasm type of the specified global.
  *
  * The returned #wasm_globaltype_t is owned by the caller.
  */
-WASM_API_EXTERN wasm_globaltype_t* wasmtime_global_type(
-    const wasmtime_context_t* store,
-    const wasmtime_global_t* global);
+WASM_API_EXTERN wasm_globaltype_t *
+wasmtime_global_type(const wasmtime_context_t *store,
+                     const wasmtime_global_t *global);
 
 /**
  * \brief Get the value of the specified global.
@@ -58,10 +56,9 @@ WASM_API_EXTERN wasm_globaltype_t* wasmtime_global_type(
  * This function returns ownership of the contents of `out`, so
  * #wasmtime_val_delete may need to be called on the value.
  */
-WASM_API_EXTERN void wasmtime_global_get(
-    wasmtime_context_t* store,
-    const wasmtime_global_t* global,
-    wasmtime_val_t* out);
+WASM_API_EXTERN void wasmtime_global_get(wasmtime_context_t *store,
+                                         const wasmtime_global_t *global,
+                                         wasmtime_val_t *out);
 
 /**
  * \brief Sets a global to a new value.
@@ -73,12 +70,12 @@ WASM_API_EXTERN void wasmtime_global_get(
  * This function may return an error if `global` is not mutable or if `val` has
  * the wrong type for `global`.
  *
- * THis does not take ownership of any argument but returns ownership of the error.
+ * THis does not take ownership of any argument but returns ownership of the
+ * error.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_global_set(
-    wasmtime_context_t* store,
-    const wasmtime_global_t* global,
-    const wasmtime_val_t* val);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_global_set(wasmtime_context_t *store, const wasmtime_global_t *global,
+                    const wasmtime_val_t *val);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/instance.h
+++ b/crates/c-api/include/wasmtime/instance.h
@@ -24,10 +24,10 @@ extern "C" {
 /// is passed to the wrong store then it may trigger an assertion to abort the
 /// process.
 typedef struct wasmtime_instance {
-    /// Internal identifier of what store this belongs to, never zero.
-    uint64_t store_id;
-    /// Internal index within the store.
-    size_t index;
+  /// Internal identifier of what store this belongs to, never zero.
+  uint64_t store_id;
+  /// Internal index within the store.
+  size_t index;
 } wasmtime_instance_t;
 
 /**
@@ -62,13 +62,11 @@ typedef struct wasmtime_instance {
  * This function does not take ownership of any of its arguments, but all return
  * values are owned by the caller.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_instance_new(
-    wasmtime_context_t* store,
-    const wasmtime_module_t* module,
-    const wasmtime_extern_t* imports,
-    size_t nimports,
-    wasmtime_instance_t* instance,
-    wasm_trap_t** trap);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_instance_new(wasmtime_context_t *store,
+                      const wasmtime_module_t *module,
+                      const wasmtime_extern_t *imports, size_t nimports,
+                      wasmtime_instance_t *instance, wasm_trap_t **trap);
 
 /**
  * \brief Get an export by name from an instance.
@@ -86,11 +84,8 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_instance_new(
  * #wasmtime_extern_t.
  */
 WASM_API_EXTERN bool wasmtime_instance_export_get(
-    wasmtime_context_t* store,
-    const wasmtime_instance_t* instance,
-    const char* name,
-    size_t name_len,
-    wasmtime_extern_t* item);
+    wasmtime_context_t *store, const wasmtime_instance_t *instance,
+    const char *name, size_t name_len, wasmtime_extern_t *item);
 
 /**
  * \brief Get an export by index from an instance.
@@ -111,15 +106,12 @@ WASM_API_EXTERN bool wasmtime_instance_export_get(
  * #wasmtime_context_t.
  */
 WASM_API_EXTERN bool wasmtime_instance_export_nth(
-    wasmtime_context_t* store,
-    const wasmtime_instance_t* instance,
-    size_t index,
-    char** name,
-    size_t* name_len,
-    wasmtime_extern_t* item);
+    wasmtime_context_t *store, const wasmtime_instance_t *instance,
+    size_t index, char **name, size_t *name_len, wasmtime_extern_t *item);
 
 /**
- * \brief A #wasmtime_instance_t, pre-instantiation, that is ready to be instantiated.
+ * \brief A #wasmtime_instance_t, pre-instantiation, that is ready to be
+ * instantiated.
  *
  * Must be deleted using #wasmtime_instance_pre_delete.
  *
@@ -132,7 +124,7 @@ typedef struct wasmtime_instance_pre wasmtime_instance_pre_t;
  * \brief Delete a previously created wasmtime_instance_pre_t.
  */
 WASM_API_EXTERN void
-wasmtime_instance_pre_delete(wasmtime_instance_pre_t* instance_pre);
+wasmtime_instance_pre_delete(wasmtime_instance_pre_t *instance_pre);
 
 /**
  * \brief Instantiates instance within the given store.
@@ -157,11 +149,9 @@ wasmtime_instance_pre_delete(wasmtime_instance_pre_t* instance_pre);
  * This function does not take ownership of any of its arguments, and all return
  * values are owned by the caller.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_instance_pre_instantiate(
-    const wasmtime_instance_pre_t* instance_pre,
-    wasmtime_store_t* store,
-    wasmtime_instance_t* instance,
-    wasm_trap_t** trap_ptr);
+WASM_API_EXTERN wasmtime_error_t *wasmtime_instance_pre_instantiate(
+    const wasmtime_instance_pre_t *instance_pre, wasmtime_store_t *store,
+    wasmtime_instance_t *instance, wasm_trap_t **trap_ptr);
 
 /**
  * \brief Get the module (as a shallow clone) for a instance_pre.
@@ -169,8 +159,8 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_instance_pre_instantiate(
  * The returned module is owned by the caller and the caller **must**
  * delete it via `wasmtime_module_delete`.
  */
-WASM_API_EXTERN wasmtime_module_t*
-wasmtime_instance_pre_module(wasmtime_instance_pre_t* instance_pre);
+WASM_API_EXTERN wasmtime_module_t *
+wasmtime_instance_pre_module(wasmtime_instance_pre_t *instance_pre);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/instance.h
+++ b/crates/c-api/include/wasmtime/instance.h
@@ -24,10 +24,10 @@ extern "C" {
 /// is passed to the wrong store then it may trigger an assertion to abort the
 /// process.
 typedef struct wasmtime_instance {
-  /// Internal identifier of what store this belongs to, never zero.
-  uint64_t store_id;
-  /// Internal index within the store.
-  size_t index;
+    /// Internal identifier of what store this belongs to, never zero.
+    uint64_t store_id;
+    /// Internal index within the store.
+    size_t index;
 } wasmtime_instance_t;
 
 /**
@@ -62,14 +62,13 @@ typedef struct wasmtime_instance {
  * This function does not take ownership of any of its arguments, but all return
  * values are owned by the caller.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_instance_new(
-    wasmtime_context_t *store,
-    const wasmtime_module_t *module,
+WASM_API_EXTERN wasmtime_error_t* wasmtime_instance_new(
+    wasmtime_context_t* store,
+    const wasmtime_module_t* module,
     const wasmtime_extern_t* imports,
     size_t nimports,
-    wasmtime_instance_t *instance,
-    wasm_trap_t **trap
-);
+    wasmtime_instance_t* instance,
+    wasm_trap_t** trap);
 
 /**
  * \brief Get an export by name from an instance.
@@ -87,12 +86,11 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_instance_new(
  * #wasmtime_extern_t.
  */
 WASM_API_EXTERN bool wasmtime_instance_export_get(
-    wasmtime_context_t *store,
-    const wasmtime_instance_t *instance,
-    const char *name,
+    wasmtime_context_t* store,
+    const wasmtime_instance_t* instance,
+    const char* name,
     size_t name_len,
-    wasmtime_extern_t *item
-);
+    wasmtime_extern_t* item);
 
 /**
  * \brief Get an export by index from an instance.
@@ -113,13 +111,12 @@ WASM_API_EXTERN bool wasmtime_instance_export_get(
  * #wasmtime_context_t.
  */
 WASM_API_EXTERN bool wasmtime_instance_export_nth(
-    wasmtime_context_t *store,
-    const wasmtime_instance_t *instance,
+    wasmtime_context_t* store,
+    const wasmtime_instance_t* instance,
     size_t index,
-    char **name,
-    size_t *name_len,
-    wasmtime_extern_t *item
-);
+    char** name,
+    size_t* name_len,
+    wasmtime_extern_t* item);
 
 /**
  * \brief A #wasmtime_instance_t, pre-instantiation, that is ready to be instantiated.
@@ -135,7 +132,7 @@ typedef struct wasmtime_instance_pre wasmtime_instance_pre_t;
  * \brief Delete a previously created wasmtime_instance_pre_t.
  */
 WASM_API_EXTERN void
-wasmtime_instance_pre_delete(wasmtime_instance_pre_t *instance_pre);
+wasmtime_instance_pre_delete(wasmtime_instance_pre_t* instance_pre);
 
 /**
  * \brief Instantiates instance within the given store.
@@ -162,9 +159,9 @@ wasmtime_instance_pre_delete(wasmtime_instance_pre_t *instance_pre);
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_instance_pre_instantiate(
     const wasmtime_instance_pre_t* instance_pre,
-    wasmtime_store_t *store,
+    wasmtime_store_t* store,
     wasmtime_instance_t* instance,
-    wasm_trap_t **trap_ptr);
+    wasm_trap_t** trap_ptr);
 
 /**
  * \brief Get the module (as a shallow clone) for a instance_pre.
@@ -173,10 +170,10 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_instance_pre_instantiate(
  * delete it via `wasmtime_module_delete`.
  */
 WASM_API_EXTERN wasmtime_module_t*
-wasmtime_instance_pre_module(wasmtime_instance_pre_t *instance_pre);
+wasmtime_instance_pre_module(wasmtime_instance_pre_t* instance_pre);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_INSTANCE_H

--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -40,12 +40,12 @@ typedef struct wasmtime_linker wasmtime_linker_t;
  * This function does not take ownership of the engine argument, and the caller
  * is expected to delete the returned linker.
  */
-WASM_API_EXTERN wasmtime_linker_t* wasmtime_linker_new(wasm_engine_t* engine);
+WASM_API_EXTERN wasmtime_linker_t *wasmtime_linker_new(wasm_engine_t *engine);
 
 /**
  * \brief Deletes a linker
  */
-WASM_API_EXTERN void wasmtime_linker_delete(wasmtime_linker_t* linker);
+WASM_API_EXTERN void wasmtime_linker_delete(wasmtime_linker_t *linker);
 
 /**
  * \brief Configures whether this linker allows later definitions to shadow
@@ -53,7 +53,8 @@ WASM_API_EXTERN void wasmtime_linker_delete(wasmtime_linker_t* linker);
  *
  * By default this setting is `false`.
  */
-WASM_API_EXTERN void wasmtime_linker_allow_shadowing(wasmtime_linker_t* linker, bool allow_shadowing);
+WASM_API_EXTERN void wasmtime_linker_allow_shadowing(wasmtime_linker_t *linker,
+                                                     bool allow_shadowing);
 
 /**
  * \brief Defines a new item in this linker.
@@ -72,14 +73,10 @@ WASM_API_EXTERN void wasmtime_linker_allow_shadowing(wasmtime_linker_t* linker, 
  * For more information about name resolution consult the [Rust
  * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#name-resolution).
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define(
-    wasmtime_linker_t* linker,
-    wasmtime_context_t* store,
-    const char* module,
-    size_t module_len,
-    const char* name,
-    size_t name_len,
-    const wasmtime_extern_t* item);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_linker_define(wasmtime_linker_t *linker, wasmtime_context_t *store,
+                       const char *module, size_t module_len, const char *name,
+                       size_t name_len, const wasmtime_extern_t *item);
 
 /**
  * \brief Defines a new function in this linker.
@@ -91,8 +88,8 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define(
  * \param name_len the byte length of `name`
  * \param ty the type of the function that's being defined
  * \param cb the host callback to invoke when the function is called
- * \param data the host-provided data to provide as the first argument to the callback
- * \param finalizer an optional finalizer for the `data` argument.
+ * \param data the host-provided data to provide as the first argument to the
+ * callback \param finalizer an optional finalizer for the `data` argument.
  *
  * \return On success `NULL` is returned, otherwise an error is returned which
  * describes why the definition failed.
@@ -106,16 +103,10 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define(
  *
  * For more information about host callbacks see #wasmtime_func_new.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func(
-    wasmtime_linker_t* linker,
-    const char* module,
-    size_t module_len,
-    const char* name,
-    size_t name_len,
-    const wasm_functype_t* ty,
-    wasmtime_func_callback_t cb,
-    void* data,
-    void (*finalizer)(void*));
+WASM_API_EXTERN wasmtime_error_t *wasmtime_linker_define_func(
+    wasmtime_linker_t *linker, const char *module, size_t module_len,
+    const char *name, size_t name_len, const wasm_functype_t *ty,
+    wasmtime_func_callback_t cb, void *data, void (*finalizer)(void *));
 
 /**
  * \brief Defines a new function in this linker.
@@ -126,16 +117,11 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func(
  * information as well as #wasmtime_func_new_unchecked for why this is an
  * unsafe API.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func_unchecked(
-    wasmtime_linker_t* linker,
-    const char* module,
-    size_t module_len,
-    const char* name,
-    size_t name_len,
-    const wasm_functype_t* ty,
-    wasmtime_func_unchecked_callback_t cb,
-    void* data,
-    void (*finalizer)(void*));
+WASM_API_EXTERN wasmtime_error_t *wasmtime_linker_define_func_unchecked(
+    wasmtime_linker_t *linker, const char *module, size_t module_len,
+    const char *name, size_t name_len, const wasm_functype_t *ty,
+    wasmtime_func_unchecked_callback_t cb, void *data,
+    void (*finalizer)(void *));
 
 /**
  * \brief Defines WASI functions in this linker.
@@ -154,8 +140,8 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func_unchecked(
  * For more information about name resolution consult the [Rust
  * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#name-resolution).
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_wasi(
-    wasmtime_linker_t* linker);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_linker_define_wasi(wasmtime_linker_t *linker);
 
 /**
  * \brief Defines an instance under the specified name in this linker.
@@ -176,12 +162,9 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_wasi(
  * For more information about name resolution consult the [Rust
  * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#name-resolution).
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_instance(
-    wasmtime_linker_t* linker,
-    wasmtime_context_t* store,
-    const char* name,
-    size_t name_len,
-    const wasmtime_instance_t* instance);
+WASM_API_EXTERN wasmtime_error_t *wasmtime_linker_define_instance(
+    wasmtime_linker_t *linker, wasmtime_context_t *store, const char *name,
+    size_t name_len, const wasmtime_instance_t *instance);
 
 /**
  * \brief Instantiates a #wasm_module_t with the items defined in this linker.
@@ -205,12 +188,11 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_instance(
  * defined in the linker than an error is returned. (or if the previously
  * defined item is of the wrong type).
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_instantiate(
-    const wasmtime_linker_t* linker,
-    wasmtime_context_t* store,
-    const wasmtime_module_t* module,
-    wasmtime_instance_t* instance,
-    wasm_trap_t** trap);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_linker_instantiate(const wasmtime_linker_t *linker,
+                            wasmtime_context_t *store,
+                            const wasmtime_module_t *module,
+                            wasmtime_instance_t *instance, wasm_trap_t **trap);
 
 /**
  * \brief Defines automatic instantiations of a #wasm_module_t in this linker.
@@ -231,12 +213,10 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_instantiate(
  * For more information see the [Rust
  * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#method.module).
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_module(
-    wasmtime_linker_t* linker,
-    wasmtime_context_t* store,
-    const char* name,
-    size_t name_len,
-    const wasmtime_module_t* module);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_linker_module(wasmtime_linker_t *linker, wasmtime_context_t *store,
+                       const char *name, size_t name_len,
+                       const wasmtime_module_t *module);
 
 /**
  * \brief Acquires the "default export" of the named module in this linker.
@@ -253,12 +233,10 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_module(
  * For more information see the [Rust
  * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#method.get_default).
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_get_default(
-    const wasmtime_linker_t* linker,
-    wasmtime_context_t* store,
-    const char* name,
-    size_t name_len,
-    wasmtime_func_t* func);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_linker_get_default(const wasmtime_linker_t *linker,
+                            wasmtime_context_t *store, const char *name,
+                            size_t name_len, wasmtime_func_t *func);
 
 /**
  * \brief Loads an item by name from this linker.
@@ -274,14 +252,11 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_get_default(
  * \return A nonzero value if the item is defined, in which case `item` is also
  * filled in. Otherwise zero is returned.
  */
-WASM_API_EXTERN bool wasmtime_linker_get(
-    const wasmtime_linker_t* linker,
-    wasmtime_context_t* store,
-    const char* module,
-    size_t module_len,
-    const char* name,
-    size_t name_len,
-    wasmtime_extern_t* item);
+WASM_API_EXTERN bool wasmtime_linker_get(const wasmtime_linker_t *linker,
+                                         wasmtime_context_t *store,
+                                         const char *module, size_t module_len,
+                                         const char *name, size_t name_len,
+                                         wasmtime_extern_t *item);
 
 /**
  * \brief Preform all the checks for instantiating `module` with the linker,
@@ -296,10 +271,10 @@ WASM_API_EXTERN bool wasmtime_linker_get(
  * For more information see the Rust documentation at:
  * https://docs.wasmtime.dev/api/wasmtime/struct.Linker.html#method.instantiate_pre
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_instantiate_pre(
-    const wasmtime_linker_t* linker,
-    const wasmtime_module_t* module,
-    wasmtime_instance_pre_t** instance_pre);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_linker_instantiate_pre(const wasmtime_linker_t *linker,
+                                const wasmtime_module_t *module,
+                                wasmtime_instance_pre_t **instance_pre);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -89,7 +89,8 @@ wasmtime_linker_define(wasmtime_linker_t *linker, wasmtime_context_t *store,
  * \param ty the type of the function that's being defined
  * \param cb the host callback to invoke when the function is called
  * \param data the host-provided data to provide as the first argument to the
- * callback \param finalizer an optional finalizer for the `data` argument.
+ *        callback
+ * \param finalizer an optional finalizer for the `data` argument.
  *
  * \return On success `NULL` is returned, otherwise an error is returned which
  * describes why the definition failed.

--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -9,8 +9,8 @@
 
 #include <wasm.h>
 #include <wasmtime/error.h>
-#include <wasmtime/store.h>
 #include <wasmtime/extern.h>
+#include <wasmtime/store.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -73,14 +73,13 @@ WASM_API_EXTERN void wasmtime_linker_allow_shadowing(wasmtime_linker_t* linker, 
  * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#name-resolution).
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define(
-    wasmtime_linker_t *linker,
-    wasmtime_context_t *store,
-    const char *module,
+    wasmtime_linker_t* linker,
+    wasmtime_context_t* store,
+    const char* module,
     size_t module_len,
-    const char *name,
+    const char* name,
     size_t name_len,
-    const wasmtime_extern_t *item
-);
+    const wasmtime_extern_t* item);
 
 /**
  * \brief Defines a new function in this linker.
@@ -108,16 +107,15 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define(
  * For more information about host callbacks see #wasmtime_func_new.
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func(
-    wasmtime_linker_t *linker,
-    const char *module,
+    wasmtime_linker_t* linker,
+    const char* module,
     size_t module_len,
-    const char *name,
+    const char* name,
     size_t name_len,
-    const wasm_functype_t *ty,
+    const wasm_functype_t* ty,
     wasmtime_func_callback_t cb,
-    void *data,
-    void (*finalizer)(void*)
-);
+    void* data,
+    void (*finalizer)(void*));
 
 /**
  * \brief Defines a new function in this linker.
@@ -129,16 +127,15 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func(
  * unsafe API.
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func_unchecked(
-    wasmtime_linker_t *linker,
-    const char *module,
+    wasmtime_linker_t* linker,
+    const char* module,
     size_t module_len,
-    const char *name,
+    const char* name,
     size_t name_len,
-    const wasm_functype_t *ty,
+    const wasm_functype_t* ty,
     wasmtime_func_unchecked_callback_t cb,
-    void *data,
-    void (*finalizer)(void*)
-);
+    void* data,
+    void (*finalizer)(void*));
 
 /**
  * \brief Defines WASI functions in this linker.
@@ -158,8 +155,7 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_func_unchecked(
  * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#name-resolution).
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_wasi(
-    wasmtime_linker_t *linker
-);
+    wasmtime_linker_t* linker);
 
 /**
  * \brief Defines an instance under the specified name in this linker.
@@ -181,12 +177,11 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_wasi(
  * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#name-resolution).
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_instance(
-    wasmtime_linker_t *linker,
-    wasmtime_context_t *store,
-    const char *name,
+    wasmtime_linker_t* linker,
+    wasmtime_context_t* store,
+    const char* name,
     size_t name_len,
-    const wasmtime_instance_t *instance
-);
+    const wasmtime_instance_t* instance);
 
 /**
  * \brief Instantiates a #wasm_module_t with the items defined in this linker.
@@ -211,12 +206,11 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_define_instance(
  * defined item is of the wrong type).
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_instantiate(
-    const wasmtime_linker_t *linker,
-    wasmtime_context_t *store,
-    const wasmtime_module_t *module,
-    wasmtime_instance_t *instance,
-    wasm_trap_t **trap
-);
+    const wasmtime_linker_t* linker,
+    wasmtime_context_t* store,
+    const wasmtime_module_t* module,
+    wasmtime_instance_t* instance,
+    wasm_trap_t** trap);
 
 /**
  * \brief Defines automatic instantiations of a #wasm_module_t in this linker.
@@ -238,12 +232,11 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_instantiate(
  * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#method.module).
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_module(
-    wasmtime_linker_t *linker,
-    wasmtime_context_t *store,
-    const char *name,
+    wasmtime_linker_t* linker,
+    wasmtime_context_t* store,
+    const char* name,
     size_t name_len,
-    const wasmtime_module_t *module
-);
+    const wasmtime_module_t* module);
 
 /**
  * \brief Acquires the "default export" of the named module in this linker.
@@ -261,12 +254,11 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_module(
  * documentation](https://bytecodealliance.github.io/wasmtime/api/wasmtime/struct.Linker.html#method.get_default).
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_get_default(
-    const wasmtime_linker_t *linker,
-    wasmtime_context_t *store,
-    const char *name,
+    const wasmtime_linker_t* linker,
+    wasmtime_context_t* store,
+    const char* name,
     size_t name_len,
-    wasmtime_func_t *func
-);
+    wasmtime_func_t* func);
 
 /**
  * \brief Loads an item by name from this linker.
@@ -283,14 +275,13 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_get_default(
  * filled in. Otherwise zero is returned.
  */
 WASM_API_EXTERN bool wasmtime_linker_get(
-    const wasmtime_linker_t *linker,
-    wasmtime_context_t *store,
-    const char *module,
+    const wasmtime_linker_t* linker,
+    wasmtime_context_t* store,
+    const char* module,
     size_t module_len,
-    const char *name,
+    const char* name,
     size_t name_len,
-    wasmtime_extern_t *item
-);
+    wasmtime_extern_t* item);
 
 /**
  * \brief Preform all the checks for instantiating `module` with the linker,
@@ -306,12 +297,12 @@ WASM_API_EXTERN bool wasmtime_linker_get(
  * https://docs.wasmtime.dev/api/wasmtime/struct.Linker.html#method.instantiate_pre
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_linker_instantiate_pre(
-    const wasmtime_linker_t *linker,
-    const wasmtime_module_t *module,
-    wasmtime_instance_pre_t **instance_pre);
+    const wasmtime_linker_t* linker,
+    const wasmtime_module_t* module,
+    wasmtime_instance_pre_t** instance_pre);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_LINKER_H

--- a/crates/c-api/include/wasmtime/memory.h
+++ b/crates/c-api/include/wasmtime/memory.h
@@ -8,9 +8,9 @@
 #define WASMTIME_MEMORY_H
 
 #include <wasm.h>
+#include <wasmtime/error.h>
 #include <wasmtime/extern.h>
 #include <wasmtime/store.h>
-#include <wasmtime/error.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -22,7 +22,7 @@ extern "C" {
  * Note that this function is preferred over #wasm_memorytype_new for
  * compatibility with the memory64 proposal.
  */
-WASM_API_EXTERN wasm_memorytype_t *wasmtime_memorytype_new(uint64_t min, bool max_present, uint64_t max, bool is_64);
+WASM_API_EXTERN wasm_memorytype_t* wasmtime_memorytype_new(uint64_t min, bool max_present, uint64_t max, bool is_64);
 
 /**
  * \brief Returns the minimum size, in pages, of the specified memory type.
@@ -30,7 +30,7 @@ WASM_API_EXTERN wasm_memorytype_t *wasmtime_memorytype_new(uint64_t min, bool ma
  * Note that this function is preferred over #wasm_memorytype_limits for
  * compatibility with the memory64 proposal.
  */
-WASM_API_EXTERN uint64_t wasmtime_memorytype_minimum(const wasm_memorytype_t *ty);
+WASM_API_EXTERN uint64_t wasmtime_memorytype_minimum(const wasm_memorytype_t* ty);
 
 /**
  * \brief Returns the maximum size, in pages, of the specified memory type.
@@ -42,12 +42,12 @@ WASM_API_EXTERN uint64_t wasmtime_memorytype_minimum(const wasm_memorytype_t *ty
  * Note that this function is preferred over #wasm_memorytype_limits for
  * compatibility with the memory64 proposal.
  */
-WASM_API_EXTERN bool wasmtime_memorytype_maximum(const wasm_memorytype_t *ty, uint64_t *max);
+WASM_API_EXTERN bool wasmtime_memorytype_maximum(const wasm_memorytype_t* ty, uint64_t* max);
 
 /**
  * \brief Returns whether this type of memory represents a 64-bit memory.
  */
-WASM_API_EXTERN bool wasmtime_memorytype_is64(const wasm_memorytype_t *ty);
+WASM_API_EXTERN bool wasmtime_memorytype_is64(const wasm_memorytype_t* ty);
 
 /**
  * \brief Creates a new WebAssembly linear memory
@@ -59,43 +59,38 @@ WASM_API_EXTERN bool wasmtime_memorytype_is64(const wasm_memorytype_t *ty);
  * If an error happens when creating the memory it's returned and owned by the
  * caller. If an error happens then `ret` is not filled in.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_memory_new(
-    wasmtime_context_t *store,
+WASM_API_EXTERN wasmtime_error_t* wasmtime_memory_new(
+    wasmtime_context_t* store,
     const wasm_memorytype_t* ty,
-    wasmtime_memory_t *ret
-);
+    wasmtime_memory_t* ret);
 
 /**
  * \brief Returns the type of the memory specified
  */
 WASM_API_EXTERN wasm_memorytype_t* wasmtime_memory_type(
-    const wasmtime_context_t *store,
-    const wasmtime_memory_t *memory
-);
+    const wasmtime_context_t* store,
+    const wasmtime_memory_t* memory);
 
 /**
  * \brief Returns the base pointer in memory where the linear memory starts.
  */
-WASM_API_EXTERN uint8_t *wasmtime_memory_data(
-    const wasmtime_context_t *store,
-    const wasmtime_memory_t *memory
-);
+WASM_API_EXTERN uint8_t* wasmtime_memory_data(
+    const wasmtime_context_t* store,
+    const wasmtime_memory_t* memory);
 
 /**
  * \brief Returns the byte length of this linear memory.
  */
 WASM_API_EXTERN size_t wasmtime_memory_data_size(
-    const wasmtime_context_t *store,
-    const wasmtime_memory_t *memory
-);
+    const wasmtime_context_t* store,
+    const wasmtime_memory_t* memory);
 
 /**
  * \brief Returns the length, in WebAssembly pages, of this linear memory
  */
 WASM_API_EXTERN uint64_t wasmtime_memory_size(
-    const wasmtime_context_t *store,
-    const wasmtime_memory_t *memory
-);
+    const wasmtime_context_t* store,
+    const wasmtime_memory_t* memory);
 
 /**
  * \brief Attempts to grow the specified memory by `delta` pages.
@@ -109,15 +104,14 @@ WASM_API_EXTERN uint64_t wasmtime_memory_size(
  * returned. Otherwise `prev_size` is set to the previous size of the memory, in
  * WebAssembly pages, and `NULL` is returned.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_memory_grow(
-    wasmtime_context_t *store,
-    const wasmtime_memory_t *memory,
+WASM_API_EXTERN wasmtime_error_t* wasmtime_memory_grow(
+    wasmtime_context_t* store,
+    const wasmtime_memory_t* memory,
     uint64_t delta,
-    uint64_t *prev_size
-);
+    uint64_t* prev_size);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_MEMORY_H

--- a/crates/c-api/include/wasmtime/memory.h
+++ b/crates/c-api/include/wasmtime/memory.h
@@ -22,7 +22,10 @@ extern "C" {
  * Note that this function is preferred over #wasm_memorytype_new for
  * compatibility with the memory64 proposal.
  */
-WASM_API_EXTERN wasm_memorytype_t* wasmtime_memorytype_new(uint64_t min, bool max_present, uint64_t max, bool is_64);
+WASM_API_EXTERN wasm_memorytype_t *wasmtime_memorytype_new(uint64_t min,
+                                                           bool max_present,
+                                                           uint64_t max,
+                                                           bool is_64);
 
 /**
  * \brief Returns the minimum size, in pages, of the specified memory type.
@@ -30,7 +33,8 @@ WASM_API_EXTERN wasm_memorytype_t* wasmtime_memorytype_new(uint64_t min, bool ma
  * Note that this function is preferred over #wasm_memorytype_limits for
  * compatibility with the memory64 proposal.
  */
-WASM_API_EXTERN uint64_t wasmtime_memorytype_minimum(const wasm_memorytype_t* ty);
+WASM_API_EXTERN uint64_t
+wasmtime_memorytype_minimum(const wasm_memorytype_t *ty);
 
 /**
  * \brief Returns the maximum size, in pages, of the specified memory type.
@@ -42,12 +46,13 @@ WASM_API_EXTERN uint64_t wasmtime_memorytype_minimum(const wasm_memorytype_t* ty
  * Note that this function is preferred over #wasm_memorytype_limits for
  * compatibility with the memory64 proposal.
  */
-WASM_API_EXTERN bool wasmtime_memorytype_maximum(const wasm_memorytype_t* ty, uint64_t* max);
+WASM_API_EXTERN bool wasmtime_memorytype_maximum(const wasm_memorytype_t *ty,
+                                                 uint64_t *max);
 
 /**
  * \brief Returns whether this type of memory represents a 64-bit memory.
  */
-WASM_API_EXTERN bool wasmtime_memorytype_is64(const wasm_memorytype_t* ty);
+WASM_API_EXTERN bool wasmtime_memorytype_is64(const wasm_memorytype_t *ty);
 
 /**
  * \brief Creates a new WebAssembly linear memory
@@ -59,38 +64,34 @@ WASM_API_EXTERN bool wasmtime_memorytype_is64(const wasm_memorytype_t* ty);
  * If an error happens when creating the memory it's returned and owned by the
  * caller. If an error happens then `ret` is not filled in.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_memory_new(
-    wasmtime_context_t* store,
-    const wasm_memorytype_t* ty,
-    wasmtime_memory_t* ret);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_memory_new(wasmtime_context_t *store, const wasm_memorytype_t *ty,
+                    wasmtime_memory_t *ret);
 
 /**
  * \brief Returns the type of the memory specified
  */
-WASM_API_EXTERN wasm_memorytype_t* wasmtime_memory_type(
-    const wasmtime_context_t* store,
-    const wasmtime_memory_t* memory);
+WASM_API_EXTERN wasm_memorytype_t *
+wasmtime_memory_type(const wasmtime_context_t *store,
+                     const wasmtime_memory_t *memory);
 
 /**
  * \brief Returns the base pointer in memory where the linear memory starts.
  */
-WASM_API_EXTERN uint8_t* wasmtime_memory_data(
-    const wasmtime_context_t* store,
-    const wasmtime_memory_t* memory);
+WASM_API_EXTERN uint8_t *wasmtime_memory_data(const wasmtime_context_t *store,
+                                              const wasmtime_memory_t *memory);
 
 /**
  * \brief Returns the byte length of this linear memory.
  */
 WASM_API_EXTERN size_t wasmtime_memory_data_size(
-    const wasmtime_context_t* store,
-    const wasmtime_memory_t* memory);
+    const wasmtime_context_t *store, const wasmtime_memory_t *memory);
 
 /**
  * \brief Returns the length, in WebAssembly pages, of this linear memory
  */
-WASM_API_EXTERN uint64_t wasmtime_memory_size(
-    const wasmtime_context_t* store,
-    const wasmtime_memory_t* memory);
+WASM_API_EXTERN uint64_t wasmtime_memory_size(const wasmtime_context_t *store,
+                                              const wasmtime_memory_t *memory);
 
 /**
  * \brief Attempts to grow the specified memory by `delta` pages.
@@ -104,11 +105,9 @@ WASM_API_EXTERN uint64_t wasmtime_memory_size(
  * returned. Otherwise `prev_size` is set to the previous size of the memory, in
  * WebAssembly pages, and `NULL` is returned.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_memory_grow(
-    wasmtime_context_t* store,
-    const wasmtime_memory_t* memory,
-    uint64_t delta,
-    uint64_t* prev_size);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_memory_grow(wasmtime_context_t *store, const wasmtime_memory_t *memory,
+                     uint64_t delta, uint64_t *prev_size);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/module.h
+++ b/crates/c-api/include/wasmtime/module.h
@@ -41,39 +41,36 @@ typedef struct wasmtime_module wasmtime_module_t;
  * This function does not take ownership of any of its arguments, but the
  * returned error and module are owned by the caller.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_module_new(
-    wasm_engine_t *engine,
-    const uint8_t *wasm,
+WASM_API_EXTERN wasmtime_error_t* wasmtime_module_new(
+    wasm_engine_t* engine,
+    const uint8_t* wasm,
     size_t wasm_len,
-    wasmtime_module_t **ret
-);
+    wasmtime_module_t** ret);
 
 /**
  * \brief Deletes a module.
  */
-WASM_API_EXTERN void wasmtime_module_delete(wasmtime_module_t *m);
+WASM_API_EXTERN void wasmtime_module_delete(wasmtime_module_t* m);
 
 /**
  * \brief Creates a shallow clone of the specified module, increasing the
  * internal reference count.
  */
-WASM_API_EXTERN wasmtime_module_t *wasmtime_module_clone(wasmtime_module_t *m);
+WASM_API_EXTERN wasmtime_module_t* wasmtime_module_clone(wasmtime_module_t* m);
 
 /**
  * \brief Same as #wasm_module_imports, but for #wasmtime_module_t.
  */
 WASM_API_EXTERN void wasmtime_module_imports(
-    const wasmtime_module_t *module,
-    wasm_importtype_vec_t *out
-);
+    const wasmtime_module_t* module,
+    wasm_importtype_vec_t* out);
 
 /**
  * \brief Same as #wasm_module_exports, but for #wasmtime_module_t.
  */
 WASM_API_EXTERN void wasmtime_module_exports(
-    const wasmtime_module_t *module,
-    wasm_exporttype_vec_t *out
-);
+    const wasmtime_module_t* module,
+    wasm_exporttype_vec_t* out);
 
 /**
  * \brief Validate a WebAssembly binary.
@@ -87,11 +84,10 @@ WASM_API_EXTERN void wasmtime_module_exports(
  * If the binary validates then `NULL` is returned, otherwise the error returned
  * describes why the binary did not validate.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_module_validate(
-    wasm_engine_t *engine,
-    const uint8_t *wasm,
-    size_t wasm_len
-);
+WASM_API_EXTERN wasmtime_error_t* wasmtime_module_validate(
+    wasm_engine_t* engine,
+    const uint8_t* wasm,
+    size_t wasm_len);
 
 /**
  * \brief This function serializes compiled module artifacts as blob data.
@@ -108,8 +104,7 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_module_validate(
  */
 WASM_API_EXTERN wasmtime_error_t* wasmtime_module_serialize(
     wasmtime_module_t* module,
-    wasm_byte_vec_t *ret
-);
+    wasm_byte_vec_t* ret);
 
 /**
  * \brief Build a module from serialized data.
@@ -121,12 +116,11 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_module_serialize(
  * documentation for more information on what inputs are safe to pass in here
  * (e.g. only that of #wasmtime_module_serialize)
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_module_deserialize(
-    wasm_engine_t *engine,
-    const uint8_t *bytes,
+WASM_API_EXTERN wasmtime_error_t* wasmtime_module_deserialize(
+    wasm_engine_t* engine,
+    const uint8_t* bytes,
     size_t bytes_len,
-    wasmtime_module_t **ret
-);
+    wasmtime_module_t** ret);
 
 /**
  * \brief Deserialize a module from an on-disk file.
@@ -142,29 +136,26 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_module_deserialize(
  * documentation for more information on what inputs are safe to pass in here
  * (e.g. only that of #wasmtime_module_serialize)
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_module_deserialize_file(
-    wasm_engine_t *engine,
-    const char *path,
-    wasmtime_module_t **ret
-);
-
+WASM_API_EXTERN wasmtime_error_t* wasmtime_module_deserialize_file(
+    wasm_engine_t* engine,
+    const char* path,
+    wasmtime_module_t** ret);
 
 /**
  * \brief Returns the range of bytes in memory where this module’s compilation image resides.
  *
- * The compilation image for a module contains executable code, data, debug information, etc. 
+ * The compilation image for a module contains executable code, data, debug information, etc.
  * This is roughly the same as the wasmtime_module_serialize but not the exact same.
  *
  * For more details see: https://docs.wasmtime.dev/api/wasmtime/struct.Module.html#method.image_range
  */
 WASM_API_EXTERN void wasmtime_module_image_range(
-    const wasmtime_module_t *module,
-    size_t *start,
-    size_t *end
-);
+    const wasmtime_module_t* module,
+    size_t* start,
+    size_t* end);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_MODULE_H

--- a/crates/c-api/include/wasmtime/module.h
+++ b/crates/c-api/include/wasmtime/module.h
@@ -41,36 +41,33 @@ typedef struct wasmtime_module wasmtime_module_t;
  * This function does not take ownership of any of its arguments, but the
  * returned error and module are owned by the caller.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_module_new(
-    wasm_engine_t* engine,
-    const uint8_t* wasm,
-    size_t wasm_len,
-    wasmtime_module_t** ret);
+WASM_API_EXTERN wasmtime_error_t *wasmtime_module_new(wasm_engine_t *engine,
+                                                      const uint8_t *wasm,
+                                                      size_t wasm_len,
+                                                      wasmtime_module_t **ret);
 
 /**
  * \brief Deletes a module.
  */
-WASM_API_EXTERN void wasmtime_module_delete(wasmtime_module_t* m);
+WASM_API_EXTERN void wasmtime_module_delete(wasmtime_module_t *m);
 
 /**
  * \brief Creates a shallow clone of the specified module, increasing the
  * internal reference count.
  */
-WASM_API_EXTERN wasmtime_module_t* wasmtime_module_clone(wasmtime_module_t* m);
+WASM_API_EXTERN wasmtime_module_t *wasmtime_module_clone(wasmtime_module_t *m);
 
 /**
  * \brief Same as #wasm_module_imports, but for #wasmtime_module_t.
  */
-WASM_API_EXTERN void wasmtime_module_imports(
-    const wasmtime_module_t* module,
-    wasm_importtype_vec_t* out);
+WASM_API_EXTERN void wasmtime_module_imports(const wasmtime_module_t *module,
+                                             wasm_importtype_vec_t *out);
 
 /**
  * \brief Same as #wasm_module_exports, but for #wasmtime_module_t.
  */
-WASM_API_EXTERN void wasmtime_module_exports(
-    const wasmtime_module_t* module,
-    wasm_exporttype_vec_t* out);
+WASM_API_EXTERN void wasmtime_module_exports(const wasmtime_module_t *module,
+                                             wasm_exporttype_vec_t *out);
 
 /**
  * \brief Validate a WebAssembly binary.
@@ -84,17 +81,16 @@ WASM_API_EXTERN void wasmtime_module_exports(
  * If the binary validates then `NULL` is returned, otherwise the error returned
  * describes why the binary did not validate.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_module_validate(
-    wasm_engine_t* engine,
-    const uint8_t* wasm,
-    size_t wasm_len);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_module_validate(wasm_engine_t *engine, const uint8_t *wasm,
+                         size_t wasm_len);
 
 /**
  * \brief This function serializes compiled module artifacts as blob data.
  *
  * \param module the module
- * \param ret if the conversion is successful, this byte vector is filled in with
- *   the serialized compiled module.
+ * \param ret if the conversion is successful, this byte vector is filled in
+ * with the serialized compiled module.
  *
  * \return a non-null error if parsing fails, or returns `NULL`. If parsing
  * fails then `ret` isn't touched.
@@ -102,9 +98,8 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_module_validate(
  * This function does not take ownership of `module`, and the caller is
  * expected to deallocate the returned #wasmtime_error_t and #wasm_byte_vec_t.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_module_serialize(
-    wasmtime_module_t* module,
-    wasm_byte_vec_t* ret);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_module_serialize(wasmtime_module_t *module, wasm_byte_vec_t *ret);
 
 /**
  * \brief Build a module from serialized data.
@@ -116,11 +111,9 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_module_serialize(
  * documentation for more information on what inputs are safe to pass in here
  * (e.g. only that of #wasmtime_module_serialize)
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_module_deserialize(
-    wasm_engine_t* engine,
-    const uint8_t* bytes,
-    size_t bytes_len,
-    wasmtime_module_t** ret);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_module_deserialize(wasm_engine_t *engine, const uint8_t *bytes,
+                            size_t bytes_len, wasmtime_module_t **ret);
 
 /**
  * \brief Deserialize a module from an on-disk file.
@@ -136,23 +129,24 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_module_deserialize(
  * documentation for more information on what inputs are safe to pass in here
  * (e.g. only that of #wasmtime_module_serialize)
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_module_deserialize_file(
-    wasm_engine_t* engine,
-    const char* path,
-    wasmtime_module_t** ret);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_module_deserialize_file(wasm_engine_t *engine, const char *path,
+                                 wasmtime_module_t **ret);
 
 /**
- * \brief Returns the range of bytes in memory where this module’s compilation image resides.
+ * \brief Returns the range of bytes in memory where this module’s compilation
+ * image resides.
  *
- * The compilation image for a module contains executable code, data, debug information, etc.
- * This is roughly the same as the wasmtime_module_serialize but not the exact same.
+ * The compilation image for a module contains executable code, data, debug
+ * information, etc. This is roughly the same as the wasmtime_module_serialize
+ * but not the exact same.
  *
- * For more details see: https://docs.wasmtime.dev/api/wasmtime/struct.Module.html#method.image_range
+ * For more details see:
+ * https://docs.wasmtime.dev/api/wasmtime/struct.Module.html#method.image_range
  */
-WASM_API_EXTERN void wasmtime_module_image_range(
-    const wasmtime_module_t* module,
-    size_t* start,
-    size_t* end);
+WASM_API_EXTERN void
+wasmtime_module_image_range(const wasmtime_module_t *module, size_t *start,
+                            size_t *end);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -7,8 +7,8 @@
 #ifndef WASMTIME_STORE_H
 #define WASMTIME_STORE_H
 
-#include <wasm.h>
 #include <wasi.h>
+#include <wasm.h>
 #include <wasmtime/error.h>
 
 #ifdef __cplusplus
@@ -68,16 +68,15 @@ typedef struct wasmtime_context wasmtime_context_t;
  * This function creates a fresh store with the provided configuration settings.
  * The returned store must be deleted with #wasmtime_store_delete.
  */
-WASM_API_EXTERN wasmtime_store_t *wasmtime_store_new(
-    wasm_engine_t *engine,
-    void *data,
-    void (*finalizer)(void*)
-);
+WASM_API_EXTERN wasmtime_store_t* wasmtime_store_new(
+    wasm_engine_t* engine,
+    void* data,
+    void (*finalizer)(void*));
 
 /**
  * \brief Returns the interior #wasmtime_context_t pointer to this store
  */
-WASM_API_EXTERN wasmtime_context_t *wasmtime_store_context(wasmtime_store_t *store);
+WASM_API_EXTERN wasmtime_context_t* wasmtime_store_context(wasmtime_store_t* store);
 
 /**
  * \brief Provides limits for a store. Used by hosts to limit resource
@@ -109,23 +108,22 @@ WASM_API_EXTERN wasmtime_context_t *wasmtime_store_context(wasmtime_store_t *sto
  * limits to the store.
  */
 WASM_API_EXTERN void wasmtime_store_limiter(
-        wasmtime_store_t *store,
-        int64_t memory_size,
-        int64_t table_elements,
-        int64_t instances,
-        int64_t tables,
-        int64_t memories
-);
+    wasmtime_store_t* store,
+    int64_t memory_size,
+    int64_t table_elements,
+    int64_t instances,
+    int64_t tables,
+    int64_t memories);
 
 /**
  * \brief Deletes a store.
  */
-WASM_API_EXTERN void wasmtime_store_delete(wasmtime_store_t *store);
+WASM_API_EXTERN void wasmtime_store_delete(wasmtime_store_t* store);
 
 /**
  * \brief Returns the user-specified data associated with the specified store
  */
-WASM_API_EXTERN void *wasmtime_context_get_data(const wasmtime_context_t* context);
+WASM_API_EXTERN void* wasmtime_context_get_data(const wasmtime_context_t* context);
 
 /**
  * \brief Overwrites the user-specified data associated with this store.
@@ -134,7 +132,7 @@ WASM_API_EXTERN void *wasmtime_context_get_data(const wasmtime_context_t* contex
  * and the original finalizer will be executed for the provided data when the
  * store is deleted.
  */
-WASM_API_EXTERN void wasmtime_context_set_data(wasmtime_context_t* context, void *data);
+WASM_API_EXTERN void wasmtime_context_set_data(wasmtime_context_t* context, void* data);
 
 /**
  * \brief Perform garbage collection within the given context.
@@ -161,7 +159,7 @@ WASM_API_EXTERN void wasmtime_context_gc(wasmtime_context_t* context);
  * If fuel is not enabled within this store then an error is returned. If fuel
  * is successfully added then NULL is returned.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_context_set_fuel(wasmtime_context_t *store, uint64_t fuel);
+WASM_API_EXTERN wasmtime_error_t* wasmtime_context_set_fuel(wasmtime_context_t* store, uint64_t fuel);
 
 /**
  * \brief Returns the amount of fuel remaining in this context's store.
@@ -173,7 +171,7 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_context_set_fuel(wasmtime_context_t *
  * Also note that fuel, if enabled, must be originally configured via
  * #wasmtime_context_set_fuel.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_context_get_fuel(const wasmtime_context_t *context, uint64_t *fuel);
+WASM_API_EXTERN wasmtime_error_t* wasmtime_context_get_fuel(const wasmtime_context_t* context, uint64_t* fuel);
 
 /**
  * \brief Configures WASI state within the specified store.
@@ -186,7 +184,7 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_context_get_fuel(const wasmtime_conte
  * of `wasi`. The caller should no longer use `wasi` after calling this function
  * (even if an error is returned).
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_context_set_wasi(wasmtime_context_t *context, wasi_config_t *wasi);
+WASM_API_EXTERN wasmtime_error_t* wasmtime_context_set_wasi(wasmtime_context_t* context, wasi_config_t* wasi);
 
 /**
  * \brief Configures the relative deadline at which point WebAssembly code will
@@ -198,14 +196,14 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_context_set_wasi(wasmtime_context_t *
  * See also #wasmtime_config_epoch_interruption_set and
  * #wasmtime_store_epoch_deadline_callback.
  */
-WASM_API_EXTERN void wasmtime_context_set_epoch_deadline(wasmtime_context_t *context, uint64_t ticks_beyond_current);
+WASM_API_EXTERN void wasmtime_context_set_epoch_deadline(wasmtime_context_t* context, uint64_t ticks_beyond_current);
 
 /// \brief An enum for the behavior before extending the epoch deadline.
 typedef uint8_t wasmtime_update_deadline_kind_t;
 /// \brief Directly continue to updating the deadline and executing WebAssembly.
 #define WASMTIME_UPDATE_DEADLINE_CONTINUE 0
 /// \brief Yield control (via async support) then update the deadline.
-#define WASMTIME_UPDATE_DEADLINE_YIELD    1
+#define WASMTIME_UPDATE_DEADLINE_YIELD 1
 
 /**
  * \brief Configures epoch deadline callback to C function.
@@ -216,32 +214,29 @@ typedef uint8_t wasmtime_update_deadline_kind_t;
  * - return a #wasmtime_error_t to terminate the function
  * - set the delta argument and return NULL to update the
  *   epoch deadline delta and resume function execution.
- * - set the delta argument, update the epoch deadline, 
+ * - set the delta argument, update the epoch deadline,
  *   set update_kind to WASMTIME_UPDATE_DEADLINE_YIELD,
- *   and return NULL to yield (via async support) and 
+ *   and return NULL to yield (via async support) and
  *   resume function execution.
  *
- * To use WASMTIME_UPDATE_DEADLINE_YIELD async support must be enabled 
+ * To use WASMTIME_UPDATE_DEADLINE_YIELD async support must be enabled
  * for this store.
  *
  * See also #wasmtime_config_epoch_interruption_set and
  * #wasmtime_context_set_epoch_deadline.
  */
 WASM_API_EXTERN void wasmtime_store_epoch_deadline_callback(
-    wasmtime_store_t *store, 
+    wasmtime_store_t* store,
     wasmtime_error_t* (*func)(
-      wasmtime_context_t* context, 
-      void* data, 
-      uint64_t* epoch_deadline_delta, 
-      wasmtime_update_deadline_kind_t* update_kind
-    ), 
-    void *data,
-    void (*finalizer)(void*)
-);
+        wasmtime_context_t* context,
+        void* data,
+        uint64_t* epoch_deadline_delta,
+        wasmtime_update_deadline_kind_t* update_kind),
+    void* data,
+    void (*finalizer)(void*));
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_STORE_H
-

--- a/crates/c-api/include/wasmtime/store.h
+++ b/crates/c-api/include/wasmtime/store.h
@@ -68,15 +68,15 @@ typedef struct wasmtime_context wasmtime_context_t;
  * This function creates a fresh store with the provided configuration settings.
  * The returned store must be deleted with #wasmtime_store_delete.
  */
-WASM_API_EXTERN wasmtime_store_t* wasmtime_store_new(
-    wasm_engine_t* engine,
-    void* data,
-    void (*finalizer)(void*));
+WASM_API_EXTERN wasmtime_store_t *wasmtime_store_new(wasm_engine_t *engine,
+                                                     void *data,
+                                                     void (*finalizer)(void *));
 
 /**
  * \brief Returns the interior #wasmtime_context_t pointer to this store
  */
-WASM_API_EXTERN wasmtime_context_t* wasmtime_store_context(wasmtime_store_t* store);
+WASM_API_EXTERN wasmtime_context_t *
+wasmtime_store_context(wasmtime_store_t *store);
 
 /**
  * \brief Provides limits for a store. Used by hosts to limit resource
@@ -107,23 +107,22 @@ WASM_API_EXTERN wasmtime_context_t* wasmtime_store_context(wasmtime_store_t* sto
  * resources in the future, this does not retroactively attempt to apply
  * limits to the store.
  */
-WASM_API_EXTERN void wasmtime_store_limiter(
-    wasmtime_store_t* store,
-    int64_t memory_size,
-    int64_t table_elements,
-    int64_t instances,
-    int64_t tables,
-    int64_t memories);
+WASM_API_EXTERN void wasmtime_store_limiter(wasmtime_store_t *store,
+                                            int64_t memory_size,
+                                            int64_t table_elements,
+                                            int64_t instances, int64_t tables,
+                                            int64_t memories);
 
 /**
  * \brief Deletes a store.
  */
-WASM_API_EXTERN void wasmtime_store_delete(wasmtime_store_t* store);
+WASM_API_EXTERN void wasmtime_store_delete(wasmtime_store_t *store);
 
 /**
  * \brief Returns the user-specified data associated with the specified store
  */
-WASM_API_EXTERN void* wasmtime_context_get_data(const wasmtime_context_t* context);
+WASM_API_EXTERN void *
+wasmtime_context_get_data(const wasmtime_context_t *context);
 
 /**
  * \brief Overwrites the user-specified data associated with this store.
@@ -132,7 +131,8 @@ WASM_API_EXTERN void* wasmtime_context_get_data(const wasmtime_context_t* contex
  * and the original finalizer will be executed for the provided data when the
  * store is deleted.
  */
-WASM_API_EXTERN void wasmtime_context_set_data(wasmtime_context_t* context, void* data);
+WASM_API_EXTERN void wasmtime_context_set_data(wasmtime_context_t *context,
+                                               void *data);
 
 /**
  * \brief Perform garbage collection within the given context.
@@ -143,7 +143,7 @@ WASM_API_EXTERN void wasmtime_context_set_data(wasmtime_context_t* context, void
  *
  * The `context` argument must not be NULL.
  */
-WASM_API_EXTERN void wasmtime_context_gc(wasmtime_context_t* context);
+WASM_API_EXTERN void wasmtime_context_gc(wasmtime_context_t *context);
 
 /**
  * \brief Set fuel to this context's store for wasm to consume while executing.
@@ -159,7 +159,8 @@ WASM_API_EXTERN void wasmtime_context_gc(wasmtime_context_t* context);
  * If fuel is not enabled within this store then an error is returned. If fuel
  * is successfully added then NULL is returned.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_context_set_fuel(wasmtime_context_t* store, uint64_t fuel);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_context_set_fuel(wasmtime_context_t *store, uint64_t fuel);
 
 /**
  * \brief Returns the amount of fuel remaining in this context's store.
@@ -171,7 +172,8 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_context_set_fuel(wasmtime_context_t* 
  * Also note that fuel, if enabled, must be originally configured via
  * #wasmtime_context_set_fuel.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_context_get_fuel(const wasmtime_context_t* context, uint64_t* fuel);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_context_get_fuel(const wasmtime_context_t *context, uint64_t *fuel);
 
 /**
  * \brief Configures WASI state within the specified store.
@@ -184,7 +186,8 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_context_get_fuel(const wasmtime_conte
  * of `wasi`. The caller should no longer use `wasi` after calling this function
  * (even if an error is returned).
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_context_set_wasi(wasmtime_context_t* context, wasi_config_t* wasi);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_context_set_wasi(wasmtime_context_t *context, wasi_config_t *wasi);
 
 /**
  * \brief Configures the relative deadline at which point WebAssembly code will
@@ -196,7 +199,9 @@ WASM_API_EXTERN wasmtime_error_t* wasmtime_context_set_wasi(wasmtime_context_t* 
  * See also #wasmtime_config_epoch_interruption_set and
  * #wasmtime_store_epoch_deadline_callback.
  */
-WASM_API_EXTERN void wasmtime_context_set_epoch_deadline(wasmtime_context_t* context, uint64_t ticks_beyond_current);
+WASM_API_EXTERN void
+wasmtime_context_set_epoch_deadline(wasmtime_context_t *context,
+                                    uint64_t ticks_beyond_current);
 
 /// \brief An enum for the behavior before extending the epoch deadline.
 typedef uint8_t wasmtime_update_deadline_kind_t;
@@ -226,14 +231,11 @@ typedef uint8_t wasmtime_update_deadline_kind_t;
  * #wasmtime_context_set_epoch_deadline.
  */
 WASM_API_EXTERN void wasmtime_store_epoch_deadline_callback(
-    wasmtime_store_t* store,
-    wasmtime_error_t* (*func)(
-        wasmtime_context_t* context,
-        void* data,
-        uint64_t* epoch_deadline_delta,
-        wasmtime_update_deadline_kind_t* update_kind),
-    void* data,
-    void (*finalizer)(void*));
+    wasmtime_store_t *store,
+    wasmtime_error_t *(*func)(wasmtime_context_t *context, void *data,
+                              uint64_t *epoch_deadline_delta,
+                              wasmtime_update_deadline_kind_t *update_kind),
+    void *data, void (*finalizer)(void *));
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/table.h
+++ b/crates/c-api/include/wasmtime/table.h
@@ -29,20 +29,19 @@ extern "C" {
  * ownership of returned error. This function may return an error if the `init`
  * value does not match `ty`, for example.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_table_new(
-    wasmtime_context_t* store,
-    const wasm_tabletype_t* ty,
-    const wasmtime_val_t* init,
-    wasmtime_table_t* table);
+WASM_API_EXTERN wasmtime_error_t *wasmtime_table_new(wasmtime_context_t *store,
+                                                     const wasm_tabletype_t *ty,
+                                                     const wasmtime_val_t *init,
+                                                     wasmtime_table_t *table);
 
 /**
  * \brief Returns the type of this table.
  *
  * The caller has ownership of the returned #wasm_tabletype_t
  */
-WASM_API_EXTERN wasm_tabletype_t* wasmtime_table_type(
-    const wasmtime_context_t* store,
-    const wasmtime_table_t* table);
+WASM_API_EXTERN wasm_tabletype_t *
+wasmtime_table_type(const wasmtime_context_t *store,
+                    const wasmtime_table_t *table);
 
 /**
  * \brief Gets a value in a table.
@@ -56,11 +55,9 @@ WASM_API_EXTERN wasm_tabletype_t* wasmtime_table_type(
  * returned then `val` is filled in and is owned by the caller. Otherwise zero
  * is returned because the `index` is out-of-bounds.
  */
-WASM_API_EXTERN bool wasmtime_table_get(
-    wasmtime_context_t* store,
-    const wasmtime_table_t* table,
-    uint32_t index,
-    wasmtime_val_t* val);
+WASM_API_EXTERN bool wasmtime_table_get(wasmtime_context_t *store,
+                                        const wasmtime_table_t *table,
+                                        uint32_t index, wasmtime_val_t *val);
 
 /**
  * \brief Sets a value in a table.
@@ -75,18 +72,15 @@ WASM_API_EXTERN bool wasmtime_table_get(
  * This function can fail if `value` has the wrong type for the table, or if
  * `index` is out of bounds.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_table_set(
-    wasmtime_context_t* store,
-    const wasmtime_table_t* table,
-    uint32_t index,
-    const wasmtime_val_t* value);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_table_set(wasmtime_context_t *store, const wasmtime_table_t *table,
+                   uint32_t index, const wasmtime_val_t *value);
 
 /**
  * \brief Returns the size, in elements, of the specified table
  */
-WASM_API_EXTERN uint32_t wasmtime_table_size(
-    const wasmtime_context_t* store,
-    const wasmtime_table_t* table);
+WASM_API_EXTERN uint32_t wasmtime_table_size(const wasmtime_context_t *store,
+                                             const wasmtime_table_t *table);
 
 /**
  * \brief Grows a table.
@@ -105,12 +99,10 @@ WASM_API_EXTERN uint32_t wasmtime_table_size(
  *
  * This function does not take ownership of any of its arguments.
  */
-WASM_API_EXTERN wasmtime_error_t* wasmtime_table_grow(
-    wasmtime_context_t* store,
-    const wasmtime_table_t* table,
-    uint32_t delta,
-    const wasmtime_val_t* init,
-    uint32_t* prev_size);
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_table_grow(wasmtime_context_t *store, const wasmtime_table_t *table,
+                    uint32_t delta, const wasmtime_val_t *init,
+                    uint32_t *prev_size);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/table.h
+++ b/crates/c-api/include/wasmtime/table.h
@@ -8,9 +8,9 @@
 #define WASMTIME_TABLE_H
 
 #include <wasm.h>
+#include <wasmtime/error.h>
 #include <wasmtime/extern.h>
 #include <wasmtime/store.h>
-#include <wasmtime/error.h>
 #include <wasmtime/val.h>
 
 #ifdef __cplusplus
@@ -29,12 +29,11 @@ extern "C" {
  * ownership of returned error. This function may return an error if the `init`
  * value does not match `ty`, for example.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_table_new(
-    wasmtime_context_t *store,
-    const wasm_tabletype_t *ty,
-    const wasmtime_val_t *init,
-    wasmtime_table_t *table
-);
+WASM_API_EXTERN wasmtime_error_t* wasmtime_table_new(
+    wasmtime_context_t* store,
+    const wasm_tabletype_t* ty,
+    const wasmtime_val_t* init,
+    wasmtime_table_t* table);
 
 /**
  * \brief Returns the type of this table.
@@ -42,9 +41,8 @@ WASM_API_EXTERN wasmtime_error_t *wasmtime_table_new(
  * The caller has ownership of the returned #wasm_tabletype_t
  */
 WASM_API_EXTERN wasm_tabletype_t* wasmtime_table_type(
-    const wasmtime_context_t *store,
-    const wasmtime_table_t *table
-);
+    const wasmtime_context_t* store,
+    const wasmtime_table_t* table);
 
 /**
  * \brief Gets a value in a table.
@@ -59,11 +57,10 @@ WASM_API_EXTERN wasm_tabletype_t* wasmtime_table_type(
  * is returned because the `index` is out-of-bounds.
  */
 WASM_API_EXTERN bool wasmtime_table_get(
-    wasmtime_context_t *store,
-    const wasmtime_table_t *table,
+    wasmtime_context_t* store,
+    const wasmtime_table_t* table,
     uint32_t index,
-    wasmtime_val_t *val
-);
+    wasmtime_val_t* val);
 
 /**
  * \brief Sets a value in a table.
@@ -78,20 +75,18 @@ WASM_API_EXTERN bool wasmtime_table_get(
  * This function can fail if `value` has the wrong type for the table, or if
  * `index` is out of bounds.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_table_set(
-    wasmtime_context_t *store,
-    const wasmtime_table_t *table,
+WASM_API_EXTERN wasmtime_error_t* wasmtime_table_set(
+    wasmtime_context_t* store,
+    const wasmtime_table_t* table,
     uint32_t index,
-    const wasmtime_val_t *value
-);
+    const wasmtime_val_t* value);
 
 /**
  * \brief Returns the size, in elements, of the specified table
  */
 WASM_API_EXTERN uint32_t wasmtime_table_size(
-    const wasmtime_context_t *store,
-    const wasmtime_table_t *table
-);
+    const wasmtime_context_t* store,
+    const wasmtime_table_t* table);
 
 /**
  * \brief Grows a table.
@@ -110,17 +105,15 @@ WASM_API_EXTERN uint32_t wasmtime_table_size(
  *
  * This function does not take ownership of any of its arguments.
  */
-WASM_API_EXTERN wasmtime_error_t *wasmtime_table_grow(
-    wasmtime_context_t *store,
-    const wasmtime_table_t *table,
+WASM_API_EXTERN wasmtime_error_t* wasmtime_table_grow(
+    wasmtime_context_t* store,
+    const wasmtime_table_t* table,
     uint32_t delta,
-    const wasmtime_val_t *init,
-    uint32_t *prev_size
-);
+    const wasmtime_val_t* init,
+    uint32_t* prev_size);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_TABLE_H
-

--- a/crates/c-api/include/wasmtime/trap.h
+++ b/crates/c-api/include/wasmtime/trap.h
@@ -24,30 +24,31 @@ typedef uint8_t wasmtime_trap_code_t;
  * \brief Trap codes for instruction traps.
  */
 enum wasmtime_trap_code_enum {
-    /// The current stack space was exhausted.
-    WASMTIME_TRAP_CODE_STACK_OVERFLOW,
-    /// An out-of-bounds memory access.
-    WASMTIME_TRAP_CODE_MEMORY_OUT_OF_BOUNDS,
-    /// A wasm atomic operation was presented with a not-naturally-aligned linear-memory address.
-    WASMTIME_TRAP_CODE_HEAP_MISALIGNED,
-    /// An out-of-bounds access to a table.
-    WASMTIME_TRAP_CODE_TABLE_OUT_OF_BOUNDS,
-    /// Indirect call to a null table entry.
-    WASMTIME_TRAP_CODE_INDIRECT_CALL_TO_NULL,
-    /// Signature mismatch on indirect call.
-    WASMTIME_TRAP_CODE_BAD_SIGNATURE,
-    /// An integer arithmetic operation caused an overflow.
-    WASMTIME_TRAP_CODE_INTEGER_OVERFLOW,
-    /// An integer division by zero.
-    WASMTIME_TRAP_CODE_INTEGER_DIVISION_BY_ZERO,
-    /// Failed float-to-int conversion.
-    WASMTIME_TRAP_CODE_BAD_CONVERSION_TO_INTEGER,
-    /// Code that was supposed to have been unreachable was reached.
-    WASMTIME_TRAP_CODE_UNREACHABLE_CODE_REACHED,
-    /// Execution has potentially run too long and may be interrupted.
-    WASMTIME_TRAP_CODE_INTERRUPT,
-    /// Execution has run out of the configured fuel amount.
-    WASMTIME_TRAP_CODE_OUT_OF_FUEL,
+  /// The current stack space was exhausted.
+  WASMTIME_TRAP_CODE_STACK_OVERFLOW,
+  /// An out-of-bounds memory access.
+  WASMTIME_TRAP_CODE_MEMORY_OUT_OF_BOUNDS,
+  /// A wasm atomic operation was presented with a not-naturally-aligned
+  /// linear-memory address.
+  WASMTIME_TRAP_CODE_HEAP_MISALIGNED,
+  /// An out-of-bounds access to a table.
+  WASMTIME_TRAP_CODE_TABLE_OUT_OF_BOUNDS,
+  /// Indirect call to a null table entry.
+  WASMTIME_TRAP_CODE_INDIRECT_CALL_TO_NULL,
+  /// Signature mismatch on indirect call.
+  WASMTIME_TRAP_CODE_BAD_SIGNATURE,
+  /// An integer arithmetic operation caused an overflow.
+  WASMTIME_TRAP_CODE_INTEGER_OVERFLOW,
+  /// An integer division by zero.
+  WASMTIME_TRAP_CODE_INTEGER_DIVISION_BY_ZERO,
+  /// Failed float-to-int conversion.
+  WASMTIME_TRAP_CODE_BAD_CONVERSION_TO_INTEGER,
+  /// Code that was supposed to have been unreachable was reached.
+  WASMTIME_TRAP_CODE_UNREACHABLE_CODE_REACHED,
+  /// Execution has potentially run too long and may be interrupted.
+  WASMTIME_TRAP_CODE_INTERRUPT,
+  /// Execution has run out of the configured fuel amount.
+  WASMTIME_TRAP_CODE_OUT_OF_FUEL,
 };
 
 /**
@@ -58,7 +59,7 @@ enum wasmtime_trap_code_enum {
  *
  * The #wasm_trap_t returned is owned by the caller.
  */
-WASM_API_EXTERN wasm_trap_t* wasmtime_trap_new(const char* msg, size_t msg_len);
+WASM_API_EXTERN wasm_trap_t *wasmtime_trap_new(const char *msg, size_t msg_len);
 
 /**
  * \brief Attempts to extract the trap code from this trap.
@@ -69,7 +70,8 @@ WASM_API_EXTERN wasm_trap_t* wasmtime_trap_new(const char* msg, size_t msg_len);
  * an instruction trap -- traps can also be created using wasm_trap_new,
  * or occur with WASI modules exiting with a certain exit code.
  */
-WASM_API_EXTERN bool wasmtime_trap_code(const wasm_trap_t*, wasmtime_trap_code_t* code);
+WASM_API_EXTERN bool wasmtime_trap_code(const wasm_trap_t *,
+                                        wasmtime_trap_code_t *code);
 
 /**
  * \brief Returns a human-readable name for this frame's function.
@@ -79,7 +81,8 @@ WASM_API_EXTERN bool wasmtime_trap_code(const wasm_trap_t*, wasmtime_trap_code_t
  *
  * The lifetime of the returned name is the same as the #wasm_frame_t itself.
  */
-WASM_API_EXTERN const wasm_name_t* wasmtime_frame_func_name(const wasm_frame_t*);
+WASM_API_EXTERN const wasm_name_t *
+wasmtime_frame_func_name(const wasm_frame_t *);
 
 /**
  * \brief Returns a human-readable name for this frame's module.
@@ -89,7 +92,8 @@ WASM_API_EXTERN const wasm_name_t* wasmtime_frame_func_name(const wasm_frame_t*)
  *
  * The lifetime of the returned name is the same as the #wasm_frame_t itself.
  */
-WASM_API_EXTERN const wasm_name_t* wasmtime_frame_module_name(const wasm_frame_t*);
+WASM_API_EXTERN const wasm_name_t *
+wasmtime_frame_module_name(const wasm_frame_t *);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/trap.h
+++ b/crates/c-api/include/wasmtime/trap.h
@@ -24,30 +24,30 @@ typedef uint8_t wasmtime_trap_code_t;
  * \brief Trap codes for instruction traps.
  */
 enum wasmtime_trap_code_enum {
-  /// The current stack space was exhausted.
-  WASMTIME_TRAP_CODE_STACK_OVERFLOW,
-  /// An out-of-bounds memory access.
-  WASMTIME_TRAP_CODE_MEMORY_OUT_OF_BOUNDS,
-  /// A wasm atomic operation was presented with a not-naturally-aligned linear-memory address.
-  WASMTIME_TRAP_CODE_HEAP_MISALIGNED,
-  /// An out-of-bounds access to a table.
-  WASMTIME_TRAP_CODE_TABLE_OUT_OF_BOUNDS,
-  /// Indirect call to a null table entry.
-  WASMTIME_TRAP_CODE_INDIRECT_CALL_TO_NULL,
-  /// Signature mismatch on indirect call.
-  WASMTIME_TRAP_CODE_BAD_SIGNATURE,
-  /// An integer arithmetic operation caused an overflow.
-  WASMTIME_TRAP_CODE_INTEGER_OVERFLOW,
-  /// An integer division by zero.
-  WASMTIME_TRAP_CODE_INTEGER_DIVISION_BY_ZERO,
-  /// Failed float-to-int conversion.
-  WASMTIME_TRAP_CODE_BAD_CONVERSION_TO_INTEGER,
-  /// Code that was supposed to have been unreachable was reached.
-  WASMTIME_TRAP_CODE_UNREACHABLE_CODE_REACHED,
-  /// Execution has potentially run too long and may be interrupted.
-  WASMTIME_TRAP_CODE_INTERRUPT,
-  /// Execution has run out of the configured fuel amount.
-  WASMTIME_TRAP_CODE_OUT_OF_FUEL,
+    /// The current stack space was exhausted.
+    WASMTIME_TRAP_CODE_STACK_OVERFLOW,
+    /// An out-of-bounds memory access.
+    WASMTIME_TRAP_CODE_MEMORY_OUT_OF_BOUNDS,
+    /// A wasm atomic operation was presented with a not-naturally-aligned linear-memory address.
+    WASMTIME_TRAP_CODE_HEAP_MISALIGNED,
+    /// An out-of-bounds access to a table.
+    WASMTIME_TRAP_CODE_TABLE_OUT_OF_BOUNDS,
+    /// Indirect call to a null table entry.
+    WASMTIME_TRAP_CODE_INDIRECT_CALL_TO_NULL,
+    /// Signature mismatch on indirect call.
+    WASMTIME_TRAP_CODE_BAD_SIGNATURE,
+    /// An integer arithmetic operation caused an overflow.
+    WASMTIME_TRAP_CODE_INTEGER_OVERFLOW,
+    /// An integer division by zero.
+    WASMTIME_TRAP_CODE_INTEGER_DIVISION_BY_ZERO,
+    /// Failed float-to-int conversion.
+    WASMTIME_TRAP_CODE_BAD_CONVERSION_TO_INTEGER,
+    /// Code that was supposed to have been unreachable was reached.
+    WASMTIME_TRAP_CODE_UNREACHABLE_CODE_REACHED,
+    /// Execution has potentially run too long and may be interrupted.
+    WASMTIME_TRAP_CODE_INTERRUPT,
+    /// Execution has run out of the configured fuel amount.
+    WASMTIME_TRAP_CODE_OUT_OF_FUEL,
 };
 
 /**
@@ -58,7 +58,7 @@ enum wasmtime_trap_code_enum {
  *
  * The #wasm_trap_t returned is owned by the caller.
  */
-WASM_API_EXTERN wasm_trap_t *wasmtime_trap_new(const char *msg, size_t msg_len);
+WASM_API_EXTERN wasm_trap_t* wasmtime_trap_new(const char* msg, size_t msg_len);
 
 /**
  * \brief Attempts to extract the trap code from this trap.
@@ -69,7 +69,7 @@ WASM_API_EXTERN wasm_trap_t *wasmtime_trap_new(const char *msg, size_t msg_len);
  * an instruction trap -- traps can also be created using wasm_trap_new,
  * or occur with WASI modules exiting with a certain exit code.
  */
-WASM_API_EXTERN bool wasmtime_trap_code(const wasm_trap_t*, wasmtime_trap_code_t *code);
+WASM_API_EXTERN bool wasmtime_trap_code(const wasm_trap_t*, wasmtime_trap_code_t* code);
 
 /**
  * \brief Returns a human-readable name for this frame's function.
@@ -79,7 +79,7 @@ WASM_API_EXTERN bool wasmtime_trap_code(const wasm_trap_t*, wasmtime_trap_code_t
  *
  * The lifetime of the returned name is the same as the #wasm_frame_t itself.
  */
-WASM_API_EXTERN const wasm_name_t *wasmtime_frame_func_name(const wasm_frame_t*);
+WASM_API_EXTERN const wasm_name_t* wasmtime_frame_func_name(const wasm_frame_t*);
 
 /**
  * \brief Returns a human-readable name for this frame's module.
@@ -89,11 +89,10 @@ WASM_API_EXTERN const wasm_name_t *wasmtime_frame_func_name(const wasm_frame_t*)
  *
  * The lifetime of the returned name is the same as the #wasm_frame_t itself.
  */
-WASM_API_EXTERN const wasm_name_t *wasmtime_frame_module_name(const wasm_frame_t*);
-
+WASM_API_EXTERN const wasm_name_t* wasmtime_frame_module_name(const wasm_frame_t*);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_TRAP_H

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -41,7 +41,8 @@ typedef struct wasmtime_externref wasmtime_externref_t;
  *
  * The returned value must be deleted with #wasmtime_externref_delete
  */
-WASM_API_EXTERN wasmtime_externref_t* wasmtime_externref_new(void* data, void (*finalizer)(void*));
+WASM_API_EXTERN wasmtime_externref_t *
+wasmtime_externref_new(void *data, void (*finalizer)(void *));
 
 /**
  * \brief Get an `externref`'s wrapped data
@@ -49,19 +50,20 @@ WASM_API_EXTERN wasmtime_externref_t* wasmtime_externref_new(void* data, void (*
  * Returns the original `data` passed to #wasmtime_externref_new. It is required
  * that `data` is not `NULL`.
  */
-WASM_API_EXTERN void* wasmtime_externref_data(wasmtime_externref_t* data);
+WASM_API_EXTERN void *wasmtime_externref_data(wasmtime_externref_t *data);
 
 /**
  * \brief Creates a shallow copy of the `externref` argument, returning a
  * separately owned pointer (increases the reference count).
  */
-WASM_API_EXTERN wasmtime_externref_t* wasmtime_externref_clone(wasmtime_externref_t* ref);
+WASM_API_EXTERN wasmtime_externref_t *
+wasmtime_externref_clone(wasmtime_externref_t *ref);
 
 /**
  * \brief Decrements the reference count of the `ref`, deleting it if it's the
  * last reference.
  */
-WASM_API_EXTERN void wasmtime_externref_delete(wasmtime_externref_t* ref);
+WASM_API_EXTERN void wasmtime_externref_delete(wasmtime_externref_t *ref);
 
 /**
  * \brief Converts a raw `externref` value coming from #wasmtime_val_raw_t into
@@ -70,7 +72,8 @@ WASM_API_EXTERN void wasmtime_externref_delete(wasmtime_externref_t* ref);
  * Note that the returned #wasmtime_externref_t is an owned value that must be
  * deleted via #wasmtime_externref_delete by the caller if it is non-null.
  */
-WASM_API_EXTERN wasmtime_externref_t* wasmtime_externref_from_raw(wasmtime_context_t* context, void* raw);
+WASM_API_EXTERN wasmtime_externref_t *
+wasmtime_externref_from_raw(wasmtime_context_t *context, void *raw);
 
 /**
  * \brief Converts a #wasmtime_externref_t to a raw value suitable for storing
@@ -82,9 +85,9 @@ WASM_API_EXTERN wasmtime_externref_t* wasmtime_externref_from_raw(wasmtime_conte
  * context of the store. Do not perform a GC between calling this function and
  * passing it to WebAssembly.
  */
-WASM_API_EXTERN void* wasmtime_externref_to_raw(
-    wasmtime_context_t* context,
-    const wasmtime_externref_t* ref);
+WASM_API_EXTERN void *
+wasmtime_externref_to_raw(wasmtime_context_t *context,
+                          const wasmtime_externref_t *ref);
 
 /// \brief Discriminant stored in #wasmtime_val::kind
 typedef uint8_t wasmtime_valkind_t;
@@ -98,9 +101,11 @@ typedef uint8_t wasmtime_valkind_t;
 #define WASMTIME_F64 3
 /// \brief Value of #wasmtime_valkind_t meaning that #wasmtime_val_t is a v128
 #define WASMTIME_V128 4
-/// \brief Value of #wasmtime_valkind_t meaning that #wasmtime_val_t is a funcref
+/// \brief Value of #wasmtime_valkind_t meaning that #wasmtime_val_t is a
+/// funcref
 #define WASMTIME_FUNCREF 5
-/// \brief Value of #wasmtime_valkind_t meaning that #wasmtime_val_t is an externref
+/// \brief Value of #wasmtime_valkind_t meaning that #wasmtime_val_t is an
+/// externref
 #define WASMTIME_EXTERNREF 6
 
 /// \brief A 128-bit value representing the WebAssembly `v128` type. Bytes are
@@ -118,26 +123,26 @@ typedef uint8_t wasmtime_v128[16];
  * various kinds of items a value can be.
  */
 typedef union wasmtime_valunion {
-    /// Field used if #wasmtime_val_t::kind is #WASMTIME_I32
-    int32_t i32;
-    /// Field used if #wasmtime_val_t::kind is #WASMTIME_I64
-    int64_t i64;
-    /// Field used if #wasmtime_val_t::kind is #WASMTIME_F32
-    float32_t f32;
-    /// Field used if #wasmtime_val_t::kind is #WASMTIME_F64
-    float64_t f64;
-    /// Field used if #wasmtime_val_t::kind is #WASMTIME_FUNCREF
-    ///
-    /// If this value represents a `ref.null func` value then the `store_id` field
-    /// is set to zero.
-    wasmtime_func_t funcref;
-    /// Field used if #wasmtime_val_t::kind is #WASMTIME_EXTERNREF
-    ///
-    /// If this value represents a `ref.null extern` value then this pointer will
-    /// be `NULL`.
-    wasmtime_externref_t* externref;
-    /// Field used if #wasmtime_val_t::kind is #WASMTIME_V128
-    wasmtime_v128 v128;
+  /// Field used if #wasmtime_val_t::kind is #WASMTIME_I32
+  int32_t i32;
+  /// Field used if #wasmtime_val_t::kind is #WASMTIME_I64
+  int64_t i64;
+  /// Field used if #wasmtime_val_t::kind is #WASMTIME_F32
+  float32_t f32;
+  /// Field used if #wasmtime_val_t::kind is #WASMTIME_F64
+  float64_t f64;
+  /// Field used if #wasmtime_val_t::kind is #WASMTIME_FUNCREF
+  ///
+  /// If this value represents a `ref.null func` value then the `store_id` field
+  /// is set to zero.
+  wasmtime_func_t funcref;
+  /// Field used if #wasmtime_val_t::kind is #WASMTIME_EXTERNREF
+  ///
+  /// If this value represents a `ref.null extern` value then this pointer will
+  /// be `NULL`.
+  wasmtime_externref_t *externref;
+  /// Field used if #wasmtime_val_t::kind is #WASMTIME_V128
+  wasmtime_v128 v128;
 } wasmtime_valunion_t;
 
 /**
@@ -154,41 +159,41 @@ typedef union wasmtime_valunion {
  * to determine the type.
  */
 typedef union wasmtime_val_raw {
-    /// Field for when this val is a WebAssembly `i32` value.
-    ///
-    /// Note that this field is always stored in a little-endian format.
-    int32_t i32;
-    /// Field for when this val is a WebAssembly `i64` value.
-    ///
-    /// Note that this field is always stored in a little-endian format.
-    int64_t i64;
-    /// Field for when this val is a WebAssembly `f32` value.
-    ///
-    /// Note that this field is always stored in a little-endian format.
-    float32_t f32;
-    /// Field for when this val is a WebAssembly `f64` value.
-    ///
-    /// Note that this field is always stored in a little-endian format.
-    float64_t f64;
-    /// Field for when this val is a WebAssembly `v128` value.
-    ///
-    /// Note that this field is always stored in a little-endian format.
-    wasmtime_v128 v128;
-    /// Field for when this val is a WebAssembly `funcref` value.
-    ///
-    /// If this is set to 0 then it's a null funcref, otherwise this must be
-    /// passed to `wasmtime_func_from_raw` to determine the `wasmtime_func_t`.
-    ///
-    /// Note that this field is always stored in a little-endian format.
-    void* funcref;
-    /// Field for when this val is a WebAssembly `externref` value.
-    ///
-    /// If this is set to 0 then it's a null externref, otherwise this must be
-    /// passed to `wasmtime_externref_from_raw` to determine the
-    /// `wasmtime_externref_t`.
-    ///
-    /// Note that this field is always stored in a little-endian format.
-    void* externref;
+  /// Field for when this val is a WebAssembly `i32` value.
+  ///
+  /// Note that this field is always stored in a little-endian format.
+  int32_t i32;
+  /// Field for when this val is a WebAssembly `i64` value.
+  ///
+  /// Note that this field is always stored in a little-endian format.
+  int64_t i64;
+  /// Field for when this val is a WebAssembly `f32` value.
+  ///
+  /// Note that this field is always stored in a little-endian format.
+  float32_t f32;
+  /// Field for when this val is a WebAssembly `f64` value.
+  ///
+  /// Note that this field is always stored in a little-endian format.
+  float64_t f64;
+  /// Field for when this val is a WebAssembly `v128` value.
+  ///
+  /// Note that this field is always stored in a little-endian format.
+  wasmtime_v128 v128;
+  /// Field for when this val is a WebAssembly `funcref` value.
+  ///
+  /// If this is set to 0 then it's a null funcref, otherwise this must be
+  /// passed to `wasmtime_func_from_raw` to determine the `wasmtime_func_t`.
+  ///
+  /// Note that this field is always stored in a little-endian format.
+  void *funcref;
+  /// Field for when this val is a WebAssembly `externref` value.
+  ///
+  /// If this is set to 0 then it's a null externref, otherwise this must be
+  /// passed to `wasmtime_externref_from_raw` to determine the
+  /// `wasmtime_externref_t`.
+  ///
+  /// Note that this field is always stored in a little-endian format.
+  void *externref;
 } wasmtime_val_raw_t;
 
 /**
@@ -205,10 +210,10 @@ typedef union wasmtime_val_raw {
  * the value.
  */
 typedef struct wasmtime_val {
-    /// Discriminant of which field of #of is valid.
-    wasmtime_valkind_t kind;
-    /// Container for the extern item's value.
-    wasmtime_valunion_t of;
+  /// Discriminant of which field of #of is valid.
+  wasmtime_valkind_t kind;
+  /// Container for the extern item's value.
+  wasmtime_valunion_t of;
 } wasmtime_val_t;
 
 /**
@@ -217,12 +222,13 @@ typedef struct wasmtime_val {
  * Note that this only deletes the contents, not the memory that `val` points to
  * itself (which is owned by the caller).
  */
-WASM_API_EXTERN void wasmtime_val_delete(wasmtime_val_t* val);
+WASM_API_EXTERN void wasmtime_val_delete(wasmtime_val_t *val);
 
 /**
  * \brief Copies `src` into `dst`.
  */
-WASM_API_EXTERN void wasmtime_val_copy(wasmtime_val_t* dst, const wasmtime_val_t* src);
+WASM_API_EXTERN void wasmtime_val_copy(wasmtime_val_t *dst,
+                                       const wasmtime_val_t *src);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -41,7 +41,7 @@ typedef struct wasmtime_externref wasmtime_externref_t;
  *
  * The returned value must be deleted with #wasmtime_externref_delete
  */
-WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_new(void *data, void (*finalizer)(void*));
+WASM_API_EXTERN wasmtime_externref_t* wasmtime_externref_new(void* data, void (*finalizer)(void*));
 
 /**
  * \brief Get an `externref`'s wrapped data
@@ -49,19 +49,19 @@ WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_new(void *data, void (*
  * Returns the original `data` passed to #wasmtime_externref_new. It is required
  * that `data` is not `NULL`.
  */
-WASM_API_EXTERN void *wasmtime_externref_data(wasmtime_externref_t *data);
+WASM_API_EXTERN void* wasmtime_externref_data(wasmtime_externref_t* data);
 
 /**
  * \brief Creates a shallow copy of the `externref` argument, returning a
  * separately owned pointer (increases the reference count).
  */
-WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_clone(wasmtime_externref_t *ref);
+WASM_API_EXTERN wasmtime_externref_t* wasmtime_externref_clone(wasmtime_externref_t* ref);
 
 /**
  * \brief Decrements the reference count of the `ref`, deleting it if it's the
  * last reference.
  */
-WASM_API_EXTERN void wasmtime_externref_delete(wasmtime_externref_t *ref);
+WASM_API_EXTERN void wasmtime_externref_delete(wasmtime_externref_t* ref);
 
 /**
  * \brief Converts a raw `externref` value coming from #wasmtime_val_raw_t into
@@ -70,7 +70,7 @@ WASM_API_EXTERN void wasmtime_externref_delete(wasmtime_externref_t *ref);
  * Note that the returned #wasmtime_externref_t is an owned value that must be
  * deleted via #wasmtime_externref_delete by the caller if it is non-null.
  */
-WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_from_raw(wasmtime_context_t *context, void *raw);
+WASM_API_EXTERN wasmtime_externref_t* wasmtime_externref_from_raw(wasmtime_context_t* context, void* raw);
 
 /**
  * \brief Converts a #wasmtime_externref_t to a raw value suitable for storing
@@ -82,9 +82,9 @@ WASM_API_EXTERN wasmtime_externref_t *wasmtime_externref_from_raw(wasmtime_conte
  * context of the store. Do not perform a GC between calling this function and
  * passing it to WebAssembly.
  */
-WASM_API_EXTERN void *wasmtime_externref_to_raw(
-    wasmtime_context_t *context,
-    const wasmtime_externref_t *ref);
+WASM_API_EXTERN void* wasmtime_externref_to_raw(
+    wasmtime_context_t* context,
+    const wasmtime_externref_t* ref);
 
 /// \brief Discriminant stored in #wasmtime_val::kind
 typedef uint8_t wasmtime_valkind_t;
@@ -118,26 +118,26 @@ typedef uint8_t wasmtime_v128[16];
  * various kinds of items a value can be.
  */
 typedef union wasmtime_valunion {
-  /// Field used if #wasmtime_val_t::kind is #WASMTIME_I32
-  int32_t i32;
-  /// Field used if #wasmtime_val_t::kind is #WASMTIME_I64
-  int64_t i64;
-  /// Field used if #wasmtime_val_t::kind is #WASMTIME_F32
-  float32_t f32;
-  /// Field used if #wasmtime_val_t::kind is #WASMTIME_F64
-  float64_t f64;
-  /// Field used if #wasmtime_val_t::kind is #WASMTIME_FUNCREF
-  ///
-  /// If this value represents a `ref.null func` value then the `store_id` field
-  /// is set to zero.
-  wasmtime_func_t funcref;
-  /// Field used if #wasmtime_val_t::kind is #WASMTIME_EXTERNREF
-  ///
-  /// If this value represents a `ref.null extern` value then this pointer will
-  /// be `NULL`.
-  wasmtime_externref_t *externref;
-  /// Field used if #wasmtime_val_t::kind is #WASMTIME_V128
-  wasmtime_v128 v128;
+    /// Field used if #wasmtime_val_t::kind is #WASMTIME_I32
+    int32_t i32;
+    /// Field used if #wasmtime_val_t::kind is #WASMTIME_I64
+    int64_t i64;
+    /// Field used if #wasmtime_val_t::kind is #WASMTIME_F32
+    float32_t f32;
+    /// Field used if #wasmtime_val_t::kind is #WASMTIME_F64
+    float64_t f64;
+    /// Field used if #wasmtime_val_t::kind is #WASMTIME_FUNCREF
+    ///
+    /// If this value represents a `ref.null func` value then the `store_id` field
+    /// is set to zero.
+    wasmtime_func_t funcref;
+    /// Field used if #wasmtime_val_t::kind is #WASMTIME_EXTERNREF
+    ///
+    /// If this value represents a `ref.null extern` value then this pointer will
+    /// be `NULL`.
+    wasmtime_externref_t* externref;
+    /// Field used if #wasmtime_val_t::kind is #WASMTIME_V128
+    wasmtime_v128 v128;
 } wasmtime_valunion_t;
 
 /**
@@ -154,41 +154,41 @@ typedef union wasmtime_valunion {
  * to determine the type.
  */
 typedef union wasmtime_val_raw {
-  /// Field for when this val is a WebAssembly `i32` value.
-  ///
-  /// Note that this field is always stored in a little-endian format.
-  int32_t i32;
-  /// Field for when this val is a WebAssembly `i64` value.
-  ///
-  /// Note that this field is always stored in a little-endian format.
-  int64_t i64;
-  /// Field for when this val is a WebAssembly `f32` value.
-  ///
-  /// Note that this field is always stored in a little-endian format.
-  float32_t f32;
-  /// Field for when this val is a WebAssembly `f64` value.
-  ///
-  /// Note that this field is always stored in a little-endian format.
-  float64_t f64;
-  /// Field for when this val is a WebAssembly `v128` value.
-  ///
-  /// Note that this field is always stored in a little-endian format.
-  wasmtime_v128 v128;
-  /// Field for when this val is a WebAssembly `funcref` value.
-  ///
-  /// If this is set to 0 then it's a null funcref, otherwise this must be
-  /// passed to `wasmtime_func_from_raw` to determine the `wasmtime_func_t`.
-  ///
-  /// Note that this field is always stored in a little-endian format.
-  void *funcref;
-  /// Field for when this val is a WebAssembly `externref` value.
-  ///
-  /// If this is set to 0 then it's a null externref, otherwise this must be
-  /// passed to `wasmtime_externref_from_raw` to determine the
-  /// `wasmtime_externref_t`.
-  ///
-  /// Note that this field is always stored in a little-endian format.
-  void *externref;
+    /// Field for when this val is a WebAssembly `i32` value.
+    ///
+    /// Note that this field is always stored in a little-endian format.
+    int32_t i32;
+    /// Field for when this val is a WebAssembly `i64` value.
+    ///
+    /// Note that this field is always stored in a little-endian format.
+    int64_t i64;
+    /// Field for when this val is a WebAssembly `f32` value.
+    ///
+    /// Note that this field is always stored in a little-endian format.
+    float32_t f32;
+    /// Field for when this val is a WebAssembly `f64` value.
+    ///
+    /// Note that this field is always stored in a little-endian format.
+    float64_t f64;
+    /// Field for when this val is a WebAssembly `v128` value.
+    ///
+    /// Note that this field is always stored in a little-endian format.
+    wasmtime_v128 v128;
+    /// Field for when this val is a WebAssembly `funcref` value.
+    ///
+    /// If this is set to 0 then it's a null funcref, otherwise this must be
+    /// passed to `wasmtime_func_from_raw` to determine the `wasmtime_func_t`.
+    ///
+    /// Note that this field is always stored in a little-endian format.
+    void* funcref;
+    /// Field for when this val is a WebAssembly `externref` value.
+    ///
+    /// If this is set to 0 then it's a null externref, otherwise this must be
+    /// passed to `wasmtime_externref_from_raw` to determine the
+    /// `wasmtime_externref_t`.
+    ///
+    /// Note that this field is always stored in a little-endian format.
+    void* externref;
 } wasmtime_val_raw_t;
 
 /**
@@ -205,10 +205,10 @@ typedef union wasmtime_val_raw {
  * the value.
  */
 typedef struct wasmtime_val {
-  /// Discriminant of which field of #of is valid.
-  wasmtime_valkind_t kind;
-  /// Container for the extern item's value.
-  wasmtime_valunion_t of;
+    /// Discriminant of which field of #of is valid.
+    wasmtime_valkind_t kind;
+    /// Container for the extern item's value.
+    wasmtime_valunion_t of;
 } wasmtime_val_t;
 
 /**
@@ -217,16 +217,15 @@ typedef struct wasmtime_val {
  * Note that this only deletes the contents, not the memory that `val` points to
  * itself (which is owned by the caller).
  */
-WASM_API_EXTERN void wasmtime_val_delete(wasmtime_val_t *val);
+WASM_API_EXTERN void wasmtime_val_delete(wasmtime_val_t* val);
 
 /**
  * \brief Copies `src` into `dst`.
  */
-WASM_API_EXTERN void wasmtime_val_copy(wasmtime_val_t *dst, const wasmtime_val_t *src);
+WASM_API_EXTERN void wasmtime_val_copy(wasmtime_val_t* dst, const wasmtime_val_t* src);
 
 #ifdef __cplusplus
-}  // extern "C"
+} // extern "C"
 #endif
 
 #endif // WASMTIME_VAL_H
-

--- a/crates/fiber/src/windows.c
+++ b/crates/fiber/src/windows.c
@@ -4,7 +4,6 @@
 #define CONCAT(a, b) CONCAT2(a, b)
 #define VERSIONED_SYMBOL(a) CONCAT(a, VERSIONED_SUFFIX)
 
-LPVOID VERSIONED_SYMBOL(wasmtime_fiber_get_current)()
-{
-    return GetCurrentFiber();
+LPVOID VERSIONED_SYMBOL(wasmtime_fiber_get_current)() {
+  return GetCurrentFiber();
 }

--- a/crates/fiber/src/windows.c
+++ b/crates/fiber/src/windows.c
@@ -1,9 +1,10 @@
 #include <windows.h>
 
-#define CONCAT2(a, b) a ## b
-#define CONCAT(a, b) CONCAT2(a , b)
+#define CONCAT2(a, b) a##b
+#define CONCAT(a, b) CONCAT2(a, b)
 #define VERSIONED_SYMBOL(a) CONCAT(a, VERSIONED_SUFFIX)
 
-LPVOID VERSIONED_SYMBOL(wasmtime_fiber_get_current)() {
-   return GetCurrentFiber();
+LPVOID VERSIONED_SYMBOL(wasmtime_fiber_get_current)()
+{
+    return GetCurrentFiber();
 }

--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -30,7 +30,7 @@ typedef jmp_buf platform_jmp_buf;
 // [clang docs]: https://llvm.org/docs/ExceptionHandling.html#llvm-eh-sjlj-setjmp
 #define platform_setjmp(buf) __builtin_setjmp(buf)
 #define platform_longjmp(buf, arg) __builtin_longjmp(buf, arg)
-typedef void *platform_jmp_buf[5]; // this is the documented size; see the docs links for details.
+typedef void* platform_jmp_buf[5]; // this is the documented size; see the docs links for details.
 
 #else
 
@@ -46,67 +46,70 @@ typedef sigjmp_buf platform_jmp_buf;
 
 #endif
 
-#define CONCAT2(a, b) a ## b
-#define CONCAT(a, b) CONCAT2(a , b)
+#define CONCAT2(a, b) a##b
+#define CONCAT(a, b) CONCAT2(a, b)
 #define VERSIONED_SYMBOL(a) CONCAT(a, VERSIONED_SUFFIX)
 
 int VERSIONED_SYMBOL(wasmtime_setjmp)(
-    void **buf_storage,
+    void** buf_storage,
     void (*body)(void*, void*),
-    void *payload,
-    void *callee) {
-  platform_jmp_buf buf;
-  if (platform_setjmp(buf) != 0) {
-    return 0;
-  }
-  *buf_storage = &buf;
-  body(payload, callee);
-  return 1;
+    void* payload,
+    void* callee)
+{
+    platform_jmp_buf buf;
+    if (platform_setjmp(buf) != 0) {
+        return 0;
+    }
+    *buf_storage = &buf;
+    body(payload, callee);
+    return 1;
 }
 
-void VERSIONED_SYMBOL(wasmtime_longjmp)(void *JmpBuf) {
-  platform_jmp_buf *buf = (platform_jmp_buf*) JmpBuf;
-  platform_longjmp(*buf, 1);
+void VERSIONED_SYMBOL(wasmtime_longjmp)(void* JmpBuf)
+{
+    platform_jmp_buf* buf = (platform_jmp_buf*)JmpBuf;
+    platform_longjmp(*buf, 1);
 }
 
 #ifdef CFG_TARGET_OS_windows
-  // export required for external access.
+// export required for external access.
 __declspec(dllexport)
 #else
-  // Note the `weak` linkage here, though, which is intended to let other code
-  // override this symbol if it's defined elsewhere, since this definition doesn't
-  // matter.
-  // Just in case cross-language LTO is enabled we set the `noinline` attribute
-  // and also try to have some sort of side effect in this function with a dummy
-  // `asm` statement.
+// Note the `weak` linkage here, though, which is intended to let other code
+// override this symbol if it's defined elsewhere, since this definition doesn't
+// matter.
+// Just in case cross-language LTO is enabled we set the `noinline` attribute
+// and also try to have some sort of side effect in this function with a dummy
+// `asm` statement.
 __attribute__((weak, noinline))
 #endif
-void __jit_debug_register_code() {
+    void __jit_debug_register_code()
+{
 #ifndef CFG_TARGET_OS_windows
-  __asm__("");
+    __asm__("");
 #endif
 }
 
 struct JITDescriptor {
-  uint32_t version_;
-  uint32_t action_flag_;
-  void* relevant_entry_;
-  void* first_entry_;
+    uint32_t version_;
+    uint32_t action_flag_;
+    void* relevant_entry_;
+    void* first_entry_;
 };
 
 #ifdef CFG_TARGET_OS_windows
-  // export required for external access.
-  __declspec(dllexport)
+// export required for external access.
+__declspec(dllexport)
 #else
-  // Note the `weak` linkage here which is the same purpose as above. We want to
-  // let other runtimes be able to override this since our own definition isn't
-  // important.
-  __attribute__((weak))
+// Note the `weak` linkage here which is the same purpose as above. We want to
+// let other runtimes be able to override this since our own definition isn't
+// important.
+__attribute__((weak))
 #endif
-struct JITDescriptor __jit_debug_descriptor = {1, 0, NULL, NULL};
+    struct JITDescriptor __jit_debug_descriptor
+    = { 1, 0, NULL, NULL };
 
-
-
-struct JITDescriptor* VERSIONED_SYMBOL(wasmtime_jit_debug_descriptor)() {
-  return &__jit_debug_descriptor;
+struct JITDescriptor* VERSIONED_SYMBOL(wasmtime_jit_debug_descriptor)()
+{
+    return &__jit_debug_descriptor;
 }

--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -27,10 +27,12 @@ typedef jmp_buf platform_jmp_buf;
 // runtime) is assuming is callee-saved.
 //
 // [GCC docs]: https://gcc.gnu.org/onlinedocs/gcc/Nonlocal-Gotos.html
-// [clang docs]: https://llvm.org/docs/ExceptionHandling.html#llvm-eh-sjlj-setjmp
+// [clang docs]:
+// https://llvm.org/docs/ExceptionHandling.html#llvm-eh-sjlj-setjmp
 #define platform_setjmp(buf) __builtin_setjmp(buf)
 #define platform_longjmp(buf, arg) __builtin_longjmp(buf, arg)
-typedef void* platform_jmp_buf[5]; // this is the documented size; see the docs links for details.
+typedef void *platform_jmp_buf[5]; // this is the documented size; see the docs
+                                   // links for details.
 
 #else
 
@@ -50,25 +52,21 @@ typedef sigjmp_buf platform_jmp_buf;
 #define CONCAT(a, b) CONCAT2(a, b)
 #define VERSIONED_SYMBOL(a) CONCAT(a, VERSIONED_SUFFIX)
 
-int VERSIONED_SYMBOL(wasmtime_setjmp)(
-    void** buf_storage,
-    void (*body)(void*, void*),
-    void* payload,
-    void* callee)
-{
-    platform_jmp_buf buf;
-    if (platform_setjmp(buf) != 0) {
-        return 0;
-    }
-    *buf_storage = &buf;
-    body(payload, callee);
-    return 1;
+int VERSIONED_SYMBOL(wasmtime_setjmp)(void **buf_storage,
+                                      void (*body)(void *, void *),
+                                      void *payload, void *callee) {
+  platform_jmp_buf buf;
+  if (platform_setjmp(buf) != 0) {
+    return 0;
+  }
+  *buf_storage = &buf;
+  body(payload, callee);
+  return 1;
 }
 
-void VERSIONED_SYMBOL(wasmtime_longjmp)(void* JmpBuf)
-{
-    platform_jmp_buf* buf = (platform_jmp_buf*)JmpBuf;
-    platform_longjmp(*buf, 1);
+void VERSIONED_SYMBOL(wasmtime_longjmp)(void *JmpBuf) {
+  platform_jmp_buf *buf = (platform_jmp_buf *)JmpBuf;
+  platform_longjmp(*buf, 1);
 }
 
 #ifdef CFG_TARGET_OS_windows
@@ -83,18 +81,17 @@ __declspec(dllexport)
 // `asm` statement.
 __attribute__((weak, noinline))
 #endif
-    void __jit_debug_register_code()
-{
+    void __jit_debug_register_code() {
 #ifndef CFG_TARGET_OS_windows
-    __asm__("");
+  __asm__("");
 #endif
 }
 
 struct JITDescriptor {
-    uint32_t version_;
-    uint32_t action_flag_;
-    void* relevant_entry_;
-    void* first_entry_;
+  uint32_t version_;
+  uint32_t action_flag_;
+  void *relevant_entry_;
+  void *first_entry_;
 };
 
 #ifdef CFG_TARGET_OS_windows
@@ -106,10 +103,8 @@ __declspec(dllexport)
 // important.
 __attribute__((weak))
 #endif
-    struct JITDescriptor __jit_debug_descriptor
-    = { 1, 0, NULL, NULL };
+    struct JITDescriptor __jit_debug_descriptor = {1, 0, NULL, NULL};
 
-struct JITDescriptor* VERSIONED_SYMBOL(wasmtime_jit_debug_descriptor)()
-{
-    return &__jit_debug_descriptor;
+struct JITDescriptor *VERSIONED_SYMBOL(wasmtime_jit_debug_descriptor)() {
+  return &__jit_debug_descriptor;
 }

--- a/crates/runtime/src/helpers.c
+++ b/crates/runtime/src/helpers.c
@@ -15,6 +15,8 @@ typedef jmp_buf platform_jmp_buf;
 
 #elif defined(WASMTIME_GCC) || defined(__x86_64__)
 
+// clang-format off
+
 // GCC and Clang on x86_64 provide `__builtin_setjmp`/`__builtin_longjmp`, which
 // differ from plain `setjmp` and `longjmp` in that they're implemented by
 // the compiler inline rather than in libc, and the compiler can avoid saving
@@ -27,8 +29,9 @@ typedef jmp_buf platform_jmp_buf;
 // runtime) is assuming is callee-saved.
 //
 // [GCC docs]: https://gcc.gnu.org/onlinedocs/gcc/Nonlocal-Gotos.html
-// [clang docs]:
-// https://llvm.org/docs/ExceptionHandling.html#llvm-eh-sjlj-setjmp
+// [clang docs]: https://llvm.org/docs/ExceptionHandling.html#llvm-eh-sjlj-setjmp
+
+// clang-format on
 #define platform_setjmp(buf) __builtin_setjmp(buf)
 #define platform_longjmp(buf, arg) __builtin_longjmp(buf, arg)
 typedef void *platform_jmp_buf[5]; // this is the documented size; see the docs

--- a/examples/async.cpp
+++ b/examples/async.cpp
@@ -39,253 +39,261 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-async
 
 namespace {
 
-template <typename T, void (*fn)(T *)> struct deleter {
-  void operator()(T *ptr) { fn(ptr); }
+template <typename T, void (*fn)(T*)>
+struct deleter {
+    void operator()(T* ptr) { fn(ptr); }
 };
-template <typename T, void (*fn)(T *)>
+template <typename T, void (*fn)(T*)>
 using handle = std::unique_ptr<T, deleter<T, fn>>;
 
-void exit_with_error(std::string msg, wasmtime_error_t *err,
-                     wasm_trap_t *trap) {
-  std::cerr << "error: " << msg << std::endl;
-  wasm_byte_vec_t error_message;
-  if (err) {
-    wasmtime_error_message(err, &error_message);
-  } else {
-    wasm_trap_message(trap, &error_message);
-  }
-  std::cerr << std::string(error_message.data, error_message.size) << std::endl;
-  wasm_byte_vec_delete(&error_message);
-  std::exit(1);
+void exit_with_error(std::string msg, wasmtime_error_t* err,
+    wasm_trap_t* trap)
+{
+    std::cerr << "error: " << msg << std::endl;
+    wasm_byte_vec_t error_message;
+    if (err) {
+        wasmtime_error_message(err, &error_message);
+    } else {
+        wasm_trap_message(trap, &error_message);
+    }
+    std::cerr << std::string(error_message.data, error_message.size) << std::endl;
+    wasm_byte_vec_delete(&error_message);
+    std::exit(1);
 }
 
-handle<wasm_engine_t, wasm_engine_delete> create_engine() {
-  wasm_config_t *config = wasm_config_new();
-  assert(config != nullptr);
-  wasmtime_config_async_support_set(config, true);
-  wasmtime_config_consume_fuel_set(config, true);
-  handle<wasm_engine_t, wasm_engine_delete> engine;
-  // this takes ownership of config
-  engine.reset(wasm_engine_new_with_config(config));
-  assert(engine);
-  return engine;
+handle<wasm_engine_t, wasm_engine_delete> create_engine()
+{
+    wasm_config_t* config = wasm_config_new();
+    assert(config != nullptr);
+    wasmtime_config_async_support_set(config, true);
+    wasmtime_config_consume_fuel_set(config, true);
+    handle<wasm_engine_t, wasm_engine_delete> engine;
+    // this takes ownership of config
+    engine.reset(wasm_engine_new_with_config(config));
+    assert(engine);
+    return engine;
 }
 
 handle<wasmtime_store_t, wasmtime_store_delete>
-create_store(wasm_engine_t *engine) {
-  handle<wasmtime_store_t, wasmtime_store_delete> store;
-  store.reset(wasmtime_store_new(engine, nullptr, nullptr));
-  assert(store);
-  return store;
+create_store(wasm_engine_t* engine)
+{
+    handle<wasmtime_store_t, wasmtime_store_delete> store;
+    store.reset(wasmtime_store_new(engine, nullptr, nullptr));
+    assert(store);
+    return store;
 }
 
 handle<wasmtime_linker_t, wasmtime_linker_delete>
-create_linker(wasm_engine_t *engine) {
-  handle<wasmtime_linker_t, wasmtime_linker_delete> linker;
-  linker.reset(wasmtime_linker_new(engine));
-  assert(linker);
-  return linker;
+create_linker(wasm_engine_t* engine)
+{
+    handle<wasmtime_linker_t, wasmtime_linker_delete> linker;
+    linker.reset(wasmtime_linker_new(engine));
+    assert(linker);
+    return linker;
 }
 
 handle<wasmtime_module_t, wasmtime_module_delete>
-compile_wat_module_from_file(wasm_engine_t *engine,
-                             const std::string &filename) {
-  std::ifstream t(filename);
-  std::stringstream buffer;
-  buffer << t.rdbuf();
-  if (t.bad()) {
-    std::cerr << "error reading file: " << filename << std::endl;
-    std::exit(1);
-  }
-  const std::string &content = buffer.str();
-  wasm_byte_vec_t wasm_bytes;
-  handle<wasmtime_error_t, wasmtime_error_delete> error{
-      wasmtime_wat2wasm(content.data(), content.size(), &wasm_bytes)};
-  if (error) {
-    exit_with_error("failed to parse wat", error.get(), nullptr);
-  }
-  wasmtime_module_t *mod_ptr = nullptr;
-  error.reset(wasmtime_module_new(engine,
-                                  reinterpret_cast<uint8_t *>(wasm_bytes.data),
-                                  wasm_bytes.size, &mod_ptr));
-  wasm_byte_vec_delete(&wasm_bytes);
-  handle<wasmtime_module_t, wasmtime_module_delete> mod{mod_ptr};
-  if (!mod) {
-    exit_with_error("failed to compile module", error.get(), nullptr);
-  }
-  return mod;
+compile_wat_module_from_file(wasm_engine_t* engine,
+    const std::string& filename)
+{
+    std::ifstream t(filename);
+    std::stringstream buffer;
+    buffer << t.rdbuf();
+    if (t.bad()) {
+        std::cerr << "error reading file: " << filename << std::endl;
+        std::exit(1);
+    }
+    const std::string& content = buffer.str();
+    wasm_byte_vec_t wasm_bytes;
+    handle<wasmtime_error_t, wasmtime_error_delete> error {
+        wasmtime_wat2wasm(content.data(), content.size(), &wasm_bytes)
+    };
+    if (error) {
+        exit_with_error("failed to parse wat", error.get(), nullptr);
+    }
+    wasmtime_module_t* mod_ptr = nullptr;
+    error.reset(wasmtime_module_new(engine,
+        reinterpret_cast<uint8_t*>(wasm_bytes.data),
+        wasm_bytes.size, &mod_ptr));
+    wasm_byte_vec_delete(&wasm_bytes);
+    handle<wasmtime_module_t, wasmtime_module_delete> mod { mod_ptr };
+    if (!mod) {
+        exit_with_error("failed to compile module", error.get(), nullptr);
+    }
+    return mod;
 }
 
 class printer_thread_state {
 public:
-  void set_value_to_print(int32_t v) {
-    _print_finished_future = _print_finished.get_future();
-    _value_to_print.set_value(v);
-  }
-  int32_t get_value_to_print() { return _value_to_print.get_future().get(); }
+    void set_value_to_print(int32_t v)
+    {
+        _print_finished_future = _print_finished.get_future();
+        _value_to_print.set_value(v);
+    }
+    int32_t get_value_to_print() { return _value_to_print.get_future().get(); }
 
-  bool print_is_pending() const {
-    return _print_finished_future.valid() &&
-           _print_finished_future.wait_for(std::chrono::seconds(0)) !=
-               std::future_status::ready;
-  }
-  void wait_for_print_result() const { _print_finished_future.wait(); }
-  void get_print_result() { _print_finished_future.get(); }
-  void set_print_success() { _print_finished.set_value(); }
+    bool print_is_pending() const
+    {
+        return _print_finished_future.valid() && _print_finished_future.wait_for(std::chrono::seconds(0)) != std::future_status::ready;
+    }
+    void wait_for_print_result() const { _print_finished_future.wait(); }
+    void get_print_result() { _print_finished_future.get(); }
+    void set_print_success() { _print_finished.set_value(); }
 
 private:
-  std::promise<int32_t> _value_to_print;
-  std::promise<void> _print_finished;
-  std::future<void> _print_finished_future;
+    std::promise<int32_t> _value_to_print;
+    std::promise<void> _print_finished;
+    std::future<void> _print_finished_future;
 };
 
 printer_thread_state printer_state;
 
 struct async_call_env {
-  wasm_trap_t **trap_ret;
+    wasm_trap_t** trap_ret;
 };
 
-bool poll_print_finished_state(void *env) {
-  std::cout << "polling async host function result" << std::endl;
-  auto *async_env = static_cast<async_call_env *>(env);
-  // Don't block, just poll the future state.
-  if (printer_state.print_is_pending()) {
-    return false;
-  }
-  try {
-    printer_state.get_print_result();
-  } catch (const std::exception &ex) {
-    std::string msg = ex.what();
-    *async_env->trap_ret = wasmtime_trap_new(msg.data(), msg.size());
-  }
-  return true;
+bool poll_print_finished_state(void* env)
+{
+    std::cout << "polling async host function result" << std::endl;
+    auto* async_env = static_cast<async_call_env*>(env);
+    // Don't block, just poll the future state.
+    if (printer_state.print_is_pending()) {
+        return false;
+    }
+    try {
+        printer_state.get_print_result();
+    } catch (const std::exception& ex) {
+        std::string msg = ex.what();
+        *async_env->trap_ret = wasmtime_trap_new(msg.data(), msg.size());
+    }
+    return true;
 }
 } // namespace
 
-int main() {
-  // A thread that will async perform host function calls.
-  std::thread printer_thread([]() {
-    int32_t value_to_print = printer_state.get_value_to_print();
-    std::cout << "recieved value to print!" << std::endl;
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    std::cout << "printing: " << value_to_print << std::endl;
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    std::cout << "signaling that value is printed" << std::endl;
-    printer_state.set_print_success();
-  });
+int main()
+{
+    // A thread that will async perform host function calls.
+    std::thread printer_thread([]() {
+        int32_t value_to_print = printer_state.get_value_to_print();
+        std::cout << "recieved value to print!" << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        std::cout << "printing: " << value_to_print << std::endl;
+        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        std::cout << "signaling that value is printed" << std::endl;
+        printer_state.set_print_success();
+    });
 
-  handle<wasmtime_error_t, wasmtime_error_delete> error;
+    handle<wasmtime_error_t, wasmtime_error_delete> error;
 
-  auto engine = create_engine();
-  auto store = create_store(engine.get());
-  // This pointer is unowned.
-  auto *context = wasmtime_store_context(store.get());
-  // Configure the store to periodically yield control
-  wasmtime_context_set_fuel(context, 100000);
-  wasmtime_context_fuel_async_yield_interval(context, /*interval=*/10000);
+    auto engine = create_engine();
+    auto store = create_store(engine.get());
+    // This pointer is unowned.
+    auto* context = wasmtime_store_context(store.get());
+    // Configure the store to periodically yield control
+    wasmtime_context_set_fuel(context, 100000);
+    wasmtime_context_fuel_async_yield_interval(context, /*interval=*/10000);
 
-  auto compiled_module =
-      compile_wat_module_from_file(engine.get(), "examples/async.wat");
+    auto compiled_module = compile_wat_module_from_file(engine.get(), "examples/async.wat");
 
-  auto linker = create_linker(engine.get());
-  static std::string host_module_name = "host";
-  static std::string host_func_name = "print";
+    auto linker = create_linker(engine.get());
+    static std::string host_module_name = "host";
+    static std::string host_func_name = "print";
 
-  // Declare our async host function's signature and definition.
-  wasm_valtype_vec_t arg_types;
-  wasm_valtype_vec_t result_types;
-  wasm_valtype_vec_new_uninitialized(&arg_types, 1);
-  arg_types.data[0] = wasm_valtype_new_i32();
-  wasm_valtype_vec_new_empty(&result_types);
-  handle<wasm_functype_t, wasm_functype_delete> functype{
-      wasm_functype_new(&arg_types, &result_types)};
+    // Declare our async host function's signature and definition.
+    wasm_valtype_vec_t arg_types;
+    wasm_valtype_vec_t result_types;
+    wasm_valtype_vec_new_uninitialized(&arg_types, 1);
+    arg_types.data[0] = wasm_valtype_new_i32();
+    wasm_valtype_vec_new_empty(&result_types);
+    handle<wasm_functype_t, wasm_functype_delete> functype {
+        wasm_functype_new(&arg_types, &result_types)
+    };
 
-  error.reset(wasmtime_linker_define_async_func(
-      linker.get(), host_module_name.data(), host_module_name.size(),
-      host_func_name.data(), host_func_name.size(), functype.get(),
-      [](void *, wasmtime_caller_t *, const wasmtime_val_t *args, size_t,
-         wasmtime_val_t *, size_t, wasm_trap_t **trap_ret,
-         wasmtime_async_continuation_t *continutation_ret) {
-        std::cout << "invoking async host function" << std::endl;
-        printer_state.set_value_to_print(args[0].of.i32);
+    error.reset(wasmtime_linker_define_async_func(
+        linker.get(), host_module_name.data(), host_module_name.size(),
+        host_func_name.data(), host_func_name.size(), functype.get(),
+        [](void*, wasmtime_caller_t*, const wasmtime_val_t* args, size_t,
+            wasmtime_val_t*, size_t, wasm_trap_t** trap_ret,
+            wasmtime_async_continuation_t* continutation_ret) {
+            std::cout << "invoking async host function" << std::endl;
+            printer_state.set_value_to_print(args[0].of.i32);
 
-        continutation_ret->callback = &poll_print_finished_state;
-        continutation_ret->env = new async_call_env{trap_ret};
-        continutation_ret->finalizer = [](void *env) {
-          std::cout << "deleting async_call_env" << std::endl;
-          delete static_cast<async_call_env *>(env);
-        };
-      },
-      /*env=*/nullptr, /*finalizer=*/nullptr));
-  if (error) {
-    exit_with_error("failed to define host function", error.get(), nullptr);
-  }
-
-  // Now instantiate our module using the linker.
-  handle<wasmtime_call_future_t, wasmtime_call_future_delete> call_future;
-  wasm_trap_t *trap_ptr = nullptr;
-  wasmtime_error_t *error_ptr = nullptr;
-  wasmtime_instance_t instance;
-  call_future.reset(wasmtime_linker_instantiate_async(
-      linker.get(), context, compiled_module.get(), &instance, &trap_ptr,
-      &error_ptr));
-  while (!wasmtime_call_future_poll(call_future.get())) {
-    std::cout << "yielding instantiation!" << std::endl;
-  }
-  error.reset(error_ptr);
-  handle<wasm_trap_t, wasm_trap_delete> trap{trap_ptr};
-  if (error || trap) {
-    exit_with_error("failed to instantiate module", error.get(), trap.get());
-  }
-  // delete call future - it's no longer needed
-  call_future = nullptr;
-  // delete the linker now that we've created our instance
-  linker = nullptr;
-
-  // Grab our exported function
-  static std::string guest_func_name = "print_fibonacci";
-  wasmtime_extern_t guest_func_extern;
-  bool found =
-      wasmtime_instance_export_get(context, &instance, guest_func_name.data(),
-                                   guest_func_name.size(), &guest_func_extern);
-  assert(found);
-  assert(guest_func_extern.kind == WASMTIME_EXTERN_FUNC);
-
-  // Now call our print_fibonacci function with n=15
-  std::array<wasmtime_val_t, 1> args;
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = 15;
-  std::array<wasmtime_val_t, 0> results;
-  call_future.reset(wasmtime_func_call_async(
-      context, &guest_func_extern.of.func, args.data(), args.size(),
-      results.data(), results.size(), &trap_ptr, &error_ptr));
-  // Poll the execution of the call. This can yield control back if there is an
-  // async host call or if we ran out of fuel.
-  while (!wasmtime_call_future_poll(call_future.get())) {
-    // if we have an async host call pending then wait for that future to finish
-    // before continuing.
-    if (printer_state.print_is_pending()) {
-      std::cout << "waiting for async host function to complete" << std::endl;
-      printer_state.wait_for_print_result();
-      std::cout << "async host function completed" << std::endl;
-      continue;
+            continutation_ret->callback = &poll_print_finished_state;
+            continutation_ret->env = new async_call_env { trap_ret };
+            continutation_ret->finalizer = [](void* env) {
+                std::cout << "deleting async_call_env" << std::endl;
+                delete static_cast<async_call_env*>(env);
+            };
+        },
+        /*env=*/nullptr, /*finalizer=*/nullptr));
+    if (error) {
+        exit_with_error("failed to define host function", error.get(), nullptr);
     }
-    // Otherwise we ran out of fuel and yielded.
-    std::cout << "yield!" << std::endl;
-  }
-  // Extract if there were failures or traps after poll returns that execution
-  // completed.
-  error.reset(error_ptr);
-  trap.reset(trap_ptr);
-  if (error || trap) {
-    exit_with_error("running guest function failed", error.get(), trap.get());
-  }
-  call_future = nullptr;
-  // At this point, if our host function returned results they would be
-  // available in the `results` array.
-  std::cout << "async function call complete!" << std::endl;
 
-  // Join our thread and exit.
-  printer_thread.join();
-  return 0;
+    // Now instantiate our module using the linker.
+    handle<wasmtime_call_future_t, wasmtime_call_future_delete> call_future;
+    wasm_trap_t* trap_ptr = nullptr;
+    wasmtime_error_t* error_ptr = nullptr;
+    wasmtime_instance_t instance;
+    call_future.reset(wasmtime_linker_instantiate_async(
+        linker.get(), context, compiled_module.get(), &instance, &trap_ptr,
+        &error_ptr));
+    while (!wasmtime_call_future_poll(call_future.get())) {
+        std::cout << "yielding instantiation!" << std::endl;
+    }
+    error.reset(error_ptr);
+    handle<wasm_trap_t, wasm_trap_delete> trap { trap_ptr };
+    if (error || trap) {
+        exit_with_error("failed to instantiate module", error.get(), trap.get());
+    }
+    // delete call future - it's no longer needed
+    call_future = nullptr;
+    // delete the linker now that we've created our instance
+    linker = nullptr;
+
+    // Grab our exported function
+    static std::string guest_func_name = "print_fibonacci";
+    wasmtime_extern_t guest_func_extern;
+    bool found = wasmtime_instance_export_get(context, &instance, guest_func_name.data(),
+        guest_func_name.size(), &guest_func_extern);
+    assert(found);
+    assert(guest_func_extern.kind == WASMTIME_EXTERN_FUNC);
+
+    // Now call our print_fibonacci function with n=15
+    std::array<wasmtime_val_t, 1> args;
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = 15;
+    std::array<wasmtime_val_t, 0> results;
+    call_future.reset(wasmtime_func_call_async(
+        context, &guest_func_extern.of.func, args.data(), args.size(),
+        results.data(), results.size(), &trap_ptr, &error_ptr));
+    // Poll the execution of the call. This can yield control back if there is an
+    // async host call or if we ran out of fuel.
+    while (!wasmtime_call_future_poll(call_future.get())) {
+        // if we have an async host call pending then wait for that future to finish
+        // before continuing.
+        if (printer_state.print_is_pending()) {
+            std::cout << "waiting for async host function to complete" << std::endl;
+            printer_state.wait_for_print_result();
+            std::cout << "async host function completed" << std::endl;
+            continue;
+        }
+        // Otherwise we ran out of fuel and yielded.
+        std::cout << "yield!" << std::endl;
+    }
+    // Extract if there were failures or traps after poll returns that execution
+    // completed.
+    error.reset(error_ptr);
+    trap.reset(trap_ptr);
+    if (error || trap) {
+        exit_with_error("running guest function failed", error.get(), trap.get());
+    }
+    call_future = nullptr;
+    // At this point, if our host function returned results they would be
+    // available in the `results` array.
+    std::cout << "async function call complete!" << std::endl;
+
+    // Join our thread and exit.
+    printer_thread.join();
+    return 0;
 }

--- a/examples/async.cpp
+++ b/examples/async.cpp
@@ -39,261 +39,253 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-async
 
 namespace {
 
-template <typename T, void (*fn)(T*)>
-struct deleter {
-    void operator()(T* ptr) { fn(ptr); }
+template <typename T, void (*fn)(T *)> struct deleter {
+  void operator()(T *ptr) { fn(ptr); }
 };
-template <typename T, void (*fn)(T*)>
+template <typename T, void (*fn)(T *)>
 using handle = std::unique_ptr<T, deleter<T, fn>>;
 
-void exit_with_error(std::string msg, wasmtime_error_t* err,
-    wasm_trap_t* trap)
-{
-    std::cerr << "error: " << msg << std::endl;
-    wasm_byte_vec_t error_message;
-    if (err) {
-        wasmtime_error_message(err, &error_message);
-    } else {
-        wasm_trap_message(trap, &error_message);
-    }
-    std::cerr << std::string(error_message.data, error_message.size) << std::endl;
-    wasm_byte_vec_delete(&error_message);
-    std::exit(1);
+void exit_with_error(std::string msg, wasmtime_error_t *err,
+                     wasm_trap_t *trap) {
+  std::cerr << "error: " << msg << std::endl;
+  wasm_byte_vec_t error_message;
+  if (err) {
+    wasmtime_error_message(err, &error_message);
+  } else {
+    wasm_trap_message(trap, &error_message);
+  }
+  std::cerr << std::string(error_message.data, error_message.size) << std::endl;
+  wasm_byte_vec_delete(&error_message);
+  std::exit(1);
 }
 
-handle<wasm_engine_t, wasm_engine_delete> create_engine()
-{
-    wasm_config_t* config = wasm_config_new();
-    assert(config != nullptr);
-    wasmtime_config_async_support_set(config, true);
-    wasmtime_config_consume_fuel_set(config, true);
-    handle<wasm_engine_t, wasm_engine_delete> engine;
-    // this takes ownership of config
-    engine.reset(wasm_engine_new_with_config(config));
-    assert(engine);
-    return engine;
+handle<wasm_engine_t, wasm_engine_delete> create_engine() {
+  wasm_config_t *config = wasm_config_new();
+  assert(config != nullptr);
+  wasmtime_config_async_support_set(config, true);
+  wasmtime_config_consume_fuel_set(config, true);
+  handle<wasm_engine_t, wasm_engine_delete> engine;
+  // this takes ownership of config
+  engine.reset(wasm_engine_new_with_config(config));
+  assert(engine);
+  return engine;
 }
 
 handle<wasmtime_store_t, wasmtime_store_delete>
-create_store(wasm_engine_t* engine)
-{
-    handle<wasmtime_store_t, wasmtime_store_delete> store;
-    store.reset(wasmtime_store_new(engine, nullptr, nullptr));
-    assert(store);
-    return store;
+create_store(wasm_engine_t *engine) {
+  handle<wasmtime_store_t, wasmtime_store_delete> store;
+  store.reset(wasmtime_store_new(engine, nullptr, nullptr));
+  assert(store);
+  return store;
 }
 
 handle<wasmtime_linker_t, wasmtime_linker_delete>
-create_linker(wasm_engine_t* engine)
-{
-    handle<wasmtime_linker_t, wasmtime_linker_delete> linker;
-    linker.reset(wasmtime_linker_new(engine));
-    assert(linker);
-    return linker;
+create_linker(wasm_engine_t *engine) {
+  handle<wasmtime_linker_t, wasmtime_linker_delete> linker;
+  linker.reset(wasmtime_linker_new(engine));
+  assert(linker);
+  return linker;
 }
 
 handle<wasmtime_module_t, wasmtime_module_delete>
-compile_wat_module_from_file(wasm_engine_t* engine,
-    const std::string& filename)
-{
-    std::ifstream t(filename);
-    std::stringstream buffer;
-    buffer << t.rdbuf();
-    if (t.bad()) {
-        std::cerr << "error reading file: " << filename << std::endl;
-        std::exit(1);
-    }
-    const std::string& content = buffer.str();
-    wasm_byte_vec_t wasm_bytes;
-    handle<wasmtime_error_t, wasmtime_error_delete> error {
-        wasmtime_wat2wasm(content.data(), content.size(), &wasm_bytes)
-    };
-    if (error) {
-        exit_with_error("failed to parse wat", error.get(), nullptr);
-    }
-    wasmtime_module_t* mod_ptr = nullptr;
-    error.reset(wasmtime_module_new(engine,
-        reinterpret_cast<uint8_t*>(wasm_bytes.data),
-        wasm_bytes.size, &mod_ptr));
-    wasm_byte_vec_delete(&wasm_bytes);
-    handle<wasmtime_module_t, wasmtime_module_delete> mod { mod_ptr };
-    if (!mod) {
-        exit_with_error("failed to compile module", error.get(), nullptr);
-    }
-    return mod;
+compile_wat_module_from_file(wasm_engine_t *engine,
+                             const std::string &filename) {
+  std::ifstream t(filename);
+  std::stringstream buffer;
+  buffer << t.rdbuf();
+  if (t.bad()) {
+    std::cerr << "error reading file: " << filename << std::endl;
+    std::exit(1);
+  }
+  const std::string &content = buffer.str();
+  wasm_byte_vec_t wasm_bytes;
+  handle<wasmtime_error_t, wasmtime_error_delete> error{
+      wasmtime_wat2wasm(content.data(), content.size(), &wasm_bytes)};
+  if (error) {
+    exit_with_error("failed to parse wat", error.get(), nullptr);
+  }
+  wasmtime_module_t *mod_ptr = nullptr;
+  error.reset(wasmtime_module_new(engine,
+                                  reinterpret_cast<uint8_t *>(wasm_bytes.data),
+                                  wasm_bytes.size, &mod_ptr));
+  wasm_byte_vec_delete(&wasm_bytes);
+  handle<wasmtime_module_t, wasmtime_module_delete> mod{mod_ptr};
+  if (!mod) {
+    exit_with_error("failed to compile module", error.get(), nullptr);
+  }
+  return mod;
 }
 
 class printer_thread_state {
 public:
-    void set_value_to_print(int32_t v)
-    {
-        _print_finished_future = _print_finished.get_future();
-        _value_to_print.set_value(v);
-    }
-    int32_t get_value_to_print() { return _value_to_print.get_future().get(); }
+  void set_value_to_print(int32_t v) {
+    _print_finished_future = _print_finished.get_future();
+    _value_to_print.set_value(v);
+  }
+  int32_t get_value_to_print() { return _value_to_print.get_future().get(); }
 
-    bool print_is_pending() const
-    {
-        return _print_finished_future.valid() && _print_finished_future.wait_for(std::chrono::seconds(0)) != std::future_status::ready;
-    }
-    void wait_for_print_result() const { _print_finished_future.wait(); }
-    void get_print_result() { _print_finished_future.get(); }
-    void set_print_success() { _print_finished.set_value(); }
+  bool print_is_pending() const {
+    return _print_finished_future.valid() &&
+           _print_finished_future.wait_for(std::chrono::seconds(0)) !=
+               std::future_status::ready;
+  }
+  void wait_for_print_result() const { _print_finished_future.wait(); }
+  void get_print_result() { _print_finished_future.get(); }
+  void set_print_success() { _print_finished.set_value(); }
 
 private:
-    std::promise<int32_t> _value_to_print;
-    std::promise<void> _print_finished;
-    std::future<void> _print_finished_future;
+  std::promise<int32_t> _value_to_print;
+  std::promise<void> _print_finished;
+  std::future<void> _print_finished_future;
 };
 
 printer_thread_state printer_state;
 
 struct async_call_env {
-    wasm_trap_t** trap_ret;
+  wasm_trap_t **trap_ret;
 };
 
-bool poll_print_finished_state(void* env)
-{
-    std::cout << "polling async host function result" << std::endl;
-    auto* async_env = static_cast<async_call_env*>(env);
-    // Don't block, just poll the future state.
-    if (printer_state.print_is_pending()) {
-        return false;
-    }
-    try {
-        printer_state.get_print_result();
-    } catch (const std::exception& ex) {
-        std::string msg = ex.what();
-        *async_env->trap_ret = wasmtime_trap_new(msg.data(), msg.size());
-    }
-    return true;
+bool poll_print_finished_state(void *env) {
+  std::cout << "polling async host function result" << std::endl;
+  auto *async_env = static_cast<async_call_env *>(env);
+  // Don't block, just poll the future state.
+  if (printer_state.print_is_pending()) {
+    return false;
+  }
+  try {
+    printer_state.get_print_result();
+  } catch (const std::exception &ex) {
+    std::string msg = ex.what();
+    *async_env->trap_ret = wasmtime_trap_new(msg.data(), msg.size());
+  }
+  return true;
 }
 } // namespace
 
-int main()
-{
-    // A thread that will async perform host function calls.
-    std::thread printer_thread([]() {
-        int32_t value_to_print = printer_state.get_value_to_print();
-        std::cout << "recieved value to print!" << std::endl;
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        std::cout << "printing: " << value_to_print << std::endl;
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-        std::cout << "signaling that value is printed" << std::endl;
-        printer_state.set_print_success();
-    });
+int main() {
+  // A thread that will async perform host function calls.
+  std::thread printer_thread([]() {
+    int32_t value_to_print = printer_state.get_value_to_print();
+    std::cout << "recieved value to print!" << std::endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::cout << "printing: " << value_to_print << std::endl;
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::cout << "signaling that value is printed" << std::endl;
+    printer_state.set_print_success();
+  });
 
-    handle<wasmtime_error_t, wasmtime_error_delete> error;
+  handle<wasmtime_error_t, wasmtime_error_delete> error;
 
-    auto engine = create_engine();
-    auto store = create_store(engine.get());
-    // This pointer is unowned.
-    auto* context = wasmtime_store_context(store.get());
-    // Configure the store to periodically yield control
-    wasmtime_context_set_fuel(context, 100000);
-    wasmtime_context_fuel_async_yield_interval(context, /*interval=*/10000);
+  auto engine = create_engine();
+  auto store = create_store(engine.get());
+  // This pointer is unowned.
+  auto *context = wasmtime_store_context(store.get());
+  // Configure the store to periodically yield control
+  wasmtime_context_set_fuel(context, 100000);
+  wasmtime_context_fuel_async_yield_interval(context, /*interval=*/10000);
 
-    auto compiled_module = compile_wat_module_from_file(engine.get(), "examples/async.wat");
+  auto compiled_module =
+      compile_wat_module_from_file(engine.get(), "examples/async.wat");
 
-    auto linker = create_linker(engine.get());
-    static std::string host_module_name = "host";
-    static std::string host_func_name = "print";
+  auto linker = create_linker(engine.get());
+  static std::string host_module_name = "host";
+  static std::string host_func_name = "print";
 
-    // Declare our async host function's signature and definition.
-    wasm_valtype_vec_t arg_types;
-    wasm_valtype_vec_t result_types;
-    wasm_valtype_vec_new_uninitialized(&arg_types, 1);
-    arg_types.data[0] = wasm_valtype_new_i32();
-    wasm_valtype_vec_new_empty(&result_types);
-    handle<wasm_functype_t, wasm_functype_delete> functype {
-        wasm_functype_new(&arg_types, &result_types)
-    };
+  // Declare our async host function's signature and definition.
+  wasm_valtype_vec_t arg_types;
+  wasm_valtype_vec_t result_types;
+  wasm_valtype_vec_new_uninitialized(&arg_types, 1);
+  arg_types.data[0] = wasm_valtype_new_i32();
+  wasm_valtype_vec_new_empty(&result_types);
+  handle<wasm_functype_t, wasm_functype_delete> functype{
+      wasm_functype_new(&arg_types, &result_types)};
 
-    error.reset(wasmtime_linker_define_async_func(
-        linker.get(), host_module_name.data(), host_module_name.size(),
-        host_func_name.data(), host_func_name.size(), functype.get(),
-        [](void*, wasmtime_caller_t*, const wasmtime_val_t* args, size_t,
-            wasmtime_val_t*, size_t, wasm_trap_t** trap_ret,
-            wasmtime_async_continuation_t* continutation_ret) {
-            std::cout << "invoking async host function" << std::endl;
-            printer_state.set_value_to_print(args[0].of.i32);
+  error.reset(wasmtime_linker_define_async_func(
+      linker.get(), host_module_name.data(), host_module_name.size(),
+      host_func_name.data(), host_func_name.size(), functype.get(),
+      [](void *, wasmtime_caller_t *, const wasmtime_val_t *args, size_t,
+         wasmtime_val_t *, size_t, wasm_trap_t **trap_ret,
+         wasmtime_async_continuation_t *continutation_ret) {
+        std::cout << "invoking async host function" << std::endl;
+        printer_state.set_value_to_print(args[0].of.i32);
 
-            continutation_ret->callback = &poll_print_finished_state;
-            continutation_ret->env = new async_call_env { trap_ret };
-            continutation_ret->finalizer = [](void* env) {
-                std::cout << "deleting async_call_env" << std::endl;
-                delete static_cast<async_call_env*>(env);
-            };
-        },
-        /*env=*/nullptr, /*finalizer=*/nullptr));
-    if (error) {
-        exit_with_error("failed to define host function", error.get(), nullptr);
+        continutation_ret->callback = &poll_print_finished_state;
+        continutation_ret->env = new async_call_env{trap_ret};
+        continutation_ret->finalizer = [](void *env) {
+          std::cout << "deleting async_call_env" << std::endl;
+          delete static_cast<async_call_env *>(env);
+        };
+      },
+      /*env=*/nullptr, /*finalizer=*/nullptr));
+  if (error) {
+    exit_with_error("failed to define host function", error.get(), nullptr);
+  }
+
+  // Now instantiate our module using the linker.
+  handle<wasmtime_call_future_t, wasmtime_call_future_delete> call_future;
+  wasm_trap_t *trap_ptr = nullptr;
+  wasmtime_error_t *error_ptr = nullptr;
+  wasmtime_instance_t instance;
+  call_future.reset(wasmtime_linker_instantiate_async(
+      linker.get(), context, compiled_module.get(), &instance, &trap_ptr,
+      &error_ptr));
+  while (!wasmtime_call_future_poll(call_future.get())) {
+    std::cout << "yielding instantiation!" << std::endl;
+  }
+  error.reset(error_ptr);
+  handle<wasm_trap_t, wasm_trap_delete> trap{trap_ptr};
+  if (error || trap) {
+    exit_with_error("failed to instantiate module", error.get(), trap.get());
+  }
+  // delete call future - it's no longer needed
+  call_future = nullptr;
+  // delete the linker now that we've created our instance
+  linker = nullptr;
+
+  // Grab our exported function
+  static std::string guest_func_name = "print_fibonacci";
+  wasmtime_extern_t guest_func_extern;
+  bool found =
+      wasmtime_instance_export_get(context, &instance, guest_func_name.data(),
+                                   guest_func_name.size(), &guest_func_extern);
+  assert(found);
+  assert(guest_func_extern.kind == WASMTIME_EXTERN_FUNC);
+
+  // Now call our print_fibonacci function with n=15
+  std::array<wasmtime_val_t, 1> args;
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = 15;
+  std::array<wasmtime_val_t, 0> results;
+  call_future.reset(wasmtime_func_call_async(
+      context, &guest_func_extern.of.func, args.data(), args.size(),
+      results.data(), results.size(), &trap_ptr, &error_ptr));
+  // Poll the execution of the call. This can yield control back if there is an
+  // async host call or if we ran out of fuel.
+  while (!wasmtime_call_future_poll(call_future.get())) {
+    // if we have an async host call pending then wait for that future to finish
+    // before continuing.
+    if (printer_state.print_is_pending()) {
+      std::cout << "waiting for async host function to complete" << std::endl;
+      printer_state.wait_for_print_result();
+      std::cout << "async host function completed" << std::endl;
+      continue;
     }
+    // Otherwise we ran out of fuel and yielded.
+    std::cout << "yield!" << std::endl;
+  }
+  // Extract if there were failures or traps after poll returns that execution
+  // completed.
+  error.reset(error_ptr);
+  trap.reset(trap_ptr);
+  if (error || trap) {
+    exit_with_error("running guest function failed", error.get(), trap.get());
+  }
+  call_future = nullptr;
+  // At this point, if our host function returned results they would be
+  // available in the `results` array.
+  std::cout << "async function call complete!" << std::endl;
 
-    // Now instantiate our module using the linker.
-    handle<wasmtime_call_future_t, wasmtime_call_future_delete> call_future;
-    wasm_trap_t* trap_ptr = nullptr;
-    wasmtime_error_t* error_ptr = nullptr;
-    wasmtime_instance_t instance;
-    call_future.reset(wasmtime_linker_instantiate_async(
-        linker.get(), context, compiled_module.get(), &instance, &trap_ptr,
-        &error_ptr));
-    while (!wasmtime_call_future_poll(call_future.get())) {
-        std::cout << "yielding instantiation!" << std::endl;
-    }
-    error.reset(error_ptr);
-    handle<wasm_trap_t, wasm_trap_delete> trap { trap_ptr };
-    if (error || trap) {
-        exit_with_error("failed to instantiate module", error.get(), trap.get());
-    }
-    // delete call future - it's no longer needed
-    call_future = nullptr;
-    // delete the linker now that we've created our instance
-    linker = nullptr;
-
-    // Grab our exported function
-    static std::string guest_func_name = "print_fibonacci";
-    wasmtime_extern_t guest_func_extern;
-    bool found = wasmtime_instance_export_get(context, &instance, guest_func_name.data(),
-        guest_func_name.size(), &guest_func_extern);
-    assert(found);
-    assert(guest_func_extern.kind == WASMTIME_EXTERN_FUNC);
-
-    // Now call our print_fibonacci function with n=15
-    std::array<wasmtime_val_t, 1> args;
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = 15;
-    std::array<wasmtime_val_t, 0> results;
-    call_future.reset(wasmtime_func_call_async(
-        context, &guest_func_extern.of.func, args.data(), args.size(),
-        results.data(), results.size(), &trap_ptr, &error_ptr));
-    // Poll the execution of the call. This can yield control back if there is an
-    // async host call or if we ran out of fuel.
-    while (!wasmtime_call_future_poll(call_future.get())) {
-        // if we have an async host call pending then wait for that future to finish
-        // before continuing.
-        if (printer_state.print_is_pending()) {
-            std::cout << "waiting for async host function to complete" << std::endl;
-            printer_state.wait_for_print_result();
-            std::cout << "async host function completed" << std::endl;
-            continue;
-        }
-        // Otherwise we ran out of fuel and yielded.
-        std::cout << "yield!" << std::endl;
-    }
-    // Extract if there were failures or traps after poll returns that execution
-    // completed.
-    error.reset(error_ptr);
-    trap.reset(trap_ptr);
-    if (error || trap) {
-        exit_with_error("running guest function failed", error.get(), trap.get());
-    }
-    call_future = nullptr;
-    // At this point, if our host function returned results they would be
-    // available in the `results` array.
-    std::cout << "async function call complete!" << std::endl;
-
-    // Join our thread and exit.
-    printer_thread.join();
-    return 0;
+  // Join our thread and exit.
+  printer_thread.join();
+  return 0;
 }

--- a/examples/externref.c
+++ b/examples/externref.c
@@ -18,7 +18,8 @@ to tweak the `-lpthread` and such annotations as well as the name of the
 
 You can also build using cmake:
 
-mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-externref
+mkdir build && cd build && cmake .. && cmake --build . --target
+wasmtime-externref
 */
 
 #include <assert.h>
@@ -28,165 +29,173 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-externr
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
-int main()
-{
-    int ret = 0;
-    bool ok = true;
-    // Create a new configuration with Wasm reference types enabled.
-    printf("Initializing...\n");
-    wasm_config_t* config = wasm_config_new();
-    assert(config != NULL);
-    wasmtime_config_wasm_reference_types_set(config, true);
+int main() {
+  int ret = 0;
+  bool ok = true;
+  // Create a new configuration with Wasm reference types enabled.
+  printf("Initializing...\n");
+  wasm_config_t *config = wasm_config_new();
+  assert(config != NULL);
+  wasmtime_config_wasm_reference_types_set(config, true);
 
-    // Create an *engine*, which is a compilation context, with our configured
-    // options.
-    wasm_engine_t* engine = wasm_engine_new_with_config(config);
-    assert(engine != NULL);
+  // Create an *engine*, which is a compilation context, with our configured
+  // options.
+  wasm_engine_t *engine = wasm_engine_new_with_config(config);
+  assert(engine != NULL);
 
-    // With an engine we can create a *store* which is a long-lived group of wasm
-    // modules.
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    assert(store != NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
+  // With an engine we can create a *store* which is a long-lived group of wasm
+  // modules.
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  assert(store != NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
 
-    // Read our input file, which in this case is a wasm text file.
-    FILE* file = fopen("examples/externref.wat", "r");
-    assert(file != NULL);
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    fseek(file, 0L, SEEK_SET);
-    wasm_byte_vec_t wat;
-    wasm_byte_vec_new_uninitialized(&wat, file_size);
-    assert(fread(wat.data, file_size, 1, file) == 1);
-    fclose(file);
+  // Read our input file, which in this case is a wasm text file.
+  FILE *file = fopen("examples/externref.wat", "r");
+  assert(file != NULL);
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  assert(fread(wat.data, file_size, 1, file) == 1);
+  fclose(file);
 
-    // Parse the wat into the binary wasm format
-    wasm_byte_vec_t wasm;
-    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-    if (error != NULL)
-        exit_with_error("failed to parse wat", error, NULL);
-    wasm_byte_vec_delete(&wat);
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t wasm;
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
 
-    // Now that we've got our binary webassembly we can compile our module.
-    printf("Compiling module...\n");
-    wasmtime_module_t* module = NULL;
-    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
-    wasm_byte_vec_delete(&wasm);
-    if (error != NULL)
-        exit_with_error("failed to compile module", error, NULL);
+  // Now that we've got our binary webassembly we can compile our module.
+  printf("Compiling module...\n");
+  wasmtime_module_t *module = NULL;
+  error = wasmtime_module_new(engine, (uint8_t *)wasm.data, wasm.size, &module);
+  wasm_byte_vec_delete(&wasm);
+  if (error != NULL)
+    exit_with_error("failed to compile module", error, NULL);
 
-    // Instantiate the module.
-    printf("Instantiating module...\n");
-    wasm_trap_t* trap = NULL;
-    wasmtime_instance_t instance;
-    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate", error, trap);
+  // Instantiate the module.
+  printf("Instantiating module...\n");
+  wasm_trap_t *trap = NULL;
+  wasmtime_instance_t instance;
+  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
 
-    printf("Creating new `externref`...\n");
+  printf("Creating new `externref`...\n");
 
-    // Create a new `externref` value.
-    //
-    // Note that the NULL here is a finalizer callback, but we don't need one for
-    // this example.
-    wasmtime_externref_t* externref = wasmtime_externref_new("Hello, World!", NULL);
+  // Create a new `externref` value.
+  //
+  // Note that the NULL here is a finalizer callback, but we don't need one for
+  // this example.
+  wasmtime_externref_t *externref =
+      wasmtime_externref_new("Hello, World!", NULL);
 
-    // The `externref`'s wrapped data should be the string "Hello, World!".
-    void* data = wasmtime_externref_data(externref);
-    assert(strcmp((char*)data, "Hello, World!") == 0);
+  // The `externref`'s wrapped data should be the string "Hello, World!".
+  void *data = wasmtime_externref_data(externref);
+  assert(strcmp((char *)data, "Hello, World!") == 0);
 
-    printf("Touching `externref` table...\n");
+  printf("Touching `externref` table...\n");
 
-    wasmtime_extern_t item;
+  wasmtime_extern_t item;
 
-    // Lookup the `table` export.
-    ok = wasmtime_instance_export_get(context, &instance, "table", strlen("table"), &item);
-    assert(ok);
-    assert(item.kind == WASMTIME_EXTERN_TABLE);
+  // Lookup the `table` export.
+  ok = wasmtime_instance_export_get(context, &instance, "table",
+                                    strlen("table"), &item);
+  assert(ok);
+  assert(item.kind == WASMTIME_EXTERN_TABLE);
 
-    // Set `table[3]` to our `externref`.
-    wasmtime_val_t externref_val;
-    externref_val.kind = WASMTIME_EXTERNREF;
-    externref_val.of.externref = externref;
-    error = wasmtime_table_set(context, &item.of.table, 3, &externref_val);
-    if (error != NULL)
-        exit_with_error("failed to set table", error, NULL);
+  // Set `table[3]` to our `externref`.
+  wasmtime_val_t externref_val;
+  externref_val.kind = WASMTIME_EXTERNREF;
+  externref_val.of.externref = externref;
+  error = wasmtime_table_set(context, &item.of.table, 3, &externref_val);
+  if (error != NULL)
+    exit_with_error("failed to set table", error, NULL);
 
-    // `table[3]` should now be our `externref`.
-    wasmtime_val_t elem;
-    ok = wasmtime_table_get(context, &item.of.table, 3, &elem);
-    assert(ok);
-    assert(elem.kind == WASMTIME_EXTERNREF);
-    assert(strcmp((char*)wasmtime_externref_data(elem.of.externref), "Hello, World!") == 0);
-    wasmtime_val_delete(&elem);
+  // `table[3]` should now be our `externref`.
+  wasmtime_val_t elem;
+  ok = wasmtime_table_get(context, &item.of.table, 3, &elem);
+  assert(ok);
+  assert(elem.kind == WASMTIME_EXTERNREF);
+  assert(strcmp((char *)wasmtime_externref_data(elem.of.externref),
+                "Hello, World!") == 0);
+  wasmtime_val_delete(&elem);
 
-    printf("Touching `externref` global...\n");
+  printf("Touching `externref` global...\n");
 
-    // Lookup the `global` export.
-    ok = wasmtime_instance_export_get(context, &instance, "global", strlen("global"), &item);
-    assert(ok);
-    assert(item.kind == WASMTIME_EXTERN_GLOBAL);
+  // Lookup the `global` export.
+  ok = wasmtime_instance_export_get(context, &instance, "global",
+                                    strlen("global"), &item);
+  assert(ok);
+  assert(item.kind == WASMTIME_EXTERN_GLOBAL);
 
-    // Set the global to our `externref`.
-    error = wasmtime_global_set(context, &item.of.global, &externref_val);
-    if (error != NULL)
-        exit_with_error("failed to set global", error, NULL);
+  // Set the global to our `externref`.
+  error = wasmtime_global_set(context, &item.of.global, &externref_val);
+  if (error != NULL)
+    exit_with_error("failed to set global", error, NULL);
 
-    // Get the global, and it should return our `externref` again.
-    wasmtime_val_t global_val;
-    wasmtime_global_get(context, &item.of.global, &global_val);
-    assert(global_val.kind == WASMTIME_EXTERNREF);
-    assert(strcmp((char*)wasmtime_externref_data(elem.of.externref), "Hello, World!") == 0);
-    wasmtime_val_delete(&global_val);
+  // Get the global, and it should return our `externref` again.
+  wasmtime_val_t global_val;
+  wasmtime_global_get(context, &item.of.global, &global_val);
+  assert(global_val.kind == WASMTIME_EXTERNREF);
+  assert(strcmp((char *)wasmtime_externref_data(elem.of.externref),
+                "Hello, World!") == 0);
+  wasmtime_val_delete(&global_val);
 
-    printf("Calling `externref` func...\n");
+  printf("Calling `externref` func...\n");
 
-    // Lookup the `func` export.
-    ok = wasmtime_instance_export_get(context, &instance, "func", strlen("func"), &item);
-    assert(ok);
-    assert(item.kind == WASMTIME_EXTERN_FUNC);
+  // Lookup the `func` export.
+  ok = wasmtime_instance_export_get(context, &instance, "func", strlen("func"),
+                                    &item);
+  assert(ok);
+  assert(item.kind == WASMTIME_EXTERN_FUNC);
 
-    // And call it!
-    wasmtime_val_t results[1];
-    error = wasmtime_func_call(context, &item.of.func, &externref_val, 1, results, 1, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to call function", error, trap);
+  // And call it!
+  wasmtime_val_t results[1];
+  error = wasmtime_func_call(context, &item.of.func, &externref_val, 1, results,
+                             1, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call function", error, trap);
 
-    // `func` returns the same reference we gave it, so `results[0]` should be our
-    // `externref`.
-    assert(results[0].kind == WASMTIME_EXTERNREF);
-    assert(strcmp((char*)wasmtime_externref_data(results[0].of.externref), "Hello, World!") == 0);
-    wasmtime_val_delete(&results[0]);
+  // `func` returns the same reference we gave it, so `results[0]` should be our
+  // `externref`.
+  assert(results[0].kind == WASMTIME_EXTERNREF);
+  assert(strcmp((char *)wasmtime_externref_data(results[0].of.externref),
+                "Hello, World!") == 0);
+  wasmtime_val_delete(&results[0]);
 
-    // We can GC any now-unused references to our externref that the store is
-    // holding.
-    printf("GCing within the store...\n");
-    wasmtime_context_gc(context);
+  // We can GC any now-unused references to our externref that the store is
+  // holding.
+  printf("GCing within the store...\n");
+  wasmtime_context_gc(context);
 
-    // Clean up after ourselves at this point
-    printf("All finished!\n");
-    ret = 0;
+  // Clean up after ourselves at this point
+  printf("All finished!\n");
+  ret = 0;
 
-    wasmtime_store_delete(store);
-    wasmtime_module_delete(module);
-    wasm_engine_delete(engine);
-    return 0;
+  wasmtime_store_delete(store);
+  wasmtime_module_delete(module);
+  wasm_engine_delete(engine);
+  return 0;
 }
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-        wasmtime_error_delete(error);
-    } else {
-        wasm_trap_message(trap, &error_message);
-        wasm_trap_delete(trap);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
-    exit(1);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+    wasmtime_error_delete(error);
+  } else {
+    wasm_trap_message(trap, &error_message);
+    wasm_trap_delete(trap);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/examples/externref.c
+++ b/examples/externref.c
@@ -28,163 +28,165 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-externr
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
-int main() {
-  int ret = 0;
-  bool ok = true;
-  // Create a new configuration with Wasm reference types enabled.
-  printf("Initializing...\n");
-  wasm_config_t *config = wasm_config_new();
-  assert(config != NULL);
-  wasmtime_config_wasm_reference_types_set(config, true);
+int main()
+{
+    int ret = 0;
+    bool ok = true;
+    // Create a new configuration with Wasm reference types enabled.
+    printf("Initializing...\n");
+    wasm_config_t* config = wasm_config_new();
+    assert(config != NULL);
+    wasmtime_config_wasm_reference_types_set(config, true);
 
-  // Create an *engine*, which is a compilation context, with our configured
-  // options.
-  wasm_engine_t *engine = wasm_engine_new_with_config(config);
-  assert(engine != NULL);
+    // Create an *engine*, which is a compilation context, with our configured
+    // options.
+    wasm_engine_t* engine = wasm_engine_new_with_config(config);
+    assert(engine != NULL);
 
-  // With an engine we can create a *store* which is a long-lived group of wasm
-  // modules.
-  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
-  assert(store != NULL);
-  wasmtime_context_t *context = wasmtime_store_context(store);
+    // With an engine we can create a *store* which is a long-lived group of wasm
+    // modules.
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    assert(store != NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
 
-  // Read our input file, which in this case is a wasm text file.
-  FILE* file = fopen("examples/externref.wat", "r");
-  assert(file != NULL);
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t wat;
-  wasm_byte_vec_new_uninitialized(&wat, file_size);
-  assert(fread(wat.data, file_size, 1, file) == 1);
-  fclose(file);
+    // Read our input file, which in this case is a wasm text file.
+    FILE* file = fopen("examples/externref.wat", "r");
+    assert(file != NULL);
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t wat;
+    wasm_byte_vec_new_uninitialized(&wat, file_size);
+    assert(fread(wat.data, file_size, 1, file) == 1);
+    fclose(file);
 
-  // Parse the wat into the binary wasm format
-  wasm_byte_vec_t wasm;
-  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-  if (error != NULL)
-    exit_with_error("failed to parse wat", error, NULL);
-  wasm_byte_vec_delete(&wat);
+    // Parse the wat into the binary wasm format
+    wasm_byte_vec_t wasm;
+    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+    if (error != NULL)
+        exit_with_error("failed to parse wat", error, NULL);
+    wasm_byte_vec_delete(&wat);
 
-  // Now that we've got our binary webassembly we can compile our module.
-  printf("Compiling module...\n");
-  wasmtime_module_t *module = NULL;
-  error = wasmtime_module_new(engine, (uint8_t*) wasm.data, wasm.size, &module);
-  wasm_byte_vec_delete(&wasm);
-  if (error != NULL)
-    exit_with_error("failed to compile module", error, NULL);
+    // Now that we've got our binary webassembly we can compile our module.
+    printf("Compiling module...\n");
+    wasmtime_module_t* module = NULL;
+    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
+    wasm_byte_vec_delete(&wasm);
+    if (error != NULL)
+        exit_with_error("failed to compile module", error, NULL);
 
-  // Instantiate the module.
-  printf("Instantiating module...\n");
-  wasm_trap_t *trap = NULL;
-  wasmtime_instance_t instance;
-  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate", error, trap);
+    // Instantiate the module.
+    printf("Instantiating module...\n");
+    wasm_trap_t* trap = NULL;
+    wasmtime_instance_t instance;
+    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate", error, trap);
 
-  printf("Creating new `externref`...\n");
+    printf("Creating new `externref`...\n");
 
-  // Create a new `externref` value.
-  //
-  // Note that the NULL here is a finalizer callback, but we don't need one for
-  // this example.
-  wasmtime_externref_t *externref = wasmtime_externref_new("Hello, World!", NULL);
+    // Create a new `externref` value.
+    //
+    // Note that the NULL here is a finalizer callback, but we don't need one for
+    // this example.
+    wasmtime_externref_t* externref = wasmtime_externref_new("Hello, World!", NULL);
 
-  // The `externref`'s wrapped data should be the string "Hello, World!".
-  void* data = wasmtime_externref_data(externref);
-  assert(strcmp((char*)data, "Hello, World!") == 0);
+    // The `externref`'s wrapped data should be the string "Hello, World!".
+    void* data = wasmtime_externref_data(externref);
+    assert(strcmp((char*)data, "Hello, World!") == 0);
 
-  printf("Touching `externref` table...\n");
+    printf("Touching `externref` table...\n");
 
-  wasmtime_extern_t item;
+    wasmtime_extern_t item;
 
-  // Lookup the `table` export.
-  ok = wasmtime_instance_export_get(context, &instance, "table", strlen("table"), &item);
-  assert(ok);
-  assert(item.kind == WASMTIME_EXTERN_TABLE);
+    // Lookup the `table` export.
+    ok = wasmtime_instance_export_get(context, &instance, "table", strlen("table"), &item);
+    assert(ok);
+    assert(item.kind == WASMTIME_EXTERN_TABLE);
 
-  // Set `table[3]` to our `externref`.
-  wasmtime_val_t externref_val;
-  externref_val.kind = WASMTIME_EXTERNREF;
-  externref_val.of.externref = externref;
-  error = wasmtime_table_set(context, &item.of.table, 3, &externref_val);
-  if (error != NULL)
-    exit_with_error("failed to set table", error, NULL);
+    // Set `table[3]` to our `externref`.
+    wasmtime_val_t externref_val;
+    externref_val.kind = WASMTIME_EXTERNREF;
+    externref_val.of.externref = externref;
+    error = wasmtime_table_set(context, &item.of.table, 3, &externref_val);
+    if (error != NULL)
+        exit_with_error("failed to set table", error, NULL);
 
-  // `table[3]` should now be our `externref`.
-  wasmtime_val_t elem;
-  ok = wasmtime_table_get(context, &item.of.table, 3, &elem);
-  assert(ok);
-  assert(elem.kind == WASMTIME_EXTERNREF);
-  assert(strcmp((char*)wasmtime_externref_data(elem.of.externref), "Hello, World!") == 0);
-  wasmtime_val_delete(&elem);
+    // `table[3]` should now be our `externref`.
+    wasmtime_val_t elem;
+    ok = wasmtime_table_get(context, &item.of.table, 3, &elem);
+    assert(ok);
+    assert(elem.kind == WASMTIME_EXTERNREF);
+    assert(strcmp((char*)wasmtime_externref_data(elem.of.externref), "Hello, World!") == 0);
+    wasmtime_val_delete(&elem);
 
-  printf("Touching `externref` global...\n");
+    printf("Touching `externref` global...\n");
 
-  // Lookup the `global` export.
-  ok = wasmtime_instance_export_get(context, &instance, "global", strlen("global"), &item);
-  assert(ok);
-  assert(item.kind == WASMTIME_EXTERN_GLOBAL);
+    // Lookup the `global` export.
+    ok = wasmtime_instance_export_get(context, &instance, "global", strlen("global"), &item);
+    assert(ok);
+    assert(item.kind == WASMTIME_EXTERN_GLOBAL);
 
-  // Set the global to our `externref`.
-  error = wasmtime_global_set(context, &item.of.global, &externref_val);
-  if (error != NULL)
-    exit_with_error("failed to set global", error, NULL);
+    // Set the global to our `externref`.
+    error = wasmtime_global_set(context, &item.of.global, &externref_val);
+    if (error != NULL)
+        exit_with_error("failed to set global", error, NULL);
 
-  // Get the global, and it should return our `externref` again.
-  wasmtime_val_t global_val;
-  wasmtime_global_get(context, &item.of.global, &global_val);
-  assert(global_val.kind == WASMTIME_EXTERNREF);
-  assert(strcmp((char*)wasmtime_externref_data(elem.of.externref), "Hello, World!") == 0);
-  wasmtime_val_delete(&global_val);
+    // Get the global, and it should return our `externref` again.
+    wasmtime_val_t global_val;
+    wasmtime_global_get(context, &item.of.global, &global_val);
+    assert(global_val.kind == WASMTIME_EXTERNREF);
+    assert(strcmp((char*)wasmtime_externref_data(elem.of.externref), "Hello, World!") == 0);
+    wasmtime_val_delete(&global_val);
 
-  printf("Calling `externref` func...\n");
+    printf("Calling `externref` func...\n");
 
-  // Lookup the `func` export.
-  ok = wasmtime_instance_export_get(context, &instance, "func", strlen("func"), &item);
-  assert(ok);
-  assert(item.kind == WASMTIME_EXTERN_FUNC);
+    // Lookup the `func` export.
+    ok = wasmtime_instance_export_get(context, &instance, "func", strlen("func"), &item);
+    assert(ok);
+    assert(item.kind == WASMTIME_EXTERN_FUNC);
 
-  // And call it!
-  wasmtime_val_t results[1];
-  error = wasmtime_func_call(context, &item.of.func, &externref_val, 1, results, 1, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to call function", error, trap);
+    // And call it!
+    wasmtime_val_t results[1];
+    error = wasmtime_func_call(context, &item.of.func, &externref_val, 1, results, 1, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to call function", error, trap);
 
-  // `func` returns the same reference we gave it, so `results[0]` should be our
-  // `externref`.
-  assert(results[0].kind == WASMTIME_EXTERNREF);
-  assert(strcmp((char*)wasmtime_externref_data(results[0].of.externref), "Hello, World!") == 0);
-  wasmtime_val_delete(&results[0]);
+    // `func` returns the same reference we gave it, so `results[0]` should be our
+    // `externref`.
+    assert(results[0].kind == WASMTIME_EXTERNREF);
+    assert(strcmp((char*)wasmtime_externref_data(results[0].of.externref), "Hello, World!") == 0);
+    wasmtime_val_delete(&results[0]);
 
-  // We can GC any now-unused references to our externref that the store is
-  // holding.
-  printf("GCing within the store...\n");
-  wasmtime_context_gc(context);
+    // We can GC any now-unused references to our externref that the store is
+    // holding.
+    printf("GCing within the store...\n");
+    wasmtime_context_gc(context);
 
-  // Clean up after ourselves at this point
-  printf("All finished!\n");
-  ret = 0;
+    // Clean up after ourselves at this point
+    printf("All finished!\n");
+    ret = 0;
 
-  wasmtime_store_delete(store);
-  wasmtime_module_delete(module);
-  wasm_engine_delete(engine);
-  return 0;
+    wasmtime_store_delete(store);
+    wasmtime_module_delete(module);
+    wasm_engine_delete(engine);
+    return 0;
 }
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-    wasmtime_error_delete(error);
-  } else {
-    wasm_trap_message(trap, &error_message);
-    wasm_trap_delete(trap);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+        wasmtime_error_delete(error);
+    } else {
+        wasm_trap_message(trap, &error_message);
+        wasm_trap_delete(trap);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/externref.c
+++ b/examples/externref.c
@@ -18,8 +18,8 @@ to tweak the `-lpthread` and such annotations as well as the name of the
 
 You can also build using cmake:
 
-mkdir build && cd build && cmake .. && cmake --build . --target
-wasmtime-externref
+mkdir build && cd build && cmake .. && \
+  cmake --build . --target wasmtime-externref
 */
 
 #include <assert.h>

--- a/examples/fib-debug/main.c
+++ b/examples/fib-debug/main.c
@@ -1,99 +1,101 @@
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 #include <wasm.h>
 #include <wasmtime.h>
 
 #define own
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
-int main(int argc, const char* argv[]) {
-  // Configuring engine to support generating of DWARF info.
-  // lldb can be used to attach to the program and observe
-  // original fib-wasm.c source code and variables.
-  wasm_config_t* config = wasm_config_new();
-  wasmtime_config_debug_info_set(config, true);
+int main(int argc, const char* argv[])
+{
+    // Configuring engine to support generating of DWARF info.
+    // lldb can be used to attach to the program and observe
+    // original fib-wasm.c source code and variables.
+    wasm_config_t* config = wasm_config_new();
+    wasmtime_config_debug_info_set(config, true);
 
-  // Initialize.
-  printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new_with_config(config);
-  wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-  wasmtime_context_t* context = wasmtime_store_context(store);
+    // Initialize.
+    printf("Initializing...\n");
+    wasm_engine_t* engine = wasm_engine_new_with_config(config);
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
 
-  // Load binary.
-  printf("Loading binary...\n");
-  FILE* file = fopen("target/wasm32-unknown-unknown/debug/fib.wasm", "rb");
-  if (!file) {
-    printf("> Error opening module!\n");
-    return 1;
-  }
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t binary;
-  wasm_byte_vec_new_uninitialized(&binary, file_size);
-  if (fread(binary.data, file_size, 1, file) != 1) {
-    printf("> Error reading module!\n");
-    return 1;
-  }
-  fclose(file);
+    // Load binary.
+    printf("Loading binary...\n");
+    FILE* file = fopen("target/wasm32-unknown-unknown/debug/fib.wasm", "rb");
+    if (!file) {
+        printf("> Error opening module!\n");
+        return 1;
+    }
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t binary;
+    wasm_byte_vec_new_uninitialized(&binary, file_size);
+    if (fread(binary.data, file_size, 1, file) != 1) {
+        printf("> Error reading module!\n");
+        return 1;
+    }
+    fclose(file);
 
-  // Compile.
-  printf("Compiling module...\n");
-  wasmtime_module_t *module = NULL;
-  wasmtime_error_t* error = wasmtime_module_new(engine, (uint8_t*) binary.data, binary.size, &module);
-  if (!module)
-    exit_with_error("failed to compile module", error, NULL);
-  wasm_byte_vec_delete(&binary);
+    // Compile.
+    printf("Compiling module...\n");
+    wasmtime_module_t* module = NULL;
+    wasmtime_error_t* error = wasmtime_module_new(engine, (uint8_t*)binary.data, binary.size, &module);
+    if (!module)
+        exit_with_error("failed to compile module", error, NULL);
+    wasm_byte_vec_delete(&binary);
 
-  // Instantiate.
-  printf("Instantiating module...\n");
-  wasmtime_instance_t instance;
-  wasm_trap_t *trap = NULL;
-  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate", error, trap);
-  wasmtime_module_delete(module);
+    // Instantiate.
+    printf("Instantiating module...\n");
+    wasmtime_instance_t instance;
+    wasm_trap_t* trap = NULL;
+    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate", error, trap);
+    wasmtime_module_delete(module);
 
-  // Extract export.
-  wasmtime_extern_t fib;
-  bool ok = wasmtime_instance_export_get(context, &instance, "fib", 3, &fib);
-  assert(ok);
+    // Extract export.
+    wasmtime_extern_t fib;
+    bool ok = wasmtime_instance_export_get(context, &instance, "fib", 3, &fib);
+    assert(ok);
 
-  // Call.
-  printf("Calling fib...\n");
-  wasmtime_val_t params[1];
-  params[0].kind = WASMTIME_I32;
-  params[0].of.i32 = 6;
-  wasmtime_val_t results[1];
-  error = wasmtime_func_call(context, &fib.of.func, params, 1, results, 1, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to call function", error, trap);
+    // Call.
+    printf("Calling fib...\n");
+    wasmtime_val_t params[1];
+    params[0].kind = WASMTIME_I32;
+    params[0].of.i32 = 6;
+    wasmtime_val_t results[1];
+    error = wasmtime_func_call(context, &fib.of.func, params, 1, results, 1, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to call function", error, trap);
 
-  assert(results[0].kind == WASMTIME_I32);
-  printf("> fib(6) = %d\n", results[0].of.i32);
+    assert(results[0].kind == WASMTIME_I32);
+    printf("> fib(6) = %d\n", results[0].of.i32);
 
-  // Shut down.
-  printf("Shutting down...\n");
-  wasmtime_store_delete(store);
-  wasm_engine_delete(engine);
+    // Shut down.
+    printf("Shutting down...\n");
+    wasmtime_store_delete(store);
+    wasm_engine_delete(engine);
 
-  // All done.
-  printf("Done.\n");
-  return 0;
+    // All done.
+    printf("Done.\n");
+    return 0;
 }
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-  } else {
-    wasm_trap_message(trap, &error_message);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+    } else {
+        wasm_trap_message(trap, &error_message);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/fib-debug/main.c
+++ b/examples/fib-debug/main.c
@@ -7,95 +7,97 @@
 
 #define own
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
-int main(int argc, const char* argv[])
-{
-    // Configuring engine to support generating of DWARF info.
-    // lldb can be used to attach to the program and observe
-    // original fib-wasm.c source code and variables.
-    wasm_config_t* config = wasm_config_new();
-    wasmtime_config_debug_info_set(config, true);
+int main(int argc, const char *argv[]) {
+  // Configuring engine to support generating of DWARF info.
+  // lldb can be used to attach to the program and observe
+  // original fib-wasm.c source code and variables.
+  wasm_config_t *config = wasm_config_new();
+  wasmtime_config_debug_info_set(config, true);
 
-    // Initialize.
-    printf("Initializing...\n");
-    wasm_engine_t* engine = wasm_engine_new_with_config(config);
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
+  // Initialize.
+  printf("Initializing...\n");
+  wasm_engine_t *engine = wasm_engine_new_with_config(config);
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
 
-    // Load binary.
-    printf("Loading binary...\n");
-    FILE* file = fopen("target/wasm32-unknown-unknown/debug/fib.wasm", "rb");
-    if (!file) {
-        printf("> Error opening module!\n");
-        return 1;
-    }
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    fseek(file, 0L, SEEK_SET);
-    wasm_byte_vec_t binary;
-    wasm_byte_vec_new_uninitialized(&binary, file_size);
-    if (fread(binary.data, file_size, 1, file) != 1) {
-        printf("> Error reading module!\n");
-        return 1;
-    }
-    fclose(file);
+  // Load binary.
+  printf("Loading binary...\n");
+  FILE *file = fopen("target/wasm32-unknown-unknown/debug/fib.wasm", "rb");
+  if (!file) {
+    printf("> Error opening module!\n");
+    return 1;
+  }
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t binary;
+  wasm_byte_vec_new_uninitialized(&binary, file_size);
+  if (fread(binary.data, file_size, 1, file) != 1) {
+    printf("> Error reading module!\n");
+    return 1;
+  }
+  fclose(file);
 
-    // Compile.
-    printf("Compiling module...\n");
-    wasmtime_module_t* module = NULL;
-    wasmtime_error_t* error = wasmtime_module_new(engine, (uint8_t*)binary.data, binary.size, &module);
-    if (!module)
-        exit_with_error("failed to compile module", error, NULL);
-    wasm_byte_vec_delete(&binary);
+  // Compile.
+  printf("Compiling module...\n");
+  wasmtime_module_t *module = NULL;
+  wasmtime_error_t *error =
+      wasmtime_module_new(engine, (uint8_t *)binary.data, binary.size, &module);
+  if (!module)
+    exit_with_error("failed to compile module", error, NULL);
+  wasm_byte_vec_delete(&binary);
 
-    // Instantiate.
-    printf("Instantiating module...\n");
-    wasmtime_instance_t instance;
-    wasm_trap_t* trap = NULL;
-    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate", error, trap);
-    wasmtime_module_delete(module);
+  // Instantiate.
+  printf("Instantiating module...\n");
+  wasmtime_instance_t instance;
+  wasm_trap_t *trap = NULL;
+  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
+  wasmtime_module_delete(module);
 
-    // Extract export.
-    wasmtime_extern_t fib;
-    bool ok = wasmtime_instance_export_get(context, &instance, "fib", 3, &fib);
-    assert(ok);
+  // Extract export.
+  wasmtime_extern_t fib;
+  bool ok = wasmtime_instance_export_get(context, &instance, "fib", 3, &fib);
+  assert(ok);
 
-    // Call.
-    printf("Calling fib...\n");
-    wasmtime_val_t params[1];
-    params[0].kind = WASMTIME_I32;
-    params[0].of.i32 = 6;
-    wasmtime_val_t results[1];
-    error = wasmtime_func_call(context, &fib.of.func, params, 1, results, 1, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to call function", error, trap);
+  // Call.
+  printf("Calling fib...\n");
+  wasmtime_val_t params[1];
+  params[0].kind = WASMTIME_I32;
+  params[0].of.i32 = 6;
+  wasmtime_val_t results[1];
+  error =
+      wasmtime_func_call(context, &fib.of.func, params, 1, results, 1, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call function", error, trap);
 
-    assert(results[0].kind == WASMTIME_I32);
-    printf("> fib(6) = %d\n", results[0].of.i32);
+  assert(results[0].kind == WASMTIME_I32);
+  printf("> fib(6) = %d\n", results[0].of.i32);
 
-    // Shut down.
-    printf("Shutting down...\n");
-    wasmtime_store_delete(store);
-    wasm_engine_delete(engine);
+  // Shut down.
+  printf("Shutting down...\n");
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
 
-    // All done.
-    printf("Done.\n");
-    return 0;
+  // All done.
+  printf("Done.\n");
+  return 0;
 }
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-    } else {
-        wasm_trap_message(trap, &error_message);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
-    exit(1);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+  } else {
+    wasm_trap_message(trap, &error_message);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/examples/fuel.c
+++ b/examples/fuel.c
@@ -27,114 +27,116 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-fuel
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
-int main() {
-  wasmtime_error_t *error = NULL;
+int main()
+{
+    wasmtime_error_t* error = NULL;
 
-  wasm_config_t *config = wasm_config_new();
-  assert(config != NULL);
-  wasmtime_config_consume_fuel_set(config, true);
+    wasm_config_t* config = wasm_config_new();
+    assert(config != NULL);
+    wasmtime_config_consume_fuel_set(config, true);
 
-  // Create an *engine*, which is a compilation context, with our configured options.
-  wasm_engine_t *engine = wasm_engine_new_with_config(config);
-  assert(engine != NULL);
-  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
-  assert(store != NULL);
-  wasmtime_context_t *context = wasmtime_store_context(store);
-
-  error = wasmtime_context_set_fuel(context, 10000);
-  if (error != NULL)
-    exit_with_error("failed to set fuel", error, NULL);
-
-  // Load our input file to parse it next
-  FILE* file = fopen("examples/fuel.wat", "r");
-  if (!file) {
-    printf("> Error loading file!\n");
-    return 1;
-  }
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t wat;
-  wasm_byte_vec_new_uninitialized(&wat, file_size);
-  if (fread(wat.data, file_size, 1, file) != 1) {
-    printf("> Error loading module!\n");
-    return 1;
-  }
-  fclose(file);
-
-  // Parse the wat into the binary wasm format
-  wasm_byte_vec_t wasm;
-  error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-  if (error != NULL)
-    exit_with_error("failed to parse wat", error, NULL);
-  wasm_byte_vec_delete(&wat);
-
-  // Compile and instantiate our module
-  wasmtime_module_t *module = NULL;
-  error = wasmtime_module_new(engine, (uint8_t*) wasm.data, wasm.size, &module);
-  if (module == NULL)
-    exit_with_error("failed to compile module", error, NULL);
-  wasm_byte_vec_delete(&wasm);
-
-  wasm_trap_t *trap = NULL;
-  wasmtime_instance_t instance;
-  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate", error, trap);
-
-  // Lookup our `fibonacci` export function
-  wasmtime_extern_t fib;
-  bool ok = wasmtime_instance_export_get(context, &instance, "fibonacci", strlen("fibonacci"), &fib);
-  assert(ok);
-  assert(fib.kind == WASMTIME_EXTERN_FUNC);
-
-  // Call it repeatedly until it fails
-  for (int n = 1; ; n++) {
-    uint64_t fuel_before;
-    wasmtime_context_get_fuel(context, &fuel_before);
-    wasmtime_val_t params[1];
-    params[0].kind = WASMTIME_I32;
-    params[0].of.i32 = n;
-    wasmtime_val_t results[1];
-    error = wasmtime_func_call(context, &fib.of.func, params, 1, results, 1, &trap);
-    if (error != NULL || trap != NULL) {
-      if (trap != NULL) {
-        wasmtime_trap_code_t code;
-        assert(wasmtime_trap_code(trap, &code));
-        assert(code == WASMTIME_TRAP_CODE_OUT_OF_FUEL);
-      }
-      printf("Exhausted fuel computing fib(%d)\n", n);
-      break;
-    }
-
-    uint64_t fuel_after;
-    wasmtime_context_get_fuel(context, &fuel_after);
-    assert(results[0].kind == WASMTIME_I32);
-    printf("fib(%d) = %d [consumed %lu fuel]\n", n, results[0].of.i32, fuel_after - fuel_before);
+    // Create an *engine*, which is a compilation context, with our configured options.
+    wasm_engine_t* engine = wasm_engine_new_with_config(config);
+    assert(engine != NULL);
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    assert(store != NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
 
     error = wasmtime_context_set_fuel(context, 10000);
     if (error != NULL)
-      exit_with_error("failed to set fuel", error, NULL);
-  }
+        exit_with_error("failed to set fuel", error, NULL);
 
-  // Clean up after ourselves at this point
-  wasmtime_module_delete(module);
-  wasmtime_store_delete(store);
-  wasm_engine_delete(engine);
-  return 0;
+    // Load our input file to parse it next
+    FILE* file = fopen("examples/fuel.wat", "r");
+    if (!file) {
+        printf("> Error loading file!\n");
+        return 1;
+    }
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t wat;
+    wasm_byte_vec_new_uninitialized(&wat, file_size);
+    if (fread(wat.data, file_size, 1, file) != 1) {
+        printf("> Error loading module!\n");
+        return 1;
+    }
+    fclose(file);
+
+    // Parse the wat into the binary wasm format
+    wasm_byte_vec_t wasm;
+    error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+    if (error != NULL)
+        exit_with_error("failed to parse wat", error, NULL);
+    wasm_byte_vec_delete(&wat);
+
+    // Compile and instantiate our module
+    wasmtime_module_t* module = NULL;
+    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
+    if (module == NULL)
+        exit_with_error("failed to compile module", error, NULL);
+    wasm_byte_vec_delete(&wasm);
+
+    wasm_trap_t* trap = NULL;
+    wasmtime_instance_t instance;
+    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate", error, trap);
+
+    // Lookup our `fibonacci` export function
+    wasmtime_extern_t fib;
+    bool ok = wasmtime_instance_export_get(context, &instance, "fibonacci", strlen("fibonacci"), &fib);
+    assert(ok);
+    assert(fib.kind == WASMTIME_EXTERN_FUNC);
+
+    // Call it repeatedly until it fails
+    for (int n = 1;; n++) {
+        uint64_t fuel_before;
+        wasmtime_context_get_fuel(context, &fuel_before);
+        wasmtime_val_t params[1];
+        params[0].kind = WASMTIME_I32;
+        params[0].of.i32 = n;
+        wasmtime_val_t results[1];
+        error = wasmtime_func_call(context, &fib.of.func, params, 1, results, 1, &trap);
+        if (error != NULL || trap != NULL) {
+            if (trap != NULL) {
+                wasmtime_trap_code_t code;
+                assert(wasmtime_trap_code(trap, &code));
+                assert(code == WASMTIME_TRAP_CODE_OUT_OF_FUEL);
+            }
+            printf("Exhausted fuel computing fib(%d)\n", n);
+            break;
+        }
+
+        uint64_t fuel_after;
+        wasmtime_context_get_fuel(context, &fuel_after);
+        assert(results[0].kind == WASMTIME_I32);
+        printf("fib(%d) = %d [consumed %lu fuel]\n", n, results[0].of.i32, fuel_after - fuel_before);
+
+        error = wasmtime_context_set_fuel(context, 10000);
+        if (error != NULL)
+            exit_with_error("failed to set fuel", error, NULL);
+    }
+
+    // Clean up after ourselves at this point
+    wasmtime_module_delete(module);
+    wasmtime_store_delete(store);
+    wasm_engine_delete(engine);
+    return 0;
 }
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-  } else {
-    wasm_trap_message(trap, &error_message);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+    } else {
+        wasm_trap_message(trap, &error_message);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/fuel.c
+++ b/examples/fuel.c
@@ -27,116 +27,120 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-fuel
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
-int main()
-{
-    wasmtime_error_t* error = NULL;
+int main() {
+  wasmtime_error_t *error = NULL;
 
-    wasm_config_t* config = wasm_config_new();
-    assert(config != NULL);
-    wasmtime_config_consume_fuel_set(config, true);
+  wasm_config_t *config = wasm_config_new();
+  assert(config != NULL);
+  wasmtime_config_consume_fuel_set(config, true);
 
-    // Create an *engine*, which is a compilation context, with our configured options.
-    wasm_engine_t* engine = wasm_engine_new_with_config(config);
-    assert(engine != NULL);
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    assert(store != NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
+  // Create an *engine*, which is a compilation context, with our configured
+  // options.
+  wasm_engine_t *engine = wasm_engine_new_with_config(config);
+  assert(engine != NULL);
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  assert(store != NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
+
+  error = wasmtime_context_set_fuel(context, 10000);
+  if (error != NULL)
+    exit_with_error("failed to set fuel", error, NULL);
+
+  // Load our input file to parse it next
+  FILE *file = fopen("examples/fuel.wat", "r");
+  if (!file) {
+    printf("> Error loading file!\n");
+    return 1;
+  }
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
+  fclose(file);
+
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t wasm;
+  error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
+
+  // Compile and instantiate our module
+  wasmtime_module_t *module = NULL;
+  error = wasmtime_module_new(engine, (uint8_t *)wasm.data, wasm.size, &module);
+  if (module == NULL)
+    exit_with_error("failed to compile module", error, NULL);
+  wasm_byte_vec_delete(&wasm);
+
+  wasm_trap_t *trap = NULL;
+  wasmtime_instance_t instance;
+  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
+
+  // Lookup our `fibonacci` export function
+  wasmtime_extern_t fib;
+  bool ok = wasmtime_instance_export_get(context, &instance, "fibonacci",
+                                         strlen("fibonacci"), &fib);
+  assert(ok);
+  assert(fib.kind == WASMTIME_EXTERN_FUNC);
+
+  // Call it repeatedly until it fails
+  for (int n = 1;; n++) {
+    uint64_t fuel_before;
+    wasmtime_context_get_fuel(context, &fuel_before);
+    wasmtime_val_t params[1];
+    params[0].kind = WASMTIME_I32;
+    params[0].of.i32 = n;
+    wasmtime_val_t results[1];
+    error =
+        wasmtime_func_call(context, &fib.of.func, params, 1, results, 1, &trap);
+    if (error != NULL || trap != NULL) {
+      if (trap != NULL) {
+        wasmtime_trap_code_t code;
+        assert(wasmtime_trap_code(trap, &code));
+        assert(code == WASMTIME_TRAP_CODE_OUT_OF_FUEL);
+      }
+      printf("Exhausted fuel computing fib(%d)\n", n);
+      break;
+    }
+
+    uint64_t fuel_after;
+    wasmtime_context_get_fuel(context, &fuel_after);
+    assert(results[0].kind == WASMTIME_I32);
+    printf("fib(%d) = %d [consumed %lu fuel]\n", n, results[0].of.i32,
+           fuel_after - fuel_before);
 
     error = wasmtime_context_set_fuel(context, 10000);
     if (error != NULL)
-        exit_with_error("failed to set fuel", error, NULL);
+      exit_with_error("failed to set fuel", error, NULL);
+  }
 
-    // Load our input file to parse it next
-    FILE* file = fopen("examples/fuel.wat", "r");
-    if (!file) {
-        printf("> Error loading file!\n");
-        return 1;
-    }
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    fseek(file, 0L, SEEK_SET);
-    wasm_byte_vec_t wat;
-    wasm_byte_vec_new_uninitialized(&wat, file_size);
-    if (fread(wat.data, file_size, 1, file) != 1) {
-        printf("> Error loading module!\n");
-        return 1;
-    }
-    fclose(file);
-
-    // Parse the wat into the binary wasm format
-    wasm_byte_vec_t wasm;
-    error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-    if (error != NULL)
-        exit_with_error("failed to parse wat", error, NULL);
-    wasm_byte_vec_delete(&wat);
-
-    // Compile and instantiate our module
-    wasmtime_module_t* module = NULL;
-    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
-    if (module == NULL)
-        exit_with_error("failed to compile module", error, NULL);
-    wasm_byte_vec_delete(&wasm);
-
-    wasm_trap_t* trap = NULL;
-    wasmtime_instance_t instance;
-    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate", error, trap);
-
-    // Lookup our `fibonacci` export function
-    wasmtime_extern_t fib;
-    bool ok = wasmtime_instance_export_get(context, &instance, "fibonacci", strlen("fibonacci"), &fib);
-    assert(ok);
-    assert(fib.kind == WASMTIME_EXTERN_FUNC);
-
-    // Call it repeatedly until it fails
-    for (int n = 1;; n++) {
-        uint64_t fuel_before;
-        wasmtime_context_get_fuel(context, &fuel_before);
-        wasmtime_val_t params[1];
-        params[0].kind = WASMTIME_I32;
-        params[0].of.i32 = n;
-        wasmtime_val_t results[1];
-        error = wasmtime_func_call(context, &fib.of.func, params, 1, results, 1, &trap);
-        if (error != NULL || trap != NULL) {
-            if (trap != NULL) {
-                wasmtime_trap_code_t code;
-                assert(wasmtime_trap_code(trap, &code));
-                assert(code == WASMTIME_TRAP_CODE_OUT_OF_FUEL);
-            }
-            printf("Exhausted fuel computing fib(%d)\n", n);
-            break;
-        }
-
-        uint64_t fuel_after;
-        wasmtime_context_get_fuel(context, &fuel_after);
-        assert(results[0].kind == WASMTIME_I32);
-        printf("fib(%d) = %d [consumed %lu fuel]\n", n, results[0].of.i32, fuel_after - fuel_before);
-
-        error = wasmtime_context_set_fuel(context, 10000);
-        if (error != NULL)
-            exit_with_error("failed to set fuel", error, NULL);
-    }
-
-    // Clean up after ourselves at this point
-    wasmtime_module_delete(module);
-    wasmtime_store_delete(store);
-    wasm_engine_delete(engine);
-    return 0;
+  // Clean up after ourselves at this point
+  wasmtime_module_delete(module);
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+  return 0;
 }
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-    } else {
-        wasm_trap_message(trap, &error_message);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
-    exit(1);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+  } else {
+    wasm_trap_message(trap, &error_message);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/examples/gcd.c
+++ b/examples/gcd.c
@@ -27,96 +27,97 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-gcd
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
-int main()
-{
-    int ret = 0;
-    // Set up our context
-    wasm_engine_t* engine = wasm_engine_new();
-    assert(engine != NULL);
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    assert(store != NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
+int main() {
+  int ret = 0;
+  // Set up our context
+  wasm_engine_t *engine = wasm_engine_new();
+  assert(engine != NULL);
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  assert(store != NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
 
-    // Load our input file to parse it next
-    FILE* file = fopen("examples/gcd.wat", "r");
-    if (!file) {
-        printf("> Error loading file!\n");
-        return 1;
-    }
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    fseek(file, 0L, SEEK_SET);
-    wasm_byte_vec_t wat;
-    wasm_byte_vec_new_uninitialized(&wat, file_size);
-    if (fread(wat.data, file_size, 1, file) != 1) {
-        printf("> Error loading module!\n");
-        return 1;
-    }
-    fclose(file);
+  // Load our input file to parse it next
+  FILE *file = fopen("examples/gcd.wat", "r");
+  if (!file) {
+    printf("> Error loading file!\n");
+    return 1;
+  }
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
+  fclose(file);
 
-    // Parse the wat into the binary wasm format
-    wasm_byte_vec_t wasm;
-    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-    if (error != NULL)
-        exit_with_error("failed to parse wat", error, NULL);
-    wasm_byte_vec_delete(&wat);
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t wasm;
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
 
-    // Compile and instantiate our module
-    wasmtime_module_t* module = NULL;
-    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
-    if (module == NULL)
-        exit_with_error("failed to compile module", error, NULL);
-    wasm_byte_vec_delete(&wasm);
+  // Compile and instantiate our module
+  wasmtime_module_t *module = NULL;
+  error = wasmtime_module_new(engine, (uint8_t *)wasm.data, wasm.size, &module);
+  if (module == NULL)
+    exit_with_error("failed to compile module", error, NULL);
+  wasm_byte_vec_delete(&wasm);
 
-    wasm_trap_t* trap = NULL;
-    wasmtime_instance_t instance;
-    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate", error, trap);
+  wasm_trap_t *trap = NULL;
+  wasmtime_instance_t instance;
+  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
 
-    // Lookup our `gcd` export function
-    wasmtime_extern_t gcd;
-    bool ok = wasmtime_instance_export_get(context, &instance, "gcd", 3, &gcd);
-    assert(ok);
-    assert(gcd.kind == WASMTIME_EXTERN_FUNC);
+  // Lookup our `gcd` export function
+  wasmtime_extern_t gcd;
+  bool ok = wasmtime_instance_export_get(context, &instance, "gcd", 3, &gcd);
+  assert(ok);
+  assert(gcd.kind == WASMTIME_EXTERN_FUNC);
 
-    // And call it!
-    int a = 6;
-    int b = 27;
-    wasmtime_val_t params[2];
-    params[0].kind = WASMTIME_I32;
-    params[0].of.i32 = a;
-    params[1].kind = WASMTIME_I32;
-    params[1].of.i32 = b;
-    wasmtime_val_t results[1];
-    error = wasmtime_func_call(context, &gcd.of.func, params, 2, results, 1, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to call gcd", error, trap);
-    assert(results[0].kind == WASMTIME_I32);
+  // And call it!
+  int a = 6;
+  int b = 27;
+  wasmtime_val_t params[2];
+  params[0].kind = WASMTIME_I32;
+  params[0].of.i32 = a;
+  params[1].kind = WASMTIME_I32;
+  params[1].of.i32 = b;
+  wasmtime_val_t results[1];
+  error =
+      wasmtime_func_call(context, &gcd.of.func, params, 2, results, 1, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call gcd", error, trap);
+  assert(results[0].kind == WASMTIME_I32);
 
-    printf("gcd(%d, %d) = %d\n", a, b, results[0].of.i32);
+  printf("gcd(%d, %d) = %d\n", a, b, results[0].of.i32);
 
-    // Clean up after ourselves at this point
-    ret = 0;
+  // Clean up after ourselves at this point
+  ret = 0;
 
-    wasmtime_module_delete(module);
-    wasmtime_store_delete(store);
-    wasm_engine_delete(engine);
-    return ret;
+  wasmtime_module_delete(module);
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+  return ret;
 }
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-    } else {
-        wasm_trap_message(trap, &error_message);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
-    exit(1);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+  } else {
+    wasm_trap_message(trap, &error_message);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/examples/gcd.c
+++ b/examples/gcd.c
@@ -27,94 +27,96 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-gcd
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
-int main() {
-  int ret = 0;
-  // Set up our context
-  wasm_engine_t *engine = wasm_engine_new();
-  assert(engine != NULL);
-  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
-  assert(store != NULL);
-  wasmtime_context_t *context = wasmtime_store_context(store);
+int main()
+{
+    int ret = 0;
+    // Set up our context
+    wasm_engine_t* engine = wasm_engine_new();
+    assert(engine != NULL);
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    assert(store != NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
 
-  // Load our input file to parse it next
-  FILE* file = fopen("examples/gcd.wat", "r");
-  if (!file) {
-    printf("> Error loading file!\n");
-    return 1;
-  }
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t wat;
-  wasm_byte_vec_new_uninitialized(&wat, file_size);
-  if (fread(wat.data, file_size, 1, file) != 1) {
-    printf("> Error loading module!\n");
-    return 1;
-  }
-  fclose(file);
+    // Load our input file to parse it next
+    FILE* file = fopen("examples/gcd.wat", "r");
+    if (!file) {
+        printf("> Error loading file!\n");
+        return 1;
+    }
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t wat;
+    wasm_byte_vec_new_uninitialized(&wat, file_size);
+    if (fread(wat.data, file_size, 1, file) != 1) {
+        printf("> Error loading module!\n");
+        return 1;
+    }
+    fclose(file);
 
-  // Parse the wat into the binary wasm format
-  wasm_byte_vec_t wasm;
-  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-  if (error != NULL)
-    exit_with_error("failed to parse wat", error, NULL);
-  wasm_byte_vec_delete(&wat);
+    // Parse the wat into the binary wasm format
+    wasm_byte_vec_t wasm;
+    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+    if (error != NULL)
+        exit_with_error("failed to parse wat", error, NULL);
+    wasm_byte_vec_delete(&wat);
 
-  // Compile and instantiate our module
-  wasmtime_module_t *module = NULL;
-  error = wasmtime_module_new(engine, (uint8_t*) wasm.data, wasm.size, &module);
-  if (module == NULL)
-    exit_with_error("failed to compile module", error, NULL);
-  wasm_byte_vec_delete(&wasm);
+    // Compile and instantiate our module
+    wasmtime_module_t* module = NULL;
+    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
+    if (module == NULL)
+        exit_with_error("failed to compile module", error, NULL);
+    wasm_byte_vec_delete(&wasm);
 
-  wasm_trap_t *trap = NULL;
-  wasmtime_instance_t instance;
-  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate", error, trap);
+    wasm_trap_t* trap = NULL;
+    wasmtime_instance_t instance;
+    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate", error, trap);
 
-  // Lookup our `gcd` export function
-  wasmtime_extern_t gcd;
-  bool ok = wasmtime_instance_export_get(context, &instance, "gcd", 3, &gcd);
-  assert(ok);
-  assert(gcd.kind == WASMTIME_EXTERN_FUNC);
+    // Lookup our `gcd` export function
+    wasmtime_extern_t gcd;
+    bool ok = wasmtime_instance_export_get(context, &instance, "gcd", 3, &gcd);
+    assert(ok);
+    assert(gcd.kind == WASMTIME_EXTERN_FUNC);
 
-  // And call it!
-  int a = 6;
-  int b = 27;
-  wasmtime_val_t params[2];
-  params[0].kind = WASMTIME_I32;
-  params[0].of.i32 = a;
-  params[1].kind = WASMTIME_I32;
-  params[1].of.i32 = b;
-  wasmtime_val_t results[1];
-  error = wasmtime_func_call(context, &gcd.of.func, params, 2, results, 1, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to call gcd", error, trap);
-  assert(results[0].kind == WASMTIME_I32);
+    // And call it!
+    int a = 6;
+    int b = 27;
+    wasmtime_val_t params[2];
+    params[0].kind = WASMTIME_I32;
+    params[0].of.i32 = a;
+    params[1].kind = WASMTIME_I32;
+    params[1].of.i32 = b;
+    wasmtime_val_t results[1];
+    error = wasmtime_func_call(context, &gcd.of.func, params, 2, results, 1, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to call gcd", error, trap);
+    assert(results[0].kind == WASMTIME_I32);
 
-  printf("gcd(%d, %d) = %d\n", a, b, results[0].of.i32);
+    printf("gcd(%d, %d) = %d\n", a, b, results[0].of.i32);
 
-  // Clean up after ourselves at this point
-  ret = 0;
+    // Clean up after ourselves at this point
+    ret = 0;
 
-  wasmtime_module_delete(module);
-  wasmtime_store_delete(store);
-  wasm_engine_delete(engine);
-  return ret;
+    wasmtime_module_delete(module);
+    wasmtime_store_delete(store);
+    wasm_engine_delete(engine);
+    return ret;
 }
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-  } else {
-    wasm_trap_message(trap, &error_message);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+    } else {
+        wasm_trap_message(trap, &error_message);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -28,122 +28,117 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-hello
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
-static wasm_trap_t* hello_callback(
-    void* env,
-    wasmtime_caller_t* caller,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    wasmtime_val_t* results,
-    size_t nresults)
-{
-    printf("Calling back...\n");
-    printf("> Hello World!\n");
-    return NULL;
+static wasm_trap_t *hello_callback(void *env, wasmtime_caller_t *caller,
+                                   const wasmtime_val_t *args, size_t nargs,
+                                   wasmtime_val_t *results, size_t nresults) {
+  printf("Calling back...\n");
+  printf("> Hello World!\n");
+  return NULL;
 }
 
-int main()
-{
-    int ret = 0;
-    // Set up our compilation context. Note that we could also work with a
-    // `wasm_config_t` here to configure what feature are enabled and various
-    // compilation settings.
-    printf("Initializing...\n");
-    wasm_engine_t* engine = wasm_engine_new();
-    assert(engine != NULL);
+int main() {
+  int ret = 0;
+  // Set up our compilation context. Note that we could also work with a
+  // `wasm_config_t` here to configure what feature are enabled and various
+  // compilation settings.
+  printf("Initializing...\n");
+  wasm_engine_t *engine = wasm_engine_new();
+  assert(engine != NULL);
 
-    // With an engine we can create a *store* which is a long-lived group of wasm
-    // modules. Note that we allocate some custom data here to live in the store,
-    // but here we skip that and specify NULL.
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    assert(store != NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
+  // With an engine we can create a *store* which is a long-lived group of wasm
+  // modules. Note that we allocate some custom data here to live in the store,
+  // but here we skip that and specify NULL.
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  assert(store != NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
 
-    // Read our input file, which in this case is a wasm text file.
-    FILE* file = fopen("examples/hello.wat", "r");
-    assert(file != NULL);
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    fseek(file, 0L, SEEK_SET);
-    wasm_byte_vec_t wat;
-    wasm_byte_vec_new_uninitialized(&wat, file_size);
-    assert(fread(wat.data, file_size, 1, file) == 1);
-    fclose(file);
+  // Read our input file, which in this case is a wasm text file.
+  FILE *file = fopen("examples/hello.wat", "r");
+  assert(file != NULL);
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  assert(fread(wat.data, file_size, 1, file) == 1);
+  fclose(file);
 
-    // Parse the wat into the binary wasm format
-    wasm_byte_vec_t wasm;
-    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-    if (error != NULL)
-        exit_with_error("failed to parse wat", error, NULL);
-    wasm_byte_vec_delete(&wat);
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t wasm;
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
 
-    // Now that we've got our binary webassembly we can compile our module.
-    printf("Compiling module...\n");
-    wasmtime_module_t* module = NULL;
-    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
-    wasm_byte_vec_delete(&wasm);
-    if (error != NULL)
-        exit_with_error("failed to compile module", error, NULL);
+  // Now that we've got our binary webassembly we can compile our module.
+  printf("Compiling module...\n");
+  wasmtime_module_t *module = NULL;
+  error = wasmtime_module_new(engine, (uint8_t *)wasm.data, wasm.size, &module);
+  wasm_byte_vec_delete(&wasm);
+  if (error != NULL)
+    exit_with_error("failed to compile module", error, NULL);
 
-    // Next up we need to create the function that the wasm module imports. Here
-    // we'll be hooking up a thunk function to the `hello_callback` native
-    // function above. Note that we can assign custom data, but we just use NULL
-    // for now).
-    printf("Creating callback...\n");
-    wasm_functype_t* hello_ty = wasm_functype_new_0_0();
-    wasmtime_func_t hello;
-    wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
+  // Next up we need to create the function that the wasm module imports. Here
+  // we'll be hooking up a thunk function to the `hello_callback` native
+  // function above. Note that we can assign custom data, but we just use NULL
+  // for now).
+  printf("Creating callback...\n");
+  wasm_functype_t *hello_ty = wasm_functype_new_0_0();
+  wasmtime_func_t hello;
+  wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
 
-    // With our callback function we can now instantiate the compiled module,
-    // giving us an instance we can then execute exports from. Note that
-    // instantiation can trap due to execution of the `start` function, so we need
-    // to handle that here too.
-    printf("Instantiating module...\n");
-    wasm_trap_t* trap = NULL;
-    wasmtime_instance_t instance;
-    wasmtime_extern_t import;
-    import.kind = WASMTIME_EXTERN_FUNC;
-    import.of.func = hello;
-    error = wasmtime_instance_new(context, module, &import, 1, &instance, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate", error, trap);
+  // With our callback function we can now instantiate the compiled module,
+  // giving us an instance we can then execute exports from. Note that
+  // instantiation can trap due to execution of the `start` function, so we need
+  // to handle that here too.
+  printf("Instantiating module...\n");
+  wasm_trap_t *trap = NULL;
+  wasmtime_instance_t instance;
+  wasmtime_extern_t import;
+  import.kind = WASMTIME_EXTERN_FUNC;
+  import.of.func = hello;
+  error = wasmtime_instance_new(context, module, &import, 1, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
 
-    // Lookup our `run` export function
-    printf("Extracting export...\n");
-    wasmtime_extern_t run;
-    bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
-    assert(ok);
-    assert(run.kind == WASMTIME_EXTERN_FUNC);
+  // Lookup our `run` export function
+  printf("Extracting export...\n");
+  wasmtime_extern_t run;
+  bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
+  assert(ok);
+  assert(run.kind == WASMTIME_EXTERN_FUNC);
 
-    // And call it!
-    printf("Calling export...\n");
-    error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to call function", error, trap);
+  // And call it!
+  printf("Calling export...\n");
+  error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call function", error, trap);
 
-    // Clean up after ourselves at this point
-    printf("All finished!\n");
-    ret = 0;
+  // Clean up after ourselves at this point
+  printf("All finished!\n");
+  ret = 0;
 
-    wasmtime_module_delete(module);
-    wasmtime_store_delete(store);
-    wasm_engine_delete(engine);
-    return ret;
+  wasmtime_module_delete(module);
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+  return ret;
 }
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-        wasmtime_error_delete(error);
-    } else {
-        wasm_trap_message(trap, &error_message);
-        wasm_trap_delete(trap);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
-    exit(1);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+    wasmtime_error_delete(error);
+  } else {
+    wasm_trap_message(trap, &error_message);
+    wasm_trap_delete(trap);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -28,120 +28,122 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-hello
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
 static wasm_trap_t* hello_callback(
-    void *env,
-    wasmtime_caller_t *caller,
-    const wasmtime_val_t *args,
+    void* env,
+    wasmtime_caller_t* caller,
+    const wasmtime_val_t* args,
     size_t nargs,
-    wasmtime_val_t *results,
-    size_t nresults
-) {
-  printf("Calling back...\n");
-  printf("> Hello World!\n");
-  return NULL;
+    wasmtime_val_t* results,
+    size_t nresults)
+{
+    printf("Calling back...\n");
+    printf("> Hello World!\n");
+    return NULL;
 }
 
-int main() {
-  int ret = 0;
-  // Set up our compilation context. Note that we could also work with a
-  // `wasm_config_t` here to configure what feature are enabled and various
-  // compilation settings.
-  printf("Initializing...\n");
-  wasm_engine_t *engine = wasm_engine_new();
-  assert(engine != NULL);
+int main()
+{
+    int ret = 0;
+    // Set up our compilation context. Note that we could also work with a
+    // `wasm_config_t` here to configure what feature are enabled and various
+    // compilation settings.
+    printf("Initializing...\n");
+    wasm_engine_t* engine = wasm_engine_new();
+    assert(engine != NULL);
 
-  // With an engine we can create a *store* which is a long-lived group of wasm
-  // modules. Note that we allocate some custom data here to live in the store,
-  // but here we skip that and specify NULL.
-  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
-  assert(store != NULL);
-  wasmtime_context_t *context = wasmtime_store_context(store);
+    // With an engine we can create a *store* which is a long-lived group of wasm
+    // modules. Note that we allocate some custom data here to live in the store,
+    // but here we skip that and specify NULL.
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    assert(store != NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
 
-  // Read our input file, which in this case is a wasm text file.
-  FILE* file = fopen("examples/hello.wat", "r");
-  assert(file != NULL);
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t wat;
-  wasm_byte_vec_new_uninitialized(&wat, file_size);
-  assert(fread(wat.data, file_size, 1, file) == 1);
-  fclose(file);
+    // Read our input file, which in this case is a wasm text file.
+    FILE* file = fopen("examples/hello.wat", "r");
+    assert(file != NULL);
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t wat;
+    wasm_byte_vec_new_uninitialized(&wat, file_size);
+    assert(fread(wat.data, file_size, 1, file) == 1);
+    fclose(file);
 
-  // Parse the wat into the binary wasm format
-  wasm_byte_vec_t wasm;
-  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-  if (error != NULL)
-    exit_with_error("failed to parse wat", error, NULL);
-  wasm_byte_vec_delete(&wat);
+    // Parse the wat into the binary wasm format
+    wasm_byte_vec_t wasm;
+    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+    if (error != NULL)
+        exit_with_error("failed to parse wat", error, NULL);
+    wasm_byte_vec_delete(&wat);
 
-  // Now that we've got our binary webassembly we can compile our module.
-  printf("Compiling module...\n");
-  wasmtime_module_t *module = NULL;
-  error = wasmtime_module_new(engine, (uint8_t*) wasm.data, wasm.size, &module);
-  wasm_byte_vec_delete(&wasm);
-  if (error != NULL)
-    exit_with_error("failed to compile module", error, NULL);
+    // Now that we've got our binary webassembly we can compile our module.
+    printf("Compiling module...\n");
+    wasmtime_module_t* module = NULL;
+    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
+    wasm_byte_vec_delete(&wasm);
+    if (error != NULL)
+        exit_with_error("failed to compile module", error, NULL);
 
-  // Next up we need to create the function that the wasm module imports. Here
-  // we'll be hooking up a thunk function to the `hello_callback` native
-  // function above. Note that we can assign custom data, but we just use NULL
-  // for now).
-  printf("Creating callback...\n");
-  wasm_functype_t *hello_ty = wasm_functype_new_0_0();
-  wasmtime_func_t hello;
-  wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
+    // Next up we need to create the function that the wasm module imports. Here
+    // we'll be hooking up a thunk function to the `hello_callback` native
+    // function above. Note that we can assign custom data, but we just use NULL
+    // for now).
+    printf("Creating callback...\n");
+    wasm_functype_t* hello_ty = wasm_functype_new_0_0();
+    wasmtime_func_t hello;
+    wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
 
-  // With our callback function we can now instantiate the compiled module,
-  // giving us an instance we can then execute exports from. Note that
-  // instantiation can trap due to execution of the `start` function, so we need
-  // to handle that here too.
-  printf("Instantiating module...\n");
-  wasm_trap_t *trap = NULL;
-  wasmtime_instance_t instance;
-  wasmtime_extern_t import;
-  import.kind = WASMTIME_EXTERN_FUNC;
-  import.of.func = hello;
-  error = wasmtime_instance_new(context, module, &import, 1, &instance, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate", error, trap);
+    // With our callback function we can now instantiate the compiled module,
+    // giving us an instance we can then execute exports from. Note that
+    // instantiation can trap due to execution of the `start` function, so we need
+    // to handle that here too.
+    printf("Instantiating module...\n");
+    wasm_trap_t* trap = NULL;
+    wasmtime_instance_t instance;
+    wasmtime_extern_t import;
+    import.kind = WASMTIME_EXTERN_FUNC;
+    import.of.func = hello;
+    error = wasmtime_instance_new(context, module, &import, 1, &instance, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate", error, trap);
 
-  // Lookup our `run` export function
-  printf("Extracting export...\n");
-  wasmtime_extern_t run;
-  bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
-  assert(ok);
-  assert(run.kind == WASMTIME_EXTERN_FUNC);
+    // Lookup our `run` export function
+    printf("Extracting export...\n");
+    wasmtime_extern_t run;
+    bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
+    assert(ok);
+    assert(run.kind == WASMTIME_EXTERN_FUNC);
 
-  // And call it!
-  printf("Calling export...\n");
-  error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to call function", error, trap);
+    // And call it!
+    printf("Calling export...\n");
+    error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to call function", error, trap);
 
-  // Clean up after ourselves at this point
-  printf("All finished!\n");
-  ret = 0;
+    // Clean up after ourselves at this point
+    printf("All finished!\n");
+    ret = 0;
 
-  wasmtime_module_delete(module);
-  wasmtime_store_delete(store);
-  wasm_engine_delete(engine);
-  return ret;
+    wasmtime_module_delete(module);
+    wasmtime_store_delete(store);
+    wasm_engine_delete(engine);
+    return ret;
 }
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-    wasmtime_error_delete(error);
-  } else {
-    wasm_trap_message(trap, &error_message);
-    wasm_trap_delete(trap);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+        wasmtime_error_delete(error);
+    } else {
+        wasm_trap_message(trap, &error_message);
+        wasm_trap_delete(trap);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -29,111 +29,116 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-interru
 #include <wasmtime.h>
 
 #ifdef _WIN32
-static void spawn_interrupt(wasm_engine_t *engine) {
-  wasmtime_engine_increment_epoch(engine);
+static void spawn_interrupt(wasm_engine_t* engine)
+{
+    wasmtime_engine_increment_epoch(engine);
 }
 #else
 #include <pthread.h>
 #include <time.h>
 
-static void* helper(void *_engine) {
-  wasm_engine_t *engine = _engine;
-  struct timespec sleep_dur;
-  sleep_dur.tv_sec = 1;
-  sleep_dur.tv_nsec = 0;
-  nanosleep(&sleep_dur, NULL);
-  printf("Sending an interrupt\n");
-  wasmtime_engine_increment_epoch(engine);
-  return 0;
+static void* helper(void* _engine)
+{
+    wasm_engine_t* engine = _engine;
+    struct timespec sleep_dur;
+    sleep_dur.tv_sec = 1;
+    sleep_dur.tv_nsec = 0;
+    nanosleep(&sleep_dur, NULL);
+    printf("Sending an interrupt\n");
+    wasmtime_engine_increment_epoch(engine);
+    return 0;
 }
 
-static void spawn_interrupt(wasm_engine_t *engine) {
-  pthread_t child;
-  int rc = pthread_create(&child, NULL, helper, engine);
-  assert(rc == 0);
+static void spawn_interrupt(wasm_engine_t* engine)
+{
+    pthread_t child;
+    int rc = pthread_create(&child, NULL, helper, engine);
+    assert(rc == 0);
 }
 #endif
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
-int main() {
-  // Create a `wasm_store_t` with interrupts enabled
-  wasm_config_t *config = wasm_config_new();
-  assert(config != NULL);
-  wasmtime_config_epoch_interruption_set(config, true);
-  wasm_engine_t *engine = wasm_engine_new_with_config(config);
-  assert(engine != NULL);
-  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
-  assert(store != NULL);
-  wasmtime_context_t *context = wasmtime_store_context(store);
+int main()
+{
+    // Create a `wasm_store_t` with interrupts enabled
+    wasm_config_t* config = wasm_config_new();
+    assert(config != NULL);
+    wasmtime_config_epoch_interruption_set(config, true);
+    wasm_engine_t* engine = wasm_engine_new_with_config(config);
+    assert(engine != NULL);
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    assert(store != NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
 
-  // Configure the epoch deadline after which WebAssembly code will trap.
-  wasmtime_context_set_epoch_deadline(context, 1);
+    // Configure the epoch deadline after which WebAssembly code will trap.
+    wasmtime_context_set_epoch_deadline(context, 1);
 
-  // Read our input file, which in this case is a wasm text file.
-  FILE* file = fopen("examples/interrupt.wat", "r");
-  assert(file != NULL);
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t wat;
-  wasm_byte_vec_new_uninitialized(&wat, file_size);
-  assert(fread(wat.data, file_size, 1, file) == 1);
-  fclose(file);
+    // Read our input file, which in this case is a wasm text file.
+    FILE* file = fopen("examples/interrupt.wat", "r");
+    assert(file != NULL);
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t wat;
+    wasm_byte_vec_new_uninitialized(&wat, file_size);
+    assert(fread(wat.data, file_size, 1, file) == 1);
+    fclose(file);
 
-  // Parse the wat into the binary wasm format
-  wasm_byte_vec_t wasm;
-  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-  if (error != NULL)
-    exit_with_error("failed to parse wat", error, NULL);
-  wasm_byte_vec_delete(&wat);
+    // Parse the wat into the binary wasm format
+    wasm_byte_vec_t wasm;
+    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+    if (error != NULL)
+        exit_with_error("failed to parse wat", error, NULL);
+    wasm_byte_vec_delete(&wat);
 
-  // Now that we've got our binary webassembly we can compile our module.
-  wasmtime_module_t *module = NULL;
-  error = wasmtime_module_new(engine, (uint8_t*) wasm.data, wasm.size, &module);
-  wasm_byte_vec_delete(&wasm);
-  if (error != NULL)
-    exit_with_error("failed to compile module", error, NULL);
+    // Now that we've got our binary webassembly we can compile our module.
+    wasmtime_module_t* module = NULL;
+    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
+    wasm_byte_vec_delete(&wasm);
+    if (error != NULL)
+        exit_with_error("failed to compile module", error, NULL);
 
-  wasm_trap_t *trap = NULL;
-  wasmtime_instance_t instance;
-  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate", error, trap);
-  wasmtime_module_delete(module);
+    wasm_trap_t* trap = NULL;
+    wasmtime_instance_t instance;
+    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate", error, trap);
+    wasmtime_module_delete(module);
 
-  // Lookup our `run` export function
-  wasmtime_extern_t run;
-  bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
-  assert(ok);
-  assert(run.kind == WASMTIME_EXTERN_FUNC);
+    // Lookup our `run` export function
+    wasmtime_extern_t run;
+    bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
+    assert(ok);
+    assert(run.kind == WASMTIME_EXTERN_FUNC);
 
-  // Spawn a thread to send us an interrupt after a period of time.
-  spawn_interrupt(engine);
+    // Spawn a thread to send us an interrupt after a period of time.
+    spawn_interrupt(engine);
 
-  // And call it!
-  printf("Entering infinite loop...\n");
-  error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
-  assert(error == NULL);
-  assert(trap != NULL);
-  printf("Got a trap!...\n");
+    // And call it!
+    printf("Entering infinite loop...\n");
+    error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
+    assert(error == NULL);
+    assert(trap != NULL);
+    printf("Got a trap!...\n");
 
-  wasmtime_store_delete(store);
-  wasm_engine_delete(engine);
-  return 0;
+    wasmtime_store_delete(store);
+    wasm_engine_delete(engine);
+    return 0;
 }
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-    wasmtime_error_delete(error);
-  } else {
-    wasm_trap_message(trap, &error_message);
-    wasm_trap_delete(trap);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+        wasmtime_error_delete(error);
+    } else {
+        wasm_trap_message(trap, &error_message);
+        wasm_trap_delete(trap);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -19,7 +19,8 @@ to tweak the `-lpthread` and such annotations as well as the name of the
 
 You can also build using cmake:
 
-mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-interrupt
+mkdir build && cd build && cmake .. && cmake --build . --target
+wasmtime-interrupt
 */
 
 #include <assert.h>
@@ -29,116 +30,113 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-interru
 #include <wasmtime.h>
 
 #ifdef _WIN32
-static void spawn_interrupt(wasm_engine_t* engine)
-{
-    wasmtime_engine_increment_epoch(engine);
+static void spawn_interrupt(wasm_engine_t *engine) {
+  wasmtime_engine_increment_epoch(engine);
 }
 #else
 #include <pthread.h>
 #include <time.h>
 
-static void* helper(void* _engine)
-{
-    wasm_engine_t* engine = _engine;
-    struct timespec sleep_dur;
-    sleep_dur.tv_sec = 1;
-    sleep_dur.tv_nsec = 0;
-    nanosleep(&sleep_dur, NULL);
-    printf("Sending an interrupt\n");
-    wasmtime_engine_increment_epoch(engine);
-    return 0;
+static void *helper(void *_engine) {
+  wasm_engine_t *engine = _engine;
+  struct timespec sleep_dur;
+  sleep_dur.tv_sec = 1;
+  sleep_dur.tv_nsec = 0;
+  nanosleep(&sleep_dur, NULL);
+  printf("Sending an interrupt\n");
+  wasmtime_engine_increment_epoch(engine);
+  return 0;
 }
 
-static void spawn_interrupt(wasm_engine_t* engine)
-{
-    pthread_t child;
-    int rc = pthread_create(&child, NULL, helper, engine);
-    assert(rc == 0);
+static void spawn_interrupt(wasm_engine_t *engine) {
+  pthread_t child;
+  int rc = pthread_create(&child, NULL, helper, engine);
+  assert(rc == 0);
 }
 #endif
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
-int main()
-{
-    // Create a `wasm_store_t` with interrupts enabled
-    wasm_config_t* config = wasm_config_new();
-    assert(config != NULL);
-    wasmtime_config_epoch_interruption_set(config, true);
-    wasm_engine_t* engine = wasm_engine_new_with_config(config);
-    assert(engine != NULL);
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    assert(store != NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
+int main() {
+  // Create a `wasm_store_t` with interrupts enabled
+  wasm_config_t *config = wasm_config_new();
+  assert(config != NULL);
+  wasmtime_config_epoch_interruption_set(config, true);
+  wasm_engine_t *engine = wasm_engine_new_with_config(config);
+  assert(engine != NULL);
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  assert(store != NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
 
-    // Configure the epoch deadline after which WebAssembly code will trap.
-    wasmtime_context_set_epoch_deadline(context, 1);
+  // Configure the epoch deadline after which WebAssembly code will trap.
+  wasmtime_context_set_epoch_deadline(context, 1);
 
-    // Read our input file, which in this case is a wasm text file.
-    FILE* file = fopen("examples/interrupt.wat", "r");
-    assert(file != NULL);
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    fseek(file, 0L, SEEK_SET);
-    wasm_byte_vec_t wat;
-    wasm_byte_vec_new_uninitialized(&wat, file_size);
-    assert(fread(wat.data, file_size, 1, file) == 1);
-    fclose(file);
+  // Read our input file, which in this case is a wasm text file.
+  FILE *file = fopen("examples/interrupt.wat", "r");
+  assert(file != NULL);
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  assert(fread(wat.data, file_size, 1, file) == 1);
+  fclose(file);
 
-    // Parse the wat into the binary wasm format
-    wasm_byte_vec_t wasm;
-    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-    if (error != NULL)
-        exit_with_error("failed to parse wat", error, NULL);
-    wasm_byte_vec_delete(&wat);
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t wasm;
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
 
-    // Now that we've got our binary webassembly we can compile our module.
-    wasmtime_module_t* module = NULL;
-    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
-    wasm_byte_vec_delete(&wasm);
-    if (error != NULL)
-        exit_with_error("failed to compile module", error, NULL);
+  // Now that we've got our binary webassembly we can compile our module.
+  wasmtime_module_t *module = NULL;
+  error = wasmtime_module_new(engine, (uint8_t *)wasm.data, wasm.size, &module);
+  wasm_byte_vec_delete(&wasm);
+  if (error != NULL)
+    exit_with_error("failed to compile module", error, NULL);
 
-    wasm_trap_t* trap = NULL;
-    wasmtime_instance_t instance;
-    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate", error, trap);
-    wasmtime_module_delete(module);
+  wasm_trap_t *trap = NULL;
+  wasmtime_instance_t instance;
+  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
+  wasmtime_module_delete(module);
 
-    // Lookup our `run` export function
-    wasmtime_extern_t run;
-    bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
-    assert(ok);
-    assert(run.kind == WASMTIME_EXTERN_FUNC);
+  // Lookup our `run` export function
+  wasmtime_extern_t run;
+  bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
+  assert(ok);
+  assert(run.kind == WASMTIME_EXTERN_FUNC);
 
-    // Spawn a thread to send us an interrupt after a period of time.
-    spawn_interrupt(engine);
+  // Spawn a thread to send us an interrupt after a period of time.
+  spawn_interrupt(engine);
 
-    // And call it!
-    printf("Entering infinite loop...\n");
-    error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
-    assert(error == NULL);
-    assert(trap != NULL);
-    printf("Got a trap!...\n");
+  // And call it!
+  printf("Entering infinite loop...\n");
+  error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
+  assert(error == NULL);
+  assert(trap != NULL);
+  printf("Got a trap!...\n");
 
-    wasmtime_store_delete(store);
-    wasm_engine_delete(engine);
-    return 0;
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+  return 0;
 }
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-        wasmtime_error_delete(error);
-    } else {
-        wasm_trap_message(trap, &error_message);
-        wasm_trap_delete(trap);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
-    exit(1);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+    wasmtime_error_delete(error);
+  } else {
+    wasm_trap_message(trap, &error_message);
+    wasm_trap_delete(trap);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -19,8 +19,8 @@ to tweak the `-lpthread` and such annotations as well as the name of the
 
 You can also build using cmake:
 
-mkdir build && cd build && cmake .. && cmake --build . --target
-wasmtime-interrupt
+mkdir build && cd build && cmake .. && \
+  cmake --build . --target wasmtime-interrupt
 */
 
 #include <assert.h>

--- a/examples/linking.c
+++ b/examples/linking.c
@@ -24,135 +24,137 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-linking
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <wasm.h>
 #include <wasi.h>
+#include <wasm.h>
 #include <wasmtime.h>
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
-static void read_wat_file(wasm_engine_t *engine, wasm_byte_vec_t *bytes, const char *file);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void read_wat_file(wasm_engine_t* engine, wasm_byte_vec_t* bytes, const char* file);
 
-int main() {
-  // Set up our context
-  wasm_engine_t *engine = wasm_engine_new();
-  assert(engine != NULL);
-  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
-  assert(store != NULL);
-  wasmtime_context_t *context = wasmtime_store_context(store);
+int main()
+{
+    // Set up our context
+    wasm_engine_t* engine = wasm_engine_new();
+    assert(engine != NULL);
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    assert(store != NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
 
-  wasm_byte_vec_t linking1_wasm, linking2_wasm;
-  read_wat_file(engine, &linking1_wasm, "examples/linking1.wat");
-  read_wat_file(engine, &linking2_wasm, "examples/linking2.wat");
+    wasm_byte_vec_t linking1_wasm, linking2_wasm;
+    read_wat_file(engine, &linking1_wasm, "examples/linking1.wat");
+    read_wat_file(engine, &linking2_wasm, "examples/linking2.wat");
 
-  // Compile our two modules
-  wasmtime_error_t *error;
-  wasmtime_module_t *linking1_module = NULL;
-  wasmtime_module_t *linking2_module = NULL;
-  error = wasmtime_module_new(engine, (uint8_t*) linking1_wasm.data, linking1_wasm.size, &linking1_module);
-  if (error != NULL)
-    exit_with_error("failed to compile linking1", error, NULL);
-  error = wasmtime_module_new(engine, (uint8_t*) linking2_wasm.data, linking2_wasm.size, &linking2_module);
-  if (error != NULL)
-    exit_with_error("failed to compile linking2", error, NULL);
-  wasm_byte_vec_delete(&linking1_wasm);
-  wasm_byte_vec_delete(&linking2_wasm);
+    // Compile our two modules
+    wasmtime_error_t* error;
+    wasmtime_module_t* linking1_module = NULL;
+    wasmtime_module_t* linking2_module = NULL;
+    error = wasmtime_module_new(engine, (uint8_t*)linking1_wasm.data, linking1_wasm.size, &linking1_module);
+    if (error != NULL)
+        exit_with_error("failed to compile linking1", error, NULL);
+    error = wasmtime_module_new(engine, (uint8_t*)linking2_wasm.data, linking2_wasm.size, &linking2_module);
+    if (error != NULL)
+        exit_with_error("failed to compile linking2", error, NULL);
+    wasm_byte_vec_delete(&linking1_wasm);
+    wasm_byte_vec_delete(&linking2_wasm);
 
-  // Configure WASI and store it within our `wasmtime_store_t`
-  wasi_config_t *wasi_config = wasi_config_new();
-  assert(wasi_config);
-  wasi_config_inherit_argv(wasi_config);
-  wasi_config_inherit_env(wasi_config);
-  wasi_config_inherit_stdin(wasi_config);
-  wasi_config_inherit_stdout(wasi_config);
-  wasi_config_inherit_stderr(wasi_config);
-  wasm_trap_t *trap = NULL;
-  error = wasmtime_context_set_wasi(context, wasi_config);
-  if (error != NULL)
-    exit_with_error("failed to instantiate wasi", NULL, trap);
+    // Configure WASI and store it within our `wasmtime_store_t`
+    wasi_config_t* wasi_config = wasi_config_new();
+    assert(wasi_config);
+    wasi_config_inherit_argv(wasi_config);
+    wasi_config_inherit_env(wasi_config);
+    wasi_config_inherit_stdin(wasi_config);
+    wasi_config_inherit_stdout(wasi_config);
+    wasi_config_inherit_stderr(wasi_config);
+    wasm_trap_t* trap = NULL;
+    error = wasmtime_context_set_wasi(context, wasi_config);
+    if (error != NULL)
+        exit_with_error("failed to instantiate wasi", NULL, trap);
 
-  // Create our linker which will be linking our modules together, and then add
-  // our WASI instance to it.
-  wasmtime_linker_t *linker = wasmtime_linker_new(engine);
-  error = wasmtime_linker_define_wasi(linker);
-  if (error != NULL)
-    exit_with_error("failed to link wasi", error, NULL);
+    // Create our linker which will be linking our modules together, and then add
+    // our WASI instance to it.
+    wasmtime_linker_t* linker = wasmtime_linker_new(engine);
+    error = wasmtime_linker_define_wasi(linker);
+    if (error != NULL)
+        exit_with_error("failed to link wasi", error, NULL);
 
-  // Instantiate `linking2` with our linker.
-  wasmtime_instance_t linking2;
-  error = wasmtime_linker_instantiate(linker, context, linking2_module, &linking2, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate linking2", error, trap);
+    // Instantiate `linking2` with our linker.
+    wasmtime_instance_t linking2;
+    error = wasmtime_linker_instantiate(linker, context, linking2_module, &linking2, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate linking2", error, trap);
 
-  // Register our new `linking2` instance with the linker
-  error = wasmtime_linker_define_instance(linker, context, "linking2", strlen("linking2"), &linking2);
-  if (error != NULL)
-    exit_with_error("failed to link linking2", error, NULL);
+    // Register our new `linking2` instance with the linker
+    error = wasmtime_linker_define_instance(linker, context, "linking2", strlen("linking2"), &linking2);
+    if (error != NULL)
+        exit_with_error("failed to link linking2", error, NULL);
 
-  // Instantiate `linking1` with the linker now that `linking2` is defined
-  wasmtime_instance_t linking1;
-  error = wasmtime_linker_instantiate(linker, context, linking1_module, &linking1, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate linking1", error, trap);
+    // Instantiate `linking1` with the linker now that `linking2` is defined
+    wasmtime_instance_t linking1;
+    error = wasmtime_linker_instantiate(linker, context, linking1_module, &linking1, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate linking1", error, trap);
 
-  // Lookup our `run` export function
-  wasmtime_extern_t run;
-  bool ok = wasmtime_instance_export_get(context, &linking1, "run", 3, &run);
-  assert(ok);
-  assert(run.kind == WASMTIME_EXTERN_FUNC);
-  error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to call run", error, trap);
+    // Lookup our `run` export function
+    wasmtime_extern_t run;
+    bool ok = wasmtime_instance_export_get(context, &linking1, "run", 3, &run);
+    assert(ok);
+    assert(run.kind == WASMTIME_EXTERN_FUNC);
+    error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to call run", error, trap);
 
-  // Clean up after ourselves at this point
-  wasmtime_linker_delete(linker);
-  wasmtime_module_delete(linking1_module);
-  wasmtime_module_delete(linking2_module);
-  wasmtime_store_delete(store);
-  wasm_engine_delete(engine);
-  return 0;
+    // Clean up after ourselves at this point
+    wasmtime_linker_delete(linker);
+    wasmtime_module_delete(linking1_module);
+    wasmtime_module_delete(linking2_module);
+    wasmtime_store_delete(store);
+    wasm_engine_delete(engine);
+    return 0;
 }
 
 static void read_wat_file(
-  wasm_engine_t *engine,
-  wasm_byte_vec_t *bytes,
-  const char *filename
-) {
-  wasm_byte_vec_t wat;
-  // Load our input file to parse it next
-  FILE* file = fopen(filename, "r");
-  if (!file) {
-    printf("> Error loading file!\n");
-    exit(1);
-  }
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  wasm_byte_vec_new_uninitialized(&wat, file_size);
-  fseek(file, 0L, SEEK_SET);
-  if (fread(wat.data, file_size, 1, file) != 1) {
-    printf("> Error loading module!\n");
-    exit(1);
-  }
-  fclose(file);
+    wasm_engine_t* engine,
+    wasm_byte_vec_t* bytes,
+    const char* filename)
+{
+    wasm_byte_vec_t wat;
+    // Load our input file to parse it next
+    FILE* file = fopen(filename, "r");
+    if (!file) {
+        printf("> Error loading file!\n");
+        exit(1);
+    }
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    wasm_byte_vec_new_uninitialized(&wat, file_size);
+    fseek(file, 0L, SEEK_SET);
+    if (fread(wat.data, file_size, 1, file) != 1) {
+        printf("> Error loading module!\n");
+        exit(1);
+    }
+    fclose(file);
 
-  // Parse the wat into the binary wasm format
-  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, bytes);
-  if (error != NULL)
-    exit_with_error("failed to parse wat", error, NULL);
-  wasm_byte_vec_delete(&wat);
+    // Parse the wat into the binary wasm format
+    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, bytes);
+    if (error != NULL)
+        exit_with_error("failed to parse wat", error, NULL);
+    wasm_byte_vec_delete(&wat);
 }
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-    wasmtime_error_delete(error);
-  } else {
-    wasm_trap_message(trap, &error_message);
-    wasm_trap_delete(trap);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+        wasmtime_error_delete(error);
+    } else {
+        wasm_trap_message(trap, &error_message);
+        wasm_trap_delete(trap);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/linking.c
+++ b/examples/linking.c
@@ -30,131 +30,134 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-linking
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
-static void read_wat_file(wasm_engine_t* engine, wasm_byte_vec_t* bytes, const char* file);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
+static void read_wat_file(wasm_engine_t *engine, wasm_byte_vec_t *bytes,
+                          const char *file);
 
-int main()
-{
-    // Set up our context
-    wasm_engine_t* engine = wasm_engine_new();
-    assert(engine != NULL);
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    assert(store != NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
+int main() {
+  // Set up our context
+  wasm_engine_t *engine = wasm_engine_new();
+  assert(engine != NULL);
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  assert(store != NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
 
-    wasm_byte_vec_t linking1_wasm, linking2_wasm;
-    read_wat_file(engine, &linking1_wasm, "examples/linking1.wat");
-    read_wat_file(engine, &linking2_wasm, "examples/linking2.wat");
+  wasm_byte_vec_t linking1_wasm, linking2_wasm;
+  read_wat_file(engine, &linking1_wasm, "examples/linking1.wat");
+  read_wat_file(engine, &linking2_wasm, "examples/linking2.wat");
 
-    // Compile our two modules
-    wasmtime_error_t* error;
-    wasmtime_module_t* linking1_module = NULL;
-    wasmtime_module_t* linking2_module = NULL;
-    error = wasmtime_module_new(engine, (uint8_t*)linking1_wasm.data, linking1_wasm.size, &linking1_module);
-    if (error != NULL)
-        exit_with_error("failed to compile linking1", error, NULL);
-    error = wasmtime_module_new(engine, (uint8_t*)linking2_wasm.data, linking2_wasm.size, &linking2_module);
-    if (error != NULL)
-        exit_with_error("failed to compile linking2", error, NULL);
-    wasm_byte_vec_delete(&linking1_wasm);
-    wasm_byte_vec_delete(&linking2_wasm);
+  // Compile our two modules
+  wasmtime_error_t *error;
+  wasmtime_module_t *linking1_module = NULL;
+  wasmtime_module_t *linking2_module = NULL;
+  error = wasmtime_module_new(engine, (uint8_t *)linking1_wasm.data,
+                              linking1_wasm.size, &linking1_module);
+  if (error != NULL)
+    exit_with_error("failed to compile linking1", error, NULL);
+  error = wasmtime_module_new(engine, (uint8_t *)linking2_wasm.data,
+                              linking2_wasm.size, &linking2_module);
+  if (error != NULL)
+    exit_with_error("failed to compile linking2", error, NULL);
+  wasm_byte_vec_delete(&linking1_wasm);
+  wasm_byte_vec_delete(&linking2_wasm);
 
-    // Configure WASI and store it within our `wasmtime_store_t`
-    wasi_config_t* wasi_config = wasi_config_new();
-    assert(wasi_config);
-    wasi_config_inherit_argv(wasi_config);
-    wasi_config_inherit_env(wasi_config);
-    wasi_config_inherit_stdin(wasi_config);
-    wasi_config_inherit_stdout(wasi_config);
-    wasi_config_inherit_stderr(wasi_config);
-    wasm_trap_t* trap = NULL;
-    error = wasmtime_context_set_wasi(context, wasi_config);
-    if (error != NULL)
-        exit_with_error("failed to instantiate wasi", NULL, trap);
+  // Configure WASI and store it within our `wasmtime_store_t`
+  wasi_config_t *wasi_config = wasi_config_new();
+  assert(wasi_config);
+  wasi_config_inherit_argv(wasi_config);
+  wasi_config_inherit_env(wasi_config);
+  wasi_config_inherit_stdin(wasi_config);
+  wasi_config_inherit_stdout(wasi_config);
+  wasi_config_inherit_stderr(wasi_config);
+  wasm_trap_t *trap = NULL;
+  error = wasmtime_context_set_wasi(context, wasi_config);
+  if (error != NULL)
+    exit_with_error("failed to instantiate wasi", NULL, trap);
 
-    // Create our linker which will be linking our modules together, and then add
-    // our WASI instance to it.
-    wasmtime_linker_t* linker = wasmtime_linker_new(engine);
-    error = wasmtime_linker_define_wasi(linker);
-    if (error != NULL)
-        exit_with_error("failed to link wasi", error, NULL);
+  // Create our linker which will be linking our modules together, and then add
+  // our WASI instance to it.
+  wasmtime_linker_t *linker = wasmtime_linker_new(engine);
+  error = wasmtime_linker_define_wasi(linker);
+  if (error != NULL)
+    exit_with_error("failed to link wasi", error, NULL);
 
-    // Instantiate `linking2` with our linker.
-    wasmtime_instance_t linking2;
-    error = wasmtime_linker_instantiate(linker, context, linking2_module, &linking2, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate linking2", error, trap);
+  // Instantiate `linking2` with our linker.
+  wasmtime_instance_t linking2;
+  error = wasmtime_linker_instantiate(linker, context, linking2_module,
+                                      &linking2, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate linking2", error, trap);
 
-    // Register our new `linking2` instance with the linker
-    error = wasmtime_linker_define_instance(linker, context, "linking2", strlen("linking2"), &linking2);
-    if (error != NULL)
-        exit_with_error("failed to link linking2", error, NULL);
+  // Register our new `linking2` instance with the linker
+  error = wasmtime_linker_define_instance(linker, context, "linking2",
+                                          strlen("linking2"), &linking2);
+  if (error != NULL)
+    exit_with_error("failed to link linking2", error, NULL);
 
-    // Instantiate `linking1` with the linker now that `linking2` is defined
-    wasmtime_instance_t linking1;
-    error = wasmtime_linker_instantiate(linker, context, linking1_module, &linking1, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate linking1", error, trap);
+  // Instantiate `linking1` with the linker now that `linking2` is defined
+  wasmtime_instance_t linking1;
+  error = wasmtime_linker_instantiate(linker, context, linking1_module,
+                                      &linking1, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate linking1", error, trap);
 
-    // Lookup our `run` export function
-    wasmtime_extern_t run;
-    bool ok = wasmtime_instance_export_get(context, &linking1, "run", 3, &run);
-    assert(ok);
-    assert(run.kind == WASMTIME_EXTERN_FUNC);
-    error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to call run", error, trap);
+  // Lookup our `run` export function
+  wasmtime_extern_t run;
+  bool ok = wasmtime_instance_export_get(context, &linking1, "run", 3, &run);
+  assert(ok);
+  assert(run.kind == WASMTIME_EXTERN_FUNC);
+  error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call run", error, trap);
 
-    // Clean up after ourselves at this point
-    wasmtime_linker_delete(linker);
-    wasmtime_module_delete(linking1_module);
-    wasmtime_module_delete(linking2_module);
-    wasmtime_store_delete(store);
-    wasm_engine_delete(engine);
-    return 0;
+  // Clean up after ourselves at this point
+  wasmtime_linker_delete(linker);
+  wasmtime_module_delete(linking1_module);
+  wasmtime_module_delete(linking2_module);
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+  return 0;
 }
 
-static void read_wat_file(
-    wasm_engine_t* engine,
-    wasm_byte_vec_t* bytes,
-    const char* filename)
-{
-    wasm_byte_vec_t wat;
-    // Load our input file to parse it next
-    FILE* file = fopen(filename, "r");
-    if (!file) {
-        printf("> Error loading file!\n");
-        exit(1);
-    }
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    wasm_byte_vec_new_uninitialized(&wat, file_size);
-    fseek(file, 0L, SEEK_SET);
-    if (fread(wat.data, file_size, 1, file) != 1) {
-        printf("> Error loading module!\n");
-        exit(1);
-    }
-    fclose(file);
-
-    // Parse the wat into the binary wasm format
-    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, bytes);
-    if (error != NULL)
-        exit_with_error("failed to parse wat", error, NULL);
-    wasm_byte_vec_delete(&wat);
-}
-
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-        wasmtime_error_delete(error);
-    } else {
-        wasm_trap_message(trap, &error_message);
-        wasm_trap_delete(trap);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
+static void read_wat_file(wasm_engine_t *engine, wasm_byte_vec_t *bytes,
+                          const char *filename) {
+  wasm_byte_vec_t wat;
+  // Load our input file to parse it next
+  FILE *file = fopen(filename, "r");
+  if (!file) {
+    printf("> Error loading file!\n");
     exit(1);
+  }
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  fseek(file, 0L, SEEK_SET);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    exit(1);
+  }
+  fclose(file);
+
+  // Parse the wat into the binary wasm format
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, bytes);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
+}
+
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+    wasmtime_error_delete(error);
+  } else {
+    wasm_trap_message(trap, &error_message);
+    wasm_trap_delete(trap);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/examples/memory.c
+++ b/examples/memory.c
@@ -32,260 +32,258 @@ originally
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
-void check(bool success)
-{
-    if (!success) {
-        printf("> Error, expected success\n");
-        exit(1);
-    }
-}
-
-void check_call(wasmtime_context_t* store,
-    wasmtime_func_t* func,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    int32_t expected)
-{
-    wasmtime_val_t results[1];
-    wasm_trap_t* trap = NULL;
-    wasmtime_error_t* error = wasmtime_func_call(
-        store, func, args, nargs, results, 1, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to call function", error, trap);
-    if (results[0].of.i32 != expected) {
-        printf("> Error on result\n");
-        exit(1);
-    }
-}
-
-void check_call0(wasmtime_context_t* store, wasmtime_func_t* func, int32_t expected)
-{
-    check_call(store, func, NULL, 0, expected);
-}
-
-void check_call1(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg, int32_t expected)
-{
-    wasmtime_val_t args[1];
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = arg;
-    check_call(store, func, args, 1, expected);
-}
-
-void check_call2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2, int32_t expected)
-{
-    wasmtime_val_t args[2];
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = arg1;
-    args[1].kind = WASMTIME_I32;
-    args[1].of.i32 = arg2;
-    check_call(store, func, args, 2, expected);
-}
-
-void check_ok(wasmtime_context_t* store, wasmtime_func_t* func, const wasmtime_val_t* args, size_t nargs)
-{
-    wasm_trap_t* trap = NULL;
-    wasmtime_error_t* error = wasmtime_func_call(store, func, args, nargs, NULL, 0, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to call function", error, trap);
-}
-
-void check_ok2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2)
-{
-    wasmtime_val_t args[2];
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = arg1;
-    args[1].kind = WASMTIME_I32;
-    args[1].of.i32 = arg2;
-    check_ok(store, func, args, 2);
-}
-
-void check_trap(wasmtime_context_t* store,
-    wasmtime_func_t* func,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    size_t num_results)
-{
-    assert(num_results <= 1);
-    wasmtime_val_t results[1];
-    wasm_trap_t* trap = NULL;
-    wasmtime_error_t* error = wasmtime_func_call(store, func, args, nargs, results, num_results, &trap);
-    if (error != NULL)
-        exit_with_error("failed to call function", error, NULL);
-    if (trap == NULL) {
-        printf("> Error on result, expected trap\n");
-        exit(1);
-    }
-    wasm_trap_delete(trap);
-}
-
-void check_trap1(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg)
-{
-    wasmtime_val_t args[1];
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = arg;
-    check_trap(store, func, args, 1, 1);
-}
-
-void check_trap2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2)
-{
-    wasmtime_val_t args[2];
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = arg1;
-    args[1].kind = WASMTIME_I32;
-    args[1].of.i32 = arg2;
-    check_trap(store, func, args, 2, 0);
-}
-
-int main(int argc, const char* argv[])
-{
-    // Initialize.
-    printf("Initializing...\n");
-    wasm_engine_t* engine = wasm_engine_new();
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
-
-    // Load our input file to parse it next
-    FILE* file = fopen("examples/memory.wat", "r");
-    if (!file) {
-        printf("> Error loading file!\n");
-        return 1;
-    }
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    fseek(file, 0L, SEEK_SET);
-    wasm_byte_vec_t wat;
-    wasm_byte_vec_new_uninitialized(&wat, file_size);
-    if (fread(wat.data, file_size, 1, file) != 1) {
-        printf("> Error loading module!\n");
-        return 1;
-    }
-    fclose(file);
-
-    // Parse the wat into the binary wasm format
-    wasm_byte_vec_t binary;
-    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
-    if (error != NULL)
-        exit_with_error("failed to parse wat", error, NULL);
-    wasm_byte_vec_delete(&wat);
-
-    // Compile.
-    printf("Compiling module...\n");
-    wasmtime_module_t* module = NULL;
-    error = wasmtime_module_new(engine, (uint8_t*)binary.data, binary.size, &module);
-    if (error)
-        exit_with_error("failed to compile module", error, NULL);
-    wasm_byte_vec_delete(&binary);
-
-    // Instantiate.
-    printf("Instantiating module...\n");
-    wasmtime_instance_t instance;
-    wasm_trap_t* trap = NULL;
-    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate", error, trap);
-    wasmtime_module_delete(module);
-
-    // Extract export.
-    printf("Extracting exports...\n");
-    wasmtime_memory_t memory;
-    wasmtime_func_t size_func, load_func, store_func;
-    wasmtime_extern_t item;
-    bool ok;
-    ok = wasmtime_instance_export_get(context, &instance, "memory", strlen("memory"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
-    memory = item.of.memory;
-    ok = wasmtime_instance_export_get(context, &instance, "size", strlen("size"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-    size_func = item.of.func;
-    ok = wasmtime_instance_export_get(context, &instance, "load", strlen("load"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-    load_func = item.of.func;
-    ok = wasmtime_instance_export_get(context, &instance, "store", strlen("store"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-    store_func = item.of.func;
-
-    // Check initial memory.
-    printf("Checking memory...\n");
-    check(wasmtime_memory_size(context, &memory) == 2);
-    check(wasmtime_memory_data_size(context, &memory) == 0x20000);
-    check(wasmtime_memory_data(context, &memory)[0] == 0);
-    check(wasmtime_memory_data(context, &memory)[0x1000] == 1);
-    check(wasmtime_memory_data(context, &memory)[0x1003] == 4);
-
-    check_call0(context, &size_func, 2);
-    check_call1(context, &load_func, 0, 0);
-    check_call1(context, &load_func, 0x1000, 1);
-    check_call1(context, &load_func, 0x1003, 4);
-    check_call1(context, &load_func, 0x1ffff, 0);
-    check_trap1(context, &load_func, 0x20000);
-
-    // Mutate memory.
-    printf("Mutating memory...\n");
-    wasmtime_memory_data(context, &memory)[0x1003] = 5;
-    check_ok2(context, &store_func, 0x1002, 6);
-    check_trap2(context, &store_func, 0x20000, 0);
-
-    check(wasmtime_memory_data(context, &memory)[0x1002] == 6);
-    check(wasmtime_memory_data(context, &memory)[0x1003] == 5);
-    check_call1(context, &load_func, 0x1002, 6);
-    check_call1(context, &load_func, 0x1003, 5);
-
-    // Grow memory.
-    printf("Growing memory...\n");
-    uint64_t old_size;
-    error = wasmtime_memory_grow(context, &memory, 1, &old_size);
-    if (error != NULL)
-        exit_with_error("failed to grow memory", error, trap);
-    check(wasmtime_memory_size(context, &memory) == 3);
-    check(wasmtime_memory_data_size(context, &memory) == 0x30000);
-
-    check_call1(context, &load_func, 0x20000, 0);
-    check_ok2(context, &store_func, 0x20000, 0);
-    check_trap1(context, &load_func, 0x30000);
-    check_trap2(context, &store_func, 0x30000, 0);
-
-    error = wasmtime_memory_grow(context, &memory, 1, &old_size);
-    assert(error != NULL);
-    wasmtime_error_delete(error);
-    error = wasmtime_memory_grow(context, &memory, 0, &old_size);
-    if (error != NULL)
-        exit_with_error("failed to grow memory", error, trap);
-
-    // Create stand-alone memory.
-    printf("Creating stand-alone memory...\n");
-    wasm_limits_t limits = { 5, 5 };
-    wasm_memorytype_t* memorytype = wasm_memorytype_new(&limits);
-    wasmtime_memory_t memory2;
-    error = wasmtime_memory_new(context, memorytype, &memory2);
-    if (error != NULL)
-        exit_with_error("failed to create memory", error, trap);
-    wasm_memorytype_delete(memorytype);
-    check(wasmtime_memory_size(context, &memory2) == 5);
-
-    // Shut down.
-    printf("Shutting down...\n");
-    wasmtime_store_delete(store);
-    wasm_engine_delete(engine);
-
-    // All done.
-    printf("Done.\n");
-    return 0;
-}
-
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-        wasmtime_error_delete(error);
-    } else {
-        wasm_trap_message(trap, &error_message);
-        wasm_trap_delete(trap);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
+void check(bool success) {
+  if (!success) {
+    printf("> Error, expected success\n");
     exit(1);
+  }
+}
+
+void check_call(wasmtime_context_t *store, wasmtime_func_t *func,
+                const wasmtime_val_t *args, size_t nargs, int32_t expected) {
+  wasmtime_val_t results[1];
+  wasm_trap_t *trap = NULL;
+  wasmtime_error_t *error =
+      wasmtime_func_call(store, func, args, nargs, results, 1, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call function", error, trap);
+  if (results[0].of.i32 != expected) {
+    printf("> Error on result\n");
+    exit(1);
+  }
+}
+
+void check_call0(wasmtime_context_t *store, wasmtime_func_t *func,
+                 int32_t expected) {
+  check_call(store, func, NULL, 0, expected);
+}
+
+void check_call1(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg,
+                 int32_t expected) {
+  wasmtime_val_t args[1];
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = arg;
+  check_call(store, func, args, 1, expected);
+}
+
+void check_call2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1,
+                 int32_t arg2, int32_t expected) {
+  wasmtime_val_t args[2];
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = arg1;
+  args[1].kind = WASMTIME_I32;
+  args[1].of.i32 = arg2;
+  check_call(store, func, args, 2, expected);
+}
+
+void check_ok(wasmtime_context_t *store, wasmtime_func_t *func,
+              const wasmtime_val_t *args, size_t nargs) {
+  wasm_trap_t *trap = NULL;
+  wasmtime_error_t *error =
+      wasmtime_func_call(store, func, args, nargs, NULL, 0, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call function", error, trap);
+}
+
+void check_ok2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1,
+               int32_t arg2) {
+  wasmtime_val_t args[2];
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = arg1;
+  args[1].kind = WASMTIME_I32;
+  args[1].of.i32 = arg2;
+  check_ok(store, func, args, 2);
+}
+
+void check_trap(wasmtime_context_t *store, wasmtime_func_t *func,
+                const wasmtime_val_t *args, size_t nargs, size_t num_results) {
+  assert(num_results <= 1);
+  wasmtime_val_t results[1];
+  wasm_trap_t *trap = NULL;
+  wasmtime_error_t *error =
+      wasmtime_func_call(store, func, args, nargs, results, num_results, &trap);
+  if (error != NULL)
+    exit_with_error("failed to call function", error, NULL);
+  if (trap == NULL) {
+    printf("> Error on result, expected trap\n");
+    exit(1);
+  }
+  wasm_trap_delete(trap);
+}
+
+void check_trap1(wasmtime_context_t *store, wasmtime_func_t *func,
+                 int32_t arg) {
+  wasmtime_val_t args[1];
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = arg;
+  check_trap(store, func, args, 1, 1);
+}
+
+void check_trap2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1,
+                 int32_t arg2) {
+  wasmtime_val_t args[2];
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = arg1;
+  args[1].kind = WASMTIME_I32;
+  args[1].of.i32 = arg2;
+  check_trap(store, func, args, 2, 0);
+}
+
+int main(int argc, const char *argv[]) {
+  // Initialize.
+  printf("Initializing...\n");
+  wasm_engine_t *engine = wasm_engine_new();
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
+
+  // Load our input file to parse it next
+  FILE *file = fopen("examples/memory.wat", "r");
+  if (!file) {
+    printf("> Error loading file!\n");
+    return 1;
+  }
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
+  fclose(file);
+
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t binary;
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
+
+  // Compile.
+  printf("Compiling module...\n");
+  wasmtime_module_t *module = NULL;
+  error =
+      wasmtime_module_new(engine, (uint8_t *)binary.data, binary.size, &module);
+  if (error)
+    exit_with_error("failed to compile module", error, NULL);
+  wasm_byte_vec_delete(&binary);
+
+  // Instantiate.
+  printf("Instantiating module...\n");
+  wasmtime_instance_t instance;
+  wasm_trap_t *trap = NULL;
+  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
+  wasmtime_module_delete(module);
+
+  // Extract export.
+  printf("Extracting exports...\n");
+  wasmtime_memory_t memory;
+  wasmtime_func_t size_func, load_func, store_func;
+  wasmtime_extern_t item;
+  bool ok;
+  ok = wasmtime_instance_export_get(context, &instance, "memory",
+                                    strlen("memory"), &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
+  memory = item.of.memory;
+  ok = wasmtime_instance_export_get(context, &instance, "size", strlen("size"),
+                                    &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+  size_func = item.of.func;
+  ok = wasmtime_instance_export_get(context, &instance, "load", strlen("load"),
+                                    &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+  load_func = item.of.func;
+  ok = wasmtime_instance_export_get(context, &instance, "store",
+                                    strlen("store"), &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+  store_func = item.of.func;
+
+  // Check initial memory.
+  printf("Checking memory...\n");
+  check(wasmtime_memory_size(context, &memory) == 2);
+  check(wasmtime_memory_data_size(context, &memory) == 0x20000);
+  check(wasmtime_memory_data(context, &memory)[0] == 0);
+  check(wasmtime_memory_data(context, &memory)[0x1000] == 1);
+  check(wasmtime_memory_data(context, &memory)[0x1003] == 4);
+
+  check_call0(context, &size_func, 2);
+  check_call1(context, &load_func, 0, 0);
+  check_call1(context, &load_func, 0x1000, 1);
+  check_call1(context, &load_func, 0x1003, 4);
+  check_call1(context, &load_func, 0x1ffff, 0);
+  check_trap1(context, &load_func, 0x20000);
+
+  // Mutate memory.
+  printf("Mutating memory...\n");
+  wasmtime_memory_data(context, &memory)[0x1003] = 5;
+  check_ok2(context, &store_func, 0x1002, 6);
+  check_trap2(context, &store_func, 0x20000, 0);
+
+  check(wasmtime_memory_data(context, &memory)[0x1002] == 6);
+  check(wasmtime_memory_data(context, &memory)[0x1003] == 5);
+  check_call1(context, &load_func, 0x1002, 6);
+  check_call1(context, &load_func, 0x1003, 5);
+
+  // Grow memory.
+  printf("Growing memory...\n");
+  uint64_t old_size;
+  error = wasmtime_memory_grow(context, &memory, 1, &old_size);
+  if (error != NULL)
+    exit_with_error("failed to grow memory", error, trap);
+  check(wasmtime_memory_size(context, &memory) == 3);
+  check(wasmtime_memory_data_size(context, &memory) == 0x30000);
+
+  check_call1(context, &load_func, 0x20000, 0);
+  check_ok2(context, &store_func, 0x20000, 0);
+  check_trap1(context, &load_func, 0x30000);
+  check_trap2(context, &store_func, 0x30000, 0);
+
+  error = wasmtime_memory_grow(context, &memory, 1, &old_size);
+  assert(error != NULL);
+  wasmtime_error_delete(error);
+  error = wasmtime_memory_grow(context, &memory, 0, &old_size);
+  if (error != NULL)
+    exit_with_error("failed to grow memory", error, trap);
+
+  // Create stand-alone memory.
+  printf("Creating stand-alone memory...\n");
+  wasm_limits_t limits = {5, 5};
+  wasm_memorytype_t *memorytype = wasm_memorytype_new(&limits);
+  wasmtime_memory_t memory2;
+  error = wasmtime_memory_new(context, memorytype, &memory2);
+  if (error != NULL)
+    exit_with_error("failed to create memory", error, trap);
+  wasm_memorytype_delete(memorytype);
+  check(wasmtime_memory_size(context, &memory2) == 5);
+
+  // Shut down.
+  printf("Shutting down...\n");
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+
+  // All done.
+  printf("Done.\n");
+  return 0;
+}
+
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+    wasmtime_error_delete(error);
+  } else {
+    wasm_trap_message(trap, &error_message);
+    wasm_trap_delete(trap);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/examples/memory.c
+++ b/examples/memory.c
@@ -32,249 +32,260 @@ originally
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
-void check(bool success) {
-  if (!success) {
-    printf("> Error, expected success\n");
-    exit(1);
-  }
+void check(bool success)
+{
+    if (!success) {
+        printf("> Error, expected success\n");
+        exit(1);
+    }
 }
 
-void check_call(wasmtime_context_t *store,
-                wasmtime_func_t *func,
-                const wasmtime_val_t* args,
-                size_t nargs,
-                int32_t expected) {
-  wasmtime_val_t results[1];
-  wasm_trap_t *trap = NULL;
-  wasmtime_error_t *error = wasmtime_func_call(
-      store, func, args, nargs, results, 1, &trap
-  );
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to call function", error, trap);
-  if (results[0].of.i32 != expected) {
-    printf("> Error on result\n");
-    exit(1);
-  }
+void check_call(wasmtime_context_t* store,
+    wasmtime_func_t* func,
+    const wasmtime_val_t* args,
+    size_t nargs,
+    int32_t expected)
+{
+    wasmtime_val_t results[1];
+    wasm_trap_t* trap = NULL;
+    wasmtime_error_t* error = wasmtime_func_call(
+        store, func, args, nargs, results, 1, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to call function", error, trap);
+    if (results[0].of.i32 != expected) {
+        printf("> Error on result\n");
+        exit(1);
+    }
 }
 
-void check_call0(wasmtime_context_t *store, wasmtime_func_t *func, int32_t expected) {
-  check_call(store, func, NULL, 0, expected);
+void check_call0(wasmtime_context_t* store, wasmtime_func_t* func, int32_t expected)
+{
+    check_call(store, func, NULL, 0, expected);
 }
 
-void check_call1(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg, int32_t expected) {
-  wasmtime_val_t args[1];
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = arg;
-  check_call(store, func, args, 1, expected);
+void check_call1(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg, int32_t expected)
+{
+    wasmtime_val_t args[1];
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = arg;
+    check_call(store, func, args, 1, expected);
 }
 
-void check_call2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1, int32_t arg2, int32_t expected) {
-  wasmtime_val_t args[2];
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = arg1;
-  args[1].kind = WASMTIME_I32;
-  args[1].of.i32 = arg2;
-  check_call(store, func, args, 2, expected);
+void check_call2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2, int32_t expected)
+{
+    wasmtime_val_t args[2];
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = arg1;
+    args[1].kind = WASMTIME_I32;
+    args[1].of.i32 = arg2;
+    check_call(store, func, args, 2, expected);
 }
 
-void check_ok(wasmtime_context_t *store, wasmtime_func_t *func, const wasmtime_val_t* args, size_t nargs) {
-  wasm_trap_t *trap = NULL;
-  wasmtime_error_t *error = wasmtime_func_call(store, func, args, nargs, NULL, 0, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to call function", error, trap);
+void check_ok(wasmtime_context_t* store, wasmtime_func_t* func, const wasmtime_val_t* args, size_t nargs)
+{
+    wasm_trap_t* trap = NULL;
+    wasmtime_error_t* error = wasmtime_func_call(store, func, args, nargs, NULL, 0, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to call function", error, trap);
 }
 
-void check_ok2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1, int32_t arg2) {
-  wasmtime_val_t args[2];
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = arg1;
-  args[1].kind = WASMTIME_I32;
-  args[1].of.i32 = arg2;
-  check_ok(store, func, args, 2);
+void check_ok2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2)
+{
+    wasmtime_val_t args[2];
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = arg1;
+    args[1].kind = WASMTIME_I32;
+    args[1].of.i32 = arg2;
+    check_ok(store, func, args, 2);
 }
 
-void check_trap(wasmtime_context_t *store,
-                wasmtime_func_t *func,
-                const wasmtime_val_t *args,
-                size_t nargs,
-                size_t num_results) {
-  assert(num_results <= 1);
-  wasmtime_val_t results[1];
-  wasm_trap_t *trap = NULL;
-  wasmtime_error_t *error = wasmtime_func_call(store, func, args, nargs, results, num_results, &trap);
-  if (error != NULL)
-    exit_with_error("failed to call function", error, NULL);
-  if (trap == NULL) {
-    printf("> Error on result, expected trap\n");
-    exit(1);
-  }
-  wasm_trap_delete(trap);
-}
-
-void check_trap1(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg) {
-  wasmtime_val_t args[1];
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = arg;
-  check_trap(store, func, args, 1, 1);
-}
-
-void check_trap2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1, int32_t arg2) {
-  wasmtime_val_t args[2];
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = arg1;
-  args[1].kind = WASMTIME_I32;
-  args[1].of.i32 = arg2;
-  check_trap(store, func, args, 2, 0);
-}
-
-int main(int argc, const char* argv[]) {
-  // Initialize.
-  printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new();
-  wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-  wasmtime_context_t *context = wasmtime_store_context(store);
-
-  // Load our input file to parse it next
-  FILE* file = fopen("examples/memory.wat", "r");
-  if (!file) {
-    printf("> Error loading file!\n");
-    return 1;
-  }
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t wat;
-  wasm_byte_vec_new_uninitialized(&wat, file_size);
-  if (fread(wat.data, file_size, 1, file) != 1) {
-    printf("> Error loading module!\n");
-    return 1;
-  }
-  fclose(file);
-
-  // Parse the wat into the binary wasm format
-  wasm_byte_vec_t binary;
-  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
-  if (error != NULL)
-    exit_with_error("failed to parse wat", error, NULL);
-  wasm_byte_vec_delete(&wat);
-
-  // Compile.
-  printf("Compiling module...\n");
-  wasmtime_module_t* module = NULL;
-  error = wasmtime_module_new(engine, (uint8_t*) binary.data, binary.size, &module);
-  if (error)
-    exit_with_error("failed to compile module", error, NULL);
-  wasm_byte_vec_delete(&binary);
-
-  // Instantiate.
-  printf("Instantiating module...\n");
-  wasmtime_instance_t instance;
-  wasm_trap_t *trap = NULL;
-  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate", error, trap);
-  wasmtime_module_delete(module);
-
-  // Extract export.
-  printf("Extracting exports...\n");
-  wasmtime_memory_t memory;
-  wasmtime_func_t size_func, load_func, store_func;
-  wasmtime_extern_t item;
-  bool ok;
-  ok = wasmtime_instance_export_get(context, &instance, "memory", strlen("memory"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
-  memory = item.of.memory;
-  ok = wasmtime_instance_export_get(context, &instance, "size", strlen("size"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-  size_func = item.of.func;
-  ok = wasmtime_instance_export_get(context, &instance, "load", strlen("load"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-  load_func = item.of.func;
-  ok = wasmtime_instance_export_get(context, &instance, "store", strlen("store"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-  store_func = item.of.func;
-
-  // Check initial memory.
-  printf("Checking memory...\n");
-  check(wasmtime_memory_size(context, &memory) == 2);
-  check(wasmtime_memory_data_size(context, &memory) == 0x20000);
-  check(wasmtime_memory_data(context, &memory)[0] == 0);
-  check(wasmtime_memory_data(context, &memory)[0x1000] == 1);
-  check(wasmtime_memory_data(context, &memory)[0x1003] == 4);
-
-  check_call0(context, &size_func, 2);
-  check_call1(context, &load_func, 0, 0);
-  check_call1(context, &load_func, 0x1000, 1);
-  check_call1(context, &load_func, 0x1003, 4);
-  check_call1(context, &load_func, 0x1ffff, 0);
-  check_trap1(context, &load_func, 0x20000);
-
-  // Mutate memory.
-  printf("Mutating memory...\n");
-  wasmtime_memory_data(context, &memory)[0x1003] = 5;
-  check_ok2(context, &store_func, 0x1002, 6);
-  check_trap2(context, &store_func, 0x20000, 0);
-
-  check(wasmtime_memory_data(context, &memory)[0x1002] == 6);
-  check(wasmtime_memory_data(context, &memory)[0x1003] == 5);
-  check_call1(context, &load_func, 0x1002, 6);
-  check_call1(context, &load_func, 0x1003, 5);
-
-  // Grow memory.
-  printf("Growing memory...\n");
-  uint64_t old_size;
-  error = wasmtime_memory_grow(context, &memory, 1, &old_size);
-  if (error != NULL)
-    exit_with_error("failed to grow memory", error, trap);
-  check(wasmtime_memory_size(context, &memory) == 3);
-  check(wasmtime_memory_data_size(context, &memory) == 0x30000);
-
-  check_call1(context, &load_func, 0x20000, 0);
-  check_ok2(context, &store_func, 0x20000, 0);
-  check_trap1(context, &load_func, 0x30000);
-  check_trap2(context, &store_func, 0x30000, 0);
-
-  error = wasmtime_memory_grow(context, &memory, 1, &old_size);
-  assert(error != NULL);
-  wasmtime_error_delete(error);
-  error = wasmtime_memory_grow(context, &memory, 0, &old_size);
-  if (error != NULL)
-    exit_with_error("failed to grow memory", error, trap);
-
-  // Create stand-alone memory.
-  printf("Creating stand-alone memory...\n");
-  wasm_limits_t limits = {5, 5};
-  wasm_memorytype_t* memorytype = wasm_memorytype_new(&limits);
-  wasmtime_memory_t memory2;
-  error = wasmtime_memory_new(context, memorytype, &memory2);
-  if (error != NULL)
-    exit_with_error("failed to create memory", error, trap);
-  wasm_memorytype_delete(memorytype);
-  check(wasmtime_memory_size(context, &memory2) == 5);
-
-  // Shut down.
-  printf("Shutting down...\n");
-  wasmtime_store_delete(store);
-  wasm_engine_delete(engine);
-
-  // All done.
-  printf("Done.\n");
-  return 0;
-}
-
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-    wasmtime_error_delete(error);
-  } else {
-    wasm_trap_message(trap, &error_message);
+void check_trap(wasmtime_context_t* store,
+    wasmtime_func_t* func,
+    const wasmtime_val_t* args,
+    size_t nargs,
+    size_t num_results)
+{
+    assert(num_results <= 1);
+    wasmtime_val_t results[1];
+    wasm_trap_t* trap = NULL;
+    wasmtime_error_t* error = wasmtime_func_call(store, func, args, nargs, results, num_results, &trap);
+    if (error != NULL)
+        exit_with_error("failed to call function", error, NULL);
+    if (trap == NULL) {
+        printf("> Error on result, expected trap\n");
+        exit(1);
+    }
     wasm_trap_delete(trap);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+}
+
+void check_trap1(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg)
+{
+    wasmtime_val_t args[1];
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = arg;
+    check_trap(store, func, args, 1, 1);
+}
+
+void check_trap2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2)
+{
+    wasmtime_val_t args[2];
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = arg1;
+    args[1].kind = WASMTIME_I32;
+    args[1].of.i32 = arg2;
+    check_trap(store, func, args, 2, 0);
+}
+
+int main(int argc, const char* argv[])
+{
+    // Initialize.
+    printf("Initializing...\n");
+    wasm_engine_t* engine = wasm_engine_new();
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
+
+    // Load our input file to parse it next
+    FILE* file = fopen("examples/memory.wat", "r");
+    if (!file) {
+        printf("> Error loading file!\n");
+        return 1;
+    }
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t wat;
+    wasm_byte_vec_new_uninitialized(&wat, file_size);
+    if (fread(wat.data, file_size, 1, file) != 1) {
+        printf("> Error loading module!\n");
+        return 1;
+    }
+    fclose(file);
+
+    // Parse the wat into the binary wasm format
+    wasm_byte_vec_t binary;
+    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
+    if (error != NULL)
+        exit_with_error("failed to parse wat", error, NULL);
+    wasm_byte_vec_delete(&wat);
+
+    // Compile.
+    printf("Compiling module...\n");
+    wasmtime_module_t* module = NULL;
+    error = wasmtime_module_new(engine, (uint8_t*)binary.data, binary.size, &module);
+    if (error)
+        exit_with_error("failed to compile module", error, NULL);
+    wasm_byte_vec_delete(&binary);
+
+    // Instantiate.
+    printf("Instantiating module...\n");
+    wasmtime_instance_t instance;
+    wasm_trap_t* trap = NULL;
+    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate", error, trap);
+    wasmtime_module_delete(module);
+
+    // Extract export.
+    printf("Extracting exports...\n");
+    wasmtime_memory_t memory;
+    wasmtime_func_t size_func, load_func, store_func;
+    wasmtime_extern_t item;
+    bool ok;
+    ok = wasmtime_instance_export_get(context, &instance, "memory", strlen("memory"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
+    memory = item.of.memory;
+    ok = wasmtime_instance_export_get(context, &instance, "size", strlen("size"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+    size_func = item.of.func;
+    ok = wasmtime_instance_export_get(context, &instance, "load", strlen("load"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+    load_func = item.of.func;
+    ok = wasmtime_instance_export_get(context, &instance, "store", strlen("store"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+    store_func = item.of.func;
+
+    // Check initial memory.
+    printf("Checking memory...\n");
+    check(wasmtime_memory_size(context, &memory) == 2);
+    check(wasmtime_memory_data_size(context, &memory) == 0x20000);
+    check(wasmtime_memory_data(context, &memory)[0] == 0);
+    check(wasmtime_memory_data(context, &memory)[0x1000] == 1);
+    check(wasmtime_memory_data(context, &memory)[0x1003] == 4);
+
+    check_call0(context, &size_func, 2);
+    check_call1(context, &load_func, 0, 0);
+    check_call1(context, &load_func, 0x1000, 1);
+    check_call1(context, &load_func, 0x1003, 4);
+    check_call1(context, &load_func, 0x1ffff, 0);
+    check_trap1(context, &load_func, 0x20000);
+
+    // Mutate memory.
+    printf("Mutating memory...\n");
+    wasmtime_memory_data(context, &memory)[0x1003] = 5;
+    check_ok2(context, &store_func, 0x1002, 6);
+    check_trap2(context, &store_func, 0x20000, 0);
+
+    check(wasmtime_memory_data(context, &memory)[0x1002] == 6);
+    check(wasmtime_memory_data(context, &memory)[0x1003] == 5);
+    check_call1(context, &load_func, 0x1002, 6);
+    check_call1(context, &load_func, 0x1003, 5);
+
+    // Grow memory.
+    printf("Growing memory...\n");
+    uint64_t old_size;
+    error = wasmtime_memory_grow(context, &memory, 1, &old_size);
+    if (error != NULL)
+        exit_with_error("failed to grow memory", error, trap);
+    check(wasmtime_memory_size(context, &memory) == 3);
+    check(wasmtime_memory_data_size(context, &memory) == 0x30000);
+
+    check_call1(context, &load_func, 0x20000, 0);
+    check_ok2(context, &store_func, 0x20000, 0);
+    check_trap1(context, &load_func, 0x30000);
+    check_trap2(context, &store_func, 0x30000, 0);
+
+    error = wasmtime_memory_grow(context, &memory, 1, &old_size);
+    assert(error != NULL);
+    wasmtime_error_delete(error);
+    error = wasmtime_memory_grow(context, &memory, 0, &old_size);
+    if (error != NULL)
+        exit_with_error("failed to grow memory", error, trap);
+
+    // Create stand-alone memory.
+    printf("Creating stand-alone memory...\n");
+    wasm_limits_t limits = { 5, 5 };
+    wasm_memorytype_t* memorytype = wasm_memorytype_new(&limits);
+    wasmtime_memory_t memory2;
+    error = wasmtime_memory_new(context, memorytype, &memory2);
+    if (error != NULL)
+        exit_with_error("failed to create memory", error, trap);
+    wasm_memorytype_delete(memorytype);
+    check(wasmtime_memory_size(context, &memory2) == 5);
+
+    // Shut down.
+    printf("Shutting down...\n");
+    wasmtime_store_delete(store);
+    wasm_engine_delete(engine);
+
+    // All done.
+    printf("Done.\n");
+    return 0;
+}
+
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+        wasmtime_error_delete(error);
+    } else {
+        wasm_trap_message(trap, &error_message);
+        wasm_trap_delete(trap);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -32,158 +32,147 @@ originally
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
 // A function to be called from Wasm code.
-wasm_trap_t* callback(
-    void* env,
-    wasmtime_caller_t* caller,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    wasmtime_val_t* results,
-    size_t nresults)
-{
-    printf("Calling back...\n");
-    printf("> %" PRIu32 " %" PRIu64 "\n", args[0].of.i32, args[1].of.i64);
-    printf("\n");
+wasm_trap_t *callback(void *env, wasmtime_caller_t *caller,
+                      const wasmtime_val_t *args, size_t nargs,
+                      wasmtime_val_t *results, size_t nresults) {
+  printf("Calling back...\n");
+  printf("> %" PRIu32 " %" PRIu64 "\n", args[0].of.i32, args[1].of.i64);
+  printf("\n");
 
-    results[0] = args[1];
-    results[1] = args[0];
-    return NULL;
+  results[0] = args[1];
+  results[1] = args[0];
+  return NULL;
 }
 
 // A function closure.
-wasm_trap_t* closure_callback(
-    void* env,
-    wasmtime_caller_t* caller,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    wasmtime_val_t* results,
-    size_t nresults)
-{
-    int i = *(int*)env;
-    printf("Calling back closure...\n");
-    printf("> %d\n", i);
+wasm_trap_t *closure_callback(void *env, wasmtime_caller_t *caller,
+                              const wasmtime_val_t *args, size_t nargs,
+                              wasmtime_val_t *results, size_t nresults) {
+  int i = *(int *)env;
+  printf("Calling back closure...\n");
+  printf("> %d\n", i);
 
-    results[0].kind = WASMTIME_I32;
-    results[0].of.i32 = (int32_t)i;
-    return NULL;
+  results[0].kind = WASMTIME_I32;
+  results[0].of.i32 = (int32_t)i;
+  return NULL;
 }
 
-int main(int argc, const char* argv[])
-{
-    // Initialize.
-    printf("Initializing...\n");
-    wasm_engine_t* engine = wasm_engine_new();
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
+int main(int argc, const char *argv[]) {
+  // Initialize.
+  printf("Initializing...\n");
+  wasm_engine_t *engine = wasm_engine_new();
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
 
-    // Load our input file to parse it next
-    FILE* file = fopen("examples/multi.wat", "r");
-    if (!file) {
-        printf("> Error loading file!\n");
-        return 1;
-    }
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    fseek(file, 0L, SEEK_SET);
-    wasm_byte_vec_t wat;
-    wasm_byte_vec_new_uninitialized(&wat, file_size);
-    if (fread(wat.data, file_size, 1, file) != 1) {
-        printf("> Error loading module!\n");
-        return 1;
-    }
-    fclose(file);
+  // Load our input file to parse it next
+  FILE *file = fopen("examples/multi.wat", "r");
+  if (!file) {
+    printf("> Error loading file!\n");
+    return 1;
+  }
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
+  fclose(file);
 
-    // Parse the wat into the binary wasm format
-    wasm_byte_vec_t binary;
-    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
-    if (error != NULL)
-        exit_with_error("failed to parse wat", error, NULL);
-    wasm_byte_vec_delete(&wat);
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t binary;
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
 
-    // Compile.
-    printf("Compiling module...\n");
-    wasmtime_module_t* module = NULL;
-    error = wasmtime_module_new(engine, (uint8_t*)binary.data, binary.size, &module);
-    if (error)
-        exit_with_error("failed to compile module", error, NULL);
-    wasm_byte_vec_delete(&binary);
+  // Compile.
+  printf("Compiling module...\n");
+  wasmtime_module_t *module = NULL;
+  error =
+      wasmtime_module_new(engine, (uint8_t *)binary.data, binary.size, &module);
+  if (error)
+    exit_with_error("failed to compile module", error, NULL);
+  wasm_byte_vec_delete(&binary);
 
-    // Create external print functions.
-    printf("Creating callback...\n");
-    wasm_functype_t* callback_type = wasm_functype_new_2_2(
-        wasm_valtype_new_i32(),
-        wasm_valtype_new_i64(),
-        wasm_valtype_new_i64(),
-        wasm_valtype_new_i32());
-    wasmtime_func_t callback_func;
-    wasmtime_func_new(context, callback_type, callback, NULL, NULL, &callback_func);
-    wasm_functype_delete(callback_type);
+  // Create external print functions.
+  printf("Creating callback...\n");
+  wasm_functype_t *callback_type =
+      wasm_functype_new_2_2(wasm_valtype_new_i32(), wasm_valtype_new_i64(),
+                            wasm_valtype_new_i64(), wasm_valtype_new_i32());
+  wasmtime_func_t callback_func;
+  wasmtime_func_new(context, callback_type, callback, NULL, NULL,
+                    &callback_func);
+  wasm_functype_delete(callback_type);
 
-    // Instantiate.
-    printf("Instantiating module...\n");
-    wasmtime_extern_t imports[1];
-    imports[0].kind = WASMTIME_EXTERN_FUNC;
-    imports[0].of.func = callback_func;
-    wasmtime_instance_t instance;
-    wasm_trap_t* trap = NULL;
-    error = wasmtime_instance_new(context, module, imports, 1, &instance, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate", error, trap);
-    wasmtime_module_delete(module);
+  // Instantiate.
+  printf("Instantiating module...\n");
+  wasmtime_extern_t imports[1];
+  imports[0].kind = WASMTIME_EXTERN_FUNC;
+  imports[0].of.func = callback_func;
+  wasmtime_instance_t instance;
+  wasm_trap_t *trap = NULL;
+  error = wasmtime_instance_new(context, module, imports, 1, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
+  wasmtime_module_delete(module);
 
-    // Extract export.
-    printf("Extracting export...\n");
-    wasmtime_extern_t run;
-    bool ok = wasmtime_instance_export_get(context, &instance, "g", 1, &run);
-    assert(ok);
-    assert(run.kind == WASMTIME_EXTERN_FUNC);
+  // Extract export.
+  printf("Extracting export...\n");
+  wasmtime_extern_t run;
+  bool ok = wasmtime_instance_export_get(context, &instance, "g", 1, &run);
+  assert(ok);
+  assert(run.kind == WASMTIME_EXTERN_FUNC);
 
-    // Call.
-    printf("Calling export...\n");
-    wasmtime_val_t args[2];
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = 1;
-    args[1].kind = WASMTIME_I64;
-    args[1].of.i64 = 2;
-    wasmtime_val_t results[2];
-    error = wasmtime_func_call(context, &run.of.func, args, 2, results, 2, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to call run", error, trap);
+  // Call.
+  printf("Calling export...\n");
+  wasmtime_val_t args[2];
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = 1;
+  args[1].kind = WASMTIME_I64;
+  args[1].of.i64 = 2;
+  wasmtime_val_t results[2];
+  error = wasmtime_func_call(context, &run.of.func, args, 2, results, 2, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call run", error, trap);
 
-    // Print result.
-    printf("Printing result...\n");
-    printf("> %" PRIu64 " %" PRIu32 "\n",
-        results[0].of.i64, results[1].of.i32);
+  // Print result.
+  printf("Printing result...\n");
+  printf("> %" PRIu64 " %" PRIu32 "\n", results[0].of.i64, results[1].of.i32);
 
-    assert(results[0].kind == WASMTIME_I64);
-    assert(results[0].of.i64 == 2);
-    assert(results[1].kind == WASMTIME_I32);
-    assert(results[1].of.i32 == 1);
+  assert(results[0].kind == WASMTIME_I64);
+  assert(results[0].of.i64 == 2);
+  assert(results[1].kind == WASMTIME_I32);
+  assert(results[1].of.i32 == 1);
 
-    // Shut down.
-    printf("Shutting down...\n");
-    wasmtime_store_delete(store);
-    wasm_engine_delete(engine);
+  // Shut down.
+  printf("Shutting down...\n");
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
 
-    // All done.
-    printf("Done.\n");
-    return 0;
+  // All done.
+  printf("Done.\n");
+  return 0;
 }
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-        wasmtime_error_delete(error);
-    } else {
-        wasm_trap_message(trap, &error_message);
-        wasm_trap_delete(trap);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
-    exit(1);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+    wasmtime_error_delete(error);
+  } else {
+    wasm_trap_message(trap, &error_message);
+    wasm_trap_delete(trap);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -25,166 +25,165 @@ https://github.com/WebAssembly/wasm-c-api/blob/master/example/multi.c
 originally
 */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <inttypes.h>
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
 // A function to be called from Wasm code.
 wasm_trap_t* callback(
-  void *env,
-  wasmtime_caller_t *caller,
-  const wasmtime_val_t* args,
-  size_t nargs,
-  wasmtime_val_t* results,
-  size_t nresults
-) {
-  printf("Calling back...\n");
-  printf("> %"PRIu32" %"PRIu64"\n", args[0].of.i32, args[1].of.i64);
-  printf("\n");
+    void* env,
+    wasmtime_caller_t* caller,
+    const wasmtime_val_t* args,
+    size_t nargs,
+    wasmtime_val_t* results,
+    size_t nresults)
+{
+    printf("Calling back...\n");
+    printf("> %" PRIu32 " %" PRIu64 "\n", args[0].of.i32, args[1].of.i64);
+    printf("\n");
 
-  results[0] = args[1];
-  results[1] = args[0];
-  return NULL;
+    results[0] = args[1];
+    results[1] = args[0];
+    return NULL;
 }
-
 
 // A function closure.
 wasm_trap_t* closure_callback(
-  void* env,
-  wasmtime_caller_t *caller,
-  const wasmtime_val_t* args,
-  size_t nargs,
-  wasmtime_val_t* results,
-  size_t nresults
-) {
-  int i = *(int*)env;
-  printf("Calling back closure...\n");
-  printf("> %d\n", i);
+    void* env,
+    wasmtime_caller_t* caller,
+    const wasmtime_val_t* args,
+    size_t nargs,
+    wasmtime_val_t* results,
+    size_t nresults)
+{
+    int i = *(int*)env;
+    printf("Calling back closure...\n");
+    printf("> %d\n", i);
 
-  results[0].kind = WASMTIME_I32;
-  results[0].of.i32 = (int32_t)i;
-  return NULL;
+    results[0].kind = WASMTIME_I32;
+    results[0].of.i32 = (int32_t)i;
+    return NULL;
 }
 
+int main(int argc, const char* argv[])
+{
+    // Initialize.
+    printf("Initializing...\n");
+    wasm_engine_t* engine = wasm_engine_new();
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
 
-int main(int argc, const char* argv[]) {
-  // Initialize.
-  printf("Initializing...\n");
-  wasm_engine_t* engine = wasm_engine_new();
-  wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-  wasmtime_context_t *context = wasmtime_store_context(store);
+    // Load our input file to parse it next
+    FILE* file = fopen("examples/multi.wat", "r");
+    if (!file) {
+        printf("> Error loading file!\n");
+        return 1;
+    }
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t wat;
+    wasm_byte_vec_new_uninitialized(&wat, file_size);
+    if (fread(wat.data, file_size, 1, file) != 1) {
+        printf("> Error loading module!\n");
+        return 1;
+    }
+    fclose(file);
 
-  // Load our input file to parse it next
-  FILE* file = fopen("examples/multi.wat", "r");
-  if (!file) {
-    printf("> Error loading file!\n");
-    return 1;
-  }
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t wat;
-  wasm_byte_vec_new_uninitialized(&wat, file_size);
-  if (fread(wat.data, file_size, 1, file) != 1) {
-    printf("> Error loading module!\n");
-    return 1;
-  }
-  fclose(file);
+    // Parse the wat into the binary wasm format
+    wasm_byte_vec_t binary;
+    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
+    if (error != NULL)
+        exit_with_error("failed to parse wat", error, NULL);
+    wasm_byte_vec_delete(&wat);
 
-  // Parse the wat into the binary wasm format
-  wasm_byte_vec_t binary;
-  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
-  if (error != NULL)
-    exit_with_error("failed to parse wat", error, NULL);
-  wasm_byte_vec_delete(&wat);
+    // Compile.
+    printf("Compiling module...\n");
+    wasmtime_module_t* module = NULL;
+    error = wasmtime_module_new(engine, (uint8_t*)binary.data, binary.size, &module);
+    if (error)
+        exit_with_error("failed to compile module", error, NULL);
+    wasm_byte_vec_delete(&binary);
 
-  // Compile.
-  printf("Compiling module...\n");
-  wasmtime_module_t* module = NULL;
-  error = wasmtime_module_new(engine, (uint8_t*) binary.data, binary.size, &module);
-  if (error)
-    exit_with_error("failed to compile module", error, NULL);
-  wasm_byte_vec_delete(&binary);
+    // Create external print functions.
+    printf("Creating callback...\n");
+    wasm_functype_t* callback_type = wasm_functype_new_2_2(
+        wasm_valtype_new_i32(),
+        wasm_valtype_new_i64(),
+        wasm_valtype_new_i64(),
+        wasm_valtype_new_i32());
+    wasmtime_func_t callback_func;
+    wasmtime_func_new(context, callback_type, callback, NULL, NULL, &callback_func);
+    wasm_functype_delete(callback_type);
 
-  // Create external print functions.
-  printf("Creating callback...\n");
-  wasm_functype_t* callback_type = wasm_functype_new_2_2(
-      wasm_valtype_new_i32(),
-      wasm_valtype_new_i64(),
-      wasm_valtype_new_i64(),
-      wasm_valtype_new_i32()
-  );
-  wasmtime_func_t callback_func;
-  wasmtime_func_new(context, callback_type, callback, NULL, NULL, &callback_func);
-  wasm_functype_delete(callback_type);
+    // Instantiate.
+    printf("Instantiating module...\n");
+    wasmtime_extern_t imports[1];
+    imports[0].kind = WASMTIME_EXTERN_FUNC;
+    imports[0].of.func = callback_func;
+    wasmtime_instance_t instance;
+    wasm_trap_t* trap = NULL;
+    error = wasmtime_instance_new(context, module, imports, 1, &instance, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate", error, trap);
+    wasmtime_module_delete(module);
 
-  // Instantiate.
-  printf("Instantiating module...\n");
-  wasmtime_extern_t imports[1];
-  imports[0].kind = WASMTIME_EXTERN_FUNC;
-  imports[0].of.func = callback_func;
-  wasmtime_instance_t instance;
-  wasm_trap_t* trap = NULL;
-  error = wasmtime_instance_new(context, module, imports, 1, &instance, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate", error, trap);
-  wasmtime_module_delete(module);
+    // Extract export.
+    printf("Extracting export...\n");
+    wasmtime_extern_t run;
+    bool ok = wasmtime_instance_export_get(context, &instance, "g", 1, &run);
+    assert(ok);
+    assert(run.kind == WASMTIME_EXTERN_FUNC);
 
-  // Extract export.
-  printf("Extracting export...\n");
-  wasmtime_extern_t run;
-  bool ok = wasmtime_instance_export_get(context, &instance, "g", 1, &run);
-  assert(ok);
-  assert(run.kind == WASMTIME_EXTERN_FUNC);
+    // Call.
+    printf("Calling export...\n");
+    wasmtime_val_t args[2];
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = 1;
+    args[1].kind = WASMTIME_I64;
+    args[1].of.i64 = 2;
+    wasmtime_val_t results[2];
+    error = wasmtime_func_call(context, &run.of.func, args, 2, results, 2, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to call run", error, trap);
 
-  // Call.
-  printf("Calling export...\n");
-  wasmtime_val_t args[2];
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = 1;
-  args[1].kind = WASMTIME_I64;
-  args[1].of.i64 = 2;
-  wasmtime_val_t results[2];
-  error = wasmtime_func_call(context, &run.of.func, args, 2, results, 2, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to call run", error, trap);
+    // Print result.
+    printf("Printing result...\n");
+    printf("> %" PRIu64 " %" PRIu32 "\n",
+        results[0].of.i64, results[1].of.i32);
 
-  // Print result.
-  printf("Printing result...\n");
-  printf("> %"PRIu64" %"PRIu32"\n",
-    results[0].of.i64, results[1].of.i32);
+    assert(results[0].kind == WASMTIME_I64);
+    assert(results[0].of.i64 == 2);
+    assert(results[1].kind == WASMTIME_I32);
+    assert(results[1].of.i32 == 1);
 
-  assert(results[0].kind == WASMTIME_I64);
-  assert(results[0].of.i64 == 2);
-  assert(results[1].kind == WASMTIME_I32);
-  assert(results[1].of.i32 == 1);
+    // Shut down.
+    printf("Shutting down...\n");
+    wasmtime_store_delete(store);
+    wasm_engine_delete(engine);
 
-  // Shut down.
-  printf("Shutting down...\n");
-  wasmtime_store_delete(store);
-  wasm_engine_delete(engine);
-
-  // All done.
-  printf("Done.\n");
-  return 0;
+    // All done.
+    printf("Done.\n");
+    return 0;
 }
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-    wasmtime_error_delete(error);
-  } else {
-    wasm_trap_message(trap, &error_message);
-    wasm_trap_delete(trap);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+        wasmtime_error_delete(error);
+    } else {
+        wasm_trap_message(trap, &error_message);
+        wasm_trap_delete(trap);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/multimemory.c
+++ b/examples/multimemory.c
@@ -17,7 +17,8 @@ to tweak the `-lpthread` and such annotations.
 
 You can also build using cmake:
 
-mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-multimemory
+mkdir build && cd build && cmake .. && cmake --build . --target
+wasmtime-multimemory
 */
 
 #include <inttypes.h>
@@ -27,316 +28,318 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-multime
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
-void check(bool success)
-{
-    if (!success) {
-        printf("> Error, expected success\n");
-        exit(1);
-    }
-}
-
-void check_call(wasmtime_context_t* store,
-    wasmtime_func_t* func,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    int32_t expected)
-{
-    wasmtime_val_t results[1];
-    wasm_trap_t* trap = NULL;
-    wasmtime_error_t* error = wasmtime_func_call(
-        store, func, args, nargs, results, 1, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to call function", error, trap);
-    if (results[0].of.i32 != expected) {
-        printf("> Error on result\n");
-        exit(1);
-    }
-}
-
-void check_call0(wasmtime_context_t* store, wasmtime_func_t* func, int32_t expected)
-{
-    check_call(store, func, NULL, 0, expected);
-}
-
-void check_call1(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg, int32_t expected)
-{
-    wasmtime_val_t args[1];
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = arg;
-    check_call(store, func, args, 1, expected);
-}
-
-void check_call2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2, int32_t expected)
-{
-    wasmtime_val_t args[2];
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = arg1;
-    args[1].kind = WASMTIME_I32;
-    args[1].of.i32 = arg2;
-    check_call(store, func, args, 2, expected);
-}
-
-void check_ok(wasmtime_context_t* store, wasmtime_func_t* func, const wasmtime_val_t* args, size_t nargs)
-{
-    wasm_trap_t* trap = NULL;
-    wasmtime_error_t* error = wasmtime_func_call(store, func, args, nargs, NULL, 0, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to call function", error, trap);
-}
-
-void check_ok2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2)
-{
-    wasmtime_val_t args[2];
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = arg1;
-    args[1].kind = WASMTIME_I32;
-    args[1].of.i32 = arg2;
-    check_ok(store, func, args, 2);
-}
-
-void check_trap(wasmtime_context_t* store,
-    wasmtime_func_t* func,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    size_t num_results)
-{
-    assert(num_results <= 1);
-    wasmtime_val_t results[1];
-    wasm_trap_t* trap = NULL;
-    wasmtime_error_t* error = wasmtime_func_call(store, func, args, nargs, results, num_results, &trap);
-    if (error != NULL)
-        exit_with_error("failed to call function", error, NULL);
-    if (trap == NULL) {
-        printf("> Error on result, expected trap\n");
-        exit(1);
-    }
-    wasm_trap_delete(trap);
-}
-
-void check_trap1(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg)
-{
-    wasmtime_val_t args[1];
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = arg;
-    check_trap(store, func, args, 1, 1);
-}
-
-void check_trap2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2)
-{
-    wasmtime_val_t args[2];
-    args[0].kind = WASMTIME_I32;
-    args[0].of.i32 = arg1;
-    args[1].kind = WASMTIME_I32;
-    args[1].of.i32 = arg2;
-    check_trap(store, func, args, 2, 0);
-}
-
-int main(int argc, const char* argv[])
-{
-    // Initialize.
-    printf("Initializing...\n");
-
-    wasm_config_t* config = wasm_config_new();
-    assert(config != NULL);
-    wasmtime_config_wasm_multi_memory_set(config, true);
-
-    wasm_engine_t* engine = wasm_engine_new_with_config(config);
-    assert(engine != NULL);
-
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
-
-    // Load our input file to parse it next
-    FILE* file = fopen("examples/multimemory.wat", "r");
-    if (!file) {
-        printf("> Error loading file!\n");
-        return 1;
-    }
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    fseek(file, 0L, SEEK_SET);
-    wasm_byte_vec_t wat;
-    wasm_byte_vec_new_uninitialized(&wat, file_size);
-    if (fread(wat.data, file_size, 1, file) != 1) {
-        printf("> Error loading module!\n");
-        return 1;
-    }
-    fclose(file);
-
-    // Parse the wat into the binary wasm format
-    wasm_byte_vec_t binary;
-    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
-    if (error != NULL)
-        exit_with_error("failed to parse wat", error, NULL);
-    wasm_byte_vec_delete(&wat);
-
-    // Compile.
-    printf("Compiling module...\n");
-    wasmtime_module_t* module = NULL;
-    error = wasmtime_module_new(engine, (uint8_t*)binary.data, binary.size, &module);
-    if (error)
-        exit_with_error("failed to compile module", error, NULL);
-    wasm_byte_vec_delete(&binary);
-
-    // Instantiate.
-    printf("Instantiating module...\n");
-    wasmtime_instance_t instance;
-    wasm_trap_t* trap = NULL;
-    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate", error, trap);
-    wasmtime_module_delete(module);
-
-    // Extract export.
-    printf("Extracting exports...\n");
-    wasmtime_memory_t memory0, memory1;
-    wasmtime_func_t size0, load0, store0, size1, load1, store1;
-    wasmtime_extern_t item;
-    bool ok;
-    ok = wasmtime_instance_export_get(context, &instance, "memory0", strlen("memory0"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
-    memory0 = item.of.memory;
-    ok = wasmtime_instance_export_get(context, &instance, "size0", strlen("size0"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-    size0 = item.of.func;
-    ok = wasmtime_instance_export_get(context, &instance, "load0", strlen("load0"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-    load0 = item.of.func;
-    ok = wasmtime_instance_export_get(context, &instance, "store0", strlen("store0"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-    store0 = item.of.func;
-    ok = wasmtime_instance_export_get(context, &instance, "memory1", strlen("memory1"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
-    memory1 = item.of.memory;
-    ok = wasmtime_instance_export_get(context, &instance, "size1", strlen("size1"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-    size1 = item.of.func;
-    ok = wasmtime_instance_export_get(context, &instance, "load1", strlen("load1"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-    load1 = item.of.func;
-    ok = wasmtime_instance_export_get(context, &instance, "store1", strlen("store1"), &item);
-    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-    store1 = item.of.func;
-
-    // Check initial memory.
-    printf("Checking memory...\n");
-    check(wasmtime_memory_size(context, &memory0) == 2);
-    check(wasmtime_memory_data_size(context, &memory0) == 0x20000);
-    check(wasmtime_memory_data(context, &memory0)[0] == 0);
-    check(wasmtime_memory_data(context, &memory0)[0x1000] == 1);
-    check(wasmtime_memory_data(context, &memory0)[0x1001] == 2);
-    check(wasmtime_memory_data(context, &memory0)[0x1002] == 3);
-    check(wasmtime_memory_data(context, &memory0)[0x1003] == 4);
-
-    check_call0(context, &size0, 2);
-    check_call1(context, &load0, 0, 0);
-    check_call1(context, &load0, 0x1000, 1);
-    check_call1(context, &load0, 0x1001, 2);
-    check_call1(context, &load0, 0x1002, 3);
-    check_call1(context, &load0, 0x1003, 4);
-    check_call1(context, &load0, 0x1ffff, 0);
-    check_trap1(context, &load0, 0x20000);
-
-    check(wasmtime_memory_size(context, &memory1) == 2);
-    check(wasmtime_memory_data_size(context, &memory1) == 0x20000);
-    check(wasmtime_memory_data(context, &memory1)[0] == 0);
-    check(wasmtime_memory_data(context, &memory1)[0x1000] == 4);
-    check(wasmtime_memory_data(context, &memory1)[0x1001] == 3);
-    check(wasmtime_memory_data(context, &memory1)[0x1002] == 2);
-    check(wasmtime_memory_data(context, &memory1)[0x1003] == 1);
-
-    check_call0(context, &size1, 2);
-    check_call1(context, &load1, 0, 0);
-    check_call1(context, &load1, 0x1000, 4);
-    check_call1(context, &load1, 0x1001, 3);
-    check_call1(context, &load1, 0x1002, 2);
-    check_call1(context, &load1, 0x1003, 1);
-    check_call1(context, &load1, 0x1ffff, 0);
-    check_trap1(context, &load1, 0x20000);
-
-    // Mutate memory.
-    printf("Mutating memory...\n");
-    wasmtime_memory_data(context, &memory0)[0x1003] = 5;
-    check_ok2(context, &store0, 0x1002, 6);
-    check_trap2(context, &store0, 0x20000, 0);
-
-    check(wasmtime_memory_data(context, &memory0)[0x1002] == 6);
-    check(wasmtime_memory_data(context, &memory0)[0x1003] == 5);
-    check_call1(context, &load0, 0x1002, 6);
-    check_call1(context, &load0, 0x1003, 5);
-
-    wasmtime_memory_data(context, &memory1)[0x1003] = 7;
-    check_ok2(context, &store1, 0x1002, 8);
-    check_trap2(context, &store1, 0x20000, 0);
-
-    check(wasmtime_memory_data(context, &memory1)[0x1002] == 8);
-    check(wasmtime_memory_data(context, &memory1)[0x1003] == 7);
-    check_call1(context, &load1, 0x1002, 8);
-    check_call1(context, &load1, 0x1003, 7);
-
-    // Grow memory.
-    printf("Growing memory...\n");
-    uint64_t old_size;
-    error = wasmtime_memory_grow(context, &memory0, 1, &old_size);
-    if (error != NULL)
-        exit_with_error("failed to grow memory", error, trap);
-    check(wasmtime_memory_size(context, &memory0) == 3);
-    check(wasmtime_memory_data_size(context, &memory0) == 0x30000);
-
-    check_call1(context, &load0, 0x20000, 0);
-    check_ok2(context, &store0, 0x20000, 0);
-    check_trap1(context, &load0, 0x30000);
-    check_trap2(context, &store0, 0x30000, 0);
-
-    error = wasmtime_memory_grow(context, &memory0, 1, &old_size);
-    assert(error != NULL);
-    wasmtime_error_delete(error);
-    error = wasmtime_memory_grow(context, &memory0, 0, &old_size);
-    if (error != NULL)
-        exit_with_error("failed to grow memory", error, trap);
-
-    error = wasmtime_memory_grow(context, &memory1, 2, &old_size);
-    if (error != NULL)
-        exit_with_error("failed to grow memory", error, trap);
-    check(wasmtime_memory_size(context, &memory1) == 4);
-    check(wasmtime_memory_data_size(context, &memory1) == 0x40000);
-
-    check_call1(context, &load1, 0x30000, 0);
-    check_ok2(context, &store1, 0x30000, 0);
-    check_trap1(context, &load1, 0x40000);
-    check_trap2(context, &store1, 0x40000, 0);
-
-    error = wasmtime_memory_grow(context, &memory1, 1, &old_size);
-    assert(error != NULL);
-    wasmtime_error_delete(error);
-    error = wasmtime_memory_grow(context, &memory1, 0, &old_size);
-    if (error != NULL)
-        exit_with_error("failed to grow memory", error, trap);
-
-    // Shut down.
-    printf("Shutting down...\n");
-    wasmtime_store_delete(store);
-    wasm_engine_delete(engine);
-
-    // All done.
-    printf("Done.\n");
-    return 0;
-}
-
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-        wasmtime_error_delete(error);
-    } else {
-        wasm_trap_message(trap, &error_message);
-        wasm_trap_delete(trap);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
+void check(bool success) {
+  if (!success) {
+    printf("> Error, expected success\n");
     exit(1);
+  }
+}
+
+void check_call(wasmtime_context_t *store, wasmtime_func_t *func,
+                const wasmtime_val_t *args, size_t nargs, int32_t expected) {
+  wasmtime_val_t results[1];
+  wasm_trap_t *trap = NULL;
+  wasmtime_error_t *error =
+      wasmtime_func_call(store, func, args, nargs, results, 1, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call function", error, trap);
+  if (results[0].of.i32 != expected) {
+    printf("> Error on result\n");
+    exit(1);
+  }
+}
+
+void check_call0(wasmtime_context_t *store, wasmtime_func_t *func,
+                 int32_t expected) {
+  check_call(store, func, NULL, 0, expected);
+}
+
+void check_call1(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg,
+                 int32_t expected) {
+  wasmtime_val_t args[1];
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = arg;
+  check_call(store, func, args, 1, expected);
+}
+
+void check_call2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1,
+                 int32_t arg2, int32_t expected) {
+  wasmtime_val_t args[2];
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = arg1;
+  args[1].kind = WASMTIME_I32;
+  args[1].of.i32 = arg2;
+  check_call(store, func, args, 2, expected);
+}
+
+void check_ok(wasmtime_context_t *store, wasmtime_func_t *func,
+              const wasmtime_val_t *args, size_t nargs) {
+  wasm_trap_t *trap = NULL;
+  wasmtime_error_t *error =
+      wasmtime_func_call(store, func, args, nargs, NULL, 0, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call function", error, trap);
+}
+
+void check_ok2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1,
+               int32_t arg2) {
+  wasmtime_val_t args[2];
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = arg1;
+  args[1].kind = WASMTIME_I32;
+  args[1].of.i32 = arg2;
+  check_ok(store, func, args, 2);
+}
+
+void check_trap(wasmtime_context_t *store, wasmtime_func_t *func,
+                const wasmtime_val_t *args, size_t nargs, size_t num_results) {
+  assert(num_results <= 1);
+  wasmtime_val_t results[1];
+  wasm_trap_t *trap = NULL;
+  wasmtime_error_t *error =
+      wasmtime_func_call(store, func, args, nargs, results, num_results, &trap);
+  if (error != NULL)
+    exit_with_error("failed to call function", error, NULL);
+  if (trap == NULL) {
+    printf("> Error on result, expected trap\n");
+    exit(1);
+  }
+  wasm_trap_delete(trap);
+}
+
+void check_trap1(wasmtime_context_t *store, wasmtime_func_t *func,
+                 int32_t arg) {
+  wasmtime_val_t args[1];
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = arg;
+  check_trap(store, func, args, 1, 1);
+}
+
+void check_trap2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1,
+                 int32_t arg2) {
+  wasmtime_val_t args[2];
+  args[0].kind = WASMTIME_I32;
+  args[0].of.i32 = arg1;
+  args[1].kind = WASMTIME_I32;
+  args[1].of.i32 = arg2;
+  check_trap(store, func, args, 2, 0);
+}
+
+int main(int argc, const char *argv[]) {
+  // Initialize.
+  printf("Initializing...\n");
+
+  wasm_config_t *config = wasm_config_new();
+  assert(config != NULL);
+  wasmtime_config_wasm_multi_memory_set(config, true);
+
+  wasm_engine_t *engine = wasm_engine_new_with_config(config);
+  assert(engine != NULL);
+
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
+
+  // Load our input file to parse it next
+  FILE *file = fopen("examples/multimemory.wat", "r");
+  if (!file) {
+    printf("> Error loading file!\n");
+    return 1;
+  }
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
+  fclose(file);
+
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t binary;
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
+
+  // Compile.
+  printf("Compiling module...\n");
+  wasmtime_module_t *module = NULL;
+  error =
+      wasmtime_module_new(engine, (uint8_t *)binary.data, binary.size, &module);
+  if (error)
+    exit_with_error("failed to compile module", error, NULL);
+  wasm_byte_vec_delete(&binary);
+
+  // Instantiate.
+  printf("Instantiating module...\n");
+  wasmtime_instance_t instance;
+  wasm_trap_t *trap = NULL;
+  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
+  wasmtime_module_delete(module);
+
+  // Extract export.
+  printf("Extracting exports...\n");
+  wasmtime_memory_t memory0, memory1;
+  wasmtime_func_t size0, load0, store0, size1, load1, store1;
+  wasmtime_extern_t item;
+  bool ok;
+  ok = wasmtime_instance_export_get(context, &instance, "memory0",
+                                    strlen("memory0"), &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
+  memory0 = item.of.memory;
+  ok = wasmtime_instance_export_get(context, &instance, "size0",
+                                    strlen("size0"), &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+  size0 = item.of.func;
+  ok = wasmtime_instance_export_get(context, &instance, "load0",
+                                    strlen("load0"), &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+  load0 = item.of.func;
+  ok = wasmtime_instance_export_get(context, &instance, "store0",
+                                    strlen("store0"), &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+  store0 = item.of.func;
+  ok = wasmtime_instance_export_get(context, &instance, "memory1",
+                                    strlen("memory1"), &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
+  memory1 = item.of.memory;
+  ok = wasmtime_instance_export_get(context, &instance, "size1",
+                                    strlen("size1"), &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+  size1 = item.of.func;
+  ok = wasmtime_instance_export_get(context, &instance, "load1",
+                                    strlen("load1"), &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+  load1 = item.of.func;
+  ok = wasmtime_instance_export_get(context, &instance, "store1",
+                                    strlen("store1"), &item);
+  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+  store1 = item.of.func;
+
+  // Check initial memory.
+  printf("Checking memory...\n");
+  check(wasmtime_memory_size(context, &memory0) == 2);
+  check(wasmtime_memory_data_size(context, &memory0) == 0x20000);
+  check(wasmtime_memory_data(context, &memory0)[0] == 0);
+  check(wasmtime_memory_data(context, &memory0)[0x1000] == 1);
+  check(wasmtime_memory_data(context, &memory0)[0x1001] == 2);
+  check(wasmtime_memory_data(context, &memory0)[0x1002] == 3);
+  check(wasmtime_memory_data(context, &memory0)[0x1003] == 4);
+
+  check_call0(context, &size0, 2);
+  check_call1(context, &load0, 0, 0);
+  check_call1(context, &load0, 0x1000, 1);
+  check_call1(context, &load0, 0x1001, 2);
+  check_call1(context, &load0, 0x1002, 3);
+  check_call1(context, &load0, 0x1003, 4);
+  check_call1(context, &load0, 0x1ffff, 0);
+  check_trap1(context, &load0, 0x20000);
+
+  check(wasmtime_memory_size(context, &memory1) == 2);
+  check(wasmtime_memory_data_size(context, &memory1) == 0x20000);
+  check(wasmtime_memory_data(context, &memory1)[0] == 0);
+  check(wasmtime_memory_data(context, &memory1)[0x1000] == 4);
+  check(wasmtime_memory_data(context, &memory1)[0x1001] == 3);
+  check(wasmtime_memory_data(context, &memory1)[0x1002] == 2);
+  check(wasmtime_memory_data(context, &memory1)[0x1003] == 1);
+
+  check_call0(context, &size1, 2);
+  check_call1(context, &load1, 0, 0);
+  check_call1(context, &load1, 0x1000, 4);
+  check_call1(context, &load1, 0x1001, 3);
+  check_call1(context, &load1, 0x1002, 2);
+  check_call1(context, &load1, 0x1003, 1);
+  check_call1(context, &load1, 0x1ffff, 0);
+  check_trap1(context, &load1, 0x20000);
+
+  // Mutate memory.
+  printf("Mutating memory...\n");
+  wasmtime_memory_data(context, &memory0)[0x1003] = 5;
+  check_ok2(context, &store0, 0x1002, 6);
+  check_trap2(context, &store0, 0x20000, 0);
+
+  check(wasmtime_memory_data(context, &memory0)[0x1002] == 6);
+  check(wasmtime_memory_data(context, &memory0)[0x1003] == 5);
+  check_call1(context, &load0, 0x1002, 6);
+  check_call1(context, &load0, 0x1003, 5);
+
+  wasmtime_memory_data(context, &memory1)[0x1003] = 7;
+  check_ok2(context, &store1, 0x1002, 8);
+  check_trap2(context, &store1, 0x20000, 0);
+
+  check(wasmtime_memory_data(context, &memory1)[0x1002] == 8);
+  check(wasmtime_memory_data(context, &memory1)[0x1003] == 7);
+  check_call1(context, &load1, 0x1002, 8);
+  check_call1(context, &load1, 0x1003, 7);
+
+  // Grow memory.
+  printf("Growing memory...\n");
+  uint64_t old_size;
+  error = wasmtime_memory_grow(context, &memory0, 1, &old_size);
+  if (error != NULL)
+    exit_with_error("failed to grow memory", error, trap);
+  check(wasmtime_memory_size(context, &memory0) == 3);
+  check(wasmtime_memory_data_size(context, &memory0) == 0x30000);
+
+  check_call1(context, &load0, 0x20000, 0);
+  check_ok2(context, &store0, 0x20000, 0);
+  check_trap1(context, &load0, 0x30000);
+  check_trap2(context, &store0, 0x30000, 0);
+
+  error = wasmtime_memory_grow(context, &memory0, 1, &old_size);
+  assert(error != NULL);
+  wasmtime_error_delete(error);
+  error = wasmtime_memory_grow(context, &memory0, 0, &old_size);
+  if (error != NULL)
+    exit_with_error("failed to grow memory", error, trap);
+
+  error = wasmtime_memory_grow(context, &memory1, 2, &old_size);
+  if (error != NULL)
+    exit_with_error("failed to grow memory", error, trap);
+  check(wasmtime_memory_size(context, &memory1) == 4);
+  check(wasmtime_memory_data_size(context, &memory1) == 0x40000);
+
+  check_call1(context, &load1, 0x30000, 0);
+  check_ok2(context, &store1, 0x30000, 0);
+  check_trap1(context, &load1, 0x40000);
+  check_trap2(context, &store1, 0x40000, 0);
+
+  error = wasmtime_memory_grow(context, &memory1, 1, &old_size);
+  assert(error != NULL);
+  wasmtime_error_delete(error);
+  error = wasmtime_memory_grow(context, &memory1, 0, &old_size);
+  if (error != NULL)
+    exit_with_error("failed to grow memory", error, trap);
+
+  // Shut down.
+  printf("Shutting down...\n");
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+
+  // All done.
+  printf("Done.\n");
+  return 0;
+}
+
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+    wasmtime_error_delete(error);
+  } else {
+    wasm_trap_message(trap, &error_message);
+    wasm_trap_delete(trap);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/examples/multimemory.c
+++ b/examples/multimemory.c
@@ -27,305 +27,316 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-multime
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
-void check(bool success) {
-  if (!success) {
-    printf("> Error, expected success\n");
-    exit(1);
-  }
+void check(bool success)
+{
+    if (!success) {
+        printf("> Error, expected success\n");
+        exit(1);
+    }
 }
 
-void check_call(wasmtime_context_t *store,
-                wasmtime_func_t *func,
-                const wasmtime_val_t* args,
-                size_t nargs,
-                int32_t expected) {
-  wasmtime_val_t results[1];
-  wasm_trap_t *trap = NULL;
-  wasmtime_error_t *error = wasmtime_func_call(
-      store, func, args, nargs, results, 1, &trap
-  );
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to call function", error, trap);
-  if (results[0].of.i32 != expected) {
-    printf("> Error on result\n");
-    exit(1);
-  }
+void check_call(wasmtime_context_t* store,
+    wasmtime_func_t* func,
+    const wasmtime_val_t* args,
+    size_t nargs,
+    int32_t expected)
+{
+    wasmtime_val_t results[1];
+    wasm_trap_t* trap = NULL;
+    wasmtime_error_t* error = wasmtime_func_call(
+        store, func, args, nargs, results, 1, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to call function", error, trap);
+    if (results[0].of.i32 != expected) {
+        printf("> Error on result\n");
+        exit(1);
+    }
 }
 
-void check_call0(wasmtime_context_t *store, wasmtime_func_t *func, int32_t expected) {
-  check_call(store, func, NULL, 0, expected);
+void check_call0(wasmtime_context_t* store, wasmtime_func_t* func, int32_t expected)
+{
+    check_call(store, func, NULL, 0, expected);
 }
 
-void check_call1(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg, int32_t expected) {
-  wasmtime_val_t args[1];
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = arg;
-  check_call(store, func, args, 1, expected);
+void check_call1(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg, int32_t expected)
+{
+    wasmtime_val_t args[1];
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = arg;
+    check_call(store, func, args, 1, expected);
 }
 
-void check_call2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1, int32_t arg2, int32_t expected) {
-  wasmtime_val_t args[2];
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = arg1;
-  args[1].kind = WASMTIME_I32;
-  args[1].of.i32 = arg2;
-  check_call(store, func, args, 2, expected);
+void check_call2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2, int32_t expected)
+{
+    wasmtime_val_t args[2];
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = arg1;
+    args[1].kind = WASMTIME_I32;
+    args[1].of.i32 = arg2;
+    check_call(store, func, args, 2, expected);
 }
 
-void check_ok(wasmtime_context_t *store, wasmtime_func_t *func, const wasmtime_val_t* args, size_t nargs) {
-  wasm_trap_t *trap = NULL;
-  wasmtime_error_t *error = wasmtime_func_call(store, func, args, nargs, NULL, 0, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to call function", error, trap);
+void check_ok(wasmtime_context_t* store, wasmtime_func_t* func, const wasmtime_val_t* args, size_t nargs)
+{
+    wasm_trap_t* trap = NULL;
+    wasmtime_error_t* error = wasmtime_func_call(store, func, args, nargs, NULL, 0, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to call function", error, trap);
 }
 
-void check_ok2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1, int32_t arg2) {
-  wasmtime_val_t args[2];
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = arg1;
-  args[1].kind = WASMTIME_I32;
-  args[1].of.i32 = arg2;
-  check_ok(store, func, args, 2);
+void check_ok2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2)
+{
+    wasmtime_val_t args[2];
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = arg1;
+    args[1].kind = WASMTIME_I32;
+    args[1].of.i32 = arg2;
+    check_ok(store, func, args, 2);
 }
 
-void check_trap(wasmtime_context_t *store,
-                wasmtime_func_t *func,
-                const wasmtime_val_t *args,
-                size_t nargs,
-                size_t num_results) {
-  assert(num_results <= 1);
-  wasmtime_val_t results[1];
-  wasm_trap_t *trap = NULL;
-  wasmtime_error_t *error = wasmtime_func_call(store, func, args, nargs, results, num_results, &trap);
-  if (error != NULL)
-    exit_with_error("failed to call function", error, NULL);
-  if (trap == NULL) {
-    printf("> Error on result, expected trap\n");
-    exit(1);
-  }
-  wasm_trap_delete(trap);
-}
-
-void check_trap1(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg) {
-  wasmtime_val_t args[1];
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = arg;
-  check_trap(store, func, args, 1, 1);
-}
-
-void check_trap2(wasmtime_context_t *store, wasmtime_func_t *func, int32_t arg1, int32_t arg2) {
-  wasmtime_val_t args[2];
-  args[0].kind = WASMTIME_I32;
-  args[0].of.i32 = arg1;
-  args[1].kind = WASMTIME_I32;
-  args[1].of.i32 = arg2;
-  check_trap(store, func, args, 2, 0);
-}
-
-int main(int argc, const char* argv[]) {
-  // Initialize.
-  printf("Initializing...\n");
-
-  wasm_config_t *config = wasm_config_new();
-  assert(config != NULL);
-  wasmtime_config_wasm_multi_memory_set(config, true);
-
-  wasm_engine_t *engine = wasm_engine_new_with_config(config);
-  assert(engine != NULL);
-
-  wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-  wasmtime_context_t *context = wasmtime_store_context(store);
-
-  // Load our input file to parse it next
-  FILE* file = fopen("examples/multimemory.wat", "r");
-  if (!file) {
-    printf("> Error loading file!\n");
-    return 1;
-  }
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t wat;
-  wasm_byte_vec_new_uninitialized(&wat, file_size);
-  if (fread(wat.data, file_size, 1, file) != 1) {
-    printf("> Error loading module!\n");
-    return 1;
-  }
-  fclose(file);
-
-  // Parse the wat into the binary wasm format
-  wasm_byte_vec_t binary;
-  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
-  if (error != NULL)
-    exit_with_error("failed to parse wat", error, NULL);
-  wasm_byte_vec_delete(&wat);
-
-  // Compile.
-  printf("Compiling module...\n");
-  wasmtime_module_t* module = NULL;
-  error = wasmtime_module_new(engine, (uint8_t*) binary.data, binary.size, &module);
-  if (error)
-    exit_with_error("failed to compile module", error, NULL);
-  wasm_byte_vec_delete(&binary);
-
-  // Instantiate.
-  printf("Instantiating module...\n");
-  wasmtime_instance_t instance;
-  wasm_trap_t *trap = NULL;
-  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate", error, trap);
-  wasmtime_module_delete(module);
-
-  // Extract export.
-  printf("Extracting exports...\n");
-  wasmtime_memory_t memory0, memory1;
-  wasmtime_func_t size0, load0, store0, size1, load1, store1;
-  wasmtime_extern_t item;
-  bool ok;
-  ok = wasmtime_instance_export_get(context, &instance, "memory0", strlen("memory0"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
-  memory0 = item.of.memory;
-  ok = wasmtime_instance_export_get(context, &instance, "size0", strlen("size0"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-  size0 = item.of.func;
-  ok = wasmtime_instance_export_get(context, &instance, "load0", strlen("load0"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-  load0 = item.of.func;
-  ok = wasmtime_instance_export_get(context, &instance, "store0", strlen("store0"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-  store0 = item.of.func;
-  ok = wasmtime_instance_export_get(context, &instance, "memory1", strlen("memory1"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
-  memory1 = item.of.memory;
-  ok = wasmtime_instance_export_get(context, &instance, "size1", strlen("size1"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-  size1 = item.of.func;
-  ok = wasmtime_instance_export_get(context, &instance, "load1", strlen("load1"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-  load1 = item.of.func;
-  ok = wasmtime_instance_export_get(context, &instance, "store1", strlen("store1"), &item);
-  assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
-  store1 = item.of.func;
-
-  // Check initial memory.
-  printf("Checking memory...\n");
-  check(wasmtime_memory_size(context, &memory0) == 2);
-  check(wasmtime_memory_data_size(context, &memory0) == 0x20000);
-  check(wasmtime_memory_data(context, &memory0)[0] == 0);
-  check(wasmtime_memory_data(context, &memory0)[0x1000] == 1);
-  check(wasmtime_memory_data(context, &memory0)[0x1001] == 2);
-  check(wasmtime_memory_data(context, &memory0)[0x1002] == 3);
-  check(wasmtime_memory_data(context, &memory0)[0x1003] == 4);
-
-  check_call0(context, &size0, 2);
-  check_call1(context, &load0, 0, 0);
-  check_call1(context, &load0, 0x1000, 1);
-  check_call1(context, &load0, 0x1001, 2);
-  check_call1(context, &load0, 0x1002, 3);
-  check_call1(context, &load0, 0x1003, 4);
-  check_call1(context, &load0, 0x1ffff, 0);
-  check_trap1(context, &load0, 0x20000);
-
-  check(wasmtime_memory_size(context, &memory1) == 2);
-  check(wasmtime_memory_data_size(context, &memory1) == 0x20000);
-  check(wasmtime_memory_data(context, &memory1)[0] == 0);
-  check(wasmtime_memory_data(context, &memory1)[0x1000] == 4);
-  check(wasmtime_memory_data(context, &memory1)[0x1001] == 3);
-  check(wasmtime_memory_data(context, &memory1)[0x1002] == 2);
-  check(wasmtime_memory_data(context, &memory1)[0x1003] == 1);
-
-  check_call0(context, &size1, 2);
-  check_call1(context, &load1, 0, 0);
-  check_call1(context, &load1, 0x1000, 4);
-  check_call1(context, &load1, 0x1001, 3);
-  check_call1(context, &load1, 0x1002, 2);
-  check_call1(context, &load1, 0x1003, 1);
-  check_call1(context, &load1, 0x1ffff, 0);
-  check_trap1(context, &load1, 0x20000);
-
-  // Mutate memory.
-  printf("Mutating memory...\n");
-  wasmtime_memory_data(context, &memory0)[0x1003] = 5;
-  check_ok2(context, &store0, 0x1002, 6);
-  check_trap2(context, &store0, 0x20000, 0);
-
-  check(wasmtime_memory_data(context, &memory0)[0x1002] == 6);
-  check(wasmtime_memory_data(context, &memory0)[0x1003] == 5);
-  check_call1(context, &load0, 0x1002, 6);
-  check_call1(context, &load0, 0x1003, 5);
-
-  wasmtime_memory_data(context, &memory1)[0x1003] = 7;
-  check_ok2(context, &store1, 0x1002, 8);
-  check_trap2(context, &store1, 0x20000, 0);
-
-  check(wasmtime_memory_data(context, &memory1)[0x1002] == 8);
-  check(wasmtime_memory_data(context, &memory1)[0x1003] == 7);
-  check_call1(context, &load1, 0x1002, 8);
-  check_call1(context, &load1, 0x1003, 7);
-
-  // Grow memory.
-  printf("Growing memory...\n");
-  uint64_t old_size;
-  error = wasmtime_memory_grow(context, &memory0, 1, &old_size);
-  if (error != NULL)
-    exit_with_error("failed to grow memory", error, trap);
-  check(wasmtime_memory_size(context, &memory0) == 3);
-  check(wasmtime_memory_data_size(context, &memory0) == 0x30000);
-
-  check_call1(context, &load0, 0x20000, 0);
-  check_ok2(context, &store0, 0x20000, 0);
-  check_trap1(context, &load0, 0x30000);
-  check_trap2(context, &store0, 0x30000, 0);
-
-  error = wasmtime_memory_grow(context, &memory0, 1, &old_size);
-  assert(error != NULL);
-  wasmtime_error_delete(error);
-  error = wasmtime_memory_grow(context, &memory0, 0, &old_size);
-  if (error != NULL)
-    exit_with_error("failed to grow memory", error, trap);
-
-  error = wasmtime_memory_grow(context, &memory1, 2, &old_size);
-  if (error != NULL)
-    exit_with_error("failed to grow memory", error, trap);
-  check(wasmtime_memory_size(context, &memory1) == 4);
-  check(wasmtime_memory_data_size(context, &memory1) == 0x40000);
-
-  check_call1(context, &load1, 0x30000, 0);
-  check_ok2(context, &store1, 0x30000, 0);
-  check_trap1(context, &load1, 0x40000);
-  check_trap2(context, &store1, 0x40000, 0);
-
-  error = wasmtime_memory_grow(context, &memory1, 1, &old_size);
-  assert(error != NULL);
-  wasmtime_error_delete(error);
-  error = wasmtime_memory_grow(context, &memory1, 0, &old_size);
-  if (error != NULL)
-    exit_with_error("failed to grow memory", error, trap);
-
-  // Shut down.
-  printf("Shutting down...\n");
-  wasmtime_store_delete(store);
-  wasm_engine_delete(engine);
-
-  // All done.
-  printf("Done.\n");
-  return 0;
-}
-
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-    wasmtime_error_delete(error);
-  } else {
-    wasm_trap_message(trap, &error_message);
+void check_trap(wasmtime_context_t* store,
+    wasmtime_func_t* func,
+    const wasmtime_val_t* args,
+    size_t nargs,
+    size_t num_results)
+{
+    assert(num_results <= 1);
+    wasmtime_val_t results[1];
+    wasm_trap_t* trap = NULL;
+    wasmtime_error_t* error = wasmtime_func_call(store, func, args, nargs, results, num_results, &trap);
+    if (error != NULL)
+        exit_with_error("failed to call function", error, NULL);
+    if (trap == NULL) {
+        printf("> Error on result, expected trap\n");
+        exit(1);
+    }
     wasm_trap_delete(trap);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+}
+
+void check_trap1(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg)
+{
+    wasmtime_val_t args[1];
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = arg;
+    check_trap(store, func, args, 1, 1);
+}
+
+void check_trap2(wasmtime_context_t* store, wasmtime_func_t* func, int32_t arg1, int32_t arg2)
+{
+    wasmtime_val_t args[2];
+    args[0].kind = WASMTIME_I32;
+    args[0].of.i32 = arg1;
+    args[1].kind = WASMTIME_I32;
+    args[1].of.i32 = arg2;
+    check_trap(store, func, args, 2, 0);
+}
+
+int main(int argc, const char* argv[])
+{
+    // Initialize.
+    printf("Initializing...\n");
+
+    wasm_config_t* config = wasm_config_new();
+    assert(config != NULL);
+    wasmtime_config_wasm_multi_memory_set(config, true);
+
+    wasm_engine_t* engine = wasm_engine_new_with_config(config);
+    assert(engine != NULL);
+
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
+
+    // Load our input file to parse it next
+    FILE* file = fopen("examples/multimemory.wat", "r");
+    if (!file) {
+        printf("> Error loading file!\n");
+        return 1;
+    }
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t wat;
+    wasm_byte_vec_new_uninitialized(&wat, file_size);
+    if (fread(wat.data, file_size, 1, file) != 1) {
+        printf("> Error loading module!\n");
+        return 1;
+    }
+    fclose(file);
+
+    // Parse the wat into the binary wasm format
+    wasm_byte_vec_t binary;
+    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
+    if (error != NULL)
+        exit_with_error("failed to parse wat", error, NULL);
+    wasm_byte_vec_delete(&wat);
+
+    // Compile.
+    printf("Compiling module...\n");
+    wasmtime_module_t* module = NULL;
+    error = wasmtime_module_new(engine, (uint8_t*)binary.data, binary.size, &module);
+    if (error)
+        exit_with_error("failed to compile module", error, NULL);
+    wasm_byte_vec_delete(&binary);
+
+    // Instantiate.
+    printf("Instantiating module...\n");
+    wasmtime_instance_t instance;
+    wasm_trap_t* trap = NULL;
+    error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate", error, trap);
+    wasmtime_module_delete(module);
+
+    // Extract export.
+    printf("Extracting exports...\n");
+    wasmtime_memory_t memory0, memory1;
+    wasmtime_func_t size0, load0, store0, size1, load1, store1;
+    wasmtime_extern_t item;
+    bool ok;
+    ok = wasmtime_instance_export_get(context, &instance, "memory0", strlen("memory0"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
+    memory0 = item.of.memory;
+    ok = wasmtime_instance_export_get(context, &instance, "size0", strlen("size0"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+    size0 = item.of.func;
+    ok = wasmtime_instance_export_get(context, &instance, "load0", strlen("load0"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+    load0 = item.of.func;
+    ok = wasmtime_instance_export_get(context, &instance, "store0", strlen("store0"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+    store0 = item.of.func;
+    ok = wasmtime_instance_export_get(context, &instance, "memory1", strlen("memory1"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_MEMORY);
+    memory1 = item.of.memory;
+    ok = wasmtime_instance_export_get(context, &instance, "size1", strlen("size1"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+    size1 = item.of.func;
+    ok = wasmtime_instance_export_get(context, &instance, "load1", strlen("load1"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+    load1 = item.of.func;
+    ok = wasmtime_instance_export_get(context, &instance, "store1", strlen("store1"), &item);
+    assert(ok && item.kind == WASMTIME_EXTERN_FUNC);
+    store1 = item.of.func;
+
+    // Check initial memory.
+    printf("Checking memory...\n");
+    check(wasmtime_memory_size(context, &memory0) == 2);
+    check(wasmtime_memory_data_size(context, &memory0) == 0x20000);
+    check(wasmtime_memory_data(context, &memory0)[0] == 0);
+    check(wasmtime_memory_data(context, &memory0)[0x1000] == 1);
+    check(wasmtime_memory_data(context, &memory0)[0x1001] == 2);
+    check(wasmtime_memory_data(context, &memory0)[0x1002] == 3);
+    check(wasmtime_memory_data(context, &memory0)[0x1003] == 4);
+
+    check_call0(context, &size0, 2);
+    check_call1(context, &load0, 0, 0);
+    check_call1(context, &load0, 0x1000, 1);
+    check_call1(context, &load0, 0x1001, 2);
+    check_call1(context, &load0, 0x1002, 3);
+    check_call1(context, &load0, 0x1003, 4);
+    check_call1(context, &load0, 0x1ffff, 0);
+    check_trap1(context, &load0, 0x20000);
+
+    check(wasmtime_memory_size(context, &memory1) == 2);
+    check(wasmtime_memory_data_size(context, &memory1) == 0x20000);
+    check(wasmtime_memory_data(context, &memory1)[0] == 0);
+    check(wasmtime_memory_data(context, &memory1)[0x1000] == 4);
+    check(wasmtime_memory_data(context, &memory1)[0x1001] == 3);
+    check(wasmtime_memory_data(context, &memory1)[0x1002] == 2);
+    check(wasmtime_memory_data(context, &memory1)[0x1003] == 1);
+
+    check_call0(context, &size1, 2);
+    check_call1(context, &load1, 0, 0);
+    check_call1(context, &load1, 0x1000, 4);
+    check_call1(context, &load1, 0x1001, 3);
+    check_call1(context, &load1, 0x1002, 2);
+    check_call1(context, &load1, 0x1003, 1);
+    check_call1(context, &load1, 0x1ffff, 0);
+    check_trap1(context, &load1, 0x20000);
+
+    // Mutate memory.
+    printf("Mutating memory...\n");
+    wasmtime_memory_data(context, &memory0)[0x1003] = 5;
+    check_ok2(context, &store0, 0x1002, 6);
+    check_trap2(context, &store0, 0x20000, 0);
+
+    check(wasmtime_memory_data(context, &memory0)[0x1002] == 6);
+    check(wasmtime_memory_data(context, &memory0)[0x1003] == 5);
+    check_call1(context, &load0, 0x1002, 6);
+    check_call1(context, &load0, 0x1003, 5);
+
+    wasmtime_memory_data(context, &memory1)[0x1003] = 7;
+    check_ok2(context, &store1, 0x1002, 8);
+    check_trap2(context, &store1, 0x20000, 0);
+
+    check(wasmtime_memory_data(context, &memory1)[0x1002] == 8);
+    check(wasmtime_memory_data(context, &memory1)[0x1003] == 7);
+    check_call1(context, &load1, 0x1002, 8);
+    check_call1(context, &load1, 0x1003, 7);
+
+    // Grow memory.
+    printf("Growing memory...\n");
+    uint64_t old_size;
+    error = wasmtime_memory_grow(context, &memory0, 1, &old_size);
+    if (error != NULL)
+        exit_with_error("failed to grow memory", error, trap);
+    check(wasmtime_memory_size(context, &memory0) == 3);
+    check(wasmtime_memory_data_size(context, &memory0) == 0x30000);
+
+    check_call1(context, &load0, 0x20000, 0);
+    check_ok2(context, &store0, 0x20000, 0);
+    check_trap1(context, &load0, 0x30000);
+    check_trap2(context, &store0, 0x30000, 0);
+
+    error = wasmtime_memory_grow(context, &memory0, 1, &old_size);
+    assert(error != NULL);
+    wasmtime_error_delete(error);
+    error = wasmtime_memory_grow(context, &memory0, 0, &old_size);
+    if (error != NULL)
+        exit_with_error("failed to grow memory", error, trap);
+
+    error = wasmtime_memory_grow(context, &memory1, 2, &old_size);
+    if (error != NULL)
+        exit_with_error("failed to grow memory", error, trap);
+    check(wasmtime_memory_size(context, &memory1) == 4);
+    check(wasmtime_memory_data_size(context, &memory1) == 0x40000);
+
+    check_call1(context, &load1, 0x30000, 0);
+    check_ok2(context, &store1, 0x30000, 0);
+    check_trap1(context, &load1, 0x40000);
+    check_trap2(context, &store1, 0x40000, 0);
+
+    error = wasmtime_memory_grow(context, &memory1, 1, &old_size);
+    assert(error != NULL);
+    wasmtime_error_delete(error);
+    error = wasmtime_memory_grow(context, &memory1, 0, &old_size);
+    if (error != NULL)
+        exit_with_error("failed to grow memory", error, trap);
+
+    // Shut down.
+    printf("Shutting down...\n");
+    wasmtime_store_delete(store);
+    wasm_engine_delete(engine);
+
+    // All done.
+    printf("Done.\n");
+    return 0;
+}
+
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+        wasmtime_error_delete(error);
+    } else {
+        wasm_trap_message(trap, &error_message);
+        wasm_trap_delete(trap);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/multimemory.c
+++ b/examples/multimemory.c
@@ -17,8 +17,8 @@ to tweak the `-lpthread` and such annotations.
 
 You can also build using cmake:
 
-mkdir build && cd build && cmake .. && cmake --build . --target
-wasmtime-multimemory
+mkdir build && cd build && cmake .. && \
+  cmake --build . --target wasmtime-multimemory
 */
 
 #include <inttypes.h>

--- a/examples/serialize.c
+++ b/examples/serialize.c
@@ -28,152 +28,157 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-seriali
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
 static wasm_trap_t* hello_callback(
-    void *env,
-    wasmtime_caller_t *caller,
+    void* env,
+    wasmtime_caller_t* caller,
     const wasmtime_val_t* args,
     size_t nargs,
     wasmtime_val_t* results,
-    size_t nresults) {
-  printf("Calling back...\n");
-  printf("> Hello World!\n");
-  return NULL;
+    size_t nresults)
+{
+    printf("Calling back...\n");
+    printf("> Hello World!\n");
+    return NULL;
 }
 
-int serialize(wasm_byte_vec_t* buffer) {
-  // Set up our compilation context. Note that we could also work with a
-  // `wasm_config_t` here to configure what feature are enabled and various
-  // compilation settings.
-  printf("Initializing...\n");
-  wasm_engine_t *engine = wasm_engine_new();
-  assert(engine != NULL);
+int serialize(wasm_byte_vec_t* buffer)
+{
+    // Set up our compilation context. Note that we could also work with a
+    // `wasm_config_t` here to configure what feature are enabled and various
+    // compilation settings.
+    printf("Initializing...\n");
+    wasm_engine_t* engine = wasm_engine_new();
+    assert(engine != NULL);
 
-  // Read our input file, which in this case is a wasm text file.
-  FILE* file = fopen("examples/hello.wat", "r");
-  assert(file != NULL);
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t wat;
-  wasm_byte_vec_new_uninitialized(&wat, file_size);
-  assert(fread(wat.data, file_size, 1, file) == 1);
-  fclose(file);
+    // Read our input file, which in this case is a wasm text file.
+    FILE* file = fopen("examples/hello.wat", "r");
+    assert(file != NULL);
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t wat;
+    wasm_byte_vec_new_uninitialized(&wat, file_size);
+    assert(fread(wat.data, file_size, 1, file) == 1);
+    fclose(file);
 
-  // Parse the wat into the binary wasm format
-  wasm_byte_vec_t wasm;
-  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-  if (error != NULL)
-    exit_with_error("failed to parse wat", error, NULL);
-  wasm_byte_vec_delete(&wat);
+    // Parse the wat into the binary wasm format
+    wasm_byte_vec_t wasm;
+    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+    if (error != NULL)
+        exit_with_error("failed to parse wat", error, NULL);
+    wasm_byte_vec_delete(&wat);
 
-  // Now that we've got our binary webassembly we can compile our module
-  // and serialize into buffer.
-  printf("Compiling and serializing module...\n");
-  wasmtime_module_t *module = NULL;
-  error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
-  wasm_byte_vec_delete(&wasm);
-  if (error != NULL)
-    exit_with_error("failed to compile module", error, NULL);
-  error = wasmtime_module_serialize(module, buffer);
-  wasmtime_module_delete(module);
-  if (error != NULL)
-    exit_with_error("failed to serialize module", error, NULL);
+    // Now that we've got our binary webassembly we can compile our module
+    // and serialize into buffer.
+    printf("Compiling and serializing module...\n");
+    wasmtime_module_t* module = NULL;
+    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
+    wasm_byte_vec_delete(&wasm);
+    if (error != NULL)
+        exit_with_error("failed to compile module", error, NULL);
+    error = wasmtime_module_serialize(module, buffer);
+    wasmtime_module_delete(module);
+    if (error != NULL)
+        exit_with_error("failed to serialize module", error, NULL);
 
-  printf("Serialized.\n");
+    printf("Serialized.\n");
 
-  wasm_engine_delete(engine);
-  return 0;
+    wasm_engine_delete(engine);
+    return 0;
 }
 
-int deserialize(wasm_byte_vec_t* buffer) {
-  // Set up our compilation context. Note that we could also work with a
-  // `wasm_config_t` here to configure what feature are enabled and various
-  // compilation settings.
-  printf("Initializing...\n");
-  wasm_engine_t *engine = wasm_engine_new();
-  assert(engine != NULL);
+int deserialize(wasm_byte_vec_t* buffer)
+{
+    // Set up our compilation context. Note that we could also work with a
+    // `wasm_config_t` here to configure what feature are enabled and various
+    // compilation settings.
+    printf("Initializing...\n");
+    wasm_engine_t* engine = wasm_engine_new();
+    assert(engine != NULL);
 
-  // With an engine we can create a *store* which is a long-lived group of wasm
-  // modules.
-  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
-  assert(store != NULL);
-  wasmtime_context_t *context = wasmtime_store_context(store);
+    // With an engine we can create a *store* which is a long-lived group of wasm
+    // modules.
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    assert(store != NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
 
-  // Deserialize compiled module.
-  printf("Deserialize module...\n");
-  wasmtime_module_t *module = NULL;
-  wasmtime_error_t *error = wasmtime_module_deserialize(engine, (uint8_t*) buffer->data, buffer->size, &module);
-  if (error != NULL)
-    exit_with_error("failed to compile module", error, NULL);
+    // Deserialize compiled module.
+    printf("Deserialize module...\n");
+    wasmtime_module_t* module = NULL;
+    wasmtime_error_t* error = wasmtime_module_deserialize(engine, (uint8_t*)buffer->data, buffer->size, &module);
+    if (error != NULL)
+        exit_with_error("failed to compile module", error, NULL);
 
-  // Next up we need to create the function that the wasm module imports. Here
-  // we'll be hooking up a thunk function to the `hello_callback` native
-  // function above.
-  printf("Creating callback...\n");
-  wasm_functype_t *hello_ty = wasm_functype_new_0_0();
-  wasmtime_func_t hello;
-  wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
+    // Next up we need to create the function that the wasm module imports. Here
+    // we'll be hooking up a thunk function to the `hello_callback` native
+    // function above.
+    printf("Creating callback...\n");
+    wasm_functype_t* hello_ty = wasm_functype_new_0_0();
+    wasmtime_func_t hello;
+    wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
 
-  // With our callback function we can now instantiate the compiled module,
-  // giving us an instance we can then execute exports from. Note that
-  // instantiation can trap due to execution of the `start` function, so we need
-  // to handle that here too.
-  printf("Instantiating module...\n");
-  wasm_trap_t *trap = NULL;
-  wasmtime_instance_t instance;
-  wasmtime_extern_t imports[1];
-  imports[0].kind = WASMTIME_EXTERN_FUNC;
-  imports[0].of.func = hello;
-  error = wasmtime_instance_new(context, module, imports, 1, &instance, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to instantiate", error, trap);
-  wasmtime_module_delete(module);
+    // With our callback function we can now instantiate the compiled module,
+    // giving us an instance we can then execute exports from. Note that
+    // instantiation can trap due to execution of the `start` function, so we need
+    // to handle that here too.
+    printf("Instantiating module...\n");
+    wasm_trap_t* trap = NULL;
+    wasmtime_instance_t instance;
+    wasmtime_extern_t imports[1];
+    imports[0].kind = WASMTIME_EXTERN_FUNC;
+    imports[0].of.func = hello;
+    error = wasmtime_instance_new(context, module, imports, 1, &instance, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to instantiate", error, trap);
+    wasmtime_module_delete(module);
 
-  // Lookup our `run` export function
-  wasmtime_extern_t run;
-  bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
-  assert(ok);
-  assert(run.kind == WASMTIME_EXTERN_FUNC);
+    // Lookup our `run` export function
+    wasmtime_extern_t run;
+    bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
+    assert(ok);
+    assert(run.kind == WASMTIME_EXTERN_FUNC);
 
-  // And call it!
-  printf("Calling export...\n");
-  error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("failed to call function", error, trap);
+    // And call it!
+    printf("Calling export...\n");
+    error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("failed to call function", error, trap);
 
-  // Clean up after ourselves at this point
-  printf("All finished!\n");
+    // Clean up after ourselves at this point
+    printf("All finished!\n");
 
-  wasmtime_store_delete(store);
-  wasm_engine_delete(engine);
-  return 0;
+    wasmtime_store_delete(store);
+    wasm_engine_delete(engine);
+    return 0;
 }
 
-int main() {
-  wasm_byte_vec_t buffer;
-  if (serialize(&buffer)) {
-    return 1;
-  }
-  if (deserialize(&buffer)) {
-    return 1;
-  }
-  wasm_byte_vec_delete(&buffer);
-  return 0;
+int main()
+{
+    wasm_byte_vec_t buffer;
+    if (serialize(&buffer)) {
+        return 1;
+    }
+    if (deserialize(&buffer)) {
+        return 1;
+    }
+    wasm_byte_vec_delete(&buffer);
+    return 0;
 }
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-    wasmtime_error_delete(error);
-  } else {
-    wasm_trap_message(trap, &error_message);
-    wasm_trap_delete(trap);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+        wasmtime_error_delete(error);
+    } else {
+        wasm_trap_message(trap, &error_message);
+        wasm_trap_delete(trap);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/serialize.c
+++ b/examples/serialize.c
@@ -19,8 +19,8 @@ to tweak the `-lpthread` and such annotations as well as the name of the
 
 You can also build using cmake:
 
-mkdir build && cd build && cmake .. && cmake --build . --target
-wasmtime-serialize
+mkdir build && cd build && cmake .. && \
+  cmake --build . --target wasmtime-serialize
 */
 
 #include <assert.h>

--- a/examples/serialize.c
+++ b/examples/serialize.c
@@ -19,7 +19,8 @@ to tweak the `-lpthread` and such annotations as well as the name of the
 
 You can also build using cmake:
 
-mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-serialize
+mkdir build && cd build && cmake .. && cmake --build . --target
+wasmtime-serialize
 */
 
 #include <assert.h>
@@ -28,157 +29,151 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-seriali
 #include <wasm.h>
 #include <wasmtime.h>
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
-static wasm_trap_t* hello_callback(
-    void* env,
-    wasmtime_caller_t* caller,
-    const wasmtime_val_t* args,
-    size_t nargs,
-    wasmtime_val_t* results,
-    size_t nresults)
-{
-    printf("Calling back...\n");
-    printf("> Hello World!\n");
-    return NULL;
+static wasm_trap_t *hello_callback(void *env, wasmtime_caller_t *caller,
+                                   const wasmtime_val_t *args, size_t nargs,
+                                   wasmtime_val_t *results, size_t nresults) {
+  printf("Calling back...\n");
+  printf("> Hello World!\n");
+  return NULL;
 }
 
-int serialize(wasm_byte_vec_t* buffer)
-{
-    // Set up our compilation context. Note that we could also work with a
-    // `wasm_config_t` here to configure what feature are enabled and various
-    // compilation settings.
-    printf("Initializing...\n");
-    wasm_engine_t* engine = wasm_engine_new();
-    assert(engine != NULL);
+int serialize(wasm_byte_vec_t *buffer) {
+  // Set up our compilation context. Note that we could also work with a
+  // `wasm_config_t` here to configure what feature are enabled and various
+  // compilation settings.
+  printf("Initializing...\n");
+  wasm_engine_t *engine = wasm_engine_new();
+  assert(engine != NULL);
 
-    // Read our input file, which in this case is a wasm text file.
-    FILE* file = fopen("examples/hello.wat", "r");
-    assert(file != NULL);
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    fseek(file, 0L, SEEK_SET);
-    wasm_byte_vec_t wat;
-    wasm_byte_vec_new_uninitialized(&wat, file_size);
-    assert(fread(wat.data, file_size, 1, file) == 1);
-    fclose(file);
+  // Read our input file, which in this case is a wasm text file.
+  FILE *file = fopen("examples/hello.wat", "r");
+  assert(file != NULL);
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  assert(fread(wat.data, file_size, 1, file) == 1);
+  fclose(file);
 
-    // Parse the wat into the binary wasm format
-    wasm_byte_vec_t wasm;
-    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
-    if (error != NULL)
-        exit_with_error("failed to parse wat", error, NULL);
-    wasm_byte_vec_delete(&wat);
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t wasm;
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
 
-    // Now that we've got our binary webassembly we can compile our module
-    // and serialize into buffer.
-    printf("Compiling and serializing module...\n");
-    wasmtime_module_t* module = NULL;
-    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
-    wasm_byte_vec_delete(&wasm);
-    if (error != NULL)
-        exit_with_error("failed to compile module", error, NULL);
-    error = wasmtime_module_serialize(module, buffer);
-    wasmtime_module_delete(module);
-    if (error != NULL)
-        exit_with_error("failed to serialize module", error, NULL);
+  // Now that we've got our binary webassembly we can compile our module
+  // and serialize into buffer.
+  printf("Compiling and serializing module...\n");
+  wasmtime_module_t *module = NULL;
+  error = wasmtime_module_new(engine, (uint8_t *)wasm.data, wasm.size, &module);
+  wasm_byte_vec_delete(&wasm);
+  if (error != NULL)
+    exit_with_error("failed to compile module", error, NULL);
+  error = wasmtime_module_serialize(module, buffer);
+  wasmtime_module_delete(module);
+  if (error != NULL)
+    exit_with_error("failed to serialize module", error, NULL);
 
-    printf("Serialized.\n");
+  printf("Serialized.\n");
 
-    wasm_engine_delete(engine);
-    return 0;
+  wasm_engine_delete(engine);
+  return 0;
 }
 
-int deserialize(wasm_byte_vec_t* buffer)
-{
-    // Set up our compilation context. Note that we could also work with a
-    // `wasm_config_t` here to configure what feature are enabled and various
-    // compilation settings.
-    printf("Initializing...\n");
-    wasm_engine_t* engine = wasm_engine_new();
-    assert(engine != NULL);
+int deserialize(wasm_byte_vec_t *buffer) {
+  // Set up our compilation context. Note that we could also work with a
+  // `wasm_config_t` here to configure what feature are enabled and various
+  // compilation settings.
+  printf("Initializing...\n");
+  wasm_engine_t *engine = wasm_engine_new();
+  assert(engine != NULL);
 
-    // With an engine we can create a *store* which is a long-lived group of wasm
-    // modules.
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    assert(store != NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
+  // With an engine we can create a *store* which is a long-lived group of wasm
+  // modules.
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  assert(store != NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
 
-    // Deserialize compiled module.
-    printf("Deserialize module...\n");
-    wasmtime_module_t* module = NULL;
-    wasmtime_error_t* error = wasmtime_module_deserialize(engine, (uint8_t*)buffer->data, buffer->size, &module);
-    if (error != NULL)
-        exit_with_error("failed to compile module", error, NULL);
+  // Deserialize compiled module.
+  printf("Deserialize module...\n");
+  wasmtime_module_t *module = NULL;
+  wasmtime_error_t *error = wasmtime_module_deserialize(
+      engine, (uint8_t *)buffer->data, buffer->size, &module);
+  if (error != NULL)
+    exit_with_error("failed to compile module", error, NULL);
 
-    // Next up we need to create the function that the wasm module imports. Here
-    // we'll be hooking up a thunk function to the `hello_callback` native
-    // function above.
-    printf("Creating callback...\n");
-    wasm_functype_t* hello_ty = wasm_functype_new_0_0();
-    wasmtime_func_t hello;
-    wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
+  // Next up we need to create the function that the wasm module imports. Here
+  // we'll be hooking up a thunk function to the `hello_callback` native
+  // function above.
+  printf("Creating callback...\n");
+  wasm_functype_t *hello_ty = wasm_functype_new_0_0();
+  wasmtime_func_t hello;
+  wasmtime_func_new(context, hello_ty, hello_callback, NULL, NULL, &hello);
 
-    // With our callback function we can now instantiate the compiled module,
-    // giving us an instance we can then execute exports from. Note that
-    // instantiation can trap due to execution of the `start` function, so we need
-    // to handle that here too.
-    printf("Instantiating module...\n");
-    wasm_trap_t* trap = NULL;
-    wasmtime_instance_t instance;
-    wasmtime_extern_t imports[1];
-    imports[0].kind = WASMTIME_EXTERN_FUNC;
-    imports[0].of.func = hello;
-    error = wasmtime_instance_new(context, module, imports, 1, &instance, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to instantiate", error, trap);
-    wasmtime_module_delete(module);
+  // With our callback function we can now instantiate the compiled module,
+  // giving us an instance we can then execute exports from. Note that
+  // instantiation can trap due to execution of the `start` function, so we need
+  // to handle that here too.
+  printf("Instantiating module...\n");
+  wasm_trap_t *trap = NULL;
+  wasmtime_instance_t instance;
+  wasmtime_extern_t imports[1];
+  imports[0].kind = WASMTIME_EXTERN_FUNC;
+  imports[0].of.func = hello;
+  error = wasmtime_instance_new(context, module, imports, 1, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
+  wasmtime_module_delete(module);
 
-    // Lookup our `run` export function
-    wasmtime_extern_t run;
-    bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
-    assert(ok);
-    assert(run.kind == WASMTIME_EXTERN_FUNC);
+  // Lookup our `run` export function
+  wasmtime_extern_t run;
+  bool ok = wasmtime_instance_export_get(context, &instance, "run", 3, &run);
+  assert(ok);
+  assert(run.kind == WASMTIME_EXTERN_FUNC);
 
-    // And call it!
-    printf("Calling export...\n");
-    error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("failed to call function", error, trap);
+  // And call it!
+  printf("Calling export...\n");
+  error = wasmtime_func_call(context, &run.of.func, NULL, 0, NULL, 0, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call function", error, trap);
 
-    // Clean up after ourselves at this point
-    printf("All finished!\n");
+  // Clean up after ourselves at this point
+  printf("All finished!\n");
 
-    wasmtime_store_delete(store);
-    wasm_engine_delete(engine);
-    return 0;
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+  return 0;
 }
 
-int main()
-{
-    wasm_byte_vec_t buffer;
-    if (serialize(&buffer)) {
-        return 1;
-    }
-    if (deserialize(&buffer)) {
-        return 1;
-    }
-    wasm_byte_vec_delete(&buffer);
-    return 0;
+int main() {
+  wasm_byte_vec_t buffer;
+  if (serialize(&buffer)) {
+    return 1;
+  }
+  if (deserialize(&buffer)) {
+    return 1;
+  }
+  wasm_byte_vec_delete(&buffer);
+  return 0;
 }
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-        wasmtime_error_delete(error);
-    } else {
-        wasm_trap_message(trap, &error_message);
-        wasm_trap_delete(trap);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
-    exit(1);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+    wasmtime_error_delete(error);
+  } else {
+    wasm_trap_message(trap, &error_message);
+    wasm_trap_delete(trap);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/examples/threads.c
+++ b/examples/threads.c
@@ -25,187 +25,190 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-threads
 #ifndef _WIN32
 
 #include <inttypes.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <pthread.h>
 #include <unistd.h>
 #include <wasm.h>
 #include <wasmtime.h>
 
 #define own
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
 const int N_THREADS = 10;
 const int N_REPS = 3;
 
 // A function to be called from Wasm code.
-own wasm_trap_t* callback(const wasm_val_vec_t* args, wasm_val_vec_t* results) {
-  assert(args->data[0].kind == WASM_I32);
-  printf("> Thread %d running\n", args->data[0].of.i32);
-  return NULL;
+own wasm_trap_t* callback(const wasm_val_vec_t* args, wasm_val_vec_t* results)
+{
+    assert(args->data[0].kind == WASM_I32);
+    printf("> Thread %d running\n", args->data[0].of.i32);
+    return NULL;
 }
-
 
 typedef struct {
-  wasm_engine_t* engine;
-  wasm_shared_module_t* module;
-  int id;
+    wasm_engine_t* engine;
+    wasm_shared_module_t* module;
+    int id;
 } thread_args;
 
-void* run(void* args_abs) {
-  thread_args* args = (thread_args*)args_abs;
+void* run(void* args_abs)
+{
+    thread_args* args = (thread_args*)args_abs;
 
-  // Rereate store and module.
-  own wasm_store_t* store = wasm_store_new(args->engine);
-  own wasm_module_t* module = wasm_module_obtain(store, args->module);
+    // Rereate store and module.
+    own wasm_store_t* store = wasm_store_new(args->engine);
+    own wasm_module_t* module = wasm_module_obtain(store, args->module);
 
-  // Run the example N times.
-  for (int i = 0; i < N_REPS; ++i) {
-    usleep(100000);
+    // Run the example N times.
+    for (int i = 0; i < N_REPS; ++i) {
+        usleep(100000);
 
-    // Create imports.
-    own wasm_functype_t* func_type = wasm_functype_new_1_0(wasm_valtype_new_i32());
-    own wasm_func_t* func = wasm_func_new(store, func_type, callback);
-    wasm_functype_delete(func_type);
+        // Create imports.
+        own wasm_functype_t* func_type = wasm_functype_new_1_0(wasm_valtype_new_i32());
+        own wasm_func_t* func = wasm_func_new(store, func_type, callback);
+        wasm_functype_delete(func_type);
 
-    wasm_val_t val = {.kind = WASM_I32, .of = {.i32 = (int32_t)args->id}};
-    own wasm_globaltype_t* global_type =
-      wasm_globaltype_new(wasm_valtype_new_i32(), WASM_CONST);
-    own wasm_global_t* global = wasm_global_new(store, global_type, &val);
-    wasm_globaltype_delete(global_type);
+        wasm_val_t val = { .kind = WASM_I32, .of = { .i32 = (int32_t)args->id } };
+        own wasm_globaltype_t* global_type = wasm_globaltype_new(wasm_valtype_new_i32(), WASM_CONST);
+        own wasm_global_t* global = wasm_global_new(store, global_type, &val);
+        wasm_globaltype_delete(global_type);
 
-    // Instantiate.
-    wasm_extern_t* imports[] = {
-      wasm_func_as_extern(func), wasm_global_as_extern(global),
-    };
-    wasm_extern_vec_t imports_vec = WASM_ARRAY_VEC(imports);
-    own wasm_instance_t* instance =
-      wasm_instance_new(store, module, &imports_vec, NULL);
-    if (!instance) {
-      printf("> Error instantiating module!\n");
-      return NULL;
+        // Instantiate.
+        wasm_extern_t* imports[] = {
+            wasm_func_as_extern(func),
+            wasm_global_as_extern(global),
+        };
+        wasm_extern_vec_t imports_vec = WASM_ARRAY_VEC(imports);
+        own wasm_instance_t* instance = wasm_instance_new(store, module, &imports_vec, NULL);
+        if (!instance) {
+            printf("> Error instantiating module!\n");
+            return NULL;
+        }
+
+        wasm_func_delete(func);
+        wasm_global_delete(global);
+
+        // Extract export.
+        own wasm_extern_vec_t exports;
+        wasm_instance_exports(instance, &exports);
+        if (exports.size == 0) {
+            printf("> Error accessing exports!\n");
+            return NULL;
+        }
+        const wasm_func_t* run_func = wasm_extern_as_func(exports.data[0]);
+        if (run_func == NULL) {
+            printf("> Error accessing export!\n");
+            return NULL;
+        }
+
+        wasm_instance_delete(instance);
+
+        // Call.
+        wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
+        wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
+        if (wasm_func_call(run_func, &args_vec, &results_vec)) {
+            printf("> Error calling function!\n");
+            return NULL;
+        }
+
+        wasm_extern_vec_delete(&exports);
     }
 
-    wasm_func_delete(func);
-    wasm_global_delete(global);
+    wasm_module_delete(module);
+    wasm_store_delete(store);
 
-    // Extract export.
-    own wasm_extern_vec_t exports;
-    wasm_instance_exports(instance, &exports);
-    if (exports.size == 0) {
-      printf("> Error accessing exports!\n");
-      return NULL;
-    }
-    const wasm_func_t *run_func = wasm_extern_as_func(exports.data[0]);
-    if (run_func == NULL) {
-      printf("> Error accessing export!\n");
-      return NULL;
-    }
+    free(args_abs);
 
-    wasm_instance_delete(instance);
-
-    // Call.
-    wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
-    wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
-    if (wasm_func_call(run_func, &args_vec, &results_vec)) {
-      printf("> Error calling function!\n");
-      return NULL;
-    }
-
-    wasm_extern_vec_delete(&exports);
-  }
-
-  wasm_module_delete(module);
-  wasm_store_delete(store);
-
-  free(args_abs);
-
-  return NULL;
+    return NULL;
 }
 
-int main(int argc, const char *argv[]) {
-  // Initialize.
-  wasm_engine_t* engine = wasm_engine_new();
+int main(int argc, const char* argv[])
+{
+    // Initialize.
+    wasm_engine_t* engine = wasm_engine_new();
 
-  // Load our input file to parse it next
-  FILE* file = fopen("examples/threads.wat", "r");
-  if (!file) {
-    printf("> Error loading file!\n");
-    return 1;
-  }
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  fseek(file, 0L, SEEK_SET);
-  wasm_byte_vec_t wat;
-  wasm_byte_vec_new_uninitialized(&wat, file_size);
-  if (fread(wat.data, file_size, 1, file) != 1) {
-    printf("> Error loading module!\n");
-    return 1;
-  }
-  fclose(file);
+    // Load our input file to parse it next
+    FILE* file = fopen("examples/threads.wat", "r");
+    if (!file) {
+        printf("> Error loading file!\n");
+        return 1;
+    }
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    fseek(file, 0L, SEEK_SET);
+    wasm_byte_vec_t wat;
+    wasm_byte_vec_new_uninitialized(&wat, file_size);
+    if (fread(wat.data, file_size, 1, file) != 1) {
+        printf("> Error loading module!\n");
+        return 1;
+    }
+    fclose(file);
 
-  // Parse the wat into the binary wasm format
-  wasm_byte_vec_t binary;
-  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
-  if (error != NULL)
-    exit_with_error("failed to parse wat", error, NULL);
-  wasm_byte_vec_delete(&wat);
+    // Parse the wat into the binary wasm format
+    wasm_byte_vec_t binary;
+    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
+    if (error != NULL)
+        exit_with_error("failed to parse wat", error, NULL);
+    wasm_byte_vec_delete(&wat);
 
-  // Compile and share.
-  own wasm_store_t* store = wasm_store_new(engine);
-  own wasm_module_t* module = wasm_module_new(store, &binary);
-  if (!module) {
-    printf("> Error compiling module!\n");
-    return 1;
-  }
+    // Compile and share.
+    own wasm_store_t* store = wasm_store_new(engine);
+    own wasm_module_t* module = wasm_module_new(store, &binary);
+    if (!module) {
+        printf("> Error compiling module!\n");
+        return 1;
+    }
 
-  wasm_byte_vec_delete(&binary);
+    wasm_byte_vec_delete(&binary);
 
-  own wasm_shared_module_t* shared = wasm_module_share(module);
+    own wasm_shared_module_t* shared = wasm_module_share(module);
 
-  wasm_module_delete(module);
-  wasm_store_delete(store);
+    wasm_module_delete(module);
+    wasm_store_delete(store);
 
-  // Spawn threads.
-  pthread_t threads[N_THREADS];
-  for (int i = 0; i < N_THREADS; i++) {
-    thread_args* args = malloc(sizeof(thread_args));
-    args->id = i;
-    args->engine = engine;
-    args->module = shared;
-    printf("Initializing thread %d...\n", i);
-    pthread_create(&threads[i], NULL, &run, args);
-  }
+    // Spawn threads.
+    pthread_t threads[N_THREADS];
+    for (int i = 0; i < N_THREADS; i++) {
+        thread_args* args = malloc(sizeof(thread_args));
+        args->id = i;
+        args->engine = engine;
+        args->module = shared;
+        printf("Initializing thread %d...\n", i);
+        pthread_create(&threads[i], NULL, &run, args);
+    }
 
-  for (int i = 0; i < N_THREADS; i++) {
-    printf("Waiting for thread: %d\n", i);
-    pthread_join(threads[i], NULL);
-  }
+    for (int i = 0; i < N_THREADS; i++) {
+        printf("Waiting for thread: %d\n", i);
+        pthread_join(threads[i], NULL);
+    }
 
-  wasm_shared_module_delete(shared);
-  wasm_engine_delete(engine);
+    wasm_shared_module_delete(shared);
+    wasm_engine_delete(engine);
 
-  return 0;
+    return 0;
 }
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-  } else {
-    wasm_trap_message(trap, &error_message);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+    } else {
+        wasm_trap_message(trap, &error_message);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }
 
 #else
 // TODO implement example for Windows
-int main(int argc, const char *argv[]) {
-  return 0;
+int main(int argc, const char* argv[])
+{
+    return 0;
 }
 #endif // _WIN32

--- a/examples/threads.c
+++ b/examples/threads.c
@@ -35,180 +35,178 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-threads
 
 #define own
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
 const int N_THREADS = 10;
 const int N_REPS = 3;
 
 // A function to be called from Wasm code.
-own wasm_trap_t* callback(const wasm_val_vec_t* args, wasm_val_vec_t* results)
-{
-    assert(args->data[0].kind == WASM_I32);
-    printf("> Thread %d running\n", args->data[0].of.i32);
-    return NULL;
+own wasm_trap_t *callback(const wasm_val_vec_t *args, wasm_val_vec_t *results) {
+  assert(args->data[0].kind == WASM_I32);
+  printf("> Thread %d running\n", args->data[0].of.i32);
+  return NULL;
 }
 
 typedef struct {
-    wasm_engine_t* engine;
-    wasm_shared_module_t* module;
-    int id;
+  wasm_engine_t *engine;
+  wasm_shared_module_t *module;
+  int id;
 } thread_args;
 
-void* run(void* args_abs)
-{
-    thread_args* args = (thread_args*)args_abs;
+void *run(void *args_abs) {
+  thread_args *args = (thread_args *)args_abs;
 
-    // Rereate store and module.
-    own wasm_store_t* store = wasm_store_new(args->engine);
-    own wasm_module_t* module = wasm_module_obtain(store, args->module);
+  // Rereate store and module.
+  own wasm_store_t *store = wasm_store_new(args->engine);
+  own wasm_module_t *module = wasm_module_obtain(store, args->module);
 
-    // Run the example N times.
-    for (int i = 0; i < N_REPS; ++i) {
-        usleep(100000);
+  // Run the example N times.
+  for (int i = 0; i < N_REPS; ++i) {
+    usleep(100000);
 
-        // Create imports.
-        own wasm_functype_t* func_type = wasm_functype_new_1_0(wasm_valtype_new_i32());
-        own wasm_func_t* func = wasm_func_new(store, func_type, callback);
-        wasm_functype_delete(func_type);
+    // Create imports.
+    own wasm_functype_t *func_type =
+        wasm_functype_new_1_0(wasm_valtype_new_i32());
+    own wasm_func_t *func = wasm_func_new(store, func_type, callback);
+    wasm_functype_delete(func_type);
 
-        wasm_val_t val = { .kind = WASM_I32, .of = { .i32 = (int32_t)args->id } };
-        own wasm_globaltype_t* global_type = wasm_globaltype_new(wasm_valtype_new_i32(), WASM_CONST);
-        own wasm_global_t* global = wasm_global_new(store, global_type, &val);
-        wasm_globaltype_delete(global_type);
+    wasm_val_t val = {.kind = WASM_I32, .of = {.i32 = (int32_t)args->id}};
+    own wasm_globaltype_t *global_type =
+        wasm_globaltype_new(wasm_valtype_new_i32(), WASM_CONST);
+    own wasm_global_t *global = wasm_global_new(store, global_type, &val);
+    wasm_globaltype_delete(global_type);
 
-        // Instantiate.
-        wasm_extern_t* imports[] = {
-            wasm_func_as_extern(func),
-            wasm_global_as_extern(global),
-        };
-        wasm_extern_vec_t imports_vec = WASM_ARRAY_VEC(imports);
-        own wasm_instance_t* instance = wasm_instance_new(store, module, &imports_vec, NULL);
-        if (!instance) {
-            printf("> Error instantiating module!\n");
-            return NULL;
-        }
-
-        wasm_func_delete(func);
-        wasm_global_delete(global);
-
-        // Extract export.
-        own wasm_extern_vec_t exports;
-        wasm_instance_exports(instance, &exports);
-        if (exports.size == 0) {
-            printf("> Error accessing exports!\n");
-            return NULL;
-        }
-        const wasm_func_t* run_func = wasm_extern_as_func(exports.data[0]);
-        if (run_func == NULL) {
-            printf("> Error accessing export!\n");
-            return NULL;
-        }
-
-        wasm_instance_delete(instance);
-
-        // Call.
-        wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
-        wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
-        if (wasm_func_call(run_func, &args_vec, &results_vec)) {
-            printf("> Error calling function!\n");
-            return NULL;
-        }
-
-        wasm_extern_vec_delete(&exports);
+    // Instantiate.
+    wasm_extern_t *imports[] = {
+        wasm_func_as_extern(func),
+        wasm_global_as_extern(global),
+    };
+    wasm_extern_vec_t imports_vec = WASM_ARRAY_VEC(imports);
+    own wasm_instance_t *instance =
+        wasm_instance_new(store, module, &imports_vec, NULL);
+    if (!instance) {
+      printf("> Error instantiating module!\n");
+      return NULL;
     }
 
-    wasm_module_delete(module);
-    wasm_store_delete(store);
+    wasm_func_delete(func);
+    wasm_global_delete(global);
 
-    free(args_abs);
+    // Extract export.
+    own wasm_extern_vec_t exports;
+    wasm_instance_exports(instance, &exports);
+    if (exports.size == 0) {
+      printf("> Error accessing exports!\n");
+      return NULL;
+    }
+    const wasm_func_t *run_func = wasm_extern_as_func(exports.data[0]);
+    if (run_func == NULL) {
+      printf("> Error accessing export!\n");
+      return NULL;
+    }
 
-    return NULL;
+    wasm_instance_delete(instance);
+
+    // Call.
+    wasm_val_vec_t args_vec = WASM_EMPTY_VEC;
+    wasm_val_vec_t results_vec = WASM_EMPTY_VEC;
+    if (wasm_func_call(run_func, &args_vec, &results_vec)) {
+      printf("> Error calling function!\n");
+      return NULL;
+    }
+
+    wasm_extern_vec_delete(&exports);
+  }
+
+  wasm_module_delete(module);
+  wasm_store_delete(store);
+
+  free(args_abs);
+
+  return NULL;
 }
 
-int main(int argc, const char* argv[])
-{
-    // Initialize.
-    wasm_engine_t* engine = wasm_engine_new();
+int main(int argc, const char *argv[]) {
+  // Initialize.
+  wasm_engine_t *engine = wasm_engine_new();
 
-    // Load our input file to parse it next
-    FILE* file = fopen("examples/threads.wat", "r");
-    if (!file) {
-        printf("> Error loading file!\n");
-        return 1;
-    }
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    fseek(file, 0L, SEEK_SET);
-    wasm_byte_vec_t wat;
-    wasm_byte_vec_new_uninitialized(&wat, file_size);
-    if (fread(wat.data, file_size, 1, file) != 1) {
-        printf("> Error loading module!\n");
-        return 1;
-    }
-    fclose(file);
+  // Load our input file to parse it next
+  FILE *file = fopen("examples/threads.wat", "r");
+  if (!file) {
+    printf("> Error loading file!\n");
+    return 1;
+  }
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
+  fclose(file);
 
-    // Parse the wat into the binary wasm format
-    wasm_byte_vec_t binary;
-    wasmtime_error_t* error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
-    if (error != NULL)
-        exit_with_error("failed to parse wat", error, NULL);
-    wasm_byte_vec_delete(&wat);
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t binary;
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &binary);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
 
-    // Compile and share.
-    own wasm_store_t* store = wasm_store_new(engine);
-    own wasm_module_t* module = wasm_module_new(store, &binary);
-    if (!module) {
-        printf("> Error compiling module!\n");
-        return 1;
-    }
+  // Compile and share.
+  own wasm_store_t *store = wasm_store_new(engine);
+  own wasm_module_t *module = wasm_module_new(store, &binary);
+  if (!module) {
+    printf("> Error compiling module!\n");
+    return 1;
+  }
 
-    wasm_byte_vec_delete(&binary);
+  wasm_byte_vec_delete(&binary);
 
-    own wasm_shared_module_t* shared = wasm_module_share(module);
+  own wasm_shared_module_t *shared = wasm_module_share(module);
 
-    wasm_module_delete(module);
-    wasm_store_delete(store);
+  wasm_module_delete(module);
+  wasm_store_delete(store);
 
-    // Spawn threads.
-    pthread_t threads[N_THREADS];
-    for (int i = 0; i < N_THREADS; i++) {
-        thread_args* args = malloc(sizeof(thread_args));
-        args->id = i;
-        args->engine = engine;
-        args->module = shared;
-        printf("Initializing thread %d...\n", i);
-        pthread_create(&threads[i], NULL, &run, args);
-    }
+  // Spawn threads.
+  pthread_t threads[N_THREADS];
+  for (int i = 0; i < N_THREADS; i++) {
+    thread_args *args = malloc(sizeof(thread_args));
+    args->id = i;
+    args->engine = engine;
+    args->module = shared;
+    printf("Initializing thread %d...\n", i);
+    pthread_create(&threads[i], NULL, &run, args);
+  }
 
-    for (int i = 0; i < N_THREADS; i++) {
-        printf("Waiting for thread: %d\n", i);
-        pthread_join(threads[i], NULL);
-    }
+  for (int i = 0; i < N_THREADS; i++) {
+    printf("Waiting for thread: %d\n", i);
+    pthread_join(threads[i], NULL);
+  }
 
-    wasm_shared_module_delete(shared);
-    wasm_engine_delete(engine);
+  wasm_shared_module_delete(shared);
+  wasm_engine_delete(engine);
 
-    return 0;
+  return 0;
 }
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-    } else {
-        wasm_trap_message(trap, &error_message);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
-    exit(1);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+  } else {
+    wasm_trap_message(trap, &error_message);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }
 
 #else
 // TODO implement example for Windows
-int main(int argc, const char* argv[])
-{
-    return 0;
-}
+int main(int argc, const char *argv[]) { return 0; }
 #endif // _WIN32

--- a/examples/wasi/main.c
+++ b/examples/wasi/main.c
@@ -24,98 +24,100 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-wasi
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <wasm.h>
 #include <wasi.h>
+#include <wasm.h>
 #include <wasmtime.h>
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
 
-int main() {
-  // Set up our context
-  wasm_engine_t *engine = wasm_engine_new();
-  assert(engine != NULL);
-  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
-  assert(store != NULL);
-  wasmtime_context_t *context = wasmtime_store_context(store);
+int main()
+{
+    // Set up our context
+    wasm_engine_t* engine = wasm_engine_new();
+    assert(engine != NULL);
+    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
+    assert(store != NULL);
+    wasmtime_context_t* context = wasmtime_store_context(store);
 
-  // Create a linker with WASI functions defined
-  wasmtime_linker_t *linker = wasmtime_linker_new(engine);
-  wasmtime_error_t *error = wasmtime_linker_define_wasi(linker);
-  if (error != NULL)
-    exit_with_error("failed to link wasi", error, NULL);
+    // Create a linker with WASI functions defined
+    wasmtime_linker_t* linker = wasmtime_linker_new(engine);
+    wasmtime_error_t* error = wasmtime_linker_define_wasi(linker);
+    if (error != NULL)
+        exit_with_error("failed to link wasi", error, NULL);
 
-  wasm_byte_vec_t wasm;
-  // Load our input file to parse it next
-  FILE* file = fopen("target/wasm32-wasi/debug/wasi.wasm", "rb");
-  if (!file) {
-    printf("> Error loading file!\n");
-    exit(1);
-  }
-  fseek(file, 0L, SEEK_END);
-  size_t file_size = ftell(file);
-  wasm_byte_vec_new_uninitialized(&wasm, file_size);
-  fseek(file, 0L, SEEK_SET);
-  if (fread(wasm.data, file_size, 1, file) != 1) {
-    printf("> Error loading module!\n");
-    exit(1);
-  }
-  fclose(file);
+    wasm_byte_vec_t wasm;
+    // Load our input file to parse it next
+    FILE* file = fopen("target/wasm32-wasi/debug/wasi.wasm", "rb");
+    if (!file) {
+        printf("> Error loading file!\n");
+        exit(1);
+    }
+    fseek(file, 0L, SEEK_END);
+    size_t file_size = ftell(file);
+    wasm_byte_vec_new_uninitialized(&wasm, file_size);
+    fseek(file, 0L, SEEK_SET);
+    if (fread(wasm.data, file_size, 1, file) != 1) {
+        printf("> Error loading module!\n");
+        exit(1);
+    }
+    fclose(file);
 
-  // Compile our modules
-  wasmtime_module_t *module = NULL;
-  error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
-  if (!module)
-    exit_with_error("failed to compile module", error, NULL);
-  wasm_byte_vec_delete(&wasm);
+    // Compile our modules
+    wasmtime_module_t* module = NULL;
+    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
+    if (!module)
+        exit_with_error("failed to compile module", error, NULL);
+    wasm_byte_vec_delete(&wasm);
 
-  // Instantiate wasi
-  wasi_config_t *wasi_config = wasi_config_new();
-  assert(wasi_config);
-  wasi_config_inherit_argv(wasi_config);
-  wasi_config_inherit_env(wasi_config);
-  wasi_config_inherit_stdin(wasi_config);
-  wasi_config_inherit_stdout(wasi_config);
-  wasi_config_inherit_stderr(wasi_config);
-  wasm_trap_t *trap = NULL;
-  error = wasmtime_context_set_wasi(context, wasi_config);
-  if (error != NULL)
-    exit_with_error("failed to instantiate WASI", error, NULL);
+    // Instantiate wasi
+    wasi_config_t* wasi_config = wasi_config_new();
+    assert(wasi_config);
+    wasi_config_inherit_argv(wasi_config);
+    wasi_config_inherit_env(wasi_config);
+    wasi_config_inherit_stdin(wasi_config);
+    wasi_config_inherit_stdout(wasi_config);
+    wasi_config_inherit_stderr(wasi_config);
+    wasm_trap_t* trap = NULL;
+    error = wasmtime_context_set_wasi(context, wasi_config);
+    if (error != NULL)
+        exit_with_error("failed to instantiate WASI", error, NULL);
 
-  // Instantiate the module
-  error = wasmtime_linker_module(linker, context, "", 0, module);
-  if (error != NULL)
-    exit_with_error("failed to instantiate module", error, NULL);
+    // Instantiate the module
+    error = wasmtime_linker_module(linker, context, "", 0, module);
+    if (error != NULL)
+        exit_with_error("failed to instantiate module", error, NULL);
 
-  // Run it.
-  wasmtime_func_t func;
-  error = wasmtime_linker_get_default(linker, context, "", 0, &func);
-  if (error != NULL)
-    exit_with_error("failed to locate default export for module", error, NULL);
+    // Run it.
+    wasmtime_func_t func;
+    error = wasmtime_linker_get_default(linker, context, "", 0, &func);
+    if (error != NULL)
+        exit_with_error("failed to locate default export for module", error, NULL);
 
-  error = wasmtime_func_call(context, &func, NULL, 0, NULL, 0, &trap);
-  if (error != NULL || trap != NULL)
-    exit_with_error("error calling default export", error, trap);
+    error = wasmtime_func_call(context, &func, NULL, 0, NULL, 0, &trap);
+    if (error != NULL || trap != NULL)
+        exit_with_error("error calling default export", error, trap);
 
-  // Clean up after ourselves at this point
-  wasmtime_module_delete(module);
-  wasmtime_store_delete(store);
-  wasm_engine_delete(engine);
-  return 0;
+    // Clean up after ourselves at this point
+    wasmtime_module_delete(module);
+    wasmtime_store_delete(store);
+    wasm_engine_delete(engine);
+    return 0;
 }
 
-static void exit_with_error(const char *message, wasmtime_error_t *error, wasm_trap_t *trap) {
-  fprintf(stderr, "error: %s\n", message);
-  wasm_byte_vec_t error_message;
-  if (error != NULL) {
-    wasmtime_error_message(error, &error_message);
-    wasmtime_error_delete(error);
-  } else {
-    wasm_trap_message(trap, &error_message);
-    wasm_trap_delete(trap);
-  }
-  fprintf(stderr, "%.*s\n", (int) error_message.size, error_message.data);
-  wasm_byte_vec_delete(&error_message);
-  exit(1);
+static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
+{
+    fprintf(stderr, "error: %s\n", message);
+    wasm_byte_vec_t error_message;
+    if (error != NULL) {
+        wasmtime_error_message(error, &error_message);
+        wasmtime_error_delete(error);
+    } else {
+        wasm_trap_message(trap, &error_message);
+        wasm_trap_delete(trap);
+    }
+    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+    wasm_byte_vec_delete(&error_message);
+    exit(1);
 }

--- a/examples/wasi/main.c
+++ b/examples/wasi/main.c
@@ -30,94 +30,94 @@ mkdir build && cd build && cmake .. && cmake --build . --target wasmtime-wasi
 
 #define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
 
-int main()
-{
-    // Set up our context
-    wasm_engine_t* engine = wasm_engine_new();
-    assert(engine != NULL);
-    wasmtime_store_t* store = wasmtime_store_new(engine, NULL, NULL);
-    assert(store != NULL);
-    wasmtime_context_t* context = wasmtime_store_context(store);
+int main() {
+  // Set up our context
+  wasm_engine_t *engine = wasm_engine_new();
+  assert(engine != NULL);
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  assert(store != NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
 
-    // Create a linker with WASI functions defined
-    wasmtime_linker_t* linker = wasmtime_linker_new(engine);
-    wasmtime_error_t* error = wasmtime_linker_define_wasi(linker);
-    if (error != NULL)
-        exit_with_error("failed to link wasi", error, NULL);
+  // Create a linker with WASI functions defined
+  wasmtime_linker_t *linker = wasmtime_linker_new(engine);
+  wasmtime_error_t *error = wasmtime_linker_define_wasi(linker);
+  if (error != NULL)
+    exit_with_error("failed to link wasi", error, NULL);
 
-    wasm_byte_vec_t wasm;
-    // Load our input file to parse it next
-    FILE* file = fopen("target/wasm32-wasi/debug/wasi.wasm", "rb");
-    if (!file) {
-        printf("> Error loading file!\n");
-        exit(1);
-    }
-    fseek(file, 0L, SEEK_END);
-    size_t file_size = ftell(file);
-    wasm_byte_vec_new_uninitialized(&wasm, file_size);
-    fseek(file, 0L, SEEK_SET);
-    if (fread(wasm.data, file_size, 1, file) != 1) {
-        printf("> Error loading module!\n");
-        exit(1);
-    }
-    fclose(file);
+  wasm_byte_vec_t wasm;
+  // Load our input file to parse it next
+  FILE *file = fopen("target/wasm32-wasi/debug/wasi.wasm", "rb");
+  if (!file) {
+    printf("> Error loading file!\n");
+    exit(1);
+  }
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  wasm_byte_vec_new_uninitialized(&wasm, file_size);
+  fseek(file, 0L, SEEK_SET);
+  if (fread(wasm.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    exit(1);
+  }
+  fclose(file);
 
-    // Compile our modules
-    wasmtime_module_t* module = NULL;
-    error = wasmtime_module_new(engine, (uint8_t*)wasm.data, wasm.size, &module);
-    if (!module)
-        exit_with_error("failed to compile module", error, NULL);
-    wasm_byte_vec_delete(&wasm);
+  // Compile our modules
+  wasmtime_module_t *module = NULL;
+  error = wasmtime_module_new(engine, (uint8_t *)wasm.data, wasm.size, &module);
+  if (!module)
+    exit_with_error("failed to compile module", error, NULL);
+  wasm_byte_vec_delete(&wasm);
 
-    // Instantiate wasi
-    wasi_config_t* wasi_config = wasi_config_new();
-    assert(wasi_config);
-    wasi_config_inherit_argv(wasi_config);
-    wasi_config_inherit_env(wasi_config);
-    wasi_config_inherit_stdin(wasi_config);
-    wasi_config_inherit_stdout(wasi_config);
-    wasi_config_inherit_stderr(wasi_config);
-    wasm_trap_t* trap = NULL;
-    error = wasmtime_context_set_wasi(context, wasi_config);
-    if (error != NULL)
-        exit_with_error("failed to instantiate WASI", error, NULL);
+  // Instantiate wasi
+  wasi_config_t *wasi_config = wasi_config_new();
+  assert(wasi_config);
+  wasi_config_inherit_argv(wasi_config);
+  wasi_config_inherit_env(wasi_config);
+  wasi_config_inherit_stdin(wasi_config);
+  wasi_config_inherit_stdout(wasi_config);
+  wasi_config_inherit_stderr(wasi_config);
+  wasm_trap_t *trap = NULL;
+  error = wasmtime_context_set_wasi(context, wasi_config);
+  if (error != NULL)
+    exit_with_error("failed to instantiate WASI", error, NULL);
 
-    // Instantiate the module
-    error = wasmtime_linker_module(linker, context, "", 0, module);
-    if (error != NULL)
-        exit_with_error("failed to instantiate module", error, NULL);
+  // Instantiate the module
+  error = wasmtime_linker_module(linker, context, "", 0, module);
+  if (error != NULL)
+    exit_with_error("failed to instantiate module", error, NULL);
 
-    // Run it.
-    wasmtime_func_t func;
-    error = wasmtime_linker_get_default(linker, context, "", 0, &func);
-    if (error != NULL)
-        exit_with_error("failed to locate default export for module", error, NULL);
+  // Run it.
+  wasmtime_func_t func;
+  error = wasmtime_linker_get_default(linker, context, "", 0, &func);
+  if (error != NULL)
+    exit_with_error("failed to locate default export for module", error, NULL);
 
-    error = wasmtime_func_call(context, &func, NULL, 0, NULL, 0, &trap);
-    if (error != NULL || trap != NULL)
-        exit_with_error("error calling default export", error, trap);
+  error = wasmtime_func_call(context, &func, NULL, 0, NULL, 0, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("error calling default export", error, trap);
 
-    // Clean up after ourselves at this point
-    wasmtime_module_delete(module);
-    wasmtime_store_delete(store);
-    wasm_engine_delete(engine);
-    return 0;
+  // Clean up after ourselves at this point
+  wasmtime_module_delete(module);
+  wasmtime_store_delete(store);
+  wasm_engine_delete(engine);
+  return 0;
 }
 
-static void exit_with_error(const char* message, wasmtime_error_t* error, wasm_trap_t* trap)
-{
-    fprintf(stderr, "error: %s\n", message);
-    wasm_byte_vec_t error_message;
-    if (error != NULL) {
-        wasmtime_error_message(error, &error_message);
-        wasmtime_error_delete(error);
-    } else {
-        wasm_trap_message(trap, &error_message);
-        wasm_trap_delete(trap);
-    }
-    fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
-    wasm_byte_vec_delete(&error_message);
-    exit(1);
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+    wasmtime_error_delete(error);
+  } else {
+    wasm_trap_message(trap, &error_message);
+    wasm_trap_delete(trap);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
 }

--- a/tests/all/debug/testsuite/dead_code.c
+++ b/tests/all/debug/testsuite/dead_code.c
@@ -1,19 +1,19 @@
 int bar(int a)
 {
-  int b[50];
-  b[0] = a;
-  b[29] = a;
-  return a;
+    int b[50];
+    b[0] = a;
+    b[29] = a;
+    return a;
 }
 
 int baz(int a);
 
 __attribute__((export_name("foo"))) int foo()
 {
-  return baz(10);
+    return baz(10);
 }
 
 __attribute__((noinline)) int baz(int a)
 {
-  return a + 5;
+    return a + 5;
 }

--- a/tests/all/debug/testsuite/dead_code.c
+++ b/tests/all/debug/testsuite/dead_code.c
@@ -1,19 +1,12 @@
-int bar(int a)
-{
-    int b[50];
-    b[0] = a;
-    b[29] = a;
-    return a;
+int bar(int a) {
+  int b[50];
+  b[0] = a;
+  b[29] = a;
+  return a;
 }
 
 int baz(int a);
 
-__attribute__((export_name("foo"))) int foo()
-{
-    return baz(10);
-}
+__attribute__((export_name("foo"))) int foo() { return baz(10); }
 
-__attribute__((noinline)) int baz(int a)
-{
-    return a + 5;
-}
+__attribute__((noinline)) int baz(int a) { return a + 5; }

--- a/tests/all/debug/testsuite/fib-wasm.c
+++ b/tests/all/debug/testsuite/fib-wasm.c
@@ -5,12 +5,13 @@
 //   clang --target=wasm32 fib-wasm.c -o fib-wasm-dwarf5.wasm -gdwarf-5 \
 //     -Wl,--no-entry,--export=fib -nostdlib -fdebug-prefix-map=$PWD=.
 
-int fib(int n) {
-  int t, a = 0, b = 1;
-  for (int i = 0; i < n; i++) {
-    t = a;
-    a = b;
-    b += t;
-  }
-  return b;
+int fib(int n)
+{
+    int t, a = 0, b = 1;
+    for (int i = 0; i < n; i++) {
+        t = a;
+        a = b;
+        b += t;
+    }
+    return b;
 }

--- a/tests/all/debug/testsuite/fib-wasm.c
+++ b/tests/all/debug/testsuite/fib-wasm.c
@@ -5,13 +5,12 @@
 //   clang --target=wasm32 fib-wasm.c -o fib-wasm-dwarf5.wasm -gdwarf-5 \
 //     -Wl,--no-entry,--export=fib -nostdlib -fdebug-prefix-map=$PWD=.
 
-int fib(int n)
-{
-    int t, a = 0, b = 1;
-    for (int i = 0; i < n; i++) {
-        t = a;
-        a = b;
-        b += t;
-    }
-    return b;
+int fib(int n) {
+  int t, a = 0, b = 1;
+  for (int i = 0; i < n; i++) {
+    t = a;
+    a = b;
+    b += t;
+  }
+  return b;
 }

--- a/tests/all/debug/testsuite/reverse-str.c
+++ b/tests/all/debug/testsuite/reverse-str.c
@@ -3,20 +3,18 @@
 //     -O0 -nostdlib -fdebug-prefix-map=$PWD=.
 #include <stdlib.h>
 
-void reverse(char* s, size_t len)
-{
-    if (!len)
-        return;
-    size_t i = 0, j = len - 1;
-    while (i < j) {
-        char t = s[i];
-        s[i++] = s[j];
-        s[j--] = t;
-    }
+void reverse(char *s, size_t len) {
+  if (!len)
+    return;
+  size_t i = 0, j = len - 1;
+  while (i < j) {
+    char t = s[i];
+    s[i++] = s[j];
+    s[j--] = t;
+  }
 }
 
-void _start()
-{
-    char hello[] = "Hello, world.";
-    reverse(hello, 13);
+void _start() {
+  char hello[] = "Hello, world.";
+  reverse(hello, 13);
 }

--- a/tests/all/debug/testsuite/reverse-str.c
+++ b/tests/all/debug/testsuite/reverse-str.c
@@ -3,9 +3,10 @@
 //     -O0 -nostdlib -fdebug-prefix-map=$PWD=.
 #include <stdlib.h>
 
-void reverse(char *s, size_t len)
+void reverse(char* s, size_t len)
 {
-    if (!len) return;
+    if (!len)
+        return;
     size_t i = 0, j = len - 1;
     while (i < j) {
         char t = s[i];

--- a/tests/all/debug/testsuite/spilled_frame_base.c
+++ b/tests/all/debug/testsuite/spilled_frame_base.c
@@ -1,17 +1,21 @@
-// Originally built using WASI SDK 20.0, "clang spilled_frame_base.c -o spilled_frame_base.wasm -g -target wasm32-wasi"
-void func_11(int x, int y, int z, int a, int b, int c, int d, int e, int f, int g, int h) { }
-void func_12(int x, int y, int z, int a, int b, int c, int d, int e, int f, int g, int h, int i) { }
-void func_13(int x, int y, int z, int a, int b, int c, int d, int e, int f, int g, int h, int i, int j) { }
-void func_14(int x, int y, int z, int a, int b, int c, int d, int e, int f, int g, int h, int i, int j, int k) { }
+// Originally built using WASI SDK 20.0, "clang spilled_frame_base.c -o
+// spilled_frame_base.wasm -g -target wasm32-wasi"
+void func_11(int x, int y, int z, int a, int b, int c, int d, int e, int f,
+             int g, int h) {}
+void func_12(int x, int y, int z, int a, int b, int c, int d, int e, int f,
+             int g, int h, int i) {}
+void func_13(int x, int y, int z, int a, int b, int c, int d, int e, int f,
+             int g, int h, int i, int j) {}
+void func_14(int x, int y, int z, int a, int b, int c, int d, int e, int f,
+             int g, int h, int i, int j, int k) {}
 
-int main()
-{
-    int i = 1;
+int main() {
+  int i = 1;
 
-    func_11(55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65);
-    func_12(66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77);
-    func_13(78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90);
-    func_14(91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104);
+  func_11(55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65);
+  func_12(66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77);
+  func_13(78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90);
+  func_14(91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104);
 
-    return i + i;
+  return i + i;
 }

--- a/tests/all/debug/testsuite/spilled_frame_base.c
+++ b/tests/all/debug/testsuite/spilled_frame_base.c
@@ -4,7 +4,8 @@ void func_12(int x, int y, int z, int a, int b, int c, int d, int e, int f, int 
 void func_13(int x, int y, int z, int a, int b, int c, int d, int e, int f, int g, int h, int i, int j) { }
 void func_14(int x, int y, int z, int a, int b, int c, int d, int e, int f, int g, int h, int i, int j, int k) { }
 
-int main() {
+int main()
+{
     int i = 1;
 
     func_11(55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65);


### PR DESCRIPTION
Add a .clang-format for the C code in wasmtime.

We choose the WebKit style because out of all the style options available in .clang-format, it was the closes to the existing style of the c-api crate. I am not really interested in tuning the settings more, but more want consistency and to let the tool format instead of it happening manually.

There is also a check added in CI for it, it always runs and should be very fast. It uses the latest installed `clang-format` binary in GitHub actions, but I am also happy to download a fixed version if we want to pin the version.
