### PR TITLE
examples: Don't `fread()` within `assert(...)`.

### DIFF
--- a/examples/externref.c
+++ b/examples/externref.c
@@ -60,7 +60,10 @@ int main() {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t wat;
   wasm_byte_vec_new_uninitialized(&wat, file_size);
-  assert(fread(wat.data, file_size, 1, file) == 1);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Parse the wat into the binary wasm format

--- a/examples/hello.c
+++ b/examples/hello.c
@@ -63,7 +63,10 @@ int main() {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t wat;
   wasm_byte_vec_new_uninitialized(&wat, file_size);
-  assert(fread(wat.data, file_size, 1, file) == 1);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Parse the wat into the binary wasm format

--- a/examples/interrupt.c
+++ b/examples/interrupt.c
@@ -80,7 +80,10 @@ int main() {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t wat;
   wasm_byte_vec_new_uninitialized(&wat, file_size);
-  assert(fread(wat.data, file_size, 1, file) == 1);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Parse the wat into the binary wasm format

--- a/examples/serialize.c
+++ b/examples/serialize.c
@@ -56,7 +56,10 @@ int serialize(wasm_byte_vec_t *buffer) {
   fseek(file, 0L, SEEK_SET);
   wasm_byte_vec_t wat;
   wasm_byte_vec_new_uninitialized(&wat, file_size);
-  assert(fread(wat.data, file_size, 1, file) == 1);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
   fclose(file);
 
   // Parse the wat into the binary wasm format


### PR DESCRIPTION
This is fine in debug builds but release builds without assertions results in the file data not being read.
