### PR TITLE
PCC [AArch64]: load_constant64_full generates incorrect fact range for 32-bit MOVN

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -307,8 +307,8 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
                     self.lower_ctx.add_range_fact(
                         rd.to_reg(),
                         64,
-                        u64::from(lower_halfword),
-                        u64::from(lower_halfword),
+                        u64::from(value),
+                        u64::from(value),
                     );
                 }
             } else {

--- a/cranelift/filetests/filetests/pcc/succeed/const.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/const.clif
@@ -28,3 +28,9 @@ block0:
     v0 = iconst.i64 0x9_ffff_ffff
     return v0
 }
+
+function %f3() -> i64 {
+block0:
+    v0 = iconst.i64 0xffff_fff7
+    return v0
+}


### PR DESCRIPTION
Hi team, find another PCC fact range issue on AArch64.
When the top 32 bits of the value are zero and the upper_halfword of the lower 32 bits is u16::MAX, load_constant64_full will emit a single `movn` instruction. In that case, add_range_fact only adds lower_halfword as the fact range, which misses the upper halfword value. We should add the hole 32-bit value as the fact range.

Here is a simple test to reproduce the issue:
```wasm
;; test_const.wat
(module
  (func (export "test_constant") (result i64) (i64.const 0xfffffff7))
)
```

Step to reproduce:

Compile the test with PCC on:
```
target/debug/wasmtime compile -C pcc=y test_const.wat
```

the output will be:
```
Error: Compilation error: Proof-carrying-code validation error: UnsupportedFact
```


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
