### PR TITLE
Better error message for wrong import implementation

### DIFF
--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -1003,7 +1003,7 @@ pub enum TypeDef {
     ComponentInstance(TypeComponentInstanceIndex),
     /// A component function, not to be confused with a core wasm function.
     ComponentFunc(TypeFuncIndex),
-    /// An interface type.
+    /// An type in an interface.
     Interface(InterfaceType),
     /// A core wasm module and its type.
     Module(TypeModuleIndex),
@@ -1014,6 +1014,21 @@ pub enum TypeDef {
     /// Note that different resource tables may point to the same underlying
     /// actual resource type, but that's a private detail.
     Resource(TypeResourceTableIndex),
+}
+
+impl TypeDef {
+    /// A human readable description of what kind of type definition this is.
+    pub fn desc(&self) -> &str {
+        match self {
+            TypeDef::Component(_) => "component",
+            TypeDef::ComponentInstance(_) => "instance",
+            TypeDef::ComponentFunc(_) => "function",
+            TypeDef::Interface(_) => "type",
+            TypeDef::Module(_) => "core module",
+            TypeDef::CoreFunc(_) => "core function",
+            TypeDef::Resource(_) => "resource",
+        }
+    }
 }
 
 // NB: Note that maps below are stored as an `IndexMap` now but the order

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -259,7 +259,7 @@ impl<T> Linker<T> {
         for (_idx, (name, ty)) in env_component.import_types.iter() {
             let import = self.map.get(name, &self.strings);
             cx.definition(ty, import)
-                .with_context(|| format!("import `{name}` has the wrong type"))?;
+                .with_context(|| format!("component imports {desc} `{name}`, but a matching implementation was not found in the linker", desc = ty.desc()))?;
         }
         Ok(cx)
     }

--- a/tests/misc_testsuite/component-model/linking.wast
+++ b/tests/misc_testsuite/component-model/linking.wast
@@ -2,7 +2,7 @@
   (component
     (import "undefined-name" (core module))
   )
-  "expected module found nothing")
+  "was not found")
 (component $i)
 (component
   (import "i" (instance))
@@ -12,7 +12,7 @@
   "expected module found instance")
 (assert_unlinkable
   (component (import "i" (func)))
-  "expected func found instance")
+  "expected function found instance")
 (assert_unlinkable
   (component (import "i" (instance (export "x" (func)))))
-  "expected func found nothing")
+  "was not found")

--- a/tests/misc_testsuite/component-model/resources.wast
+++ b/tests/misc_testsuite/component-model/resources.wast
@@ -167,7 +167,7 @@
       (export "missing" (type (sub resource)))
     ))
   )
-  "expected resource found nothing")
+  "was not found")
 (assert_unlinkable
   (component
     (import "host" (instance


### PR DESCRIPTION
This changes improve the error message when a component is importing/exporting something that the linker is either missing or has the wrong type.

Previously the error message for a missing function implementation would be:

```
Error: import `my-import` has the wrong type

Caused by:
    expected func found nothing
```

Now, this error will be:

```
Error: component imports `my-import`, but a correct implementation of `my-import` could not be found

Caused by:
    function implementation is missing
```

I went back and forth on whether the error message should reference the linker. For direct users of `Linker` this would surely help, but this error message also gets displayed to indirect users of `Linker` so talking at a higher level of abstraction seemed appropriate. 