### PR TITLE
Add `fields.has` to query if a header is present in a `fields`

### DIFF
--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -24,7 +24,7 @@ impl bindings::exports::wasi::http::incoming_handler::Guest for T {
         let req_hdrs = request.headers();
 
         assert!(
-            req_hdrs.get(&header).is_empty(),
+            req_hdrs.get(&header).is_none(),
             "forbidden `custom-forbidden-header` found in request"
         );
 
@@ -32,7 +32,7 @@ impl bindings::exports::wasi::http::incoming_handler::Guest for T {
         assert!(req_hdrs.append(&header, &b"no".to_vec()).is_err());
 
         assert!(
-            req_hdrs.get(&header).is_empty(),
+            req_hdrs.get(&header).is_none(),
             "append of forbidden header succeeded"
         );
 

--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -24,7 +24,7 @@ impl bindings::exports::wasi::http::incoming_handler::Guest for T {
         let req_hdrs = request.headers();
 
         assert!(
-            req_hdrs.get(&header).is_none(),
+            !req_hdrs.has(&header),
             "forbidden `custom-forbidden-header` found in request"
         );
 
@@ -32,7 +32,7 @@ impl bindings::exports::wasi::http::incoming_handler::Guest for T {
         assert!(req_hdrs.append(&header, &b"no".to_vec()).is_err());
 
         assert!(
-            req_hdrs.get(&header).is_none(),
+            !req_hdrs.has(&header),
             "append of forbidden header succeeded"
         );
 

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -144,19 +144,24 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFields for T {
         &mut self,
         fields: Resource<HostFields>,
         name: String,
-    ) -> wasmtime::Result<Vec<Vec<u8>>> {
+    ) -> wasmtime::Result<Option<Vec<Vec<u8>>>> {
+        let fields = get_fields(self.table(), &fields).context("[fields_get] getting fields")?;
+
         let header = match hyper::header::HeaderName::from_bytes(name.as_bytes()) {
             Ok(header) => header,
-            Err(_) => return Ok(vec![]),
+            Err(_) => return Ok(None),
         };
 
-        let res = get_fields(self.table(), &fields)
-            .context("[fields_get] getting fields")?
-            .get_all(header)
+        if !fields.contains_key(&header) {
+            return Ok(None);
+        }
+
+        let res = fields
+            .get_all(&header)
             .into_iter()
             .map(|val| val.as_bytes().to_owned())
             .collect();
-        Ok(res)
+        Ok(Some(res))
     }
 
     fn set(

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -330,14 +330,14 @@ interface types {
 
     /// Set the timeout for the initial connect to the HTTP Server. An error
     /// return value indicates that this timeout is not supported.
-    set-connect-timeout: func(ms: option<duration>) -> result;
+    set-connect-timeout: func(duration: option<duration>) -> result;
 
     /// The timeout for receiving the first byte of the Response body.
     first-byte-timeout: func() -> option<duration>;
 
     /// Set the timeout for receiving the first byte of the Response body. An
     /// error return value indicates that this timeout is not supported.
-    set-first-byte-timeout: func(ms: option<duration>) -> result;
+    set-first-byte-timeout: func(duration: option<duration>) -> result;
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
@@ -346,7 +346,7 @@ interface types {
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
     /// body stream. An error return value indicates that this timeout is not
     /// supported.
-    set-between-bytes-timeout: func(ms: option<duration>) -> result;
+    set-between-bytes-timeout: func(duration: option<duration>) -> result;
   }
 
   /// Represents the ability to send an HTTP Response.

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -169,8 +169,10 @@ interface types {
       entries: list<tuple<field-key,field-value>>
     ) -> result<fields, header-error>;
 
-    /// Get all of the values corresponding to a key.
-    get: func(name: field-key) -> list<field-value>;
+    /// Get all of the values corresponding to a key. Returns a `none` value
+    /// when the key isn't present, to distinguish from the case where it's
+    /// present but empty.
+    get: func(name: field-key) -> option<list<field-value>>;
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -169,10 +169,15 @@ interface types {
       entries: list<tuple<field-key,field-value>>
     ) -> result<fields, header-error>;
 
-    /// Get all of the values corresponding to a key. Returns a `none` value
-    /// when the key isn't present, to distinguish from the case where it's
-    /// present but empty.
-    get: func(name: field-key) -> option<list<field-value>>;
+    /// Get all of the values corresponding to a key. If the key is not present
+    /// in this `fields`, an empty list is returned. However, if the key is
+    /// present but empty, this is represented by a list with one or more
+    /// empty field-values present.
+    get: func(name: field-key) -> list<field-value>;
+
+    /// Returns `true` when the key is present in this `fields`. If the key is
+    /// syntactically invalid, `false` is returned.
+    has: func(name: field-key) -> bool;
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -198,7 +198,7 @@ interface types {
     append: func(name: field-key, value: field-value) -> result<_, header-error>;
 
     /// Retrieve the full set of keys and values in the Fields. Like the
-    /// constructor, the list represents each key-value pair. 
+    /// constructor, the list represents each key-value pair.
     ///
     /// The outer list represents each key-value pair in the Fields. Keys
     /// which have multiple values are represented by multiple entries in this
@@ -315,8 +315,9 @@ interface types {
     headers: func() -> headers;
   }
 
-  /// Parameters for making an HTTP Request. Each of these parameters is an
-  /// optional timeout, applicable to the transport layer of the HTTP protocol.
+  /// Parameters for making an HTTP Request. Each of these parameters is
+  /// currently an optional timeout applicable to the transport layer of the
+  /// HTTP protocol.
   ///
   /// These timeouts are separate from any the user may use to bound a
   /// blocking call to `wasi:io/poll.poll`.
@@ -329,14 +330,14 @@ interface types {
 
     /// Set the timeout for the initial connect to the HTTP Server. An error
     /// return value indicates that this timeout is not supported.
-    set-connect-timeout: func(duration: option<duration>) -> result;
+    set-connect-timeout: func(ms: option<duration>) -> result;
 
     /// The timeout for receiving the first byte of the Response body.
     first-byte-timeout: func() -> option<duration>;
 
     /// Set the timeout for receiving the first byte of the Response body. An
     /// error return value indicates that this timeout is not supported.
-    set-first-byte-timeout: func(duration: option<duration>) -> result;
+    set-first-byte-timeout: func(ms: option<duration>) -> result;
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
@@ -345,7 +346,7 @@ interface types {
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
     /// body stream. An error return value indicates that this timeout is not
     /// supported.
-    set-between-bytes-timeout: func(duration: option<duration>) -> result;
+    set-between-bytes-timeout: func(ms: option<duration>) -> result;
   }
 
   /// Represents the ability to send an HTTP Response.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -330,14 +330,14 @@ interface types {
 
     /// Set the timeout for the initial connect to the HTTP Server. An error
     /// return value indicates that this timeout is not supported.
-    set-connect-timeout: func(ms: option<duration>) -> result;
+    set-connect-timeout: func(duration: option<duration>) -> result;
 
     /// The timeout for receiving the first byte of the Response body.
     first-byte-timeout: func() -> option<duration>;
 
     /// Set the timeout for receiving the first byte of the Response body. An
     /// error return value indicates that this timeout is not supported.
-    set-first-byte-timeout: func(ms: option<duration>) -> result;
+    set-first-byte-timeout: func(duration: option<duration>) -> result;
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
@@ -346,7 +346,7 @@ interface types {
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
     /// body stream. An error return value indicates that this timeout is not
     /// supported.
-    set-between-bytes-timeout: func(ms: option<duration>) -> result;
+    set-between-bytes-timeout: func(duration: option<duration>) -> result;
   }
 
   /// Represents the ability to send an HTTP Response.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -169,8 +169,10 @@ interface types {
       entries: list<tuple<field-key,field-value>>
     ) -> result<fields, header-error>;
 
-    /// Get all of the values corresponding to a key.
-    get: func(name: field-key) -> list<field-value>;
+    /// Get all of the values corresponding to a key. Returns a `none` value
+    /// when the key isn't present, to distinguish from the case where it's
+    /// present but empty.
+    get: func(name: field-key) -> option<list<field-value>>;
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -169,10 +169,15 @@ interface types {
       entries: list<tuple<field-key,field-value>>
     ) -> result<fields, header-error>;
 
-    /// Get all of the values corresponding to a key. Returns a `none` value
-    /// when the key isn't present, to distinguish from the case where it's
-    /// present but empty.
-    get: func(name: field-key) -> option<list<field-value>>;
+    /// Get all of the values corresponding to a key. If the key is not present
+    /// in this `fields`, an empty list is returned. However, if the key is
+    /// present but empty, this is represented by a list with one or more
+    /// empty field-values present.
+    get: func(name: field-key) -> list<field-value>;
+
+    /// Returns `true` when the key is present in this `fields`. If the key is
+    /// syntactically invalid, `false` is returned.
+    has: func(name: field-key) -> bool;
 
     /// Set all of the values for a key. Clears any existing values for that
     /// key, if they have been set.

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -198,7 +198,7 @@ interface types {
     append: func(name: field-key, value: field-value) -> result<_, header-error>;
 
     /// Retrieve the full set of keys and values in the Fields. Like the
-    /// constructor, the list represents each key-value pair. 
+    /// constructor, the list represents each key-value pair.
     ///
     /// The outer list represents each key-value pair in the Fields. Keys
     /// which have multiple values are represented by multiple entries in this
@@ -315,8 +315,9 @@ interface types {
     headers: func() -> headers;
   }
 
-  /// Parameters for making an HTTP Request. Each of these parameters is an
-  /// optional timeout, applicable to the transport layer of the HTTP protocol.
+  /// Parameters for making an HTTP Request. Each of these parameters is
+  /// currently an optional timeout applicable to the transport layer of the
+  /// HTTP protocol.
   ///
   /// These timeouts are separate from any the user may use to bound a
   /// blocking call to `wasi:io/poll.poll`.
@@ -329,14 +330,14 @@ interface types {
 
     /// Set the timeout for the initial connect to the HTTP Server. An error
     /// return value indicates that this timeout is not supported.
-    set-connect-timeout: func(duration: option<duration>) -> result;
+    set-connect-timeout: func(ms: option<duration>) -> result;
 
     /// The timeout for receiving the first byte of the Response body.
     first-byte-timeout: func() -> option<duration>;
 
     /// Set the timeout for receiving the first byte of the Response body. An
     /// error return value indicates that this timeout is not supported.
-    set-first-byte-timeout: func(duration: option<duration>) -> result;
+    set-first-byte-timeout: func(ms: option<duration>) -> result;
 
     /// The timeout for receiving subsequent chunks of bytes in the Response
     /// body stream.
@@ -345,7 +346,7 @@ interface types {
     /// Set the timeout for receiving subsequent chunks of bytes in the Response
     /// body stream. An error return value indicates that this timeout is not
     /// supported.
-    set-between-bytes-timeout: func(duration: option<duration>) -> result;
+    set-between-bytes-timeout: func(ms: option<duration>) -> result;
   }
 
   /// Represents the ability to send an HTTP Response.


### PR DESCRIPTION
As discussed in https://github.com/WebAssembly/wasi-http/issues/82, it would be nice to be able to know when a header value exists, vs when it's empty.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
