### PR TITLE
include `wasi:random/insecure{_seed}` in `command::add_to_linker`

### DIFF
--- a/crates/wasi/src/preview2/command.rs
+++ b/crates/wasi/src/preview2/command.rs
@@ -35,6 +35,8 @@ pub fn add_to_linker<T: WasiView>(l: &mut wasmtime::component::Linker<T>) -> any
     crate::preview2::bindings::io::poll::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::io::streams::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::random::random::add_to_linker(l, |t| t)?;
+    crate::preview2::bindings::random::insecure::add_to_linker(l, |t| t)?;
+    crate::preview2::bindings::random::insecure_seed::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::cli::exit::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::cli::environment::add_to_linker(l, |t| t)?;
     crate::preview2::bindings::cli::stdin::add_to_linker(l, |t| t)?;
@@ -96,6 +98,8 @@ pub mod sync {
         crate::preview2::bindings::sync_io::io::poll::add_to_linker(l, |t| t)?;
         crate::preview2::bindings::sync_io::io::streams::add_to_linker(l, |t| t)?;
         crate::preview2::bindings::random::random::add_to_linker(l, |t| t)?;
+        crate::preview2::bindings::random::insecure::add_to_linker(l, |t| t)?;
+        crate::preview2::bindings::random::insecure_seed::add_to_linker(l, |t| t)?;
         crate::preview2::bindings::cli::exit::add_to_linker(l, |t| t)?;
         crate::preview2::bindings::cli::environment::add_to_linker(l, |t| t)?;
         crate::preview2::bindings::cli::stdin::add_to_linker(l, |t| t)?;


### PR DESCRIPTION
I believe these were omitted by mistake.

TODO: We should definitely use the `wasmtime-wit-bindgen`-generated `add_to_linker` function for the `command` world if possible, which would avoid such mistakes in the future.
