### PR TITLE
Update some `cargo vet`-related metadata

### DIFF
--- a/.github/actions/install-cargo-vet/action.yml
+++ b/.github/actions/install-cargo-vet/action.yml
@@ -5,7 +5,7 @@ inputs:
   version:
     description: 'Version to install'
     required: false
-    default: '0.8.0'
+    default: '0.9.0'
 
 runs:
   using: composite

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,9 +1313,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d308f63daf4181410c242d34c11f928dcb3aa105852019e043c9d1f4e4368a"
+checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
 dependencies = [
  "bytes",
  "fnv",

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1345,6 +1345,12 @@ criteria = "safe-to-deploy"
 delta = "0.3.19 -> 0.4.0"
 notes = "A number of changes but nothing adding new `unsafe` or anything outside the purview of what this crate already manages."
 
+[[audits.h2]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.4.0 -> 0.4.2"
+notes = "Minor updates and fixes in this version bump, nothing major."
+
 [[audits.hashbrown]]
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -2,7 +2,7 @@
 # cargo-vet config file
 
 [cargo-vet]
-version = "0.8"
+version = "0.9"
 
 [imports.embark-studios]
 url = "https://raw.githubusercontent.com/EmbarkStudios/rust-ecosystem/main/audits.toml"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -609,6 +609,22 @@ criteria = "safe-to-deploy"
 version = "0.11.0+wasi-snapshot-preview1"
 criteria = "safe-to-deploy"
 
+[[exemptions.wasmi]]
+version = "0.31.1"
+criteria = "safe-to-run"
+
+[[exemptions.wasmi_arena]]
+version = "0.4.1"
+criteria = "safe-to-run"
+
+[[exemptions.wasmi_core]]
+version = "0.13.0"
+criteria = "safe-to-run"
+
+[[exemptions.wasmparser-nostd]]
+version = "0.100.1"
+criteria = "safe-to-run"
+
 [[exemptions.web-sys]]
 version = "0.3.57"
 criteria = "safe-to-deploy"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2445,30 +2445,6 @@ when = "2023-12-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
-[[publisher.wasmtime-jit]]
-version = "14.0.2"
-when = "2023-10-26"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-jit]]
-version = "14.0.4"
-when = "2023-11-01"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-jit]]
-version = "15.0.1"
-when = "2023-12-01"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-jit]]
-version = "16.0.0"
-when = "2023-12-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
 [[publisher.wasmtime-jit-debug]]
 version = "14.0.2"
 when = "2023-10-26"


### PR DESCRIPTION
* Update to `cargo vet` 0.9.0
* Update h2 to 0.4.2 to resolve a security advisory
* Add vet exemptions for https://github.com/bytecodealliance/wasmtime/pull/7791