### PR TITLE
Remove unnecessary macro argument

### DIFF
--- a/crates/wasmtime/src/func/typed.rs
+++ b/crates/wasmtime/src/func/typed.rs
@@ -239,7 +239,7 @@ pub unsafe trait WasmTy: Send {
 }
 
 macro_rules! integers {
-    ($($primitive:ident/$get_primitive:ident => $ty:ident in $raw:ident)*) => ($(
+    ($($primitive:ident/$get_primitive:ident => $ty:ident)*) => ($(
         unsafe impl WasmTy for $primitive {
             type Abi = $primitive;
             #[inline]
@@ -275,10 +275,10 @@ macro_rules! integers {
 }
 
 integers! {
-    i32/get_i32 => I32 in i32
-    i64/get_i64 => I64 in i64
-    u32/get_u32 => I32 in i32
-    u64/get_u64 => I64 in i64
+    i32/get_i32 => I32
+    i64/get_i64 => I64
+    u32/get_u32 => I32
+    u64/get_u64 => I64
 }
 
 macro_rules! floats {


### PR DESCRIPTION
The `$raw:ident` in this macro was unused as far as I could tell; this change removes it.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
