### PR TITLE
feat: support component type introspection

### DIFF
--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -184,8 +184,14 @@ pub enum Export {
         options: CanonicalOptions,
     },
     ModuleStatic(StaticModuleIndex),
-    ModuleImport(RuntimeImportIndex),
-    Instance(IndexMap<String, Export>),
+    ModuleImport {
+        ty: TypeModuleIndex,
+        import: RuntimeImportIndex,
+    },
+    Instance {
+        ty: Option<TypeComponentInstanceIndex>,
+        exports: IndexMap<String, Export>,
+    },
     Type(TypeDef),
 }
 
@@ -487,12 +493,17 @@ impl LinearizeDfg<'_> {
                 }
             }
             Export::ModuleStatic(i) => info::Export::ModuleStatic(*i),
-            Export::ModuleImport(i) => info::Export::ModuleImport(*i),
-            Export::Instance(map) => info::Export::Instance(
-                map.iter()
+            Export::ModuleImport { ty, import } => info::Export::ModuleImport {
+                ty: *ty,
+                import: *import,
+            },
+            Export::Instance { ty, exports } => info::Export::Instance {
+                ty: *ty,
+                exports: exports
+                    .iter()
                     .map(|(name, export)| (name.clone(), self.export(export)))
                     .collect(),
-            ),
+            },
             Export::Type(def) => info::Export::Type(*def),
         }
     }

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -411,7 +411,7 @@ pub enum Export {
     /// A nested instance is being exported which has recursively defined
     /// `Export` items.
     Instance {
-        /// Instance type index, if such exists
+        /// Instance type index, if such is assigned
         ty: Option<TypeComponentInstanceIndex>,
         /// Instance export map
         exports: IndexMap<String, Export>,

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -402,10 +402,20 @@ pub enum Export {
     /// A module defined within this component is exported.
     ModuleStatic(StaticModuleIndex),
     /// A module imported into this component is exported.
-    ModuleImport(RuntimeImportIndex),
+    ModuleImport {
+        /// Module type index
+        ty: TypeModuleIndex,
+        /// Module runtime import index
+        import: RuntimeImportIndex,
+    },
     /// A nested instance is being exported which has recursively defined
     /// `Export` items.
-    Instance(IndexMap<String, Export>),
+    Instance {
+        /// Instance type index, if such exists
+        ty: Option<TypeComponentInstanceIndex>,
+        /// Instance export map
+        exports: IndexMap<String, Export>,
+    },
     /// An exported type from a component or instance, currently only
     /// informational.
     Type(TypeDef),

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -398,10 +398,24 @@ macro_rules! intern_and_fill_flat_types {
 
 impl ComponentTypesBuilder {
     /// Finishes this list of component types and returns the finished
-    /// structure.
-    pub fn finish(mut self) -> ComponentTypes {
+    /// structure and the [`TypeComponentIndex`] corresponding to top-level component
+    /// with `imports` and `exports` specified.
+    pub fn finish(
+        mut self,
+        imports: impl IntoIterator<Item = (String, TypeDef)>,
+        exports: impl IntoIterator<Item = (String, TypeDef)>,
+    ) -> (ComponentTypes, TypeComponentIndex) {
+        let mut component_ty = TypeComponent::default();
+        for (name, ty) in imports {
+            component_ty.imports.insert(name, ty);
+        }
+        for (name, ty) in exports {
+            component_ty.exports.insert(name, ty);
+        }
+        let ty = self.component_types.components.push(component_ty);
+
         self.component_types.module_types = self.module_types.finish();
-        self.component_types
+        (self.component_types, ty)
     }
 
     /// Smaller helper method to find a `SignatureIndex` which corresponds to

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -1,7 +1,7 @@
-use crate::component::{MAX_FLAT_PARAMS, MAX_FLAT_RESULTS};
+use crate::component::{Export, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS};
 use crate::{
-    EntityType, ModuleTypes, ModuleTypesBuilder, PrimaryMap, SignatureIndex, TypeConvert,
-    WasmHeapType, WasmType,
+    CompiledModuleInfo, EntityType, ModuleTypes, ModuleTypesBuilder, PrimaryMap, SignatureIndex,
+    TypeConvert, WasmHeapType, WasmType,
 };
 use anyhow::{bail, Result};
 use cranelift_entity::EntityRef;
@@ -397,20 +397,62 @@ macro_rules! intern_and_fill_flat_types {
 }
 
 impl ComponentTypesBuilder {
+    fn export_type_def(
+        &mut self,
+        static_modules: &PrimaryMap<StaticModuleIndex, CompiledModuleInfo>,
+        ty: &Export,
+    ) -> TypeDef {
+        match ty {
+            Export::LiftedFunction { ty, .. } => TypeDef::ComponentFunc(*ty),
+            Export::ModuleStatic(idx) => {
+                let mut module_ty = TypeModule::default();
+                let module = &static_modules[*idx].module;
+                for (namespace, name, ty) in module.imports() {
+                    module_ty
+                        .imports
+                        .insert((namespace.to_string(), name.to_string()), ty);
+                }
+                for (name, ty) in module.exports.iter() {
+                    module_ty
+                        .exports
+                        .insert(name.to_string(), module.type_of(*ty));
+                }
+                TypeDef::Module(self.component_types.modules.push(module_ty))
+            }
+            Export::ModuleImport { ty, .. } => TypeDef::Module(*ty),
+            Export::Instance { ty: Some(ty), .. } => TypeDef::ComponentInstance(*ty),
+            Export::Instance { exports, .. } => {
+                let mut instance_ty = TypeComponentInstance::default();
+                for (name, ty) in exports {
+                    instance_ty
+                        .exports
+                        .insert(name.to_string(), self.export_type_def(static_modules, ty));
+                }
+                TypeDef::ComponentInstance(
+                    self.component_types.component_instances.push(instance_ty),
+                )
+            }
+            Export::Type(ty) => *ty,
+        }
+    }
+
     /// Finishes this list of component types and returns the finished
     /// structure and the [`TypeComponentIndex`] corresponding to top-level component
     /// with `imports` and `exports` specified.
-    pub fn finish(
+    pub fn finish<'a>(
         mut self,
+        static_modules: &PrimaryMap<StaticModuleIndex, CompiledModuleInfo>,
         imports: impl IntoIterator<Item = (String, TypeDef)>,
-        exports: impl IntoIterator<Item = (String, TypeDef)>,
+        exports: impl IntoIterator<Item = (String, &'a Export)>,
     ) -> (ComponentTypes, TypeComponentIndex) {
         let mut component_ty = TypeComponent::default();
         for (name, ty) in imports {
             component_ty.imports.insert(name, ty);
         }
         for (name, ty) in exports {
-            component_ty.exports.insert(name, ty);
+            component_ty
+                .exports
+                .insert(name, self.export_type_def(static_modules, ty));
         }
         let ty = self.component_types.components.push(component_ty);
 
@@ -572,7 +614,7 @@ impl ComponentTypesBuilder {
         Ok(self.component_types.components.push(result))
     }
 
-    fn convert_instance(
+    pub(crate) fn convert_instance(
         &mut self,
         types: types::TypesRef<'_>,
         id: types::ComponentInstanceTypeId,

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -714,8 +714,8 @@ impl<'a, 'store> ExportInstance<'a, 'store> {
                 options,
             )),
             Export::ModuleStatic(_)
-            | Export::ModuleImport(_)
-            | Export::Instance(_)
+            | Export::ModuleImport { .. }
+            | Export::Instance { .. }
             | Export::Type(_) => None,
         }
     }
@@ -738,7 +738,7 @@ impl<'a, 'store> ExportInstance<'a, 'store> {
     pub fn module(&mut self, name: &str) -> Option<&'a Module> {
         match self.exports.get(name)? {
             Export::ModuleStatic(idx) => Some(&self.data.component.static_module(*idx)),
-            Export::ModuleImport(idx) => Some(match &self.data.imports[*idx] {
+            Export::ModuleImport { import, .. } => Some(match &self.data.imports[*import] {
                 RuntimeImport::Module(m) => m,
                 _ => unreachable!(),
             }),
@@ -753,8 +753,8 @@ impl<'a, 'store> ExportInstance<'a, 'store> {
             Export::Type(_)
             | Export::LiftedFunction { .. }
             | Export::ModuleStatic(_)
-            | Export::ModuleImport(_)
-            | Export::Instance(_) => None,
+            | Export::ModuleImport { .. }
+            | Export::Instance { .. } => None,
         }
     }
 
@@ -774,7 +774,7 @@ impl<'a, 'store> ExportInstance<'a, 'store> {
         self.exports.iter().filter_map(|(name, export)| {
             let module = match *export {
                 Export::ModuleStatic(idx) => self.data.component.static_module(idx),
-                Export::ModuleImport(idx) => match &self.data.imports[idx] {
+                Export::ModuleImport { import, .. } => match &self.data.imports[import] {
                     RuntimeImport::Module(m) => m,
                     _ => unreachable!(),
                 },
@@ -803,7 +803,7 @@ impl<'a, 'store> ExportInstance<'a, 'store> {
     /// return value with the same lifetimes.
     pub fn into_instance(self, name: &str) -> Option<ExportInstance<'a, 'store>> {
         match self.exports.get(name)? {
-            Export::Instance(exports) => Some(ExportInstance {
+            Export::Instance { exports, .. } => Some(ExportInstance {
                 exports,
                 instance: self.instance,
                 data: self.data,

--- a/crates/wasmtime/src/component/instance.rs
+++ b/crates/wasmtime/src/component/instance.rs
@@ -1,13 +1,12 @@
 use crate::component::func::HostFunc;
 use crate::component::matching::InstanceType;
 use crate::component::{
-    Component, ComponentItemType, ComponentNamedList, Func, Lift, Lower, ResourceImportIndex,
-    ResourceType, TypedFunc,
+    Component, ComponentNamedList, Func, Lift, Lower, ResourceImportIndex, ResourceType, TypedFunc,
 };
 use crate::instance::OwnedImports;
 use crate::linker::DefinitionType;
 use crate::store::{StoreOpaque, Stored};
-use crate::{AsContextMut, Module, StoreContext, StoreContextMut};
+use crate::{AsContextMut, Module, StoreContextMut};
 use anyhow::{anyhow, Context, Result};
 use indexmap::IndexMap;
 use std::marker;
@@ -62,25 +61,6 @@ pub(crate) struct InstanceData {
 }
 
 impl Instance {
-    /// Iterates over all types imported by this component instance
-    ///
-    /// # Panics
-    ///
-    /// Panics if `store` does not own this instance.
-    pub fn import_types<'a, T: 'a>(
-        &self,
-        store: impl Into<StoreContext<'a, T>>,
-    ) -> impl Iterator<Item = (&'a String, ComponentItemType)> {
-        let store = store.into();
-        let data = store.0[self.0].as_ref().unwrap();
-        let instance_ty = data.ty();
-        data.component
-            .env_component()
-            .import_types
-            .iter()
-            .map(move |(_, (name, ty))| (name, ComponentItemType::from(ty, &instance_ty)))
-    }
-
     /// Returns information about the exports of this instance.
     ///
     /// This method can be used to extract exported values from this component

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -24,7 +24,11 @@ pub use self::instance::{ExportInstance, Exports, Instance, InstancePre};
 pub use self::linker::{Linker, LinkerInstance, ResourceImportIndex};
 pub use self::resource_table::{ResourceTable, ResourceTableError};
 pub use self::resources::{Resource, ResourceAny};
-pub use self::types::{ResourceType, Type};
+pub use self::types::{
+    ComponentFunc as ComponentFuncType, ComponentInstance as ComponentInstanceType,
+    ComponentItem as ComponentItemType, CoreFunc as CoreFuncType, Module as ModuleType,
+    ResourceType, Type,
+};
 pub use self::values::{Enum, Flags, List, OptionVal, Record, ResultVal, Tuple, Val, Variant};
 pub use wasmtime_component_macro::{flags, ComponentType, Lift, Lower};
 

--- a/crates/wasmtime/src/component/mod.rs
+++ b/crates/wasmtime/src/component/mod.rs
@@ -24,11 +24,7 @@ pub use self::instance::{ExportInstance, Exports, Instance, InstancePre};
 pub use self::linker::{Linker, LinkerInstance, ResourceImportIndex};
 pub use self::resource_table::{ResourceTable, ResourceTableError};
 pub use self::resources::{Resource, ResourceAny};
-pub use self::types::{
-    ComponentFunc as ComponentFuncType, ComponentInstance as ComponentInstanceType,
-    ComponentItem as ComponentItemType, CoreFunc as CoreFuncType, Module as ModuleType,
-    ResourceType, Type,
-};
+pub use self::types::{ResourceType, Type};
 pub use self::values::{Enum, Flags, List, OptionVal, Record, ResultVal, Tuple, Val, Variant};
 pub use wasmtime_component_macro::{flags, ComponentType, Lift, Lower};
 

--- a/crates/wasmtime/src/component/types.rs
+++ b/crates/wasmtime/src/component/types.rs
@@ -762,7 +762,7 @@ impl Type {
 }
 
 /// Component function type
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ComponentFunc(Handle<TypeFuncIndex>);
 
 impl ComponentFunc {
@@ -790,7 +790,7 @@ impl ComponentFunc {
 }
 
 /// Core module type
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Module(Handle<TypeModuleIndex>);
 
 impl Module {
@@ -823,7 +823,7 @@ impl Module {
 }
 
 /// Component type
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Component(Handle<TypeComponentIndex>);
 
 impl Component {
@@ -865,7 +865,7 @@ impl Component {
 }
 
 /// Component instance type
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct ComponentInstance(Handle<TypeComponentInstanceIndex>);
 
 impl ComponentInstance {
@@ -891,7 +891,7 @@ impl ComponentInstance {
 }
 
 /// Type of an item contained within the component
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum ComponentItem {
     /// Component function item
     ComponentFunc(ComponentFunc),

--- a/crates/wasmtime/src/component/types.rs
+++ b/crates/wasmtime/src/component/types.rs
@@ -771,7 +771,7 @@ impl ComponentFunc {
     }
 
     /// Iterates over types of function parameters
-    pub fn params(&self) -> impl Iterator<Item = Type> + '_ {
+    pub fn params(&self) -> impl ExactSizeIterator<Item = Type> + '_ {
         let params = self.0.types[self.0.index].params;
         self.0.types[params]
             .types
@@ -780,7 +780,7 @@ impl ComponentFunc {
     }
 
     /// Iterates over types of function results
-    pub fn results(&self) -> impl Iterator<Item = Type> + '_ {
+    pub fn results(&self) -> impl ExactSizeIterator<Item = Type> + '_ {
         let results = self.0.types[self.0.index].results;
         self.0.types[results]
             .types

--- a/crates/wasmtime/src/component/types.rs
+++ b/crates/wasmtime/src/component/types.rs
@@ -275,6 +275,7 @@ impl List {
 }
 
 /// A field declaration belonging to a `record`
+#[derive(Debug)]
 pub struct Field<'a> {
     /// The name of the field
     pub name: &'a str,


### PR DESCRIPTION
This allows for embedders to introspect the component type to e.g. construct `Val`s of complex types expected by the components at runtime.
Closes #7726 
I'll work on adding a simple test once I verify this covers my own use case

cc @alexcrichton 