### PR TITLE
Reserve handle index 0 in the component model

### DIFF
--- a/crates/runtime/src/component.rs
+++ b/crates/runtime/src/component.rs
@@ -531,7 +531,7 @@ impl ComponentInstance {
 
     /// Implementation of the `resource.new` intrinsic for `i32`
     /// representations.
-    pub fn resource_new32(&mut self, resource: TypeResourceTableIndex, rep: u32) -> u32 {
+    pub fn resource_new32(&mut self, resource: TypeResourceTableIndex, rep: u32) -> Result<u32> {
         self.resource_tables().resource_new(Some(resource), rep)
     }
 
@@ -600,7 +600,7 @@ impl ComponentInstance {
     ) -> Result<u32> {
         let mut tables = self.resource_tables();
         let rep = tables.resource_lift_own(Some(src), idx)?;
-        Ok(tables.resource_lower_own(Some(dst), rep))
+        tables.resource_lower_own(Some(dst), rep)
     }
 
     pub(crate) fn resource_transfer_borrow(
@@ -623,7 +623,7 @@ impl ComponentInstance {
         if dst_owns_resource {
             return Ok(rep);
         }
-        Ok(tables.resource_lower_borrow(Some(dst), rep))
+        tables.resource_lower_borrow(Some(dst), rep)
     }
 
     pub(crate) fn resource_enter_call(&mut self) {

--- a/crates/runtime/src/component/libcalls.rs
+++ b/crates/runtime/src/component/libcalls.rs
@@ -519,9 +519,7 @@ fn inflate_latin1_bytes(dst: &mut [u16], latin1_bytes_so_far: usize) -> &mut [u1
 
 unsafe fn resource_new32(vmctx: *mut VMComponentContext, resource: u32, rep: u32) -> Result<u32> {
     let resource = TypeResourceTableIndex::from_u32(resource);
-    Ok(ComponentInstance::from_vmctx(vmctx, |instance| {
-        instance.resource_new32(resource, rep)
-    }))
+    ComponentInstance::from_vmctx(vmctx, |instance| instance.resource_new32(resource, rep))
 }
 
 unsafe fn resource_rep32(vmctx: *mut VMComponentContext, resource: u32, idx: u32) -> Result<u32> {

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -289,13 +289,21 @@ impl<'a, T> LowerContext<'a, T> {
     /// into a guest-local index.
     ///
     /// The `ty` provided is which table to put this into.
-    pub fn guest_resource_lower_own(&mut self, ty: TypeResourceTableIndex, rep: u32) -> u32 {
+    pub fn guest_resource_lower_own(
+        &mut self,
+        ty: TypeResourceTableIndex,
+        rep: u32,
+    ) -> Result<u32> {
         self.resource_tables().guest_resource_lower_own(rep, ty)
     }
 
     /// Lowers a `borrow` resource into the guest, converting the `rep` to a
     /// guest-local index in the `ty` table specified.
-    pub fn guest_resource_lower_borrow(&mut self, ty: TypeResourceTableIndex, rep: u32) -> u32 {
+    pub fn guest_resource_lower_borrow(
+        &mut self,
+        ty: TypeResourceTableIndex,
+        rep: u32,
+    ) -> Result<u32> {
         // Implement `lower_borrow`'s special case here where if a borrow is
         // inserted into a table owned by the instance which implemented the
         // original resource then no borrow tracking is employed and instead the
@@ -308,7 +316,7 @@ impl<'a, T> LowerContext<'a, T> {
         // Note that the unsafety here should be valid given the contract of
         // `LowerContext::new`.
         if unsafe { (*self.instance).resource_owned_by_own_instance(ty) } {
-            return rep;
+            return Ok(rep);
         }
         self.resource_tables().guest_resource_lower_borrow(rep, ty)
     }
@@ -330,7 +338,7 @@ impl<'a, T> LowerContext<'a, T> {
     ///
     /// Note that this is a special case for `Resource<T>`. Most of the time a
     /// host value shouldn't be lowered with a lowering context.
-    pub fn host_resource_lower_own(&mut self, rep: u32) -> HostResourceIndex {
+    pub fn host_resource_lower_own(&mut self, rep: u32) -> Result<HostResourceIndex> {
         self.resource_tables().host_resource_lower_own(rep)
     }
 
@@ -483,13 +491,13 @@ impl<'a> LiftContext<'a> {
 
     /// Lowers a resource into the host-owned table, returning the index it was
     /// inserted at.
-    pub fn host_resource_lower_own(&mut self, rep: u32) -> HostResourceIndex {
+    pub fn host_resource_lower_own(&mut self, rep: u32) -> Result<HostResourceIndex> {
         self.resource_tables().host_resource_lower_own(rep)
     }
 
     /// Lowers a resource into the host-owned table, returning the index it was
     /// inserted at.
-    pub fn host_resource_lower_borrow(&mut self, rep: u32) -> HostResourceIndex {
+    pub fn host_resource_lower_borrow(&mut self, rep: u32) -> Result<HostResourceIndex> {
         self.resource_tables().host_resource_lower_borrow(rep)
     }
 

--- a/tests/all/component_model/resources.rs
+++ b/tests/all/component_model/resources.rs
@@ -233,7 +233,7 @@ fn mismatch_intrinsics() -> Result<()> {
     let ctor = i.get_typed_func::<(u32,), (ResourceAny,)>(&mut store, "ctor")?;
     assert_eq!(
         ctor.call(&mut store, (100,)).unwrap_err().to_string(),
-        "unknown handle index 0"
+        "unknown handle index 1"
     );
 
     Ok(())
@@ -371,7 +371,7 @@ fn drop_guest_twice() -> Result<()> {
 
     assert_eq!(
         dtor.call(&mut store, (&t,)).unwrap_err().to_string(),
-        "unknown handle index 0"
+        "unknown handle index 1"
     );
 
     Ok(())
@@ -1250,7 +1250,7 @@ fn pass_guest_back_as_borrow() -> Result<()> {
 
     // Should not be valid to use `resource` again
     let err = take.call(&mut store, (&resource,)).unwrap_err();
-    assert_eq!(err.to_string(), "unknown handle index 0");
+    assert_eq!(err.to_string(), "unknown handle index 1");
 
     Ok(())
 }
@@ -1412,9 +1412,9 @@ fn guest_different_host_same() -> Result<()> {
                     (import "" "drop2" (func $drop2 (param i32)))
 
                     (func (export "f") (param i32 i32)
-                        ;; separate tables both have initial index of 0
-                        (if (i32.ne (local.get 0) (i32.const 0)) (then (unreachable)))
-                        (if (i32.ne (local.get 1) (i32.const 0)) (then (unreachable)))
+                        ;; separate tables both have initial index of 1
+                        (if (i32.ne (local.get 0) (i32.const 1)) (then (unreachable)))
+                        (if (i32.ne (local.get 1) (i32.const 1)) (then (unreachable)))
 
                         ;; host should end up getting the same resource
                         (call $f (local.get 0) (local.get 1))

--- a/tests/misc_testsuite/component-model/resources.wast
+++ b/tests/misc_testsuite/component-model/resources.wast
@@ -14,7 +14,7 @@
        (local $r i32)
        (local.set $r (call $new (i32.const 100)))
 
-       (if (i32.ne (local.get $r) (i32.const 0)) (then (unreachable)))
+       (if (i32.ne (local.get $r) (i32.const 1)) (then (unreachable)))
        (if (i32.ne (call $rep (local.get $r)) (i32.const 100)) (then (unreachable)))
 
        (call $drop (local.get $r))
@@ -95,13 +95,13 @@
 
        ;; resources assigned sequentially
        (local.set $r1 (call $new (i32.const 100)))
-       (if (i32.ne (local.get $r1) (i32.const 0)) (then (unreachable)))
+       (if (i32.ne (local.get $r1) (i32.const 1)) (then (unreachable)))
 
        (local.set $r2 (call $new (i32.const 200)))
-       (if (i32.ne (local.get $r2) (i32.const 1)) (then (unreachable)))
+       (if (i32.ne (local.get $r2) (i32.const 2)) (then (unreachable)))
 
        (local.set $r3 (call $new (i32.const 300)))
-       (if (i32.ne (local.get $r3) (i32.const 2)) (then (unreachable)))
+       (if (i32.ne (local.get $r3) (i32.const 3)) (then (unreachable)))
 
        ;; representations all look good
        (if (i32.ne (call $rep (local.get $r1)) (i32.const 100)) (then (unreachable)))
@@ -113,7 +113,7 @@
        (local.set $r2 (call $new (i32.const 400)))
 
        ;; should have reused index 1
-       (if (i32.ne (local.get $r2) (i32.const 1)) (then (unreachable)))
+       (if (i32.ne (local.get $r2) (i32.const 2)) (then (unreachable)))
 
        ;; representations all look good
        (if (i32.ne (call $rep (local.get $r1)) (i32.const 100)) (then (unreachable)))
@@ -135,13 +135,13 @@
        (if (i32.ne (call $rep (local.get $r3)) (i32.const 700)) (then (unreachable)))
 
        ;; indices should be lifo
-       (if (i32.ne (local.get $r1) (i32.const 2)) (then (unreachable)))
-       (if (i32.ne (local.get $r2) (i32.const 1)) (then (unreachable)))
-       (if (i32.ne (local.get $r3) (i32.const 0)) (then (unreachable)))
+       (if (i32.ne (local.get $r1) (i32.const 3)) (then (unreachable)))
+       (if (i32.ne (local.get $r2) (i32.const 2)) (then (unreachable)))
+       (if (i32.ne (local.get $r3) (i32.const 1)) (then (unreachable)))
 
        ;; bump one more time
        (local.set $r4 (call $new (i32.const 800)))
-       (if (i32.ne (local.get $r4) (i32.const 3)) (then (unreachable)))
+       (if (i32.ne (local.get $r4) (i32.const 4)) (then (unreachable)))
 
        ;; deallocate everything
        (call $drop (local.get $r1))
@@ -241,13 +241,13 @@
        (local.set $r2 (call $ctor (i32.const 200)))
 
        ;; assert r1/r2 are sequential
-       (if (i32.ne (local.get $r1) (i32.const 0)) (then (unreachable)))
-       (if (i32.ne (local.get $r2) (i32.const 1)) (then (unreachable)))
+       (if (i32.ne (local.get $r1) (i32.const 1)) (then (unreachable)))
+       (if (i32.ne (local.get $r2) (i32.const 2)) (then (unreachable)))
 
        ;; reallocate r1 and it should be reassigned the same index
        (call $drop (local.get $r1))
        (local.set $r1 (call $ctor (i32.const 300)))
-       (if (i32.ne (local.get $r1) (i32.const 0)) (then (unreachable)))
+       (if (i32.ne (local.get $r1) (i32.const 1)) (then (unreachable)))
 
        ;; internal values should match
        (call $assert (local.get $r1) (i32.const 300))
@@ -443,7 +443,7 @@
       (import "" "ctor" (func $ctor (param i32) (result i32)))
 
       (func $start
-        (if (i32.ne (call $ctor (i32.const 100)) (i32.const 0)) (then (unreachable)))
+        (if (i32.ne (call $ctor (i32.const 100)) (i32.const 1)) (then (unreachable)))
       )
       (start $start)
     )
@@ -464,7 +464,7 @@
      (import "" "drop" (func $drop (param i32)))
 
      (func (export "f")
-        (call $drop (i32.const 0))
+        (call $drop (i32.const 1))
      )
   )
   (core instance $i (instantiate $m
@@ -492,10 +492,10 @@
       (import "" "drop" (func $drop (param i32)))
 
       (func (export "alloc")
-        (if (i32.ne (call $ctor (i32.const 100)) (i32.const 0)) (then (unreachable)))
+        (if (i32.ne (call $ctor (i32.const 100)) (i32.const 1)) (then (unreachable)))
       )
       (func (export "dealloc")
-        (call $drop (i32.const 0))
+        (call $drop (i32.const 1))
       )
     )
     (core instance $i (instantiate $m
@@ -552,10 +552,10 @@
       (import "" "drop" (func $drop (param i32)))
 
       (func (export "alloc")
-        (if (i32.ne (call $ctor (i32.const 100)) (i32.const 0)) (then (unreachable)))
+        (if (i32.ne (call $ctor (i32.const 100)) (i32.const 1)) (then (unreachable)))
       )
       (func (export "dealloc")
-        (call $drop (i32.const 0))
+        (call $drop (i32.const 1))
       )
     )
     (core instance $i (instantiate $m
@@ -617,12 +617,12 @@
       (call $drop2 (call $new2 (i32.const 104)))
 
       ;; should be referencing the same namespace
-      (if (i32.ne (call $new1 (i32.const 105)) (i32.const 0)) (then (unreachable)))
-      (if (i32.ne (call $new2 (i32.const 105)) (i32.const 1)) (then (unreachable)))
+      (if (i32.ne (call $new1 (i32.const 105)) (i32.const 1)) (then (unreachable)))
+      (if (i32.ne (call $new2 (i32.const 105)) (i32.const 2)) (then (unreachable)))
 
       ;; use different drops out of order
-      (call $drop2 (i32.const 0))
-      (call $drop1 (i32.const 1))
+      (call $drop2 (i32.const 1))
+      (call $drop1 (i32.const 2))
     )
 
     (start $start)
@@ -701,8 +701,8 @@
       (local.set $r2 (call $new2 (i32.const 200)))
 
       ;; both should be index 0
-      (if (i32.ne (local.get $r1) (i32.const 0)) (then (unreachable)))
-      (if (i32.ne (local.get $r2) (i32.const 0)) (then (unreachable)))
+      (if (i32.ne (local.get $r1) (i32.const 1)) (then (unreachable)))
+      (if (i32.ne (local.get $r2) (i32.const 1)) (then (unreachable)))
 
       ;; nothing should be dropped yet
       (if (i32.ne (call $drops) (i32.const 0)) (then (unreachable)))
@@ -866,7 +866,7 @@
 
       ;; table should be empty at this point, so a fresh allocation should get
       ;; index 0
-      (if (i32.ne (call $ctor (i32.const 600)) (i32.const 0)) (then (unreachable)))
+      (if (i32.ne (call $ctor (i32.const 600)) (i32.const 1)) (then (unreachable)))
     )
 
     (start $start)
@@ -1024,8 +1024,8 @@
         (local.set $r1 (call $ctor (i32.const 100)))
         (local.set $r2 (call $ctor (i32.const 200)))
 
-        (if (i32.ne (local.get $r1) (i32.const 0)) (then (unreachable)))
-        (if (i32.ne (local.get $r2) (i32.const 1)) (then (unreachable)))
+        (if (i32.ne (local.get $r1) (i32.const 1)) (then (unreachable)))
+        (if (i32.ne (local.get $r2) (i32.const 2)) (then (unreachable)))
 
         (call $assert-borrow (local.get $r2) (i32.const 200))
         (call $assert-borrow (local.get $r1) (i32.const 100))


### PR DESCRIPTION
This commit updates the allocation scheme for resources in the component model to start at 1 instead of 0 when communicating with components. This is an implementation of WebAssembly/component-model#284.

While this broke a number of tests we have this shouldn't actually break any components in practice. The broken tests were all overly-precise in their assertions and error messages and this shouldn't idiomatically come up in any guest language, so this should not be a practically breaking change.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
