### PR TITLE
Change update of gcc on MinGW

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -431,7 +431,7 @@ jobs:
       if: matrix.target == 'x86_64-pc-windows-gnu'
 
     # Update binutils if MinGW due to https://github.com/rust-lang/rust/issues/112368
-    - run: C:/msys64/usr/bin/pacman.exe -Syu --needed mingw-w64-x86_64-gcc --noconfirm
+    - run: C:/msys64/usr/bin/pacman.exe -S --needed mingw-w64-x86_64-gcc --noconfirm
       if: matrix.target == 'x86_64-pc-windows-gnu'
     - shell: pwsh
       run: echo "C:\msys64\mingw64\bin" >> $Env:GITHUB_PATH


### PR DESCRIPTION
Try not passing `-y -u` to `pacman` to avoid full system updates. Currently full system updates might update the `msys2-runtime` package before actually updating the package we requested, meaning that this might not actually update anything given an update. This is what's currently happening on CI which is breaking due to an update of gcc not actually updating gcc. I'm mostly reading the invocation in rust-lang/rust CI and seeing that it doesn't pass `-y -u` and hopeing that by copying that here things might work.

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
