### PR TITLE
Increase stack size in `examples/threads.c`

### DIFF
--- a/examples/threads.c
+++ b/examples/threads.c
@@ -178,7 +178,14 @@ int main(int argc, const char *argv[]) {
     args->engine = engine;
     args->module = shared;
     printf("Initializing thread %d...\n", i);
-    pthread_create(&threads[i], NULL, &run, args);
+
+    // Guarantee at least 2MB of stack to allow running Cranelift in debug mode
+    // on CI.
+    pthread_attr_t attrs;
+    pthread_attr_init(&attrs);
+    pthread_attr_setstacksize(&attrs, 2 << 20);
+    pthread_create(&threads[i], &attrs, &run, args);
+    pthread_attr_destroy(&attrs);
   }
 
   for (int i = 0; i < N_THREADS; i++) {


### PR DESCRIPTION
This commit is an attempt to address the CI failure popping up in #7636. I can reproduce the failure locally and it appears to be due to the fact that macOS is giving spawned threads via `pthread_create` a 512K stack by default. Cranelift when compiled in debug mode is taking more stack than this (but working in release mode). I was talking with Trevor and Jamey about possible ways to reduce the stack size here but for now I'm going with Jamey's suggestion of increasing the stack size as the best course of action for now.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
