### PR TITLE
Add extended version information to `wasmtime --version`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -13,6 +13,8 @@ use std::process::Command;
 fn main() -> anyhow::Result<()> {
     println!("cargo:rerun-if-changed=build.rs");
 
+    set_commit_info_for_rustc();
+
     let out_dir = PathBuf::from(
         env::var_os("OUT_DIR").expect("The OUT_DIR environment variable must be set"),
     );
@@ -280,4 +282,31 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
 
         _ => false,
     }
+}
+
+fn set_commit_info_for_rustc() {
+    if !Path::new(".git").exists() {
+        return;
+    }
+    let output = match Command::new("git")
+        .arg("log")
+        .arg("-1")
+        .arg("--date=short")
+        .arg("--format=%H %h %cd")
+        .arg("--abbrev=9")
+        .output()
+    {
+        Ok(output) if output.status.success() => output,
+        _ => return,
+    };
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let mut parts = stdout.split_whitespace();
+    let mut next = || parts.next().unwrap();
+    println!("cargo:rustc-env=WASMTIME_GIT_HASH={}", next());
+    println!(
+        "cargo:rustc-env=WASMTIME_VERSION_INFO={} ({} {})",
+        env!("CARGO_PKG_VERSION"),
+        next(),
+        next()
+    );
 }

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 /// Wasmtime WebAssembly Runtime
 #[derive(Parser, PartialEq)]
 #[clap(
-    version,
+    version = version(),
     after_help = "If a subcommand is not provided, the `run` subcommand will be used.\n\
                   \n\
                   Usage examples:\n\
@@ -38,6 +38,11 @@ struct Wasmtime {
     subcommand: Option<Subcommand>,
     #[clap(flatten)]
     run: wasmtime_cli::commands::RunCommand,
+}
+
+/// If WASMTIME_VERSION_INFO is set, use it, otherwise use CARGO_PKG_VERSION.
+fn version() -> &'static str {
+    option_env!("WASMTIME_VERSION_INFO").unwrap_or(env!("CARGO_PKG_VERSION"))
 }
 
 #[derive(Parser, PartialEq)]


### PR DESCRIPTION
This commit adds some more information to `wasmtime --version` which includes the git commit plus the git commit's date. This matches `rustc -V` for example which was additionally copied to `wasm-tools` and mirrored as `wasm-tools -V`.

Personally I've found this useful since it can help point to exact commits and additionally quickly get a sense of how old a version is based on its commit date presented.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
