### PR TITLE
mpk: add an example testing the memory limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -169,6 +169,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.68.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+dependencies = [
+ "bitflags 2.4.1",
+ "cexpr",
+ "clang-sys",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.32",
+ "which",
 ]
 
 [[package]]
@@ -239,6 +262,12 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "bytesize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
 
 [[package]]
 name = "camino"
@@ -395,6 +424,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -425,6 +463,17 @@ checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -459,7 +508,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -501,7 +550,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -947,7 +996,7 @@ checksum = "53e0efad4403bfc52dc201159c4b842a246a14b98c64b55dfd0f2d89729dfeb8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1634,6 +1683,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,6 +1728,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
+name = "libproc"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229004ebba9d1d5caf41623f1523b6d52abb47d9f6ab87f7e6fc992e3b854aef"
+dependencies = [
+ "bindgen",
+ "errno",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,6 +1769,15 @@ name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
 dependencies = [
  "libc",
 ]
@@ -1756,6 +1831,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1773,6 +1854,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -1909,6 +2000,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,12 +2078,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.32",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-maps"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec8fdc22cb95c02f6a26a91fb1cd60a7a115916c2ed3b09d0a312e11785bd57"
+dependencies = [
+ "anyhow",
+ "bindgen",
+ "libc",
+ "libproc",
+ "mach2",
+ "winapi",
 ]
 
 [[package]]
@@ -2332,7 +2453,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2374,6 +2495,12 @@ checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
 dependencies = [
  "dirs-next",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "shuffling-allocator"
@@ -2509,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2624,7 +2751,7 @@ checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2688,7 +2815,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2745,7 +2872,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3032,7 +3159,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -3054,7 +3181,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3313,6 +3440,7 @@ dependencies = [
  "async-trait",
  "bstr",
  "bytes",
+ "bytesize",
  "clap",
  "component-macro-test",
  "component-test-util",
@@ -3329,6 +3457,7 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
+ "proc-maps",
  "rayon",
  "rustix",
  "serde",
@@ -3380,7 +3509,7 @@ dependencies = [
  "component-macro-test-helpers",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "tracing",
  "wasmtime",
  "wasmtime-component-util",
@@ -3641,7 +3770,7 @@ version = "16.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3855,7 +3984,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "shellexpand",
- "syn 2.0.29",
+ "syn 2.0.32",
  "witx",
 ]
 
@@ -3865,7 +3994,7 @@ version = "16.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "wiggle",
  "wiggle-generate",
 ]
@@ -3954,7 +4083,7 @@ dependencies = [
  "glob",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -4097,7 +4226,7 @@ dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "wit-bindgen-core",
  "wit-bindgen-rust",
  "wit-component 0.18.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -172,29 +172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.68.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
-dependencies = [
- "bitflags 2.4.1",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.32",
- "which",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,15 +401,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,17 +431,6 @@ checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1683,12 +1640,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1728,17 +1679,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
-name = "libproc"
-version = "0.14.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229004ebba9d1d5caf41623f1523b6d52abb47d9f6ab87f7e6fc992e3b854aef"
-dependencies = [
- "bindgen",
- "errno",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,15 +1709,6 @@ name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "mach2"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
 dependencies = [
  "libc",
 ]
@@ -1831,12 +1762,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,16 +1779,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -2000,12 +1915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2078,36 +1987,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
-dependencies = [
- "proc-macro2",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "proc-maps"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec8fdc22cb95c02f6a26a91fb1cd60a7a115916c2ed3b09d0a312e11785bd57"
-dependencies = [
- "anyhow",
- "bindgen",
- "libc",
- "libproc",
- "mach2",
- "winapi",
 ]
 
 [[package]]
@@ -2495,12 +2380,6 @@ checksum = "83bdb7831b2d85ddf4a7b148aa19d0587eddbe8671a436b7bd1182eaad0f2829"
 dependencies = [
  "dirs-next",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "shuffling-allocator"
@@ -3457,7 +3336,6 @@ dependencies = [
  "memchr",
  "num_cpus",
  "once_cell",
- "proc-maps",
  "rayon",
  "rustix",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 walkdir = { workspace = true }
 test-programs-artifacts = { workspace = true }
-proc-maps = "0.3.2"
 bytesize = "1.3.0"
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 walkdir = { workspace = true }
 test-programs-artifacts = { workspace = true }
+proc-maps = "0.3.2"
+bytesize = "1.3.0"
 
 [target.'cfg(windows)'.dev-dependencies]
 windows-sys = { workspace = true, features = ["Win32_System_Memory"] }

--- a/crates/runtime/src/instance/allocator/pooling/memory_pool.rs
+++ b/crates/runtime/src/instance/allocator/pooling/memory_pool.rs
@@ -189,7 +189,10 @@ impl MemoryPool {
         // region to start--`PROT_NONE`.
         let constraints = SlabConstraints::new(&config.limits, tunables, pkeys.len())?;
         let layout = calculate(&constraints)?;
-        log::debug!("creating memory pool: {constraints:?} -> {layout:?}");
+        log::debug!(
+            "creating memory pool: {constraints:?} -> {layout:?} (total: {})",
+            layout.total_slab_bytes()?
+        );
         let mut mapping = Mmap::accessible_reserved(0, layout.total_slab_bytes()?)
             .context("failed to create memory pool mapping")?;
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2409,7 +2409,7 @@ impl PoolingAllocationConfig {
     /// same method that [`MpkEnabled::Auto`] does. See
     /// [`PoolingAllocationConfig::memory_protection_keys`] for more
     /// information.
-    pub fn are_memory_protection_keys_available(&self) -> bool {
+    pub fn are_memory_protection_keys_available() -> bool {
         mpk::is_supported()
     }
 }

--- a/examples/mpk.rs
+++ b/examples/mpk.rs
@@ -1,0 +1,229 @@
+//! This example demonstrates:
+//! - how to enable memory protection keys (MPK) in a Wasmtime embedding (see
+//!   [`build_engine`])
+//! - the expected memory compression from using MPK: it will probe the system
+//!   by creating larger and larger memory pools until system memory is
+//!   exhausted (see [`probe_engine_size`]). Then, it prints a comparison of the
+//!   memory used in both the MPK enabled and MPK disabled configurations.
+//!
+//! You can execute this example with:
+//!
+//! ```console
+//! $ cargo run --example mpk
+//! ```
+//!
+//! Append `-- --help` for details about the configuring the memory size of the
+//! pool. Also, to inspect interesting configuration values used for
+//! constructing the pool, turn on logging:
+//!
+//! ```console
+//! $ RUST_LOG=debug cargo run --example mpk -- --memory-size 512MiB
+//! ```
+//!
+//! Note that OS limits on the number of virtual memory areas (VMAs) can
+//! significantly restrict the total number MPK-striped memory slots; each
+//! MPK-protected slot ends up using a new VMA entry. On Linux, one can raise
+//! this limit:
+//!
+//! ```console
+//! $ sysctl vm.max_map_count
+//! 65530
+//! $ sysctl vm.max_map_count=$LARGER_LIMIT
+//! ```
+
+use anyhow::{anyhow, Result};
+use bytesize::ByteSize;
+use clap::Parser;
+use log::{info, warn};
+use std::str::FromStr;
+use wasmtime::*;
+
+fn main() -> Result<()> {
+    drop(env_logger::try_init());
+    let args = Args::parse();
+    info!("{:?}", args);
+
+    let without_mpk = probe_engine_size(&args, MpkEnabled::Disable)?;
+    println!("without MPK:\t{}", without_mpk.to_string());
+
+    if PoolingAllocationConfig::are_memory_protection_keys_available() {
+        let with_mpk = probe_engine_size(&args, MpkEnabled::Enable)?;
+        println!("with MPK:\t{}", with_mpk.to_string());
+        println!(
+            "\t\t{}x more slots per reserved memory",
+            with_mpk.compare(&without_mpk)
+        );
+    } else {
+        println!("with MPK:\tunavailable\t\tunavailable");
+    }
+
+    Ok(())
+}
+
+#[derive(Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// The maximum number of bytes for each WebAssembly linear memory in the
+    /// pool.
+    #[arg(long, default_value = "128MiB", value_parser = parse_byte_size)]
+    memory_size: u64,
+
+    /// The maximum number of bytes a memory is considered static; see
+    /// `Config::static_memory_maximum_size` for more details and the default
+    /// value if unset.
+    #[arg(long, value_parser = parse_byte_size)]
+    static_memory_maximum_size: Option<u64>,
+
+    /// The size in bytes of the guard region to expect between static memory
+    /// slots; see [`Config::static_memory_guard_size`] for more details and the
+    /// default value if unset.
+    #[arg(long, value_parser = parse_byte_size)]
+    static_memory_guard_size: Option<u64>,
+}
+
+/// Parse a human-readable byte size--e.g., "512 MiB"--into the correct number
+/// of bytes.
+fn parse_byte_size(value: &str) -> Result<u64> {
+    let size = ByteSize::from_str(value).map_err(|e| anyhow!(e))?;
+    Ok(size.as_u64())
+}
+
+/// Find the engine with the largest number of memories we can create on this
+/// machine.
+fn probe_engine_size(args: &Args, mpk: MpkEnabled) -> Result<Pool> {
+    let mut search = ExponentialSearch::new();
+    let mut mapped_bytes = 0;
+    while !search.done() {
+        match build_engine(&args, search.next(), mpk) {
+            Ok(rb) => {
+                // TODO: assert!(rb >= mapped_bytes);
+                mapped_bytes = rb;
+                search.record(true)
+            }
+            Err(e) => {
+                warn!("failed engine allocation, continuing search: {:?}", e);
+                search.record(false)
+            }
+        }
+    }
+    Ok(Pool {
+        num_memories: search.next(),
+        mapped_bytes,
+    })
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct Pool {
+    num_memories: u32,
+    mapped_bytes: usize,
+}
+impl Pool {
+    /// Print a human-readable, tab-separated description of this structure.
+    fn to_string(&self) -> String {
+        let human_size = ByteSize::b(self.mapped_bytes as u64).to_string_as(true);
+        format!(
+            "{} memory slots\t{} reserved",
+            self.num_memories, human_size
+        )
+    }
+    /// Return the number of times more memory slots in `self` than `other`
+    /// after normalizing by the mapped bytes sizes. Rounds to three decimal
+    /// places arbitrarily; no significance intended.
+    fn compare(&self, other: &Pool) -> f64 {
+        let size_ratio = other.mapped_bytes as f64 / self.mapped_bytes as f64;
+        let slots_ratio = self.num_memories as f64 / other.num_memories as f64;
+        let times_more_efficient = slots_ratio * size_ratio;
+        (times_more_efficient * 1000.0).round() / 1000.0
+    }
+}
+
+/// Exponentially increase the `next` value until the attempts fail, then
+/// perform a binary search to find the maximum attempted value that still
+/// succeeds.
+#[derive(Debug)]
+struct ExponentialSearch {
+    /// Determines if we are in the growth phase.
+    growing: bool,
+    /// The last successful value tried; this is the algorithm's lower bound.
+    last: u32,
+    /// The next value to try; this is the algorithm's upper bound.
+    next: u32,
+}
+impl ExponentialSearch {
+    fn new() -> Self {
+        Self {
+            growing: true,
+            last: 0,
+            next: 1,
+        }
+    }
+    fn next(&self) -> u32 {
+        self.next
+    }
+    fn record(&mut self, success: bool) {
+        if !success {
+            self.growing = false
+        }
+        let diff = if self.growing {
+            (self.next - self.last) * 2
+        } else {
+            (self.next - self.last + 1) / 2
+        };
+        if success {
+            self.last = self.next;
+            self.next = self.next + diff;
+        } else {
+            self.next = self.next - diff;
+        }
+    }
+    fn done(&self) -> bool {
+        self.last == self.next
+    }
+}
+
+/// Build a pool-allocated engine with `num_memories` slots.
+fn build_engine(args: &Args, num_memories: u32, enable_mpk: MpkEnabled) -> Result<usize> {
+    // Configure the memory pool.
+    let mut pool = PoolingAllocationConfig::default();
+    let memory_pages = args.memory_size / u64::from(wasmtime_environ::WASM_PAGE_SIZE);
+    pool.memory_pages(memory_pages);
+    pool.total_memories(num_memories)
+        .memory_protection_keys(enable_mpk);
+
+    // Configure the engine itself.
+    let mut config = Config::new();
+    if let Some(static_memory_maximum_size) = args.static_memory_maximum_size {
+        config.static_memory_maximum_size(static_memory_maximum_size);
+    }
+    if let Some(static_memory_guard_size) = args.static_memory_guard_size {
+        config.static_memory_guard_size(static_memory_guard_size);
+    }
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
+
+    // Measure memory use before and after the engine is built.
+    let mapped_bytes_before = num_bytes_mapped()?;
+    let engine = Engine::new(&config)?;
+    let mapped_bytes_after = num_bytes_mapped()?;
+
+    // Ensure we actually use the engine somehow.
+    engine.increment_epoch();
+
+    let mapped_bytes = mapped_bytes_after - mapped_bytes_before;
+    info!(
+        "{}-slot pool ({:?}): {} bytes mapped",
+        num_memories, enable_mpk, mapped_bytes
+    );
+    Ok(mapped_bytes)
+}
+
+/// Add up the sizes of all the mapped virtual memory regions for the current
+/// process. On Linux, this is parsed from `/proc/PID/maps` ([reference]).
+///
+/// [reference]: https://github.com/rbspy/proc-maps/blob/93cdede6e626c272badfe51f0062f87befb0c024/src/linux_maps.rs#L52
+fn num_bytes_mapped() -> Result<usize> {
+    let pid = std::process::id().try_into().unwrap();
+    let maps = proc_maps::get_process_maps(pid)?;
+    let total = maps.iter().map(|m| m.size()).sum();
+    Ok(total)
+}

--- a/examples/mpk.rs
+++ b/examples/mpk.rs
@@ -39,7 +39,7 @@ use std::str::FromStr;
 use wasmtime::*;
 
 fn main() -> Result<()> {
-    drop(env_logger::try_init());
+    env_logger::init();
     let args = Args::parse();
     info!("{:?}", args);
 

--- a/examples/mpk.rs
+++ b/examples/mpk.rs
@@ -40,6 +40,12 @@ use std::io::{BufRead, BufReader};
 use std::str::FromStr;
 use wasmtime::*;
 
+#[cfg(not(target_os = "linux"))]
+fn main() -> Result<()> {
+    println!("due to how this example measures reserved memory it only works on Linux");
+    Ok(())
+}
+
 #[cfg(target_os = "linux")]
 fn main() -> Result<()> {
     env_logger::init();

--- a/examples/mpk.rs
+++ b/examples/mpk.rs
@@ -20,10 +20,10 @@
 //! $ RUST_LOG=debug cargo run --example mpk -- --memory-size 512MiB
 //! ```
 //!
-//! Note that OS limits on the number of virtual memory areas (VMAs) can
-//! significantly restrict the total number MPK-striped memory slots; each
-//! MPK-protected slot ends up using a new VMA entry. On Linux, one can raise
-//! this limit:
+//! Note that MPK support is limited to x86 Linux systems. OS limits on the
+//! number of virtual memory areas (VMAs) can significantly restrict the total
+//! number MPK-striped memory slots; each MPK-protected slot ends up using a new
+//! VMA entry. On Linux, one can raise this limit:
 //!
 //! ```console
 //! $ sysctl vm.max_map_count

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -833,6 +833,11 @@ criteria = "safe-to-deploy"
 version = "3.11.1"
 notes = "I am the author of this crate."
 
+[[audits.bytesize]]
+who = "Andrew Brown <andrew.brown@intel.com>"
+criteria = "safe-to-deploy"
+version = "1.3.0"
+
 [[audits.camino]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1013,6 +1013,13 @@ user-id = 3618
 user-login = "dtolnay"
 user-name = "David Tolnay"
 
+[[publisher.syn]]
+version = "2.0.32"
+when = "2023-09-10"
+user-id = 3618
+user-login = "dtolnay"
+user-name = "David Tolnay"
+
 [[publisher.system-interface]]
 version = "0.26.0"
 when = "2023-06-30"


### PR DESCRIPTION
This change adds an example program showing:
- how to build a pool-allocated engine that uses MPK
- the difference in the number of memory slots when creating an engine with MPK versus not

The output could look like:

```console
$ cargo run --example mpk
without MPK:    14591 memory slots      85.5 TiB reserved
with MPK:       218861 memory slots     85.5 TiB reserved
                14.999x more slots per reserved memory
```

The example program probes exponentially larger memory pools to find the maximum available on the current system. This search is highly dependent on the memory available, the OS limits on VMAs, and various engine configuration parameters. See the example docs for more details.