### PR TITLE
winch: Emit unwind info in the x64 backend

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -204,30 +204,7 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
     assert!(strategy == "Cranelift" || strategy == "Winch");
 
     // Ignore everything except the winch misc test suite.
-    // We ignore tests that assert for traps on windows, given
-    // that Winch doesn't encode unwind information for Windows, yet.
     if strategy == "Winch" {
-        let assert_trap = [
-            "i32",
-            "i64",
-            "call",
-            "call_indirect",
-            "conversions",
-            "table_fill",
-            "table_init",
-            "table_copy",
-            "table_set",
-            "table_get",
-            "memory_grow",
-            "memory_init",
-            "memory_fill",
-        ]
-        .contains(&testname);
-
-        if assert_trap && env::var("CARGO_CFG_TARGET_OS").unwrap().as_str() == "windows" {
-            return true;
-        }
-
         if testsuite == "misc_testsuite" {
             // The misc/call_indirect is fully supported by Winch.
             if testname != "call_indirect" {

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -59,8 +59,8 @@ pub use crate::machinst::buffer::{
 };
 pub use crate::machinst::{
     CompiledCode, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit,
-    MachInstEmitState, MachLabel, Reg, TextSectionBuilder, VCodeConstantData, VCodeConstants,
-    Writable,
+    MachInstEmitState, MachLabel, RealReg, Reg, TextSectionBuilder, VCodeConstantData,
+    VCodeConstants, Writable,
 };
 
 mod alias_analysis;

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -112,6 +112,7 @@ impl RealReg {
         self.0.class()
     }
 
+    /// The physical register number.
     pub fn hw_enc(self) -> u8 {
         PReg::from(self).hw_enc() as u8
     }

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -64,6 +64,27 @@ impl Compiler {
         context.allocations = allocs;
         self.contexts.lock().unwrap().push(context);
     }
+
+    /// Emit unwind info into the [`CompiledFunction`].
+    fn emit_unwind_info(
+        &self,
+        compiled_function: &mut CompiledFunction<CompiledFuncEnv>,
+    ) -> Result<(), CompileError> {
+        let kind = match self.isa.triple().operating_system {
+            target_lexicon::OperatingSystem::Windows => UnwindInfoKind::Windows,
+            _ => UnwindInfoKind::SystemV,
+        };
+
+        if let Some(info) = self
+            .isa
+            .emit_unwind_info(&compiled_function.buffer, kind)
+            .map_err(|e| CompileError::Codegen(format!("{e:?}")))?
+        {
+            compiled_function.set_unwind_info(info);
+        }
+
+        Ok(())
+    }
 }
 
 impl wasmtime_environ::Compiler for Compiler {
@@ -104,18 +125,7 @@ impl wasmtime_environ::Compiler for Compiler {
             CompiledFunction::new(buffer, CompiledFuncEnv {}, self.isa.function_alignment());
 
         if self.isa.flags().unwind_info() {
-            let kind = match self.isa.triple().operating_system {
-                target_lexicon::OperatingSystem::Windows => UnwindInfoKind::Windows,
-                _ => UnwindInfoKind::SystemV,
-            };
-
-            if let Some(info) = self
-                .isa
-                .emit_unwind_info(&compiled_function.buffer, kind)
-                .map_err(|e| CompileError::Codegen(format!("{e:?}")))?
-            {
-                compiled_function.set_unwind_info(info);
-            }
+            self.emit_unwind_info(&mut compiled_function)?;
         }
 
         Ok((
@@ -145,18 +155,7 @@ impl wasmtime_environ::Compiler for Compiler {
             CompiledFunction::new(buffer, CompiledFuncEnv {}, self.isa.function_alignment());
 
         if self.isa.flags().unwind_info() {
-            let kind = match self.isa.triple().operating_system {
-                target_lexicon::OperatingSystem::Windows => UnwindInfoKind::Windows,
-                _ => UnwindInfoKind::SystemV,
-            };
-
-            if let Some(info) = self
-                .isa
-                .emit_unwind_info(&compiled_function.buffer, kind)
-                .map_err(|e| CompileError::Codegen(format!("{e:?}")))?
-            {
-                compiled_function.set_unwind_info(info);
-            }
+            self.emit_unwind_info(&mut compiled_function)?;
         }
 
         Ok(Box::new(compiled_function))
@@ -181,18 +180,7 @@ impl wasmtime_environ::Compiler for Compiler {
             CompiledFunction::new(buffer, CompiledFuncEnv {}, self.isa.function_alignment());
 
         if self.isa.flags().unwind_info() {
-            let kind = match self.isa.triple().operating_system {
-                target_lexicon::OperatingSystem::Windows => UnwindInfoKind::Windows,
-                _ => UnwindInfoKind::SystemV,
-            };
-
-            if let Some(info) = self
-                .isa
-                .emit_unwind_info(&compiled_function.buffer, kind)
-                .map_err(|e| CompileError::Codegen(format!("{e:?}")))?
-            {
-                compiled_function.set_unwind_info(info);
-            }
+            self.emit_unwind_info(&mut compiled_function)?;
         }
 
         Ok(Box::new(compiled_function))
@@ -211,18 +199,7 @@ impl wasmtime_environ::Compiler for Compiler {
             CompiledFunction::new(buffer, CompiledFuncEnv {}, self.isa.function_alignment());
 
         if self.isa.flags().unwind_info() {
-            let kind = match self.isa.triple().operating_system {
-                target_lexicon::OperatingSystem::Windows => UnwindInfoKind::Windows,
-                _ => UnwindInfoKind::SystemV,
-            };
-
-            if let Some(info) = self
-                .isa
-                .emit_unwind_info(&compiled_function.buffer, kind)
-                .map_err(|e| CompileError::Codegen(format!("{e:?}")))?
-            {
-                compiled_function.set_unwind_info(info);
-            }
+            self.emit_unwind_info(&mut compiled_function)?;
         }
 
         Ok(Box::new(compiled_function))

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use cranelift_codegen::isa::unwind::UnwindInfoKind;
 use object::write::{Object, SymbolId};
 use std::any::Any;
 use std::mem;
@@ -98,8 +99,24 @@ impl wasmtime_environ::Compiler for Compiler {
             .map_err(|e| CompileError::Codegen(format!("{e:?}")));
         self.save_context(context, validator.into_allocations());
         let buffer = buffer?;
-        let compiled_function =
+
+        let mut compiled_function =
             CompiledFunction::new(buffer, CompiledFuncEnv {}, self.isa.function_alignment());
+
+        if self.isa.flags().unwind_info() {
+            let kind = match self.isa.triple().operating_system {
+                target_lexicon::OperatingSystem::Windows => UnwindInfoKind::Windows,
+                _ => UnwindInfoKind::SystemV,
+            };
+
+            if let Some(info) = self
+                .isa
+                .emit_unwind_info(&compiled_function.buffer, kind)
+                .map_err(|e| CompileError::Codegen(format!("{e:?}")))?
+            {
+                compiled_function.set_unwind_info(info);
+            }
+        }
 
         Ok((
             WasmFunctionInfo {
@@ -123,8 +140,24 @@ impl wasmtime_environ::Compiler for Compiler {
             .isa
             .compile_trampoline(&ty, TrampolineKind::ArrayToWasm(func_index))
             .map_err(|e| CompileError::Codegen(format!("{:?}", e)))?;
-        let compiled_function =
+
+        let mut compiled_function =
             CompiledFunction::new(buffer, CompiledFuncEnv {}, self.isa.function_alignment());
+
+        if self.isa.flags().unwind_info() {
+            let kind = match self.isa.triple().operating_system {
+                target_lexicon::OperatingSystem::Windows => UnwindInfoKind::Windows,
+                _ => UnwindInfoKind::SystemV,
+            };
+
+            if let Some(info) = self
+                .isa
+                .emit_unwind_info(&compiled_function.buffer, kind)
+                .map_err(|e| CompileError::Codegen(format!("{e:?}")))?
+            {
+                compiled_function.set_unwind_info(info);
+            }
+        }
 
         Ok(Box::new(compiled_function))
     }
@@ -144,8 +177,23 @@ impl wasmtime_environ::Compiler for Compiler {
             .compile_trampoline(ty, TrampolineKind::NativeToWasm(func_index))
             .map_err(|e| CompileError::Codegen(format!("{:?}", e)))?;
 
-        let compiled_function =
+        let mut compiled_function =
             CompiledFunction::new(buffer, CompiledFuncEnv {}, self.isa.function_alignment());
+
+        if self.isa.flags().unwind_info() {
+            let kind = match self.isa.triple().operating_system {
+                target_lexicon::OperatingSystem::Windows => UnwindInfoKind::Windows,
+                _ => UnwindInfoKind::SystemV,
+            };
+
+            if let Some(info) = self
+                .isa
+                .emit_unwind_info(&compiled_function.buffer, kind)
+                .map_err(|e| CompileError::Codegen(format!("{e:?}")))?
+            {
+                compiled_function.set_unwind_info(info);
+            }
+        }
 
         Ok(Box::new(compiled_function))
     }
@@ -159,8 +207,23 @@ impl wasmtime_environ::Compiler for Compiler {
             .compile_trampoline(wasm_func_ty, TrampolineKind::WasmToNative)
             .map_err(|e| CompileError::Codegen(format!("{:?}", e)))?;
 
-        let compiled_function =
+        let mut compiled_function =
             CompiledFunction::new(buffer, CompiledFuncEnv {}, self.isa.function_alignment());
+
+        if self.isa.flags().unwind_info() {
+            let kind = match self.isa.triple().operating_system {
+                target_lexicon::OperatingSystem::Windows => UnwindInfoKind::Windows,
+                _ => UnwindInfoKind::SystemV,
+            };
+
+            if let Some(info) = self
+                .isa
+                .emit_unwind_info(&compiled_function.buffer, kind)
+                .map_err(|e| CompileError::Codegen(format!("{e:?}")))?
+            {
+                compiled_function.set_unwind_info(info);
+            }
+        }
 
         Ok(Box::new(compiled_function))
     }

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -19,7 +19,7 @@ target-lexicon = { workspace = true, features = ["std"] }
 # mostly to have access to `PReg`s and the calling convention.
 # In the next iteration we'll factor out the common bits so that they can be consumed
 # by Cranelift and Winch.
-cranelift-codegen = { workspace = true }
+cranelift-codegen = { workspace = true, features = ["unwind"] }
 regalloc2 = { workspace = true }
 gimli = { workspace = true }
 wasmtime-environ = { workspace = true }

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -134,4 +134,12 @@ impl TargetIsa for Aarch64 {
     ) -> Result<MachBufferFinalized<Final>> {
         todo!()
     }
+
+    fn emit_unwind_info(
+        &self,
+        _result: &MachBufferFinalized<Final>,
+        _kind: cranelift_codegen::isa::unwind::UnwindInfoKind,
+    ) -> Result<Option<cranelift_codegen::isa::unwind::UnwindInfo>> {
+        todo!()
+    }
 }

--- a/winch/codegen/src/isa/mod.rs
+++ b/winch/codegen/src/isa/mod.rs
@@ -1,6 +1,7 @@
 use crate::{BuiltinFunctions, TrampolineKind};
 use anyhow::{anyhow, Result};
 use core::fmt::Formatter;
+use cranelift_codegen::isa::unwind::{UnwindInfo, UnwindInfoKind};
 use cranelift_codegen::isa::{CallConv, IsaBuilder};
 use cranelift_codegen::settings;
 use cranelift_codegen::{Final, MachBufferFinalized, TextSectionBuilder};
@@ -183,6 +184,12 @@ pub trait TargetIsa: Send + Sync {
     fn endianness(&self) -> target_lexicon::Endianness {
         self.triple().endianness().unwrap()
     }
+
+    fn emit_unwind_info(
+        &self,
+        _result: &MachBufferFinalized<Final>,
+        _kind: UnwindInfoKind,
+    ) -> Result<Option<UnwindInfo>>;
 
     /// See `cranelift_codegen::isa::TargetIsa::create_systemv_cie`.
     fn create_systemv_cie(&self) -> Option<gimli::write::CommonInformationEntry> {

--- a/winch/codegen/src/isa/reg.rs
+++ b/winch/codegen/src/isa/reg.rs
@@ -1,5 +1,6 @@
-use regalloc2::PReg;
+use cranelift_codegen::RealReg;
 pub use regalloc2::RegClass;
+use regalloc2::{PReg, VReg};
 
 /// A newtype abstraction on top of a physical register.
 //
@@ -69,5 +70,17 @@ impl From<Reg> for cranelift_codegen::Reg {
 impl std::fmt::Debug for Reg {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.0)
+    }
+}
+
+impl Into<VReg> for Reg {
+    fn into(self) -> VReg {
+        VReg::new(self.inner().index(), self.class())
+    }
+}
+
+impl Into<RealReg> for Reg {
+    fn into(self) -> RealReg {
+        Into::<VReg>::into(self).into()
     }
 }

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -8,6 +8,7 @@ use cranelift_codegen::{
     entity::EntityRef,
     ir::{types, ConstantPool, ExternalName, LibCall, Opcode, TrapCode, UserExternalNameRef},
     isa::{
+        unwind::UnwindInst,
         x64::{
             args::{
                 self, AluRmiROpcode, Amode, CmpOpcode, DivSignedness, ExtMode, FromWritableReg,
@@ -227,6 +228,11 @@ impl Assembler {
                 SyntheticAmode::ConstantOffset(constant)
             }
         }
+    }
+
+    /// Emit an unwind instruction.
+    pub fn emit_unwind_inst(&mut self, inst: UnwindInst) {
+        self.emit(Inst::Unwind { inst })
     }
 
     /// Push register.

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -67,6 +67,9 @@ impl Masm for MacroAssembler {
         if self.shared_flags.unwind_info() {
             self.asm.emit_unwind_inst(UnwindInst::DefineNewFrame {
                 offset_upward_to_caller_sp: Self::ABI::arg_base_offset().try_into().unwrap(),
+
+                // Clobbers appear directly after the RET and FP if they're present. As we just
+                // pushed the frame pointer, the offset to the clobbers will be `0`.
                 offset_downward_to_clobbers: 0,
             })
         }

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -124,6 +124,19 @@ impl Masm for MacroAssembler {
         }
     }
 
+    fn save(&mut self, clobber_offset: u32, reg: Reg, size: OperandSize) -> StackSlot {
+        let slot = self.push(reg, size);
+
+        if self.shared_flags.unwind_info() {
+            self.asm.emit_unwind_inst(UnwindInst::SaveReg {
+                clobber_offset,
+                reg: reg.into(),
+            });
+        }
+
+        slot
+    }
+
     fn reserve_stack(&mut self, bytes: u32) {
         if bytes == 0 {
             return;

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -57,8 +57,7 @@ impl Masm for MacroAssembler {
 
         if self.shared_flags.unwind_info() {
             self.asm.emit_unwind_inst(UnwindInst::PushFrameRegs {
-                // RBP, return address
-                offset_upward_to_caller_sp: 16,
+                offset_upward_to_caller_sp: Self::ABI::arg_base_offset().try_into().unwrap(),
             })
         }
 
@@ -67,8 +66,7 @@ impl Masm for MacroAssembler {
 
         if self.shared_flags.unwind_info() {
             self.asm.emit_unwind_inst(UnwindInst::DefineNewFrame {
-                // RBP, return address
-                offset_upward_to_caller_sp: 16,
+                offset_upward_to_caller_sp: Self::ABI::arg_base_offset().try_into().unwrap(),
                 offset_downward_to_clobbers: 0,
             })
         }

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -169,4 +169,16 @@ impl TargetIsa for X64 {
 
         Ok(masm.finalize())
     }
+
+    fn emit_unwind_info(
+        &self,
+        buffer: &MachBufferFinalized<Final>,
+        kind: cranelift_codegen::isa::unwind::UnwindInfoKind,
+    ) -> Result<Option<cranelift_codegen::isa::unwind::UnwindInfo>> {
+        Ok(cranelift_codegen::isa::x64::emit_unwind_info(buffer, kind)?)
+    }
+
+    fn create_systemv_cie(&self) -> Option<gimli::write::CommonInformationEntry> {
+        Some(cranelift_codegen::isa::x64::create_cie())
+    }
 }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -766,4 +766,11 @@ pub(crate) trait MacroAssembler {
             self.free_stack(bytes);
         }
     }
+
+    /// Save the value of this register to the stack. By default this is the same as pushing the
+    /// register, however it's present in the [`MacroAssembler`] trait to ensure that it's possible
+    /// to add unwind info for register saves in backends.
+    fn save(&mut self, _off: u32, src: Reg, size: OperandSize) -> StackSlot {
+        self.push(src, size)
+    }
 }

--- a/winch/codegen/src/trampoline.rs
+++ b/winch/codegen/src/trampoline.rs
@@ -705,8 +705,10 @@ where
     fn prologue_with_callee_saved(&mut self) {
         self.masm.prologue();
         // Save any callee-saved registers.
+        let mut off = 0;
         for (r, s) in &self.callee_saved_regs {
-            self.masm.push(*r, *s);
+            let slot = self.masm.save(off, *r, *s);
+            off += slot.size;
         }
     }
 


### PR DESCRIPTION
Reuse cranelift's implementation of unwinding info for windows, allowing for traps to work properly in winch. Some `cranelift-codegen` details were necessary to expose to allow for this, most notably the `RealReg` type needed to be exported. Additionally, I opted to reuse functionality from cranelift by adding public functions for ingesting the unwind info present, which greatly simplified the implementation in winch.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
