### PR TITLE
Rename `WasmType` to `WasmValType`

### DIFF
--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -8,7 +8,7 @@
 use crate::environ::{FuncEnvironment, GlobalVariable, ModuleEnvironment, TargetEnvironment};
 use crate::func_translator::FuncTranslator;
 use crate::state::FuncTranslationState;
-use crate::WasmType;
+use crate::WasmValType;
 use crate::{
     DataIndex, DefinedFuncIndex, ElemIndex, FuncIndex, Global, GlobalIndex, GlobalInit, Heap,
     HeapData, HeapStyle, Memory, MemoryIndex, Table, TableIndex, TypeConvert, TypeIndex,
@@ -280,12 +280,12 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
             gv: vmctx,
             offset,
             ty: match self.mod_info.globals[index].entity.wasm_ty {
-                WasmType::I32 => ir::types::I32,
-                WasmType::I64 => ir::types::I64,
-                WasmType::F32 => ir::types::F32,
-                WasmType::F64 => ir::types::F64,
-                WasmType::V128 => ir::types::I8X16,
-                WasmType::Ref(_) => ir::types::R64,
+                WasmValType::I32 => ir::types::I32,
+                WasmValType::I64 => ir::types::I64,
+                WasmValType::F32 => ir::types::F32,
+                WasmValType::F64 => ir::types::F64,
+                WasmValType::V128 => ir::types::I8X16,
+                WasmValType::Ref(_) => ir::types::R64,
             },
         })
     }
@@ -726,19 +726,19 @@ impl TargetEnvironment for DummyEnvironment {
 impl<'data> ModuleEnvironment<'data> for DummyEnvironment {
     fn declare_type_func(&mut self, wasm: WasmFuncType) -> WasmResult<()> {
         let mut sig = ir::Signature::new(CallConv::Fast);
-        let mut cvt = |ty: &WasmType| {
+        let mut cvt = |ty: &WasmValType| {
             let reference_type = match self.pointer_type() {
                 ir::types::I32 => ir::types::R32,
                 ir::types::I64 => ir::types::R64,
                 _ => panic!("unsupported pointer type"),
             };
             ir::AbiParam::new(match ty {
-                WasmType::I32 => ir::types::I32,
-                WasmType::I64 => ir::types::I64,
-                WasmType::F32 => ir::types::F32,
-                WasmType::F64 => ir::types::F64,
-                WasmType::V128 => ir::types::I8X16,
-                WasmType::Ref(_) => reference_type,
+                WasmValType::I32 => ir::types::I32,
+                WasmValType::I64 => ir::types::I64,
+                WasmValType::F32 => ir::types::F32,
+                WasmValType::F64 => ir::types::F64,
+                WasmValType::V128 => ir::types::I8X16,
+                WasmValType::Ref(_) => reference_type,
             })
         };
         sig.params.extend(wasm.params().iter().map(&mut cvt));

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -17,7 +17,7 @@ use cranelift_entity::{EntityRef, PrimaryMap};
 use cranelift_frontend::FunctionBuilder;
 use cranelift_wasm::{
     DefinedFuncIndex, FuncIndex, FuncTranslator, MemoryIndex, OwnedMemoryIndex, WasmFuncType,
-    WasmType,
+    WasmValType,
 };
 use object::write::{Object, StandardSegment, SymbolId};
 use object::{RelocationEncoding, RelocationKind, SectionKind};
@@ -893,7 +893,7 @@ impl Compiler {
     fn store_values_to_array(
         &self,
         builder: &mut FunctionBuilder,
-        types: &[WasmType],
+        types: &[WasmValType],
         values: &[Value],
         values_vec_ptr: Value,
         values_vec_capacity: Value,
@@ -925,7 +925,7 @@ impl Compiler {
     /// function that uses the array calling convention.
     fn load_values_from_array(
         &self,
-        types: &[WasmType],
+        types: &[WasmValType],
         builder: &mut FunctionBuilder,
         values_vec_ptr: Value,
         values_vec_capacity: Value,
@@ -1266,10 +1266,10 @@ impl NativeRet {
                 let mut max_align = 1;
                 for ty in other[1..].iter() {
                     let size = match ty {
-                        WasmType::I32 | WasmType::F32 => 4,
-                        WasmType::I64 | WasmType::F64 => 8,
-                        WasmType::Ref(_) => pointer_type.bytes(),
-                        WasmType::V128 => 16,
+                        WasmValType::I32 | WasmValType::F32 => 4,
+                        WasmValType::I64 | WasmValType::F64 => 8,
+                        WasmValType::Ref(_) => pointer_type.bytes(),
+                        WasmValType::V128 => 16,
                     };
                     offset = align_to(offset, size);
                     offsets.push(offset);

--- a/crates/cranelift/src/compiler/component.rs
+++ b/crates/cranelift/src/compiler/component.rs
@@ -9,7 +9,7 @@ use cranelift_wasm::ModuleInternedTypeIndex;
 use std::any::Any;
 use wasmtime_cranelift_shared::{ALWAYS_TRAP_CODE, CANNOT_ENTER_CODE};
 use wasmtime_environ::component::*;
-use wasmtime_environ::{PtrSize, WasmType};
+use wasmtime_environ::{PtrSize, WasmValType};
 
 struct TrampolineCompiler<'a> {
     compiler: &'a Compiler,
@@ -289,7 +289,7 @@ impl<'a> TrampolineCompiler<'a> {
         host_args.push(args[2]);
 
         // Currently this only support resources represented by `i32`
-        assert_eq!(self.types[self.signature].params()[0], WasmType::I32);
+        assert_eq!(self.types[self.signature].params()[0], WasmValType::I32);
         let (host_sig, offset) = host::resource_new32(self.isa, &mut self.builder.func);
 
         let host_fn = self.load_libcall(vmctx, offset);
@@ -320,7 +320,7 @@ impl<'a> TrampolineCompiler<'a> {
         host_args.push(args[2]);
 
         // Currently this only support resources represented by `i32`
-        assert_eq!(self.types[self.signature].returns()[0], WasmType::I32);
+        assert_eq!(self.types[self.signature].returns()[0], WasmValType::I32);
         let (host_sig, offset) = host::resource_rep32(self.isa, &mut self.builder.func);
 
         let host_fn = self.load_libcall(vmctx, offset);

--- a/crates/cranelift/src/debug/transform/simulate.rs
+++ b/crates/cranelift/src/debug/transform/simulate.rs
@@ -12,7 +12,8 @@ use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
 use wasmtime_environ::{
-    DebugInfoData, DefinedFuncIndex, EntityRef, FuncIndex, FunctionMetadata, WasmFileInfo, WasmType,
+    DebugInfoData, DefinedFuncIndex, EntityRef, FuncIndex, FunctionMetadata, WasmFileInfo,
+    WasmValType,
 };
 
 const PRODUCER_NAME: &str = "wasmtime";
@@ -173,10 +174,10 @@ fn resolve_var_type(
         (func_meta.locals[j].1, false)
     };
     let type_die_id = match ty {
-        WasmType::I32 => wasm_types.i32,
-        WasmType::I64 => wasm_types.i64,
-        WasmType::F32 => wasm_types.f32,
-        WasmType::F64 => wasm_types.f64,
+        WasmValType::I32 => wasm_types.i32,
+        WasmValType::I64 => wasm_types.i64,
+        WasmValType::F32 => wasm_types.f32,
+        WasmValType::F64 => wasm_types.f64,
         _ => {
             // Ignore unsupported types.
             return None;

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -15,7 +15,7 @@ use cranelift_frontend::Variable;
 use cranelift_wasm::{
     self, FuncIndex, FuncTranslationState, GlobalIndex, GlobalVariable, Heap, HeapData, HeapStyle,
     MemoryIndex, TableIndex, TargetEnvironment, TypeIndex, WasmHeapType, WasmRefType, WasmResult,
-    WasmType,
+    WasmValType,
 };
 use std::convert::TryFrom;
 use std::mem;
@@ -1729,7 +1729,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     ) -> WasmResult<ir::Value> {
         debug_assert_eq!(
             self.module.globals[index].wasm_ty,
-            WasmType::Ref(WasmRefType::EXTERNREF),
+            WasmValType::Ref(WasmRefType::EXTERNREF),
             "We only use GlobalVariable::Custom for externref"
         );
 
@@ -1757,7 +1757,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     ) -> WasmResult<()> {
         debug_assert_eq!(
             self.module.globals[index].wasm_ty,
-            WasmType::Ref(WasmRefType::EXTERNREF),
+            WasmValType::Ref(WasmRefType::EXTERNREF),
             "We only use GlobalVariable::Custom for externref"
         );
 
@@ -2022,7 +2022,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             // `GlobalVariable::Custom`, as that is the only kind of
             // `GlobalVariable` for which `cranelift-wasm` supports custom
             // access translation.
-            WasmType::Ref(WasmRefType {
+            WasmValType::Ref(WasmRefType {
                 heap_type: WasmHeapType::Extern,
                 ..
             }) => return Ok(GlobalVariable::Custom),
@@ -2030,14 +2030,18 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             // Funcrefs are represented as pointers which survive for the
             // entire lifetime of the `Store` so there's no need for barriers.
             // This means that they can fall through to memory as well.
-            WasmType::Ref(WasmRefType {
+            WasmValType::Ref(WasmRefType {
                 heap_type: WasmHeapType::Func | WasmHeapType::TypedFunc(_),
                 ..
             }) => {}
 
             // Value types all live in memory so let them fall through to a
             // memory-based global.
-            WasmType::I32 | WasmType::I64 | WasmType::F32 | WasmType::F64 | WasmType::V128 => {}
+            WasmValType::I32
+            | WasmValType::I64
+            | WasmValType::F32
+            | WasmValType::F64
+            | WasmValType::V128 => {}
         }
 
         let (gv, offset) = self.get_global_location(func, index);

--- a/crates/environ/src/component/dfg.rs
+++ b/crates/environ/src/component/dfg.rs
@@ -28,7 +28,7 @@
 //! fused adapters, what arguments make their way to core wasm modules, etc.
 
 use crate::component::*;
-use crate::{EntityIndex, EntityRef, PrimaryMap, WasmType};
+use crate::{EntityIndex, EntityRef, PrimaryMap, WasmValType};
 use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::hash::Hash;
@@ -284,7 +284,7 @@ pub struct CanonicalOptions {
 /// Same as `info::Resource`
 #[allow(missing_docs)]
 pub struct Resource {
-    pub rep: WasmType,
+    pub rep: WasmValType,
     pub dtor: Option<CoreDef>,
     pub instance: RuntimeComponentInstanceIndex,
 }

--- a/crates/environ/src/component/info.rs
+++ b/crates/environ/src/component/info.rs
@@ -47,7 +47,7 @@
 // requirements of embeddings change over time.
 
 use crate::component::*;
-use crate::{EntityIndex, PrimaryMap, WasmType};
+use crate::{EntityIndex, PrimaryMap, WasmValType};
 use indexmap::IndexMap;
 use serde_derive::{Deserialize, Serialize};
 use wasmtime_types::ModuleInternedTypeIndex;
@@ -467,7 +467,7 @@ pub struct Resource {
     /// The local index of the resource being defined.
     pub index: DefinedResourceIndex,
     /// Core wasm representation of this resource.
-    pub rep: WasmType,
+    pub rep: WasmValType,
     /// Optionally-specified destructor and where it comes from.
     pub dtor: Option<CoreDef>,
     /// Which component instance this resource logically belongs to.

--- a/crates/environ/src/component/translate.rs
+++ b/crates/environ/src/component/translate.rs
@@ -2,7 +2,7 @@ use crate::component::*;
 use crate::ScopeVec;
 use crate::{
     EntityIndex, ModuleEnvironment, ModuleTranslation, ModuleTypesBuilder, PrimaryMap, Tunables,
-    TypeConvert, WasmHeapType, WasmType,
+    TypeConvert, WasmHeapType, WasmValType,
 };
 use anyhow::{bail, Result};
 use indexmap::IndexMap;
@@ -180,7 +180,7 @@ enum LocalInitializer<'data> {
     Lift(ComponentFuncTypeId, FuncIndex, LocalCanonicalOptions),
 
     // resources
-    Resource(AliasableResourceId, WasmType, Option<FuncIndex>),
+    Resource(AliasableResourceId, WasmValType, Option<FuncIndex>),
     ResourceNew(AliasableResourceId, ModuleInternedTypeIndex),
     ResourceRep(AliasableResourceId, ModuleInternedTypeIndex),
     ResourceDrop(AliasableResourceId, ModuleInternedTypeIndex),

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -1,7 +1,7 @@
 use crate::component::{Export, MAX_FLAT_PARAMS, MAX_FLAT_RESULTS};
 use crate::{
     CompiledModuleInfo, EntityType, ModuleTypes, ModuleTypesBuilder, PrimaryMap, TypeConvert,
-    WasmHeapType, WasmType,
+    WasmHeapType, WasmValType,
 };
 use anyhow::{bail, Result};
 use cranelift_entity::EntityRef;
@@ -475,7 +475,7 @@ impl ComponentTypesBuilder {
             .find(|(_, sig)| {
                 sig.params().len() == 1
                     && sig.returns().len() == 0
-                    && sig.params()[0] == WasmType::I32
+                    && sig.params()[0] == WasmValType::I32
             })
             .map(|(i, _)| i)
     }

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -5,7 +5,7 @@ use crate::module::{
 use crate::{
     DataIndex, DefinedFuncIndex, ElemIndex, EntityIndex, EntityType, FuncIndex, GlobalIndex,
     GlobalInit, MemoryIndex, ModuleTypesBuilder, PrimaryMap, TableIndex, TableInitialValue,
-    Tunables, TypeConvert, TypeIndex, Unsigned, WasmError, WasmHeapType, WasmResult, WasmType,
+    Tunables, TypeConvert, TypeIndex, Unsigned, WasmError, WasmHeapType, WasmResult, WasmValType,
     WasmparserTypeConverter,
 };
 use cranelift_entity::packed_option::ReservedValue;
@@ -153,8 +153,8 @@ pub struct WasmFileInfo {
 #[derive(Debug)]
 #[allow(missing_docs)]
 pub struct FunctionMetadata {
-    pub params: Box<[WasmType]>,
-    pub locals: Box<[(u32, WasmType)]>,
+    pub params: Box<[WasmValType]>,
+    pub locals: Box<[(u32, WasmValType)]>,
 }
 
 impl<'a, 'data> ModuleEnvironment<'a, 'data> {

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -31,7 +31,7 @@ use wasmtime_environ::{
     packed_option::ReservedValue, DataIndex, DefinedGlobalIndex, DefinedMemoryIndex,
     DefinedTableIndex, ElemIndex, EntityIndex, EntityRef, EntitySet, FuncIndex, GlobalIndex,
     GlobalInit, HostPtr, MemoryIndex, MemoryPlan, Module, PrimaryMap, TableIndex,
-    TableInitialValue, Trap, VMOffsets, WasmHeapType, WasmRefType, WasmType, VMCONTEXT_MAGIC,
+    TableInitialValue, Trap, VMOffsets, WasmHeapType, WasmRefType, WasmValType, VMCONTEXT_MAGIC,
 };
 #[cfg(feature = "wmemcheck")]
 use wasmtime_wmemcheck::Wmemcheck;
@@ -1235,7 +1235,7 @@ impl Instance {
                     // count as values move between globals, everything else is just
                     // copy-able bits.
                     match wasm_ty {
-                        WasmType::Ref(WasmRefType {
+                        WasmValType::Ref(WasmRefType {
                             heap_type: WasmHeapType::Extern,
                             ..
                         }) => *(*to).as_externref_mut() = from.as_externref().clone(),
@@ -1247,7 +1247,7 @@ impl Instance {
                 }
                 GlobalInit::RefNullConst => match wasm_ty {
                     // `VMGlobalDefinition::new()` already zeroed out the bits
-                    WasmType::Ref(WasmRefType { nullable: true, .. }) => {}
+                    WasmValType::Ref(WasmRefType { nullable: true, .. }) => {}
                     ty => panic!("unsupported reference type for global: {:?}", ty),
                 },
             }
@@ -1283,7 +1283,7 @@ impl Drop for Instance {
             };
             match global.wasm_ty {
                 // For now only externref globals need to get destroyed
-                WasmType::Ref(WasmRefType {
+                WasmValType::Ref(WasmRefType {
                     heap_type: WasmHeapType::Extern,
                     ..
                 }) => {}

--- a/crates/runtime/src/instance/allocator.rs
+++ b/crates/runtime/src/instance/allocator.rs
@@ -9,7 +9,7 @@ use std::{alloc, any::Any, mem, ptr, sync::Arc};
 use wasmtime_environ::{
     DefinedMemoryIndex, DefinedTableIndex, HostPtr, InitMemory, MemoryInitialization,
     MemoryInitializer, MemoryPlan, Module, PrimaryMap, TableInitialValue, TablePlan, TableSegment,
-    Trap, VMOffsets, WasmType, WASM_PAGE_SIZE,
+    Trap, VMOffsets, WasmValType, WASM_PAGE_SIZE,
 };
 
 #[cfg(feature = "component-model")]
@@ -613,7 +613,7 @@ fn initialize_memories(instance: &mut Instance, module: &Module) -> Result<()> {
     // 32-bit globals which can be used as the base for 32-bit memories.
     let get_global_as_u64 = &mut |instance: &mut Instance, global| unsafe {
         let def = instance.defined_or_imported_global_ptr(global);
-        if module.globals[global].wasm_ty == WasmType::I64 {
+        if module.globals[global].wasm_ty == WasmValType::I64 {
             *(*def).as_u64()
         } else {
             u64::from(*(*def).as_u32())

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -10,9 +10,9 @@ use std::fmt;
 mod error;
 pub use error::*;
 
-/// WebAssembly value type -- equivalent of `wasmparser`'s Type.
+/// WebAssembly value type -- equivalent of `wasmparser::ValType`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum WasmType {
+pub enum WasmValType {
     /// I32 type
     I32,
     /// I64 type
@@ -27,15 +27,15 @@ pub enum WasmType {
     Ref(WasmRefType),
 }
 
-impl fmt::Display for WasmType {
+impl fmt::Display for WasmValType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            WasmType::I32 => write!(f, "i32"),
-            WasmType::I64 => write!(f, "i64"),
-            WasmType::F32 => write!(f, "f32"),
-            WasmType::F64 => write!(f, "f64"),
-            WasmType::V128 => write!(f, "v128"),
-            WasmType::Ref(rt) => write!(f, "{rt}"),
+            WasmValType::I32 => write!(f, "i32"),
+            WasmValType::I64 => write!(f, "i64"),
+            WasmValType::F32 => write!(f, "f32"),
+            WasmValType::F64 => write!(f, "f64"),
+            WasmValType::V128 => write!(f, "v128"),
+            WasmValType::Ref(rt) => write!(f, "{rt}"),
         }
     }
 }
@@ -105,26 +105,26 @@ impl fmt::Display for WasmHeapType {
 /// WebAssembly function type -- equivalent of `wasmparser`'s FuncType.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct WasmFuncType {
-    params: Box<[WasmType]>,
+    params: Box<[WasmValType]>,
     externref_params_count: usize,
-    returns: Box<[WasmType]>,
+    returns: Box<[WasmValType]>,
     externref_returns_count: usize,
 }
 
 impl WasmFuncType {
     #[inline]
-    pub fn new(params: Box<[WasmType]>, returns: Box<[WasmType]>) -> Self {
+    pub fn new(params: Box<[WasmValType]>, returns: Box<[WasmValType]>) -> Self {
         let externref_params_count = params
             .iter()
             .filter(|p| match **p {
-                WasmType::Ref(rt) => rt.heap_type == WasmHeapType::Extern,
+                WasmValType::Ref(rt) => rt.heap_type == WasmHeapType::Extern,
                 _ => false,
             })
             .count();
         let externref_returns_count = returns
             .iter()
             .filter(|r| match **r {
-                WasmType::Ref(rt) => rt.heap_type == WasmHeapType::Extern,
+                WasmValType::Ref(rt) => rt.heap_type == WasmHeapType::Extern,
                 _ => false,
             })
             .count();
@@ -138,7 +138,7 @@ impl WasmFuncType {
 
     /// Function params types.
     #[inline]
-    pub fn params(&self) -> &[WasmType] {
+    pub fn params(&self) -> &[WasmValType] {
         &self.params
     }
 
@@ -150,7 +150,7 @@ impl WasmFuncType {
 
     /// Returns params types.
     #[inline]
-    pub fn returns(&self) -> &[WasmType] {
+    pub fn returns(&self) -> &[WasmValType] {
         &self.returns
     }
 
@@ -350,7 +350,7 @@ impl EntityType {
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Global {
     /// The Wasm type of the value stored in the global.
-    pub wasm_ty: crate::WasmType,
+    pub wasm_ty: crate::WasmValType,
     /// A flag indicating whether the value may change at runtime.
     pub mutability: bool,
 }
@@ -463,14 +463,14 @@ pub trait TypeConvert {
     }
 
     /// Converts a wasmparser value type to a wasmtime type
-    fn convert_valtype(&self, ty: wasmparser::ValType) -> WasmType {
+    fn convert_valtype(&self, ty: wasmparser::ValType) -> WasmValType {
         match ty {
-            wasmparser::ValType::I32 => WasmType::I32,
-            wasmparser::ValType::I64 => WasmType::I64,
-            wasmparser::ValType::F32 => WasmType::F32,
-            wasmparser::ValType::F64 => WasmType::F64,
-            wasmparser::ValType::V128 => WasmType::V128,
-            wasmparser::ValType::Ref(t) => WasmType::Ref(self.convert_ref_type(t)),
+            wasmparser::ValType::I32 => WasmValType::I32,
+            wasmparser::ValType::I64 => WasmValType::I64,
+            wasmparser::ValType::F32 => WasmValType::F32,
+            wasmparser::ValType::F64 => WasmValType::F64,
+            wasmparser::ValType::V128 => WasmValType::V128,
+            wasmparser::ValType::Ref(t) => WasmValType::Ref(self.convert_ref_type(t)),
         }
     }
 

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -13,7 +13,7 @@ use std::marker;
 use std::ptr::NonNull;
 use std::sync::Arc;
 use wasmtime_environ::component::*;
-use wasmtime_environ::{EntityIndex, EntityType, Global, PrimaryMap, WasmType};
+use wasmtime_environ::{EntityIndex, EntityType, Global, PrimaryMap, WasmValType};
 use wasmtime_runtime::component::{ComponentInstance, OwnedComponentInstance};
 use wasmtime_runtime::VMFuncRef;
 
@@ -160,7 +160,7 @@ impl InstanceData {
                 wasmtime_runtime::Export::Global(wasmtime_runtime::ExportGlobal {
                     definition: self.state.instance_flags(*idx).as_raw(),
                     global: Global {
-                        wasm_ty: WasmType::I32,
+                        wasm_ty: WasmValType::I32,
                         mutability: true,
                     },
                 })

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 use wasmtime_environ::{
-    EntityType, Global, Memory, ModuleTypes, Table, WasmFuncType, WasmRefType, WasmType,
+    EntityType, Global, Memory, ModuleTypes, Table, WasmFuncType, WasmRefType, WasmValType,
 };
 
 pub(crate) mod matching;
@@ -73,34 +73,34 @@ impl ValType {
         }
     }
 
-    pub(crate) fn to_wasm_type(&self) -> WasmType {
+    pub(crate) fn to_wasm_type(&self) -> WasmValType {
         match self {
-            Self::I32 => WasmType::I32,
-            Self::I64 => WasmType::I64,
-            Self::F32 => WasmType::F32,
-            Self::F64 => WasmType::F64,
-            Self::V128 => WasmType::V128,
-            Self::FuncRef => WasmType::Ref(WasmRefType::FUNCREF),
-            Self::ExternRef => WasmType::Ref(WasmRefType::EXTERNREF),
+            Self::I32 => WasmValType::I32,
+            Self::I64 => WasmValType::I64,
+            Self::F32 => WasmValType::F32,
+            Self::F64 => WasmValType::F64,
+            Self::V128 => WasmValType::V128,
+            Self::FuncRef => WasmValType::Ref(WasmRefType::FUNCREF),
+            Self::ExternRef => WasmValType::Ref(WasmRefType::EXTERNREF),
         }
     }
 
-    pub(crate) fn from_wasm_type(ty: &WasmType) -> Self {
+    pub(crate) fn from_wasm_type(ty: &WasmValType) -> Self {
         match ty {
-            WasmType::I32 => Self::I32,
-            WasmType::I64 => Self::I64,
-            WasmType::F32 => Self::F32,
-            WasmType::F64 => Self::F64,
-            WasmType::V128 => Self::V128,
-            WasmType::Ref(WasmRefType::FUNCREF) => Self::FuncRef,
-            WasmType::Ref(WasmRefType::EXTERNREF) => Self::ExternRef,
+            WasmValType::I32 => Self::I32,
+            WasmValType::I64 => Self::I64,
+            WasmValType::F32 => Self::F32,
+            WasmValType::F64 => Self::F64,
+            WasmValType::V128 => Self::V128,
+            WasmValType::Ref(WasmRefType::FUNCREF) => Self::FuncRef,
+            WasmValType::Ref(WasmRefType::EXTERNREF) => Self::ExternRef,
             // FIXME: exposing the full function-references (and beyond)
             // proposals will require redesigning the embedder API for `ValType`
             // and types in Wasmtime. That is a large undertaking which is
             // deferred for later. The intention for now is that
             // function-references types can't show up in the "public API" of a
             // core wasm module but it can use everything internally still.
-            WasmType::Ref(_) => {
+            WasmValType::Ref(_) => {
                 unimplemented!("typed function references are not exposed in the public API yet")
             }
         }
@@ -331,7 +331,7 @@ impl TableType {
 
     /// Returns the element value type of this table.
     pub fn element(&self) -> ValType {
-        ValType::from_wasm_type(&WasmType::Ref(self.ty.wasm_ty))
+        ValType::from_wasm_type(&WasmValType::Ref(self.ty.wasm_ty))
     }
 
     /// Returns minimum number of elements this table must have

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -3,7 +3,7 @@ use crate::{type_registry::TypeCollection, Engine};
 use anyhow::{anyhow, bail, Result};
 use wasmtime_environ::{
     EntityType, Global, Memory, ModuleInternedTypeIndex, ModuleTypes, Table, WasmFuncType,
-    WasmHeapType, WasmRefType, WasmType,
+    WasmHeapType, WasmRefType, WasmValType,
 };
 use wasmtime_runtime::VMSharedTypeIndex;
 
@@ -153,8 +153,8 @@ fn global_ty(expected: &Global, actual: &Global) -> Result<()> {
 
 fn table_ty(expected: &Table, actual: &Table, actual_runtime_size: Option<u32>) -> Result<()> {
     equal_ty(
-        WasmType::Ref(expected.wasm_ty),
-        WasmType::Ref(actual.wasm_ty),
+        WasmValType::Ref(expected.wasm_ty),
+        WasmValType::Ref(actual.wasm_ty),
         "table",
     )?;
     match_limits(
@@ -231,14 +231,14 @@ fn match_ref(expected: WasmRefType, actual: WasmRefType, desc: &str) -> Result<(
 
 // Checks whether actual is a subtype of expected, i.e. `actual <: expected`
 // (note the parameters are given the other way around in code).
-fn match_ty(expected: WasmType, actual: WasmType, desc: &str) -> Result<()> {
+fn match_ty(expected: WasmValType, actual: WasmValType, desc: &str) -> Result<()> {
     match (actual, expected) {
-        (WasmType::Ref(actual), WasmType::Ref(expected)) => match_ref(expected, actual, desc),
+        (WasmValType::Ref(actual), WasmValType::Ref(expected)) => match_ref(expected, actual, desc),
         (actual, expected) => equal_ty(expected, actual, desc),
     }
 }
 
-fn equal_ty(expected: WasmType, actual: WasmType, desc: &str) -> Result<()> {
+fn equal_ty(expected: WasmValType, actual: WasmValType, desc: &str) -> Result<()> {
     if expected == actual {
         return Ok(());
     }

--- a/winch/codegen/src/abi/local.rs
+++ b/winch/codegen/src/abi/local.rs
@@ -1,4 +1,4 @@
-use wasmtime_environ::WasmType;
+use wasmtime_environ::WasmValType;
 
 /// Base register used to address the local slot.
 ///
@@ -31,7 +31,7 @@ pub(crate) struct LocalSlot {
     /// The offset of the local slot.
     pub offset: u32,
     /// The type contained by this local slot.
-    pub ty: WasmType,
+    pub ty: WasmValType,
     /// Base register associated to this local slot.
     base: Base,
 }
@@ -39,7 +39,7 @@ pub(crate) struct LocalSlot {
 impl LocalSlot {
     /// Creates a local slot for a function defined local or
     /// for a spilled argument register.
-    pub fn new(ty: WasmType, offset: u32) -> Self {
+    pub fn new(ty: WasmValType, offset: u32) -> Self {
         Self {
             ty,
             offset,
@@ -50,7 +50,7 @@ impl LocalSlot {
     /// Int32 shortcut for `new`.
     pub fn i32(offset: u32) -> Self {
         Self {
-            ty: WasmType::I32,
+            ty: WasmValType::I32,
             offset,
             base: Base::SP,
         }
@@ -59,14 +59,14 @@ impl LocalSlot {
     /// Int64 shortcut for `new`.
     pub fn i64(offset: u32) -> Self {
         Self {
-            ty: WasmType::I64,
+            ty: WasmValType::I64,
             offset,
             base: Base::SP,
         }
     }
 
     /// Creates a local slot for a stack function argument.
-    pub fn stack_arg(ty: WasmType, offset: u32) -> Self {
+    pub fn stack_arg(ty: WasmValType, offset: u32) -> Self {
         Self {
             ty,
             offset,

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -47,7 +47,7 @@ use crate::masm::{OperandSize, SPOffset};
 use smallvec::SmallVec;
 use std::collections::HashSet;
 use std::ops::{Add, BitAnd, Not, Sub};
-use wasmtime_environ::{WasmFuncType, WasmHeapType, WasmRefType, WasmType};
+use wasmtime_environ::{WasmFuncType, WasmHeapType, WasmRefType, WasmValType};
 
 pub(crate) mod local;
 pub(crate) use local::*;
@@ -81,11 +81,14 @@ pub(crate) trait ABI {
     fn sig(wasm_sig: &WasmFuncType, call_conv: &CallingConvention) -> ABISig;
 
     /// Construct an ABI signature from WasmType params and returns.
-    fn sig_from(params: &[WasmType], returns: &[WasmType], call_conv: &CallingConvention)
-        -> ABISig;
+    fn sig_from(
+        params: &[WasmValType],
+        returns: &[WasmValType],
+        call_conv: &CallingConvention,
+    ) -> ABISig;
 
     /// Construct [`ABIResults`] from a slice of [`WasmType`].
-    fn abi_results(returns: &[WasmType], call_conv: &CallingConvention) -> ABIResults;
+    fn abi_results(returns: &[WasmValType], call_conv: &CallingConvention) -> ABIResults;
 
     /// Returns the number of bits in a word.
     fn word_bits() -> u32;
@@ -102,15 +105,15 @@ pub(crate) trait ABI {
     fn float_scratch_reg() -> Reg;
 
     /// Returns the designated scratch register for the given [WasmType].
-    fn scratch_for(ty: &WasmType) -> Reg {
+    fn scratch_for(ty: &WasmValType) -> Reg {
         match ty {
-            WasmType::I32
-            | WasmType::I64
-            | WasmType::Ref(WasmRefType {
+            WasmValType::I32
+            | WasmValType::I64
+            | WasmValType::Ref(WasmRefType {
                 heap_type: WasmHeapType::Func,
                 ..
             }) => Self::scratch_reg(),
-            WasmType::F32 | WasmType::F64 => Self::float_scratch_reg(),
+            WasmValType::F32 | WasmValType::F64 => Self::float_scratch_reg(),
             _ => unimplemented!(),
         }
     }
@@ -133,7 +136,7 @@ pub(crate) trait ABI {
     fn stack_slot_size() -> u32;
 
     /// Returns the size in bytes of the given [`WasmType`].
-    fn sizeof(ty: &WasmType) -> u32;
+    fn sizeof(ty: &WasmValType) -> u32;
 }
 
 /// ABI-specific representation of function argument or result.
@@ -142,7 +145,7 @@ pub enum ABIOperand {
     /// A register [`ABIOperand`].
     Reg {
         /// The type of the [`ABIOperand`].
-        ty: WasmType,
+        ty: WasmValType,
         /// Register holding the [`ABIOperand`].
         reg: Reg,
         /// The size of the [`ABIOperand`], in bytes.
@@ -151,7 +154,7 @@ pub enum ABIOperand {
     /// A stack [`ABIOperand`].
     Stack {
         /// The type of the [`ABIOperand`].
-        ty: WasmType,
+        ty: WasmValType,
         /// Offset of the operand referenced through FP by the callee and
         /// through SP by the caller.
         offset: u32,
@@ -162,12 +165,12 @@ pub enum ABIOperand {
 
 impl ABIOperand {
     /// Allocate a new register [`ABIOperand`].
-    pub fn reg(reg: Reg, ty: WasmType, size: u32) -> Self {
+    pub fn reg(reg: Reg, ty: WasmValType, size: u32) -> Self {
         Self::Reg { reg, ty, size }
     }
 
     /// Allocate a new stack [`ABIOperand`].
-    pub fn stack_offset(offset: u32, ty: WasmType, size: u32) -> Self {
+    pub fn stack_offset(offset: u32, ty: WasmValType, size: u32) -> Self {
         Self::Stack { ty, offset, size }
     }
 
@@ -199,7 +202,7 @@ impl ABIOperand {
     }
 
     /// Get the type associated to this [`ABIOperand`].
-    pub fn ty(&self) -> WasmType {
+    pub fn ty(&self) -> WasmValType {
         match *self {
             ABIOperand::Reg { ty, .. } | ABIOperand::Stack { ty, .. } => ty,
         }
@@ -307,9 +310,9 @@ impl ABIResults {
     /// representation, according to the calling convention. In the case of
     /// results, one result is stored in registers and the rest at particular
     /// offsets in the stack.
-    pub fn from<F>(returns: &[WasmType], call_conv: &CallingConvention, mut map: F) -> Self
+    pub fn from<F>(returns: &[WasmValType], call_conv: &CallingConvention, mut map: F) -> Self
     where
-        F: FnMut(&WasmType, u32) -> (ABIOperand, u32),
+        F: FnMut(&WasmValType, u32) -> (ABIOperand, u32),
     {
         if returns.len() == 0 {
             return Self::default();
@@ -452,13 +455,13 @@ impl ABIParams {
     /// params, multiple params may be passed in registers and the rest on the
     /// stack depending on the calling convention.
     pub fn from<F, A: ABI>(
-        params: &[WasmType],
+        params: &[WasmValType],
         initial_bytes: u32,
         needs_stack_results: bool,
         mut map: F,
     ) -> Self
     where
-        F: FnMut(&WasmType, u32) -> (ABIOperand, u32),
+        F: FnMut(&WasmValType, u32) -> (ABIOperand, u32),
     {
         if params.len() == 0 && !needs_stack_results {
             return Self::with_bytes(initial_bytes);

--- a/winch/codegen/src/codegen/builtin.rs
+++ b/winch/codegen/src/codegen/builtin.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use cranelift_codegen::ir::LibCall;
 use std::sync::Arc;
-use wasmtime_environ::{BuiltinFunctionIndex, PtrSize, VMOffsets, WasmType};
+use wasmtime_environ::{BuiltinFunctionIndex, PtrSize, VMOffsets, WasmValType};
 
 #[derive(Copy, Clone)]
 pub(crate) enum BuiltinType {
@@ -73,7 +73,7 @@ macro_rules! declare_function_sig {
             /// The target pointer size.
             ptr_size: u8,
             /// The target pointer type, as a WebAssembly type.
-            ptr_type: WasmType,
+            ptr_type: WasmValType,
             /// The builtin functions base relative to the VMContext.
             base: u32,
             /// F32 Ceil.
@@ -121,31 +121,31 @@ macro_rules! declare_function_sig {
                 }
             }
 
-            fn pointer(&self) -> WasmType {
+            fn pointer(&self) -> WasmValType {
                 self.ptr_type
             }
 
-            fn vmctx(&self) -> WasmType {
+            fn vmctx(&self) -> WasmValType {
                 self.pointer()
             }
 
-            fn i32(&self) -> WasmType {
-                WasmType::I32
+            fn i32(&self) -> WasmValType {
+                WasmValType::I32
             }
 
-            fn f32(&self) -> WasmType {
-                WasmType::F32
+            fn f32(&self) -> WasmValType {
+                WasmValType::F32
             }
 
-            fn f64(&self) -> WasmType {
-                WasmType::F64
+            fn f64(&self) -> WasmValType {
+                WasmValType::F64
             }
 
-            fn i64(&self) -> WasmType {
-                WasmType::I64
+            fn i64(&self) -> WasmValType {
+                WasmValType::I64
             }
 
-            fn reference(&self) -> WasmType {
+            fn reference(&self) -> WasmValType {
                 self.pointer()
             }
 

--- a/winch/codegen/src/codegen/call.rs
+++ b/winch/codegen/src/codegen/call.rs
@@ -69,7 +69,7 @@ use crate::{
 };
 use smallvec::SmallVec;
 use std::borrow::Cow;
-use wasmtime_environ::{PtrSize, VMOffsets, WasmType};
+use wasmtime_environ::{PtrSize, VMOffsets, WasmValType};
 
 /// All the information needed to emit a function call.
 #[derive(Copy, Clone)]
@@ -124,11 +124,11 @@ impl FnCall {
     }
 
     /// Derive the [`ABISig`] for a particular [`Callee`].
-    fn get_sig<M: MacroAssembler>(callee: &Callee, ptr_type: WasmType) -> Cow<'_, ABISig> {
+    fn get_sig<M: MacroAssembler>(callee: &Callee, ptr_type: WasmValType) -> Cow<'_, ABISig> {
         match callee {
             Callee::Builtin(info) => Cow::Borrowed(info.sig()),
             Callee::Import(info) => {
-                let mut params: SmallVec<[WasmType; 6]> =
+                let mut params: SmallVec<[WasmValType; 6]> =
                     SmallVec::with_capacity(info.ty.params().len() + 2);
                 params.extend_from_slice(&[ptr_type, ptr_type]);
                 params.extend_from_slice(info.ty.params());

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -1,4 +1,4 @@
-use wasmtime_environ::{VMOffsets, WasmHeapType, WasmType};
+use wasmtime_environ::{VMOffsets, WasmHeapType, WasmValType};
 
 use super::ControlStackFrame;
 use crate::{
@@ -70,8 +70,8 @@ impl<'a, 'builtins> CodeGenContext<'a, 'builtins> {
     }
 
     /// Allocate a register for the given WebAssembly type.
-    pub fn reg_for_type<M: MacroAssembler>(&mut self, ty: WasmType, masm: &mut M) -> Reg {
-        use WasmType::*;
+    pub fn reg_for_type<M: MacroAssembler>(&mut self, ty: WasmValType, masm: &mut M) -> Reg {
+        use WasmValType::*;
         match ty {
             I32 | I64 => self.reg_for_class(RegClass::Int, masm),
             F32 | F64 => self.reg_for_class(RegClass::Float, masm),
@@ -323,7 +323,7 @@ impl<'a, 'builtins> CodeGenContext<'a, 'builtins> {
     }
 
     /// Prepares arguments for emitting a convert operation.
-    pub fn convert_op<F, M>(&mut self, masm: &mut M, dst_ty: WasmType, mut emit: F)
+    pub fn convert_op<F, M>(&mut self, masm: &mut M, dst_ty: WasmValType, mut emit: F)
     where
         F: FnMut(&mut M, Reg, Reg, OperandSize),
         M: MacroAssembler,
@@ -331,12 +331,12 @@ impl<'a, 'builtins> CodeGenContext<'a, 'builtins> {
         let src = self.pop_to_reg(masm, None);
         let dst = self.reg_for_type(dst_ty, masm);
         let dst_size = match dst_ty {
-            WasmType::I32 => OperandSize::S32,
-            WasmType::I64 => OperandSize::S64,
-            WasmType::F32 => OperandSize::S32,
-            WasmType::F64 => OperandSize::S64,
-            WasmType::V128 => unreachable!(),
-            WasmType::Ref(_) => unreachable!(),
+            WasmValType::I32 => OperandSize::S32,
+            WasmValType::I64 => OperandSize::S64,
+            WasmValType::F32 => OperandSize::S32,
+            WasmValType::F64 => OperandSize::S64,
+            WasmValType::V128 => unreachable!(),
+            WasmValType::Ref(_) => unreachable!(),
         };
 
         emit(masm, dst, src.into(), dst_size);
@@ -350,7 +350,7 @@ impl<'a, 'builtins> CodeGenContext<'a, 'builtins> {
     pub fn convert_op_with_tmp_reg<F, M>(
         &mut self,
         masm: &mut M,
-        dst_ty: WasmType,
+        dst_ty: WasmValType,
         tmp_reg_class: RegClass,
         mut emit: F,
     ) where

--- a/winch/codegen/src/codegen/control.rs
+++ b/winch/codegen/src/codegen/control.rs
@@ -14,7 +14,7 @@ use crate::{
     CallingConvention,
 };
 use cranelift_codegen::MachLabel;
-use wasmtime_environ::{WasmFuncType, WasmType};
+use wasmtime_environ::{WasmFuncType, WasmValType};
 
 /// Categorization of the type of the block.
 #[derive(Debug, Clone)]
@@ -22,7 +22,7 @@ pub(crate) enum BlockType {
     /// Doesn't produce or consume any values.
     Void,
     /// Produces a single value.
-    Single(WasmType),
+    Single(WasmValType),
     /// Consumes multiple values and produces multiple values.
     Func(WasmFuncType),
     /// An already resolved ABI signature.
@@ -147,7 +147,7 @@ impl BlockType {
     }
 
     /// Create a [BlockType::Single] from the given [WasmType].
-    pub fn single(ty: WasmType) -> Self {
+    pub fn single(ty: WasmValType) -> Self {
         Self::Single(ty)
     }
 

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::Result;
 use smallvec::SmallVec;
 use wasmparser::{BinaryReader, FuncValidator, Operator, ValidatorResources, VisitOperator};
-use wasmtime_environ::{PtrSize, TableIndex, TypeIndex, WasmHeapType, WasmType, FUNCREF_MASK};
+use wasmtime_environ::{PtrSize, TableIndex, TypeIndex, WasmHeapType, WasmValType, FUNCREF_MASK};
 
 mod context;
 pub(crate) use context::*;
@@ -307,7 +307,7 @@ where
     }
 
     fn spill_register_arguments(&mut self) {
-        use WasmType::*;
+        use WasmValType::*;
         self.sig
             // Skip the results base param if any; [Self::emit_body],
             // will handle spilling the results base param if it's in a register.

--- a/winch/codegen/src/frame/mod.rs
+++ b/winch/codegen/src/frame/mod.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use smallvec::SmallVec;
 use std::ops::Range;
 use wasmparser::{BinaryReader, FuncValidator, ValidatorResources};
-use wasmtime_environ::{TypeConvert, WasmType};
+use wasmtime_environ::{TypeConvert, WasmValType};
 
 // TODO:
 // SpiderMonkey's implementation uses 16;
@@ -154,7 +154,7 @@ impl Frame {
         &self,
         index: u32,
         masm: &mut M,
-    ) -> (WasmType, M::Address) {
+    ) -> (WasmValType, M::Address) {
         self.get_local(index)
             .map(|slot| (slot.ty, masm.local_address(slot)))
             .unwrap_or_else(|| panic!("Invalid local slot: {}", index))

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -28,7 +28,7 @@ use cranelift_codegen::{
     MachBufferFinalized, MachLabel,
 };
 
-use wasmtime_environ::{PtrSize, WasmType, WASM_PAGE_SIZE};
+use wasmtime_environ::{PtrSize, WasmValType, WASM_PAGE_SIZE};
 
 /// x64 MacroAssembler.
 pub(crate) struct MacroAssembler {
@@ -285,8 +285,8 @@ impl Masm for MacroAssembler {
         // Ensure that the constant is correctly typed according to the heap
         // type to reduce register pressure when emitting the shift operation.
         match heap_data.ty {
-            WasmType::I32 => context.stack.push(Val::i32(pow as i32)),
-            WasmType::I64 => context.stack.push(Val::i64(pow as i64)),
+            WasmValType::I32 => context.stack.push(Val::i32(pow as i32)),
+            WasmValType::I64 => context.stack.push(Val::i64(pow as i64)),
             _ => unreachable!(),
         }
 

--- a/winch/codegen/src/stack.rs
+++ b/winch/codegen/src/stack.rs
@@ -1,6 +1,6 @@
 use crate::{isa::reg::Reg, masm::StackSlot};
 use wasmparser::{Ieee32, Ieee64};
-use wasmtime_environ::WasmType;
+use wasmtime_environ::WasmValType;
 
 /// A typed register value used to track register values in the value
 /// stack.
@@ -9,19 +9,19 @@ pub struct TypedReg {
     /// The physical register.
     pub reg: Reg,
     /// The type associated to the physical register.
-    pub ty: WasmType,
+    pub ty: WasmValType,
 }
 
 impl TypedReg {
     /// Create a new [`TypedReg`].
-    pub fn new(ty: WasmType, reg: Reg) -> Self {
+    pub fn new(ty: WasmValType, reg: Reg) -> Self {
         Self { ty, reg }
     }
 
     /// Create an i64 [`TypedReg`].
     pub fn i64(reg: Reg) -> Self {
         Self {
-            ty: WasmType::I64,
+            ty: WasmValType::I64,
             reg,
         }
     }
@@ -29,7 +29,7 @@ impl TypedReg {
     /// Create an i32 [`TypedReg`].
     pub fn i32(reg: Reg) -> Self {
         Self {
-            ty: WasmType::I32,
+            ty: WasmValType::I32,
             reg,
         }
     }
@@ -37,7 +37,7 @@ impl TypedReg {
     /// Create an f64 [`TypedReg`].
     pub fn f64(reg: Reg) -> Self {
         Self {
-            ty: WasmType::F64,
+            ty: WasmValType::F64,
             reg,
         }
     }
@@ -45,7 +45,7 @@ impl TypedReg {
     /// Create an f32 [`TypedReg`].
     pub fn f32(reg: Reg) -> Self {
         Self {
-            ty: WasmType::F32,
+            ty: WasmValType::F32,
             reg,
         }
     }
@@ -63,14 +63,14 @@ pub struct Local {
     /// The index of the local.
     pub index: u32,
     /// The type of the local.
-    pub ty: WasmType,
+    pub ty: WasmValType,
 }
 
 /// A memory value.
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub struct Memory {
     /// The type associated with the memory offset.
-    pub ty: WasmType,
+    pub ty: WasmValType,
     /// The stack slot corresponding to the memory value.
     pub slot: StackSlot,
 }
@@ -140,17 +140,17 @@ impl Val {
     }
 
     /// Create a new Reg value.
-    pub fn reg(reg: Reg, ty: WasmType) -> Self {
+    pub fn reg(reg: Reg, ty: WasmValType) -> Self {
         Self::Reg(TypedReg { reg, ty })
     }
 
     /// Create a new Local value.
-    pub fn local(index: u32, ty: WasmType) -> Self {
+    pub fn local(index: u32, ty: WasmValType) -> Self {
         Self::Local(Local { index, ty })
     }
 
     /// Create a Memory value.
-    pub fn mem(ty: WasmType, slot: StackSlot) -> Self {
+    pub fn mem(ty: WasmValType, slot: StackSlot) -> Self {
         Self::Memory(Memory { ty, slot })
     }
 
@@ -244,12 +244,12 @@ impl Val {
     }
 
     /// Get the type of the value.
-    pub fn ty(&self) -> WasmType {
+    pub fn ty(&self) -> WasmValType {
         match self {
-            Val::I32(_) => WasmType::I32,
-            Val::I64(_) => WasmType::I64,
-            Val::F32(_) => WasmType::F32,
-            Val::F64(_) => WasmType::F64,
+            Val::I32(_) => WasmValType::I32,
+            Val::I64(_) => WasmValType::I64,
+            Val::F32(_) => WasmValType::F32,
+            Val::F64(_) => WasmValType::F64,
             Val::Reg(r) => r.ty,
             Val::Memory(m) => m.ty,
             Val::Local(l) => l.ty,
@@ -401,7 +401,7 @@ impl Stack {
 mod tests {
     use super::{Stack, Val};
     use crate::isa::reg::Reg;
-    use wasmtime_environ::WasmType;
+    use wasmtime_environ::WasmValType;
 
     #[test]
     fn test_pop_i32_const() {
@@ -409,7 +409,7 @@ mod tests {
         stack.push(Val::i32(33i32));
         assert_eq!(33, stack.pop_i32_const().unwrap());
 
-        stack.push(Val::local(10, WasmType::I32));
+        stack.push(Val::local(10, WasmValType::I32));
         assert!(stack.pop_i32_const().is_none());
     }
 
@@ -417,7 +417,7 @@ mod tests {
     fn test_pop_reg() {
         let mut stack = Stack::new();
         let reg = Reg::int(2usize);
-        stack.push(Val::reg(reg, WasmType::I32));
+        stack.push(Val::reg(reg, WasmValType::I32));
         stack.push(Val::i32(4));
 
         assert_eq!(None, stack.pop_reg());
@@ -429,8 +429,8 @@ mod tests {
     fn test_pop_named_reg() {
         let mut stack = Stack::new();
         let reg = Reg::int(2usize);
-        stack.push(Val::reg(reg, WasmType::I32));
-        stack.push(Val::reg(Reg::int(4), WasmType::I32));
+        stack.push(Val::reg(reg, WasmValType::I32));
+        stack.push(Val::reg(Reg::int(4), WasmValType::I32));
 
         assert_eq!(None, stack.pop_named_reg(reg));
         let _ = stack.pop().unwrap();

--- a/winch/codegen/src/trampoline.rs
+++ b/winch/codegen/src/trampoline.rs
@@ -19,7 +19,7 @@ use crate::{
 use anyhow::{anyhow, Result};
 use smallvec::SmallVec;
 use std::mem;
-use wasmtime_environ::{FuncIndex, PtrSize, WasmFuncType, WasmType};
+use wasmtime_environ::{FuncIndex, PtrSize, WasmFuncType, WasmValType};
 
 /// The supported trampoline kinds.
 /// See <https://github.com/bytecodealliance/rfcs/blob/main/accepted/tail-calls.md#new-trampolines-and-vmcallercheckedanyfunc-changes>
@@ -60,7 +60,7 @@ where
     /// The pointer size of the current ISA.
     pointer_size: M::Ptr,
     /// WasmType representation of the pointer size.
-    pointer_type: WasmType,
+    pointer_type: WasmValType,
 }
 
 impl<'a, M> Trampoline<'a, M>
@@ -495,7 +495,7 @@ where
     }
 
     /// Get the type of the caller and callee VM contexts.
-    fn callee_and_caller_vmctx_types(&self) -> SmallVec<[WasmType; 2]> {
+    fn callee_and_caller_vmctx_types(&self) -> SmallVec<[WasmValType; 2]> {
         std::iter::repeat(self.pointer_type).take(2).collect()
     }
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -17,8 +17,8 @@ use smallvec::SmallVec;
 use wasmparser::BrTable;
 use wasmparser::{BlockType, Ieee32, Ieee64, VisitOperator};
 use wasmtime_environ::{
-    FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TableStyle, TypeIndex, WasmHeapType, WasmType,
-    FUNCREF_INIT_BIT,
+    FuncIndex, GlobalIndex, MemoryIndex, TableIndex, TableStyle, TypeIndex, WasmHeapType,
+    WasmValType, FUNCREF_INIT_BIT,
 };
 
 /// A macro to define unsupported WebAssembly operators.
@@ -598,7 +598,7 @@ where
 
     fn visit_f32_convert_i32_s(&mut self) {
         self.context
-            .convert_op(self.masm, WasmType::F32, |masm, dst, src, dst_size| {
+            .convert_op(self.masm, WasmValType::F32, |masm, dst, src, dst_size| {
                 masm.signed_convert(src, dst, OperandSize::S32, dst_size);
             });
     }
@@ -606,7 +606,7 @@ where
     fn visit_f32_convert_i32_u(&mut self) {
         self.context.convert_op_with_tmp_reg(
             self.masm,
-            WasmType::F32,
+            WasmValType::F32,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
                 masm.unsigned_convert(src, dst, tmp_gpr, OperandSize::S32, dst_size);
@@ -616,7 +616,7 @@ where
 
     fn visit_f32_convert_i64_s(&mut self) {
         self.context
-            .convert_op(self.masm, WasmType::F32, |masm, dst, src, dst_size| {
+            .convert_op(self.masm, WasmValType::F32, |masm, dst, src, dst_size| {
                 masm.signed_convert(src, dst, OperandSize::S64, dst_size);
             });
     }
@@ -624,7 +624,7 @@ where
     fn visit_f32_convert_i64_u(&mut self) {
         self.context.convert_op_with_tmp_reg(
             self.masm,
-            WasmType::F32,
+            WasmValType::F32,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
                 masm.unsigned_convert(src, dst, tmp_gpr, OperandSize::S64, dst_size);
@@ -634,7 +634,7 @@ where
 
     fn visit_f64_convert_i32_s(&mut self) {
         self.context
-            .convert_op(self.masm, WasmType::F64, |masm, dst, src, dst_size| {
+            .convert_op(self.masm, WasmValType::F64, |masm, dst, src, dst_size| {
                 masm.signed_convert(src, dst, OperandSize::S32, dst_size);
             });
     }
@@ -642,7 +642,7 @@ where
     fn visit_f64_convert_i32_u(&mut self) {
         self.context.convert_op_with_tmp_reg(
             self.masm,
-            WasmType::F64,
+            WasmValType::F64,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
                 masm.unsigned_convert(src, dst, tmp_gpr, OperandSize::S32, dst_size);
@@ -652,7 +652,7 @@ where
 
     fn visit_f64_convert_i64_s(&mut self) {
         self.context
-            .convert_op(self.masm, WasmType::F64, |masm, dst, src, dst_size| {
+            .convert_op(self.masm, WasmValType::F64, |masm, dst, src, dst_size| {
                 masm.signed_convert(src, dst, OperandSize::S64, dst_size);
             });
     }
@@ -660,7 +660,7 @@ where
     fn visit_f64_convert_i64_u(&mut self) {
         self.context.convert_op_with_tmp_reg(
             self.masm,
-            WasmType::F64,
+            WasmValType::F64,
             RegClass::Int,
             |masm, dst, src, tmp_gpr, dst_size| {
                 masm.unsigned_convert(src, dst, tmp_gpr, OperandSize::S64, dst_size);
@@ -670,14 +670,14 @@ where
 
     fn visit_f32_reinterpret_i32(&mut self) {
         self.context
-            .convert_op(self.masm, WasmType::F32, |masm, dst, src, size| {
+            .convert_op(self.masm, WasmValType::F32, |masm, dst, src, size| {
                 masm.reinterpret_int_as_float(src.into(), dst, size);
             });
     }
 
     fn visit_f64_reinterpret_i64(&mut self) {
         self.context
-            .convert_op(self.masm, WasmType::F64, |masm, dst, src, size| {
+            .convert_op(self.masm, WasmValType::F64, |masm, dst, src, size| {
                 masm.reinterpret_int_as_float(src.into(), dst, size);
             });
     }
@@ -1138,7 +1138,7 @@ where
         use OperandSize::*;
 
         self.context
-            .convert_op(self.masm, WasmType::I32, |masm, dst, src, dst_size| {
+            .convert_op(self.masm, WasmValType::I32, |masm, dst, src, dst_size| {
                 masm.signed_truncate(src, dst, S32, dst_size);
             });
     }
@@ -1148,7 +1148,7 @@ where
 
         self.context.convert_op_with_tmp_reg(
             self.masm,
-            WasmType::I32,
+            WasmValType::I32,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
                 masm.unsigned_truncate(src, dst, tmp_fpr, S32, dst_size);
@@ -1160,7 +1160,7 @@ where
         use OperandSize::*;
 
         self.context
-            .convert_op(self.masm, WasmType::I32, |masm, dst, src, dst_size| {
+            .convert_op(self.masm, WasmValType::I32, |masm, dst, src, dst_size| {
                 masm.signed_truncate(src, dst, S64, dst_size);
             });
     }
@@ -1170,7 +1170,7 @@ where
 
         self.context.convert_op_with_tmp_reg(
             self.masm,
-            WasmType::I32,
+            WasmValType::I32,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
                 masm.unsigned_truncate(src, dst, tmp_fpr, S64, dst_size);
@@ -1182,7 +1182,7 @@ where
         use OperandSize::*;
 
         self.context
-            .convert_op(self.masm, WasmType::I64, |masm, dst, src, dst_size| {
+            .convert_op(self.masm, WasmValType::I64, |masm, dst, src, dst_size| {
                 masm.signed_truncate(src, dst, S32, dst_size);
             });
     }
@@ -1192,7 +1192,7 @@ where
 
         self.context.convert_op_with_tmp_reg(
             self.masm,
-            WasmType::I64,
+            WasmValType::I64,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
                 masm.unsigned_truncate(src, dst, tmp_fpr, S32, dst_size);
@@ -1204,7 +1204,7 @@ where
         use OperandSize::*;
 
         self.context
-            .convert_op(self.masm, WasmType::I64, |masm, dst, src, dst_size| {
+            .convert_op(self.masm, WasmValType::I64, |masm, dst, src, dst_size| {
                 masm.signed_truncate(src, dst, S64, dst_size);
             });
     }
@@ -1214,7 +1214,7 @@ where
 
         self.context.convert_op_with_tmp_reg(
             self.masm,
-            WasmType::I64,
+            WasmValType::I64,
             RegClass::Float,
             |masm, dst, src, tmp_fpr, dst_size| {
                 masm.unsigned_truncate(src, dst, tmp_fpr, S64, dst_size);
@@ -1224,20 +1224,20 @@ where
 
     fn visit_i32_reinterpret_f32(&mut self) {
         self.context
-            .convert_op(self.masm, WasmType::I32, |masm, dst, src, size| {
+            .convert_op(self.masm, WasmValType::I32, |masm, dst, src, size| {
                 masm.reinterpret_float_as_int(src.into(), dst, size);
             });
     }
 
     fn visit_i64_reinterpret_f64(&mut self) {
         self.context
-            .convert_op(self.masm, WasmType::I64, |masm, dst, src, size| {
+            .convert_op(self.masm, WasmValType::I64, |masm, dst, src, size| {
                 masm.reinterpret_float_as_int(src.into(), dst, size);
             });
     }
 
     fn visit_local_get(&mut self, index: u32) {
-        use WasmType::*;
+        use WasmValType::*;
         let context = &mut self.context;
         let slot = context
             .frame
@@ -1827,12 +1827,12 @@ where
     }
 }
 
-impl From<WasmType> for OperandSize {
-    fn from(ty: WasmType) -> OperandSize {
+impl From<WasmValType> for OperandSize {
+    fn from(ty: WasmValType) -> OperandSize {
         match ty {
-            WasmType::I32 | WasmType::F32 => OperandSize::S32,
-            WasmType::I64 | WasmType::F64 => OperandSize::S64,
-            WasmType::Ref(rt) => {
+            WasmValType::I32 | WasmValType::F32 => OperandSize::S32,
+            WasmValType::I64 | WasmValType::F64 => OperandSize::S64,
+            WasmValType::Ref(rt) => {
                 match rt.heap_type {
                     // TODO: Harcoded size, assuming 64-bit support only. Once
                     // Wasmtime supports 32-bit architectures, this will need


### PR DESCRIPTION
Purely mechanical, no functional changes.

This is to help differentiate between value types (i32, i64, reference types, etc...) and defined types (function signatures, struct definitions, array definitions).

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
