### PR TITLE
Enable the `component-model` feature by default in Wasmtime

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -326,6 +326,7 @@ default = [
   "coredump",
   "addr2line",
   "debug-builtins",
+  "component-model",
 
   # Enable some nice features of clap by default, but they come at a binary size
   # cost, so allow disabling this through disabling of our own `default`

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -97,6 +97,7 @@ default = [
   'coredump',
   'debug-builtins',
   'runtime',
+  'component-model',
 ]
 
 # An on-by-default feature enabling runtime compilation of WebAssembly modules


### PR DESCRIPTION
This commit updates the `wasmtime` crate itself to have the `component-model` feature enabled by default. This was also done for the CLI but only for clarity because the `component-model` feature was already eanbled by default transitively through the `serve` feature.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
