### PR TITLE
Rename generated structures to `Guest` in bindgen

### DIFF
--- a/crates/component-macro/build.rs
+++ b/crates/component-macro/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    println!("cargo:rustc-env=DEBUG_OUTPUT_DIR={out_dir}");
+}

--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -3,6 +3,7 @@ use quote::ToTokens;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 use syn::parse::{Error, Parse, ParseStream, Result};
 use syn::punctuated::Punctuated;
 use syn::{braced, token, Token};
@@ -24,7 +25,31 @@ pub fn expand(input: &Config) -> Result<TokenStream> {
         ));
     }
 
-    let src = input.opts.generate(&input.resolve, input.world);
+    let mut src = input.opts.generate(&input.resolve, input.world);
+
+    // If a magical `WASMTIME_DEBUG_BINDGEN` environment variable is set then
+    // place a formatted version of the expanded code into a file. This file
+    // will then show up in rustc error messages for any codegen issues and can
+    // be inspected manually.
+    if std::env::var("WASMTIME_DEBUG_BINDGEN").is_ok() {
+        static INVOCATION: AtomicUsize = AtomicUsize::new(0);
+        let root = Path::new(env!("DEBUG_OUTPUT_DIR"));
+        let world_name = &input.resolve.worlds[input.world].name;
+        let n = INVOCATION.fetch_add(1, Relaxed);
+        let path = root.join(format!("{world_name}{n}.rs"));
+
+        std::fs::write(&path, &src).unwrap();
+
+        // optimistically format the code but don't require success
+        drop(
+            std::process::Command::new("rustfmt")
+                .arg(&path)
+                .arg("--edition=2021")
+                .output(),
+        );
+
+        src = format!("include!({path:?});");
+    }
     let mut contents = src.parse::<TokenStream>().unwrap();
 
     // Include a dummy `include_str!` for any files we read so rustc knows that

--- a/crates/component-macro/tests/codegen/wat.wit
+++ b/crates/component-macro/tests/codegen/wat.wit
@@ -1,0 +1,10 @@
+package same:name;
+
+interface this-name-is-duplicated {
+  resource this-name-is-duplicated {
+  }
+}
+
+world example {
+  export this-name-is-duplicated;
+}


### PR DESCRIPTION
This mirrors how traits for the host are all called `Host` and it avoids name clashes with types that share the name of the interface they are in.

I've also added some simple debugging of macro-generated code to get better error messages.

Closes #7775

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
