### PR TITLE
Fix `ty_half_width` in isle prelude

### DIFF
--- a/cranelift/codegen/src/isle_prelude.rs
+++ b/cranelift/codegen/src/isle_prelude.rs
@@ -775,15 +775,7 @@ macro_rules! isle_common_prelude_methods {
 
         #[inline]
         fn ty_half_width(&mut self, ty: Type) -> Option<Type> {
-            let new_lane = match ty.lane_type() {
-                I16 => I8,
-                I32 => I16,
-                I64 => I32,
-                F64 => F32,
-                _ => return None,
-            };
-
-            new_lane.by(ty.lane_count())
+            ty.half_width()
         }
 
         #[inline]


### PR DESCRIPTION
I spent way too long trying to figure out how I'd gotten a rule wrong, only to find out that `ty_half_width` in ISLE was doing something different from [`Type::half_width`](https://docs.rs/cranelift/latest/cranelift/prelude/struct.Type.html#method.half_width) in the rest of the codebase.

Thus this PR, which stops it having a custom implementation in ISLE and just calls the normal method.  I think anywhere in ISLE rules that wants to exclude the other cases should be using `fits_in_64` or similar, not having the `ty_half_width` extern do something surprising.

The existing uses

https://github.com/bytecodealliance/wasmtime/blob/37300d3f4b51e0e3374e3c4fc382b7603b065c8b/cranelift/codegen/src/isa/riscv64/lower.isle#L115-L123

are under `ty_vec_fits_in_register` already, so it's fine.
