### PR TITLE
Add a test for `allow-ip-name-lookup=no`

### DIFF
--- a/crates/test-programs/src/bin/cli_no_ip_name_lookup.rs
+++ b/crates/test-programs/src/bin/cli_no_ip_name_lookup.rs
@@ -1,0 +1,15 @@
+//! This test assumes that it will be run without ip lookup support enabled
+use test_programs::wasi::sockets::{
+    ip_name_lookup::{ErrorCode, IpAddress},
+    network::Network,
+};
+
+fn main() {
+    let res = resolve("example.com");
+    eprintln!("Result of resolve: {res:?}");
+    assert!(matches!(res, Err(ErrorCode::PermanentResolverFailure)));
+}
+
+fn resolve(name: &str) -> Result<Vec<IpAddress>, ErrorCode> {
+    Network::default().permissive_blocking_resolve_addresses(name)
+}

--- a/crates/test-programs/src/bin/preview2_ip_name_lookup.rs
+++ b/crates/test-programs/src/bin/preview2_ip_name_lookup.rs
@@ -1,5 +1,5 @@
+use test_programs::wasi::sockets::instance_network::Network;
 use test_programs::wasi::sockets::network::{ErrorCode, IpAddress};
-use test_programs::wasi::sockets::*;
 
 fn main() {
     // Valid domains
@@ -50,19 +50,7 @@ fn main() {
 }
 
 fn resolve(name: &str) -> Result<Vec<IpAddress>, ErrorCode> {
-    let network = instance_network::instance_network();
-
-    match network.blocking_resolve_addresses(name) {
-        // The following error codes signal that the input passed validation
-        // and a lookup was actually attempted, but failed. Ignore these to
-        // make the CI tests less flaky:
-        Err(
-            ErrorCode::NameUnresolvable
-            | ErrorCode::TemporaryResolverFailure
-            | ErrorCode::PermanentResolverFailure,
-        ) => Ok(vec![]),
-        r => r,
-    }
+    Network::default().permissive_blocking_resolve_addresses(name)
 }
 
 fn resolve_one(name: &str) -> Result<IpAddress, ErrorCode> {

--- a/crates/test-programs/src/sockets.rs
+++ b/crates/test-programs/src/sockets.rs
@@ -80,6 +80,21 @@ impl Network {
             }
         }
     }
+
+    /// Same as `Network::blocking_resolve_addresses` but ignores post validation errors
+    ///
+    /// The ignored error codes signal that the input passed validation
+    /// and a lookup was actually attempted, but failed. These are ignored to
+    /// make the CI tests less flaky.
+    pub fn permissive_blocking_resolve_addresses(
+        &self,
+        name: &str,
+    ) -> Result<Vec<IpAddress>, ErrorCode> {
+        match self.blocking_resolve_addresses(name) {
+            Err(ErrorCode::NameUnresolvable | ErrorCode::TemporaryResolverFailure) => Ok(vec![]),
+            r => r,
+        }
+    }
 }
 
 impl TcpSocket {

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1530,4 +1530,20 @@ mod test_programs {
         assert!(output.status.success());
         Ok(())
     }
+
+    #[test]
+    fn cli_no_ip_name_lookup() -> Result<()> {
+        let output = super::run_wasmtime_for_output(
+            &[
+                "-Wcomponent-model",
+                // Turn on network but ensure name lookup is disabled
+                "-Sinherit-network,allow-ip-name-lookup=no",
+                CLI_NO_IP_NAME_LOOKUP_COMPONENT,
+            ],
+            None,
+        )?;
+        println!("{}", String::from_utf8_lossy(&output.stderr));
+        assert!(output.status.success());
+        Ok(())
+    }
 }


### PR DESCRIPTION
The test simply tries looking up example.com and ensuring it fails with `PermanentResolverFailure`. Additionally, `PermanentResolverFailure` is removed as one of the allowed errors in the normal ip name lookup test as those allowed errors should only be transient lookup errors and `PermanentResolverFailure` is very much not a transient error.
