### PR TITLE
demange names in guest-profiler output

### DIFF
--- a/crates/wasmtime/src/profiling.rs
+++ b/crates/wasmtime/src/profiling.rs
@@ -10,6 +10,7 @@ use fxprof_processed_profile::{
 use std::ops::Range;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
+use wasmtime_environ::demangle_function_name;
 use wasmtime_runtime::Backtrace;
 
 // TODO: collect more data
@@ -186,9 +187,10 @@ fn module_symbols(name: String, compiled: &CompiledModule) -> Option<LibraryInfo
     let symbols = Vec::from_iter(compiled.finished_functions().map(|(defined_idx, _)| {
         let loc = compiled.func_loc(defined_idx);
         let func_idx = compiled.module().func_index(defined_idx);
-        let name = match compiled.func_name(func_idx) {
-            None => format!("wasm_function_{}", defined_idx.as_u32()),
-            Some(name) => name.to_string(),
+        let mut name = String::new();
+        match compiled.func_name(func_idx) {
+            None => name = format!("wasm_function_{}", defined_idx.as_u32()),
+            Some(func_name) => demangle_function_name(&mut name, func_name).unwrap(),
         };
         Symbol {
             address: loc.start,


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
issue #7665 
