### PR TITLE
mpk: allow benchmarking MPK

### DIFF
--- a/crates/runtime/src/mpk/enabled.rs
+++ b/crates/runtime/src/mpk/enabled.rs
@@ -50,7 +50,11 @@ static KEYS: OnceLock<Vec<ProtectionKey>> = OnceLock::new();
 /// Any accesses to pages marked by another key will result in a `SIGSEGV`
 /// fault.
 pub fn allow(mask: ProtectionMask) {
-    let previous = pkru::read();
+    let previous = if log::log_enabled!(log::Level::Trace) {
+        pkru::read()
+    } else {
+        0
+    };
     pkru::write(mask.0);
     log::trace!("PKRU change: {:#034b} => {:#034b}", previous, pkru::read());
 }

--- a/crates/runtime/src/mpk/pkru.rs
+++ b/crates/runtime/src/mpk/pkru.rs
@@ -30,6 +30,7 @@ pub const ALLOW_ACCESS: u32 = 0;
 pub const DISABLE_ACCESS: u32 = 0b11111111_11111111_11111111_11111111;
 
 /// Read the value of the `PKRU` register.
+#[inline]
 pub fn read() -> u32 {
     // ECX must be 0 to prevent a general protection exception (#GP).
     let ecx: u32 = 0;
@@ -42,6 +43,7 @@ pub fn read() -> u32 {
 }
 
 /// Write a value to the `PKRU` register.
+#[inline]
 pub fn write(pkru: u32) {
     // Both ECX and EDX must be 0 to prevent a general protection exception
     // (#GP).


### PR DESCRIPTION
These changes allow one to measure the effect of MPK on WebAssembly boundary crossings (guest-host and vice-versa). I also includes some small but distracting bits that affect the measured overhead.