### PR TITLE
Additional `extend` opt patterns

### DIFF
--- a/cranelift/codegen/src/opts/extends.isle
+++ b/cranelift/codegen/src/opts/extends.isle
@@ -4,6 +4,14 @@
 (rule (simplify (sextend ty (sextend _intermediate_ty x)))
       (sextend ty x))
 
+;; Once something has be `uextend`ed, further `sextend`ing is the same as `uextend`
+(rule (simplify (sextend ty (uextend _intermediate_ty x)))
+      (uextend ty x))
+
+;; `icmp` is zero or one, so sign-extending is the same as zero-extending
+(rule (simplify (sextend ty x@(icmp _ _ _ _)))
+      (uextend ty x))
+
 ;; Masking out any of the top bits of the result of `uextend` is a no-op. (This
 ;; is like a cheap version of known-bits analysis.)
 (rule (simplify (band wide x @ (uextend _ (value_type narrow)) (iconst _ (u64_from_imm64 mask))))

--- a/cranelift/filetests/filetests/egraph/extends.clif
+++ b/cranelift/filetests/filetests/egraph/extends.clif
@@ -54,6 +54,28 @@ block0(v1: i16):
 ; check: v4 = sextend.i64 v1
 ; check: return v4
 
+function %suextend_icmp(i16, i16) -> i64 {
+block0(v0: i16, v1: i16):
+    v2 = icmp slt v0, v1
+    v3 = uextend.i32 v2
+    v4 = sextend.i64 v3
+    return v4
+}
+
+; check: v5 = uextend.i64 v2
+; check: return v5
+
+function %usextend_icmp(i16, i16) -> i64 {
+block0(v0: i16, v1: i16):
+    v2 = icmp uge v0, v1
+    v3 = sextend.i32 v2
+    v4 = uextend.i64 v3
+    return v4
+}
+
+; check: v7 = uextend.i64 v2
+; check: return v7
+
 function %sextend_then_reduce(i16) -> i16 {
 block0(v1: i16):
     v2 = sextend.i32 v1


### PR DESCRIPTION
It already had the homogeneous chaining cases

https://github.com/bytecodealliance/wasmtime/blob/5c8bce70a11657ad6740f56a852f64d147f93494/cranelift/codegen/src/opts/extends.isle#L1-L5

This PR adds heterogeneous chaining cases, where possible.