### PR TITLE
Add options to WasiCtx for toggling TCP and UDP on and off

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -259,6 +259,10 @@ wasmtime_option_group! {
         pub inherit_network: Option<bool>,
         /// Indicates whether `wasi:sockets/ip-name-lookup` is enabled or not.
         pub allow_ip_name_lookup: Option<bool>,
+        /// Indicates whether `wasi:sockets` TCP support is enabled or not.
+        pub tcp: Option<bool>,
+        /// Indicates whether `wasi:sockets` UDP support is enabled or not.
+        pub udp: Option<bool>,
         /// Allows imports from the `wasi_unstable` core wasm module.
         pub preview0: Option<bool>,
     }

--- a/crates/test-programs/src/bin/cli_no_tcp.rs
+++ b/crates/test-programs/src/bin/cli_no_tcp.rs
@@ -1,0 +1,28 @@
+//! This test assumes that it will be run without tcp support enabled
+use test_programs::wasi::sockets::{
+    network::IpAddress,
+    tcp::{ErrorCode, IpAddressFamily, IpSocketAddress, Network, TcpSocket},
+};
+
+fn main() {
+    let net = Network::default();
+    let family = IpAddressFamily::Ipv4;
+    let remote1 = IpSocketAddress::new(IpAddress::new_loopback(family), 4321);
+    let sock = TcpSocket::new(family).unwrap();
+
+    let bind = sock.blocking_bind(&net, remote1);
+    eprintln!("Result of binding: {bind:?}");
+    assert!(matches!(bind, Err(ErrorCode::AccessDenied)));
+
+    let listen = sock.blocking_listen();
+    eprintln!("Result of listen: {listen:?}");
+    assert!(matches!(listen, Err(ErrorCode::AccessDenied)));
+
+    let connect = sock.blocking_connect(&net, remote1);
+    eprintln!("Result of connect: {connect:?}");
+    assert!(matches!(connect, Err(ErrorCode::AccessDenied)));
+
+    let accept = sock.blocking_accept();
+    eprintln!("Result of accept: {accept:?}");
+    assert!(matches!(accept, Err(ErrorCode::AccessDenied)));
+}

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -254,15 +254,15 @@ impl WasiCtxBuilder {
         self
     }
 
-    /// Disallow usage of UDP
-    pub fn disallow_udp(&mut self, disable: bool) -> &mut Self {
-        self.allowed_network_uses.udp = !disable;
+    /// Allow usage of UDP
+    pub fn allow_udp(&mut self, enable: bool) -> &mut Self {
+        self.allowed_network_uses.udp = enable;
         self
     }
 
-    /// Disallow usage of TCP
-    pub fn disallow_tcp(&mut self, disable: bool) -> &mut Self {
-        self.allowed_network_uses.tcp = !disable;
+    /// Allow usage of TCP
+    pub fn allow_tcp(&mut self, enable: bool) -> &mut Self {
+        self.allowed_network_uses.tcp = enable;
         self
     }
 

--- a/crates/wasi/src/preview2/host/instance_network.rs
+++ b/crates/wasi/src/preview2/host/instance_network.rs
@@ -7,7 +7,7 @@ impl<T: WasiView> instance_network::Host for T {
     fn instance_network(&mut self) -> Result<Resource<Network>, anyhow::Error> {
         let network = Network {
             pool: self.ctx().pool.clone(),
-            allow_ip_name_lookup: self.ctx().allow_ip_name_lookup,
+            allow_ip_name_lookup: self.ctx().allowed_network_uses.ip_name_lookup,
         };
         let network = self.table_mut().push(network)?;
         Ok(network)

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -28,6 +28,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         network: Resource<Network>,
         local_address: IpSocketAddress,
     ) -> SocketResult<()> {
+        self.ctx().allowed_network_uses.check_allowed_tcp()?;
         let table = self.table_mut();
         let socket = table.get(&this)?;
         let network = table.get(&network)?;
@@ -88,6 +89,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         network: Resource<Network>,
         remote_address: IpSocketAddress,
     ) -> SocketResult<()> {
+        self.ctx().allowed_network_uses.check_allowed_tcp()?;
         let table = self.table_mut();
         let r = {
             let socket = table.get(&this)?;
@@ -186,6 +188,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     }
 
     fn start_listen(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<()> {
+        self.ctx().allowed_network_uses.check_allowed_tcp()?;
         let table = self.table_mut();
         let socket = table.get_mut(&this)?;
 
@@ -233,6 +236,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         Resource<InputStream>,
         Resource<OutputStream>,
     )> {
+        self.ctx().allowed_network_uses.check_allowed_tcp()?;
         let table = self.table();
         let socket = table.get(&this)?;
 

--- a/crates/wasi/src/preview2/host/udp.rs
+++ b/crates/wasi/src/preview2/host/udp.rs
@@ -33,6 +33,7 @@ impl<T: WasiView> udp::HostUdpSocket for T {
         network: Resource<Network>,
         local_address: IpSocketAddress,
     ) -> SocketResult<()> {
+        self.ctx().allowed_network_uses.check_allowed_udp()?;
         let table = self.table_mut();
         let socket = table.get(&this)?;
         let network = table.get(&network)?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -778,6 +778,12 @@ impl RunCommand {
         if let Some(enable) = self.run.common.wasi.allow_ip_name_lookup {
             builder.allow_ip_name_lookup(enable);
         }
+        if let Some(enable) = self.run.common.wasi.tcp {
+            builder.allow_tcp(enable);
+        }
+        if let Some(enable) = self.run.common.wasi.udp {
+            builder.allow_tcp(enable);
+        }
 
         store.data_mut().preview2_ctx = Some(Arc::new(builder.build()));
         Ok(())

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1498,4 +1498,20 @@ mod test_programs {
         ])?;
         Ok(())
     }
+
+    #[test]
+    fn cli_no_tcp() -> Result<()> {
+        let output = super::run_wasmtime_for_output(
+            &[
+                "-Wcomponent-model",
+                // Turn on network but turn off TCP
+                "-Sinherit-network,tcp=no",
+                CLI_NO_TCP_COMPONENT,
+            ],
+            None,
+        )?;
+        println!("{}", String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success());
+        Ok(())
+    }
 }


### PR DESCRIPTION
This adds options to `WasiCtx` that allow disabling TCP and UDP wholesale. For TCP this prevents usage of binding, connecting, listening, and accepting while for UDP it prevents binding. 