### PR TITLE
[WASI] Dynamic `SocketAddr` check for outbound socket traffic

### DIFF
--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -1,4 +1,7 @@
-use super::clocks::host::{monotonic_clock, wall_clock};
+use super::{
+    clocks::host::{monotonic_clock, wall_clock},
+    network::Pool,
+};
 use crate::preview2::{
     clocks::{self, HostMonotonicClock, HostWallClock},
     filesystem::Dir,
@@ -7,12 +10,9 @@ use crate::preview2::{
     DirPerms, FilePerms,
 };
 use cap_rand::{Rng, RngCore, SeedableRng};
-use cap_std::ipnet::{self, IpNet};
-use cap_std::net::Pool;
-use cap_std::{ambient_authority, AmbientAuthority};
-use std::mem;
-use std::net::{Ipv4Addr, Ipv6Addr};
+use cap_std::ipnet;
 use std::sync::Arc;
+use std::{mem, net::SocketAddr};
 use wasmtime::component::ResourceTable;
 
 pub struct WasiCtxBuilder {
@@ -191,16 +191,22 @@ impl WasiCtxBuilder {
         self
     }
 
-    /// Add all network addresses accessable to the host to the pool.
-    pub fn inherit_network(&mut self, ambient_authority: AmbientAuthority) -> &mut Self {
-        self.pool.insert_ip_net_port_any(
-            IpNet::new(Ipv4Addr::UNSPECIFIED.into(), 0).unwrap(),
-            ambient_authority,
-        );
-        self.pool.insert_ip_net_port_any(
-            IpNet::new(Ipv6Addr::UNSPECIFIED.into(), 0).unwrap(),
-            ambient_authority,
-        );
+    /// Add all network addresses accessible to the host to the pool.
+    pub fn inherit_network(&mut self) -> &mut Self {
+        self.pool.inherit_network();
+        self
+    }
+
+    /// Add a dynamic check of whether a socket addr is allowed
+    ///
+    /// Returning `true` will permit socket connections to the `SocketAddr`,
+    /// while returning `false` will lead to the other non-dynamic checks
+    /// being performed.
+    pub fn dynamic_socket_addr_check<F>(&mut self, check: F) -> &mut Self
+    where
+        F: Fn(SocketAddr) -> bool + Send + Sync + 'static,
+    {
+        self.pool.add_dynamic_check(Box::new(check));
         self
     }
 
@@ -209,13 +215,13 @@ impl WasiCtxBuilder {
         &mut self,
         addrs: A,
     ) -> std::io::Result<&mut Self> {
-        self.pool.insert(addrs, ambient_authority())?;
+        self.pool.insert(addrs)?;
         Ok(self)
     }
 
     /// Add a specific [`cap_std::net::SocketAddr`] to the pool.
     pub fn insert_socket_addr(&mut self, addr: cap_std::net::SocketAddr) -> &mut Self {
-        self.pool.insert_socket_addr(addr, ambient_authority());
+        let _ = self.insert_addr(addr);
         self
     }
 
@@ -223,8 +229,7 @@ impl WasiCtxBuilder {
     ///
     /// Unlike `insert_ip_net`, this function grants access to any requested port.
     pub fn insert_ip_net_port_any(&mut self, ip_net: ipnet::IpNet) -> &mut Self {
-        self.pool
-            .insert_ip_net_port_any(ip_net, ambient_authority());
+        self.pool.insert_ip_net_port_any(ip_net);
         self
     }
 
@@ -240,13 +245,13 @@ impl WasiCtxBuilder {
         ports_end: Option<u16>,
     ) -> &mut Self {
         self.pool
-            .insert_ip_net_port_range(ip_net, ports_start, ports_end, ambient_authority());
+            .insert_ip_net_port_range(ip_net, ports_start, ports_end);
         self
     }
 
     /// Add a range of network addresses with a specific port to the pool.
     pub fn insert_ip_net(&mut self, ip_net: ipnet::IpNet, port: u16) -> &mut Self {
-        self.pool.insert_ip_net(ip_net, port, ambient_authority());
+        self.pool.insert_ip_net(ip_net, port);
         self
     }
 

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -4,7 +4,7 @@ use crate::preview2::{
         HostMonotonicClock, HostWallClock,
     },
     filesystem::Dir,
-    network::SocketAddrCheck,
+    network::{SocketAddrCheck, SocketAddrUse},
     pipe, random, stdio,
     stdio::{StdinStream, StdoutStream},
     DirPerms, FilePerms,
@@ -21,7 +21,6 @@ pub struct WasiCtxBuilder {
     env: Vec<(String, String)>,
     args: Vec<String>,
     preopens: Vec<(Dir, String)>,
-
     socket_addr_check: SocketAddrCheck,
     random: Box<dyn RngCore + Send + Sync>,
     insecure_random: Box<dyn RngCore + Send + Sync>,
@@ -190,7 +189,7 @@ impl WasiCtxBuilder {
 
     /// Allow all network addresses accessible to the host
     pub fn inherit_network(&mut self) -> &mut Self {
-        self.socket_addr_check(|_| true)
+        self.socket_addr_check(|_, _| true)
     }
 
     /// A check that will be called for each socket address that is used.
@@ -199,7 +198,7 @@ impl WasiCtxBuilder {
     /// while returning `false` will reject the connection.
     pub fn socket_addr_check<F>(&mut self, check: F) -> &mut Self
     where
-        F: Fn(&SocketAddr) -> bool + Send + Sync + 'static,
+        F: Fn(&SocketAddr, SocketAddrUse) -> bool + Send + Sync + 'static,
     {
         self.socket_addr_check = SocketAddrCheck(Arc::new(check));
         self

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -1,16 +1,15 @@
-use super::{
-    clocks::host::{monotonic_clock, wall_clock},
-    network::Pool,
-};
 use crate::preview2::{
-    clocks::{self, HostMonotonicClock, HostWallClock},
+    clocks::{
+        host::{monotonic_clock, wall_clock},
+        HostMonotonicClock, HostWallClock,
+    },
     filesystem::Dir,
+    network::SocketAddrCheck,
     pipe, random, stdio,
     stdio::{StdinStream, StdoutStream},
     DirPerms, FilePerms,
 };
 use cap_rand::{Rng, RngCore, SeedableRng};
-use cap_std::ipnet;
 use std::sync::Arc;
 use std::{mem, net::SocketAddr};
 use wasmtime::component::ResourceTable;
@@ -23,7 +22,7 @@ pub struct WasiCtxBuilder {
     args: Vec<String>,
     preopens: Vec<(Dir, String)>,
 
-    pool: Pool,
+    socket_addr_check: SocketAddrCheck,
     random: Box<dyn RngCore + Send + Sync>,
     insecure_random: Box<dyn RngCore + Send + Sync>,
     insecure_random_seed: u128,
@@ -73,7 +72,7 @@ impl WasiCtxBuilder {
             env: Vec::new(),
             args: Vec::new(),
             preopens: Vec::new(),
-            pool: Pool::new(),
+            socket_addr_check: SocketAddrCheck::default(),
             random: random::thread_rng(),
             insecure_random,
             insecure_random_seed,
@@ -173,85 +172,36 @@ impl WasiCtxBuilder {
         self.insecure_random = Box::new(insecure_random);
         self
     }
+
     pub fn insecure_random_seed(&mut self, insecure_random_seed: u128) -> &mut Self {
         self.insecure_random_seed = insecure_random_seed;
         self
     }
 
-    pub fn wall_clock(&mut self, clock: impl clocks::HostWallClock + 'static) -> &mut Self {
+    pub fn wall_clock(&mut self, clock: impl HostWallClock + 'static) -> &mut Self {
         self.wall_clock = Box::new(clock);
         self
     }
 
-    pub fn monotonic_clock(
-        &mut self,
-        clock: impl clocks::HostMonotonicClock + 'static,
-    ) -> &mut Self {
+    pub fn monotonic_clock(&mut self, clock: impl HostMonotonicClock + 'static) -> &mut Self {
         self.monotonic_clock = Box::new(clock);
         self
     }
 
-    /// Add all network addresses accessible to the host to the pool.
+    /// Allow all network addresses accessible to the host
     pub fn inherit_network(&mut self) -> &mut Self {
-        self.pool.inherit_network();
-        self
+        self.socket_addr_check(|_| true)
     }
 
-    /// Add a dynamic check of whether a socket addr is allowed
+    /// A check that will be called for each socket address that is used.
     ///
     /// Returning `true` will permit socket connections to the `SocketAddr`,
-    /// while returning `false` will lead to the other non-dynamic checks
-    /// being performed.
-    pub fn dynamic_socket_addr_check<F>(&mut self, check: F) -> &mut Self
+    /// while returning `false` will reject the connection.
+    pub fn socket_addr_check<F>(&mut self, check: F) -> &mut Self
     where
-        F: Fn(SocketAddr) -> bool + Send + Sync + 'static,
+        F: Fn(&SocketAddr) -> bool + Send + Sync + 'static,
     {
-        self.pool.add_dynamic_check(Box::new(check));
-        self
-    }
-
-    /// Add network addresses to the pool.
-    pub fn insert_addr<A: cap_std::net::ToSocketAddrs>(
-        &mut self,
-        addrs: A,
-    ) -> std::io::Result<&mut Self> {
-        self.pool.insert(addrs)?;
-        Ok(self)
-    }
-
-    /// Add a specific [`cap_std::net::SocketAddr`] to the pool.
-    pub fn insert_socket_addr(&mut self, addr: cap_std::net::SocketAddr) -> &mut Self {
-        let _ = self.insert_addr(addr);
-        self
-    }
-
-    /// Add a range of network addresses, accepting any port, to the pool.
-    ///
-    /// Unlike `insert_ip_net`, this function grants access to any requested port.
-    pub fn insert_ip_net_port_any(&mut self, ip_net: ipnet::IpNet) -> &mut Self {
-        self.pool.insert_ip_net_port_any(ip_net);
-        self
-    }
-
-    /// Add a range of network addresses, accepting a range of ports, to
-    /// per-instance networks.
-    ///
-    /// This grants access to the port range starting at `ports_start` and, if
-    /// `ports_end` is provided, ending before `ports_end`.
-    pub fn insert_ip_net_port_range(
-        &mut self,
-        ip_net: ipnet::IpNet,
-        ports_start: u16,
-        ports_end: Option<u16>,
-    ) -> &mut Self {
-        self.pool
-            .insert_ip_net_port_range(ip_net, ports_start, ports_end);
-        self
-    }
-
-    /// Add a range of network addresses with a specific port to the pool.
-    pub fn insert_ip_net(&mut self, ip_net: ipnet::IpNet, port: u16) -> &mut Self {
-        self.pool.insert_ip_net(ip_net, port);
+        self.socket_addr_check = SocketAddrCheck(Arc::new(check));
         self
     }
 
@@ -291,7 +241,7 @@ impl WasiCtxBuilder {
             env,
             args,
             preopens,
-            pool,
+            socket_addr_check,
             random,
             insecure_random,
             insecure_random_seed,
@@ -309,7 +259,7 @@ impl WasiCtxBuilder {
             env,
             args,
             preopens,
-            pool: Arc::new(pool),
+            socket_addr_check,
             random,
             insecure_random,
             insecure_random_seed,
@@ -339,7 +289,7 @@ pub struct WasiCtx {
     pub(crate) stdin: Box<dyn StdinStream>,
     pub(crate) stdout: Box<dyn StdoutStream>,
     pub(crate) stderr: Box<dyn StdoutStream>,
-    pub(crate) pool: Arc<Pool>,
+    pub(crate) socket_addr_check: SocketAddrCheck,
     pub(crate) allowed_network_uses: AllowedNetworkUses,
 }
 
@@ -365,8 +315,7 @@ impl AllowedNetworkUses {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
                 "UDP is not allowed",
-            )
-            .into());
+            ));
         }
 
         Ok(())
@@ -377,8 +326,7 @@ impl AllowedNetworkUses {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::PermissionDenied,
                 "TCP is not allowed",
-            )
-            .into());
+            ));
         }
 
         Ok(())

--- a/crates/wasi/src/preview2/host/instance_network.rs
+++ b/crates/wasi/src/preview2/host/instance_network.rs
@@ -6,7 +6,7 @@ use wasmtime::component::Resource;
 impl<T: WasiView> instance_network::Host for T {
     fn instance_network(&mut self) -> Result<Resource<Network>, anyhow::Error> {
         let network = Network {
-            pool: self.ctx().pool.clone(),
+            socket_addr_check: self.ctx().socket_addr_check.clone(),
             allow_ip_name_lookup: self.ctx().allowed_network_uses.ip_name_lookup,
         };
         let network = self.table_mut().push(network)?;

--- a/crates/wasi/src/preview2/host/network.rs
+++ b/crates/wasi/src/preview2/host/network.rs
@@ -218,7 +218,7 @@ pub(crate) mod util {
     use crate::preview2::bindings::sockets::network::ErrorCode;
     use crate::preview2::network::SocketAddressFamily;
     use crate::preview2::SocketResult;
-    use cap_net_ext::{Blocking, TcpBinder, TcpConnecter, TcpListenerExt, UdpBinder};
+    use cap_net_ext::{Blocking, TcpListenerExt};
     use cap_std::net::{TcpListener, TcpStream, UdpSocket};
     use rustix::fd::AsFd;
     use rustix::io::Errno;
@@ -302,42 +302,38 @@ pub(crate) mod util {
      * Syscalls wrappers with (opinionated) portability fixes.
      */
 
-    pub fn tcp_bind(listener: &TcpListener, binder: &TcpBinder) -> std::io::Result<()> {
-        binder
-            .bind_existing_tcp_listener(listener)
-            .map_err(|error| match Errno::from_io_error(&error) {
-                // See: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind#:~:text=WSAENOBUFS
-                // Windows returns WSAENOBUFS when the ephemeral ports have been exhausted.
-                #[cfg(windows)]
-                Some(Errno::NOBUFS) => Errno::ADDRINUSE.into(),
-                _ => error,
-            })
+    pub fn tcp_bind(listener: &TcpListener, addr: &SocketAddr) -> std::io::Result<()> {
+        rustix::net::bind(listener, addr).map_err(|error| match error {
+            // See: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind#:~:text=WSAENOBUFS
+            // Windows returns WSAENOBUFS when the ephemeral ports have been exhausted.
+            #[cfg(windows)]
+            Errno::NOBUFS => Errno::ADDRINUSE.into(),
+            _ => error.into(),
+        })
     }
 
-    pub fn udp_bind(socket: &UdpSocket, binder: &UdpBinder) -> std::io::Result<()> {
-        binder.bind_existing_udp_socket(socket).map_err(|error| {
-            match Errno::from_io_error(&error) {
+    pub fn udp_bind(socket: &UdpSocket, addr: &SocketAddr) -> std::io::Result<()> {
+        rustix::net::bind(socket, addr).map_err(|error| {
+            match error {
                 // See: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind#:~:text=WSAENOBUFS
                 // Windows returns WSAENOBUFS when the ephemeral ports have been exhausted.
                 #[cfg(windows)]
                 Some(Errno::NOBUFS) => Errno::ADDRINUSE.into(),
-                _ => error,
+                _ => error.into(),
             }
         })
     }
 
-    pub fn tcp_connect(listener: &TcpListener, connecter: &TcpConnecter) -> std::io::Result<()> {
-        connecter.connect_existing_tcp_listener(listener).map_err(
-            |error| match Errno::from_io_error(&error) {
-                // On POSIX, non-blocking `connect` returns `EINPROGRESS`.
-                // Windows returns `WSAEWOULDBLOCK`.
-                //
-                // This normalized error code is depended upon by: tcp.rs
-                #[cfg(windows)]
-                Some(Errno::WOULDBLOCK) => Errno::INPROGRESS.into(),
-                _ => error,
-            },
-        )
+    pub fn tcp_connect(listener: &TcpListener, addr: &SocketAddr) -> std::io::Result<()> {
+        rustix::net::connect(listener, addr).map_err(|error| match error {
+            // On POSIX, non-blocking `connect` returns `EINPROGRESS`.
+            // Windows returns `WSAEWOULDBLOCK`.
+            //
+            // This normalized error code is depended upon by: tcp.rs
+            #[cfg(windows)]
+            Some(Errno::WOULDBLOCK) => Errno::INPROGRESS.into(),
+            _ => error.into(),
+        })
     }
 
     pub fn tcp_listen(listener: &TcpListener, backlog: Option<i32>) -> std::io::Result<()> {

--- a/crates/wasi/src/preview2/host/network.rs
+++ b/crates/wasi/src/preview2/host/network.rs
@@ -318,7 +318,7 @@ pub(crate) mod util {
                 // See: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind#:~:text=WSAENOBUFS
                 // Windows returns WSAENOBUFS when the ephemeral ports have been exhausted.
                 #[cfg(windows)]
-                Some(Errno::NOBUFS) => Errno::ADDRINUSE.into(),
+                Errno::NOBUFS => Errno::ADDRINUSE.into(),
                 _ => error.into(),
             }
         })
@@ -331,7 +331,7 @@ pub(crate) mod util {
             //
             // This normalized error code is depended upon by: tcp.rs
             #[cfg(windows)]
-            Some(Errno::WOULDBLOCK) => Errno::INPROGRESS.into(),
+            Errno::WOULDBLOCK => Errno::INPROGRESS.into(),
             _ => error.into(),
         })
     }

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -1,4 +1,5 @@
 use crate::preview2::host::network::util;
+use crate::preview2::network::SocketAddrUse;
 use crate::preview2::tcp::{TcpSocket, TcpState};
 use crate::preview2::{
     bindings::{
@@ -45,7 +46,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
 
         {
             // Ensure that we're allowed to connect to this address.
-            network.check_socket_addr(&local_address)?;
+            network.check_socket_addr(&local_address, SocketAddrUse::TcpBind)?;
             let listener = &*socket.tcp_socket().as_socketlike_view::<TcpListener>();
 
             // Perform the OS bind call.
@@ -114,7 +115,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
             util::validate_address_family(&remote_address, &socket.family)?;
 
             // Ensure that we're allowed to connect to this address.
-            network.check_socket_addr(&remote_address)?;
+            network.check_socket_addr(&remote_address, SocketAddrUse::TcpConnect)?;
             let listener = &*socket.tcp_socket().as_socketlike_view::<TcpListener>();
 
             // Do an OS `connect`. Our socket is non-blocking, so it'll either...

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -9,7 +9,7 @@ use crate::preview2::{
     network::SocketAddressFamily,
 };
 use crate::preview2::{Pollable, SocketResult, WasiView};
-use cap_net_ext::{Blocking, PoolExt};
+use cap_net_ext::Blocking;
 use cap_std::net::TcpListener;
 use io_lifetimes::AsSocketlike;
 use rustix::io::Errno;

--- a/crates/wasi/src/preview2/host/udp.rs
+++ b/crates/wasi/src/preview2/host/udp.rs
@@ -11,7 +11,6 @@ use crate::preview2::{
 use crate::preview2::{Pollable, SocketError, SocketResult, WasiView};
 use anyhow::anyhow;
 use async_trait::async_trait;
-use cap_net_ext::PoolExt;
 use io_lifetimes::AsSocketlike;
 use rustix::io::Errno;
 use rustix::net::sockopt;
@@ -461,8 +460,7 @@ impl<T: WasiView> udp::HostOutgoingDatagramStream for T {
                     let Some(pool) = stream.pool.as_ref() else {
                         return Err(ErrorCode::InvalidState.into());
                     };
-                    // We don't actually use the connecter, we just use it to verify that `addr`
-                    // is allowed. We only need to check the provided addr as the stream's remote
+                    // We only need to check the provided addr as the stream's remote
                     // address was checked when the stream was created.
                     let _ = pool.udp_connecter(addr)?;
                     addr

--- a/crates/wasi/src/preview2/network.rs
+++ b/crates/wasi/src/preview2/network.rs
@@ -1,117 +1,40 @@
 use crate::preview2::bindings::sockets::network::{Ipv4Address, Ipv6Address};
 use crate::preview2::bindings::wasi::sockets::network::ErrorCode;
 use crate::preview2::TrappableError;
-use cap_net_ext::{PoolExt, TcpBinder, TcpConnecter, UdpBinder, UdpConnecter};
-use cap_std::ipnet::IpNet;
-use cap_std::net as cap_net;
-use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 pub struct Network {
-    pub pool: Arc<Pool>,
+    pub socket_addr_check: SocketAddrCheck,
     pub allow_ip_name_lookup: bool,
 }
 
-pub struct Pool {
-    inner: cap_net::Pool,
-    all_allowed: cap_net::Pool,
-    check: Option<Box<dyn Fn(SocketAddr) -> bool + Send + Sync>>,
+impl Network {
+    pub fn check_socket_addr(&self, addr: &SocketAddr) -> std::io::Result<()> {
+        self.socket_addr_check.check(addr)
+    }
 }
 
-impl Pool {
-    pub fn new() -> Self {
-        let mut all_allowed = cap_net::Pool::new();
-        all_allowed.insert_ip_net_port_any(
-            IpNet::new(Ipv4Addr::UNSPECIFIED.into(), 0).unwrap(),
-            cap_std::ambient_authority(),
-        );
-        all_allowed.insert_ip_net_port_any(
-            IpNet::new(Ipv6Addr::UNSPECIFIED.into(), 0).unwrap(),
-            cap_std::ambient_authority(),
-        );
+/// A check that will be called for each socket address that is used.
+#[derive(Clone)]
+pub struct SocketAddrCheck(pub(crate) Arc<dyn Fn(&SocketAddr) -> bool + Send + Sync>);
 
-        Self {
-            inner: cap_net::Pool::new(),
-            all_allowed,
-            check: None,
+impl SocketAddrCheck {
+    pub fn check(&self, addr: &SocketAddr) -> std::io::Result<()> {
+        if (self.0)(addr) {
+            Ok(())
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::PermissionDenied,
+                "An address was not permitted by the socket address check.",
+            ))
         }
     }
+}
 
-    pub fn check_addr(&self, addr: SocketAddr) -> std::io::Result<()> {
-        // We don't actually use the connecter, we just use it to verify that `addr` is allowed
-        let _ = self.checked_inner(addr)?.udp_binder(addr)?;
-        Ok(())
-    }
-
-    pub fn tcp_binder(&self, addr: SocketAddr) -> std::io::Result<TcpBinder> {
-        self.checked_inner(addr)?.tcp_binder(addr)
-    }
-
-    pub fn tcp_connecter(&self, addr: SocketAddr) -> std::io::Result<TcpConnecter> {
-        self.checked_inner(addr)?.tcp_connecter(addr)
-    }
-
-    pub fn udp_binder(&self, addr: SocketAddr) -> std::io::Result<UdpBinder> {
-        self.checked_inner(addr)?.udp_binder(addr)
-    }
-
-    pub fn udp_connecter(&self, addr: SocketAddr) -> std::io::Result<UdpConnecter> {
-        self.checked_inner(addr)?.udp_connecter(addr)
-    }
-
-    pub fn add_dynamic_check(
-        &mut self,
-        func: Box<dyn Fn(SocketAddr) -> bool + Send + Sync + 'static>,
-    ) {
-        self.check = Some(func)
-    }
-
-    pub fn inherit_network(&mut self) {
-        self.inner.insert_ip_net_port_any(
-            IpNet::new(Ipv4Addr::UNSPECIFIED.into(), 0).unwrap(),
-            cap_std::ambient_authority(),
-        );
-        self.inner.insert_ip_net_port_any(
-            IpNet::new(Ipv6Addr::UNSPECIFIED.into(), 0).unwrap(),
-            cap_std::ambient_authority(),
-        );
-    }
-
-    pub fn insert<A: cap_std::net::ToSocketAddrs>(&mut self, addrs: A) -> std::io::Result<()> {
-        self.inner.insert(addrs, cap_std::ambient_authority())
-    }
-
-    pub(crate) fn insert_ip_net_port_any(&mut self, ip_net: IpNet) {
-        self.inner
-            .insert_ip_net_port_any(ip_net, cap_std::ambient_authority());
-    }
-
-    pub(crate) fn insert_ip_net_port_range(
-        &mut self,
-        ip_net: IpNet,
-        ports_start: u16,
-        ports_end: Option<u16>,
-    ) {
-        self.inner.insert_ip_net_port_range(
-            ip_net,
-            ports_start,
-            ports_end,
-            cap_std::ambient_authority(),
-        )
-    }
-
-    pub(crate) fn insert_ip_net(&mut self, ip_net: IpNet, port: u16) {
-        self.inner
-            .insert_ip_net(ip_net, port, cap_std::ambient_authority())
-    }
-
-    fn checked_inner(&self, addr: SocketAddr) -> std::io::Result<&cap_net::Pool> {
-        if let Some(check) = &self.check {
-            if check(addr) {
-                return Ok(&self.all_allowed);
-            }
-        }
-        Ok(&self.inner)
+impl Default for SocketAddrCheck {
+    fn default() -> Self {
+        Self(Arc::new(|_| false))
     }
 }
 

--- a/crates/wasi/src/preview2/network.rs
+++ b/crates/wasi/src/preview2/network.rs
@@ -1,12 +1,118 @@
 use crate::preview2::bindings::sockets::network::{Ipv4Address, Ipv6Address};
 use crate::preview2::bindings::wasi::sockets::network::ErrorCode;
 use crate::preview2::TrappableError;
-use cap_std::net::Pool;
+use cap_net_ext::{PoolExt, TcpBinder, TcpConnecter, UdpBinder, UdpConnecter};
+use cap_std::ipnet::IpNet;
+use cap_std::net as cap_net;
+use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 
 pub struct Network {
     pub pool: Arc<Pool>,
     pub allow_ip_name_lookup: bool,
+}
+
+pub struct Pool {
+    inner: cap_net::Pool,
+    all_allowed: cap_net::Pool,
+    check: Option<Box<dyn Fn(SocketAddr) -> bool + Send + Sync>>,
+}
+
+impl Pool {
+    pub fn new() -> Self {
+        let mut all_allowed = cap_net::Pool::new();
+        all_allowed.insert_ip_net_port_any(
+            IpNet::new(Ipv4Addr::UNSPECIFIED.into(), 0).unwrap(),
+            cap_std::ambient_authority(),
+        );
+        all_allowed.insert_ip_net_port_any(
+            IpNet::new(Ipv6Addr::UNSPECIFIED.into(), 0).unwrap(),
+            cap_std::ambient_authority(),
+        );
+
+        Self {
+            inner: cap_net::Pool::new(),
+            all_allowed,
+            check: None,
+        }
+    }
+
+    pub fn check_addr(&self, addr: SocketAddr) -> std::io::Result<()> {
+        // We don't actually use the connecter, we just use it to verify that `addr` is allowed
+        let _ = self.checked_inner(addr)?.udp_binder(addr)?;
+        Ok(())
+    }
+
+    pub fn tcp_binder(&self, addr: SocketAddr) -> std::io::Result<TcpBinder> {
+        self.checked_inner(addr)?.tcp_binder(addr)
+    }
+
+    pub fn tcp_connecter(&self, addr: SocketAddr) -> std::io::Result<TcpConnecter> {
+        self.checked_inner(addr)?.tcp_connecter(addr)
+    }
+
+    pub fn udp_binder(&self, addr: SocketAddr) -> std::io::Result<UdpBinder> {
+        self.checked_inner(addr)?.udp_binder(addr)
+    }
+
+    pub fn udp_connecter(&self, addr: SocketAddr) -> std::io::Result<UdpConnecter> {
+        self.checked_inner(addr)?.udp_connecter(addr)
+    }
+
+    pub fn add_dynamic_check(
+        &mut self,
+        func: Box<dyn Fn(SocketAddr) -> bool + Send + Sync + 'static>,
+    ) {
+        self.check = Some(func)
+    }
+
+    pub fn inherit_network(&mut self) {
+        self.inner.insert_ip_net_port_any(
+            IpNet::new(Ipv4Addr::UNSPECIFIED.into(), 0).unwrap(),
+            cap_std::ambient_authority(),
+        );
+        self.inner.insert_ip_net_port_any(
+            IpNet::new(Ipv6Addr::UNSPECIFIED.into(), 0).unwrap(),
+            cap_std::ambient_authority(),
+        );
+    }
+
+    pub fn insert<A: cap_std::net::ToSocketAddrs>(&mut self, addrs: A) -> std::io::Result<()> {
+        self.inner.insert(addrs, cap_std::ambient_authority())
+    }
+
+    pub(crate) fn insert_ip_net_port_any(&mut self, ip_net: IpNet) {
+        self.inner
+            .insert_ip_net_port_any(ip_net, cap_std::ambient_authority());
+    }
+
+    pub(crate) fn insert_ip_net_port_range(
+        &mut self,
+        ip_net: IpNet,
+        ports_start: u16,
+        ports_end: Option<u16>,
+    ) {
+        self.inner.insert_ip_net_port_range(
+            ip_net,
+            ports_start,
+            ports_end,
+            cap_std::ambient_authority(),
+        )
+    }
+
+    pub(crate) fn insert_ip_net(&mut self, ip_net: IpNet, port: u16) {
+        self.inner
+            .insert_ip_net(ip_net, port, cap_std::ambient_authority())
+    }
+
+    fn checked_inner(&self, addr: SocketAddr) -> std::io::Result<&cap_net::Pool> {
+        if let Some(check) = &self.check {
+            if check(addr) {
+                return Ok(&self.all_allowed);
+            }
+        }
+        Ok(&self.inner)
+    }
 }
 
 pub type SocketResult<T> = Result<T, SocketError>;

--- a/crates/wasi/src/preview2/udp.rs
+++ b/crates/wasi/src/preview2/udp.rs
@@ -2,13 +2,12 @@ use crate::preview2::poll::Subscribe;
 use crate::preview2::with_ambient_tokio_runtime;
 use async_trait::async_trait;
 use cap_net_ext::{AddressFamily, Blocking, UdpSocketExt};
-use cap_std::net::Pool;
 use io_lifetimes::raw::{FromRawSocketlike, IntoRawSocketlike};
 use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use super::network::SocketAddressFamily;
+use super::network::{Pool, SocketAddressFamily};
 
 /// The state of a UDP socket.
 ///

--- a/crates/wasi/src/preview2/udp.rs
+++ b/crates/wasi/src/preview2/udp.rs
@@ -7,7 +7,7 @@ use std::io;
 use std::net::SocketAddr;
 use std::sync::Arc;
 
-use super::network::{Pool, SocketAddressFamily};
+use super::network::{SocketAddrCheck, SocketAddressFamily};
 
 /// The state of a UDP socket.
 ///
@@ -43,8 +43,8 @@ pub struct UdpSocket {
     /// Socket address family.
     pub(crate) family: SocketAddressFamily,
 
-    /// The pool of allowed addresses
-    pub(crate) pool: Option<Arc<Pool>>,
+    /// The check of allowed addresses
+    pub(crate) socket_addr_check: Option<SocketAddrCheck>,
 }
 
 #[async_trait]
@@ -70,7 +70,7 @@ impl UdpSocket {
             inner: Arc::new(socket),
             udp_state: UdpState::Default,
             family: socket_address_family,
-            pool: None,
+            socket_addr_check: None,
         })
     }
 
@@ -109,8 +109,8 @@ pub struct OutgoingDatagramStream {
 
     pub(crate) send_state: SendState,
 
-    /// The pool of allowed addresses
-    pub(crate) pool: Option<Arc<Pool>>,
+    /// The check of allowed addresses
+    pub(crate) socket_addr_check: Option<SocketAddrCheck>,
 }
 
 pub(crate) enum SendState {

--- a/crates/wasi/tests/all/main.rs
+++ b/crates/wasi/tests/all/main.rs
@@ -1,5 +1,4 @@
 use anyhow::Result;
-use cap_std::ambient_authority;
 use tempfile::TempDir;
 use wasmtime::{
     component::{Component, Linker, ResourceTable},
@@ -64,7 +63,7 @@ fn store(engine: &Engine, name: &str, inherit_stdio: bool) -> Result<(Store<Ctx>
 
     builder
         .args(&[name, "."])
-        .inherit_network(ambient_authority())
+        .inherit_network()
         .allow_ip_name_lookup(true);
     println!("preopen: {:?}", workspace);
     let preopen_dir =

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -772,7 +772,7 @@ impl RunCommand {
         }
 
         if self.run.common.wasi.inherit_network == Some(true) {
-            builder.inherit_network(ambient_authority());
+            builder.inherit_network();
         }
         if let Some(enable) = self.run.common.wasi.allow_ip_name_lookup {
             builder.allow_ip_name_lookup(enable);


### PR DESCRIPTION
This PR adds the ability to do dynamic checks of whether to allow outbound socket traffic to a given `SocketAddr`. The checks are purely additive over the underlying `cap_std::net::Pool`. If the check returns `true` the traffic is allowed, while if it returns false, the underlying `cap_std::net::Pool` is then checked. 

This also changes the `WasiCtx::inherit_network` function to not take an `AmbientAuthority` since all other methods on `WasiCtx` do not take this value. 