### PR TITLE
unionfind: robustly avoid changing `Idx`s in the GVN map

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -367,6 +367,7 @@ impl Context {
         );
         pass.run();
         log::debug!("egraph stats: {:?}", pass.stats);
+        trace!("pinned_union_count: {}", pass.eclasses.pinned_union_count);
         trace!("After egraph optimization:\n{}", self.func.display());
 
         self.verify_if(fisa)

--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -109,7 +109,7 @@ impl NewOrExistingInst {
             NewOrExistingInst::New(data, ty) => (*ty, *data),
             NewOrExistingInst::Existing(inst) => {
                 let ty = dfg.ctrl_typevar(*inst);
-                (ty, dfg.insts[*inst].clone())
+                (ty, dfg.insts[*inst])
             }
         }
     }
@@ -195,15 +195,17 @@ where
             };
 
             let opt_value = self.optimize_pure_enode(inst);
+
+            for &argument in self.func.dfg.inst_args(inst) {
+                self.eclasses.pin_index(argument);
+            }
+
             let gvn_context = GVNContext {
                 union_find: self.eclasses,
                 value_lists: &self.func.dfg.value_lists,
             };
-            self.gvn_map.insert(
-                (ty, self.func.dfg.insts[inst].clone()),
-                opt_value,
-                &gvn_context,
-            );
+            self.gvn_map
+                .insert((ty, self.func.dfg.insts[inst]), opt_value, &gvn_context);
             self.value_to_opt_value[result] = opt_value;
             opt_value
         }

--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -67,7 +67,7 @@ pub struct EgraphPass<'a> {
     pub(crate) stats: Stats,
     /// Union-find that maps all members of a Union tree (eclass) back
     /// to the *oldest* (lowest-numbered) `Value`.
-    eclasses: UnionFind<Value>,
+    pub(crate) eclasses: UnionFind<Value>,
 }
 
 // The maximum number of rewrites we will take from a single call into ISLE.
@@ -436,6 +436,7 @@ impl<'a> EgraphPass<'a> {
             }
         }
         trace!("stats: {:#?}", self.stats);
+        trace!("pinned_union_count: {}", self.eclasses.pinned_union_count);
         self.elaborate();
     }
 

--- a/cranelift/filetests/filetests/egraph/shifts.clif
+++ b/cranelift/filetests/filetests/egraph/shifts.clif
@@ -701,8 +701,8 @@ block0(v0: i8):
 }
 
 ; check: v2 = iconst.i8 1
-; check: v16 = rotr v0, v2  ; v2 = 1
-; check: return v16
+; check: v15 = rotr v0, v2  ; v2 = 1
+; check: return v15
 
 function %rotl_rotr_add(i8, i8, i8) -> i8 {
 block0(v0: i8, v1: i8, v2: i8):
@@ -725,8 +725,8 @@ block0(v0: i8):
 }
 
 ; check: v2 = iconst.i8 1
-; check: v16 = rotl v0, v2  ; v2 = 1
-; check: return v16
+; check: v15 = rotl v0, v2  ; v2 = 1
+; check: return v15
 
 function %rotl_rotr_add(i8, i8, i8) -> i8 {
 block0(v0: i8, v1: i8, v2: i8):

--- a/cranelift/filetests/filetests/egraph/unordered.clif
+++ b/cranelift/filetests/filetests/egraph/unordered.clif
@@ -1,0 +1,24 @@
+test optimize precise-output
+set opt_level=speed
+target x86_64
+
+; https://github.com/bytecodealliance/wasmtime/issues/6126
+;
+; In this example, iconst defines v2, and later an identical iconst defines v1. 
+; In between, v2 is used in an iadd instruction that's added to the GVN map.
+; Finally, v1 is used in another iadd which should unify with the first one.
+function %unordered(i32) -> i32, i32 {
+block0(v0: i32):
+    v2 = iconst.i32 42
+    v3 = iadd v0, v2
+    v1 = iconst.i32 42
+    v4 = iadd v0, v1
+    return v3, v4
+}
+
+; function %unordered(i32) -> i32, i32 fast {
+; block0(v0: i32):
+;     v2 = iconst.i32 42
+;     v3 = iadd v0, v2  ; v2 = 42
+;     return v3, v3
+; }


### PR DESCRIPTION
Stop hoping that keeping the smallest Idx as canonical will yield good results, and instead explicitly inform the UnionFind of what we expect not to move.

Fixes #6126

I attempted running the sightglass benchmark on this, but I think my setup was too noisy – any differences in performance disappeared when I re-ran the specific benchmark on which the difference was reported (though I only did it manually for the few first reported differences).