### PR TITLE
Replace an explicit implementation of `Service` with `service_fn`

### DIFF
--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -3,7 +3,6 @@ use anyhow::{anyhow, bail, Result};
 use clap::Parser;
 use std::{
     path::PathBuf,
-    pin::Pin,
     sync::{
         atomic::{AtomicBool, AtomicU64, Ordering},
         Arc,
@@ -281,10 +280,13 @@ impl ServeCommand {
             let (stream, _) = listener.accept().await?;
             let stream = TokioIo::new(stream);
             let h = handler.clone();
-            tokio::task::spawn(async move {
+            tokio::task::spawn(async {
                 if let Err(e) = http1::Builder::new()
                     .keep_alive(true)
-                    .serve_connection(stream, h)
+                    .serve_connection(
+                        stream,
+                        hyper::service::service_fn(move |req| handle_request(h.clone(), req)),
+                    )
                     .await
                 {
                     eprintln!("error: {e:?}");
@@ -355,87 +357,80 @@ impl ProxyHandler {
 
 type Request = hyper::Request<hyper::body::Incoming>;
 
-impl hyper::service::Service<Request> for ProxyHandler {
-    type Response = hyper::Response<HyperOutgoingBody>;
-    type Error = anyhow::Error;
-    type Future = Pin<Box<dyn std::future::Future<Output = Result<Self::Response>> + Send>>;
+async fn handle_request(
+    ProxyHandler(inner): ProxyHandler,
+    req: Request,
+) -> Result<hyper::Response<HyperOutgoingBody>> {
+    use http_body_util::BodyExt;
 
-    fn call(&self, req: Request) -> Self::Future {
-        use http_body_util::BodyExt;
+    let (sender, receiver) = tokio::sync::oneshot::channel();
 
-        let ProxyHandler(inner) = self.clone();
+    // TODO: need to track the join handle, but don't want to block the response on it
+    tokio::task::spawn(async move {
+        let req_id = inner.next_req_id();
+        let (mut parts, body) = req.into_parts();
 
-        let (sender, receiver) = tokio::sync::oneshot::channel();
+        parts.uri = {
+            let uri_parts = parts.uri.into_parts();
 
-        // TODO: need to track the join handle, but don't want to block the response on it
-        tokio::task::spawn(async move {
-            let req_id = inner.next_req_id();
-            let (mut parts, body) = req.into_parts();
+            let scheme = uri_parts.scheme.unwrap_or(http::uri::Scheme::HTTP);
 
-            parts.uri = {
-                let uri_parts = parts.uri.into_parts();
-
-                let scheme = uri_parts.scheme.unwrap_or(http::uri::Scheme::HTTP);
-
-                let host = if let Some(val) = parts.headers.get(hyper::header::HOST) {
-                    std::str::from_utf8(val.as_bytes())
-                        .map_err(|_| http_types::ErrorCode::HttpRequestUriInvalid)?
-                } else {
-                    uri_parts
-                        .authority
-                        .as_ref()
-                        .ok_or(http_types::ErrorCode::HttpRequestUriInvalid)?
-                        .host()
-                };
-
-                let path_with_query = uri_parts
-                    .path_and_query
-                    .ok_or(http_types::ErrorCode::HttpRequestUriInvalid)?;
-
-                hyper::Uri::builder()
-                    .scheme(scheme)
-                    .authority(host)
-                    .path_and_query(path_with_query)
-                    .build()
+            let host = if let Some(val) = parts.headers.get(hyper::header::HOST) {
+                std::str::from_utf8(val.as_bytes())
                     .map_err(|_| http_types::ErrorCode::HttpRequestUriInvalid)?
+            } else {
+                uri_parts
+                    .authority
+                    .as_ref()
+                    .ok_or(http_types::ErrorCode::HttpRequestUriInvalid)?
+                    .host()
             };
 
-            let req = hyper::Request::from_parts(parts, body.map_err(hyper_response_error).boxed());
+            let path_with_query = uri_parts
+                .path_and_query
+                .ok_or(http_types::ErrorCode::HttpRequestUriInvalid)?;
 
-            log::info!(
-                "Request {req_id} handling {} to {}",
-                req.method(),
-                req.uri()
-            );
+            hyper::Uri::builder()
+                .scheme(scheme)
+                .authority(host)
+                .path_and_query(path_with_query)
+                .build()
+                .map_err(|_| http_types::ErrorCode::HttpRequestUriInvalid)?
+        };
 
-            let mut store = inner.cmd.new_store(&inner.engine, req_id)?;
+        let req = hyper::Request::from_parts(parts, body.map_err(hyper_response_error).boxed());
 
-            let req = store.data_mut().new_incoming_request(req)?;
-            let out = store.data_mut().new_response_outparam(sender)?;
+        log::info!(
+            "Request {req_id} handling {} to {}",
+            req.method(),
+            req.uri()
+        );
 
-            let (proxy, _inst) =
-                wasmtime_wasi_http::proxy::Proxy::instantiate_pre(&mut store, &inner.instance_pre)
-                    .await?;
+        let mut store = inner.cmd.new_store(&inner.engine, req_id)?;
 
-            if let Err(e) = proxy
-                .wasi_http_incoming_handler()
-                .call_handle(store, req, out)
-                .await
-            {
-                log::error!("[{req_id}] :: {:#?}", e);
-                return Err(e);
-            }
+        let req = store.data_mut().new_incoming_request(req)?;
+        let out = store.data_mut().new_response_outparam(sender)?;
 
-            Ok(())
-        });
+        let (proxy, _inst) =
+            wasmtime_wasi_http::proxy::Proxy::instantiate_pre(&mut store, &inner.instance_pre)
+                .await?;
 
-        Box::pin(async move {
-            match receiver.await {
-                Ok(Ok(resp)) => Ok(resp),
-                Ok(Err(e)) => Err(e.into()),
-                Err(_) => bail!("guest never invoked `response-outparam::set` method"),
-            }
-        })
+        if let Err(e) = proxy
+            .wasi_http_incoming_handler()
+            .call_handle(store, req, out)
+            .await
+        {
+            log::error!("[{req_id}] :: {:#?}", e);
+            return Err(e);
+        }
+
+        Ok(())
+    });
+
+    match receiver.await {
+        Ok(Ok(resp)) => Ok(resp),
+        Ok(Err(e)) => Err(e.into()),
+        Err(_) => bail!("guest never invoked `response-outparam::set` method"),
     }
 }
 


### PR DESCRIPTION
Simplify the implementation of the serve command by removing the explicit Service trait impl, and using `service_fn` instead.

Co-authored-by: Jamey Sharp <jsharp@fastly.com>

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
