### PR TITLE
wasi-sockets: Factor out cap-std

### DIFF
--- a/crates/wasi/src/preview2/host/network.rs
+++ b/crates/wasi/src/preview2/host/network.rs
@@ -218,9 +218,9 @@ pub(crate) mod util {
     use crate::preview2::bindings::sockets::network::ErrorCode;
     use crate::preview2::network::SocketAddressFamily;
     use crate::preview2::SocketResult;
-    use cap_net_ext::{Blocking, TcpListenerExt};
-    use cap_std::net::{TcpListener, TcpStream};
-    use rustix::fd::AsFd;
+    use cap_net_ext::{AddressFamily, Blocking, TcpListenerExt, UdpSocketExt};
+    use io_lifetimes::AsSocketlike;
+    use rustix::fd::{AsFd, OwnedFd};
     use rustix::io::Errno;
     use rustix::net::sockopt;
 
@@ -302,6 +302,26 @@ pub(crate) mod util {
      * Syscalls wrappers with (opinionated) portability fixes.
      */
 
+    pub fn tcp_socket(family: AddressFamily, blocking: Blocking) -> std::io::Result<OwnedFd> {
+        // Delegate socket creation to cap_net_ext. They handle a couple of things for us:
+        // - On Windows: call WSAStartup if not done before.
+        // - Set the NONBLOCK and CLOEXEC flags. Either immediately during socket creation,
+        //   or afterwards using ioctl or fcntl. Exact method depends on the platform.
+
+        let listener = cap_std::net::TcpListener::new(family, blocking)?;
+        Ok(OwnedFd::from(listener))
+    }
+
+    pub fn udp_socket(family: AddressFamily, blocking: Blocking) -> std::io::Result<OwnedFd> {
+        // Delegate socket creation to cap_net_ext. They handle a couple of things for us:
+        // - On Windows: call WSAStartup if not done before.
+        // - Set the NONBLOCK and CLOEXEC flags. Either immediately during socket creation,
+        //   or afterwards using ioctl or fcntl. Exact method depends on the platform.
+
+        let socket = cap_std::net::UdpSocket::new(family, blocking)?;
+        Ok(OwnedFd::from(socket))
+    }
+
     pub fn tcp_bind<Fd: AsFd>(sockfd: Fd, addr: &SocketAddr) -> rustix::io::Result<()> {
         rustix::net::bind(sockfd, addr).map_err(|error| match error {
             // See: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind#:~:text=WSAENOBUFS
@@ -334,8 +354,12 @@ pub(crate) mod util {
         })
     }
 
-    pub fn tcp_listen(listener: &TcpListener, backlog: Option<i32>) -> std::io::Result<()> {
-        listener
+    pub fn tcp_listen<Fd: AsFd>(sockfd: Fd, backlog: Option<i32>) -> std::io::Result<()> {
+        // Delegate `listen` to cap_net_ext. That is a thin wrapper around rustix::net::listen,
+        // with a platform-dependent default value for the backlog size.
+        sockfd
+            .as_fd()
+            .as_socketlike_view::<cap_std::net::TcpListener>()
             .listen(backlog)
             .map_err(|error| match Errno::from_io_error(&error) {
                 // See: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen#:~:text=WSAEMFILE
@@ -349,15 +373,22 @@ pub(crate) mod util {
                 // on Microsoft's documentation here.
                 #[cfg(windows)]
                 Some(Errno::MFILE) => Errno::NOBUFS.into(),
+
                 _ => error,
             })
     }
 
-    pub fn tcp_accept(
-        listener: &TcpListener,
+    pub fn tcp_accept<Fd: AsFd>(
+        sockfd: Fd,
         blocking: Blocking,
-    ) -> std::io::Result<(TcpStream, SocketAddr)> {
-        listener
+    ) -> std::io::Result<(OwnedFd, SocketAddr)> {
+        // Delegate `accept` to cap_net_ext. They set the NONBLOCK and CLOEXEC flags
+        // for us. Either immediately as a flag to `accept`, or afterwards using
+        // ioctl or fcntl. Exact method depends on the platform.
+
+        let (client, addr) = sockfd
+            .as_fd()
+            .as_socketlike_view::<cap_std::net::TcpListener>()
             .accept_with(blocking)
             .map_err(|error| match Errno::from_io_error(&error) {
                 // From: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept#:~:text=WSAEINPROGRESS
@@ -391,7 +422,9 @@ pub(crate) mod util {
                 ) => Errno::CONNABORTED.into(),
 
                 _ => error,
-            })
+            })?;
+
+        Ok((client.into(), addr))
     }
 
     pub fn udp_disconnect<Fd: AsFd>(sockfd: Fd) -> rustix::io::Result<()> {

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -47,21 +47,18 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         {
             // Ensure that we're allowed to connect to this address.
             network.check_socket_addr(&local_address, SocketAddrUse::TcpBind)?;
-            let listener = &*socket.tcp_socket().as_socketlike_view::<TcpListener>();
 
             // Perform the OS bind call.
-            util::tcp_bind(listener, &local_address).map_err(|error| {
-                match Errno::from_io_error(&error) {
-                    // From https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html:
-                    // > [EAFNOSUPPORT] The specified address is not a valid address for the address family of the specified socket
-                    //
-                    // The most common reasons for this error should have already
-                    // been handled by our own validation slightly higher up in this
-                    // function. This error mapping is here just in case there is
-                    // an edge case we didn't catch.
-                    Some(Errno::AFNOSUPPORT) => ErrorCode::InvalidArgument,
-                    _ => ErrorCode::from(error),
-                }
+            util::tcp_bind(socket.tcp_socket(), &local_address).map_err(|error| match error {
+                // From https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html:
+                // > [EAFNOSUPPORT] The specified address is not a valid address for the address family of the specified socket
+                //
+                // The most common reasons for this error should have already
+                // been handled by our own validation slightly higher up in this
+                // function. This error mapping is here just in case there is
+                // an edge case we didn't catch.
+                Errno::AFNOSUPPORT => ErrorCode::InvalidArgument,
+                _ => ErrorCode::from(error),
             })?;
         }
 
@@ -116,10 +113,9 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
 
             // Ensure that we're allowed to connect to this address.
             network.check_socket_addr(&remote_address, SocketAddrUse::TcpConnect)?;
-            let listener = &*socket.tcp_socket().as_socketlike_view::<TcpListener>();
 
             // Do an OS `connect`. Our socket is non-blocking, so it'll either...
-            util::tcp_connect(listener, &remote_address)
+            util::tcp_connect(socket.tcp_socket(), &remote_address)
         };
 
         match r {
@@ -130,11 +126,11 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
                 return Ok(());
             }
             // continue in progress,
-            Err(err) if Errno::from_io_error(&err) == Some(Errno::INPROGRESS) => {}
+            Err(err) if err == Errno::INPROGRESS => {}
             // or fail immediately.
             Err(err) => {
-                return Err(match Errno::from_io_error(&err) {
-                    Some(Errno::AFNOSUPPORT) => ErrorCode::InvalidArgument.into(), // See `bind` implementation.
+                return Err(match err {
+                    Errno::AFNOSUPPORT => ErrorCode::InvalidArgument.into(), // See `bind` implementation.
                     _ => err.into(),
                 });
             }

--- a/crates/wasi/src/preview2/udp.rs
+++ b/crates/wasi/src/preview2/udp.rs
@@ -1,7 +1,8 @@
+use crate::preview2::host::network::util;
 use crate::preview2::poll::Subscribe;
 use crate::preview2::with_ambient_tokio_runtime;
 use async_trait::async_trait;
-use cap_net_ext::{AddressFamily, Blocking, UdpSocketExt};
+use cap_net_ext::{AddressFamily, Blocking};
 use io_lifetimes::raw::{FromRawSocketlike, IntoRawSocketlike};
 use std::io;
 use std::net::SocketAddr;
@@ -57,14 +58,18 @@ impl Subscribe for UdpSocket {
 impl UdpSocket {
     /// Create a new socket in the given family.
     pub fn new(family: AddressFamily) -> io::Result<Self> {
-        let socket = Self::new_tokio_socket(family)?;
+        // Create a new host socket and set it to non-blocking, which is needed
+        // by our async implementation.
+        let fd = util::udp_socket(family, Blocking::No)?;
 
         let socket_address_family = match family {
             AddressFamily::Ipv4 => SocketAddressFamily::Ipv4,
             AddressFamily::Ipv6 => SocketAddressFamily::Ipv6 {
-                v6only: rustix::net::sockopt::get_ipv6_v6only(&socket)?,
+                v6only: rustix::net::sockopt::get_ipv6_v6only(&fd)?,
             },
         };
+
+        let socket = Self::setup_tokio_udp_socket(fd)?;
 
         Ok(UdpSocket {
             inner: Arc::new(socket),
@@ -74,16 +79,10 @@ impl UdpSocket {
         })
     }
 
-    fn new_tokio_socket(family: AddressFamily) -> io::Result<tokio::net::UdpSocket> {
-        // Create a new host socket and set it to non-blocking, which is needed
-        // by our async implementation.
-        let cap_std_socket = cap_std::net::UdpSocket::new(family, Blocking::No)?;
-        let fd = cap_std_socket.into_raw_socketlike();
-        let std_socket = unsafe { std::net::UdpSocket::from_raw_socketlike(fd) };
-        let tokio_socket =
-            with_ambient_tokio_runtime(|| tokio::net::UdpSocket::try_from(std_socket))?;
-
-        Ok(tokio_socket)
+    fn setup_tokio_udp_socket(fd: rustix::fd::OwnedFd) -> io::Result<tokio::net::UdpSocket> {
+        let std_socket =
+            unsafe { std::net::UdpSocket::from_raw_socketlike(fd.into_raw_socketlike()) };
+        with_ambient_tokio_runtime(|| tokio::net::UdpSocket::try_from(std_socket))
     }
 
     pub fn udp_socket(&self) -> &tokio::net::UdpSocket {


### PR DESCRIPTION
Previously we already didn't use cap-std quite as intended for sockets. #7662 removed our usage of Pool, which effectively took out the "cap" from cap-std.
This PR cleans up many of the remaining references to cap-std from the sockets code. Some references remain, and those have been pushed into network::util, because that's all `cap_net_ext` does for us now: provide platform compatibility fixes.