### PR TITLE
Fix contributor documentation for building the C API

### DIFF
--- a/docs/contributing-building.md
+++ b/docs/contributing-building.md
@@ -57,7 +57,7 @@ with `cargo run`.
 To build the C API of Wasmtime you can run:
 
 ```shell
-cargo build --release --manifest-path crates/c-api/Cargo.toml
+cargo build --release -p wasmtime-c-api
 ```
 
 This will place the shared library inside of `target/release`. On Linux it will


### PR DESCRIPTION
Needs to account for historical changes around rejiggering the build process here.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
