### PR TITLE
Update itertools to 0.12 in cranelift_wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ dependencies = [
  "cranelift-entity",
  "cranelift-frontend",
  "hashbrown 0.14.0",
- "itertools",
+ "itertools 0.12.1",
  "log",
  "serde",
  "serde_derive",
@@ -869,7 +869,7 @@ dependencies = [
  "clap",
  "criterion-plot",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
@@ -890,7 +890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1588,9 +1588,18 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.3"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -21,7 +21,7 @@ cranelift-entity = { workspace = true }
 cranelift-frontend = { workspace = true }
 wasmtime-types = { workspace = true }
 hashbrown = { workspace = true, optional = true }
-itertools = "0.10.0"
+itertools = "0.12.0"
 log = { workspace = true }
 serde = { version = "1.0.188", optional = true }
 serde_derive = { version = "1.0.188", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -59,4 +59,7 @@ skip-tree = [
     # They want to publish version 2.0 to upgrade `hashbrown` so in the meantime
     # it is duplicated for us.
     { name = "indexmap", depth = 2 },
+
+    # criterion is on old version, will update on next release.
+    { name = "itertools" },
 ]


### PR DESCRIPTION
Small dependency version bump to decrease duplicated crates in the dependency tree for consumers.