### PR TITLE
Preview 2 filesystem: track open_mode instead of reporting the permissions

### DIFF
--- a/crates/test-programs/src/bin/preview1_fd_filestat_set.rs
+++ b/crates/test-programs/src/bin/preview1_fd_filestat_set.rs
@@ -132,14 +132,18 @@ fn main() {
     };
 
     // Run the tests.
-    //
+
     unsafe { test_fd_filestat_set_size_rw(dir_fd) }
     unsafe { test_fd_filestat_set_size_ro(dir_fd) }
-    //
+
     // The fd_filestat_set_times function should behave the same whether the file
     // descriptor is open for read-only or read-write, because the underlying
     // permissions of the file determine whether or not the filestat can be
     // set or not, not than the open mode.
-    unsafe { test_fd_filestat_set_times(dir_fd, wasi::RIGHTS_FD_READ) }
+    if test_programs::preview1::config().support_dangling_filesystem() {
+        // Guarding to run on non-windows filesystems. Windows rejects set-times on read-only
+        // files.
+        unsafe { test_fd_filestat_set_times(dir_fd, wasi::RIGHTS_FD_READ) }
+    }
     unsafe { test_fd_filestat_set_times(dir_fd, wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE) }
 }

--- a/crates/test-programs/src/bin/preview1_fd_filestat_set.rs
+++ b/crates/test-programs/src/bin/preview1_fd_filestat_set.rs
@@ -1,9 +1,10 @@
 use std::{env, process, time::Duration};
-use test_programs::preview1::{assert_fs_time_eq, open_scratch_directory, TestConfig};
+use test_programs::preview1::{
+    assert_errno, assert_fs_time_eq, open_scratch_directory, TestConfig,
+};
 
-unsafe fn test_fd_filestat_set(dir_fd: wasi::Fd) {
-    let cfg = TestConfig::from_env();
-    // Create a file in the scratch directory.
+unsafe fn test_fd_filestat_set_size_rw(dir_fd: wasi::Fd) {
+    // Create a file in the scratch directory, opened read/write
     let file_fd = wasi::path_open(
         dir_fd,
         0,
@@ -29,6 +30,55 @@ unsafe fn test_fd_filestat_set(dir_fd: wasi::Fd) {
     let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat 2");
     assert_eq!(stat.size, 100, "file size should be 100");
 
+    wasi::fd_close(file_fd).expect("failed to close fd");
+    wasi::path_unlink_file(dir_fd, "file").expect("failed to remove file");
+}
+
+unsafe fn test_fd_filestat_set_size_ro(dir_fd: wasi::Fd) {
+    // Create a file in the scratch directory. Creating a file implies opening it for writing, so
+    // we have to close and re-open read-only to observe read-only behavior.
+    let file_fd = wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_CREAT, 0, 0, 0)
+        .expect("failed to create file");
+    wasi::fd_close(file_fd).expect("failed to close fd");
+
+    // Open the created file read-only
+    let file_fd = wasi::path_open(dir_fd, 0, "file", 0, wasi::RIGHTS_FD_READ, 0, 0)
+        .expect("failed to create file");
+
+    // Check file size
+    let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat");
+    assert_eq!(stat.size, 0, "file size should be 0");
+
+    // Check fd_filestat_set_size on a file opened read-only fails with EINVAL, like ftruncate is defined to do on posix
+    assert_errno!(
+        wasi::fd_filestat_set_size(file_fd, 100)
+            .expect_err("fd_filestat_set_size should error when file is opened read-only"),
+        wasi::ERRNO_INVAL
+    );
+
+    let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat 2");
+    assert_eq!(stat.size, 0, "file size should remain 0");
+
+    wasi::fd_close(file_fd).expect("failed to close fd");
+    wasi::path_unlink_file(dir_fd, "file").expect("failed to remove file");
+}
+
+unsafe fn test_fd_filestat_set_times(dir_fd: wasi::Fd, rights: wasi::Rights) {
+    let cfg = TestConfig::from_env();
+
+    // Create a file in the scratch directory. OFLAGS_CREAT implies opening for writing, so we will
+    // close it and re-open with the desired rights (FD_READ for read only, FD_READ | FD_WRITE for
+    // readwrite)
+    let file_fd = wasi::path_open(dir_fd, 0, "file", wasi::OFLAGS_CREAT, 0, 0, 0)
+        .expect("failed to create file");
+    wasi::fd_close(file_fd).expect("failed to close fd");
+
+    // Open the file with the rights given.
+    let file_fd =
+        wasi::path_open(dir_fd, 0, "file", 0, rights, 0, 0).expect("failed to create file");
+
+    let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat 2");
+
     // Check fd_filestat_set_times
     let old_atim = Duration::from_nanos(stat.atim);
     let new_mtim = Duration::from_nanos(stat.mtim) - cfg.fs_time_precision() * 2;
@@ -41,7 +91,7 @@ unsafe fn test_fd_filestat_set(dir_fd: wasi::Fd) {
     .expect("fd_filestat_set_times");
 
     let stat = wasi::fd_filestat_get(file_fd).expect("failed filestat 3");
-    assert_eq!(stat.size, 100, "file size should remain unchanged at 100");
+    assert_eq!(stat.size, 0, "file size should remain unchanged at 0");
 
     // Support accuracy up to at least 1ms
     assert_fs_time_eq!(
@@ -59,7 +109,7 @@ unsafe fn test_fd_filestat_set(dir_fd: wasi::Fd) {
     // assert_eq!(status, wasi::EINVAL, "ATIM & ATIM_NOW can't both be set");
 
     wasi::fd_close(file_fd).expect("failed to close fd");
-    wasi::path_unlink_file(dir_fd, "file").expect("failed to remove dir");
+    wasi::path_unlink_file(dir_fd, "file").expect("failed to remove file");
 }
 fn main() {
     let mut args = env::args();
@@ -81,5 +131,14 @@ fn main() {
     };
 
     // Run the tests.
-    unsafe { test_fd_filestat_set(dir_fd) }
+    //
+    unsafe { test_fd_filestat_set_size_rw(dir_fd) }
+    unsafe { test_fd_filestat_set_size_ro(dir_fd) }
+    //
+    // The fd_filestat_set_times function should behave the same whether the file
+    // descriptor is open for read-only or read-write, because the underlying
+    // permissions of the file determine whether or not the filestat can be
+    // set or not, not than the open mode.
+    unsafe { test_fd_filestat_set_times(dir_fd, wasi::RIGHTS_FD_READ) }
+    unsafe { test_fd_filestat_set_times(dir_fd, wasi::RIGHTS_FD_READ | wasi::RIGHTS_FD_WRITE) }
 }

--- a/crates/test-programs/src/bin/preview1_fd_filestat_set.rs
+++ b/crates/test-programs/src/bin/preview1_fd_filestat_set.rs
@@ -53,6 +53,7 @@ unsafe fn test_fd_filestat_set_size_ro(dir_fd: wasi::Fd) {
     assert_errno!(
         wasi::fd_filestat_set_size(file_fd, 100)
             .expect_err("fd_filestat_set_size should error when file is opened read-only"),
+        windows => wasi::ERRNO_ACCES,
         wasi::ERRNO_INVAL
     );
 

--- a/crates/test-programs/src/bin/preview1_path_open_read_write.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_read_write.rs
@@ -57,10 +57,12 @@ unsafe fn test_path_open_read_write(dir_fd: wasi::Fd) {
         "writeonly has write right"
     );
 
+    // See above for description of PERM
     assert_errno!(
         wasi::fd_read(f_writeonly, &[iovec])
             .err()
             .expect("read of writeonly fails"),
+        wasi::ERRNO_PERM,
         wasi::ERRNO_BADF
     );
     let bytes_written = wasi::fd_write(f_writeonly, &[ciovec]).expect("write to writeonly");

--- a/crates/test-programs/src/bin/preview1_path_open_read_write.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_read_write.rs
@@ -30,11 +30,14 @@ unsafe fn test_path_open_read_write(dir_fd: wasi::Fd) {
         buf: write_buffer.as_ptr(),
         buf_len: write_buffer.len(),
     };
+    // PERM is only the failure on windows under wasmtime-wasi. wasi-common
+    // fails on windows with BADF, so we cant use the `windows =>` syntax
+    // because that doesnt support alternatives like the agnostic syntax does.
     assert_errno!(
         wasi::fd_write(f_readonly, &[ciovec])
             .err()
             .expect("read of writeonly fails"),
-        windows => wasi::ERRNO_PERM,
+        wasi::ERRNO_PERM,
         wasi::ERRNO_BADF
     );
 

--- a/crates/test-programs/src/bin/preview1_path_open_read_write.rs
+++ b/crates/test-programs/src/bin/preview1_path_open_read_write.rs
@@ -34,6 +34,7 @@ unsafe fn test_path_open_read_write(dir_fd: wasi::Fd) {
         wasi::fd_write(f_readonly, &[ciovec])
             .err()
             .expect("read of writeonly fails"),
+        windows => wasi::ERRNO_PERM,
         wasi::ERRNO_BADF
     );
 


### PR DESCRIPTION
First update the fd_filestat_set test to assert that the filestat_set operations on a file descriptor behaves the same whether opened readonly or readwrite. This test now reproduces the behavior reported in https://github.com/bytecodealliance/wasmtime/issues/7829. wasi-common passes this changed test, but wasmtime-wasi::preview2 does not, showing that this is a regression between the two implementations.

Then, in preview2 implementation, track open_mode for a File and Dir, and use that instead of reporting permissions in DescriptorFlags.

FilePerms/DirPerms is a way of having wasmtime-wasi, instead of the operating system, mediate permissions on a preview2 Descriptor. This was conflated with the open mode, which should determine whether DescriptorFlags contains READ or WRITE or MUTATE_DIRECTORY.

* don't mask FilePerms with the DescriptorFlags (oflags) in path_open
* File and Dir now track their open_mode (represented using FilePerms)
  and report them in DescriptorFlags
