### PR TITLE
Use the compilation cache for components

### DIFF
--- a/crates/wasmtime/src/component/component.rs
+++ b/crates/wasmtime/src/component/component.rs
@@ -127,14 +127,53 @@ impl Component {
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     #[cfg_attr(nightlydoc, doc(cfg(any(feature = "cranelift", feature = "winch"))))]
     pub fn from_binary(engine: &Engine, binary: &[u8]) -> Result<Component> {
+        use crate::module::HashedEngineCompileEnv;
+
         engine
             .check_compatible_with_native_host()
             .context("compilation settings are not compatible with the native host")?;
 
-        let (mmap, artifacts) = Component::build_artifacts(engine, binary)?;
-        let mut code_memory = CodeMemory::new(mmap)?;
-        code_memory.publish()?;
-        Component::from_parts(engine, Arc::new(code_memory), Some(artifacts))
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "cache")] {
+                let state = (HashedEngineCompileEnv(engine), binary);
+                let (code, artifacts) = wasmtime_cache::ModuleCacheEntry::new(
+                    "wasmtime",
+                    engine.cache_config(),
+                )
+                .get_data_raw(
+                    &state,
+
+                    // Cache miss, compute the actual artifacts
+                    |(engine, wasm)| -> Result<_> {
+                        let (mmap, artifacts) = Component::build_artifacts(engine.0, wasm)?;
+                        let code = publish_mmap(mmap)?;
+                        Ok((code, Some(artifacts)))
+                    },
+
+                    // Implementation of how to serialize artifacts
+                    |(_engine, _wasm), (code, _info_and_types)| {
+                        Some(code.mmap().to_vec())
+                    },
+
+                    // Cache hit, deserialize the provided artifacts
+                    |(engine, _wasm), serialized_bytes| {
+                        let code = engine.0.load_code_bytes(&serialized_bytes, ObjectKind::Component).ok()?;
+                        Some((code, None))
+                    },
+                )?;
+            } else {
+                let (mmap, artifacts) = Component::build_artifacts(engine, binary)?;
+                let code = publish_mmap(mmap)?;
+            }
+        };
+
+        return Component::from_parts(engine, code, artifacts);
+
+        fn publish_mmap(mmap: MmapVec) -> Result<Arc<CodeMemory>> {
+            let mut code = CodeMemory::new(mmap)?;
+            code.publish()?;
+            Ok(Arc::new(code))
+        }
     }
 
     /// Same as [`Module::deserialize`], but for components.

--- a/crates/wasmtime/src/component/component.rs
+++ b/crates/wasmtime/src/component/component.rs
@@ -163,6 +163,7 @@ impl Component {
                 )?;
             } else {
                 let (mmap, artifacts) = Component::build_artifacts(engine, binary)?;
+                let artifacts = Some(artifacts);
                 let code = publish_mmap(mmap)?;
             }
         };


### PR DESCRIPTION
Cache whole components in the compilation cache. This doesn't address the situation where we could cache individual modules used within the component separately, and reuse those results across multiple components. However, it does improve the runtime of command-line uses of components today, and anecdotally people are benchmarking `wasmtime run` with components.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
