### PR TITLE
Add missing subsume uses in egraph rules

### DIFF
--- a/cranelift/codegen/src/opts/README.md
+++ b/cranelift/codegen/src/opts/README.md
@@ -38,6 +38,12 @@ of it boils down to the fact that, unlike traditional e-graphs, our rules are
    place of `x` in such cases would introduce uses of `y` where it is not
    defined.
 
+   An exception to this rule is discarding constants, as they can be
+   rematerialized anywhere without introducing correctness issues. For example,
+   the (admittedly silly) rule `(select 1 x (iconst_u _)) => x` would be a good
+   candidate for not using `subsume`, as it does not discard any non-constant
+   values introduced in its LHS.
+
 3. Avoid overly general rewrites like commutativity and associativity. Instead,
    prefer targeted instances of the rewrite (for example, canonicalizing adds
    where one operand is a constant such that the constant is always the add's

--- a/cranelift/codegen/src/opts/extends.isle
+++ b/cranelift/codegen/src/opts/extends.isle
@@ -29,12 +29,12 @@
        (slt ty
              (uextend $I64 x @ (value_type $I32))
              (iconst_u _ 0)))
-      (iconst_u ty 0))
+      (subsume (iconst_u ty 0)))
 (rule (simplify
        (sge ty
              (uextend $I64 x @ (value_type $I32))
              (iconst_u _ 0)))
-      (iconst_u ty 1))
+      (subsume (iconst_u ty 1)))
 
 ;; Sign-extending can't change whether a number is zero nor how it signed-compares to zero
 (rule (simplify (eq _ (sextend _ x@(value_type ty)) (iconst_s _ 0)))

--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -2,16 +2,16 @@
 
 ;; `x == x` is always true for integers; `x != x` is false. Strict
 ;; inequalities are false, and loose inequalities are true.
-(rule (simplify (eq  (ty_int ty) x x)) (iconst_u ty 1))
-(rule (simplify (ne  (ty_int ty) x x)) (iconst_u ty 0))
-(rule (simplify (ugt (ty_int ty) x x)) (iconst_u ty 0))
-(rule (simplify (uge (ty_int ty) x x)) (iconst_u ty 1))
-(rule (simplify (sgt (ty_int ty) x x)) (iconst_u ty 0))
-(rule (simplify (sge (ty_int ty) x x)) (iconst_u ty 1))
-(rule (simplify (ult (ty_int ty) x x)) (iconst_u ty 0))
-(rule (simplify (ule (ty_int ty) x x)) (iconst_u ty 1))
-(rule (simplify (slt (ty_int ty) x x)) (iconst_u ty 0))
-(rule (simplify (sle (ty_int ty) x x)) (iconst_u ty 1))
+(rule (simplify (eq  (ty_int ty) x x)) (subsume (iconst_u ty 1)))
+(rule (simplify (ne  (ty_int ty) x x)) (subsume (iconst_u ty 0)))
+(rule (simplify (ugt (ty_int ty) x x)) (subsume (iconst_u ty 0)))
+(rule (simplify (uge (ty_int ty) x x)) (subsume (iconst_u ty 1)))
+(rule (simplify (sgt (ty_int ty) x x)) (subsume (iconst_u ty 0)))
+(rule (simplify (sge (ty_int ty) x x)) (subsume (iconst_u ty 1)))
+(rule (simplify (ult (ty_int ty) x x)) (subsume (iconst_u ty 0)))
+(rule (simplify (ule (ty_int ty) x x)) (subsume (iconst_u ty 1)))
+(rule (simplify (slt (ty_int ty) x x)) (subsume (iconst_u ty 0)))
+(rule (simplify (sle (ty_int ty) x x)) (subsume (iconst_u ty 1)))
 
 ;; Optimize icmp-of-icmp.
 (rule (simplify (ne ty


### PR DESCRIPTION
I took a quick pass over the egraph rules to look for cases that violate our new guidelines about when `subsume` is required. There were a few cases where `subsume` was needed, and though I believe those instances were benign I think they're worth adding to make sure we're following the spirit of our new guidelines.

I've also added some clarifying text about constants in the text of guideline 2, to make it more obvious that cases where we discard constants are okay without `subsume`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
