### PR TITLE
wasi: Test multiple pollables of the same stream

### DIFF
--- a/crates/test-programs/src/bin/piped_multiple.rs
+++ b/crates/test-programs/src/bin/piped_multiple.rs
@@ -1,0 +1,34 @@
+use test_programs::wasi::cli::{stdin, stdout};
+
+fn main() {
+    match std::env::var("PIPED_SIDE")
+        .expect("piped tests require the PIPED_SIDE env var")
+        .as_str()
+    {
+        "PRODUCER" => producer(),
+        "CONSUMER" => consumer(),
+        side => panic!("unknown piped test side: {side}"),
+    }
+}
+
+const CHUNK: &[u8] = &[b'a'; 50];
+
+fn producer() {
+    let out = stdout::get_stdout();
+    let n = out.check_write().unwrap() as usize;
+    assert!(n > CHUNK.len());
+    out.write(CHUNK).unwrap();
+}
+
+fn consumer() {
+    let stdin = stdin::get_stdin();
+    let stdin_pollable1 = stdin.subscribe();
+    let stdin_pollable2 = stdin.subscribe();
+
+    // The two pollables are subscribed to the same resource, and must report the same readyness
+    stdin_pollable1.block();
+    assert!(stdin_pollable1.ready() && stdin_pollable2.ready());
+
+    let bytes = stdin.read(CHUNK.len() as u64).unwrap();
+    assert_eq!(&bytes, CHUNK);
+}


### PR DESCRIPTION
Multiple pollables of the same stream should report the same ready status when data is available.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
