### PR TITLE
Document internals of DomTreeWithChildren

### DIFF
--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -51,7 +51,8 @@ pub struct EgraphPass<'a> {
     /// Alias analysis, used during optimization.
     alias_analysis: &'a mut AliasAnalysis<'a>,
     /// "Domtree with children": like `domtree`, but with an explicit
-    /// list of children, rather than just parent pointers.
+    /// list of children, complementing the parent pointers stored
+    /// in `domtree`.
     domtree_children: DomTreeWithChildren,
     /// Loop analysis results, used for built-in LICM during
     /// elaboration.


### PR DESCRIPTION
I had a look at `egraph/domtree.rs` and spent a good few minutes confused by what exactly is happening. This PR adds some comments to explain how the data is represented, which should hopefully help the next person to look at this code grasp it much faster.

In particular, I clarified the comment in `egraph.rs` to avoid implying that `DomTreeWithChildren` duplicates the parent pointers.