### PR TITLE
feat: implement `ResourceAny` -> `Resource<T>` conversion

### DIFF
--- a/tests/all/component_model/resources.rs
+++ b/tests/all/component_model/resources.rs
@@ -582,6 +582,15 @@ fn dynamic_val() -> Result<()> {
     match &results[0] {
         Val::Resource(resource) => {
             assert_eq!(resource.ty(), ResourceType::host::<MyType>());
+            assert!(resource.owned());
+
+            let resource = resource.try_into_resource::<MyType>(&mut store)?;
+            assert_eq!(resource.rep(), 100);
+            assert!(resource.owned());
+
+            let resource = resource.try_into_resource_any(&mut store, &i_pre, idx)?;
+            assert_eq!(resource.ty(), ResourceType::host::<MyType>());
+            assert!(resource.owned());
         }
         _ => unreachable!(),
     }
@@ -593,21 +602,46 @@ fn dynamic_val() -> Result<()> {
     match &results[0] {
         Val::Resource(resource) => {
             assert_eq!(resource.ty(), ResourceType::host::<MyType>());
+            assert!(resource.owned());
+
+            let resource = resource.try_into_resource::<MyType>(&mut store)?;
+            assert_eq!(resource.rep(), 100);
+            assert!(resource.owned());
+
+            let resource = resource.try_into_resource_any(&mut store, &i_pre, idx)?;
+            assert_eq!(resource.ty(), ResourceType::host::<MyType>());
+            assert!(resource.owned());
         }
         _ => unreachable!(),
     }
 
-    let t1 = Resource::new_own(100);
+    let t1 = Resource::<MyType>::new_own(100)
+        .try_into_resource_any(&mut store, &i_pre, idx)?
+        .try_into_resource(&mut store)?;
     let (t1,) = a_typed_result.call(&mut store, (t1,))?;
     a_typed_result.post_return(&mut store)?;
+    assert_eq!(t1.rep(), 100);
+    assert!(t1.owned());
 
-    let t1_any = t1.try_into_resource_any(&mut store, &i_pre, idx)?;
+    let t1_any = t1
+        .try_into_resource_any(&mut store, &i_pre, idx)?
+        .try_into_resource::<MyType>(&mut store)?
+        .try_into_resource_any(&mut store, &i_pre, idx)?;
     let mut results = [Val::Bool(false)];
     a.call(&mut store, &[Val::Resource(t1_any)], &mut results)?;
     a.post_return(&mut store)?;
     match &results[0] {
         Val::Resource(resource) => {
             assert_eq!(resource.ty(), ResourceType::host::<MyType>());
+            assert!(resource.owned());
+
+            let resource = resource.try_into_resource::<MyType>(&mut store)?;
+            assert_eq!(resource.rep(), 100);
+            assert!(resource.owned());
+
+            let resource = resource.try_into_resource_any(&mut store, &i_pre, idx)?;
+            assert_eq!(resource.ty(), ResourceType::host::<MyType>());
+            assert!(resource.owned());
         }
         _ => unreachable!(),
     }


### PR DESCRIPTION
Closes #7704 
Follow-up on #7688  (based on that PR for simplicity) 

Once #7688 is merged, I'll rebase such that only https://github.com/bytecodealliance/wasmtime/pull/7712/commits/5b20daf013bf064a32c53aefc93e7d4d52473c86 would be in this PR. Also happy to move the commit to #7688 if you prefer