### PR TITLE
Support finishing component types without compilation artifacts

### DIFF
--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -438,6 +438,13 @@ impl ComponentTypesBuilder {
     }
 
     /// Finishes this list of component types and returns the finished
+    /// structure.
+    pub fn finish_sans_reflection(mut self) -> ComponentTypes {
+        self.component_types.module_types = self.module_types.finish();
+        self.component_types
+    }
+
+    /// Finishes this list of component types and returns the finished
     /// structure and the [`TypeComponentIndex`] corresponding to top-level component
     /// with `imports` and `exports` specified.
     pub fn finish<'a>(


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

As referenced in [this PR](https://github.com/bytecodealliance/jco/pull/368), the [addition of component type reflection support](https://github.com/bytecodealliance/wasmtime/pull/7804) breaks jco's current dependence on `wasmtime-environ`, and since jco doesn't leverage an `Engine`, I'm not immediately aware of a good way to adapt jco.  So this PR just does the simple thing and reintroduces the old `finish` function with the new name `finish_sans_reflection`, right next to the one that was updated for reflection support, though if there's a way I'm missing to adapt jco, then this could be reconsidered.
