### PR TITLE
mpk: optimize layout of protected stripes, again

### DIFF
--- a/crates/runtime/proptest-regressions/instance/allocator/pooling/memory_pool.txt
+++ b/crates/runtime/proptest-regressions/instance/allocator/pooling/memory_pool.txt
@@ -6,3 +6,4 @@
 # everyone who runs the test benefits from these saved cases.
 cc 696808084287d5d58b85c60c4720227ab4dd83ada7be6841a67162023aaf4914 # shrinks to c = SlabConstraints { max_memory_bytes: 0, num_memory_slots: 1, num_pkeys_available: 0, guard_bytes: 9223372036854775808 }
 cc cf9f6c36659f7f56ed8ea646e8c699cbf46708cef6911cdd376418ad69ea1388 # shrinks to c = SlabConstraints { max_memory_bytes: 14161452635954640438, num_memory_slots: 0, num_pkeys_available: 0, guard_bytes: 4285291437754911178 }
+cc 58f42405c4fbfb4b464950f372995d4d08a77d6884335e38c2e68d590cacf7d8 # shrinks to c = SlabConstraints { expected_slot_bytes: 0, max_memory_bytes: 8483846582232735745, num_slots: 0, num_pkeys_available: 0, guard_bytes: 0, guard_before_slots: false }

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -1349,18 +1349,56 @@ fn wasm_fault_address_reported_by_default() -> Result<()> {
 
     // NB: at this time there's no programmatic access to the fault address
     // because it's not always available for load/store traps. Only static
-    // memories on 32-bit have this information, but bounds-checked memories
-    // use manual trapping instructions and otherwise don't have a means of
+    // memories on 32-bit have this information, but bounds-checked memories use
+    // manual trapping instructions and otherwise don't have a means of
     // communicating the faulting address at this time.
     //
     // It looks like the exact reported fault address may not be deterministic,
-    // so assert that we have the right error message, but not the exact address.
+    // so assert that we have the right error message, but not the exact
+    // address.
     let err = format!("{err:?}");
     assert!(
         err.contains("memory fault at wasm address ")
             && err.contains(" in linear memory of size 0x10000"),
         "bad error: {err}"
     );
+    Ok(())
+}
+
+#[test]
+fn wasm_fault_address_reported_from_mpk_protected_memory() -> Result<()> {
+    // Trigger the case where an OOB memory access causes a segfault and the
+    // store attempts to convert it into a `WasmFault`, calculating the Wasm
+    // address from the raw faulting address. Previously, a store could not do
+    // this calculation for MPK-protected, causing an abort.
+    let mut pool = crate::small_pool_config();
+    pool.total_memories(16);
+    pool.memory_protection_keys(MpkEnabled::Auto);
+    let mut config = Config::new();
+    config.allocation_strategy(InstanceAllocationStrategy::Pooling(pool));
+    let engine = Engine::new(&config)?;
+
+    let mut store = Store::new(&engine, ());
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (memory 1)
+                (func $start
+                    i32.const 0xdeadbeef
+                    i32.load
+                    drop)
+                (start $start)
+            )
+        "#,
+    )?;
+    let err = Instance::new(&mut store, &module, &[]).unwrap_err();
+
+    // We expect an error here, not an abort; but we also check that the store
+    // can now calculate the correct Wasm address. If this test is failing with
+    // an abort, use `--nocapture` to see more details.
+    let err = format!("{err:?}");
+    assert!(err.contains("0xdeadbeef"), "bad error: {err}");
     Ok(())
 }
 


### PR DESCRIPTION
This is another attempt at #7603, attempting reduce the slab layout sizes of MPK-protected stripes. While experimenting with the limits of MPK-protected memory pools, @alexcrichton and I discovered that the current slab layout calculations were too conservative. This meant that the memory pool could not pack in as many memories as it should have been able: we were expecting, but not seeing, ~15x more memory slots over non-MPK memory pools.

This change brings together several fixes:
- it more aggressively divides up the stripes (as in b212152)
- it eliminates an extra stripe (as in 8813a30)
- it replaces some uses of `checked_*` with `saturating_*` (as in fb22a20)
- it improves some documentation
- and, crucially, it reports back a larger value for `memory_and_guard_size`

The failures observed with #7603 when run with MPK (`WASMTIME_TEST_FORCE_MPK=1 cargo test`) were due to `Store::wasm_fault` not being able to identify which memory an OOB address belonged to. This is because the `MemoryPool` was underreporting the size of the region in which OOB accesses would fault. The correct value is provided by the new `SlabLayout::bytes_to_next_stripe_slot`: any OOB access within that larger region must fault because (1) the other stripes have different protection keys and (2) a `Store` can only use one protection key. We also use (2) to guarantee that `Store::wasm_fault` will be able to calculate the Wasm address from the raw address.

This change also provides a new `traps` test that will reproduce the failures from #7603; if we observe `SIGABRT` from that test, it will be a regression.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
