### PR TITLE
feat(wasmtime): allow definition of dynamic resource types in the linker

### DIFF
--- a/crates/wit-bindgen/src/lib.rs
+++ b/crates/wit-bindgen/src/lib.rs
@@ -807,8 +807,9 @@ impl Wasmtime {
             let camel = name.to_upper_camel_case();
             uwriteln!(
                 self.src,
-                "linker.resource::<{camel}>(
+                "linker.resource(
                     \"{name}\",
+                    wasmtime::component::ResourceType::host::<{camel}>(),
                     move |mut store, rep| -> wasmtime::Result<()> {{
                         Host{camel}::drop(get(store.data_mut()), wasmtime::component::Resource::new_own(rep))
                     }},
@@ -1604,8 +1605,9 @@ impl<'a> InterfaceGenerator<'a> {
             let camel = name.to_upper_camel_case();
             uwriteln!(
                 self.src,
-                "inst.resource::<{camel}>(
+                "inst.resource(
                     \"{name}\",
+                    wasmtime::component::ResourceType::host::<{camel}>(),
                     move |mut store, rep| -> wasmtime::Result<()> {{
                         Host{camel}::drop(get(store.data_mut()), wasmtime::component::Resource::new_own(rep))
                     }},


### PR DESCRIPTION
This addresses the first part of https://github.com/bytecodealliance/wasmtime/issues/7676#issuecomment-1852531249, I still need to study the internals a bit more to figure out how to take `Resource<T>` into a `ResourceAny`, which will be addressed in a follow-up