### PR TITLE
Add more necessary linkers to wasi-http

### DIFF
--- a/crates/wasi-http/src/proxy.rs
+++ b/crates/wasi-http/src/proxy.rs
@@ -6,12 +6,16 @@ wasmtime::component::bindgen!({
     tracing: true,
     async: true,
     with: {
+        "wasi:cli/environment": preview2::bindings::cli::environment,
+        "wasi:cli/exit": preview2::bindings::cli::exit,
         "wasi:cli/stderr": preview2::bindings::cli::stderr,
         "wasi:cli/stdin": preview2::bindings::cli::stdin,
         "wasi:cli/stdout": preview2::bindings::cli::stdout,
         "wasi:clocks/monotonic-clock": preview2::bindings::clocks::monotonic_clock,
         "wasi:clocks/timezone": preview2::bindings::clocks::timezone,
         "wasi:clocks/wall-clock": preview2::bindings::clocks::wall_clock,
+        "wasi:filesystem/preopens": preview2::bindings::filesystem::preopens,
+        "wasi:filesystem/types": preview2::bindings::filesystem::types,
         "wasi:http/incoming-handler": bindings::http::incoming_handler,
         "wasi:http/outgoing-handler": bindings::http::outgoing_handler,
         "wasi:http/types": bindings::http::types,
@@ -27,9 +31,13 @@ where
 {
     preview2::bindings::clocks::wall_clock::add_to_linker(l, |t| t)?;
     preview2::bindings::clocks::monotonic_clock::add_to_linker(l, |t| t)?;
+    preview2::bindings::filesystem::preopens::add_to_linker(l, |t| t)?;
+    preview2::bindings::filesystem::types::add_to_linker(l, |t| t)?;
     preview2::bindings::io::poll::add_to_linker(l, |t| t)?;
     preview2::bindings::io::error::add_to_linker(l, |t| t)?;
     preview2::bindings::io::streams::add_to_linker(l, |t| t)?;
+    preview2::bindings::cli::environment::add_to_linker(l, |t| t)?;
+    preview2::bindings::cli::exit::add_to_linker(l, |t| t)?;
     preview2::bindings::cli::stdin::add_to_linker(l, |t| t)?;
     preview2::bindings::cli::stdout::add_to_linker(l, |t| t)?;
     preview2::bindings::cli::stderr::add_to_linker(l, |t| t)?;


### PR DESCRIPTION
When I attempt to run the [hello-wasi-http](https://github.com/sunfishcode/hello-wasi-http) example using wasmtime 16, I encounter the following error(which did not occur in previous versions):

```
$ wasmtime serve hello_wasi_http.wasm

Error: import `wasi:cli/environment@0.2.0-rc-2023-12-05` has the wrong type

Caused by:
    0: instance export `get-environment` has the wrong type
    1: expected func found nothing
```

 I realize that this may be related to PR #7597, where we might have trimmed too much "world" to the point where a simple HTTP hello world example cannot run. So, this patch adds some content, and now the example can run successfully:

```
$ ./target/debug/wasmtime serve hello_wasi_http.wasm

Serving HTTP on http://0.0.0.0:8080/
```

Related: #7716 