### PR TITLE
Switch winch's internal stack from a VecDeque to a Vec

### DIFF
--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -333,10 +333,10 @@ impl<'a, 'builtins> CodeGenContext<'a, 'builtins> {
             let len = self.stack.len();
             assert!(last <= len);
             let truncate = self.stack.len() - last;
-            let stack_mut = &mut self.stack.inner_mut();
+            let stack_mut = self.stack.inner_mut();
 
             // Invoke the callback in top-to-bottom order.
-            for v in stack_mut.range(truncate..).rev() {
+            for v in stack_mut[truncate..].into_iter().rev() {
                 f(&mut self.regalloc, v)
             }
             stack_mut.truncate(truncate);

--- a/winch/codegen/src/stack.rs
+++ b/winch/codegen/src/stack.rs
@@ -1,5 +1,4 @@
 use crate::{isa::reg::Reg, masm::StackSlot};
-use std::collections::VecDeque;
 use wasmparser::{Ieee32, Ieee64};
 use wasmtime_environ::WasmType;
 
@@ -261,7 +260,7 @@ impl Val {
 /// The shadow stack used for compilation.
 #[derive(Default, Debug)]
 pub(crate) struct Stack {
-    inner: VecDeque<Val>,
+    inner: Vec<Val>,
 }
 
 impl Stack {
@@ -314,12 +313,12 @@ impl Stack {
 
     /// Push a value to the stack.
     pub fn push(&mut self, val: Val) {
-        self.inner.push_back(val);
+        self.inner.push(val);
     }
 
     /// Peek into the top in the stack.
     pub fn peek(&self) -> Option<&Val> {
-        self.inner.back()
+        self.inner.last()
     }
 
     /// Returns an iterator referencing the last n items of the stack,
@@ -329,7 +328,7 @@ impl Stack {
         assert!(n <= len);
 
         let partition = len - n;
-        self.inner.range(partition..)
+        self.inner[partition..].into_iter()
     }
 
     /// Duplicates the top `n` elements of the stack.
@@ -351,7 +350,7 @@ impl Stack {
 
     /// Pops the top element of the stack, if any.
     pub fn pop(&mut self) -> Option<Val> {
-        self.inner.pop_back()
+        self.inner.pop()
     }
 
     /// Pops the element at the top of the stack if it is an i32 const;
@@ -393,7 +392,7 @@ impl Stack {
     }
 
     /// Get a mutable reference to the inner stack representation.
-    pub fn inner_mut(&mut self) -> &mut VecDeque<Val> {
+    pub fn inner_mut(&mut self) -> &mut Vec<Val> {
         &mut self.inner
     }
 


### PR DESCRIPTION
It doesn't look like which needs to modify the front of the `VecDeque` that it uses to model the value stack, and can instead use a `Vec`. This shouldn't change functionality at all, but seems nice for documentation purposes, as I initially assumed that there must be operations modifying the front of the stack given the use of `VecDeque`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
