### PR TITLE
Document disabling `debug-builtins` a bit more

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -48,6 +48,10 @@ Released 2023-12-20
   when Wasmtime is built from a git checkout.
   [#7610](https://github.com/bytecodealliance/wasmtime/pull/7610)
 
+* Debug intrinsic symbols required by LLDB and GDB have been moved behind a
+  `debug-builtins` feature of the `wasmtime` crate which is enabled by default.
+  [#7626](https://github.com/bytecodealliance/wasmtime/pull/7626)
+
 ### Fixed
 
 * MPK support is now explicitly disabled on AMD-based CPUs since the

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -370,6 +370,10 @@ impl Config {
     /// Configures whether DWARF debug information will be emitted during
     /// compilation.
     ///
+    /// Note that the `debug-builtins` compile-time Cargo feature must also be
+    /// enabled for native debuggers such as GDB or LLDB to be able to debug
+    /// guest WebAssembly programs.
+    ///
     /// By default this option is `false`.
     pub fn debug_info(&mut self, enable: bool) -> &mut Self {
         self.tunables.generate_native_debuginfo = enable;

--- a/crates/wasmtime/src/lib.rs
+++ b/crates/wasmtime/src/lib.rs
@@ -300,6 +300,12 @@
 //!   will attempt to parse DWARF debug information and convert WebAssembly
 //!   addresses to source filenames and line numbers.
 //!
+//! * `debug-builtins` - Enabled by default, this feature includes some built-in
+//!   debugging utilities and symbols for native debuggers such as GDB and LLDB
+//!   to attach to the process Wasmtime is used within. The intrinsics provided
+//!   will enable debugging guest code compiled to WebAssembly. This must also
+//!   be enabled via [`Config::debug_info`] as well for guests.
+//!
 //! More crate features can be found in the [manifest] of Wasmtime itself for
 //! seeing what can be enabled and disabled.
 //!


### PR DESCRIPTION
Closes #7720

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
