### PR TITLE
Discard 0-sized writes to files

### DIFF
--- a/crates/wasi-common/src/sync/file.rs
+++ b/crates/wasi-common/src/sync/file.rs
@@ -111,6 +111,9 @@ impl WasiFile for File {
         bufs: &[io::IoSlice<'a>],
         offset: u64,
     ) -> Result<u64, Error> {
+        if bufs.iter().map(|i| i.len()).sum::<usize>() == 0 {
+            return Ok(0);
+        }
         let n = self.0.write_vectored_at(bufs, offset)?;
         Ok(n.try_into()?)
     }

--- a/crates/wasi-common/src/tokio/file.rs
+++ b/crates/wasi-common/src/tokio/file.rs
@@ -148,6 +148,9 @@ macro_rules! wasi_file_impl {
                 bufs: &[io::IoSlice<'a>],
                 offset: u64,
             ) -> Result<u64, Error> {
+                if bufs.iter().map(|i| i.len()).sum::<usize>() == 0 {
+                    return Ok(0);
+                }
                 block_on_dummy_executor(move || self.0.write_vectored_at(bufs, offset))
             }
             async fn seek(&self, pos: std::io::SeekFrom) -> Result<u64, Error> {

--- a/crates/wasi/src/preview2/filesystem.rs
+++ b/crates/wasi/src/preview2/filesystem.rs
@@ -272,6 +272,10 @@ impl HostOutputStream for FileOutputStream {
             }
         }
 
+        if buf.is_empty() {
+            return Ok(());
+        }
+
         let f = Arc::clone(&self.file);
         let m = self.mode;
         let task = spawn_blocking(move || match m {


### PR DESCRIPTION
This commit comes from #7633 where Windows and Unix would behave differently when writing at a particular file offset. Notably Unix semantics [indicate]:

> Before any action described below is taken, and if nbyte is zero
> and the file is a regular file, the write() function may detect
> and return errors as described below. In the absence of errors,
> or if error detection is not performed, the write() function
> shall return zero and have no other results. If nbyte is zero and
> the file is not a regular file, the results are unspecified.

These semantics are a bit easier to emulate on Windows so the host implementation now discards any attempt to perform I/O if a zero-sized write is detected.

[indicate]: https://man7.org/linux/man-pages/man3/write.3p.html

Closes #7633

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
