### PR TITLE
Remove wasi-http "checking authority" log

### DIFF
--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -490,7 +490,6 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingRequest for T {
         let req = self.table().get_mut(&request)?;
 
         if let Some(s) = authority.as_ref() {
-            println!("checking authority {s}");
             let auth = match http::uri::Authority::from_str(s.as_str()) {
                 Ok(auth) => auth,
                 Err(_) => return Ok(Err(())),


### PR DESCRIPTION
The Spin framework uses `wasi-http` as a crate.  Since updating to Wasmtime 15, whenever a Spin guest makes an outbound HTTP call, it prints "checking authority (whatever)".  This PR removes that extraneous print.
