### PR TITLE
Make `shutdown` close the input/output-streams.

### DIFF
--- a/crates/test-programs/src/bin/preview2_tcp_shutdown.rs
+++ b/crates/test-programs/src/bin/preview2_tcp_shutdown.rs
@@ -1,0 +1,108 @@
+use test_programs::wasi::io::streams::{InputStream, OutputStream, StreamError};
+use test_programs::wasi::sockets::network::{IpAddress, IpAddressFamily, IpSocketAddress, Network};
+use test_programs::wasi::sockets::tcp::{ShutdownType, TcpSocket};
+
+/// InputStream::read should return `StreamError::Closed` after the connection has been shut down for receiving.
+fn test_tcp_shutdown_input_stream_read(net: &Network, family: IpAddressFamily) {
+    setup(net, family, |client, input, _output| {
+        // The stream should be readable:
+        assert_eq!(input.read(10).unwrap().len(), 10);
+
+        // Also test the 0 input length edge case:
+        assert_eq!(input.read(0).unwrap().len(), 0);
+
+        // Perform the shutdown
+        client.shutdown(ShutdownType::Receive).unwrap();
+
+        // Stream should be closed:
+        assert!(matches!(input.read(10), Err(StreamError::Closed)));
+
+        // Stream should still be closed, even when requesting 0 bytes:
+        assert!(matches!(input.read(0), Err(StreamError::Closed)));
+    });
+}
+
+/// OutputStream::check_write methods should return `StreamError::Closed` after the connection has been shut down for sending.
+fn test_tcp_shutdown_output_stream_check_write(net: &Network, family: IpAddressFamily) {
+    setup(net, family, |client, _input, output| {
+        // The stream should be writable:
+        assert!(output.check_write().unwrap() > 0);
+
+        // Perform the shutdown
+        client.shutdown(ShutdownType::Send).unwrap();
+
+        // Stream should be closed:
+        assert!(matches!(output.check_write(), Err(StreamError::Closed)));
+    });
+}
+
+/// OutputStream::check_write methods should return `StreamError::Closed` after the connection has been shut down for sending.
+fn test_tcp_shutdown_output_stream_write(net: &Network, family: IpAddressFamily) {
+    setup(net, family, |client, _input, output| {
+        let message = b"Hi!";
+
+        // The stream should be writable:
+        assert!(output.check_write().unwrap() as usize > message.len());
+
+        // Perform the shutdown
+        client.shutdown(ShutdownType::Send).unwrap();
+
+        // Stream should be closed:
+        assert!(matches!(output.write(message), Err(StreamError::Closed)));
+    });
+}
+
+/// OutputStream::check_write methods should return `StreamError::Closed` after the connection has been shut down for sending.
+fn test_tcp_shutdown_output_stream_flush(net: &Network, family: IpAddressFamily) {
+    setup(net, family, |client, _input, output| {
+        // The stream should be writable:
+        assert!(output.check_write().unwrap() > 0);
+
+        // Perform the shutdown
+        client.shutdown(ShutdownType::Send).unwrap();
+
+        // Stream should be closed:
+        assert!(matches!(output.flush(), Err(StreamError::Closed)));
+    });
+}
+
+fn main() {
+    let net = Network::default();
+
+    test_tcp_shutdown_input_stream_read(&net, IpAddressFamily::Ipv4);
+    test_tcp_shutdown_input_stream_read(&net, IpAddressFamily::Ipv6);
+
+    test_tcp_shutdown_output_stream_check_write(&net, IpAddressFamily::Ipv4);
+    test_tcp_shutdown_output_stream_check_write(&net, IpAddressFamily::Ipv6);
+    test_tcp_shutdown_output_stream_write(&net, IpAddressFamily::Ipv4);
+    test_tcp_shutdown_output_stream_write(&net, IpAddressFamily::Ipv6);
+    test_tcp_shutdown_output_stream_flush(&net, IpAddressFamily::Ipv4);
+    test_tcp_shutdown_output_stream_flush(&net, IpAddressFamily::Ipv6);
+}
+
+fn setup(
+    net: &Network,
+    family: IpAddressFamily,
+    body: impl FnOnce(&TcpSocket, &InputStream, &OutputStream),
+) {
+    // Set up a connected TCP client:
+    let bind_address = IpSocketAddress::new(IpAddress::new_loopback(family), 0);
+    let listener = TcpSocket::new(family).unwrap();
+    listener.blocking_bind(&net, bind_address).unwrap();
+    listener.blocking_listen().unwrap();
+    let bound_address = listener.local_address().unwrap();
+    let client = TcpSocket::new(family).unwrap();
+    let (input, output) = client.blocking_connect(net, bound_address).unwrap();
+    let (accepted, i, o) = listener.blocking_accept().unwrap();
+
+    // On Linux, `recv` continues to work even after `shutdown(sock, SHUT_RD)`
+    // has been called. To properly test that this behavior doesn't happen in
+    // WASI, we make sure there's some data to read by the client:
+    o.blocking_write_util(b"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.").unwrap();
+
+    body(&client, &input, &output);
+
+    drop(i);
+    drop(o);
+    drop(accepted);
+}

--- a/crates/wasi-http/wit/deps/sockets/tcp.wit
+++ b/crates/wasi-http/wit/deps/sockets/tcp.wit
@@ -304,12 +304,13 @@ interface tcp {
 
         /// Initiate a graceful shutdown.
         ///
-        /// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
-        ///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.
-        ///   Any data still in the receive queue at time of calling `shutdown` will be discarded.
-        /// - send: the socket is not expecting to send any more data to the peer. All subsequent write
-        ///   operations on the `output-stream` associated with this socket will return an error.
-        /// - both: same effect as receive & send combined.
+        /// - `receive`: The socket is not expecting to receive any data from
+        ///   the peer. The `input-stream` associated with this socket will be
+        ///   closed. Any data still in the receive queue at time of calling
+        ///   this method will be discarded.
+        /// - `send`: The socket has no more data to send to the peer. The `output-stream`
+        ///   associated with this socket will be closed and a FIN packet will be sent.
+        /// - `both`: Same effect as `receive` & `send` combined.
         ///
         /// The shutdown function does not close (drop) the socket.
         ///

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -613,16 +613,14 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
             _ => return Err(ErrorCode::InvalidState.into()),
         }
 
-        let how = match shutdown_type {
-            ShutdownType::Receive => std::net::Shutdown::Read,
-            ShutdownType::Send => std::net::Shutdown::Write,
-            ShutdownType::Both => std::net::Shutdown::Both,
-        };
+        if let ShutdownType::Receive | ShutdownType::Both = shutdown_type {
+            socket.inner.shutdown_recv()?;
+        }
 
-        socket
-            .tcp_socket()
-            .as_socketlike_view::<std::net::TcpStream>()
-            .shutdown(how)?;
+        if let ShutdownType::Send | ShutdownType::Both = shutdown_type {
+            socket.inner.shutdown_send()?;
+        }
+
         Ok(())
     }
 

--- a/crates/wasi/tests/all/async_.rs
+++ b/crates/wasi/tests/all/async_.rs
@@ -317,6 +317,10 @@ async fn preview2_tcp_connect() {
     run(PREVIEW2_TCP_CONNECT_COMPONENT, false).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn preview2_tcp_shutdown() {
+    run(PREVIEW2_TCP_SHUTDOWN_COMPONENT, false).await.unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn preview2_udp_sockopts() {
     run(PREVIEW2_UDP_SOCKOPTS_COMPONENT, false).await.unwrap()
 }

--- a/crates/wasi/tests/all/sync.rs
+++ b/crates/wasi/tests/all/sync.rs
@@ -262,6 +262,10 @@ fn preview2_tcp_connect() {
     run(PREVIEW2_TCP_CONNECT_COMPONENT, false).unwrap()
 }
 #[test_log::test]
+fn preview2_tcp_shutdown() {
+    run(PREVIEW2_TCP_SHUTDOWN_COMPONENT, false).unwrap()
+}
+#[test_log::test]
 fn preview2_udp_sockopts() {
     run(PREVIEW2_UDP_SOCKOPTS_COMPONENT, false).unwrap()
 }

--- a/crates/wasi/wit/deps/sockets/tcp.wit
+++ b/crates/wasi/wit/deps/sockets/tcp.wit
@@ -304,12 +304,13 @@ interface tcp {
 
         /// Initiate a graceful shutdown.
         ///
-        /// - receive: the socket is not expecting to receive any more data from the peer. All subsequent read
-        ///   operations on the `input-stream` associated with this socket will return an End Of Stream indication.
-        ///   Any data still in the receive queue at time of calling `shutdown` will be discarded.
-        /// - send: the socket is not expecting to send any more data to the peer. All subsequent write
-        ///   operations on the `output-stream` associated with this socket will return an error.
-        /// - both: same effect as receive & send combined.
+        /// - `receive`: The socket is not expecting to receive any data from
+        ///   the peer. The `input-stream` associated with this socket will be
+        ///   closed. Any data still in the receive queue at time of calling
+        ///   this method will be discarded.
+        /// - `send`: The socket has no more data to send to the peer. The `output-stream`
+        ///   associated with this socket will be closed and a FIN packet will be sent.
+        /// - `both`: Same effect as `receive` & `send` combined.
         ///
         /// The shutdown function does not close (drop) the socket.
         ///


### PR DESCRIPTION
Make `tcp-socket::shutdown` close the input/output-streams.
This was already specified in the WITs, but not implemented nor enforced by any tests.
