### PR TITLE
Accept explicit CPU delta time in GuestProfiler

### DIFF
--- a/crates/c-api/include/wasmtime/profiling.h
+++ b/crates/c-api/include/wasmtime/profiling.h
@@ -85,6 +85,23 @@ wasmtime_guestprofiler_sample(wasmtime_guestprofiler_t *guestprofiler,
                               const wasmtime_store_t *store);
 
 /**
+ * \brief Add a sample to the profile, additionally specifying used CPU time.
+ *
+ * \param guestprofiler the profiler the sample is being added to
+ * \param store         store that is being used to collect the backtraces
+ * \param delta_nanos   CPU time in nanoseconds that was used by this guest
+ *                      since the previous sample
+ *
+ * This function does not take ownership of the arguments.
+ *
+ * For more information see the Rust documentation at:
+ * https://docs.wasmtime.dev/api/wasmtime/struct.GuestProfiler.html#method.sample_with_delta
+ */
+WASM_API_EXTERN void wasmtime_guestprofiler_sample_with_delta(
+    wasmtime_guestprofiler_t *guestprofiler, const wasmtime_store_t *store,
+    uint64_t delta_nanos);
+
+/**
  * \brief Writes out the captured profile.
  *
  * \param guestprofiler the profiler which is being finished and deleted

--- a/crates/c-api/include/wasmtime/profiling.h
+++ b/crates/c-api/include/wasmtime/profiling.h
@@ -74,7 +74,11 @@ WASM_API_EXTERN /* own */ wasmtime_guestprofiler_t *wasmtime_guestprofiler_new(
  *
  * \param guestprofiler the profiler the sample is being added to
  * \param store         store that is being used to collect the backtraces
+ * \param delta_nanos   CPU time in nanoseconds that was used by this guest
+ *                      since the previous sample
  *
+ * Zero can be passed as `delta_nanos` if recording CPU usage information
+ * is not needed.
  * This function does not take ownership of the arguments.
  *
  * For more information see the Rust documentation at:
@@ -82,24 +86,8 @@ WASM_API_EXTERN /* own */ wasmtime_guestprofiler_t *wasmtime_guestprofiler_new(
  */
 WASM_API_EXTERN void
 wasmtime_guestprofiler_sample(wasmtime_guestprofiler_t *guestprofiler,
-                              const wasmtime_store_t *store);
-
-/**
- * \brief Add a sample to the profile, additionally specifying used CPU time.
- *
- * \param guestprofiler the profiler the sample is being added to
- * \param store         store that is being used to collect the backtraces
- * \param delta_nanos   CPU time in nanoseconds that was used by this guest
- *                      since the previous sample
- *
- * This function does not take ownership of the arguments.
- *
- * For more information see the Rust documentation at:
- * https://docs.wasmtime.dev/api/wasmtime/struct.GuestProfiler.html#method.sample_with_delta
- */
-WASM_API_EXTERN void wasmtime_guestprofiler_sample_with_delta(
-    wasmtime_guestprofiler_t *guestprofiler, const wasmtime_store_t *store,
-    uint64_t delta_nanos);
+                              const wasmtime_store_t *store,
+                              uint64_t delta_nanos);
 
 /**
  * \brief Writes out the captured profile.

--- a/crates/c-api/src/profiling.rs
+++ b/crates/c-api/src/profiling.rs
@@ -44,19 +44,11 @@ pub unsafe extern "C" fn wasmtime_guestprofiler_new(
 pub extern "C" fn wasmtime_guestprofiler_sample(
     guestprofiler: &mut wasmtime_guestprofiler_t,
     store: &wasmtime_store_t,
-) {
-    guestprofiler.guest_profiler.sample(&store.store);
-}
-
-#[no_mangle]
-pub extern "C" fn wasmtime_guestprofiler_sample_with_delta(
-    guestprofiler: &mut wasmtime_guestprofiler_t,
-    store: &wasmtime_store_t,
     delta_nanos: u64,
 ) {
     guestprofiler
         .guest_profiler
-        .sample_with_delta(&store.store, Duration::from_nanos(delta_nanos));
+        .sample(&store.store, Duration::from_nanos(delta_nanos));
 }
 
 #[no_mangle]

--- a/crates/c-api/src/profiling.rs
+++ b/crates/c-api/src/profiling.rs
@@ -49,6 +49,17 @@ pub extern "C" fn wasmtime_guestprofiler_sample(
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_guestprofiler_sample_with_delta(
+    guestprofiler: &mut wasmtime_guestprofiler_t,
+    store: &wasmtime_store_t,
+    delta_nanos: u64,
+) {
+    guestprofiler
+        .guest_profiler
+        .sample_with_delta(&store.store, Duration::from_nanos(delta_nanos));
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_guestprofiler_finish(
     guestprofiler: Box<wasmtime_guestprofiler_t>,
     out: &mut wasm_byte_vec_t,

--- a/crates/wasmtime/src/runtime/profiling.rs
+++ b/crates/wasmtime/src/runtime/profiling.rs
@@ -4,7 +4,7 @@ use anyhow::bail;
 use anyhow::Result;
 #[cfg(feature = "profiling")]
 use fxprof_processed_profile::{
-    debugid::DebugId, CategoryHandle, CpuDelta, Frame, FrameFlags, FrameInfo, LibraryInfo, Profile,
+    debugid::DebugId, CategoryHandle, Frame, FrameFlags, FrameInfo, LibraryInfo, Profile,
     ReferenceTimestamp, Symbol, SymbolTable, Timestamp,
 };
 use std::ops::Range;

--- a/crates/wasmtime/src/runtime/profiling.rs
+++ b/crates/wasmtime/src/runtime/profiling.rs
@@ -128,11 +128,21 @@ impl GuestProfiler {
         }
     }
 
+    /// Add a sample to the profile. This equivalent to
+    /// [`GuestProfiler::sample_with_delta()`](crate::GuestProfiler::sample_with_delta)
+    /// but without specifying used CPU time.
+    pub fn sample(&mut self, store: impl AsContext) {
+        self.sample_with_delta(store, Duration::ZERO)
+    }
+
     /// Add a sample to the profile. This function collects a backtrace from
     /// any stack frames for allowed modules on the current stack. It should
     /// typically be called from a callback registered using
     /// [`Store::epoch_deadline_callback()`](crate::Store::epoch_deadline_callback).
-    pub fn sample(&mut self, store: impl AsContext) {
+    ///
+    /// The `delta` parameter is the amount of CPU time that was used by this
+    /// guest since the previous sample.
+    pub fn sample_with_delta(&mut self, store: impl AsContext, delta: Duration) {
         let now = Timestamp::from_nanos_since_reference(
             self.start.elapsed().as_nanos().try_into().unwrap(),
         );
@@ -164,7 +174,7 @@ impl GuestProfiler {
             });
 
         self.profile
-            .add_sample(self.thread, now, frames, CpuDelta::ZERO, 1);
+            .add_sample(self.thread, now, frames, delta.into(), 1);
     }
 
     /// When the guest finishes running, call this function to write the

--- a/crates/wasmtime/src/runtime/profiling.rs
+++ b/crates/wasmtime/src/runtime/profiling.rs
@@ -128,21 +128,15 @@ impl GuestProfiler {
         }
     }
 
-    /// Add a sample to the profile. This equivalent to
-    /// [`GuestProfiler::sample_with_delta()`](crate::GuestProfiler::sample_with_delta)
-    /// but without specifying used CPU time.
-    pub fn sample(&mut self, store: impl AsContext) {
-        self.sample_with_delta(store, Duration::ZERO)
-    }
-
     /// Add a sample to the profile. This function collects a backtrace from
     /// any stack frames for allowed modules on the current stack. It should
     /// typically be called from a callback registered using
     /// [`Store::epoch_deadline_callback()`](crate::Store::epoch_deadline_callback).
     ///
     /// The `delta` parameter is the amount of CPU time that was used by this
-    /// guest since the previous sample.
-    pub fn sample_with_delta(&mut self, store: impl AsContext, delta: Duration) {
+    /// guest since the previous sample. It is allowed to pass `Duration::ZERO`
+    /// here if recording CPU usage information is not needed.
+    pub fn sample(&mut self, store: impl AsContext, delta: Duration) {
         let now = Timestamp::from_nanos_since_reference(
             self.start.elapsed().as_nanos().try_into().unwrap(),
         );

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -13,6 +13,7 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 use wasmtime::{Engine, Func, Module, Store, StoreLimits, Val, ValType};
 use wasmtime_wasi::maybe_exit_on_error;
 use wasmtime_wasi::preview2;
@@ -329,7 +330,7 @@ impl RunCommand {
                 .unwrap();
             Arc::get_mut(&mut profiler)
                 .expect("profiling doesn't support threads yet")
-                .sample(&store);
+                .sample(&store, Duration::ZERO);
             store.as_context_mut().data_mut().guest_profiler = Some(profiler);
         }
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -13,7 +13,6 @@ use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
-use std::time::Duration;
 use wasmtime::{Engine, Func, Module, Store, StoreLimits, Val, ValType};
 use wasmtime_wasi::maybe_exit_on_error;
 use wasmtime_wasi::preview2;
@@ -330,7 +329,7 @@ impl RunCommand {
                 .unwrap();
             Arc::get_mut(&mut profiler)
                 .expect("profiling doesn't support threads yet")
-                .sample(&store, Duration::ZERO);
+                .sample(&store, std::time::Duration::ZERO);
             store.as_context_mut().data_mut().guest_profiler = Some(profiler);
         }
 


### PR DESCRIPTION
Currently `GuestProfiler::sample` always records zero CPU time delta. This makes resulting profiles hard to interpret, especially because sampling is usually performed from epoch callback, which necessarily means that no samples at all are captured when guest is not running, thus there is no distinguishable "idle" stacktrace of any sort.

While it is possible to read OS thread time counters for that, GuestProfiler is not aware whether current thread is used exclusively for running that guest. For example, I'm running multiple guests on single-threaded event loop and that would partially misattribute CPU time to neighboring guests on first/last sample. Thus I think that the embedder is better suited to measure and provide time delta to sampling function.

I left old signature intact not to break any existing users. For symmetry C bindings also got new signature, though maybe old one should be removed as it doesn't have any users yet?