### PR TITLE
Ensure `remote-address` is allowed when creating UDP stream

### DIFF
--- a/crates/test-programs/src/bin/cli_no_udp.rs
+++ b/crates/test-programs/src/bin/cli_no_udp.rs
@@ -1,0 +1,16 @@
+//! This test assumes that it will be run without udp support enabled
+use test_programs::wasi::sockets::{
+    network::IpAddress,
+    udp::{ErrorCode, IpAddressFamily, IpSocketAddress, Network, UdpSocket},
+};
+
+fn main() {
+    let net = Network::default();
+    let family = IpAddressFamily::Ipv4;
+    let remote1 = IpSocketAddress::new(IpAddress::new_loopback(family), 4321);
+    let sock = UdpSocket::new(family).unwrap();
+
+    let bind = sock.blocking_bind(&net, remote1);
+    eprintln!("Result of binding: {bind:?}");
+    assert!(matches!(bind, Err(ErrorCode::AccessDenied)));
+}

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -12,6 +12,7 @@ use cap_std::net::Pool;
 use cap_std::{ambient_authority, AmbientAuthority};
 use std::mem;
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::sync::Arc;
 use wasmtime::component::ResourceTable;
 
 pub struct WasiCtxBuilder {
@@ -303,7 +304,7 @@ impl WasiCtxBuilder {
             env,
             args,
             preopens,
-            pool,
+            pool: Arc::new(pool),
             random,
             insecure_random,
             insecure_random_seed,
@@ -333,7 +334,7 @@ pub struct WasiCtx {
     pub(crate) stdin: Box<dyn StdinStream>,
     pub(crate) stdout: Box<dyn StdoutStream>,
     pub(crate) stderr: Box<dyn StdoutStream>,
-    pub(crate) pool: Pool,
+    pub(crate) pool: Arc<Pool>,
     pub(crate) allowed_network_uses: AllowedNetworkUses,
 }
 

--- a/crates/wasi/src/preview2/network.rs
+++ b/crates/wasi/src/preview2/network.rs
@@ -2,9 +2,10 @@ use crate::preview2::bindings::sockets::network::{Ipv4Address, Ipv6Address};
 use crate::preview2::bindings::wasi::sockets::network::ErrorCode;
 use crate::preview2::TrappableError;
 use cap_std::net::Pool;
+use std::sync::Arc;
 
 pub struct Network {
-    pub pool: Pool,
+    pub pool: Arc<Pool>,
     pub allow_ip_name_lookup: bool,
 }
 

--- a/crates/wasi/src/preview2/udp.rs
+++ b/crates/wasi/src/preview2/udp.rs
@@ -2,6 +2,7 @@ use crate::preview2::poll::Subscribe;
 use crate::preview2::with_ambient_tokio_runtime;
 use async_trait::async_trait;
 use cap_net_ext::{AddressFamily, Blocking, UdpSocketExt};
+use cap_std::net::Pool;
 use io_lifetimes::raw::{FromRawSocketlike, IntoRawSocketlike};
 use std::io;
 use std::net::SocketAddr;
@@ -42,6 +43,9 @@ pub struct UdpSocket {
 
     /// Socket address family.
     pub(crate) family: SocketAddressFamily,
+
+    /// The pool of allowed address
+    pub(crate) pool: Pool,
 }
 
 #[async_trait]
@@ -67,6 +71,7 @@ impl UdpSocket {
             inner: Arc::new(socket),
             udp_state: UdpState::Default,
             family: socket_address_family,
+            pool: Pool::new(),
         })
     }
 

--- a/crates/wasi/src/preview2/udp.rs
+++ b/crates/wasi/src/preview2/udp.rs
@@ -45,7 +45,7 @@ pub struct UdpSocket {
     pub(crate) family: SocketAddressFamily,
 
     /// The pool of allowed address
-    pub(crate) pool: Pool,
+    pub(crate) pool: Arc<Pool>,
 }
 
 #[async_trait]
@@ -71,7 +71,7 @@ impl UdpSocket {
             inner: Arc::new(socket),
             udp_state: UdpState::Default,
             family: socket_address_family,
-            pool: Pool::new(),
+            pool: Arc::new(Pool::new()),
         })
     }
 

--- a/crates/wasi/src/preview2/udp.rs
+++ b/crates/wasi/src/preview2/udp.rs
@@ -109,6 +109,9 @@ pub struct OutgoingDatagramStream {
     pub(crate) family: SocketAddressFamily,
 
     pub(crate) send_state: SendState,
+
+    /// The pool of allowed addresses
+    pub(crate) pool: Arc<Pool>,
 }
 
 pub(crate) enum SendState {

--- a/crates/wasi/src/preview2/udp.rs
+++ b/crates/wasi/src/preview2/udp.rs
@@ -44,8 +44,8 @@ pub struct UdpSocket {
     /// Socket address family.
     pub(crate) family: SocketAddressFamily,
 
-    /// The pool of allowed address
-    pub(crate) pool: Arc<Pool>,
+    /// The pool of allowed addresses
+    pub(crate) pool: Option<Arc<Pool>>,
 }
 
 #[async_trait]
@@ -71,7 +71,7 @@ impl UdpSocket {
             inner: Arc::new(socket),
             udp_state: UdpState::Default,
             family: socket_address_family,
-            pool: Arc::new(Pool::new()),
+            pool: None,
         })
     }
 
@@ -111,7 +111,7 @@ pub struct OutgoingDatagramStream {
     pub(crate) send_state: SendState,
 
     /// The pool of allowed addresses
-    pub(crate) pool: Arc<Pool>,
+    pub(crate) pool: Option<Arc<Pool>>,
 }
 
 pub(crate) enum SendState {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -782,7 +782,7 @@ impl RunCommand {
             builder.allow_tcp(enable);
         }
         if let Some(enable) = self.run.common.wasi.udp {
-            builder.allow_tcp(enable);
+            builder.allow_udp(enable);
         }
 
         store.data_mut().preview2_ctx = Some(Arc::new(builder.build()));

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1514,4 +1514,20 @@ mod test_programs {
         assert!(output.status.success());
         Ok(())
     }
+
+    #[test]
+    fn cli_no_udp() -> Result<()> {
+        let output = super::run_wasmtime_for_output(
+            &[
+                "-Wcomponent-model",
+                // Turn on network but turn off UDP
+                "-Sinherit-network,udp=no",
+                CLI_NO_UDP_COMPONENT,
+            ],
+            None,
+        )?;
+        println!("{}", String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success());
+        Ok(())
+    }
 }


### PR DESCRIPTION
Until now, the `remote-address` argument to `wasi:sockets/udp-socket#stream` was not checked against the `Pool` of allowed IP addresses. Now, we store the `Pool` from `network` into the `socket` object in `wasi:sockets/udp-socket#bind` and later use that `Pool` in `wasi:sockets/udp-socket#stream` to check that `remote-address` is allowed.

The check itself is a bit hacky since `Pool` doesn't seem to expose a way to just check an address so we use `PoolExt` to create a `UdpConnecter` which we will fail if we don't have permission to connect to the remote address.

I can add a test once I figure out the testing story in https://github.com/bytecodealliance/wasmtime/pull/7647