### PR TITLE
mpk: enable MPK if available in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -520,6 +520,18 @@ jobs:
       shell: pwsh
       if: matrix.os == 'windows-latest'
 
+    # Since MPK (PKU) is not present on some GitHub runners, we check if it is
+    # available before force-enabling it. This occasional testing is better than
+    # none at all; ideally we would test in a system-mode QEMU VM.
+    - name: Force-run with MPK enabled, if available
+      run: |
+        if cargo run --example mpk-available; then
+          echo "::warning::This CI run will force-enable MPK; this ensures tests conditioned with the \`WASMTIME_TEST_FORCE_MPK\` environment variable will run with MPK-protected memory pool stripes."
+          echo WASMTIME_TEST_FORCE_MPK=1 >> $GITHUB_ENV
+        else
+          echo "::warning::This CI run will not test MPK; it has been detected as not available on this machine (\`cargo run --example mpk-available\`)."
+        fi
+
     # Build and test all features
     - run: ./ci/run-tests.sh --locked
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -524,9 +524,10 @@ jobs:
     # available before force-enabling it. This occasional testing is better than
     # none at all; ideally we would test in a system-mode QEMU VM.
     - name: Force-run with MPK enabled, if available
+      if: ${{ contains(matrix.name, 'MPK') }}
       run: |
         if cargo run --example mpk-available; then
-          echo "::warning::This CI run will force-enable MPK; this ensures tests conditioned with the \`WASMTIME_TEST_FORCE_MPK\` environment variable will run with MPK-protected memory pool stripes."
+          echo "::notice::This CI run will force-enable MPK; this ensures tests conditioned with the \`WASMTIME_TEST_FORCE_MPK\` environment variable will run with MPK-protected memory pool stripes."
           echo WASMTIME_TEST_FORCE_MPK=1 >> $GITHUB_ENV
         else
           echo "::warning::This CI run will not test MPK; it has been detected as not available on this machine (\`cargo run --example mpk-available\`)."

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -49,6 +49,12 @@ const array = [
     "rust": "msrv",
   },
   {
+    "os": "ubuntu-latest",
+    "name": "Test Linux x86_64 with MPK",
+    "filter": "linux-x64",
+    "isa": "x64"
+  },
+  {
     "os": "macos-latest",
     "name": "Test macOS x86_64",
     "filter": "macos-x64"

--- a/examples/mpk-available.rs
+++ b/examples/mpk-available.rs
@@ -1,0 +1,16 @@
+//! This example checks if memory protection keys (MPK) are available on the
+//! current system using the
+//! [`PoolingAllocationConfig::are_memory_protection_keys_available`] API.
+
+use std::process::exit;
+use wasmtime::*;
+
+fn main() {
+    if PoolingAllocationConfig::are_memory_protection_keys_available() {
+        eprintln!("MPK is available");
+        exit(0);
+    } else {
+        eprintln!("MPK is not available");
+        exit(1);
+    }
+}


### PR DESCRIPTION
After discussing several options for testing MPK in CI, this stopgap
measure at least provides some coverage. Other options include
maintaining a separate MPK-enabled CI runner (configuration is not
transparent, hard to maintain) or running the MPK-enabled tests in a
system-mode QEMU VM (tricky to get right, also hard to maintain). For
now, those of us at the Cranelift meeting agreed this at least gets some
CI testing for the MPK bits, which shouldn't be changing too often.
Since not all GitHub runners have MPK available, we only set the
`WASMTIME_TEST_FORCE_MPK` environment variable when it is. This change
also emits a warning to the GitHub logs in either case for easier
troubleshooting (e.g., to attempt to provide context if MPK logic breaks
and is only found in a later CI run).

prtest:full

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
