### PR TITLE
Add cloning for DWARF String attributes

### DIFF
--- a/crates/cranelift/src/debug/transform/attr.rs
+++ b/crates/cranelift/src/debug/transform/attr.rs
@@ -295,6 +295,7 @@ where
                 pending_di_refs.insert(current_scope_id, attr.name(), offset);
                 continue;
             }
+            AttributeValue::String(d) => write::AttributeValue::String(d.to_slice()?.to_vec()),
             a => bail!("Unexpected attribute: {:?}", a),
         };
         let current_scope = out_unit.get_mut(current_scope_id);


### PR DESCRIPTION
This PR (my first here), adds cloning for DWARF `String` attributes, copying how `Block` was done.  This allows `wasmtime -D debug-info` to work with programs compiled with emscripten:

```
emcc 1.c -o 1.wasm -g -gdwarf-5 -sWASM_BIGINT=1 -sSTANDALONE_WASM=1
```
And consequently that they can be debugged in lldb:

![image](https://github.com/bytecodealliance/wasmtime/assets/2720041/e149ab81-d9ff-4c50-9b75-8f93e239703c)
