### PR TITLE
preview 1 test-programs: fdflags_sync always unsupported

### DIFF
--- a/crates/test-programs/artifacts/src/lib.rs
+++ b/crates/test-programs/artifacts/src/lib.rs
@@ -15,25 +15,15 @@ pub fn wasi_tests_environment() -> &'static [(&'static str, &'static str)] {
             // Windows does not support renaming a directory to an empty directory -
             // empty directory must be deleted.
             ("NO_RENAME_DIR_TO_EMPTY_DIR", "1"),
-            // cap-std-sync does not support the sync family of fdflags
-            ("NO_FDFLAGS_SYNC_SUPPORT", "1"),
         ]
     }
     #[cfg(all(unix, not(target_os = "macos")))]
     {
-        &[
-            ("ERRNO_MODE_UNIX", "1"),
-            // cap-std-sync does not support the sync family of fdflags
-            ("NO_FDFLAGS_SYNC_SUPPORT", "1"),
-        ]
+        &[("ERRNO_MODE_UNIX", "1")]
     }
     #[cfg(target_os = "macos")]
     {
-        &[
-            ("ERRNO_MODE_MACOS", "1"),
-            // cap-std-sync does not support the sync family of fdflags
-            ("NO_FDFLAGS_SYNC_SUPPORT", "1"),
-        ]
+        &[("ERRNO_MODE_MACOS", "1")]
     }
 }
 

--- a/crates/test-programs/src/bin/preview1_path_filestat.rs
+++ b/crates/test-programs/src/bin/preview1_path_filestat.rs
@@ -5,11 +5,7 @@ use test_programs::preview1::{
 
 unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
     let cfg = TestConfig::from_env();
-    let fdflags = if config().support_fdflags_sync() {
-        wasi::FDFLAGS_APPEND | wasi::FDFLAGS_SYNC
-    } else {
-        wasi::FDFLAGS_APPEND
-    };
+    let fdflags = wasi::FDFLAGS_APPEND;
 
     // Create a file in the scratch directory.
     let file_fd = wasi::path_open(
@@ -34,29 +30,19 @@ unsafe fn test_path_filestat(dir_fd: wasi::Fd) {
         wasi::FDFLAGS_APPEND,
         "file should have the APPEND fdflag used to create the file"
     );
-    if config().support_fdflags_sync() {
-        assert_eq!(
-            fdstat.fs_flags & wasi::FDFLAGS_SYNC,
+    assert_errno!(
+        wasi::path_open(
+            dir_fd,
+            0,
+            "file",
+            0,
+            wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
+            0,
             wasi::FDFLAGS_SYNC,
-            "file should have the SYNC fdflag used to create the file"
-        );
-    }
-
-    if !config().support_fdflags_sync() {
-        assert_errno!(
-            wasi::path_open(
-                dir_fd,
-                0,
-                "file",
-                0,
-                wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE,
-                0,
-                wasi::FDFLAGS_SYNC,
-            )
-            .expect_err("FDFLAGS_SYNC not supported by platform"),
-            wasi::ERRNO_NOTSUP
-        );
-    }
+        )
+        .expect_err("FDFLAGS_SYNC not supported by platform"),
+        wasi::ERRNO_NOTSUP
+    );
 
     // Check file size
     let file_stat = wasi::path_filestat_get(dir_fd, 0, "file").expect("reading file stats");

--- a/crates/test-programs/src/preview1.rs
+++ b/crates/test-programs/src/preview1.rs
@@ -127,7 +127,6 @@ pub struct TestConfig {
     fs_time_precision: u64,
     no_dangling_filesystem: bool,
     no_rename_dir_to_empty_dir: bool,
-    no_fdflags_sync_support: bool,
 }
 
 enum ErrnoMode {
@@ -154,13 +153,11 @@ impl TestConfig {
         };
         let no_dangling_filesystem = std::env::var("NO_DANGLING_FILESYSTEM").is_ok();
         let no_rename_dir_to_empty_dir = std::env::var("NO_RENAME_DIR_TO_EMPTY_DIR").is_ok();
-        let no_fdflags_sync_support = std::env::var("NO_FDFLAGS_SYNC_SUPPORT").is_ok();
         TestConfig {
             errno_mode,
             fs_time_precision,
             no_dangling_filesystem,
             no_rename_dir_to_empty_dir,
-            no_fdflags_sync_support,
         }
     }
     pub fn errno_expect_unix(&self) -> bool {
@@ -189,8 +186,5 @@ impl TestConfig {
     }
     pub fn support_rename_dir_to_empty_dir(&self) -> bool {
         !self.no_rename_dir_to_empty_dir
-    }
-    pub fn support_fdflags_sync(&self) -> bool {
-        !self.no_fdflags_sync_support
     }
 }


### PR DESCRIPTION
We never pursued making the fdflags_sync supported on any platform. Rather than carry around the baggage of potentially, one day, supporting it somewhere, delete the configuration variable and make the single test that considered it always assert that fdflags_sync is not supported.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
