### PR TITLE
Rework first_non_empty_iovec to match first_non_empty_ciovec

### DIFF
--- a/crates/wasi/src/preview2/preview1.rs
+++ b/crates/wasi/src/preview2/preview1.rs
@@ -821,17 +821,14 @@ fn first_non_empty_ciovec<'a, 'b>(
 
 // Find first non-empty buffer.
 fn first_non_empty_iovec<'a>(iovs: &types::IovecArray<'a>) -> Result<Option<GuestPtr<'a, [u8]>>> {
-    iovs.iter()
-        .map(|iov| {
-            let iov = iov?.read()?;
-            if iov.buf_len == 0 {
-                return Ok(None);
-            }
-            let slice = iov.buf.as_array(iov.buf_len);
-            Ok(Some(slice))
-        })
-        .find_map(Result::transpose)
-        .transpose()
+    for iov in iovs.iter() {
+        let iov = iov?.read()?;
+        if iov.buf_len == 0 {
+            continue;
+        }
+        return Ok(Some(iov.buf.as_array(iov.buf_len)));
+    }
+    Ok(None)
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
Refactor the `first_non_empty_iovec` to use an explicit for loop, matching the implementation of `first_non_empty_ciovec`. This implementation is easier to understand at a glance, and matches the other implementation for consistency.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
