### PR TITLE
Add small tests for `wasi:random/{random,insecure}`

### DIFF
--- a/crates/test-programs/src/bin/preview2_random.rs
+++ b/crates/test-programs/src/bin/preview2_random.rs
@@ -1,6 +1,40 @@
+use test_programs::wasi::random;
+
 fn main() {
     let mut bytes = [0_u8; 256];
     getrandom::getrandom(&mut bytes).unwrap();
 
     assert!(bytes.iter().any(|x| *x != 0));
+
+    // Acquired random bytes should be of the expected length.
+    let array = random::random::get_random_bytes(100);
+    assert_eq!(array.len(), 100);
+
+    // It shouldn't take 100+ tries to get a nonzero random integer.
+    for i in 0.. {
+        if random::random::get_random_u64() == 0 {
+            continue;
+        }
+        assert!(i < 100);
+        break;
+    }
+
+    // The `insecure_seed` API should return the same result each time.
+    let (a1, b1) = random::insecure_seed::insecure_seed();
+    let (a2, b2) = random::insecure_seed::insecure_seed();
+    assert_eq!(a1, a2);
+    assert_eq!(b1, b2);
+
+    // Acquired random bytes should be of the expected length.
+    let array = random::insecure::get_insecure_random_bytes(100);
+    assert_eq!(array.len(), 100);
+
+    // It shouldn't take 100+ tries to get a nonzero random integer.
+    for i in 0.. {
+        if random::insecure::get_insecure_random_u64() == 0 {
+            continue;
+        }
+        assert!(i < 100);
+        break;
+    }
 }


### PR DESCRIPTION
This followed #7613 with a test to ensure that the interface isn't accidentally left out in the future too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
