### PR TITLE
docs: Update documentation for `Store::get_fuel`

### DIFF
--- a/crates/wasmtime/src/store.rs
+++ b/crates/wasmtime/src/store.rs
@@ -780,12 +780,13 @@ impl<T> Store<T> {
         self.inner.gc()
     }
 
-    /// Returns the amount fuel in this [`Store`].
+    /// Returns the amount fuel in this [`Store`]. When fuel is enabled, it must
+    /// be configured via [`Store::set_fuel`].
     ///
-    /// If fuel consumption is not enabled via
-    /// [`Config::consume_fuel`](crate::Config::consume_fuel) then this
-    /// function will return `None`. Also note that fuel, if enabled, must be
-    /// originally configured via [`Store::set_fuel`].
+    /// # Errors
+    ///
+    /// This function will return an error if fuel consumption is not enabled
+    /// via [`Config::consume_fuel`](crate::Config::consume_fuel).
     pub fn get_fuel(&self) -> Result<u64> {
         self.inner.get_fuel()
     }


### PR DESCRIPTION
This commit updates the documentation for Store::get_fuel to match its signature, which returns a `Result` instead of an `Option`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
