### PR TITLE
WASI: remove unnecessary Sync constraints

### DIFF
--- a/crates/wasi-http/tests/all/http_server.rs
+++ b/crates/wasi-http/tests/all/http_server.rs
@@ -32,7 +32,7 @@ pub struct Server {
 
 impl Server {
     fn new<F>(
-        run: impl FnOnce(TokioIo<tokio::net::TcpStream>) -> F + Send + Sync + 'static,
+        run: impl FnOnce(TokioIo<tokio::net::TcpStream>) -> F + Send + 'static,
     ) -> Result<Self>
     where
         F: Future<Output = Result<()>>,

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -38,16 +38,10 @@ struct Ctx {
 }
 
 impl WasiView for Ctx {
-    fn table(&self) -> &ResourceTable {
-        &self.table
-    }
-    fn table_mut(&mut self) -> &mut ResourceTable {
+    fn table(&mut self) -> &mut ResourceTable {
         &mut self.table
     }
-    fn ctx(&self) -> &WasiCtx {
-        &self.wasi
-    }
-    fn ctx_mut(&mut self) -> &mut WasiCtx {
+    fn ctx(&mut self) -> &mut WasiCtx {
         &mut self.wasi
     }
 }
@@ -277,9 +271,7 @@ async fn do_wasi_http_hash_all(override_send_request: bool) -> Result<()> {
                         between_bytes_timeout,
                     })
                 });
-                Ok(view
-                    .table()
-                    .push(HostFutureIncomingResponse::Ready(response))?)
+                Ok(WasiHttpView::table(view).push(HostFutureIncomingResponse::Ready(response))?)
             },
         ) as RequestSender)
     } else {

--- a/crates/wasi/src/preview2/clocks.rs
+++ b/crates/wasi/src/preview2/clocks.rs
@@ -1,12 +1,12 @@
 pub mod host;
 use cap_std::time::Duration;
 
-pub trait HostWallClock: Send + Sync {
+pub trait HostWallClock: Send {
     fn resolution(&self) -> Duration;
     fn now(&self) -> Duration;
 }
 
-pub trait HostMonotonicClock: Send + Sync {
+pub trait HostMonotonicClock: Send {
     fn resolution(&self) -> u64;
     fn now(&self) -> u64;
 }

--- a/crates/wasi/src/preview2/clocks/host.rs
+++ b/crates/wasi/src/preview2/clocks/host.rs
@@ -64,10 +64,10 @@ impl HostMonotonicClock for MonotonicClock {
     }
 }
 
-pub fn monotonic_clock() -> Box<dyn HostMonotonicClock + Send + Sync> {
+pub fn monotonic_clock() -> Box<dyn HostMonotonicClock + Send> {
     Box::new(MonotonicClock::new(ambient_authority()))
 }
 
-pub fn wall_clock() -> Box<dyn HostWallClock + Send + Sync> {
+pub fn wall_clock() -> Box<dyn HostWallClock + Send> {
     Box::new(WallClock::new(ambient_authority()))
 }

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -267,10 +267,8 @@ impl WasiCtxBuilder {
 }
 
 pub trait WasiView: Send {
-    fn table(&self) -> &ResourceTable;
-    fn table_mut(&mut self) -> &mut ResourceTable;
-    fn ctx(&self) -> &WasiCtx;
-    fn ctx_mut(&mut self) -> &mut WasiCtx;
+    fn table(&mut self) -> &mut ResourceTable;
+    fn ctx(&mut self) -> &mut WasiCtx;
 }
 
 pub struct WasiCtx {

--- a/crates/wasi/src/preview2/ctx.rs
+++ b/crates/wasi/src/preview2/ctx.rs
@@ -22,11 +22,11 @@ pub struct WasiCtxBuilder {
     args: Vec<String>,
     preopens: Vec<(Dir, String)>,
     socket_addr_check: SocketAddrCheck,
-    random: Box<dyn RngCore + Send + Sync>,
-    insecure_random: Box<dyn RngCore + Send + Sync>,
+    random: Box<dyn RngCore + Send>,
+    insecure_random: Box<dyn RngCore + Send>,
     insecure_random_seed: u128,
-    wall_clock: Box<dyn HostWallClock + Send + Sync>,
-    monotonic_clock: Box<dyn HostMonotonicClock + Send + Sync>,
+    wall_clock: Box<dyn HostWallClock + Send>,
+    monotonic_clock: Box<dyn HostMonotonicClock + Send>,
     allowed_network_uses: AllowedNetworkUses,
     built: bool,
 }
@@ -159,15 +159,12 @@ impl WasiCtxBuilder {
     /// unpredictable random data in order to maintain its security invariants,
     /// and ideally should use the insecure random API otherwise, so using any
     /// prerecorded or otherwise predictable data may compromise security.
-    pub fn secure_random(&mut self, random: impl RngCore + Send + Sync + 'static) -> &mut Self {
+    pub fn secure_random(&mut self, random: impl RngCore + Send + 'static) -> &mut Self {
         self.random = Box::new(random);
         self
     }
 
-    pub fn insecure_random(
-        &mut self,
-        insecure_random: impl RngCore + Send + Sync + 'static,
-    ) -> &mut Self {
+    pub fn insecure_random(&mut self, insecure_random: impl RngCore + Send + 'static) -> &mut Self {
         self.insecure_random = Box::new(insecure_random);
         self
     }
@@ -277,11 +274,11 @@ pub trait WasiView: Send {
 }
 
 pub struct WasiCtx {
-    pub(crate) random: Box<dyn RngCore + Send + Sync>,
-    pub(crate) insecure_random: Box<dyn RngCore + Send + Sync>,
+    pub(crate) random: Box<dyn RngCore + Send>,
+    pub(crate) insecure_random: Box<dyn RngCore + Send>,
     pub(crate) insecure_random_seed: u128,
-    pub(crate) wall_clock: Box<dyn HostWallClock + Send + Sync>,
-    pub(crate) monotonic_clock: Box<dyn HostMonotonicClock + Send + Sync>,
+    pub(crate) wall_clock: Box<dyn HostWallClock + Send>,
+    pub(crate) monotonic_clock: Box<dyn HostMonotonicClock + Send>,
     pub(crate) env: Vec<(String, String)>,
     pub(crate) args: Vec<String>,
     pub(crate) preopens: Vec<(Dir, String)>,

--- a/crates/wasi/src/preview2/host/clocks.rs
+++ b/crates/wasi/src/preview2/host/clocks.rs
@@ -77,11 +77,11 @@ impl<T: WasiView> monotonic_clock::Host for T {
         } else {
             Duration::from_nanos(0)
         };
-        subscribe_to_duration(&mut self.table_mut(), duration)
+        subscribe_to_duration(&mut self.table(), duration)
     }
 
     fn subscribe_duration(&mut self, duration: WasiDuration) -> anyhow::Result<Resource<Pollable>> {
-        subscribe_to_duration(&mut self.table_mut(), Duration::from_nanos(duration))
+        subscribe_to_duration(&mut self.table(), Duration::from_nanos(duration))
     }
 }
 

--- a/crates/wasi/src/preview2/host/instance_network.rs
+++ b/crates/wasi/src/preview2/host/instance_network.rs
@@ -9,7 +9,7 @@ impl<T: WasiView> instance_network::Host for T {
             socket_addr_check: self.ctx().socket_addr_check.clone(),
             allow_ip_name_lookup: self.ctx().allowed_network_uses.ip_name_lookup,
         };
-        let network = self.table_mut().push(network)?;
+        let network = self.table().push(network)?;
         Ok(network)
     }
 }

--- a/crates/wasi/src/preview2/host/network.rs
+++ b/crates/wasi/src/preview2/host/network.rs
@@ -16,7 +16,7 @@ impl<T: WasiView> network::Host for T {
 
 impl<T: WasiView> crate::preview2::bindings::sockets::network::HostNetwork for T {
     fn drop(&mut self, this: Resource<network::Network>) -> Result<(), anyhow::Error> {
-        let table = self.table_mut();
+        let table = self.table();
 
         table.delete(this)?;
 

--- a/crates/wasi/src/preview2/host/random.rs
+++ b/crates/wasi/src/preview2/host/random.rs
@@ -4,33 +4,33 @@ use cap_rand::{distributions::Standard, Rng};
 
 impl<T: WasiView> random::Host for T {
     fn get_random_bytes(&mut self, len: u64) -> anyhow::Result<Vec<u8>> {
-        Ok((&mut self.ctx_mut().random)
+        Ok((&mut self.ctx().random)
             .sample_iter(Standard)
             .take(len as usize)
             .collect())
     }
 
     fn get_random_u64(&mut self) -> anyhow::Result<u64> {
-        Ok(self.ctx_mut().random.sample(Standard))
+        Ok(self.ctx().random.sample(Standard))
     }
 }
 
 impl<T: WasiView> insecure::Host for T {
     fn get_insecure_random_bytes(&mut self, len: u64) -> anyhow::Result<Vec<u8>> {
-        Ok((&mut self.ctx_mut().insecure_random)
+        Ok((&mut self.ctx().insecure_random)
             .sample_iter(Standard)
             .take(len as usize)
             .collect())
     }
 
     fn get_insecure_random_u64(&mut self) -> anyhow::Result<u64> {
-        Ok(self.ctx_mut().insecure_random.sample(Standard))
+        Ok(self.ctx().insecure_random.sample(Standard))
     }
 }
 
 impl<T: WasiView> insecure_seed::Host for T {
     fn insecure_seed(&mut self) -> anyhow::Result<(u64, u64)> {
-        let seed: u128 = self.ctx_mut().insecure_random_seed;
+        let seed: u128 = self.ctx().insecure_random_seed;
         Ok((seed as u64, (seed >> 64) as u64))
     }
 }

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -29,7 +29,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         local_address: IpSocketAddress,
     ) -> SocketResult<()> {
         self.ctx().allowed_network_uses.check_allowed_tcp()?;
-        let table = self.table_mut();
+        let table = self.table();
         let socket = table.get(&this)?;
         let network = table.get(&network)?;
         let local_address: SocketAddr = local_address.into();
@@ -77,7 +77,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     }
 
     fn finish_bind(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<()> {
-        let table = self.table_mut();
+        let table = self.table();
         let socket = table.get_mut(&this)?;
 
         match socket.tcp_state {
@@ -97,7 +97,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         remote_address: IpSocketAddress,
     ) -> SocketResult<()> {
         self.ctx().allowed_network_uses.check_allowed_tcp()?;
-        let table = self.table_mut();
+        let table = self.table();
         let r = {
             let socket = table.get(&this)?;
             let network = table.get(&network)?;
@@ -154,7 +154,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         &mut self,
         this: Resource<tcp::TcpSocket>,
     ) -> SocketResult<(Resource<InputStream>, Resource<OutputStream>)> {
-        let table = self.table_mut();
+        let table = self.table();
         let socket = table.get_mut(&this)?;
 
         match socket.tcp_state {
@@ -188,15 +188,15 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
 
         socket.tcp_state = TcpState::Connected;
         let (input, output) = socket.as_split();
-        let input_stream = self.table_mut().push_child(input, &this)?;
-        let output_stream = self.table_mut().push_child(output, &this)?;
+        let input_stream = self.table().push_child(input, &this)?;
+        let output_stream = self.table().push_child(output, &this)?;
 
         Ok((input_stream, output_stream))
     }
 
     fn start_listen(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<()> {
         self.ctx().allowed_network_uses.check_allowed_tcp()?;
-        let table = self.table_mut();
+        let table = self.table();
         let socket = table.get_mut(&this)?;
 
         match socket.tcp_state {
@@ -219,7 +219,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     }
 
     fn finish_listen(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<()> {
-        let table = self.table_mut();
+        let table = self.table();
         let socket = table.get_mut(&this)?;
 
         match socket.tcp_state {
@@ -287,9 +287,9 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         let (input, output) = tcp_socket.as_split();
         let output: OutputStream = output;
 
-        let tcp_socket = self.table_mut().push(tcp_socket)?;
-        let input_stream = self.table_mut().push_child(input, &tcp_socket)?;
-        let output_stream = self.table_mut().push_child(output, &tcp_socket)?;
+        let tcp_socket = self.table().push(tcp_socket)?;
+        let input_stream = self.table().push_child(input, &tcp_socket)?;
+        let output_stream = self.table().push_child(output, &tcp_socket)?;
 
         Ok((tcp_socket, input_stream, output_stream))
     }
@@ -361,7 +361,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         const MIN_BACKLOG: i32 = 1;
         const MAX_BACKLOG: i32 = i32::MAX; // OS'es will most likely limit it down even further.
 
-        let table = self.table_mut();
+        let table = self.table();
         let socket = table.get_mut(&this)?;
 
         if value == 0 {
@@ -426,7 +426,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         this: Resource<tcp::TcpSocket>,
         value: u64,
     ) -> SocketResult<()> {
-        let table = self.table_mut();
+        let table = self.table();
         let socket = table.get_mut(&this)?;
 
         let duration = Duration::from_nanos(value);
@@ -489,7 +489,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     }
 
     fn set_hop_limit(&mut self, this: Resource<tcp::TcpSocket>, value: u8) -> SocketResult<()> {
-        let table = self.table_mut();
+        let table = self.table();
         let socket = table.get_mut(&this)?;
 
         match socket.family {
@@ -518,7 +518,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         this: Resource<tcp::TcpSocket>,
         value: u64,
     ) -> SocketResult<()> {
-        let table = self.table_mut();
+        let table = self.table();
         let socket = table.get_mut(&this)?;
         let value = value.try_into().unwrap_or(usize::MAX);
 
@@ -545,7 +545,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         this: Resource<tcp::TcpSocket>,
         value: u64,
     ) -> SocketResult<()> {
-        let table = self.table_mut();
+        let table = self.table();
         let socket = table.get_mut(&this)?;
         let value = value.try_into().unwrap_or(usize::MAX);
 
@@ -560,7 +560,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     }
 
     fn subscribe(&mut self, this: Resource<tcp::TcpSocket>) -> anyhow::Result<Resource<Pollable>> {
-        crate::preview2::poll::subscribe(self.table_mut(), this)
+        crate::preview2::poll::subscribe(self.table(), this)
     }
 
     fn shutdown(
@@ -593,7 +593,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     }
 
     fn drop(&mut self, this: Resource<tcp::TcpSocket>) -> Result<(), anyhow::Error> {
-        let table = self.table_mut();
+        let table = self.table();
 
         // As in the filesystem implementation, we assume closing a socket
         // doesn't block.

--- a/crates/wasi/src/preview2/host/tcp_create_socket.rs
+++ b/crates/wasi/src/preview2/host/tcp_create_socket.rs
@@ -9,7 +9,7 @@ impl<T: WasiView> tcp_create_socket::Host for T {
         address_family: IpAddressFamily,
     ) -> SocketResult<Resource<TcpSocket>> {
         let socket = TcpSocket::new(address_family.into())?;
-        let socket = self.table_mut().push(socket)?;
+        let socket = self.table().push(socket)?;
         Ok(socket)
     }
 }

--- a/crates/wasi/src/preview2/host/udp.rs
+++ b/crates/wasi/src/preview2/host/udp.rs
@@ -32,7 +32,7 @@ impl<T: WasiView> udp::HostUdpSocket for T {
         local_address: IpSocketAddress,
     ) -> SocketResult<()> {
         self.ctx().allowed_network_uses.check_allowed_udp()?;
-        let table = self.table_mut();
+        let table = self.table();
 
         match table.get(&this)?.udp_state {
             UdpState::Default => {}
@@ -76,7 +76,7 @@ impl<T: WasiView> udp::HostUdpSocket for T {
     }
 
     fn finish_bind(&mut self, this: Resource<udp::UdpSocket>) -> SocketResult<()> {
-        let table = self.table_mut();
+        let table = self.table();
         let socket = table.get_mut(&this)?;
 
         match socket.udp_state {
@@ -96,7 +96,7 @@ impl<T: WasiView> udp::HostUdpSocket for T {
         Resource<udp::IncomingDatagramStream>,
         Resource<udp::OutgoingDatagramStream>,
     )> {
-        let table = self.table_mut();
+        let table = self.table();
 
         let has_active_streams = table
             .iter_children(&this)?
@@ -161,8 +161,8 @@ impl<T: WasiView> udp::HostUdpSocket for T {
         };
 
         Ok((
-            self.table_mut().push_child(incoming_stream, &this)?,
-            self.table_mut().push_child(outgoing_stream, &this)?,
+            self.table().push_child(incoming_stream, &this)?,
+            self.table().push_child(outgoing_stream, &this)?,
         ))
     }
 
@@ -283,11 +283,11 @@ impl<T: WasiView> udp::HostUdpSocket for T {
     }
 
     fn subscribe(&mut self, this: Resource<udp::UdpSocket>) -> anyhow::Result<Resource<Pollable>> {
-        crate::preview2::poll::subscribe(self.table_mut(), this)
+        crate::preview2::poll::subscribe(self.table(), this)
     }
 
     fn drop(&mut self, this: Resource<udp::UdpSocket>) -> Result<(), anyhow::Error> {
-        let table = self.table_mut();
+        let table = self.table();
 
         // As in the filesystem implementation, we assume closing a socket
         // doesn't block.
@@ -363,11 +363,11 @@ impl<T: WasiView> udp::HostIncomingDatagramStream for T {
         &mut self,
         this: Resource<udp::IncomingDatagramStream>,
     ) -> anyhow::Result<Resource<Pollable>> {
-        crate::preview2::poll::subscribe(self.table_mut(), this)
+        crate::preview2::poll::subscribe(self.table(), this)
     }
 
     fn drop(&mut self, this: Resource<udp::IncomingDatagramStream>) -> Result<(), anyhow::Error> {
-        let table = self.table_mut();
+        let table = self.table();
 
         // As in the filesystem implementation, we assume closing a socket
         // doesn't block.
@@ -391,7 +391,7 @@ impl Subscribe for IncomingDatagramStream {
 
 impl<T: WasiView> udp::HostOutgoingDatagramStream for T {
     fn check_send(&mut self, this: Resource<udp::OutgoingDatagramStream>) -> SocketResult<u64> {
-        let table = self.table_mut();
+        let table = self.table();
         let stream = table.get_mut(&this)?;
 
         let permit = match stream.send_state {
@@ -448,7 +448,7 @@ impl<T: WasiView> udp::HostOutgoingDatagramStream for T {
             Ok(())
         }
 
-        let table = self.table_mut();
+        let table = self.table();
         let stream = table.get_mut(&this)?;
 
         match stream.send_state {
@@ -497,11 +497,11 @@ impl<T: WasiView> udp::HostOutgoingDatagramStream for T {
         &mut self,
         this: Resource<udp::OutgoingDatagramStream>,
     ) -> anyhow::Result<Resource<Pollable>> {
-        crate::preview2::poll::subscribe(self.table_mut(), this)
+        crate::preview2::poll::subscribe(self.table(), this)
     }
 
     fn drop(&mut self, this: Resource<udp::OutgoingDatagramStream>) -> Result<(), anyhow::Error> {
-        let table = self.table_mut();
+        let table = self.table();
 
         // As in the filesystem implementation, we assume closing a socket
         // doesn't block.

--- a/crates/wasi/src/preview2/host/udp_create_socket.rs
+++ b/crates/wasi/src/preview2/host/udp_create_socket.rs
@@ -9,7 +9,7 @@ impl<T: WasiView> udp_create_socket::Host for T {
         address_family: IpAddressFamily,
     ) -> SocketResult<Resource<UdpSocket>> {
         let socket = UdpSocket::new(address_family.into())?;
-        let socket = self.table_mut().push(socket)?;
+        let socket = self.table().push(socket)?;
         Ok(socket)
     }
 }

--- a/crates/wasi/src/preview2/ip_name_lookup.rs
+++ b/crates/wasi/src/preview2/ip_name_lookup.rs
@@ -34,7 +34,7 @@ impl<T: WasiView> Host for T {
         }
 
         let task = spawn_blocking(move || blocking_resolve(&host));
-        let resource = self.table_mut().push(ResolveAddressStream::Waiting(task))?;
+        let resource = self.table().push(ResolveAddressStream::Waiting(task))?;
         Ok(resource)
     }
 }
@@ -45,7 +45,7 @@ impl<T: WasiView> HostResolveAddressStream for T {
         &mut self,
         resource: Resource<ResolveAddressStream>,
     ) -> Result<Option<IpAddress>, SocketError> {
-        let stream = self.table_mut().get_mut(&resource)?;
+        let stream: &mut ResolveAddressStream = self.table().get_mut(&resource)?;
         loop {
             match stream {
                 ResolveAddressStream::Waiting(future) => {
@@ -69,11 +69,11 @@ impl<T: WasiView> HostResolveAddressStream for T {
         &mut self,
         resource: Resource<ResolveAddressStream>,
     ) -> Result<Resource<Pollable>> {
-        subscribe(self.table_mut(), resource)
+        subscribe(self.table(), resource)
     }
 
     fn drop(&mut self, resource: Resource<ResolveAddressStream>) -> Result<()> {
-        self.table_mut().delete(resource)?;
+        self.table().delete(resource)?;
         Ok(())
     }
 }

--- a/crates/wasi/src/preview2/pipe.rs
+++ b/crates/wasi/src/preview2/pipe.rs
@@ -118,7 +118,7 @@ pub struct AsyncReadStream {
 impl AsyncReadStream {
     /// Create a [`AsyncReadStream`]. In order to use the [`HostInputStream`] impl
     /// provided by this struct, the argument must impl [`tokio::io::AsyncRead`].
-    pub fn new<T: tokio::io::AsyncRead + Send + Sync + Unpin + 'static>(mut reader: T) -> Self {
+    pub fn new<T: tokio::io::AsyncRead + Send + Unpin + 'static>(mut reader: T) -> Self {
         let (sender, receiver) = mpsc::channel(1);
         let join_handle = crate::preview2::spawn(async move {
             loop {
@@ -354,7 +354,7 @@ mod test {
         assert_eq!(bs.len(), 0);
     }
 
-    async fn finite_async_reader(contents: &[u8]) -> impl AsyncRead + Send + Sync + 'static {
+    async fn finite_async_reader(contents: &[u8]) -> impl AsyncRead + Send + 'static {
         let (r, mut w) = simplex(contents.len());
         w.write_all(contents).await.unwrap();
         r

--- a/crates/wasi/src/preview2/poll.rs
+++ b/crates/wasi/src/preview2/poll.rs
@@ -68,7 +68,7 @@ impl<T: WasiView> poll::Host for T {
     async fn poll(&mut self, pollables: Vec<Resource<Pollable>>) -> Result<Vec<u32>> {
         type ReadylistIndex = u32;
 
-        let table = self.table_mut();
+        let table = self.table();
 
         let mut table_futures: HashMap<u32, (MakeFuture, Vec<ReadylistIndex>)> = HashMap::new();
 
@@ -121,14 +121,14 @@ impl<T: WasiView> poll::Host for T {
 #[async_trait::async_trait]
 impl<T: WasiView> crate::preview2::bindings::io::poll::HostPollable for T {
     async fn block(&mut self, pollable: Resource<Pollable>) -> Result<()> {
-        let table = self.table_mut();
+        let table = self.table();
         let pollable = table.get(&pollable)?;
         let ready = (pollable.make_future)(table.get_any_mut(pollable.index)?);
         ready.await;
         Ok(())
     }
     async fn ready(&mut self, pollable: Resource<Pollable>) -> Result<bool> {
-        let table = self.table_mut();
+        let table = self.table();
         let pollable = table.get(&pollable)?;
         let ready = (pollable.make_future)(table.get_any_mut(pollable.index)?);
         futures::pin_mut!(ready);
@@ -138,9 +138,9 @@ impl<T: WasiView> crate::preview2::bindings::io::poll::HostPollable for T {
         ))
     }
     fn drop(&mut self, pollable: Resource<Pollable>) -> Result<()> {
-        let pollable = self.table_mut().delete(pollable)?;
+        let pollable = self.table().delete(pollable)?;
         if let Some(delete) = pollable.remove_index_on_delete {
-            delete(self.table_mut(), pollable.index)?;
+            delete(self.table(), pollable.index)?;
         }
         Ok(())
     }

--- a/crates/wasi/src/preview2/poll.rs
+++ b/crates/wasi/src/preview2/poll.rs
@@ -9,7 +9,7 @@ use wasmtime::component::{Resource, ResourceTable};
 
 pub type PollableFuture<'a> = Pin<Box<dyn Future<Output = ()> + Send + 'a>>;
 pub type MakeFuture = for<'a> fn(&'a mut dyn Any) -> PollableFuture<'a>;
-pub type ClosureFuture = Box<dyn Fn() -> PollableFuture<'static> + Send + Sync + 'static>;
+pub type ClosureFuture = Box<dyn Fn() -> PollableFuture<'static> + Send + 'static>;
 
 /// A host representation of the `wasi:io/poll.pollable` resource.
 ///
@@ -24,7 +24,7 @@ pub struct Pollable {
 }
 
 #[async_trait::async_trait]
-pub trait Subscribe: Send + Sync + 'static {
+pub trait Subscribe: Send + 'static {
     async fn ready(&mut self);
 }
 

--- a/crates/wasi/src/preview2/preview0.rs
+++ b/crates/wasi/src/preview2/preview0.rs
@@ -4,13 +4,13 @@ use crate::preview2::preview1::wasi_snapshot_preview1::WasiSnapshotPreview1 as S
 use crate::preview2::preview1::WasiPreview1View;
 use wiggle::{GuestError, GuestPtr};
 
-pub fn add_to_linker_async<T: WasiPreview1View + Sync>(
+pub fn add_to_linker_async<T: WasiPreview1View>(
     linker: &mut wasmtime::Linker<T>,
 ) -> anyhow::Result<()> {
     wasi_unstable::add_to_linker(linker, |t| t)
 }
 
-pub fn add_to_linker_sync<T: WasiPreview1View + Sync>(
+pub fn add_to_linker_sync<T: WasiPreview1View>(
     linker: &mut wasmtime::Linker<T>,
 ) -> anyhow::Result<()> {
     sync::add_wasi_unstable_to_linker(linker, |t| t)

--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -499,13 +499,13 @@ trait WasiPreview1ViewExt:
 
 impl<T: WasiPreview1View + preopens::Host> WasiPreview1ViewExt for T {}
 
-pub fn add_to_linker_async<T: WasiPreview1View + Sync>(
+pub fn add_to_linker_async<T: WasiPreview1View>(
     linker: &mut wasmtime::Linker<T>,
 ) -> anyhow::Result<()> {
     wasi_snapshot_preview1::add_to_linker(linker, |t| t)
 }
 
-pub fn add_to_linker_sync<T: WasiPreview1View + Sync>(
+pub fn add_to_linker_sync<T: WasiPreview1View>(
     linker: &mut wasmtime::Linker<T>,
 ) -> anyhow::Result<()> {
     sync::add_wasi_snapshot_preview1_to_linker(linker, |t| t)

--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -1664,7 +1664,7 @@ impl<
 
         let mut dir = Vec::new();
         for (entry, d_next) in self
-            .table_mut()
+            .table()
             // remove iterator from table and use it directly:
             .delete(stream)?
             .into_iter()

--- a/crates/wasi/src/preview2/random.rs
+++ b/crates/wasi/src/preview2/random.rs
@@ -51,7 +51,7 @@ mod test {
     }
 }
 
-pub fn thread_rng() -> Box<dyn RngCore + Send + Sync> {
+pub fn thread_rng() -> Box<dyn RngCore + Send> {
     use cap_rand::{Rng, SeedableRng};
     let mut rng = cap_rand::thread_rng(cap_rand::ambient_authority());
     Box::new(cap_rand::rngs::StdRng::from_seed(rng.gen()))

--- a/crates/wasi/src/preview2/stdio.rs
+++ b/crates/wasi/src/preview2/stdio.rs
@@ -18,7 +18,7 @@ use wasmtime::component::Resource;
 ///
 /// Built-in implementations are provided for [`Stdin`],
 /// [`pipe::MemoryInputPipe`], and [`pipe::ClosedInputStream`].
-pub trait StdinStream: Send + Sync {
+pub trait StdinStream: Send {
     /// Creates a fresh stream which is reading stdin.
     ///
     /// Note that the returned stream must share state with all other streams
@@ -60,7 +60,7 @@ mod worker_thread_stdin;
 pub use self::worker_thread_stdin::{stdin, Stdin};
 
 /// Similar to [`StdinStream`], except for output.
-pub trait StdoutStream: Send + Sync {
+pub trait StdoutStream: Send {
     /// Returns a fresh new stream which can write to this output stream.
     ///
     /// Note that all output streams should output to the same logical source.

--- a/crates/wasi/src/preview2/stdio.rs
+++ b/crates/wasi/src/preview2/stdio.rs
@@ -191,22 +191,22 @@ pub enum IsATTY {
 
 impl<T: WasiView> stdin::Host for T {
     fn get_stdin(&mut self) -> Result<Resource<streams::InputStream>, anyhow::Error> {
-        let stream = self.ctx_mut().stdin.stream();
-        Ok(self.table_mut().push(streams::InputStream::Host(stream))?)
+        let stream = self.ctx().stdin.stream();
+        Ok(self.table().push(streams::InputStream::Host(stream))?)
     }
 }
 
 impl<T: WasiView> stdout::Host for T {
     fn get_stdout(&mut self) -> Result<Resource<streams::OutputStream>, anyhow::Error> {
-        let stream = self.ctx_mut().stdout.stream();
-        Ok(self.table_mut().push(stream)?)
+        let stream = self.ctx().stdout.stream();
+        Ok(self.table().push(stream)?)
     }
 }
 
 impl<T: WasiView> stderr::Host for T {
     fn get_stderr(&mut self) -> Result<Resource<streams::OutputStream>, anyhow::Error> {
-        let stream = self.ctx_mut().stderr.stream();
-        Ok(self.table_mut().push(stream)?)
+        let stream = self.ctx().stderr.stream();
+        Ok(self.table().push(stream)?)
     }
 }
 
@@ -216,21 +216,21 @@ pub struct TerminalOutput;
 impl<T: WasiView> terminal_input::Host for T {}
 impl<T: WasiView> terminal_input::HostTerminalInput for T {
     fn drop(&mut self, r: Resource<TerminalInput>) -> anyhow::Result<()> {
-        self.table_mut().delete(r)?;
+        self.table().delete(r)?;
         Ok(())
     }
 }
 impl<T: WasiView> terminal_output::Host for T {}
 impl<T: WasiView> terminal_output::HostTerminalOutput for T {
     fn drop(&mut self, r: Resource<TerminalOutput>) -> anyhow::Result<()> {
-        self.table_mut().delete(r)?;
+        self.table().delete(r)?;
         Ok(())
     }
 }
 impl<T: WasiView> terminal_stdin::Host for T {
     fn get_terminal_stdin(&mut self) -> anyhow::Result<Option<Resource<TerminalInput>>> {
         if self.ctx().stdin.isatty() {
-            let fd = self.table_mut().push(TerminalInput)?;
+            let fd = self.table().push(TerminalInput)?;
             Ok(Some(fd))
         } else {
             Ok(None)
@@ -240,7 +240,7 @@ impl<T: WasiView> terminal_stdin::Host for T {
 impl<T: WasiView> terminal_stdout::Host for T {
     fn get_terminal_stdout(&mut self) -> anyhow::Result<Option<Resource<TerminalOutput>>> {
         if self.ctx().stdout.isatty() {
-            let fd = self.table_mut().push(TerminalOutput)?;
+            let fd = self.table().push(TerminalOutput)?;
             Ok(Some(fd))
         } else {
             Ok(None)
@@ -250,7 +250,7 @@ impl<T: WasiView> terminal_stdout::Host for T {
 impl<T: WasiView> terminal_stderr::Host for T {
     fn get_terminal_stderr(&mut self) -> anyhow::Result<Option<Resource<TerminalOutput>>> {
         if self.ctx().stderr.isatty() {
-            let fd = self.table_mut().push(TerminalOutput)?;
+            let fd = self.table().push(TerminalOutput)?;
             Ok(Some(fd))
         } else {
             Ok(None)

--- a/crates/wasi/src/preview2/write_stream.rs
+++ b/crates/wasi/src/preview2/write_stream.rs
@@ -99,7 +99,7 @@ impl Worker {
         }
         self.write_ready_changed.notify_one();
     }
-    async fn work<T: tokio::io::AsyncWrite + Send + Sync + Unpin + 'static>(&self, mut writer: T) {
+    async fn work<T: tokio::io::AsyncWrite + Send + Unpin + 'static>(&self, mut writer: T) {
         use tokio::io::AsyncWriteExt;
         loop {
             while let Some(job) = self.pop() {
@@ -145,7 +145,7 @@ pub struct AsyncWriteStream {
 impl AsyncWriteStream {
     /// Create a [`AsyncWriteStream`]. In order to use the [`HostOutputStream`] impl
     /// provided by this struct, the argument must impl [`tokio::io::AsyncWrite`].
-    pub fn new<T: tokio::io::AsyncWrite + Send + Sync + Unpin + 'static>(
+    pub fn new<T: tokio::io::AsyncWrite + Send + Unpin + 'static>(
         write_budget: usize,
         writer: T,
     ) -> Self {

--- a/crates/wasi/tests/all/api.rs
+++ b/crates/wasi/tests/all/api.rs
@@ -19,16 +19,10 @@ struct CommandCtx {
 }
 
 impl WasiView for CommandCtx {
-    fn table(&self) -> &ResourceTable {
-        &self.table
-    }
-    fn table_mut(&mut self) -> &mut ResourceTable {
+    fn table(&mut self) -> &mut ResourceTable {
         &mut self.table
     }
-    fn ctx(&self) -> &WasiCtx {
-        &self.wasi
-    }
-    fn ctx_mut(&mut self) -> &mut WasiCtx {
+    fn ctx(&mut self) -> &mut WasiCtx {
         &mut self.wasi
     }
 }
@@ -184,7 +178,7 @@ async fn api_reactor() -> Result<()> {
     // `host` crate for `streams`, not because of `with` in the bindgen macro.
     let writepipe = preview2::pipe::MemoryOutputPipe::new(4096);
     let stream: preview2::OutputStream = Box::new(writepipe.clone());
-    let table_ix = store.data_mut().table_mut().push(stream)?;
+    let table_ix = store.data_mut().table().push(stream)?;
     let r = reactor.call_write_strings_to(&mut store, table_ix).await?;
     assert_eq!(r, Ok(()));
 

--- a/crates/wasi/tests/all/main.rs
+++ b/crates/wasi/tests/all/main.rs
@@ -19,16 +19,10 @@ struct Ctx {
 }
 
 impl WasiView for Ctx {
-    fn table(&self) -> &ResourceTable {
-        &self.table
-    }
-    fn table_mut(&mut self) -> &mut ResourceTable {
+    fn table(&mut self) -> &mut ResourceTable {
         &mut self.table
     }
-    fn ctx(&self) -> &WasiCtx {
-        &self.wasi
-    }
-    fn ctx_mut(&mut self) -> &mut WasiCtx {
+    fn ctx(&mut self) -> &mut WasiCtx {
         &mut self.wasi
     }
 }

--- a/crates/wasmtime/src/component/resource_table.rs
+++ b/crates/wasmtime/src/component/resource_table.rs
@@ -69,7 +69,7 @@ impl Entry {
 #[derive(Debug)]
 struct TableEntry {
     /// The entry in the table, as a boxed dynamically-typed object
-    entry: Box<dyn Any + Send + Sync>,
+    entry: Box<dyn Any + Send>,
     /// The index of the parent of this entry, if it has one.
     parent: Option<u32>,
     /// The indicies of any children of this entry.
@@ -77,7 +77,7 @@ struct TableEntry {
 }
 
 impl TableEntry {
-    fn new(entry: Box<dyn Any + Send + Sync>, parent: Option<u32>) -> Self {
+    fn new(entry: Box<dyn Any + Send>, parent: Option<u32>) -> Self {
         Self {
             entry,
             parent,
@@ -115,7 +115,7 @@ impl ResourceTable {
     /// `Resource<T>` which can be used to refer to it after it was inserted.
     pub fn push<T>(&mut self, entry: T) -> Result<Resource<T>, ResourceTableError>
     where
-        T: Send + Sync + 'static,
+        T: Send + 'static,
     {
         let idx = self.push_(TableEntry::new(Box::new(entry), None))?;
         Ok(Resource::new_own(idx))
@@ -209,7 +209,7 @@ impl ResourceTable {
         parent: &Resource<U>,
     ) -> Result<Resource<T>, ResourceTableError>
     where
-        T: Send + Sync + 'static,
+        T: Send + 'static,
         U: 'static,
     {
         let parent = parent.rep();
@@ -301,7 +301,7 @@ impl ResourceTable {
     pub fn iter_children<T>(
         &self,
         parent: &Resource<T>,
-    ) -> Result<impl Iterator<Item = &(dyn Any + Send + Sync)>, ResourceTableError>
+    ) -> Result<impl Iterator<Item = &(dyn Any + Send)>, ResourceTableError>
     where
         T: 'static,
     {

--- a/examples/wasi-async/main.rs
+++ b/examples/wasi-async/main.rs
@@ -18,19 +18,11 @@ struct WasiHostCtx {
 }
 
 impl preview2::WasiView for WasiHostCtx {
-    fn table(&self) -> &wasmtime::component::ResourceTable {
-        &self.preview2_table
-    }
-
-    fn table_mut(&mut self) -> &mut wasmtime::component::ResourceTable {
+    fn table(&mut self) -> &mut wasmtime::component::ResourceTable {
         &mut self.preview2_table
     }
 
-    fn ctx(&self) -> &preview2::WasiCtx {
-        &self.preview2_ctx
-    }
-
-    fn ctx_mut(&mut self) -> &mut preview2::WasiCtx {
+    fn ctx(&mut self) -> &mut preview2::WasiCtx {
         &mut self.preview2_ctx
     }
 }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -794,9 +794,9 @@ impl RunCommand {
 struct Host {
     preview1_ctx: Option<wasmtime_wasi::WasiCtx>,
 
-    // The Mutex is only needed to satisfy the Sync constraint, but we never
-    // actually perform any locking on it as use Mutex::get_mut for
-    // all accesses.
+    // The Mutex is only needed to satisfy the Sync constraint but we never
+    // actually perform any locking on it as we use Mutex::get_mut for every
+    // access.
     preview2_ctx: Option<Arc<Mutex<preview2::WasiCtx>>>,
 
     // Resource table for preview2 if the `preview2_ctx` is in use, otherwise

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, bail, Context as _, Error, Result};
 use clap::Parser;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use wasmtime::{Engine, Func, Module, Store, StoreLimits, Val, ValType};
 use wasmtime_wasi::maybe_exit_on_error;
@@ -784,7 +784,8 @@ impl RunCommand {
             builder.allow_udp(enable);
         }
 
-        store.data_mut().preview2_ctx = Some(Arc::new(builder.build()));
+        let ctx = builder.build();
+        store.data_mut().preview2_ctx = Some(Arc::new(Mutex::new(ctx)));
         Ok(())
     }
 }
@@ -792,11 +793,15 @@ impl RunCommand {
 #[derive(Default, Clone)]
 struct Host {
     preview1_ctx: Option<wasmtime_wasi::WasiCtx>,
-    preview2_ctx: Option<Arc<preview2::WasiCtx>>,
+
+    // The Mutex is only needed to satisfy the Sync constraint, but we never
+    // actually perform any locking on it as use Mutex::get_mut for
+    // all accesses.
+    preview2_ctx: Option<Arc<Mutex<preview2::WasiCtx>>>,
 
     // Resource table for preview2 if the `preview2_ctx` is in use, otherwise
     // "just" an empty table.
-    preview2_table: Arc<wasmtime::component::ResourceTable>,
+    preview2_table: Arc<Mutex<wasmtime::component::ResourceTable>>,
 
     // State necessary for the preview1 implementation of WASI backed by the
     // preview2 host implementation. Only used with the `--preview2` flag right
@@ -815,21 +820,19 @@ struct Host {
 }
 
 impl preview2::WasiView for Host {
-    fn table(&self) -> &wasmtime::component::ResourceTable {
-        &self.preview2_table
+    fn table(&mut self) -> &mut wasmtime::component::ResourceTable {
+        Arc::get_mut(&mut self.preview2_table)
+            .expect("preview2 is not compatible with threads")
+            .get_mut()
+            .unwrap()
     }
 
-    fn table_mut(&mut self) -> &mut wasmtime::component::ResourceTable {
-        Arc::get_mut(&mut self.preview2_table).expect("preview2 is not compatible with threads")
-    }
-
-    fn ctx(&self) -> &preview2::WasiCtx {
-        self.preview2_ctx.as_ref().unwrap()
-    }
-
-    fn ctx_mut(&mut self) -> &mut preview2::WasiCtx {
+    fn ctx(&mut self) -> &mut preview2::WasiCtx {
         let ctx = self.preview2_ctx.as_mut().unwrap();
-        Arc::get_mut(ctx).expect("preview2 is not compatible with threads")
+        Arc::get_mut(ctx)
+            .expect("preview2 is not compatible with threads")
+            .get_mut()
+            .unwrap()
     }
 }
 
@@ -851,7 +854,10 @@ impl wasmtime_wasi_http::types::WasiHttpView for Host {
     }
 
     fn table(&mut self) -> &mut wasmtime::component::ResourceTable {
-        Arc::get_mut(&mut self.preview2_table).expect("preview2 is not compatible with threads")
+        Arc::get_mut(&mut self.preview2_table)
+            .expect("preview2 is not compatible with threads")
+            .get_mut()
+            .unwrap()
     }
 }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -33,19 +33,11 @@ struct Host {
 }
 
 impl WasiView for Host {
-    fn table(&self) -> &wasmtime::component::ResourceTable {
-        &self.table
-    }
-
-    fn table_mut(&mut self) -> &mut wasmtime::component::ResourceTable {
+    fn table(&mut self) -> &mut wasmtime::component::ResourceTable {
         &mut self.table
     }
 
-    fn ctx(&self) -> &WasiCtx {
-        &self.ctx
-    }
-
-    fn ctx_mut(&mut self) -> &mut WasiCtx {
+    fn ctx(&mut self) -> &mut WasiCtx {
         &mut self.ctx
     }
 }


### PR DESCRIPTION
Fundamentally, preview2 is fully synchronous. So at least in theory there should be no need for all the Sync constraints. In practice it took me a while to figure out how to actually make it work. In summary:
- Removed many `+ Sync` constraints
- Removed the immutable reference accessors on WasiView. I also dropped the _mut suffix for consistency with WasiHttpView.
- Had to do a bit of refactoring in `crates/wasi/src/preview2/host/filesystem.rs` [here](https://github.com/bytecodealliance/wasmtime/commit/6b4d634c8ea0de212229c0e9528e06598dacbd22#diff-dff18465028496004c5e0e50b9d35bc5303ea19e2c50d6f1284dd45c6fe7a2c4) and `crates/wasi/src/preview2/preview1.rs` [here](https://github.com/bytecodealliance/wasmtime/commit/1e766c240df9081fcd2b617e1bc76a63dc719363) to make them play along.

---

Chat: https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime/topic/Wasmtime.20preview2.20.60Sync.60