### PR TITLE
Update tutorial to use wasi_snapshot_preview1

### DIFF
--- a/docs/WASI-tutorial.md
+++ b/docs/WASI-tutorial.md
@@ -270,7 +270,7 @@ First, create a new `demo.wat` file:
     ;; Import the required fd_write WASI function which will write the given io vectors to stdout
     ;; The function signature for fd_write is:
     ;; (File Descriptor, *iovs, iovs_len, nwritten) -> Returns number of bytes written
-    (import "wasi_unstable" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))
+    (import "wasi_snapshot_preview1" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))
 
     (memory 1)
     (export "memory" (memory 0))


### PR DESCRIPTION

- Was going through the tutorial and noticed it used the older (I think?) `wasi_unstable` which no longer updated. So updating here.