### PR TITLE
[bindgen] Include Version in the export name if needed

### DIFF
--- a/crates/component-macro/tests/codegen/multiversion/root.wit
+++ b/crates/component-macro/tests/codegen/multiversion/root.wit
@@ -3,5 +3,6 @@ package foo:bar;
 world foo {
   import my:dep/a@0.1.0;
   import my:dep/a@0.2.0;
+  export my:dep/a@0.1.0;
   export my:dep/a@0.2.0;
 }

--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -474,7 +474,7 @@ impl Wasmtime {
                         format!(
                             "{}_{}_{snake}",
                             pkgname.namespace.to_snake_case(),
-                            pkgname.name.to_snake_case()
+                            self.name_package_module(resolve, iface.package.unwrap())
                         ),
                     ),
                     None => (format!("exports::{snake}::{camel}"), snake.clone()),


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

When exporting multiple versions of the same package the version name needs to be included.

Before this change the generator would produce:

```
pub fn test_dep_test(&self) -> &exports::test::dep0_1_0::test::Test { &self.interface1 } 
pub fn test_dep_test(&self) -> &exports::test::dep0_2_0::test::Test { &self.interface2 }
```

now it will produce: 

```
pub fn test_dep_0_1_0_test(&self) -> &exports::test::dep0_1_0::test::Test { &self.interface1 } 
pub fn test_dep_0_2_0_test(&self) -> &exports::test::dep0_2_0::test::Test { &self.interface2 }
```

Found in https://github.com/bytecodealliance/wit-bindgen/pull/787/files#r1416724258
Discussed in https://bytecodealliance.zulipchat.com/#narrow/stream/327223-wit-bindgen/topic/Host.20Exports.20across.20versions
