### PR TITLE
mpk: restore PKRU state when a fiber resumes execution

### DIFF
--- a/crates/runtime/src/mpk/disabled.rs
+++ b/crates/runtime/src/mpk/disabled.rs
@@ -13,6 +13,10 @@ pub fn keys(_: usize) -> &'static [ProtectionKey] {
 }
 pub fn allow(_: ProtectionMask) {}
 
+pub fn current_mask() -> ProtectionMask {
+    ProtectionMask
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum ProtectionKey {}
 impl ProtectionKey {

--- a/crates/runtime/src/mpk/enabled.rs
+++ b/crates/runtime/src/mpk/enabled.rs
@@ -59,6 +59,11 @@ pub fn allow(mask: ProtectionMask) {
     log::trace!("PKRU change: {:#034b} => {:#034b}", previous, pkru::read());
 }
 
+/// Retrieve the current protection mask.
+pub fn current_mask() -> ProtectionMask {
+    ProtectionMask(pkru::read())
+}
+
 /// An MPK protection key.
 ///
 /// The expected usage is:

--- a/crates/runtime/src/mpk/mod.rs
+++ b/crates/runtime/src/mpk/mod.rs
@@ -34,10 +34,10 @@ cfg_if::cfg_if! {
         mod enabled;
         mod pkru;
         mod sys;
-        pub use enabled::{allow, is_supported, keys, ProtectionKey, ProtectionMask};
+        pub use enabled::{allow, current_mask, is_supported, keys, ProtectionKey, ProtectionMask};
     } else {
         mod disabled;
-        pub use disabled::{allow, is_supported, keys, ProtectionKey, ProtectionMask};
+        pub use disabled::{allow, current_mask, is_supported, keys, ProtectionKey, ProtectionMask};
     }
 }
 


### PR DESCRIPTION
Previously, when a fiber was suspended, other computation could change the PKRU state on the current CPU. This means that the fiber could be resumed with a different PKRU state. This could be bad, resulting in situations in which the fiber can access more memory slots than it should or cannot even access its own memory slots.

This change saves the PKRU state prior to a fiber being suspended. When the fiber resumes execution, that PKRU state is restored.
