### PR TITLE
Update `*_badfd` methods in the adapter to return an errno

### DIFF
--- a/crates/test-programs/src/bin/preview2_adapter_badfd.rs
+++ b/crates/test-programs/src/bin/preview2_adapter_badfd.rs
@@ -2,15 +2,15 @@ fn main() {
     #[link(wasm_import_module = "wasi_snapshot_preview1")]
     extern "C" {
         #[cfg_attr(target_arch = "wasm32", link_name = "adapter_open_badfd")]
-        fn adapter_open_badfd(fd: *mut u32) -> bool;
+        fn adapter_open_badfd(fd: *mut u32) -> wasi::Errno;
 
         #[cfg_attr(target_arch = "wasm32", link_name = "adapter_close_badfd")]
-        fn adapter_close_badfd(fd: u32) -> bool;
+        fn adapter_close_badfd(fd: u32) -> wasi::Errno;
     }
 
     unsafe {
         let mut fd = 0;
-        assert!(adapter_open_badfd(&mut fd));
+        assert_eq!(adapter_open_badfd(&mut fd), wasi::ERRNO_SUCCESS);
 
         assert_eq!(wasi::fd_close(fd), Err(wasi::ERRNO_BADF));
 
@@ -41,6 +41,6 @@ fn main() {
             Err(wasi::ERRNO_BADF)
         );
 
-        assert!(adapter_close_badfd(fd));
+        assert_eq!(adapter_close_badfd(fd), wasi::ERRNO_SUCCESS);
     }
 }

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -152,17 +152,17 @@ impl<T, E> TrappingUnwrap<T> for Result<T, E> {
 /// from WASI Preview 1 to Preview 2.  It will use this function to reserve
 /// descriptors for its own use, valid only for use with libc functions.
 #[no_mangle]
-pub unsafe extern "C" fn adapter_open_badfd(fd: *mut u32) -> bool {
+pub unsafe extern "C" fn adapter_open_badfd(fd: *mut u32) -> Errno {
     State::with(|state| {
         *fd = state.descriptors_mut().open(Descriptor::Bad)?;
         Ok(())
-    }) == wasi::ERRNO_SUCCESS
+    })
 }
 
 /// Close a descriptor previously opened using `adapter_open_badfd`.
 #[no_mangle]
-pub unsafe extern "C" fn adapter_close_badfd(fd: u32) -> bool {
-    State::with(|state| state.descriptors_mut().close(fd)) == wasi::ERRNO_SUCCESS
+pub unsafe extern "C" fn adapter_close_badfd(fd: u32) -> Errno {
+    State::with(|state| state.descriptors_mut().close(fd))
 }
 
 #[no_mangle]


### PR DESCRIPTION
Makes them a bit more consistent with the rest of the WASI functions as opposed to returning a boolean.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
