### PR TITLE
Tweak a feature directive for `wasmtime-cli`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -360,7 +360,7 @@ wasi-http = ["component-model", "dep:wasmtime-wasi-http", "dep:tokio", "dep:hype
 pooling-allocator = ["wasmtime/pooling-allocator", "wasmtime-cli-flags/pooling-allocator"]
 component-model = [
   "wasmtime/component-model",
-  "wasmtime-wast/component-model",
+  "wasmtime-wast?/component-model",
   "wasmtime-cli-flags/component-model"
 ]
 wat = ["dep:wat", "wasmtime/wat"]


### PR DESCRIPTION
Don't force-enable the `wasmtime-wast` crate if the `component-model` feature is active, only activate component model support if `wasmtime-wast` is otherwise activated.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
