### PR TITLE
fix(wasi-common): convert `ErrorKind::WouldBlock` instead of trapping

### DIFF
--- a/crates/wasi-common/src/snapshots/preview_1/error.rs
+++ b/crates/wasi-common/src/snapshots/preview_1/error.rs
@@ -216,6 +216,7 @@ impl From<std::io::Error> for Error {
                 std::io::ErrorKind::PermissionDenied => Errno::Perm.into(),
                 std::io::ErrorKind::AlreadyExists => Errno::Exist.into(),
                 std::io::ErrorKind::InvalidInput => Errno::Inval.into(),
+                std::io::ErrorKind::WouldBlock => Errno::Again.into(),
                 _ => Error::trap(anyhow::anyhow!(err).context("Unknown OS error")),
             },
         }


### PR DESCRIPTION
Fixes

```
Caused by:
    0: error while executing at wasm backtrace:
           0: 0x31b84 - wasi::lib_generated::fd_read::h1fcd502250db20a8
                           at /cargo/registry/src/index.crates.io-6f17d22bba15001f/wasi-0.11.0+wasi-snapshot-preview1/src/lib_generated.rs:1568:15
           1: 0x2d3c9 - std::sys::wasi::fd::WasiFd::read_buf::h1312cce7ac06e1bc
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/sys/wasi/fd.rs:55:19              - std::sys::wasi::fs::File::read_buf::h0ca7167b0ca5b60a
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/sys/wasi/fs.rs:444:9              - <std::fs::File as std::io::Read>::read_buf::h8adf939d301eeec5
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/fs.rs:754:9
           2: 0x90ca - std::io::impls::<impl std::io::Read for &mut R>::read_buf::he16fcc35b9c33c8b
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/io/impls.rs:25:9
           3: 0x906c - std::io::impls::<impl std::io::Read for &mut R>::read_buf::hc5e0ce1a6791ef6b
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/io/impls.rs:25:9
           4: 0xad21 - std::io::buffered::bufreader::buffer::Buffer::fill_buf::h3242158c3a177d7e
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/io/buffered/bufreader/buffer.rs:114:13
           5: 0xb260 - <std::io::buffered::bufreader::BufReader<R> as std::io::BufRead>::fill_buf::h4649de3e84258773
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/io/buffered/bufreader.rs:376:9
           6: 0xe8f9 - std::io::read_until::h9db73250f385c902
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/io/mod.rs:1928:35
           7: 0xef49 - std::io::BufRead::read_line::{{closure}}::h6bf04b54cf41082e
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/io/mod.rs:2223:44
           8: 0xed2c - std::io::append_to_string::he57ad3fa45facdec
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/io/mod.rs:340:15
           9: 0xaf70 - std::io::BufRead::read_line::h19a09c8def82c7d8
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/io/mod.rs:2223:18
          10: 0x12cec - enarx_wasm_tests::assert_copy_line::h5d59fd155afd7cc8
                           at /home/harald/git/enarx/enarx/tests/crates/enarx_wasm_tests/src/lib.rs:15:15
          11: 0x12a63 - enarx_wasm_tests::assert_stream::hbeb69ada561a9d6e
                           at /home/harald/git/enarx/enarx/tests/crates/enarx_wasm_tests/src/lib.rs:51:5
          12: 0x112fb - listen::main::h659bfd5eb99767e6
                           at /home/harald/git/enarx/enarx/tests/crates/enarx_wasm_tests/src/bin/listen.rs:41:5
          13: 0x971d - core::ops::function::FnOnce::call_once::h68036f3375670974
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/core/src/ops/function.rs:250:5
          14: 0x7330 - std::sys_common::backtrace::__rust_begin_short_backtrace::he16b7e0314041306
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/sys_common/backtrace.rs:134:18
          15: 0x1322b - std::rt::lang_start::{{closure}}::hdb99de76d99bbf78
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/rt.rs:166:18
          16: 0x2b405 - core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once::hef13acc07fb495a1
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/core/src/ops/function.rs:287:13              - std::panicking::try::do_call::hbe2c8138241fe21b
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/panicking.rs:485:40              - std::panicking::try::h1cede0ac0e99262c
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/panicking.rs:449:19              - std::panic::catch_unwind::h4d1cf95a1e500514
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/panic.rs:140:14              - std::rt::lang_start_internal::{{closure}}::h8997a9c00b45f195
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/rt.rs:148:48              - std::panicking::try::do_call::h0d25fe933c44f263
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/panicking.rs:485:40              - std::panicking::try::h2f9f2a031d18c02e
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/panicking.rs:449:19              - std::panic::catch_unwind::h4be34609b24e707a
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/panic.rs:140:14              - std::rt::lang_start_internal::h6c23e823dc99289d
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/rt.rs:148:20
          17: 0x131c7 - std::rt::lang_start::hf469253146897dfa
                           at /rustc/84dd17b56a931a631a23dfd5ef2018fd3ef49108/library/std/src/rt.rs:165:17
          18: 0x12039 - <unknown>!__main_void
          19:  0xa22 - <unknown>!_start
    1: Unknown OS error
    2: operation would block
```