### PR TITLE
mpk: add `--memory-protection-keys` to the CLI options

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -513,9 +513,6 @@ impl CommonOptions {
         match_feature! {
             ["pooling-allocator" : self.opts.pooling_allocator]
             enable => {
-                if !enable && self.opts.memory_protection_keys.unwrap_or(false) {
-                    anyhow::bail!("memory protection keys require the pooling allocator");
-                }
                 if enable {
                     let mut cfg = wasmtime::PoolingAllocationConfig::default();
                     if let Some(size) = self.opts.pooling_memory_keep_resident {
@@ -533,6 +530,12 @@ impl CommonOptions {
                 }
             },
             true => err,
+        }
+
+        if self.opts.memory_protection_keys.unwrap_or(false)
+            && !self.opts.pooling_allocator.unwrap_or(false)
+        {
+            anyhow::bail!("memory protection keys require the pooling allocator");
         }
 
         if let Some(max) = self.wasm.max_wasm_stack {

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use clap::Parser;
 use std::time::Duration;
-use wasmtime::{Config, MpkEnabled};
+use wasmtime::Config;
 
 pub mod opt;
 
@@ -523,7 +523,7 @@ impl CommonOptions {
                     }
                     if let Some(enable) = self.opts.memory_protection_keys {
                         if enable {
-                            cfg.memory_protection_keys(MpkEnabled::Enable);
+                            cfg.memory_protection_keys(wasmtime::MpkEnabled::Enable);
                         }
                     }
                     config.allocation_strategy(wasmtime::InstanceAllocationStrategy::Pooling(cfg));

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1208,6 +1208,24 @@ fn float_args() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn mpk_without_pooling() -> Result<()> {
+    let output = get_wasmtime_command()?
+        .args(&[
+            "run",
+            "-O",
+            "memory-protection-keys=y",
+            "--invoke",
+            "echo_f32",
+            "tests/all/cli_tests/simple.wat",
+            "1.0",
+        ])
+        .env("WASMTIME_NEW_CLI", "1")
+        .output()?;
+    assert!(!output.status.success());
+    Ok(())
+}
+
 mod test_programs {
     use super::{get_wasmtime_command, run_wasmtime};
     use anyhow::Result;


### PR DESCRIPTION
This only adds MPK configuration to the new Wasmtime flags.