### PR TITLE
use released WASI Preview 2 (version 0.2.0) wits

### DIFF
--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -11,9 +11,9 @@ pub mod bindings {
     wasmtime::component::bindgen!({
         path: "wit",
         interfaces: "
-            import wasi:http/incoming-handler@0.2.0-rc-2024-01-16;
-            import wasi:http/outgoing-handler@0.2.0-rc-2024-01-16;
-            import wasi:http/types@0.2.0-rc-2024-01-16;
+            import wasi:http/incoming-handler@0.2.0;
+            import wasi:http/outgoing-handler@0.2.0;
+            import wasi:http/types@0.2.0;
         ",
         tracing: true,
         async: false,

--- a/crates/wasi-http/wit/command-extended.wit
+++ b/crates/wasi-http/wit/command-extended.wit
@@ -1,6 +1,6 @@
 // All of the same imports and exports available in the wasi:cli/command world
 // with addition of HTTP proxy related imports:
 world command-extended {
-  include wasi:cli/command@0.2.0-rc-2024-01-16;
-  import wasi:http/outgoing-handler@0.2.0-rc-2024-01-16;
+  include wasi:cli/command@0.2.0;
+  import wasi:http/outgoing-handler@0.2.0;
 }

--- a/crates/wasi-http/wit/deps/cli/command.wit
+++ b/crates/wasi-http/wit/deps/cli/command.wit
@@ -1,4 +1,4 @@
-package wasi:cli@0.2.0-rc-2024-01-16;
+package wasi:cli@0.2.0;
 
 world command {
   include imports;

--- a/crates/wasi-http/wit/deps/cli/imports.wit
+++ b/crates/wasi-http/wit/deps/cli/imports.wit
@@ -1,11 +1,11 @@
-package wasi:cli@0.2.0-rc-2024-01-16;
+package wasi:cli@0.2.0;
 
 world imports {
-  include wasi:clocks/imports@0.2.0-rc-2023-11-10;
-  include wasi:filesystem/imports@0.2.0-rc-2023-11-10;
-  include wasi:sockets/imports@0.2.0-rc-2024-01-16;
-  include wasi:random/imports@0.2.0-rc-2023-11-10;
-  include wasi:io/imports@0.2.0-rc-2023-11-10;
+  include wasi:clocks/imports@0.2.0;
+  include wasi:filesystem/imports@0.2.0;
+  include wasi:sockets/imports@0.2.0;
+  include wasi:random/imports@0.2.0;
+  include wasi:io/imports@0.2.0;
 
   import environment;
   import exit;

--- a/crates/wasi-http/wit/deps/cli/stdio.wit
+++ b/crates/wasi-http/wit/deps/cli/stdio.wit
@@ -1,17 +1,17 @@
 interface stdin {
-  use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream};
+  use wasi:io/streams@0.2.0.{input-stream};
 
   get-stdin: func() -> input-stream;
 }
 
 interface stdout {
-  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
+  use wasi:io/streams@0.2.0.{output-stream};
 
   get-stdout: func() -> output-stream;
 }
 
 interface stderr {
-  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
+  use wasi:io/streams@0.2.0.{output-stream};
 
   get-stderr: func() -> output-stream;
 }

--- a/crates/wasi-http/wit/deps/clocks/monotonic-clock.wit
+++ b/crates/wasi-http/wit/deps/clocks/monotonic-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.0-rc-2023-11-10;
+package wasi:clocks@0.2.0;
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
 ///
@@ -10,7 +10,7 @@ package wasi:clocks@0.2.0-rc-2023-11-10;
 ///
 /// It is intended for measuring elapsed time.
 interface monotonic-clock {
-    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+    use wasi:io/poll@0.2.0.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from

--- a/crates/wasi-http/wit/deps/clocks/wall-clock.wit
+++ b/crates/wasi-http/wit/deps/clocks/wall-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.0-rc-2023-11-10;
+package wasi:clocks@0.2.0;
 /// WASI Wall Clock is a clock API intended to let users query the current
 /// time. The name "wall" makes an analogy to a "clock on the wall", which
 /// is not necessarily monotonic as it may be reset.

--- a/crates/wasi-http/wit/deps/clocks/world.wit
+++ b/crates/wasi-http/wit/deps/clocks/world.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.0-rc-2023-11-10;
+package wasi:clocks@0.2.0;
 
 world imports {
     import monotonic-clock;

--- a/crates/wasi-http/wit/deps/filesystem/preopens.wit
+++ b/crates/wasi-http/wit/deps/filesystem/preopens.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.0-rc-2023-11-10;
+package wasi:filesystem@0.2.0;
 
 interface preopens {
     use types.{descriptor};

--- a/crates/wasi-http/wit/deps/filesystem/types.wit
+++ b/crates/wasi-http/wit/deps/filesystem/types.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.0-rc-2023-11-10;
+package wasi:filesystem@0.2.0;
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
 /// significant overhead.
@@ -24,8 +24,8 @@ package wasi:filesystem@0.2.0-rc-2023-11-10;
 ///
 /// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
 interface types {
-    use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream, error};
-    use wasi:clocks/wall-clock@0.2.0-rc-2023-11-10.{datetime};
+    use wasi:io/streams@0.2.0.{input-stream, output-stream, error};
+    use wasi:clocks/wall-clock@0.2.0.{datetime};
 
     /// File size or length of a region within a file.
     type filesize = u64;

--- a/crates/wasi-http/wit/deps/filesystem/world.wit
+++ b/crates/wasi-http/wit/deps/filesystem/world.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.0-rc-2023-11-10;
+package wasi:filesystem@0.2.0;
 
 world imports {
     import types;

--- a/crates/wasi-http/wit/deps/http/proxy.wit
+++ b/crates/wasi-http/wit/deps/http/proxy.wit
@@ -1,4 +1,4 @@
-package wasi:http@0.2.0-rc-2024-01-16;
+package wasi:http@0.2.0;
 
 /// The `wasi:http/proxy` world captures a widely-implementable intersection of
 /// hosts that includes HTTP forward and reverse proxies. Components targeting
@@ -6,19 +6,19 @@ package wasi:http@0.2.0-rc-2024-01-16;
 /// outgoing HTTP requests.
 world proxy {
   /// HTTP proxies have access to time and randomness.
-  include wasi:clocks/imports@0.2.0-rc-2023-11-10;
-  import wasi:random/random@0.2.0-rc-2023-11-10;
+  include wasi:clocks/imports@0.2.0;
+  import wasi:random/random@0.2.0;
 
   /// Proxies have standard output and error streams which are expected to
   /// terminate in a developer-facing console provided by the host.
-  import wasi:cli/stdout@0.2.0-rc-2024-01-16;
-  import wasi:cli/stderr@0.2.0-rc-2024-01-16;
+  import wasi:cli/stdout@0.2.0;
+  import wasi:cli/stderr@0.2.0;
 
   /// TODO: this is a temporary workaround until component tooling is able to
   /// gracefully handle the absence of stdin. Hosts must return an eof stream
   /// for this import, which is what wasi-libc + tooling will do automatically
   /// when this import is properly removed.
-  import wasi:cli/stdin@0.2.0-rc-2024-01-16;
+  import wasi:cli/stdin@0.2.0;
 
   /// This is the default handler to use when user code simply wants to make an
   /// HTTP request (e.g., via `fetch()`).

--- a/crates/wasi-http/wit/deps/http/types.wit
+++ b/crates/wasi-http/wit/deps/http/types.wit
@@ -2,10 +2,10 @@
 /// HTTP Requests and Responses, both incoming and outgoing, as well as
 /// their headers, trailers, and bodies.
 interface types {
-  use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10.{duration};
-  use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
-  use wasi:io/error@0.2.0-rc-2023-11-10.{error as io-error};
-  use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+  use wasi:clocks/monotonic-clock@0.2.0.{duration};
+  use wasi:io/streams@0.2.0.{input-stream, output-stream};
+  use wasi:io/error@0.2.0.{error as io-error};
+  use wasi:io/poll@0.2.0.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
   variant method {

--- a/crates/wasi-http/wit/deps/io/error.wit
+++ b/crates/wasi-http/wit/deps/io/error.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-10;
+package wasi:io@0.2.0;
 
 
 interface error {

--- a/crates/wasi-http/wit/deps/io/poll.wit
+++ b/crates/wasi-http/wit/deps/io/poll.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-10;
+package wasi:io@0.2.0;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.

--- a/crates/wasi-http/wit/deps/io/streams.wit
+++ b/crates/wasi-http/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-10;
+package wasi:io@0.2.0;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.

--- a/crates/wasi-http/wit/deps/io/world.wit
+++ b/crates/wasi-http/wit/deps/io/world.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-10;
+package wasi:io@0.2.0;
 
 world imports {
     import streams;

--- a/crates/wasi-http/wit/deps/random/insecure-seed.wit
+++ b/crates/wasi-http/wit/deps/random/insecure-seed.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.0-rc-2023-11-10;
+package wasi:random@0.2.0;
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi-http/wit/deps/random/insecure.wit
+++ b/crates/wasi-http/wit/deps/random/insecure.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.0-rc-2023-11-10;
+package wasi:random@0.2.0;
 /// The insecure interface for insecure pseudo-random numbers.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi-http/wit/deps/random/random.wit
+++ b/crates/wasi-http/wit/deps/random/random.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.0-rc-2023-11-10;
+package wasi:random@0.2.0;
 /// WASI Random is a random data API.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi-http/wit/deps/random/world.wit
+++ b/crates/wasi-http/wit/deps/random/world.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.0-rc-2023-11-10;
+package wasi:random@0.2.0;
 
 world imports {
     import random;

--- a/crates/wasi-http/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi-http/wit/deps/sockets/ip-name-lookup.wit
@@ -1,6 +1,6 @@
 
 interface ip-name-lookup {
-    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+    use wasi:io/poll@0.2.0.{pollable};
     use network.{network, error-code, ip-address};
 
 

--- a/crates/wasi-http/wit/deps/sockets/tcp.wit
+++ b/crates/wasi-http/wit/deps/sockets/tcp.wit
@@ -1,8 +1,8 @@
 
 interface tcp {
-    use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
-    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
-    use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10.{duration};
+    use wasi:io/streams@0.2.0.{input-stream, output-stream};
+    use wasi:io/poll@0.2.0.{pollable};
+    use wasi:clocks/monotonic-clock@0.2.0.{duration};
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
     enum shutdown-type {

--- a/crates/wasi-http/wit/deps/sockets/udp.wit
+++ b/crates/wasi-http/wit/deps/sockets/udp.wit
@@ -1,6 +1,6 @@
 
 interface udp {
-    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+    use wasi:io/poll@0.2.0.{pollable};
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
     /// A received datagram.

--- a/crates/wasi-http/wit/deps/sockets/world.wit
+++ b/crates/wasi-http/wit/deps/sockets/world.wit
@@ -1,4 +1,4 @@
-package wasi:sockets@0.2.0-rc-2024-01-16;
+package wasi:sockets@0.2.0;
 
 world imports {
     import instance-network;

--- a/crates/wasi-http/wit/test.wit
+++ b/crates/wasi-http/wit/test.wit
@@ -2,21 +2,21 @@ package wasmtime:wasi;
 
 // only used as part of `test-programs`
 world test-reactor {
-  include wasi:cli/imports@0.2.0-rc-2024-01-16;
+  include wasi:cli/imports@0.2.0;
 
   export add-strings: func(s: list<string>) -> u32;
   export get-strings: func() -> list<string>;
 
-  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
+  use wasi:io/streams@0.2.0.{output-stream};
 
   export write-strings-to: func(o: output-stream) -> result;
 
-  use wasi:filesystem/types@0.2.0-rc-2023-11-10.{descriptor-stat};
+  use wasi:filesystem/types@0.2.0.{descriptor-stat};
   export pass-an-imported-record: func(d: descriptor-stat) -> string;
 }
 
 world test-command {
-  include wasi:cli/imports@0.2.0-rc-2024-01-16;
-  import wasi:http/types@0.2.0-rc-2024-01-16;
-  import wasi:http/outgoing-handler@0.2.0-rc-2024-01-16;
+  include wasi:cli/imports@0.2.0;
+  import wasi:http/types@0.2.0;
+  import wasi:http/outgoing-handler@0.2.0;
 }

--- a/crates/wasi-preview1-component-adapter/src/descriptors.rs
+++ b/crates/wasi-preview1-component-adapter/src/descriptors.rs
@@ -194,7 +194,7 @@ impl Descriptors {
 
     #[cfg(not(feature = "proxy"))]
     fn open_preopens(&self, import_alloc: &ImportAlloc, arena: &BumpArena) {
-        #[link(wasm_import_module = "wasi:filesystem/preopens@0.2.0-rc-2023-11-10")]
+        #[link(wasm_import_module = "wasi:filesystem/preopens@0.2.0")]
         #[allow(improper_ctypes)] // FIXME(bytecodealliance/wit-bindgen#684)
         extern "C" {
             #[link_name = "get-directories"]

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -84,12 +84,12 @@ pub mod bindings {
             package wasmtime:adapter;
 
             world adapter {
-                import wasi:clocks/wall-clock@0.2.0-rc-2023-11-10;
-                import wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10;
-                import wasi:random/random@0.2.0-rc-2023-11-10;
-                import wasi:cli/stdout@0.2.0-rc-2024-01-16;
-                import wasi:cli/stderr@0.2.0-rc-2024-01-16;
-                import wasi:cli/stdin@0.2.0-rc-2024-01-16;
+                import wasi:clocks/wall-clock@0.2.0;
+                import wasi:clocks/monotonic-clock@0.2.0;
+                import wasi:random/random@0.2.0;
+                import wasi:cli/stdout@0.2.0;
+                import wasi:cli/stderr@0.2.0;
+                import wasi:cli/stdin@0.2.0;
             }
         "#,
         std_feature,
@@ -98,7 +98,7 @@ pub mod bindings {
     });
 }
 
-#[export_name = "wasi:cli/run@0.2.0-rc-2024-01-16#run"]
+#[export_name = "wasi:cli/run@0.2.0#run"]
 #[cfg(feature = "command")]
 pub unsafe extern "C" fn run() -> u32 {
     #[link(wasm_import_module = "__main_module__")]
@@ -1942,7 +1942,7 @@ pub unsafe extern "C" fn poll_oneoff(
             });
         }
 
-        #[link(wasm_import_module = "wasi:io/poll@0.2.0-rc-2023-11-10")]
+        #[link(wasm_import_module = "wasi:io/poll@0.2.0")]
         #[allow(improper_ctypes)] // FIXME(bytecodealliance/wit-bindgen#684)
         extern "C" {
             #[link_name = "poll"]
@@ -2665,7 +2665,7 @@ impl State {
     #[cfg(not(feature = "proxy"))]
     fn get_environment(&self) -> &[StrTuple] {
         if self.env_vars.get().is_none() {
-            #[link(wasm_import_module = "wasi:cli/environment@0.2.0-rc-2024-01-16")]
+            #[link(wasm_import_module = "wasi:cli/environment@0.2.0")]
             extern "C" {
                 #[link_name = "get-environment"]
                 fn get_environment_import(rval: *mut StrTupleList);
@@ -2690,7 +2690,7 @@ impl State {
     #[cfg(not(feature = "proxy"))]
     fn get_args(&self) -> &[WasmStr] {
         if self.args.get().is_none() {
-            #[link(wasm_import_module = "wasi:cli/environment@0.2.0-rc-2024-01-16")]
+            #[link(wasm_import_module = "wasi:cli/environment@0.2.0")]
             extern "C" {
                 #[link_name = "get-arguments"]
                 fn get_args_import(rval: *mut WasmStrList);

--- a/crates/wasi/src/preview2/mod.rs
+++ b/crates/wasi/src/preview2/mod.rs
@@ -69,9 +69,9 @@ pub mod bindings {
             wasmtime::component::bindgen!({
                 path: "wit",
                 interfaces: "
-                    import wasi:io/poll@0.2.0-rc-2023-11-10;
-                    import wasi:io/streams@0.2.0-rc-2023-11-10;
-                    import wasi:filesystem/types@0.2.0-rc-2023-11-10;
+                    import wasi:io/poll@0.2.0;
+                    import wasi:io/streams@0.2.0;
+                    import wasi:filesystem/types@0.2.0;
                 ",
                 tracing: true,
                 trappable_error_type: {

--- a/crates/wasi/wit/command-extended.wit
+++ b/crates/wasi/wit/command-extended.wit
@@ -1,6 +1,6 @@
 // All of the same imports and exports available in the wasi:cli/command world
 // with addition of HTTP proxy related imports:
 world command-extended {
-  include wasi:cli/command@0.2.0-rc-2024-01-16;
-  import wasi:http/outgoing-handler@0.2.0-rc-2024-01-16;
+  include wasi:cli/command@0.2.0;
+  import wasi:http/outgoing-handler@0.2.0;
 }

--- a/crates/wasi/wit/deps/cli/command.wit
+++ b/crates/wasi/wit/deps/cli/command.wit
@@ -1,4 +1,4 @@
-package wasi:cli@0.2.0-rc-2024-01-16;
+package wasi:cli@0.2.0;
 
 world command {
   include imports;

--- a/crates/wasi/wit/deps/cli/imports.wit
+++ b/crates/wasi/wit/deps/cli/imports.wit
@@ -1,11 +1,11 @@
-package wasi:cli@0.2.0-rc-2024-01-16;
+package wasi:cli@0.2.0;
 
 world imports {
-  include wasi:clocks/imports@0.2.0-rc-2023-11-10;
-  include wasi:filesystem/imports@0.2.0-rc-2023-11-10;
-  include wasi:sockets/imports@0.2.0-rc-2024-01-16;
-  include wasi:random/imports@0.2.0-rc-2023-11-10;
-  include wasi:io/imports@0.2.0-rc-2023-11-10;
+  include wasi:clocks/imports@0.2.0;
+  include wasi:filesystem/imports@0.2.0;
+  include wasi:sockets/imports@0.2.0;
+  include wasi:random/imports@0.2.0;
+  include wasi:io/imports@0.2.0;
 
   import environment;
   import exit;

--- a/crates/wasi/wit/deps/cli/stdio.wit
+++ b/crates/wasi/wit/deps/cli/stdio.wit
@@ -1,17 +1,17 @@
 interface stdin {
-  use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream};
+  use wasi:io/streams@0.2.0.{input-stream};
 
   get-stdin: func() -> input-stream;
 }
 
 interface stdout {
-  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
+  use wasi:io/streams@0.2.0.{output-stream};
 
   get-stdout: func() -> output-stream;
 }
 
 interface stderr {
-  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
+  use wasi:io/streams@0.2.0.{output-stream};
 
   get-stderr: func() -> output-stream;
 }

--- a/crates/wasi/wit/deps/clocks/monotonic-clock.wit
+++ b/crates/wasi/wit/deps/clocks/monotonic-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.0-rc-2023-11-10;
+package wasi:clocks@0.2.0;
 /// WASI Monotonic Clock is a clock API intended to let users measure elapsed
 /// time.
 ///
@@ -10,7 +10,7 @@ package wasi:clocks@0.2.0-rc-2023-11-10;
 ///
 /// It is intended for measuring elapsed time.
 interface monotonic-clock {
-    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+    use wasi:io/poll@0.2.0.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from

--- a/crates/wasi/wit/deps/clocks/wall-clock.wit
+++ b/crates/wasi/wit/deps/clocks/wall-clock.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.0-rc-2023-11-10;
+package wasi:clocks@0.2.0;
 /// WASI Wall Clock is a clock API intended to let users query the current
 /// time. The name "wall" makes an analogy to a "clock on the wall", which
 /// is not necessarily monotonic as it may be reset.

--- a/crates/wasi/wit/deps/clocks/world.wit
+++ b/crates/wasi/wit/deps/clocks/world.wit
@@ -1,4 +1,4 @@
-package wasi:clocks@0.2.0-rc-2023-11-10;
+package wasi:clocks@0.2.0;
 
 world imports {
     import monotonic-clock;

--- a/crates/wasi/wit/deps/filesystem/preopens.wit
+++ b/crates/wasi/wit/deps/filesystem/preopens.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.0-rc-2023-11-10;
+package wasi:filesystem@0.2.0;
 
 interface preopens {
     use types.{descriptor};

--- a/crates/wasi/wit/deps/filesystem/types.wit
+++ b/crates/wasi/wit/deps/filesystem/types.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.0-rc-2023-11-10;
+package wasi:filesystem@0.2.0;
 /// WASI filesystem is a filesystem API primarily intended to let users run WASI
 /// programs that access their files on their existing filesystems, without
 /// significant overhead.
@@ -24,8 +24,8 @@ package wasi:filesystem@0.2.0-rc-2023-11-10;
 ///
 /// [WASI filesystem path resolution]: https://github.com/WebAssembly/wasi-filesystem/blob/main/path-resolution.md
 interface types {
-    use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream, error};
-    use wasi:clocks/wall-clock@0.2.0-rc-2023-11-10.{datetime};
+    use wasi:io/streams@0.2.0.{input-stream, output-stream, error};
+    use wasi:clocks/wall-clock@0.2.0.{datetime};
 
     /// File size or length of a region within a file.
     type filesize = u64;

--- a/crates/wasi/wit/deps/filesystem/world.wit
+++ b/crates/wasi/wit/deps/filesystem/world.wit
@@ -1,4 +1,4 @@
-package wasi:filesystem@0.2.0-rc-2023-11-10;
+package wasi:filesystem@0.2.0;
 
 world imports {
     import types;

--- a/crates/wasi/wit/deps/http/proxy.wit
+++ b/crates/wasi/wit/deps/http/proxy.wit
@@ -1,4 +1,4 @@
-package wasi:http@0.2.0-rc-2024-01-16;
+package wasi:http@0.2.0;
 
 /// The `wasi:http/proxy` world captures a widely-implementable intersection of
 /// hosts that includes HTTP forward and reverse proxies. Components targeting
@@ -6,19 +6,19 @@ package wasi:http@0.2.0-rc-2024-01-16;
 /// outgoing HTTP requests.
 world proxy {
   /// HTTP proxies have access to time and randomness.
-  include wasi:clocks/imports@0.2.0-rc-2023-11-10;
-  import wasi:random/random@0.2.0-rc-2023-11-10;
+  include wasi:clocks/imports@0.2.0;
+  import wasi:random/random@0.2.0;
 
   /// Proxies have standard output and error streams which are expected to
   /// terminate in a developer-facing console provided by the host.
-  import wasi:cli/stdout@0.2.0-rc-2024-01-16;
-  import wasi:cli/stderr@0.2.0-rc-2024-01-16;
+  import wasi:cli/stdout@0.2.0;
+  import wasi:cli/stderr@0.2.0;
 
   /// TODO: this is a temporary workaround until component tooling is able to
   /// gracefully handle the absence of stdin. Hosts must return an eof stream
   /// for this import, which is what wasi-libc + tooling will do automatically
   /// when this import is properly removed.
-  import wasi:cli/stdin@0.2.0-rc-2024-01-16;
+  import wasi:cli/stdin@0.2.0;
 
   /// This is the default handler to use when user code simply wants to make an
   /// HTTP request (e.g., via `fetch()`).

--- a/crates/wasi/wit/deps/http/types.wit
+++ b/crates/wasi/wit/deps/http/types.wit
@@ -2,10 +2,10 @@
 /// HTTP Requests and Responses, both incoming and outgoing, as well as
 /// their headers, trailers, and bodies.
 interface types {
-  use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10.{duration};
-  use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
-  use wasi:io/error@0.2.0-rc-2023-11-10.{error as io-error};
-  use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+  use wasi:clocks/monotonic-clock@0.2.0.{duration};
+  use wasi:io/streams@0.2.0.{input-stream, output-stream};
+  use wasi:io/error@0.2.0.{error as io-error};
+  use wasi:io/poll@0.2.0.{pollable};
 
   /// This type corresponds to HTTP standard Methods.
   variant method {

--- a/crates/wasi/wit/deps/io/error.wit
+++ b/crates/wasi/wit/deps/io/error.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-10;
+package wasi:io@0.2.0;
 
 
 interface error {

--- a/crates/wasi/wit/deps/io/poll.wit
+++ b/crates/wasi/wit/deps/io/poll.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-10;
+package wasi:io@0.2.0;
 
 /// A poll API intended to let users wait for I/O events on multiple handles
 /// at once.

--- a/crates/wasi/wit/deps/io/streams.wit
+++ b/crates/wasi/wit/deps/io/streams.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-10;
+package wasi:io@0.2.0;
 
 /// WASI I/O is an I/O abstraction API which is currently focused on providing
 /// stream types.

--- a/crates/wasi/wit/deps/io/world.wit
+++ b/crates/wasi/wit/deps/io/world.wit
@@ -1,4 +1,4 @@
-package wasi:io@0.2.0-rc-2023-11-10;
+package wasi:io@0.2.0;
 
 world imports {
     import streams;

--- a/crates/wasi/wit/deps/random/insecure-seed.wit
+++ b/crates/wasi/wit/deps/random/insecure-seed.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.0-rc-2023-11-10;
+package wasi:random@0.2.0;
 /// The insecure-seed interface for seeding hash-map DoS resistance.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi/wit/deps/random/insecure.wit
+++ b/crates/wasi/wit/deps/random/insecure.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.0-rc-2023-11-10;
+package wasi:random@0.2.0;
 /// The insecure interface for insecure pseudo-random numbers.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi/wit/deps/random/random.wit
+++ b/crates/wasi/wit/deps/random/random.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.0-rc-2023-11-10;
+package wasi:random@0.2.0;
 /// WASI Random is a random data API.
 ///
 /// It is intended to be portable at least between Unix-family platforms and

--- a/crates/wasi/wit/deps/random/world.wit
+++ b/crates/wasi/wit/deps/random/world.wit
@@ -1,4 +1,4 @@
-package wasi:random@0.2.0-rc-2023-11-10;
+package wasi:random@0.2.0;
 
 world imports {
     import random;

--- a/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
+++ b/crates/wasi/wit/deps/sockets/ip-name-lookup.wit
@@ -1,6 +1,6 @@
 
 interface ip-name-lookup {
-    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+    use wasi:io/poll@0.2.0.{pollable};
     use network.{network, error-code, ip-address};
 
 

--- a/crates/wasi/wit/deps/sockets/tcp.wit
+++ b/crates/wasi/wit/deps/sockets/tcp.wit
@@ -1,8 +1,8 @@
 
 interface tcp {
-    use wasi:io/streams@0.2.0-rc-2023-11-10.{input-stream, output-stream};
-    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
-    use wasi:clocks/monotonic-clock@0.2.0-rc-2023-11-10.{duration};
+    use wasi:io/streams@0.2.0.{input-stream, output-stream};
+    use wasi:io/poll@0.2.0.{pollable};
+    use wasi:clocks/monotonic-clock@0.2.0.{duration};
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
     enum shutdown-type {

--- a/crates/wasi/wit/deps/sockets/udp.wit
+++ b/crates/wasi/wit/deps/sockets/udp.wit
@@ -1,6 +1,6 @@
 
 interface udp {
-    use wasi:io/poll@0.2.0-rc-2023-11-10.{pollable};
+    use wasi:io/poll@0.2.0.{pollable};
     use network.{network, error-code, ip-socket-address, ip-address-family};
 
     /// A received datagram.

--- a/crates/wasi/wit/deps/sockets/world.wit
+++ b/crates/wasi/wit/deps/sockets/world.wit
@@ -1,4 +1,4 @@
-package wasi:sockets@0.2.0-rc-2024-01-16;
+package wasi:sockets@0.2.0;
 
 world imports {
     import instance-network;

--- a/crates/wasi/wit/test.wit
+++ b/crates/wasi/wit/test.wit
@@ -2,21 +2,21 @@ package wasmtime:wasi;
 
 // only used as part of `test-programs`
 world test-reactor {
-  include wasi:cli/imports@0.2.0-rc-2024-01-16;
+  include wasi:cli/imports@0.2.0;
 
   export add-strings: func(s: list<string>) -> u32;
   export get-strings: func() -> list<string>;
 
-  use wasi:io/streams@0.2.0-rc-2023-11-10.{output-stream};
+  use wasi:io/streams@0.2.0.{output-stream};
 
   export write-strings-to: func(o: output-stream) -> result;
 
-  use wasi:filesystem/types@0.2.0-rc-2023-11-10.{descriptor-stat};
+  use wasi:filesystem/types@0.2.0.{descriptor-stat};
   export pass-an-imported-record: func(d: descriptor-stat) -> string;
 }
 
 world test-command {
-  include wasi:cli/imports@0.2.0-rc-2024-01-16;
-  import wasi:http/types@0.2.0-rc-2024-01-16;
-  import wasi:http/outgoing-handler@0.2.0-rc-2024-01-16;
+  include wasi:cli/imports@0.2.0;
+  import wasi:http/types@0.2.0;
+  import wasi:http/outgoing-handler@0.2.0;
 }

--- a/tests/all/cli_tests/component-basic.wat
+++ b/tests/all/cli_tests/component-basic.wat
@@ -7,6 +7,6 @@
   (func $run (result (result))
     (canon lift (core func $i "run")))
 
-  (instance (export (interface "wasi:cli/run@0.2.0-rc-2024-01-16"))
+  (instance (export (interface "wasi:cli/run@0.2.0"))
     (export "run" (func $run)))
 )


### PR DESCRIPTION
Pending the WASI Preview 2 launch vote at the 1/25 WASI Subgroup meeting, this updates all of the WASI wit files, as well as all use sites, to expect and use version 0.2.0.

There are no functional changes between the latest release candidates used in tree, and version 0.2.0, aside from changing the version of each wit package.