### PR TITLE
Replace clap attributes with command and arg

### DIFF
--- a/cranelift/isle/islec/src/main.rs
+++ b/cranelift/isle/islec/src/main.rs
@@ -12,11 +12,11 @@ use std::{
 struct Opts {
     /// The output file to write the generated Rust code to. `stdout` is used if
     /// this is not given.
-    #[clap(short, long)]
+    #[arg(short, long)]
     output: Option<PathBuf>,
 
     /// The input ISLE DSL source files.
-    #[clap(required = true)]
+    #[arg(required = true)]
     inputs: Vec<PathBuf>,
 }
 

--- a/cranelift/serde/src/clif-json.rs
+++ b/cranelift/serde/src/clif-json.rs
@@ -37,12 +37,12 @@ fn call_de(file: &File) -> Result<(), String> {
 
 /// Cranelift JSON serializer/deserializer utility
 #[derive(Parser, Debug)]
-#[clap(about)]
+#[command(about)]
 enum Args {
     /// Serializes Cranelift IR into JSON
     Serialize {
         /// Generate pretty json
-        #[clap(long, short)]
+        #[arg(long, short)]
         pretty: bool,
 
         /// Input file for serialization

--- a/cranelift/src/bugpoint.rs
+++ b/cranelift/src/bugpoint.rs
@@ -26,14 +26,14 @@ pub struct Options {
     file: PathBuf,
 
     /// Configure Cranelift settings
-    #[clap(long = "set")]
+    #[arg(long = "set")]
     settings: Vec<String>,
 
     /// Specify the target architecture.
     target: String,
 
     /// Be more verbose
-    #[clap(short, long)]
+    #[arg(short, long)]
     verbose: bool,
 }
 

--- a/cranelift/src/cat.rs
+++ b/cranelift/src/cat.rs
@@ -13,7 +13,7 @@ use std::path::{Path, PathBuf};
 #[derive(Parser)]
 pub struct Options {
     /// Specify input file(s) to be used. Use '-' for stdin.
-    #[clap(required = true)]
+    #[arg(required = true)]
     files: Vec<PathBuf>,
 }
 

--- a/cranelift/src/clif-util.rs
+++ b/cranelift/src/clif-util.rs
@@ -43,15 +43,15 @@ enum Commands {
 #[derive(Parser)]
 struct TestOptions {
     /// Be more verbose
-    #[clap(short, long)]
+    #[arg(short, long)]
     verbose: bool,
 
     /// Print pass timing report for test
-    #[clap(short = 'T')]
+    #[arg(short = 'T')]
     time_passes: bool,
 
     /// Specify an input file to be used. Use '-' for stdin.
-    #[clap(required = true)]
+    #[arg(required = true)]
     files: Vec<PathBuf>,
 }
 
@@ -59,11 +59,11 @@ struct TestOptions {
 #[derive(Parser)]
 struct PassOptions {
     /// Be more verbose
-    #[clap(short, long)]
+    #[arg(short, long)]
     verbose: bool,
 
     /// Print pass timing report for test
-    #[clap(short = 'T')]
+    #[arg(short = 'T')]
     time_passes: bool,
 
     /// Specify an input file to be used. Use '-' for stdin.
@@ -73,7 +73,7 @@ struct PassOptions {
     target: String,
 
     /// Specify pass(es) to be run on the input file
-    #[clap(required = true)]
+    #[arg(required = true)]
     passes: Vec<String>,
 }
 

--- a/cranelift/src/compile.rs
+++ b/cranelift/src/compile.rs
@@ -17,30 +17,30 @@ use std::path::PathBuf;
 #[derive(Parser)]
 pub struct Options {
     /// Print the resulting Cranelift IR
-    #[clap(short)]
+    #[arg(short)]
     print: bool,
 
     /// Print pass timing report
-    #[clap(short = 'T')]
+    #[arg(short = 'T')]
     report_times: bool,
 
     /// Print machine code disassembly
-    #[clap(short = 'D', long)]
+    #[arg(short = 'D', long)]
     disasm: bool,
 
     /// Configure Cranelift settings
-    #[clap(long = "set")]
+    #[arg(long = "set")]
     settings: Vec<String>,
 
     /// Specify the Cranelift target
-    #[clap(long = "target")]
+    #[arg(long = "target")]
     target: String,
 
     /// Specify an input file to be used. Use '-' for stdin.
     files: Vec<PathBuf>,
 
     /// Output object file
-    #[clap(short = 'o', long = "output")]
+    #[arg(short = 'o', long = "output")]
     output: Option<PathBuf>,
 }
 

--- a/cranelift/src/interpret.rs
+++ b/cranelift/src/interpret.rs
@@ -14,11 +14,11 @@ use thiserror::Error;
 #[derive(Parser)]
 pub struct Options {
     /// Specify an input file to be used. Use '-' for stdin.
-    #[clap(required = true)]
+    #[arg(required = true)]
     files: Vec<PathBuf>,
 
     /// Be more verbose
-    #[clap(short, long)]
+    #[arg(short, long)]
     verbose: bool,
 }
 

--- a/cranelift/src/print_cfg.rs
+++ b/cranelift/src/print_cfg.rs
@@ -14,7 +14,7 @@ use std::path::{Path, PathBuf};
 #[derive(Parser)]
 pub struct Options {
     /// Specify an input file to be used. Use '-' for stdin.
-    #[clap(required = true)]
+    #[arg(required = true)]
     files: Vec<PathBuf>,
 }
 

--- a/cranelift/src/run.rs
+++ b/cranelift/src/run.rs
@@ -14,11 +14,11 @@ use target_lexicon::Triple;
 #[derive(Parser)]
 pub struct Options {
     /// Specify an input file to be used. Use '-' for stdin.
-    #[clap(required = true)]
+    #[arg(required = true)]
     files: Vec<PathBuf>,
 
     /// Be more verbose
-    #[clap(short, long)]
+    #[arg(short, long)]
     verbose: bool,
 }
 

--- a/cranelift/src/souper_harvest.rs
+++ b/cranelift/src/souper_harvest.rs
@@ -22,21 +22,21 @@ pub struct Options {
 
     /// Specify the directory where harvested left-hand side files should be
     /// written to.
-    #[clap(short, long)]
+    #[arg(short, long)]
     output_dir: PathBuf,
 
     /// Configure Cranelift settings
-    #[clap(long = "set")]
+    #[arg(long = "set")]
     settings: Vec<String>,
 
     /// Specify the Cranelift target
-    #[clap(long = "target")]
+    #[arg(long = "target")]
     target: String,
 
     /// Add a comment from which CLIF variable and function each left-hand side
     /// was harvested from. This prevents deduplicating harvested left-hand
     /// sides.
-    #[clap(long)]
+    #[arg(long)]
     add_harvest_source: bool,
 }
 
@@ -56,7 +56,7 @@ pub fn run(options: &Options) -> Result<()> {
         ))
     };
 
-    match std::fs::create_dir_all(&options.output_dir) {
+    match fs::create_dir_all(&options.output_dir) {
         Ok(_) => {}
         Err(e)
             if e.kind() == io::ErrorKind::AlreadyExists

--- a/cranelift/src/wasm.rs
+++ b/cranelift/src/wasm.rs
@@ -59,46 +59,46 @@ macro_rules! vcprint {
 #[derive(Parser)]
 pub struct Options {
     /// Be more verbose
-    #[clap(short, long)]
+    #[arg(short, long)]
     verbose: bool,
 
     /// Print the resulting Cranelift IR
-    #[clap(short)]
+    #[arg(short)]
     print: bool,
 
     /// Print pass timing report
-    #[clap(short = 'T')]
+    #[arg(short = 'T')]
     report_times: bool,
 
     /// Print machine code disassembly
-    #[clap(short = 'D', long)]
+    #[arg(short = 'D', long)]
     disasm: bool,
 
     /// Configure Cranelift settings
-    #[clap(long = "set")]
+    #[arg(long = "set")]
     settings: Vec<String>,
 
     /// Specify the Cranelift target
-    #[clap(long = "target")]
+    #[arg(long = "target")]
     target: String,
 
     /// Specify an input file to be used. Use '-' for stdin.
     files: Vec<PathBuf>,
 
     /// Print bytecode size
-    #[clap(short = 'X')]
+    #[arg(short = 'X')]
     print_size: bool,
 
     /// Just decode Wasm into Cranelift IR, don't compile it to native code
-    #[clap(short = 't')]
+    #[arg(short = 't')]
     just_decode: bool,
 
     /// Just checks the correctness of Cranelift IR translated from Wasm
-    #[clap(short = 'c')]
+    #[arg(short = 'c')]
     check_translation: bool,
 
     /// Use colors in output? [options: auto/never/always; default: auto]
-    #[clap(long = "color", default_value("auto"))]
+    #[arg(long = "color", default_value("auto"))]
     color: ColorOpt,
 }
 

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -290,39 +290,39 @@ pub struct CommonOptions {
     // now.
     /// Optimization and tuning related options for wasm performance, `-O help` to
     /// see all.
-    #[clap(short = 'O', long = "optimize", value_name = "KEY[=VAL[,..]]")]
+    #[arg(short = 'O', long = "optimize", value_name = "KEY[=VAL[,..]]")]
     opts_raw: Vec<opt::CommaSeparated<Optimize>>,
 
     /// Codegen-related configuration options, `-C help` to see all.
-    #[clap(short = 'C', long = "codegen", value_name = "KEY[=VAL[,..]]")]
+    #[arg(short = 'C', long = "codegen", value_name = "KEY[=VAL[,..]]")]
     codegen_raw: Vec<opt::CommaSeparated<Codegen>>,
 
     /// Debug-related configuration options, `-D help` to see all.
-    #[clap(short = 'D', long = "debug", value_name = "KEY[=VAL[,..]]")]
+    #[arg(short = 'D', long = "debug", value_name = "KEY[=VAL[,..]]")]
     debug_raw: Vec<opt::CommaSeparated<Debug>>,
 
     /// Options for configuring semantic execution of WebAssembly, `-W help` to see
     /// all.
-    #[clap(short = 'W', long = "wasm", value_name = "KEY[=VAL[,..]]")]
+    #[arg(short = 'W', long = "wasm", value_name = "KEY[=VAL[,..]]")]
     wasm_raw: Vec<opt::CommaSeparated<Wasm>>,
 
     /// Options for configuring WASI and its proposals, `-S help` to see all.
-    #[clap(short = 'S', long = "wasi", value_name = "KEY[=VAL[,..]]")]
+    #[arg(short = 'S', long = "wasi", value_name = "KEY[=VAL[,..]]")]
     wasi_raw: Vec<opt::CommaSeparated<Wasi>>,
 
     // These fields are filled in by the `configure` method below via the
     // options parsed from the CLI above. This is what the CLI should use.
-    #[clap(skip)]
+    #[arg(skip)]
     configured: bool,
-    #[clap(skip)]
+    #[arg(skip)]
     pub opts: OptimizeOptions,
-    #[clap(skip)]
+    #[arg(skip)]
     pub codegen: CodegenOptions,
-    #[clap(skip)]
+    #[arg(skip)]
     pub debug: DebugOptions,
-    #[clap(skip)]
+    #[arg(skip)]
     pub wasm: WasmOptions,
-    #[clap(skip)]
+    #[arg(skip)]
     pub wasi: WasiOptions,
 }
 

--- a/crates/environ/examples/factc.rs
+++ b/crates/environ/examples/factc.rs
@@ -24,53 +24,53 @@ use wasmtime_environ::fact::Module;
 #[derive(Parser)]
 struct Factc {
     /// Whether or not debug code is inserted into the generated adapter.
-    #[clap(long)]
+    #[arg(long)]
     debug: bool,
 
     /// Whether or not the lifting options (the callee of the exported adapter)
     /// uses a 64-bit memory as opposed to a 32-bit memory.
-    #[clap(long)]
+    #[arg(long)]
     lift64: bool,
 
     /// Whether or not the lowering options (the caller of the exported adapter)
     /// uses a 64-bit memory as opposed to a 32-bit memory.
-    #[clap(long)]
+    #[arg(long)]
     lower64: bool,
 
     /// Whether or not a call to a `post-return` configured function is enabled
     /// or not.
-    #[clap(long)]
+    #[arg(long)]
     post_return: bool,
 
     /// Whether or not to skip validation of the generated adapter module.
-    #[clap(long)]
+    #[arg(long)]
     skip_validate: bool,
 
     /// Where to place the generated adapter module. Standard output is used if
     /// this is not specified.
-    #[clap(short, long)]
+    #[arg(short, long)]
     output: Option<PathBuf>,
 
     /// Output the text format for WebAssembly instead of the binary format.
-    #[clap(short, long)]
+    #[arg(short, long)]
     text: bool,
 
-    #[clap(long, value_parser = parse_string_encoding, default_value = "utf8")]
+    #[arg(long, value_parser = parse_string_encoding, default_value = "utf8")]
     lift_str: StringEncoding,
 
-    #[clap(long, value_parser = parse_string_encoding, default_value = "utf8")]
+    #[arg(long, value_parser = parse_string_encoding, default_value = "utf8")]
     lower_str: StringEncoding,
 
     /// TODO
     input: PathBuf,
 }
 
-fn parse_string_encoding(name: &str) -> anyhow::Result<StringEncoding> {
+fn parse_string_encoding(name: &str) -> Result<StringEncoding> {
     Ok(match name {
         "utf8" => StringEncoding::Utf8,
         "utf16" => StringEncoding::Utf16,
         "compact-utf16" => StringEncoding::CompactUtf16,
-        other => anyhow::bail!("invalid string encoding: `{other}`"),
+        other => bail!("invalid string encoding: `{other}`"),
     })
 }
 

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -8,7 +8,7 @@ use clap::Parser;
 
 /// Wasmtime WebAssembly Runtime
 #[derive(Parser, PartialEq)]
-#[clap(
+#[command(
     version = version(),
     after_help = "If a subcommand is not provided, the `run` subcommand will be used.\n\
                   \n\
@@ -34,9 +34,9 @@ use clap::Parser;
     args_conflicts_with_subcommands = true
 )]
 struct Wasmtime {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: Option<Subcommand>,
-    #[clap(flatten)]
+    #[command(flatten)]
     run: wasmtime_cli::commands::RunCommand,
 }
 

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -30,30 +30,29 @@ static AFTER_HELP: Lazy<String> = Lazy::new(|| {
 
 /// Compiles a WebAssembly module.
 #[derive(Parser, PartialEq)]
-#[structopt(
-    name = "compile",
+#[command(
     version,
     after_help = AFTER_HELP.as_str()
 )]
 pub struct CompileCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     #[allow(missing_docs)]
     pub common: CommonOptions,
 
     /// The target triple; default is the host triple
-    #[clap(long, value_name = "TARGET")]
+    #[arg(long, value_name = "TARGET")]
     pub target: Option<String>,
 
     /// The path of the output compiled module; defaults to <MODULE>.cwasm
-    #[clap(short = 'o', long, value_name = "OUTPUT")]
+    #[arg(short = 'o', long, value_name = "OUTPUT")]
     pub output: Option<PathBuf>,
 
     /// The directory path to write clif files into, one clif file per wasm function.
-    #[clap(long = "emit-clif", value_name = "PATH")]
+    #[arg(long = "emit-clif", value_name = "PATH")]
     pub emit_clif: Option<PathBuf>,
 
     /// The path of the WebAssembly to compile
-    #[clap(index = 1, value_name = "MODULE")]
+    #[arg(index = 1, value_name = "MODULE")]
     pub module: PathBuf,
 }
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,23 +1,22 @@
 //! The module that implements the `wasmtime config` command.
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{Parser, Subcommand};
 
 const CONFIG_NEW_AFTER_HELP: &str =
     "If no file path is specified, the system configuration file path will be used.";
 
 /// Controls Wasmtime configuration settings
 #[derive(Parser, PartialEq)]
-#[clap(name = "config")]
 pub struct ConfigCommand {
-    #[clap(subcommand)]
+    #[command(subcommand)]
     subcommand: ConfigSubcommand,
 }
 
-#[derive(clap::Subcommand, PartialEq)]
+#[derive(Subcommand, PartialEq)]
 enum ConfigSubcommand {
     /// Creates a new Wasmtime configuration file
-    #[clap(after_help = CONFIG_NEW_AFTER_HELP)]
+    #[command(after_help = CONFIG_NEW_AFTER_HELP)]
     New(ConfigNewCommand),
 }
 
@@ -32,10 +31,9 @@ impl ConfigCommand {
 
 /// Creates a new Wasmtime configuration file
 #[derive(Parser, PartialEq)]
-#[clap(name = "new", after_help = CONFIG_NEW_AFTER_HELP)]
 pub struct ConfigNewCommand {
     /// The path of the new configuration file
-    #[clap(index = 1, value_name = "FILE_PATH")]
+    #[arg(index = 1, value_name = "FILE_PATH")]
     path: Option<String>,
 }
 

--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -7,22 +7,21 @@ use wasmtime_cli_flags::CommonOptions;
 
 /// Explore the compilation of a WebAssembly module to native code.
 #[derive(Parser, PartialEq)]
-#[clap(name = "explore")]
 pub struct ExploreCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     common: CommonOptions,
 
     /// The target triple; default is the host triple
-    #[clap(long, value_name = "TARGET")]
+    #[arg(long, value_name = "TARGET")]
     target: Option<String>,
 
     /// The path of the WebAssembly module to compile
-    #[clap(required = true, value_name = "MODULE")]
+    #[arg(required = true, value_name = "MODULE")]
     module: PathBuf,
 
     /// The path of the explorer output (derived from the MODULE name if none
     /// provided)
-    #[clap(short, long)]
+    #[arg(short, long)]
     output: Option<PathBuf>,
 }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -55,9 +55,8 @@ fn parse_preloads(s: &str) -> Result<(String, PathBuf)> {
 
 /// Runs a WebAssembly module
 #[derive(Parser, PartialEq)]
-#[structopt(name = "run")]
 pub struct RunCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     #[allow(missing_docs)]
     pub run: RunCommon,
 
@@ -67,7 +66,7 @@ pub struct RunCommand {
     /// host is made available within the guest. If specified as `HOST::GUEST`
     /// then the `HOST` directory is opened and made available as the name
     /// `GUEST` in the guest.
-    #[clap(long = "dir", value_name = "HOST_DIR[::GUEST_DIR]", value_parser = parse_dirs)]
+    #[arg(long = "dir", value_name = "HOST_DIR[::GUEST_DIR]", value_parser = parse_dirs)]
     pub dirs: Vec<(String, String)>,
 
     /// Pass an environment variable to the program.
@@ -77,15 +76,15 @@ pub struct RunCommand {
     /// form will set the environment variable named `FOO` to the same value it
     /// has in the calling process for the guest, or in other words it will
     /// cause the environment variable `FOO` to be inherited.
-    #[clap(long = "env", number_of_values = 1, value_name = "NAME[=VAL]", value_parser = parse_env_var)]
+    #[arg(long = "env", number_of_values = 1, value_name = "NAME[=VAL]", value_parser = parse_env_var)]
     pub vars: Vec<(String, Option<String>)>,
 
     /// The name of the function to run
-    #[clap(long, value_name = "FUNCTION")]
+    #[arg(long, value_name = "FUNCTION")]
     pub invoke: Option<String>,
 
     /// Load the given WebAssembly module before the main module
-    #[clap(
+    #[arg(
         long = "preload",
         number_of_values = 1,
         value_name = "NAME=MODULE_PATH",
@@ -98,7 +97,7 @@ pub struct RunCommand {
     /// Arguments passed to the wasm module will be configured as WASI CLI
     /// arguments unless the `--invoke` CLI argument is passed in which case
     /// arguments will be interpreted as arguments to the function specified.
-    #[clap(value_name = "WASM", trailing_var_arg = true, required = true)]
+    #[arg(value_name = "WASM", trailing_var_arg = true, required = true)]
     pub module_and_args: Vec<OsString>,
 }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -67,17 +67,16 @@ const DEFAULT_ADDR: std::net::SocketAddr = std::net::SocketAddr::new(
 
 /// Runs a WebAssembly module
 #[derive(Parser, PartialEq)]
-#[structopt(name = "serve")]
 pub struct ServeCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     run: RunCommon,
 
     /// Socket address for the web server to bind to.
-    #[clap(long = "addr", value_name = "SOCKADDR", default_value_t = DEFAULT_ADDR )]
+    #[arg(long = "addr", value_name = "SOCKADDR", default_value_t = DEFAULT_ADDR )]
     addr: std::net::SocketAddr,
 
     /// The WebAssembly component to run.
-    #[clap(value_name = "WASM", required = true)]
+    #[arg(value_name = "WASM", required = true)]
     component: PathBuf,
 }
 

--- a/src/commands/settings.rs
+++ b/src/commands/settings.rs
@@ -9,14 +9,13 @@ use wasmtime_environ::{CompilerBuilder, FlagValue, Setting, SettingKind};
 
 /// Displays available Cranelift settings for a target.
 #[derive(Parser, PartialEq)]
-#[clap(name = "run")]
 pub struct SettingsCommand {
     /// The target triple to get the settings for; defaults to the host triple.
-    #[clap(long, value_name = "TARGET")]
+    #[arg(long, value_name = "TARGET")]
     target: Option<String>,
 
     /// Switch output format to JSON
-    #[clap(long)]
+    #[arg(long)]
     json: bool,
 }
 

--- a/src/commands/wast.rs
+++ b/src/commands/wast.rs
@@ -9,13 +9,12 @@ use wasmtime_wast::WastContext;
 
 /// Runs a WebAssembly test script file
 #[derive(Parser, PartialEq)]
-#[clap(name = "wast", version)]
 pub struct WastCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     common: CommonOptions,
 
     /// The path of the WebAssembly test script to run
-    #[clap(required = true, value_name = "SCRIPT_FILE")]
+    #[arg(required = true, value_name = "SCRIPT_FILE")]
     scripts: Vec<PathBuf>,
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -37,7 +37,7 @@ impl RunTarget {
 /// Common command line arguments for run commands.
 #[derive(Parser, PartialEq)]
 pub struct RunCommon {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub common: CommonOptions,
 
     /// Allow executing precompiled WebAssembly modules as `*.cwasm` files.
@@ -46,7 +46,7 @@ pub struct RunCommon {
     /// is arbitrary user input. Only `wasmtime`-precompiled modules generated
     /// via the `wasmtime compile` command or equivalent should be passed as an
     /// argument with this option specified.
-    #[clap(long = "allow-precompiled")]
+    #[arg(long = "allow-precompiled")]
     pub allow_precompiled: bool,
 
     /// Profiling strategy (valid options are: perfmap, jitdump, vtune, guest)
@@ -64,7 +64,7 @@ pub struct RunCommon {
     /// where `path` is where to write the profile and `interval` is the
     /// duration between samples. When used with `--wasm-timeout` the timeout
     /// will be rounded up to the nearest multiple of this interval.
-    #[clap(
+    #[arg(
         long,
         value_name = "STRATEGY",
         value_parser = Profile::parse,

--- a/src/old_cli.rs
+++ b/src/old_cli.rs
@@ -10,7 +10,7 @@ use std::time::Duration;
 
 /// Wasmtime WebAssembly Runtime
 #[derive(Parser)]
-#[clap(
+#[command(
     version,
     after_help = "If a subcommand is not provided, the `run` subcommand will be used.\n\
                   \n\
@@ -50,23 +50,23 @@ pub enum Subcommand {
 }
 
 #[derive(Parser)]
-#[structopt(name = "run", trailing_var_arg = true)]
+#[command(trailing_var_arg = true)]
 pub struct RunCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     common: CommonOptions,
 
     /// Allow unknown exports when running commands.
-    #[clap(long = "allow-unknown-exports")]
+    #[arg(long = "allow-unknown-exports")]
     allow_unknown_exports: bool,
 
     /// Allow the main module to import unknown functions, using an
     /// implementation that immediately traps, when running commands.
-    #[clap(long = "trap-unknown-imports")]
+    #[arg(long = "trap-unknown-imports")]
     trap_unknown_imports: bool,
 
     /// Allow the main module to import unknown functions, using an
     /// implementation that returns default values, when running commands.
-    #[clap(long = "default-values-unknown-imports")]
+    #[arg(long = "default-values-unknown-imports")]
     default_values_unknown_imports: bool,
 
     /// Allow executing precompiled WebAssembly modules as `*.cwasm` files.
@@ -75,16 +75,16 @@ pub struct RunCommand {
     /// is arbitrary user input. Only `wasmtime`-precompiled modules generated
     /// via the `wasmtime compile` command or equivalent should be passed as an
     /// argument with this option specified.
-    #[clap(long = "allow-precompiled")]
+    #[arg(long = "allow-precompiled")]
     allow_precompiled: bool,
 
     /// Inherit environment variables and file descriptors following the
     /// systemd listen fd specification (UNIX only)
-    #[clap(long = "listenfd")]
+    #[arg(long = "listenfd")]
     listenfd: bool,
 
     /// Grant access to the given TCP listen socket
-    #[clap(
+    #[arg(
         long = "tcplisten",
         number_of_values = 1,
         value_name = "SOCKET ADDRESS"
@@ -92,7 +92,7 @@ pub struct RunCommand {
     tcplisten: Vec<String>,
 
     /// Grant access to the given host directory
-    #[clap(long = "dir", number_of_values = 1, value_name = "DIRECTORY")]
+    #[arg(long = "dir", number_of_values = 1, value_name = "DIRECTORY")]
     dirs: Vec<String>,
 
     /// Pass an environment variable to the program.
@@ -102,15 +102,15 @@ pub struct RunCommand {
     /// form will set the environment variable named `FOO` to the same value it
     /// has in the calling process for the guest, or in other words it will
     /// cause the environment variable `FOO` to be inherited.
-    #[clap(long = "env", number_of_values = 1, value_name = "NAME[=VAL]", value_parser = parse_env_var)]
+    #[arg(long = "env", number_of_values = 1, value_name = "NAME[=VAL]", value_parser = parse_env_var)]
     vars: Vec<(String, Option<String>)>,
 
     /// The name of the function to run
-    #[clap(long, value_name = "FUNCTION")]
+    #[arg(long, value_name = "FUNCTION")]
     invoke: Option<String>,
 
     /// Grant access to a guest directory mapped as a host directory
-    #[clap(long = "mapdir", number_of_values = 1, value_name = "GUEST_DIR::HOST_DIR", value_parser = parse_map_dirs)]
+    #[arg(long = "mapdir", number_of_values = 1, value_name = "GUEST_DIR::HOST_DIR", value_parser = parse_map_dirs)]
     map_dirs: Vec<(String, String)>,
 
     /// Pre-load machine learning graphs (i.e., models) for use by wasi-nn.
@@ -121,11 +121,11 @@ pub struct RunCommand {
     /// an OpenVINO model named `bar`. Note that which model encodings are
     /// available is dependent on the backends implemented in the
     /// `wasmtime_wasi_nn` crate.
-    #[clap(long = "wasi-nn-graph", value_name = "FORMAT::HOST_DIR", value_parser = parse_graphs)]
+    #[arg(long = "wasi-nn-graph", value_name = "FORMAT::HOST_DIR", value_parser = parse_graphs)]
     graphs: Vec<(String, String)>,
 
     /// The path of the WebAssembly module to run
-    #[clap(
+    #[arg(
 		required = true,
         value_name = "MODULE",
         value_parser = OsStringValueParser::new().try_map(parse_module),
@@ -133,7 +133,7 @@ pub struct RunCommand {
     module: PathBuf,
 
     /// Load the given WebAssembly module before the main module
-    #[clap(
+    #[arg(
         long = "preload",
         number_of_values = 1,
         value_name = "NAME=MODULE_PATH",
@@ -142,7 +142,7 @@ pub struct RunCommand {
     preloads: Vec<(String, PathBuf)>,
 
     /// Maximum execution time of wasm code before timing out (1, 2s, 100ms, etc)
-    #[clap(
+    #[arg(
         long = "wasm-timeout",
         value_name = "TIME",
         value_parser = parse_dur,
@@ -164,7 +164,7 @@ pub struct RunCommand {
     /// where `path` is where to write the profile and `interval` is the
     /// duration between samples. When used with `--wasm-timeout` the timeout
     /// will be rounded up to the nearest multiple of this interval.
-    #[clap(
+    #[arg(
         long,
         value_name = "STRATEGY",
         value_parser = parse_profile,
@@ -172,35 +172,35 @@ pub struct RunCommand {
     profile: Option<Profile>,
 
     /// Enable coredump generation after a WebAssembly trap.
-    #[clap(long = "coredump-on-trap", value_name = "PATH")]
+    #[arg(long = "coredump-on-trap", value_name = "PATH")]
     coredump_on_trap: Option<String>,
 
     // NOTE: this must come last for trailing varargs
     /// The arguments to pass to the module
-    #[clap(value_name = "ARGS")]
+    #[arg(value_name = "ARGS")]
     module_args: Vec<String>,
 
     /// Maximum size, in bytes, that a linear memory is allowed to reach.
     ///
     /// Growth beyond this limit will cause `memory.grow` instructions in
     /// WebAssembly modules to return -1 and fail.
-    #[clap(long, value_name = "BYTES")]
+    #[arg(long, value_name = "BYTES")]
     max_memory_size: Option<usize>,
 
     /// Maximum size, in table elements, that a table is allowed to reach.
-    #[clap(long)]
+    #[arg(long)]
     max_table_elements: Option<u32>,
 
     /// Maximum number of WebAssembly instances allowed to be created.
-    #[clap(long)]
+    #[arg(long)]
     max_instances: Option<usize>,
 
     /// Maximum number of WebAssembly tables allowed to be created.
-    #[clap(long)]
+    #[arg(long)]
     max_tables: Option<usize>,
 
     /// Maximum number of WebAssembly linear memories allowed to be created.
-    #[clap(long)]
+    #[arg(long)]
     max_memories: Option<usize>,
 
     /// Force a trap to be raised on `memory.grow` and `table.grow` failure
@@ -209,7 +209,7 @@ pub struct RunCommand {
     /// This is not necessarily a spec-compliant option to enable but can be
     /// useful for tracking down a backtrace of what is requesting so much
     /// memory, for example.
-    #[clap(long)]
+    #[arg(long)]
     trap_on_grow_failure: bool,
 
     /// Indicates that the implementation of WASI preview1 should be backed by
@@ -217,18 +217,18 @@ pub struct RunCommand {
     ///
     /// This will become the default in the future and this option will be
     /// removed. For now this is primarily here for testing.
-    #[clap(long)]
+    #[arg(long)]
     preview2: bool,
 
     /// Enables memory error checking.
     ///
     /// See wmemcheck.md for documentation on how to use.
-    #[clap(long)]
+    #[arg(long)]
     wmemcheck: bool,
 
     /// Flag for WASI preview2 to inherit the host's network within the guest so
     /// it has full access to all addresses/ports/etc.
-    #[clap(long)]
+    #[arg(long)]
     inherit_network: bool,
 }
 fn parse_module(s: OsString) -> anyhow::Result<PathBuf> {
@@ -315,23 +315,23 @@ fn parse_profile(s: &str) -> Result<Profile> {
 /// Compiles a WebAssembly module.
 #[derive(Parser)]
 pub struct CompileCommand {
-    #[clap(flatten)]
+    #[command(flatten)]
     pub common: CommonOptions,
 
     /// The target triple; default is the host triple
-    #[clap(long, value_name = "TARGET")]
+    #[arg(long, value_name = "TARGET")]
     pub target: Option<String>,
 
     /// The path of the output compiled module; defaults to <MODULE>.cwasm
-    #[clap(short = 'o', long, value_name = "OUTPUT")]
+    #[arg(short = 'o', long, value_name = "OUTPUT")]
     pub output: Option<PathBuf>,
 
     /// The directory path to write clif files into, one clif file per wasm function.
-    #[clap(long = "emit-clif", value_name = "PATH")]
+    #[arg(long = "emit-clif", value_name = "PATH")]
     pub emit_clif: Option<PathBuf>,
 
     /// The path of the WebAssembly to compile
-    #[clap(index = 1, value_name = "MODULE")]
+    #[arg(index = 1, value_name = "MODULE")]
     pub module: PathBuf,
 }
 
@@ -340,45 +340,45 @@ pub struct CompileCommand {
 #[cfg_attr(test, derive(Debug, PartialEq))]
 pub struct CommonOptions {
     /// Use specified configuration file
-    #[clap(long, value_name = "CONFIG_PATH")]
+    #[arg(long, value_name = "CONFIG_PATH")]
     pub config: Option<PathBuf>,
 
     /// Disable logging
-    #[clap(long, conflicts_with = "log_to_files")]
+    #[arg(long, conflicts_with = "log_to_files")]
     pub disable_logging: bool,
 
     /// Log to per-thread log files instead of stderr
-    #[clap(long)]
+    #[arg(long)]
     pub log_to_files: bool,
 
     /// Generate debug information
-    #[clap(short = 'g')]
+    #[arg(short = 'g')]
     pub debug_info: bool,
 
     /// Disable cache system
-    #[clap(long)]
+    #[arg(long)]
     pub disable_cache: bool,
 
     /// Disable parallel compilation
-    #[clap(long)]
+    #[arg(long)]
     pub disable_parallel_compilation: bool,
 
     /// Enable or disable WebAssembly features
-    #[clap(long, value_name = "FEATURE,FEATURE,...", value_parser = parse_wasm_features)]
+    #[arg(long, value_name = "FEATURE,FEATURE,...", value_parser = parse_wasm_features)]
     pub wasm_features: Option<WasmFeatures>,
 
     /// Enable or disable WASI modules
-    #[clap(long, value_name = "MODULE,MODULE,...", value_parser = parse_wasi_modules)]
+    #[arg(long, value_name = "MODULE,MODULE,...", value_parser = parse_wasi_modules)]
     pub wasi_modules: Option<WasiModules>,
 
     /// Generate jitdump file (supported on --features=profiling build)
     /// Run optimization passes on translated functions, on by default
-    #[clap(short = 'O', long)]
+    #[arg(short = 'O', long)]
     pub optimize: bool,
 
     /// Optimization level for generated functions
     /// Supported levels: 0 (none), 1, 2 (most), or s (size); default is "most"
-    #[clap(
+    #[arg(
         long,
         value_name = "LEVEL",
         value_parser = parse_opt_level,
@@ -388,7 +388,7 @@ pub struct CommonOptions {
 
     /// Set a Cranelift setting to a given value.
     /// Use `wasmtime settings` to list Cranelift settings for a target.
-    #[clap(
+    #[arg(
         long = "cranelift-set",
         value_name = "NAME=VALUE",
         number_of_values = 1,
@@ -399,7 +399,7 @@ pub struct CommonOptions {
 
     /// Enable a Cranelift boolean setting or preset.
     /// Use `wasmtime settings` to list Cranelift settings for a target.
-    #[clap(
+    #[arg(
         long,
         value_name = "SETTING",
         number_of_values = 1,
@@ -409,32 +409,32 @@ pub struct CommonOptions {
 
     /// Maximum size in bytes of wasm memory before it becomes dynamically
     /// relocatable instead of up-front-reserved.
-    #[clap(long, value_name = "MAXIMUM")]
+    #[arg(long, value_name = "MAXIMUM")]
     pub static_memory_maximum_size: Option<u64>,
 
     /// Force using a "static" style for all wasm memories
-    #[clap(long)]
+    #[arg(long)]
     pub static_memory_forced: bool,
 
     /// Byte size of the guard region after static memories are allocated
-    #[clap(long, value_name = "SIZE")]
+    #[arg(long, value_name = "SIZE")]
     pub static_memory_guard_size: Option<u64>,
 
     /// Byte size of the guard region after dynamic memories are allocated
-    #[clap(long, value_name = "SIZE")]
+    #[arg(long, value_name = "SIZE")]
     pub dynamic_memory_guard_size: Option<u64>,
 
     /// Bytes to reserve at the end of linear memory for growth for dynamic
     /// memories.
-    #[clap(long, value_name = "SIZE")]
+    #[arg(long, value_name = "SIZE")]
     pub dynamic_memory_reserved_for_growth: Option<u64>,
 
     /// Enable Cranelift's internal debug verifier (expensive)
-    #[clap(long)]
+    #[arg(long)]
     pub enable_cranelift_debug_verifier: bool,
 
     /// Enable Cranelift's internal NaN canonicalization
-    #[clap(long)]
+    #[arg(long)]
     pub enable_cranelift_nan_canonicalization: bool,
 
     /// Enable execution fuel with N units fuel, where execution will trap after
@@ -444,33 +444,33 @@ pub struct CommonOptions {
     /// such as `nop`, `drop`, `block`, and `loop`, consume 0 units, as any
     /// execution cost associated with them involves other instructions which do
     /// consume fuel.
-    #[clap(long, value_name = "N")]
+    #[arg(long, value_name = "N")]
     pub fuel: Option<u64>,
 
     /// Executing wasm code will yield when a global epoch counter
     /// changes, allowing for async operation without blocking the
     /// executor.
-    #[clap(long)]
+    #[arg(long)]
     pub epoch_interruption: bool,
 
     /// Disable the on-by-default address map from native code to wasm code
-    #[clap(long)]
+    #[arg(long)]
     pub disable_address_map: bool,
 
     /// Disable the default of attempting to initialize linear memory via a
     /// copy-on-write mapping
-    #[clap(long)]
+    #[arg(long)]
     pub disable_memory_init_cow: bool,
 
     /// Enable the pooling allocator, in place of the on-demand
     /// allocator.
     #[cfg(feature = "pooling-allocator")]
-    #[clap(long)]
+    #[arg(long)]
     pub pooling_allocator: bool,
 
     /// Maximum stack size, in bytes, that wasm is allowed to consume before a
     /// stack overflow is reported.
-    #[clap(long)]
+    #[arg(long)]
     pub max_wasm_stack: Option<usize>,
 
     /// Whether or not to force deterministic and host-independent behavior of
@@ -481,14 +481,14 @@ pub struct CommonOptions {
     /// of these instructions to match the deterministic behavior classified in
     /// the specification. Note that enabling this option may come at a
     /// performance cost.
-    #[clap(long)]
+    #[arg(long)]
     pub relaxed_simd_deterministic: bool,
 
     /// Explicitly specify the name of the compiler to use for WebAssembly.
     ///
     /// Currently only `cranelift` and `winch` are supported, but not all builds
     /// of Wasmtime have both built in.
-    #[clap(long)]
+    #[arg(long)]
     pub compiler: Option<String>,
 }
 

--- a/winch/src/compile.rs
+++ b/winch/src/compile.rs
@@ -17,7 +17,7 @@ pub struct Options {
     input: PathBuf,
 
     /// The target architecture.
-    #[clap(long = "target")]
+    #[arg(long = "target")]
     target: String,
 }
 

--- a/winch/src/filetests.rs
+++ b/winch/src/filetests.rs
@@ -7,7 +7,7 @@ use clap::Parser;
 pub struct Options {
     /// Passes extra arguments to `cargo test --package winch-filetests`. For example, to run a single
     /// test, use `-- --test-threads 1 --test single_test_name`.
-    #[clap(last = true, value_parser)]
+    #[arg(last = true, value_parser)]
     cargo_test_args: Vec<String>,
 }
 


### PR DESCRIPTION
While reading the code, I noticed that we were mixing clap's `clap`, `command`, `arg`, and `structopt` attributes, and it seemed quite messy, and even though `#[clap()]` still works, `#[arg()]` and `#[command()]` are now recommended since clap v4, ref https://github.com/clap-rs/clap/pull/4180.

So this patch standardizes them, eliminating the use of outdated `clap` attributes and removing some meaningless name configurations.