### PR TITLE
refactor: allow `Subscribe::ready` to be fallible

### DIFF
--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -430,9 +430,10 @@ impl HostFutureIncomingResponse {
 
 #[async_trait::async_trait]
 impl Subscribe for HostFutureIncomingResponse {
-    async fn ready(&mut self) {
+    async fn ready(&mut self) -> wasmtime::Result<()> {
         if let Self::Pending(handle) = self {
             *self = Self::Ready(handle.await);
         }
+        Ok(())
     }
 }

--- a/crates/wasi/src/preview2/filesystem.rs
+++ b/crates/wasi/src/preview2/filesystem.rs
@@ -285,7 +285,7 @@ impl HostOutputStream for FileOutputStream {
 
 #[async_trait::async_trait]
 impl Subscribe for FileOutputStream {
-    async fn ready(&mut self) {
+    async fn ready(&mut self) -> wasmtime::Result<()> {
         if let OutputState::Waiting(task) = &mut self.state {
             self.state = match task.await {
                 Ok(nwritten) => {
@@ -297,6 +297,7 @@ impl Subscribe for FileOutputStream {
                 Err(e) => OutputState::Error(e),
             };
         }
+        Ok(())
     }
 }
 

--- a/crates/wasi/src/preview2/host/clocks.rs
+++ b/crates/wasi/src/preview2/host/clocks.rs
@@ -93,11 +93,12 @@ enum Deadline {
 
 #[async_trait::async_trait]
 impl Subscribe for Deadline {
-    async fn ready(&mut self) {
+    async fn ready(&mut self) -> wasmtime::Result<()> {
         match self {
             Deadline::Past => {}
             Deadline::Instant(instant) => tokio::time::sleep_until(*instant).await,
             Deadline::Never => std::future::pending().await,
         }
+        Ok(())
     }
 }

--- a/crates/wasi/src/preview2/host/io.rs
+++ b/crates/wasi/src/preview2/host/io.rs
@@ -165,9 +165,17 @@ impl<T: WasiView> streams::HostOutputStream for T {
     ) -> StreamResult<u64> {
         use crate::preview2::Subscribe;
 
-        self.table_mut().get_mut(&dest)?.ready().await;
+        self.table_mut()
+            .get_mut(&dest)?
+            .ready()
+            .await
+            .map_err(StreamError::Trap)?;
 
-        self.table_mut().get_mut(&src)?.ready().await;
+        self.table_mut()
+            .get_mut(&src)?
+            .ready()
+            .await
+            .map_err(StreamError::Trap)?;
 
         self.splice(dest, src, len).await
     }
@@ -196,7 +204,7 @@ impl<T: WasiView> streams::HostInputStream for T {
         len: u64,
     ) -> StreamResult<Vec<u8>> {
         if let InputStream::Host(s) = self.table_mut().get_mut(&stream)? {
-            s.ready().await;
+            s.ready().await.map_err(StreamError::Trap)?;
         }
         self.read(stream, len).await
     }
@@ -216,7 +224,7 @@ impl<T: WasiView> streams::HostInputStream for T {
         len: u64,
     ) -> StreamResult<u64> {
         if let InputStream::Host(s) = self.table_mut().get_mut(&stream)? {
-            s.ready().await;
+            s.ready().await.map_err(StreamError::Trap)?;
         }
         self.skip(stream, len).await
     }

--- a/crates/wasi/src/preview2/host/udp.rs
+++ b/crates/wasi/src/preview2/host/udp.rs
@@ -411,12 +411,13 @@ impl<T: WasiView> udp::HostIncomingDatagramStream for T {
 
 #[async_trait]
 impl Subscribe for IncomingDatagramStream {
-    async fn ready(&mut self) {
+    async fn ready(&mut self) -> wasmtime::Result<()> {
         // FIXME: Add `Interest::ERROR` when we update to tokio 1.32.
         self.inner
             .ready(Interest::READABLE)
             .await
             .expect("failed to await UDP socket readiness");
+        Ok(())
     }
 }
 
@@ -545,7 +546,7 @@ impl<T: WasiView> udp::HostOutgoingDatagramStream for T {
 
 #[async_trait]
 impl Subscribe for OutgoingDatagramStream {
-    async fn ready(&mut self) {
+    async fn ready(&mut self) -> wasmtime::Result<()> {
         match self.send_state {
             SendState::Idle | SendState::Permitted(_) => {}
             SendState::Waiting => {
@@ -557,5 +558,6 @@ impl Subscribe for OutgoingDatagramStream {
                 self.send_state = SendState::Idle;
             }
         }
+        Ok(())
     }
 }

--- a/crates/wasi/src/preview2/ip_name_lookup.rs
+++ b/crates/wasi/src/preview2/ip_name_lookup.rs
@@ -80,10 +80,11 @@ impl<T: WasiView> HostResolveAddressStream for T {
 
 #[async_trait::async_trait]
 impl Subscribe for ResolveAddressStream {
-    async fn ready(&mut self) {
+    async fn ready(&mut self) -> Result<()> {
         if let ResolveAddressStream::Waiting(future) = self {
             *self = ResolveAddressStream::Done(future.await.map(|v| v.into_iter()));
         }
+        Ok(())
     }
 }
 

--- a/crates/wasi/src/preview2/stdio.rs
+++ b/crates/wasi/src/preview2/stdio.rs
@@ -180,7 +180,9 @@ impl HostOutputStream for OutputStream {
 
 #[async_trait::async_trait]
 impl Subscribe for OutputStream {
-    async fn ready(&mut self) {}
+    async fn ready(&mut self) -> wasmtime::Result<()> {
+        Ok(())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/wasi/src/preview2/stdio/worker_thread_stdin.rs
+++ b/crates/wasi/src/preview2/stdio/worker_thread_stdin.rs
@@ -149,7 +149,7 @@ impl HostInputStream for Stdin {
 
 #[async_trait::async_trait]
 impl Subscribe for Stdin {
-    async fn ready(&mut self) {
+    async fn ready(&mut self) -> wasmtime::Result<()> {
         let g = GlobalStdin::get();
 
         // Scope the synchronous `state.lock()` to this block which does not
@@ -164,10 +164,11 @@ impl Subscribe for Stdin {
                     g.read_completed.notified()
                 }
                 StdinState::ReadRequested => g.read_completed.notified(),
-                StdinState::Data(_) | StdinState::Closed | StdinState::Error(_) => return,
+                StdinState::Data(_) | StdinState::Closed | StdinState::Error(_) => return Ok(()),
             }
         };
 
         notified.await;
+        Ok(())
     }
 }

--- a/crates/wasi/src/preview2/udp.rs
+++ b/crates/wasi/src/preview2/udp.rs
@@ -50,8 +50,9 @@ pub struct UdpSocket {
 
 #[async_trait]
 impl Subscribe for UdpSocket {
-    async fn ready(&mut self) {
+    async fn ready(&mut self) -> wasmtime::Result<()> {
         // None of the socket-level operations block natively
+        Ok(())
     }
 }
 

--- a/crates/wasi/src/preview2/write_stream.rs
+++ b/crates/wasi/src/preview2/write_stream.rs
@@ -197,7 +197,8 @@ impl HostOutputStream for AsyncWriteStream {
 }
 #[async_trait::async_trait]
 impl Subscribe for AsyncWriteStream {
-    async fn ready(&mut self) {
+    async fn ready(&mut self) -> wasmtime::Result<()> {
         self.worker.ready().await;
+        Ok(())
     }
 }

--- a/crates/wasi/tests/process_stdin.rs
+++ b/crates/wasi/tests/process_stdin.rs
@@ -55,7 +55,7 @@ fn main() {
                         let mut buffer = String::new();
                         loop {
                             println!("child: waiting for stdin to be ready");
-                            stdin.ready().await;
+                            stdin.ready().await.expect("`ready` should not fail");
 
                             println!("child: reading input");
                             // We can't effectively test for the case where stdin was closed, so panic if it is...

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -514,5 +514,7 @@ impl preview2::HostOutputStream for LogStream {
 
 #[async_trait::async_trait]
 impl preview2::Subscribe for LogStream {
-    async fn ready(&mut self) {}
+    async fn ready(&mut self) -> wasmtime::Result<()> {
+        Ok(())
+    }
 }


### PR DESCRIPTION
In the current implementation [`Subscribe::ready`](https://docs.rs/wasmtime-wasi/latest/wasmtime_wasi/preview2/trait.Subscribe.html#tymethod.ready) is assumed to be infallible, which does not work in a generic case, where the implementation may require, in fact, to cause a trap in the guest.
This is important, because implementations that require ability to trap in host `wasi::io::poll/pollable` would otherwise require to implement their own `wasi::io::poll/pollable`, meaning that they would not be able to reuse all the existing WASI crate implementations (https://docs.rs/wasmtime-wasi/latest/wasmtime_wasi/preview2/trait.Subscribe.html#implementors), potentially locking developers out of most of WASI functionality (due to the [`Pollable`](https://docs.rs/wasmtime-wasi/latest/wasmtime_wasi/preview2/struct.Pollable.html) concrete type being used in signatures, which cannot be externally constructed)