### PR TITLE
fix: allow dynamic owned resources to be used as borrowed parameters

### DIFF
--- a/crates/wasmtime/src/component/func.rs
+++ b/crates/wasmtime/src/component/func.rs
@@ -362,7 +362,8 @@ impl Func {
         }
 
         for (param, ty) in params.iter().zip(param_tys.iter()) {
-            ty.check(param).context("type mismatch with parameters")?;
+            ty.is_supertype_of(param)
+                .context("type mismatch with parameters")?;
         }
 
         self.call_raw(

--- a/crates/wasmtime/src/component/func/host.rs
+++ b/crates/wasmtime/src/component/func/host.rs
@@ -385,7 +385,7 @@ where
     let mut cx = LowerContext::new(store, &options, types, instance);
     let instance = cx.instance_type();
     for (val, ty) in result_vals.iter().zip(result_tys.types.iter()) {
-        Type::from(ty, &instance).check(val)?;
+        Type::from(ty, &instance).is_supertype_of(val)?;
     }
     if let Some(cnt) = result_tys.abi.flat_count(MAX_FLAT_RESULTS) {
         let mut dst = storage[..cnt].iter_mut();

--- a/crates/wasmtime/src/component/types.rs
+++ b/crates/wasmtime/src/component/types.rs
@@ -675,9 +675,16 @@ impl Type {
         }
     }
 
-    pub(crate) fn check(&self, value: &Val) -> Result<()> {
+    /// Checks whether type of `value` is a subtype of `self`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error in case of a type mismatch
+    pub(crate) fn is_supertype_of(&self, value: &Val) -> Result<()> {
         let other = &value.ty();
-        if self == other {
+        if self == other
+            || matches!((self, other), (Self::Borrow(s), Self::Own(other)) if s == other)
+        {
             Ok(())
         } else if mem::discriminant(self) != mem::discriminant(other) {
             Err(anyhow!(


### PR DESCRIPTION
This enables using owned resources in places where borrowed resources of the same type are expected (e.g. dynamically-typed functions/methods defined in `Linker::func_new`)
Note, that this is already possible in e.g. https://github.com/bytecodealliance/wasmtime/blob/4b2425dc3044ec57ddbfa94bcbe2d774df249d03/crates/wasmtime/src/component/resources.rs#L340-L352

cc @alexcrichton , we discussed this on a call, I believe this is the changeset we agreed upon