### PR TITLE
feat: implement `Resource<T>` -> `ResourceAny` conversion

### DIFF
--- a/cranelift/entity/src/primary.rs
+++ b/cranelift/entity/src/primary.rs
@@ -306,6 +306,18 @@ where
     }
 }
 
+impl<K, V> From<Vec<V>> for PrimaryMap<K, V>
+where
+    K: EntityRef,
+{
+    fn from(elems: Vec<V>) -> Self {
+        Self {
+            elems,
+            unused: PhantomData,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -490,6 +502,19 @@ mod tests {
         m.push(33);
 
         let n = m.values().collect::<PrimaryMap<E, _>>();
+        assert!(m.len() == n.len());
+        for (me, ne) in m.values().zip(n.values()) {
+            assert!(*me == **ne);
+        }
+    }
+
+    #[test]
+    fn from_vec() {
+        let mut m: PrimaryMap<E, usize> = PrimaryMap::new();
+        m.push(12);
+        m.push(33);
+
+        let n = PrimaryMap::<E, &usize>::from(m.values().collect::<Vec<_>>());
         assert!(m.len() == n.len());
         for (me, ne) in m.values().zip(n.values()) {
             assert!(*me == **ne);

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -38,7 +38,7 @@ pub(crate) struct InstanceData {
     // Otherwise the full guts of this component should only ever be used during
     // the instantiation of this instance, meaning that after instantiation much
     // of the component can be thrown away (theoretically).
-    component: Component,
+    pub(crate) component: Component,
 
     state: OwnedComponentInstance,
 

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -1,7 +1,7 @@
 use crate::component::func::HostFunc;
 use crate::component::matching::InstanceType;
 use crate::component::{
-    Component, ComponentNamedList, Func, Lift, Lower, PathIndex, ResourceType, TypedFunc,
+    Component, ComponentNamedList, Func, Lift, Lower, ResourceImportIndex, ResourceType, TypedFunc,
 };
 use crate::instance::OwnedImports;
 use crate::linker::DefinitionType;
@@ -522,7 +522,7 @@ impl<'a> Instantiator<'a> {
 pub struct InstancePre<T> {
     component: Component,
     imports: Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
-    paths: Arc<Vec<Option<RuntimeImportIndex>>>,
+    resource_imports: Arc<Vec<Option<RuntimeImportIndex>>>,
     _marker: marker::PhantomData<fn() -> T>,
 }
 
@@ -532,7 +532,7 @@ impl<T> Clone for InstancePre<T> {
         Self {
             component: self.component.clone(),
             imports: self.imports.clone(),
-            paths: self.paths.clone(),
+            resource_imports: self.resource_imports.clone(),
             _marker: self._marker,
         }
     }
@@ -548,22 +548,25 @@ impl<T> InstancePre<T> {
     pub(crate) unsafe fn new_unchecked(
         component: Component,
         imports: PrimaryMap<RuntimeImportIndex, RuntimeImport>,
-        paths: Vec<Option<RuntimeImportIndex>>,
+        resource_imports: Vec<Option<RuntimeImportIndex>>,
     ) -> InstancePre<T> {
         InstancePre {
             component,
             imports: Arc::new(imports),
-            paths: Arc::new(paths),
+            resource_imports: Arc::new(resource_imports),
             _marker: marker::PhantomData,
         }
     }
 
-    pub(crate) fn runtime_import_index(&self, path: PathIndex) -> Option<RuntimeImportIndex> {
-        *self.paths.get(*path)?
+    pub(crate) fn resource_import_index(
+        &self,
+        path: ResourceImportIndex,
+    ) -> Option<RuntimeImportIndex> {
+        *self.resource_imports.get(*path)?
     }
 
-    pub(crate) fn import_by_path(&self, path: PathIndex) -> Option<&RuntimeImport> {
-        let idx = self.runtime_import_index(path)?;
+    pub(crate) fn resource_import(&self, path: ResourceImportIndex) -> Option<&RuntimeImport> {
+        let idx = self.resource_import_index(path)?;
         self.imports.get(idx)
     }
 

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -522,7 +522,7 @@ impl<'a> Instantiator<'a> {
 pub struct InstancePre<T> {
     component: Component,
     imports: Arc<PrimaryMap<RuntimeImportIndex, RuntimeImport>>,
-    resource_imports: Arc<Vec<Option<RuntimeImportIndex>>>,
+    resource_imports: Arc<PrimaryMap<ResourceImportIndex, Option<RuntimeImportIndex>>>,
     _marker: marker::PhantomData<fn() -> T>,
 }
 
@@ -548,7 +548,7 @@ impl<T> InstancePre<T> {
     pub(crate) unsafe fn new_unchecked(
         component: Component,
         imports: PrimaryMap<RuntimeImportIndex, RuntimeImport>,
-        resource_imports: Vec<Option<RuntimeImportIndex>>,
+        resource_imports: PrimaryMap<ResourceImportIndex, Option<RuntimeImportIndex>>,
     ) -> InstancePre<T> {
         InstancePre {
             component,
@@ -562,7 +562,7 @@ impl<T> InstancePre<T> {
         &self,
         path: ResourceImportIndex,
     ) -> Option<RuntimeImportIndex> {
-        *self.resource_imports.get(*path)?
+        *self.resource_imports.get(path)?
     }
 
     pub(crate) fn resource_import(&self, path: ResourceImportIndex) -> Option<&RuntimeImport> {

--- a/crates/wasmtime/src/component/linker.rs
+++ b/crates/wasmtime/src/component/linker.rs
@@ -68,7 +68,12 @@ pub struct LinkerInstance<'a, T> {
     _marker: marker::PhantomData<fn() -> T>,
 }
 
-/// Index correlating a resource definition to the import path
+/// Index correlating a resource definition to the import path.
+/// This is assigned by [`Linker::resource`] and may be used to associate it to
+/// [`RuntimeImportIndex`](wasmtime_environ::component::RuntimeImportIndex)
+/// at a later stage
+///
+/// [`Linker::resource`]: crate::component::LinkerInstance::resource
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct ResourceImportIndex(usize);
 

--- a/crates/wasmtime/src/component/linker.rs
+++ b/crates/wasmtime/src/component/linker.rs
@@ -503,24 +503,12 @@ impl<T> LinkerInstance<'_, T> {
             &self.engine,
             move |mut cx: crate::Caller<'_, T>, param: u32| dtor(cx.as_context_mut(), param),
         ));
-        let entry = self.map.entry(name);
-        if !self.allow_shadowing && matches!(entry, Entry::Occupied(_)) {
-            bail!("import of `{}` defined twice", self.strings.strings[name])
-        }
         let idx = ResourceImportIndex::new(*self.resource_imports);
         *self.resource_imports = self
             .resource_imports
             .checked_add(1)
             .context("resource import count would overflow")?;
-        let def = Definition::Resource(idx, ty, dtor);
-        match entry {
-            Entry::Occupied(mut o) => {
-                o.insert(def);
-            }
-            Entry::Vacant(v) => {
-                v.insert(def);
-            }
-        }
+        self.insert(name, Definition::Resource(idx, ty, dtor))?;
         Ok(idx)
     }
 

--- a/crates/wasmtime/src/component/matching.rs
+++ b/crates/wasmtime/src/component/matching.rs
@@ -152,7 +152,8 @@ impl TypeChecker<'_> {
             let actual = self
                 .strings
                 .lookup(name)
-                .and_then(|name| actual?.get(&name));
+                .and_then(|name| actual?.get(&name))
+                .map(|(_, actual)| actual);
             self.definition(expected, actual)
                 .with_context(|| format!("instance export `{name}` has the wrong type"))?;
         }

--- a/crates/wasmtime/src/component/matching.rs
+++ b/crates/wasmtime/src/component/matching.rs
@@ -53,7 +53,7 @@ impl TypeChecker<'_> {
             TypeDef::Resource(i) => {
                 let i = self.types[i].ty;
                 let actual = match actual {
-                    Some(Definition::Resource(actual, _dtor)) => actual,
+                    Some(Definition::Resource(_idx, actual, _dtor)) => actual,
 
                     // If a resource is imported yet nothing was supplied then
                     // that's only successful if the resource has itself
@@ -152,8 +152,7 @@ impl TypeChecker<'_> {
             let actual = self
                 .strings
                 .lookup(name)
-                .and_then(|name| actual?.get(&name))
-                .map(|(_, actual)| actual);
+                .and_then(|name| actual?.get(&name));
             self.definition(expected, actual)
                 .with_context(|| format!("instance export `{name}` has the wrong type"))?;
         }

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -21,7 +21,7 @@ pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,
 };
 pub use self::instance::{ExportInstance, Exports, Instance, InstancePre};
-pub use self::linker::{Linker, LinkerInstance};
+pub use self::linker::{Linker, LinkerInstance, PathIndex};
 pub use self::resource_table::{ResourceTable, ResourceTableError};
 pub use self::resources::{Resource, ResourceAny};
 pub use self::types::{ResourceType, Type};

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -21,7 +21,7 @@ pub use self::func::{
     ComponentNamedList, ComponentType, Func, Lift, Lower, TypedFunc, WasmList, WasmStr,
 };
 pub use self::instance::{ExportInstance, Exports, Instance, InstancePre};
-pub use self::linker::{Linker, LinkerInstance, PathIndex};
+pub use self::linker::{Linker, LinkerInstance, ResourceImportIndex};
 pub use self::resource_table::{ResourceTable, ResourceTableError};
 pub use self::resources::{Resource, ResourceAny};
 pub use self::types::{ResourceType, Type};

--- a/crates/wasmtime/src/component/resources.rs
+++ b/crates/wasmtime/src/component/resources.rs
@@ -517,6 +517,8 @@ struct OwnState {
 impl ResourceAny {
     /// Attempts to convert an imported [`Resource`] into [`ResourceAny`].
     /// `idx` is the [`ResourceImportIndex`] returned by [`Linker::resource`].
+    ///
+    /// [`Linker::resource`]: crate::component::LinkerInstance::resource
     pub fn try_from_resource<T: 'static, U>(
         Resource { rep, state, .. }: Resource<T>,
         mut store: impl AsContextMut,

--- a/crates/wasmtime/src/component/resources.rs
+++ b/crates/wasmtime/src/component/resources.rs
@@ -1,18 +1,17 @@
 use crate::component::func::{bad_type_info, desc, LiftContext, LowerContext};
+use crate::component::instance::RuntimeImport;
+use crate::component::linker::PathIndex;
 use crate::component::matching::InstanceType;
-use crate::component::{ComponentType, Instance, Lift, Lower};
+use crate::component::{ComponentType, InstancePre, Lift, Lower};
 use crate::store::{StoreId, StoreOpaque};
 use crate::{AsContextMut, StoreContextMut, Trap};
-use anyhow::{bail, Context, Result};
+use anyhow::{bail, ensure, Context, Result};
 use std::any::TypeId;
 use std::fmt;
 use std::marker;
 use std::mem::MaybeUninit;
 use std::sync::atomic::{AtomicU32, Ordering::Relaxed};
-use wasmtime_environ::component::{
-    CanonicalAbiInfo, ComponentTypes, DefinedResourceIndex, InterfaceType, TypeDef,
-    TypeResourceTableIndex,
-};
+use wasmtime_environ::component::{CanonicalAbiInfo, DefinedResourceIndex, InterfaceType};
 use wasmtime_runtime::component::{ComponentInstance, InstanceFlags, ResourceTables};
 use wasmtime_runtime::{SendSyncPtr, VMFuncRef, ValRaw};
 
@@ -399,14 +398,13 @@ where
     }
 
     /// See [`ResourceAny::try_from_resource`]
-    pub fn try_into_resource_any(
+    pub fn try_into_resource_any<U>(
         self,
         store: impl AsContextMut,
-        instance: &Instance,
-        root: &str,
-        path: &[&str],
+        instance: &InstancePre<U>,
+        name: PathIndex,
     ) -> Result<ResourceAny> {
-        ResourceAny::try_from_resource(self, store, instance, root, path)
+        ResourceAny::try_from_resource(self, store, instance, name)
     }
 }
 
@@ -514,55 +512,25 @@ struct OwnState {
     dtor: Option<SendSyncPtr<VMFuncRef>>,
 }
 
-fn resource_import_type_index(
-    types: &ComponentTypes,
-    mut ty: TypeDef,
-    path: &[&str],
-) -> Option<TypeResourceTableIndex> {
-    'outer: while let Some((head, path)) = path.split_first() {
-        match ty {
-            TypeDef::ComponentInstance(cty) => {
-                for (name, cty) in &types[cty].exports {
-                    if name == head {
-                        ty = *cty;
-                        continue 'outer;
-                    }
-                }
-                return None;
-            }
-            TypeDef::Resource(cty) if path.is_empty() => return Some(cty),
-            _ => return None,
-        }
-    }
-    None
-}
-
 impl ResourceAny {
     /// Attempts to convert an imported [`Resource`] into [`ResourceAny`].
     /// `root` is the import root name and `path` is the import path within `root`.
-    pub fn try_from_resource<T: 'static>(
+    pub fn try_from_resource<T: 'static, U>(
         Resource { rep, state, .. }: Resource<T>,
         mut store: impl AsContextMut,
-        instance: &Instance,
-        root: &str,
-        path: &[&str],
+        instance: &InstancePre<U>,
+        name: PathIndex,
     ) -> Result<Self> {
         let store = store.as_context_mut();
-        let instance = store[instance.0]
-            .as_ref()
-            .context("instance data missing")?;
-        let env_component = instance.component.env_component();
-        let ty = env_component
-            .imports
-            .iter()
-            .find_map(|(_, (import, import_path))| {
-                let (root_name, ty) = env_component.import_types.get(*import)?;
-                (root_name == root && import_path == path).then_some(ty)
-            })
-            .context("component import not found")?;
-        let ty = resource_import_type_index(instance.component_types(), *ty, path)
-            .context("component import is not a resource")?;
-        let (dtor, flags) = instance.instance().dtor_and_flags(ty);
+        let import = instance.import_by_path(name).context("import not found")?;
+        let RuntimeImport::Resource {
+            ty, dtor_funcref, ..
+        } = import
+        else {
+            bail!("import is not a resource")
+        };
+        ensure!(*ty == ResourceType::host::<T>(), "resource type mismatch");
+
         let mut tables = host_resource_tables(store.0);
         let (idx, own_state) = match state.load(Relaxed) {
             BORROW => (tables.resource_lower_borrow(None, rep), None),
@@ -571,18 +539,25 @@ impl ResourceAny {
                 (
                     idx,
                     Some(OwnState {
-                        dtor: dtor.map(SendSyncPtr::new),
-                        flags,
+                        dtor: Some(dtor_funcref.into()),
+                        flags: None,
                         store: store.0.id(),
                     }),
                 )
             }
             TAKEN => bail!("host resource already consumed"),
-            idx => (idx, None),
+            idx => (
+                idx,
+                Some(OwnState {
+                    dtor: Some(dtor_funcref.into()),
+                    flags: None,
+                    store: store.0.id(),
+                }),
+            ),
         };
         Ok(Self {
             idx,
-            ty: ResourceType::host::<T>(),
+            ty: *ty,
             own_state,
         })
     }


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/wasmtime/issues/7676
Follow-up on #7680 

~This feature requires changes in the resource table to allow specifying the `ResourceType` associated with the resource stored (since assumption that it's always equal to `ResourceType::host::<T>()` is no longer valid)~

Add support for `Resource<T>` -> `ResourceAny` conversion to allow invoking component functions without bindings generated at compile-time.