### PR TITLE
Serve guest-profiler results from a local web server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,6 +1227,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb14ed937631bd8b8b8977f2c198443447a8355b6e3ca599f38c975e5a963b6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.92",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1245,10 +1256,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -3358,6 +3371,7 @@ dependencies = [
  "criterion",
  "env_logger",
  "filecheck",
+ "futures-util",
  "http",
  "http-body-util",
  "humantime",
@@ -3377,6 +3391,7 @@ dependencies = [
  "tempfile",
  "test-programs-artifacts",
  "tokio",
+ "tokio-util",
  "tracing",
  "walkdir",
  "wasmparser 0.120.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,9 @@ humantime = { workspace = true }
 
 async-trait = { workspace = true }
 bytes = { workspace = true }
-tokio = { workspace = true, optional = true, features = [ "signal", "macros" ] }
+futures-util = { version = "*", optional = true }
+tokio = { workspace = true, optional = true, features = [ "fs", "signal", "macros" ] }
+tokio-util = { version = "*", optional = true }
 hyper = { workspace = true, optional = true }
 http = { workspace = true, optional = true }
 http-body-util = { workspace = true, optional = true }
@@ -369,7 +371,7 @@ parallel-compilation = ["wasmtime-cli-flags/parallel-compilation"]
 logging = ["wasmtime-cli-flags/logging"]
 demangle = ["wasmtime/demangle"]
 cranelift = ["wasmtime-cli-flags/cranelift", "dep:wasmtime-cranelift"]
-profiling = ["wasmtime/profiling"]
+profiling = ["wasmtime/profiling", "dep:futures-util", "dep:hyper", "dep:tokio-util"]
 coredump = ["wasmtime-cli-flags/coredump"]
 addr2line = ["wasmtime/addr2line"]
 debug-builtins = ["wasmtime/debug-builtins"]


### PR DESCRIPTION
This is a proof of concept for #7666, but needs quite a bit of polish before merging.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
