### PR TITLE
c-api: expose tail call configuration option in c api

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -150,6 +150,13 @@ WASMTIME_CONFIG_PROP(void, max_wasm_stack, size_t)
 WASMTIME_CONFIG_PROP(void, wasm_threads, bool)
 
 /**
+ * \brief Configures whether the WebAssembly tail call proposal is enabled.
+ *
+ * This setting is `false` by default.
+ */
+WASMTIME_CONFIG_PROP(void, wasm_tail_call, bool)
+
+/**
  * \brief Configures whether the WebAssembly reference types proposal is
  * enabled.
  *

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -76,6 +76,11 @@ pub extern "C" fn wasmtime_config_wasm_threads_set(c: &mut wasm_config_t, enable
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_config_wasm_tail_call_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.wasm_tail_call(enable);
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_config_wasm_reference_types_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_reference_types(enable);
 }


### PR DESCRIPTION
The tail call proposal configuration is not yet exposed by the C api.
This change intends to allow configuring the option in e.g. the python library bindings:
https://github.com/bytecodealliance/wasmtime-py/issues/204

I wanted to test this change doing the following:

Following the [docs](https://docs.wasmtime.dev/contributing-building.html), I ran
`cargo build --release --manifest-path crates/c-api/Cargo.toml` which should place `libwasmtime.{a,so}` in `target/release`.
The command succeeded, but the file is not generated (and I cannot find libwasmtime.so with `find`).

~I thus didn't test the change further than the fact that it compiles, in particular I didn't yet test the change
with the python library.~
Tested to work together with the PR: https://github.com/bytecodealliance/wasmtime-py/pull/205 adjusting the python bindings.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
