### PR TITLE
Update to windows-sys 0.52

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -434,7 +434,7 @@ jobs:
         pacboy: binutils
       if: matrix.target == 'x86_64-pc-windows-gnu'
     - shell: p2sh
-      run: "C:\\msys64\\mingw64\bin" >> $env:GITHUB_PATH
+      run: "C:\\msys64\\mingw64\\bin" >> $env:GITHUB_PATH
       if: matrix.target == 'x86_64-pc-windows-gnu'
 
     - run: cargo fetch --locked

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -431,11 +431,13 @@ jobs:
       with:
         msystem: mingw64
         update: true
-        pacboy: binutils
+      if: matrix.target == 'x86_64-pc-windows-gnu'
+    - shell: msys2 {0}
+      run: pacman -Syu --needed base-devel mingw-w64-x86_64-gcc --noconfirm
       if: matrix.target == 'x86_64-pc-windows-gnu'
     - shell: pwsh
       run: |
-        "C:\\msys64\\mingw64\\bin" >> $env:GITHUB_PATH
+        echo "RUSTFLAGS=-C linker=C:\mingw64\bin\x86_64-w64-mingw32-gcc.exe" >> $Env:GITHUB_ENV
       if: matrix.target == 'x86_64-pc-windows-gnu'
 
     - run: cargo fetch --locked

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -427,17 +427,10 @@ jobs:
       if: matrix.target == 'x86_64-pc-windows-gnu'
 
     # Update binutils if MinGW due to https://github.com/rust-lang/rust/issues/112368
-    - uses: msys2/setup-msys2@v2
-      with:
-        msystem: mingw64
-        update: true
-      if: matrix.target == 'x86_64-pc-windows-gnu'
-    - shell: msys2 {0}
-      run: pacman -Syu --needed base-devel mingw-w64-x86_64-gcc --noconfirm
+    - run: C:/msys64/usr/bin/pacman.exe -Syu --needed mingw-w64-x86_64-gcc --noconfirm
       if: matrix.target == 'x86_64-pc-windows-gnu'
     - shell: pwsh
-      run: |
-        echo "RUSTFLAGS=-C linker=C:\mingw64\bin\x86_64-w64-mingw32-gcc.exe" >> $Env:GITHUB_ENV
+      run: echo "C:\msys64\mingw64\bin" >> $Env:GITHUB_PATH
       if: matrix.target == 'x86_64-pc-windows-gnu'
 
     - run: cargo fetch --locked

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -584,26 +584,6 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
-
-  bench:
-    needs: determine
-    if: needs.determine.outputs.run-full
-    name: Run benchmarks
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: true
-    - uses: ./.github/actions/install-rust
-    - run: rustup target add wasm32-wasi
-    - run: cargo test --benches --release
-
-    # common logic to cancel the entire run if this job fails
-    - run: gh run cancel ${{ github.run_id }}
-      if: failure() && github.event_name != 'pull_request'
-      env:
-        GH_TOKEN: ${{ github.token }}
-
   # Verify that cranelift's code generation is deterministic
   meta_deterministic_check:
     needs: determine

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -426,6 +426,17 @@ jobs:
     - run: echo CFLAGS=-g0 >> $GITHUB_ENV
       if: matrix.target == 'x86_64-pc-windows-gnu'
 
+    # Update binutils if MinGW due to https://github.com/rust-lang/rust/issues/112368
+    - uses: msys2/setup-msys2@v2
+      with:
+        msystem: mingw64
+        update: true
+        pacboy: binutils
+      if: matrix.target == 'x86_64-pc-windows-gnu'
+    - shell: p2sh
+      run: "C:\msys64\mingw64\bin" >> $env:GITHUB_PATH
+      if: matrix.target == 'x86_64-pc-windows-gnu'
+
     - run: cargo fetch --locked
 
     - uses: actions/cache@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -434,7 +434,8 @@ jobs:
         pacboy: binutils
       if: matrix.target == 'x86_64-pc-windows-gnu'
     - shell: pwsh
-      run: "C:\\msys64\\mingw64\\bin" >> $env:GITHUB_PATH
+      run: |
+        "C:\\msys64\\mingw64\\bin" >> $env:GITHUB_PATH
       if: matrix.target == 'x86_64-pc-windows-gnu'
 
     - run: cargo fetch --locked

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -433,7 +433,7 @@ jobs:
         update: true
         pacboy: binutils
       if: matrix.target == 'x86_64-pc-windows-gnu'
-    - shell: p2sh
+    - shell: pwsh
       run: "C:\\msys64\\mingw64\\bin" >> $env:GITHUB_PATH
       if: matrix.target == 'x86_64-pc-windows-gnu'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -434,7 +434,7 @@ jobs:
         pacboy: binutils
       if: matrix.target == 'x86_64-pc-windows-gnu'
     - shell: p2sh
-      run: "C:\msys64\mingw64\bin" >> $env:GITHUB_PATH
+      run: "C:\\msys64\\mingw64\bin" >> $env:GITHUB_PATH
       if: matrix.target == 'x86_64-pc-windows-gnu'
 
     - run: cargo fetch --locked

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -584,6 +584,26 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
+
+  bench:
+    needs: determine
+    if: needs.determine.outputs.run-full
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+    - run: rustup target add wasm32-wasi
+    - run: cargo test --benches --release
+
+    # common logic to cancel the entire run if this job fails
+    - run: gh run cancel ${{ github.run_id }}
+      if: failure() && github.event_name != 'pull_request'
+      env:
+        GH_TOKEN: ${{ github.token }}
+
   # Verify that cranelift's code generation is deterministic
   meta_deterministic_check:
     needs: determine

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -95,7 +95,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -264,7 +264,7 @@ dependencies = [
  "cap-primitives",
  "cap-std",
  "io-lifetimes",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -292,7 +292,7 @@ dependencies = [
  "ipnet",
  "maybe-owned",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
  "winx",
 ]
 
@@ -726,7 +726,7 @@ dependencies = [
  "region",
  "target-lexicon",
  "wasmtime-jit-icache-coherence",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1077,7 +1077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c18ee0ed65a5f1f81cac6b1d213b69c35fa47d4252ad41f1486dbd8226fe36e"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1112,7 +1112,7 @@ checksum = "0b0377f1edc77dbd1118507bc7a66e4ab64d2b90c66f90726dc801e73a8c68f9"
 dependencies = [
  "cfg-if",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1176,7 +1176,7 @@ checksum = "dd738b84894214045e8414eaded76359b4a5773f0a0a56b16575110739cdcf39"
 dependencies = [
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1535,7 +1535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d3c230ee517ee76b1cc593b52939ff68deda3fae9e41eca426c6b4993df51c4"
 dependencies = [
  "io-lifetimes",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.0",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1778,7 +1778,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "wasi",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2244,7 +2244,7 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2536,7 +2536,7 @@ dependencies = [
  "fd-lock",
  "io-lifetimes",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
  "winx",
 ]
 
@@ -2556,7 +2556,7 @@ dependencies = [
  "fastrand",
  "redox_syscall 0.3.5",
  "rustix",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2683,7 +2683,7 @@ dependencies = [
  "signal-hook-registry",
  "socket2",
  "tokio-macros",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2962,7 +2962,7 @@ dependencies = [
  "tempfile",
  "tracing",
  "wasi-common",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2986,7 +2986,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "wiggle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3227,7 +3227,7 @@ dependencies = [
  "wasmtime-wasi",
  "wasmtime-winch",
  "wat",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3306,7 +3306,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "toml",
- "windows-sys",
+ "windows-sys 0.52.0",
  "zstd",
 ]
 
@@ -3362,7 +3362,7 @@ dependencies = [
  "wasmtime-wast",
  "wast 69.0.1",
  "wat",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3498,7 +3498,7 @@ dependencies = [
  "rustix",
  "wasmtime-asm-macros",
  "wasmtime-versioned-export-macros",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3578,7 +3578,7 @@ dependencies = [
  "wasmtime-jit-debug",
  "wasmtime-jit-icache-coherence",
  "wasmtime-runtime",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3597,7 +3597,7 @@ version = "17.0.0"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3628,7 +3628,7 @@ dependencies = [
  "wasmtime-jit-debug",
  "wasmtime-versioned-export-macros",
  "wasmtime-wmemcheck",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3686,7 +3686,7 @@ dependencies = [
  "wasi-tokio",
  "wasmtime",
  "wiggle",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3991,7 +3991,16 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.0",
 ]
 
 [[package]]
@@ -4000,13 +4009,28 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a18201040b24831fbb9e4eb208f8892e1f50a37feb53cc7ff887feb8f50e7cd"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.0",
+ "windows_aarch64_msvc 0.52.0",
+ "windows_i686_gnu 0.52.0",
+ "windows_i686_msvc 0.52.0",
+ "windows_x86_64_gnu 0.52.0",
+ "windows_x86_64_gnullvm 0.52.0",
+ "windows_x86_64_msvc 0.52.0",
 ]
 
 [[package]]
@@ -4016,10 +4040,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7764e35d4db8a7921e09562a0304bf2f93e0a51bfccee0bd0bb0b666b015ea"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbaa0368d4f1d2aaefc55b6fcfee13f41544ddf36801e793edbbfd7d7df075ef"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4028,10 +4064,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28637cb1fa3560a16915793afb20081aba2c92ee8af57b4d5f28e4b3e7df313"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffe5e8e31046ce6230cc7215707b816e339ff4d4d67c65dffa206fd0f7aa7b9a"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4040,10 +4088,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d6fa32db2bc4a2f5abeacf2b69f7992cd09dca97498da74a151a3132c26befd"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a657e1e9d3f514745a572a6846d3c7aa7dbe1658c056ed9c3344c4109a6949e"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -4052,13 +4112,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
 name = "winx"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4857cedf8371f690bb6782a3e2b065c54d1b6661be068aaf3eac8b45e813fdf8"
 dependencies = [
  "bitflags 2.4.1",
- "windows-sys",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,7 +246,7 @@ wit-component = "0.19.0"
 object = { version = "0.32", default-features = false, features = ['read_core', 'elf', 'std'] }
 gimli = { version = "0.28.0", default-features = false, features = ['read', 'std'] }
 anyhow = "1.0.22"
-windows-sys = "0.48.0"
+windows-sys = "0.52.0"
 env_logger = "0.10"
 log = { version = "0.4.8", default-features = false }
 clap = { version = "4.3.12", default-features = false, features = ["std", "derive"] }

--- a/crates/runtime/src/sys/windows/mmap.rs
+++ b/crates/runtime/src/sys/windows/mmap.rs
@@ -104,7 +104,7 @@ impl Mmap {
                 0,
                 0,
                 len,
-            ) as *mut std::ffi::c_void;
+            ).Value;
             let err = io::Error::last_os_error();
             CloseHandle(mapping);
             if ptr.is_null() {

--- a/crates/runtime/src/sys/windows/mmap.rs
+++ b/crates/runtime/src/sys/windows/mmap.rs
@@ -204,7 +204,7 @@ impl Drop for Mmap {
         if self.is_file {
             let r = unsafe {
                 UnmapViewOfFile(MEMORY_MAPPED_VIEW_ADDRESS {
-                    Value: self.as_mut_ptr(),
+                    Value: self.as_mut_ptr().cast(),
                 })
             };
             assert_ne!(r, 0);

--- a/crates/runtime/src/sys/windows/mmap.rs
+++ b/crates/runtime/src/sys/windows/mmap.rs
@@ -201,7 +201,7 @@ impl Drop for Mmap {
         }
 
         if self.is_file {
-            let r = unsafe { UnmapViewOfFile(self.as_mut_ptr() as MEMORYMAPPEDVIEW_HANDLE) };
+            let r = unsafe { UnmapViewOfFile(self.as_mut_ptr() as MEMORY_MAPPED_VIEW_ADDRESS) };
             assert_ne!(r, 0);
         } else {
             let r = unsafe { VirtualFree(self.as_mut_ptr().cast(), 0, MEM_RELEASE) };

--- a/crates/runtime/src/sys/windows/mmap.rs
+++ b/crates/runtime/src/sys/windows/mmap.rs
@@ -202,7 +202,11 @@ impl Drop for Mmap {
         }
 
         if self.is_file {
-            let r = unsafe { UnmapViewOfFile(self.as_mut_ptr() as MEMORY_MAPPED_VIEW_ADDRESS) };
+            let r = unsafe {
+                UnmapViewOfFile(MEMORY_MAPPED_VIEW_ADDRESS {
+                    Value: self.as_mut_ptr(),
+                })
+            };
             assert_ne!(r, 0);
         } else {
             let r = unsafe { VirtualFree(self.as_mut_ptr().cast(), 0, MEM_RELEASE) };

--- a/crates/runtime/src/sys/windows/mmap.rs
+++ b/crates/runtime/src/sys/windows/mmap.rs
@@ -104,7 +104,8 @@ impl Mmap {
                 0,
                 0,
                 len,
-            ).Value;
+            )
+            .Value;
             let err = io::Error::last_os_error();
             CloseHandle(mapping);
             if ptr.is_null() {


### PR DESCRIPTION
Unfortunately, due to the C dependencies, I couldn't locally verify this builds.

I did use the GitHub CI to verify it builds and the tests passed, yet due to the size of the CI *and the fact I on-purposely didn't add a new vet statement which made the CI self-cancel*, I'm unsure this is completely valid at this time.

On the belief this is a valid patch, my question is how should vet be handled. Personally, I see no reason to trust the windows-sys 0.48 published by Microsoft yet not windows-sys 0.51 given its FFI bindings, not some original library. If an attestation the changes are as expected is needed, I'd ask someone who has experience doing said reviews *and whose name actually means something to this project* performs said review. If no such explicit review is needed, I'd be happy to update the existing vet attestation if informed how.