### PR TITLE
Make wasmtime dependency in wiggle and wasi-common optional with a default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -179,7 +179,7 @@ component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
 wiggle = { path = "crates/wiggle", version = "=18.0.0", default-features = false }
 wiggle-macro = { path = "crates/wiggle/macro", version = "=18.0.0" }
 wiggle-generate = { path = "crates/wiggle/generate", version = "=18.0.0" }
-wasi-common = { path = "crates/wasi-common", version = "=18.0.0" }
+wasi-common = { path = "crates/wasi-common", version = "=18.0.0", default-features = false }
 wasi-tokio = { path = "crates/wasi-common/tokio", version = "=18.0.0" }
 wasi-cap-std-sync = { path = "crates/wasi-common/cap-std-sync", version = "=18.0.0" }
 wasmtime-fuzzing = { path = "crates/fuzzing" }

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -24,7 +24,7 @@ workspace = true
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 wiggle = { workspace = true }
-wasmtime = { workspace = true }
+wasmtime = { workspace = true, optional = true }
 tracing = { workspace = true }
 cap-std = { workspace = true }
 cap-rand = { workspace = true }
@@ -54,7 +54,7 @@ test-programs-artifacts = { workspace = true }
 tokio = { workspace = true, features = ['macros', 'rt-multi-thread'] }
 
 [features]
-default = ["trace_log"]
+default = ["trace_log", "wasmtime"]
 # This feature enables the `tracing` logs in the calls to target the `log`
 # ecosystem of backends (e.g. `env_logger`. Disable this if you want to use
 # `tracing-subscriber`.
@@ -62,3 +62,5 @@ trace_log = [ "wiggle/tracing_log", "tracing/log" ]
 # Need to make the wiggle_metadata feature available to consumers of this
 # crate if they want the snapshots to have metadata available.
 wiggle_metadata = ["wiggle/wiggle_metadata"]
+# This feature enables integration with wasmtime.
+wasmtime = ["dep:wasmtime", "wiggle/wasmtime"]

--- a/crates/wasi/Cargo.toml
+++ b/crates/wasi/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = { workspace = true }
 wasi-common = { workspace = true }
 wasi-cap-std-sync = { workspace = true, optional = true }
 wasi-tokio = { workspace = true, optional = true }
-wiggle = { workspace = true, optional = true }
+wiggle = { workspace = true, optional = true, features = ["wasmtime"] }
 libc = { workspace = true }
 once_cell = { workspace = true }
 log = { workspace = true }

--- a/crates/wiggle/Cargo.toml
+++ b/crates/wiggle/Cargo.toml
@@ -20,13 +20,14 @@ wiggle-macro = { workspace = true }
 tracing = { workspace = true }
 bitflags = { workspace = true }
 async-trait = { workspace = true }
-wasmtime = { workspace = true }
+wasmtime = { workspace = true, optional = true }
 anyhow = { workspace = true }
 
 [dev-dependencies]
 wiggle-test = { path = "test-helpers" }
 proptest = "1.0.0"
 tokio = { version = "1", features = ["rt-multi-thread","time", "macros"] }
+wasmtime = { workspace = true }
 
 [[test]]
 name = "atoms_async"
@@ -62,7 +63,10 @@ wiggle_metadata = ['witx', "wiggle-macro/wiggle_metadata"]
 # the logs out of wiggle-generated libraries.
 tracing_log = [ "tracing/log" ]
 
+# This feature enables integration with wasmtime.
+wasmtime = ["dep:wasmtime"]
+
 # Support for async in the wasmtime crates.
 wasmtime_async = [ "wasmtime/async" ]
 
-default = ["wiggle_metadata", "wasmtime_async" ]
+default = ["wiggle_metadata", "wasmtime", "wasmtime_async" ]

--- a/crates/wiggle/src/lib.rs
+++ b/crates/wiggle/src/lib.rs
@@ -32,6 +32,7 @@ pub mod async_trait_crate {
 }
 
 pub mod wasmtime;
+#[cfg(feature = "wasmtime")]
 pub mod wasmtime_crate {
     pub use wasmtime::*;
 }


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

I am trying to use `wasi-common` (and thus also `wiggle`) to provide a common `WasiCtx` implementation that is reused between `wasmtime` and a custom runtime (as briefly mentioned in https://github.com/bytecodealliance/wasmtime/issues/7776). At the moment, compiling these packages also compiles `wasmtime`, which is not supported on my platform. I propose to add an enabled-by-default feature to `wasi-common` and `wiggle` that guards all `wasmtime`-specific code and allows both packages to be compiled without a dependency on `wasmtime` using `default-features = false`.