### PR TITLE
Update the Wasmi fuzzing oracle to version `0.31.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3163,9 +3163,9 @@ dependencies = [
 
 [[package]]
 name = "wasmi_arena"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
+checksum = "104a7f73be44570cac297b3035d76b169d6599637631cf37a1703326a0727073"
 
 [[package]]
 name = "wasmi_core"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3150,10 +3150,11 @@ dependencies = [
 
 [[package]]
 name = "wasmi"
-version = "0.20.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01bf50edb2ea9d922aa75a7bf3c15e26a6c9e2d18c56e862b49737a582901729"
+checksum = "acfc1e384a36ca532d070a315925887247f3c7e23567e23e0ac9b1c5d6b8bf76"
 dependencies = [
+ "smallvec",
  "spin 0.9.4",
  "wasmi_arena",
  "wasmi_core",
@@ -3162,19 +3163,20 @@ dependencies = [
 
 [[package]]
 name = "wasmi_arena"
-version = "0.1.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ea379cbb0b41f3a9f0bf7b47036d036aae7f43383d8cc487d4deccf40dee0a"
+checksum = "401c1f35e413fac1846d4843745589d9ec678977ab35a384db8ae7830525d468"
 
 [[package]]
 name = "wasmi_core"
-version = "0.5.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5bf998ab792be85e20e771fe14182b4295571ad1d4f89d3da521c1bef5f597a"
+checksum = "dcf1a7db34bff95b85c261002720c00c3a6168256dcb93041d3fa2054d19856a"
 dependencies = [
  "downcast-rs",
  "libm",
  "num-traits",
+ "paste",
 ]
 
 [[package]]
@@ -3200,9 +3202,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser-nostd"
-version = "0.91.0"
+version = "0.100.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c37f310b5a62bfd5ae7c0f1d8e6f98af16a5d6d84ba764e9c36439ec14e318b"
+checksum = "9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724"
 dependencies = [
  "indexmap-nostd",
 ]

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -28,7 +28,7 @@ wasm-encoder = { workspace = true }
 wasm-smith = { workspace = true }
 wasm-mutate = { workspace = true }
 wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true }
-wasmi = "0.20.0"
+wasmi = "0.31.0"
 
 # We rely on precompiled v8 binaries, but rusty-v8 doesn't have a precompiled
 # binary for MinGW which is built on our CI. It does have one for Windows-msvc,

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -28,7 +28,7 @@ wasm-encoder = { workspace = true }
 wasm-smith = { workspace = true }
 wasm-mutate = { workspace = true }
 wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true }
-wasmi = "0.31.0"
+wasmi = "0.31.1"
 
 # We rely on precompiled v8 binaries, but rusty-v8 doesn't have a precompiled
 # binary for MinGW which is built on our CI. It does have one for Windows-msvc,

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -20,8 +20,6 @@ impl WasmiEngine {
         config.exceptions_enabled = false;
         config.max_memories = config.max_memories.min(1);
         config.min_memories = config.min_memories.min(1);
-        config.max_tables = config.max_tables.min(1);
-        config.min_tables = config.min_tables.min(1);
 
         let mut wasmi_config = wasmi::Config::default();
         wasmi_config

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -13,12 +13,18 @@ pub struct WasmiEngine {
 impl WasmiEngine {
     pub(crate) fn new(config: &mut Config) -> Self {
         let config = &mut config.module_config.config;
+        config.multi_value_enabled = true;
+        config.sign_extension_ops_enabled = true;
+        config.saturating_float_to_int_enabled = true;
         config.reference_types_enabled = true;
         config.simd_enabled = false;
+        config.relaxed_simd_enabled = false;
         config.memory64_enabled = false;
+        config.threads_enabled = false;
         config.bulk_memory_enabled = true;
         config.threads_enabled = false;
         config.tail_call_enabled = true;
+        config.exceptions_enabled = false;
         config.max_memories = config.max_memories.min(1);
         config.min_memories = config.min_memories.min(1);
         config.max_tables = config.max_tables.min(1);

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -13,6 +13,7 @@ pub struct WasmiEngine {
 impl WasmiEngine {
     pub(crate) fn new(config: &mut Config) -> Self {
         let config = &mut config.module_config.config;
+        // Force generated Wasm modules to never have features that Wasmi doesn't support.
         config.simd_enabled = false;
         config.relaxed_simd_enabled = false;
         config.memory64_enabled = false;

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -13,25 +13,31 @@ pub struct WasmiEngine {
 impl WasmiEngine {
     pub(crate) fn new(config: &mut Config) -> Self {
         let config = &mut config.module_config.config;
-        config.multi_value_enabled = true;
-        config.sign_extension_ops_enabled = true;
-        config.saturating_float_to_int_enabled = true;
-        config.reference_types_enabled = true;
         config.simd_enabled = false;
         config.relaxed_simd_enabled = false;
         config.memory64_enabled = false;
         config.threads_enabled = false;
-        config.bulk_memory_enabled = true;
         config.threads_enabled = false;
-        config.tail_call_enabled = true;
         config.exceptions_enabled = false;
         config.max_memories = config.max_memories.min(1);
         config.min_memories = config.min_memories.min(1);
         config.max_tables = config.max_tables.min(1);
         config.min_tables = config.min_tables.min(1);
 
+        let mut wasmi_config = wasmi::Config::default();
+        wasmi_config
+            .consume_fuel(false)
+            .floats(true)
+            .wasm_mutable_global(true)
+            .wasm_sign_extension(config.sign_extension_ops_enabled)
+            .wasm_saturating_float_to_int(config.saturating_float_to_int_enabled)
+            .wasm_multi_value(config.multi_value_enabled)
+            .wasm_bulk_memory(config.bulk_memory_enabled)
+            .wasm_reference_types(config.reference_types_enabled)
+            .wasm_tail_call(config.tail_call_enabled)
+            .wasm_extended_const(true);
         Self {
-            engine: wasmi::Engine::default(),
+            engine: wasmi::Engine::new(&wasmi_config),
         }
     }
 }

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -13,7 +13,6 @@ pub struct WasmiEngine {
 impl WasmiEngine {
     pub(crate) fn new(config: &mut Config) -> Self {
         let config = &mut config.module_config.config;
-        // Force generated Wasm modules to never have features that Wasmi doesn't support.
         config.simd_enabled = false;
         config.relaxed_simd_enabled = false;
         config.memory64_enabled = false;

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -78,7 +78,10 @@ impl DiffEngine for WasmiEngine {
                 .expect(&format!("not a trap: {:?}", err)),
         };
         assert!(wasmi.trap_code().is_some());
-        assert_eq!(wasmi_to_wasmtime_trap_code(wasmi.trap_code().unwrap()), *trap);
+        assert_eq!(
+            wasmi_to_wasmtime_trap_code(wasmi.trap_code().unwrap()),
+            *trap
+        );
     }
 
     fn is_stack_overflow(&self, err: &Error) -> bool {

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -17,7 +17,6 @@ impl WasmiEngine {
         config.relaxed_simd_enabled = false;
         config.memory64_enabled = false;
         config.threads_enabled = false;
-        config.threads_enabled = false;
         config.exceptions_enabled = false;
         config.max_memories = config.max_memories.min(1);
         config.min_memories = config.min_memories.min(1);

--- a/crates/fuzzing/src/oracles/diff_wasmi.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmi.rs
@@ -13,11 +13,12 @@ pub struct WasmiEngine {
 impl WasmiEngine {
     pub(crate) fn new(config: &mut Config) -> Self {
         let config = &mut config.module_config.config;
-        config.reference_types_enabled = false;
+        config.reference_types_enabled = true;
         config.simd_enabled = false;
         config.memory64_enabled = false;
-        config.bulk_memory_enabled = false;
+        config.bulk_memory_enabled = true;
         config.threads_enabled = false;
+        config.tail_call_enabled = true;
         config.max_memories = config.max_memories.min(1);
         config.min_memories = config.min_memories.min(1);
         config.max_tables = config.max_tables.min(1);
@@ -38,7 +39,7 @@ impl DiffEngine for WasmiEngine {
         let module =
             wasmi::Module::new(&self.engine, wasm).context("unable to validate Wasm module")?;
         let mut store = wasmi::Store::new(&self.engine, ());
-        let instance = wasmi::Linker::<()>::new()
+        let instance = wasmi::Linker::<()>::new(&self.engine)
             .instantiate(&mut store, &module)
             .and_then(|i| i.start(&mut store))
             .context("unable to instantiate module in wasmi")?;
@@ -76,8 +77,8 @@ impl DiffEngine for WasmiEngine {
                 .downcast_ref::<wasmi::core::Trap>()
                 .expect(&format!("not a trap: {:?}", err)),
         };
-        assert!(wasmi.as_code().is_some());
-        assert_eq!(wasmi_to_wasmtime_trap_code(wasmi.as_code().unwrap()), *trap);
+        assert!(wasmi.trap_code().is_some());
+        assert_eq!(wasmi_to_wasmtime_trap_code(wasmi.trap_code().unwrap()), *trap);
     }
 
     fn is_stack_overflow(&self, err: &Error) -> bool {
@@ -89,7 +90,7 @@ impl DiffEngine for WasmiEngine {
                 None => return false,
             },
         };
-        matches!(trap.as_code(), Some(wasmi::core::TrapCode::StackOverflow))
+        matches!(trap.trap_code(), Some(wasmi::core::TrapCode::StackOverflow))
     }
 }
 
@@ -97,15 +98,17 @@ impl DiffEngine for WasmiEngine {
 fn wasmi_to_wasmtime_trap_code(trap: wasmi::core::TrapCode) -> Trap {
     use wasmi::core::TrapCode;
     match trap {
-        TrapCode::Unreachable => Trap::UnreachableCodeReached,
-        TrapCode::MemoryAccessOutOfBounds => Trap::MemoryOutOfBounds,
-        TrapCode::TableAccessOutOfBounds => Trap::TableOutOfBounds,
-        TrapCode::ElemUninitialized => Trap::IndirectCallToNull,
-        TrapCode::DivisionByZero => Trap::IntegerDivisionByZero,
+        TrapCode::UnreachableCodeReached => Trap::UnreachableCodeReached,
+        TrapCode::MemoryOutOfBounds => Trap::MemoryOutOfBounds,
+        TrapCode::TableOutOfBounds => Trap::TableOutOfBounds,
+        TrapCode::IndirectCallToNull => Trap::IndirectCallToNull,
+        TrapCode::IntegerDivisionByZero => Trap::IntegerDivisionByZero,
         TrapCode::IntegerOverflow => Trap::IntegerOverflow,
-        TrapCode::InvalidConversionToInt => Trap::BadConversionToInteger,
+        TrapCode::BadConversionToInteger => Trap::BadConversionToInteger,
         TrapCode::StackOverflow => Trap::StackOverflow,
-        TrapCode::UnexpectedSignature => Trap::BadSignature,
+        TrapCode::BadSignature => Trap::BadSignature,
+        TrapCode::OutOfFuel => unimplemented!("built-in fuel metering is unused"),
+        TrapCode::GrowthOperationLimited => unimplemented!("resource limiter is unused"),
     }
 }
 
@@ -132,7 +135,7 @@ impl DiffInstance for WasmiInstance {
             .and_then(wasmi::Extern::into_func)
             .unwrap();
         let arguments: Vec<_> = arguments.iter().map(|x| x.into()).collect();
-        let mut results = vec![wasmi::core::Value::I32(0); result_tys.len()];
+        let mut results = vec![wasmi::Value::I32(0); result_tys.len()];
         function
             .call(&mut self.store, &arguments, &mut results)
             .context("wasmi function trap")?;
@@ -165,29 +168,37 @@ impl DiffInstance for WasmiInstance {
     }
 }
 
-impl From<&DiffValue> for wasmi::core::Value {
+impl From<&DiffValue> for wasmi::Value {
     fn from(v: &DiffValue) -> Self {
-        use wasmi::core::Value::*;
+        use wasmi::Value as WasmiValue;
         match *v {
-            DiffValue::I32(n) => I32(n),
-            DiffValue::I64(n) => I64(n),
-            DiffValue::F32(n) => F32(wasmi::core::F32::from_bits(n)),
-            DiffValue::F64(n) => F64(wasmi::core::F64::from_bits(n)),
-            DiffValue::V128(_) | DiffValue::FuncRef { .. } | DiffValue::ExternRef { .. } => {
-                unimplemented!()
+            DiffValue::I32(n) => WasmiValue::I32(n),
+            DiffValue::I64(n) => WasmiValue::I64(n),
+            DiffValue::F32(n) => WasmiValue::F32(wasmi::core::F32::from_bits(n)),
+            DiffValue::F64(n) => WasmiValue::F64(wasmi::core::F64::from_bits(n)),
+            DiffValue::V128(_) => unimplemented!(),
+            DiffValue::FuncRef { null } => {
+                assert!(null);
+                WasmiValue::FuncRef(wasmi::FuncRef::null())
+            }
+            DiffValue::ExternRef { null } => {
+                assert!(null);
+                WasmiValue::ExternRef(wasmi::ExternRef::null())
             }
         }
     }
 }
 
-impl From<wasmi::core::Value> for DiffValue {
-    fn from(value: wasmi::core::Value) -> Self {
-        use wasmi::core::Value as WasmiValue;
+impl From<wasmi::Value> for DiffValue {
+    fn from(value: wasmi::Value) -> Self {
+        use wasmi::Value as WasmiValue;
         match value {
             WasmiValue::I32(n) => DiffValue::I32(n),
             WasmiValue::I64(n) => DiffValue::I64(n),
             WasmiValue::F32(n) => DiffValue::F32(n.to_bits()),
             WasmiValue::F64(n) => DiffValue::F64(n.to_bits()),
+            WasmiValue::FuncRef(f) => DiffValue::FuncRef { null: f.is_null() },
+            WasmiValue::ExternRef(e) => DiffValue::ExternRef { null: e.is_null() },
         }
     }
 }


### PR DESCRIPTION
Currently Wasmtime uses the 2 years old Wasmi version `0.20.0`.

Since then Wasmi has improved substantially and added support for new Wasm proposals such as `bulk-memory`, `reference-types` and `tail-calls` which we can now enable.
Wasmi `v0.31.0` has recently been audited and is used by some large projects, thus is a lot more battle tested than the previous `v0.20.0`.

Besides that the most notable change are performance improvements which should make fuzzing with Wasmi a tiny bit faster.

Look into the future: Since roughly half a year I am working on the next major Wasmi version `v0.32.0` which is a complete rewrite of the Wasmi executor featuring a much more powerful register-machine execution model and optional lazy compilation & validation. I hope that it becomes stable enough for use soon to provide it as fuzzing oracle to Wasmtime. Due to the changes we refer to the new Wasmi version as Wasmi (register) and the old Wasmi as Wasmi (stack). It might even make sense to have both versions as oracles at the same time because they have very different strengths.