### PR TITLE
Winch: Change emits to return TypedReg to put on stack

### DIFF
--- a/winch/codegen/src/stack.rs
+++ b/winch/codegen/src/stack.rs
@@ -34,6 +34,22 @@ impl TypedReg {
             reg,
         }
     }
+
+    /// Create an f64 [`TypedReg`].
+    pub fn f64(reg: Reg) -> Self {
+        Self {
+            ty: WasmType::F64,
+            reg,
+        }
+    }
+
+    /// Create an f32 [`TypedReg`].
+    pub fn f32(reg: Reg) -> Self {
+        Self {
+            ty: WasmType::F32,
+            reg,
+        }
+    }
 }
 
 impl From<TypedReg> for Reg {

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -203,6 +203,7 @@ where
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_add(dst, dst, src, size);
+                TypedReg::f32(dst)
             },
         );
     }
@@ -213,6 +214,7 @@ where
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_add(dst, dst, src, size);
+                TypedReg::f64(dst)
             },
         );
     }
@@ -223,6 +225,7 @@ where
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_sub(dst, dst, src, size);
+                TypedReg::f32(dst)
             },
         );
     }
@@ -233,6 +236,7 @@ where
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_sub(dst, dst, src, size);
+                TypedReg::f64(dst)
             },
         );
     }
@@ -243,6 +247,7 @@ where
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_mul(dst, dst, src, size);
+                TypedReg::f32(dst)
             },
         );
     }
@@ -253,6 +258,7 @@ where
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_mul(dst, dst, src, size);
+                TypedReg::f64(dst)
             },
         );
     }
@@ -263,6 +269,7 @@ where
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_div(dst, dst, src, size);
+                TypedReg::f32(dst)
             },
         );
     }
@@ -273,6 +280,7 @@ where
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_div(dst, dst, src, size);
+                TypedReg::f64(dst)
             },
         );
     }
@@ -283,6 +291,7 @@ where
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_min(dst, dst, src, size);
+                TypedReg::f32(dst)
             },
         );
     }
@@ -293,6 +302,7 @@ where
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_min(dst, dst, src, size);
+                TypedReg::f64(dst)
             },
         );
     }
@@ -303,6 +313,7 @@ where
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_max(dst, dst, src, size);
+                TypedReg::f32(dst)
             },
         );
     }
@@ -313,6 +324,7 @@ where
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_max(dst, dst, src, size);
+                TypedReg::f64(dst)
             },
         );
     }
@@ -323,6 +335,7 @@ where
             OperandSize::S32,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_copysign(dst, dst, src, size);
+                TypedReg::f32(dst)
             },
         );
     }
@@ -333,6 +346,7 @@ where
             OperandSize::S64,
             &mut |masm: &mut M, dst, src, size| {
                 masm.float_copysign(dst, dst, src, size);
+                TypedReg::f64(dst)
             },
         );
     }
@@ -341,6 +355,7 @@ where
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
                 masm.float_abs(reg, size);
+                TypedReg::f32(reg)
             });
     }
 
@@ -348,6 +363,7 @@ where
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
                 masm.float_abs(reg, size);
+                TypedReg::f64(reg)
             });
     }
 
@@ -355,6 +371,7 @@ where
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
                 masm.float_neg(reg, size);
+                TypedReg::f32(reg)
             });
     }
 
@@ -362,6 +379,7 @@ where
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
                 masm.float_neg(reg, size);
+                TypedReg::f64(reg)
             });
     }
 
@@ -409,6 +427,7 @@ where
         self.context
             .unop(self.masm, OperandSize::S32, &mut |masm, reg, size| {
                 masm.float_sqrt(reg, reg, size);
+                TypedReg::f32(reg)
             });
     }
 
@@ -416,6 +435,7 @@ where
         self.context
             .unop(self.masm, OperandSize::S64, &mut |masm, reg, size| {
                 masm.float_sqrt(reg, reg, size);
+                TypedReg::f64(reg)
             });
     }
 
@@ -542,36 +562,42 @@ where
     fn visit_i32_add(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
             masm.add(dst, dst, src, size);
+            TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_add(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
             masm.add(dst, dst, src, size);
+            TypedReg::i64(dst)
         });
     }
 
     fn visit_i32_sub(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
             masm.sub(dst, dst, src, size);
+            TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_sub(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
             masm.sub(dst, dst, src, size);
+            TypedReg::i64(dst)
         });
     }
 
     fn visit_i32_mul(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
             masm.mul(dst, dst, src, size);
+            TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_mul(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
             masm.mul(dst, dst, src, size);
+            TypedReg::i64(dst)
         });
     }
 
@@ -716,6 +742,7 @@ where
 
         self.context.unop(self.masm, S32, &mut |masm, reg, size| {
             masm.cmp_with_set(RegImm::i32(0), reg.into(), IntCmpKind::Eq, size);
+            TypedReg::i32(reg)
         });
     }
 
@@ -724,6 +751,7 @@ where
 
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
             masm.cmp_with_set(RegImm::i64(0), reg.into(), IntCmpKind::Eq, size);
+            TypedReg::i32(reg) // Return value for `i64.eqz` is an `i32`.
         });
     }
 
@@ -732,6 +760,7 @@ where
 
         self.context.unop(self.masm, S32, &mut |masm, reg, size| {
             masm.clz(reg, reg, size);
+            TypedReg::i32(reg)
         });
     }
 
@@ -740,6 +769,7 @@ where
 
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
             masm.clz(reg, reg, size);
+            TypedReg::i64(reg)
         });
     }
 
@@ -748,6 +778,7 @@ where
 
         self.context.unop(self.masm, S32, &mut |masm, reg, size| {
             masm.ctz(reg, reg, size);
+            TypedReg::i32(reg)
         });
     }
 
@@ -756,42 +787,49 @@ where
 
         self.context.unop(self.masm, S64, &mut |masm, reg, size| {
             masm.ctz(reg, reg, size);
+            TypedReg::i64(reg)
         });
     }
 
     fn visit_i32_and(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
             masm.and(dst, dst, src, size);
+            TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_and(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
             masm.and(dst, dst, src, size);
+            TypedReg::i64(dst)
         });
     }
 
     fn visit_i32_or(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
             masm.or(dst, dst, src, size);
+            TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_or(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
             masm.or(dst, dst, src, size);
+            TypedReg::i64(dst)
         });
     }
 
     fn visit_i32_xor(&mut self) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
             masm.xor(dst, dst, src, size);
+            TypedReg::i32(dst)
         });
     }
 
     fn visit_i64_xor(&mut self) {
         self.context.i64_binop(self.masm, |masm, dst, src, size| {
             masm.xor(dst, dst, src, size);
+            TypedReg::i64(dst)
         });
     }
 
@@ -1368,6 +1406,7 @@ where
     fn cmp_i32s(&mut self, kind: IntCmpKind) {
         self.context.i32_binop(self.masm, |masm, dst, src, size| {
             masm.cmp_with_set(src, dst, kind, size);
+            TypedReg::i32(dst)
         });
     }
 
@@ -1375,6 +1414,7 @@ where
         self.context
             .i64_binop(self.masm, move |masm, dst, src, size| {
                 masm.cmp_with_set(src, dst, kind, size);
+                TypedReg::i32(dst) // Return value for comparisons is an `i32`.
             });
     }
 }

--- a/winch/filetests/filetests/x64/i64_eq/locals.wat
+++ b/winch/filetests/filetests/x64/i64_eq/locals.wat
@@ -31,7 +31,7 @@
 ;;   3b:	 4839c1               	cmp	rcx, rax
 ;;   3e:	 b900000000           	mov	ecx, 0
 ;;   43:	 400f94c1             	sete	cl
-;;   47:	 4889c8               	mov	rax, rcx
-;;   4a:	 4883c418             	add	rsp, 0x18
-;;   4e:	 5d                   	pop	rbp
-;;   4f:	 c3                   	ret	
+;;   47:	 89c8                 	mov	eax, ecx
+;;   49:	 4883c418             	add	rsp, 0x18
+;;   4d:	 5d                   	pop	rbp
+;;   4e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_eq/params.wat
+++ b/winch/filetests/filetests/x64/i64_eq/params.wat
@@ -18,7 +18,7 @@
 ;;   20:	 4839c1               	cmp	rcx, rax
 ;;   23:	 b900000000           	mov	ecx, 0
 ;;   28:	 400f94c1             	sete	cl
-;;   2c:	 4889c8               	mov	rax, rcx
-;;   2f:	 4883c418             	add	rsp, 0x18
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89c8                 	mov	eax, ecx
+;;   2e:	 4883c418             	add	rsp, 0x18
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_eqz/spilled.wat
+++ b/winch/filetests/filetests/x64/i64_eqz/spilled.wat
@@ -1,0 +1,25 @@
+;;! target = "x86_64"
+
+(module
+    (func (result i32)
+        i64.const 1
+        i64.eqz
+        block
+        end
+    )
+)
+;;    0:	 55                   	push	rbp
+;;    1:	 4889e5               	mov	rbp, rsp
+;;    4:	 4883ec08             	sub	rsp, 8
+;;    8:	 4c893424             	mov	qword ptr [rsp], r14
+;;    c:	 48c7c001000000       	mov	rax, 1
+;;   13:	 4883f800             	cmp	rax, 0
+;;   17:	 b800000000           	mov	eax, 0
+;;   1c:	 400f94c0             	sete	al
+;;   20:	 4883ec04             	sub	rsp, 4
+;;   24:	 890424               	mov	dword ptr [rsp], eax
+;;   27:	 8b0424               	mov	eax, dword ptr [rsp]
+;;   2a:	 4883c404             	add	rsp, 4
+;;   2e:	 4883c408             	add	rsp, 8
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/locals.wat
@@ -31,7 +31,7 @@
 ;;   3b:	 4839c1               	cmp	rcx, rax
 ;;   3e:	 b900000000           	mov	ecx, 0
 ;;   43:	 400f9dc1             	setge	cl
-;;   47:	 4889c8               	mov	rax, rcx
-;;   4a:	 4883c418             	add	rsp, 0x18
-;;   4e:	 5d                   	pop	rbp
-;;   4f:	 c3                   	ret	
+;;   47:	 89c8                 	mov	eax, ecx
+;;   49:	 4883c418             	add	rsp, 0x18
+;;   4d:	 5d                   	pop	rbp
+;;   4e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/params.wat
@@ -18,7 +18,7 @@
 ;;   20:	 4839c1               	cmp	rcx, rax
 ;;   23:	 b900000000           	mov	ecx, 0
 ;;   28:	 400f9dc1             	setge	cl
-;;   2c:	 4889c8               	mov	rax, rcx
-;;   2f:	 4883c418             	add	rsp, 0x18
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89c8                 	mov	eax, ecx
+;;   2e:	 4883c418             	add	rsp, 0x18
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/locals.wat
@@ -31,7 +31,7 @@
 ;;   3b:	 4839c1               	cmp	rcx, rax
 ;;   3e:	 b900000000           	mov	ecx, 0
 ;;   43:	 400f93c1             	setae	cl
-;;   47:	 4889c8               	mov	rax, rcx
-;;   4a:	 4883c418             	add	rsp, 0x18
-;;   4e:	 5d                   	pop	rbp
-;;   4f:	 c3                   	ret	
+;;   47:	 89c8                 	mov	eax, ecx
+;;   49:	 4883c418             	add	rsp, 0x18
+;;   4d:	 5d                   	pop	rbp
+;;   4e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ge_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/params.wat
@@ -18,7 +18,7 @@
 ;;   20:	 4839c1               	cmp	rcx, rax
 ;;   23:	 b900000000           	mov	ecx, 0
 ;;   28:	 400f93c1             	setae	cl
-;;   2c:	 4889c8               	mov	rax, rcx
-;;   2f:	 4883c418             	add	rsp, 0x18
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89c8                 	mov	eax, ecx
+;;   2e:	 4883c418             	add	rsp, 0x18
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/locals.wat
@@ -31,7 +31,7 @@
 ;;   3b:	 4839c1               	cmp	rcx, rax
 ;;   3e:	 b900000000           	mov	ecx, 0
 ;;   43:	 400f9fc1             	setg	cl
-;;   47:	 4889c8               	mov	rax, rcx
-;;   4a:	 4883c418             	add	rsp, 0x18
-;;   4e:	 5d                   	pop	rbp
-;;   4f:	 c3                   	ret	
+;;   47:	 89c8                 	mov	eax, ecx
+;;   49:	 4883c418             	add	rsp, 0x18
+;;   4d:	 5d                   	pop	rbp
+;;   4e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/params.wat
@@ -18,7 +18,7 @@
 ;;   20:	 4839c1               	cmp	rcx, rax
 ;;   23:	 b900000000           	mov	ecx, 0
 ;;   28:	 400f9fc1             	setg	cl
-;;   2c:	 4889c8               	mov	rax, rcx
-;;   2f:	 4883c418             	add	rsp, 0x18
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89c8                 	mov	eax, ecx
+;;   2e:	 4883c418             	add	rsp, 0x18
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/locals.wat
@@ -31,7 +31,7 @@
 ;;   3b:	 4839c1               	cmp	rcx, rax
 ;;   3e:	 b900000000           	mov	ecx, 0
 ;;   43:	 400f97c1             	seta	cl
-;;   47:	 4889c8               	mov	rax, rcx
-;;   4a:	 4883c418             	add	rsp, 0x18
-;;   4e:	 5d                   	pop	rbp
-;;   4f:	 c3                   	ret	
+;;   47:	 89c8                 	mov	eax, ecx
+;;   49:	 4883c418             	add	rsp, 0x18
+;;   4d:	 5d                   	pop	rbp
+;;   4e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_gt_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/params.wat
@@ -18,7 +18,7 @@
 ;;   20:	 4839c1               	cmp	rcx, rax
 ;;   23:	 b900000000           	mov	ecx, 0
 ;;   28:	 400f97c1             	seta	cl
-;;   2c:	 4889c8               	mov	rax, rcx
-;;   2f:	 4883c418             	add	rsp, 0x18
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89c8                 	mov	eax, ecx
+;;   2e:	 4883c418             	add	rsp, 0x18
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/locals.wat
@@ -31,7 +31,7 @@
 ;;   3b:	 4839c1               	cmp	rcx, rax
 ;;   3e:	 b900000000           	mov	ecx, 0
 ;;   43:	 400f9ec1             	setle	cl
-;;   47:	 4889c8               	mov	rax, rcx
-;;   4a:	 4883c418             	add	rsp, 0x18
-;;   4e:	 5d                   	pop	rbp
-;;   4f:	 c3                   	ret	
+;;   47:	 89c8                 	mov	eax, ecx
+;;   49:	 4883c418             	add	rsp, 0x18
+;;   4d:	 5d                   	pop	rbp
+;;   4e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/params.wat
@@ -18,7 +18,7 @@
 ;;   20:	 4839c1               	cmp	rcx, rax
 ;;   23:	 b900000000           	mov	ecx, 0
 ;;   28:	 400f9ec1             	setle	cl
-;;   2c:	 4889c8               	mov	rax, rcx
-;;   2f:	 4883c418             	add	rsp, 0x18
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89c8                 	mov	eax, ecx
+;;   2e:	 4883c418             	add	rsp, 0x18
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/locals.wat
@@ -31,7 +31,7 @@
 ;;   3b:	 4839c1               	cmp	rcx, rax
 ;;   3e:	 b900000000           	mov	ecx, 0
 ;;   43:	 400f96c1             	setbe	cl
-;;   47:	 4889c8               	mov	rax, rcx
-;;   4a:	 4883c418             	add	rsp, 0x18
-;;   4e:	 5d                   	pop	rbp
-;;   4f:	 c3                   	ret	
+;;   47:	 89c8                 	mov	eax, ecx
+;;   49:	 4883c418             	add	rsp, 0x18
+;;   4d:	 5d                   	pop	rbp
+;;   4e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_le_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/params.wat
@@ -18,7 +18,7 @@
 ;;   20:	 4839c1               	cmp	rcx, rax
 ;;   23:	 b900000000           	mov	ecx, 0
 ;;   28:	 400f96c1             	setbe	cl
-;;   2c:	 4889c8               	mov	rax, rcx
-;;   2f:	 4883c418             	add	rsp, 0x18
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89c8                 	mov	eax, ecx
+;;   2e:	 4883c418             	add	rsp, 0x18
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/locals.wat
@@ -32,7 +32,7 @@
 ;;   3b:	 4839c1               	cmp	rcx, rax
 ;;   3e:	 b900000000           	mov	ecx, 0
 ;;   43:	 400f9cc1             	setl	cl
-;;   47:	 4889c8               	mov	rax, rcx
-;;   4a:	 4883c418             	add	rsp, 0x18
-;;   4e:	 5d                   	pop	rbp
-;;   4f:	 c3                   	ret	
+;;   47:	 89c8                 	mov	eax, ecx
+;;   49:	 4883c418             	add	rsp, 0x18
+;;   4d:	 5d                   	pop	rbp
+;;   4e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/params.wat
@@ -19,7 +19,7 @@
 ;;   20:	 4839c1               	cmp	rcx, rax
 ;;   23:	 b900000000           	mov	ecx, 0
 ;;   28:	 400f9cc1             	setl	cl
-;;   2c:	 4889c8               	mov	rax, rcx
-;;   2f:	 4883c418             	add	rsp, 0x18
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89c8                 	mov	eax, ecx
+;;   2e:	 4883c418             	add	rsp, 0x18
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/locals.wat
@@ -31,7 +31,7 @@
 ;;   3b:	 4839c1               	cmp	rcx, rax
 ;;   3e:	 b900000000           	mov	ecx, 0
 ;;   43:	 400f92c1             	setb	cl
-;;   47:	 4889c8               	mov	rax, rcx
-;;   4a:	 4883c418             	add	rsp, 0x18
-;;   4e:	 5d                   	pop	rbp
-;;   4f:	 c3                   	ret	
+;;   47:	 89c8                 	mov	eax, ecx
+;;   49:	 4883c418             	add	rsp, 0x18
+;;   4d:	 5d                   	pop	rbp
+;;   4e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_lt_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/params.wat
@@ -18,7 +18,7 @@
 ;;   20:	 4839c1               	cmp	rcx, rax
 ;;   23:	 b900000000           	mov	ecx, 0
 ;;   28:	 400f92c1             	setb	cl
-;;   2c:	 4889c8               	mov	rax, rcx
-;;   2f:	 4883c418             	add	rsp, 0x18
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89c8                 	mov	eax, ecx
+;;   2e:	 4883c418             	add	rsp, 0x18
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ne/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ne/locals.wat
@@ -32,7 +32,7 @@
 ;;   3b:	 4839c1               	cmp	rcx, rax
 ;;   3e:	 b900000000           	mov	ecx, 0
 ;;   43:	 400f95c1             	setne	cl
-;;   47:	 4889c8               	mov	rax, rcx
-;;   4a:	 4883c418             	add	rsp, 0x18
-;;   4e:	 5d                   	pop	rbp
-;;   4f:	 c3                   	ret	
+;;   47:	 89c8                 	mov	eax, ecx
+;;   49:	 4883c418             	add	rsp, 0x18
+;;   4d:	 5d                   	pop	rbp
+;;   4e:	 c3                   	ret	

--- a/winch/filetests/filetests/x64/i64_ne/params.wat
+++ b/winch/filetests/filetests/x64/i64_ne/params.wat
@@ -19,7 +19,7 @@
 ;;   20:	 4839c1               	cmp	rcx, rax
 ;;   23:	 b900000000           	mov	ecx, 0
 ;;   28:	 400f95c1             	setne	cl
-;;   2c:	 4889c8               	mov	rax, rcx
-;;   2f:	 4883c418             	add	rsp, 0x18
-;;   33:	 5d                   	pop	rbp
-;;   34:	 c3                   	ret	
+;;   2c:	 89c8                 	mov	eax, ecx
+;;   2e:	 4883c418             	add	rsp, 0x18
+;;   32:	 5d                   	pop	rbp
+;;   33:	 c3                   	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
There is a small bug where some instructions are putting values containing `TypedReg`s with the incorrect type on the stack. Specifically `i64.eqz` and the i64 comparison instructions. This change has the `emit` functions in the `unop` and `binop` helpers return the the typed registers to put on the stack instead of assigning a type that is the same as the input type.

The filetests for the comparison operators should now be moving the `e` variant of registers instead of the `r` variant of registers. I also needed to add an additional test for `i64.eqz` since the existing tests did not change as a result of fixing this issue.