### PR TITLE
Fix typo in lib name of c-api crate

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 workspace = true
 
 [lib]
-name = "wamstime_c_api"
+name = "wasmtime_c_api"
 doc = false
 test = false
 doctest = false


### PR DESCRIPTION
This PR fixes a typo in the `Cargo.toml` for the `c-api` crate  (`wams -> wasm`).