### PR TITLE
Fix clif-util run fails directly when target is specified

### DIFF
--- a/cranelift/src/run.rs
+++ b/cranelift/src/run.rs
@@ -8,7 +8,7 @@ use cranelift_filetests::TestFileCompiler;
 use cranelift_native::builder as host_isa_builder;
 use cranelift_reader::{parse_run_command, parse_test, Details, IsaSpec, ParseOptions};
 use std::path::{Path, PathBuf};
-use target_lexicon::Triple;
+use target_lexicon::{HOST, Triple};
 
 /// Execute clif code and verify with test expressions
 #[derive(Parser)]
@@ -106,15 +106,22 @@ fn run_file_contents(file_contents: String) -> Result<()> {
 
 /// Build an ISA based on the current machine running this code (the host)
 fn create_target_isa(isa_spec: &IsaSpec) -> Result<OwnedTargetIsa> {
-    if let IsaSpec::None(flags) = isa_spec {
-        // build an ISA for the current machine
-        let builder = host_isa_builder().map_err(|s| anyhow::anyhow!("{}", s))?;
-        Ok(builder.finish(flags.clone())?)
-    } else {
-        anyhow::bail!(
-            "A target ISA was specified in the file but should not have been--only \
-             the host ISA can be used for running CLIF files"
-        )
+    let builder = host_isa_builder().map_err(|s| anyhow::anyhow!("{}", s))?;
+    match *isa_spec {
+        IsaSpec::None(ref flags) => {
+            // build an ISA for the current machine
+            Ok(builder.finish(flags.clone())?)
+        }
+        IsaSpec::Some(ref isas) => {
+            for isa in isas {
+                if isa.triple().architecture == HOST.architecture {
+                    return Ok(builder.finish(isa.flags().clone())?);
+                }
+            }
+            anyhow::bail!(
+                "The target ISA specified in the file is not compatible with the host ISA"
+            )
+        }
     }
 }
 

--- a/cranelift/src/run.rs
+++ b/cranelift/src/run.rs
@@ -8,7 +8,7 @@ use cranelift_filetests::TestFileCompiler;
 use cranelift_native::builder as host_isa_builder;
 use cranelift_reader::{parse_run_command, parse_test, Details, IsaSpec, ParseOptions};
 use std::path::{Path, PathBuf};
-use target_lexicon::{HOST, Triple};
+use target_lexicon::{Triple, HOST};
 
 /// Execute clif code and verify with test expressions
 #[derive(Parser)]


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
In testing.md doc, The `test run` command requires the `target`
https://github.com/bytecodealliance/wasmtime/blob/b583c54fda13b53dea362861125dd1e2ced1381d/cranelift/docs/testing.md?plain=1#L298-L300

However, when executing the `clif-util run` command (e.g `clif-util run cranelift/filetests/filetests/runtests/const.clif`), any file is found to fail. Because it is not allowed to specify a `target` in the `test run` command in the actual code.
https://github.com/bytecodealliance/wasmtime/blob/b583c54fda13b53dea362861125dd1e2ced1381d/cranelift/src/run.rs#L114-L117

In this PR I've modified it to filter only on architectures, as described in the documentation. The host platform's native targets will be used to actually compile the tests.