### PR TITLE
Refactor `wasmtime::FuncType` to hold a handle to its registered type

### DIFF
--- a/benches/call.rs
+++ b/benches/call.rs
@@ -302,9 +302,9 @@ fn wasm_to_host(c: &mut Criterion) {
 
         let mut untyped = Linker::new(&engine);
         untyped
-            .func_new("", "nop", FuncType::new([], []), |_, _, _| Ok(()))
+            .func_new("", "nop", FuncType::new(&engine, [], []), |_, _, _| Ok(()))
             .unwrap();
-        let ty = FuncType::new([ValType::I32, ValType::I64], [ValType::F32]);
+        let ty = FuncType::new(&engine, [ValType::I32, ValType::I64], [ValType::F32]);
         untyped
             .func_new(
                 "",
@@ -336,9 +336,9 @@ fn wasm_to_host(c: &mut Criterion) {
         unsafe {
             let mut unchecked = Linker::new(&engine);
             unchecked
-                .func_new_unchecked("", "nop", FuncType::new([], []), |_, _| Ok(()))
+                .func_new_unchecked("", "nop", FuncType::new(&engine, [], []), |_, _| Ok(()))
                 .unwrap();
-            let ty = FuncType::new([ValType::I32, ValType::I64], [ValType::F32]);
+            let ty = FuncType::new(&engine, [ValType::I32, ValType::I64], [ValType::F32]);
             unchecked
                 .func_new_unchecked("", "nop-params-and-results", ty, |mut caller, space| {
                     match Val::from_raw(&mut caller, space[0], ValType::I32) {

--- a/benches/trap.rs
+++ b/benches/trap.rs
@@ -187,7 +187,7 @@ fn bench_host_wasm_frames_traps(c: &mut Criterion) {
                     let mut store = Store::new(&engine, ());
                     let host_func = Func::new(
                         &mut store,
-                        FuncType::new(vec![ValType::I32], vec![]),
+                        FuncType::new(&engine, vec![ValType::I32], vec![]),
                         |mut caller, args, _results| {
                             let f = caller.get_export("f").unwrap();
                             let f = f.into_func().unwrap();

--- a/crates/c-api/src/async.rs
+++ b/crates/c-api/src/async.rs
@@ -271,7 +271,7 @@ pub unsafe extern "C" fn wasmtime_linker_define_async_func(
     data: *mut c_void,
     finalizer: Option<extern "C" fn(*mut std::ffi::c_void)>,
 ) -> Option<Box<wasmtime_error_t>> {
-    let ty = ty.ty().ty.clone();
+    let ty = ty.ty().ty(linker.linker.engine());
     let module = to_str!(module, module_len);
     let name = to_str!(name, name_len);
     let cb = c_async_callback_to_rust_fn(callback, data, finalizer);

--- a/crates/c-api/src/extern.rs
+++ b/crates/c-api/src/extern.rs
@@ -26,7 +26,9 @@ pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externtype_t> {
-    Box::new(wasm_externtype_t::from_extern_type(e.which.ty(&e.store.context())))
+    Box::new(wasm_externtype_t::from_extern_type(
+        e.which.ty(&e.store.context()),
+    ))
 }
 
 #[no_mangle]

--- a/crates/c-api/src/extern.rs
+++ b/crates/c-api/src/extern.rs
@@ -26,7 +26,7 @@ pub extern "C" fn wasm_extern_kind(e: &wasm_extern_t) -> wasm_externkind_t {
 
 #[no_mangle]
 pub unsafe extern "C" fn wasm_extern_type(e: &wasm_extern_t) -> Box<wasm_externtype_t> {
-    Box::new(wasm_externtype_t::new(e.which.ty(&e.store.context())))
+    Box::new(wasm_externtype_t::from_extern_type(e.which.ty(&e.store.context())))
 }
 
 #[no_mangle]
@@ -135,5 +135,5 @@ pub unsafe extern "C" fn wasmtime_extern_type(
     store: CStoreContext<'_>,
     e: &wasmtime_extern_t,
 ) -> Box<wasm_externtype_t> {
-    Box::new(wasm_externtype_t::new(e.to_extern().ty(store)))
+    Box::new(wasm_externtype_t::from_extern_type(e.to_extern().ty(store)))
 }

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -55,7 +55,7 @@ unsafe fn create_function(
         + Sync
         + 'static,
 ) -> Box<wasm_func_t> {
-    let ty = ty.ty().ty.clone();
+    let ty = ty.ty().ty(store.store.context().engine());
     let func = Func::new(
         store.store.context_mut(),
         ty,
@@ -228,7 +228,7 @@ pub unsafe extern "C" fn wasmtime_func_new(
     finalizer: Option<extern "C" fn(*mut std::ffi::c_void)>,
     func: &mut Func,
 ) {
-    let ty = ty.ty().ty.clone();
+    let ty = ty.ty().ty(store.engine());
     let cb = c_callback_to_rust_fn(callback, data, finalizer);
     let f = Func::new(store, ty, cb);
     *func = f;
@@ -293,7 +293,7 @@ pub unsafe extern "C" fn wasmtime_func_new_unchecked(
     finalizer: Option<extern "C" fn(*mut std::ffi::c_void)>,
     func: &mut Func,
 ) {
-    let ty = ty.ty().ty.clone();
+    let ty = ty.ty().ty(store.engine());
     let cb = c_unchecked_callback_to_rust_fn(callback, data, finalizer);
     *func = Func::new_unchecked(store, ty, cb);
 }

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn wasmtime_linker_define_func(
     data: *mut c_void,
     finalizer: Option<extern "C" fn(*mut std::ffi::c_void)>,
 ) -> Option<Box<wasmtime_error_t>> {
-    let ty = ty.ty().ty.clone();
+    let ty = ty.ty().ty(linker.linker.engine());
     let module = to_str!(module, module_len);
     let name = to_str!(name, name_len);
     let cb = crate::func::c_callback_to_rust_fn(callback, data, finalizer);
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn wasmtime_linker_define_func_unchecked(
     data: *mut c_void,
     finalizer: Option<extern "C" fn(*mut std::ffi::c_void)>,
 ) -> Option<Box<wasmtime_error_t>> {
-    let ty = ty.ty().ty.clone();
+    let ty = ty.ty().ty(linker.linker.engine());
     let module = to_str!(module, module_len);
     let name = to_str!(name, name_len);
     let cb = crate::func::c_unchecked_callback_to_rust_fn(callback, data, finalizer);

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -1,6 +1,6 @@
 use crate::{
     handle_result, wasm_byte_vec_t, wasm_engine_t, wasm_exporttype_t, wasm_exporttype_vec_t,
-    wasm_importtype_t, wasm_importtype_vec_t, wasm_store_t, wasmtime_error_t,
+    wasm_importtype_t, wasm_importtype_vec_t, wasm_store_t, wasmtime_error_t, CExternType,
 };
 use anyhow::Context;
 use std::ffi::CStr;
@@ -53,7 +53,7 @@ fn fill_exports(module: &Module, out: &mut wasm_exporttype_vec_t) {
         .map(|e| {
             Some(Box::new(wasm_exporttype_t::new(
                 e.name().to_owned(),
-                e.ty(),
+                CExternType::new(e.ty()),
             )))
         })
         .collect::<Vec<_>>();
@@ -67,7 +67,7 @@ fn fill_imports(module: &Module, out: &mut wasm_importtype_vec_t) {
             Some(Box::new(wasm_importtype_t::new(
                 i.module().to_owned(),
                 i.name().to_owned(),
-                i.ty(),
+                CExternType::new(i.ty()),
             )))
         })
         .collect::<Vec<_>>();

--- a/crates/c-api/src/types/export.rs
+++ b/crates/c-api/src/types/export.rs
@@ -1,12 +1,11 @@
-use crate::{wasm_externtype_t, wasm_name_t};
+use crate::{wasm_externtype_t, wasm_name_t, CExternType};
 use once_cell::unsync::OnceCell;
-use wasmtime::ExternType;
 
 #[repr(C)]
 #[derive(Clone)]
 pub struct wasm_exporttype_t {
     name: String,
-    ty: ExternType,
+    ty: CExternType,
     name_cache: OnceCell<wasm_name_t>,
     type_cache: OnceCell<wasm_externtype_t>,
 }
@@ -14,7 +13,7 @@ pub struct wasm_exporttype_t {
 wasmtime_c_api_macros::declare_ty!(wasm_exporttype_t);
 
 impl wasm_exporttype_t {
-    pub(crate) fn new(name: String, ty: ExternType) -> wasm_exporttype_t {
+    pub(crate) fn new(name: String, ty: CExternType) -> wasm_exporttype_t {
         wasm_exporttype_t {
             name,
             ty,
@@ -31,7 +30,7 @@ pub extern "C" fn wasm_exporttype_new(
 ) -> Option<Box<wasm_exporttype_t>> {
     let name = name.take();
     let name = String::from_utf8(name).ok()?;
-    Some(Box::new(wasm_exporttype_t::new(name, ty.ty())))
+    Some(Box::new(wasm_exporttype_t::new(name, ty.which.clone())))
 }
 
 #[no_mangle]
@@ -43,5 +42,5 @@ pub extern "C" fn wasm_exporttype_name(et: &wasm_exporttype_t) -> &wasm_name_t {
 #[no_mangle]
 pub extern "C" fn wasm_exporttype_type(et: &wasm_exporttype_t) -> &wasm_externtype_t {
     et.type_cache
-        .get_or_init(|| wasm_externtype_t::new(et.ty.clone()))
+        .get_or_init(|| wasm_externtype_t::from_cextern_type(et.ty.clone()))
 }

--- a/crates/c-api/src/types/extern.rs
+++ b/crates/c-api/src/types/extern.rs
@@ -18,6 +18,17 @@ pub(crate) enum CExternType {
     Table(CTableType),
 }
 
+impl CExternType {
+    pub(crate) fn new(ty: ExternType) -> CExternType {
+        match ty {
+            ExternType::Func(f) => CExternType::Func(CFuncType::new(f)),
+            ExternType::Global(f) => CExternType::Global(CGlobalType::new(f)),
+            ExternType::Memory(f) => CExternType::Memory(CMemoryType::new(f)),
+            ExternType::Table(f) => CExternType::Table(CTableType::new(f)),
+        }
+    }
+}
+
 pub type wasm_externkind_t = u8;
 
 pub const WASM_EXTERN_FUNC: wasm_externkind_t = 0;
@@ -26,24 +37,14 @@ pub const WASM_EXTERN_TABLE: wasm_externkind_t = 2;
 pub const WASM_EXTERN_MEMORY: wasm_externkind_t = 3;
 
 impl wasm_externtype_t {
-    pub(crate) fn new(ty: ExternType) -> wasm_externtype_t {
+    pub(crate) fn from_extern_type(ty: ExternType) -> wasm_externtype_t {
         wasm_externtype_t {
-            which: match ty {
-                ExternType::Func(f) => CExternType::Func(CFuncType::new(f)),
-                ExternType::Global(f) => CExternType::Global(CGlobalType::new(f)),
-                ExternType::Memory(f) => CExternType::Memory(CMemoryType::new(f)),
-                ExternType::Table(f) => CExternType::Table(CTableType::new(f)),
-            },
+            which: CExternType::new(ty),
         }
     }
 
-    pub(crate) fn ty(&self) -> ExternType {
-        match &self.which {
-            CExternType::Func(f) => ExternType::Func(f.ty.clone()),
-            CExternType::Table(f) => ExternType::Table(f.ty.clone()),
-            CExternType::Global(f) => ExternType::Global(f.ty.clone()),
-            CExternType::Memory(f) => ExternType::Memory(f.ty.clone()),
-        }
+    pub(crate) fn from_cextern_type(ty: CExternType) -> wasm_externtype_t {
+        wasm_externtype_t { which: ty }
     }
 }
 

--- a/crates/c-api/src/types/func.rs
+++ b/crates/c-api/src/types/func.rs
@@ -1,6 +1,10 @@
 use crate::{wasm_externtype_t, wasm_valtype_t, wasm_valtype_vec_t, CExternType};
 use once_cell::unsync::OnceCell;
-use wasmtime::FuncType;
+use std::{
+    mem,
+    sync::{Arc, Mutex},
+};
+use wasmtime::{Engine, FuncType, ValType};
 
 #[repr(transparent)]
 #[derive(Clone)]
@@ -11,8 +15,74 @@ pub struct wasm_functype_t {
 wasmtime_c_api_macros::declare_ty!(wasm_functype_t);
 
 #[derive(Clone)]
+enum LazyFuncType {
+    Lazy {
+        params: Vec<ValType>,
+        results: Vec<ValType>,
+    },
+    FuncType(FuncType),
+}
+
+impl LazyFuncType {
+    pub(crate) fn force(&mut self, engine: &Engine) -> FuncType {
+        match self {
+            LazyFuncType::FuncType(ty) => ty.clone(),
+            LazyFuncType::Lazy { params, results } => {
+                let params = mem::take(params);
+                let results = mem::take(results);
+                let ty = FuncType::new(engine, params, results);
+                *self = LazyFuncType::FuncType(ty.clone());
+                ty
+            }
+        }
+    }
+
+    fn params(&self) -> impl ExactSizeIterator<Item = ValType> + '_ {
+        match self {
+            LazyFuncType::Lazy { params, .. } => LazyFuncTypeIter::Lazy(params.iter()),
+            LazyFuncType::FuncType(f) => LazyFuncTypeIter::FuncType(f.params()),
+        }
+    }
+
+    fn results(&self) -> impl ExactSizeIterator<Item = ValType> + '_ {
+        match self {
+            LazyFuncType::Lazy { results, .. } => LazyFuncTypeIter::Lazy(results.iter()),
+            LazyFuncType::FuncType(f) => LazyFuncTypeIter::FuncType(f.results()),
+        }
+    }
+}
+
+enum LazyFuncTypeIter<'a, T> {
+    Lazy(std::slice::Iter<'a, ValType>),
+    FuncType(T),
+}
+
+impl<'a, T> Iterator for LazyFuncTypeIter<'a, T>
+where
+    T: Iterator<Item = ValType>,
+{
+    type Item = ValType;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            LazyFuncTypeIter::FuncType(i) => i.next(),
+            LazyFuncTypeIter::Lazy(i) => i.next().cloned(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            LazyFuncTypeIter::FuncType(i) => i.size_hint(),
+            LazyFuncTypeIter::Lazy(i) => i.size_hint(),
+        }
+    }
+}
+
+impl<'a, T> ExactSizeIterator for LazyFuncTypeIter<'a, T> where T: ExactSizeIterator<Item = ValType> {}
+
+#[derive(Clone)]
 pub(crate) struct CFuncType {
-    pub(crate) ty: FuncType,
+    ty: Arc<Mutex<LazyFuncType>>,
     params_cache: OnceCell<wasm_valtype_vec_t>,
     returns_cache: OnceCell<wasm_valtype_vec_t>,
 }
@@ -20,7 +90,15 @@ pub(crate) struct CFuncType {
 impl wasm_functype_t {
     pub(crate) fn new(ty: FuncType) -> wasm_functype_t {
         wasm_functype_t {
-            ext: wasm_externtype_t::new(ty.into()),
+            ext: wasm_externtype_t::from_extern_type(ty.into()),
+        }
+    }
+
+    pub(crate) fn lazy(params: Vec<ValType>, results: Vec<ValType>) -> wasm_functype_t {
+        wasm_functype_t {
+            ext: wasm_externtype_t::from_cextern_type(CExternType::Func(CFuncType::lazy(
+                params, results,
+            ))),
         }
     }
 
@@ -42,10 +120,23 @@ impl wasm_functype_t {
 impl CFuncType {
     pub(crate) fn new(ty: FuncType) -> CFuncType {
         CFuncType {
-            ty,
+            ty: Arc::new(Mutex::new(LazyFuncType::FuncType(ty))),
             params_cache: OnceCell::new(),
             returns_cache: OnceCell::new(),
         }
+    }
+
+    pub(crate) fn lazy(params: Vec<ValType>, results: Vec<ValType>) -> CFuncType {
+        CFuncType {
+            ty: Arc::new(Mutex::new(LazyFuncType::Lazy { params, results })),
+            params_cache: OnceCell::new(),
+            returns_cache: OnceCell::new(),
+        }
+    }
+
+    pub(crate) fn ty(&self, engine: &Engine) -> FuncType {
+        let mut ty = self.ty.lock().unwrap();
+        ty.force(engine)
     }
 }
 
@@ -54,18 +145,25 @@ pub extern "C" fn wasm_functype_new(
     params: &mut wasm_valtype_vec_t,
     results: &mut wasm_valtype_vec_t,
 ) -> Box<wasm_functype_t> {
-    let params = params.take().into_iter().map(|vt| vt.unwrap().ty.clone());
-    let results = results.take().into_iter().map(|vt| vt.unwrap().ty.clone());
-    let functype = FuncType::new(params, results);
-    Box::new(wasm_functype_t::new(functype))
+    let params = params
+        .take()
+        .into_iter()
+        .map(|vt| vt.unwrap().ty.clone())
+        .collect();
+    let results = results
+        .take()
+        .into_iter()
+        .map(|vt| vt.unwrap().ty.clone())
+        .collect();
+    Box::new(wasm_functype_t::lazy(params, results))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     let ft = ft.ty();
     ft.params_cache.get_or_init(|| {
-        ft.ty
-            .params()
+        let ty = ft.ty.lock().unwrap();
+        ty.params()
             .map(|p| Some(Box::new(wasm_valtype_t { ty: p.clone() })))
             .collect::<Vec<_>>()
             .into()
@@ -76,8 +174,8 @@ pub extern "C" fn wasm_functype_params(ft: &wasm_functype_t) -> &wasm_valtype_ve
 pub extern "C" fn wasm_functype_results(ft: &wasm_functype_t) -> &wasm_valtype_vec_t {
     let ft = ft.ty();
     ft.returns_cache.get_or_init(|| {
-        ft.ty
-            .results()
+        let ty = ft.ty.lock().unwrap();
+        ty.results()
             .map(|p| Some(Box::new(wasm_valtype_t { ty: p.clone() })))
             .collect::<Vec<_>>()
             .into()

--- a/crates/c-api/src/types/global.rs
+++ b/crates/c-api/src/types/global.rs
@@ -24,7 +24,7 @@ pub(crate) struct CGlobalType {
 impl wasm_globaltype_t {
     pub(crate) fn new(ty: GlobalType) -> wasm_globaltype_t {
         wasm_globaltype_t {
-            ext: wasm_externtype_t::new(ty.into()),
+            ext: wasm_externtype_t::from_extern_type(ty.into()),
         }
     }
 

--- a/crates/c-api/src/types/import.rs
+++ b/crates/c-api/src/types/import.rs
@@ -1,13 +1,12 @@
-use crate::{wasm_externtype_t, wasm_name_t};
+use crate::{wasm_externtype_t, wasm_name_t, CExternType};
 use once_cell::unsync::OnceCell;
-use wasmtime::ExternType;
 
 #[repr(C)]
 #[derive(Clone)]
 pub struct wasm_importtype_t {
     pub(crate) module: String,
     pub(crate) name: String,
-    pub(crate) ty: ExternType,
+    pub(crate) ty: CExternType,
     module_cache: OnceCell<wasm_name_t>,
     name_cache: OnceCell<wasm_name_t>,
     type_cache: OnceCell<wasm_externtype_t>,
@@ -16,7 +15,7 @@ pub struct wasm_importtype_t {
 wasmtime_c_api_macros::declare_ty!(wasm_importtype_t);
 
 impl wasm_importtype_t {
-    pub(crate) fn new(module: String, name: String, ty: ExternType) -> wasm_importtype_t {
+    pub(crate) fn new(module: String, name: String, ty: CExternType) -> wasm_importtype_t {
         wasm_importtype_t {
             module,
             name,
@@ -38,7 +37,11 @@ pub extern "C" fn wasm_importtype_new(
     let name = name.take();
     let module = String::from_utf8(module).ok()?;
     let name = String::from_utf8(name).ok()?;
-    Some(Box::new(wasm_importtype_t::new(module, name, ty.ty())))
+    Some(Box::new(wasm_importtype_t::new(
+        module,
+        name,
+        ty.which.clone(),
+    )))
 }
 
 #[no_mangle]
@@ -56,5 +59,5 @@ pub extern "C" fn wasm_importtype_name(it: &wasm_importtype_t) -> &wasm_name_t {
 #[no_mangle]
 pub extern "C" fn wasm_importtype_type(it: &wasm_importtype_t) -> &wasm_externtype_t {
     it.type_cache
-        .get_or_init(|| wasm_externtype_t::new(it.ty.clone()))
+        .get_or_init(|| wasm_externtype_t::from_cextern_type(it.ty.clone()))
 }

--- a/crates/c-api/src/types/memory.rs
+++ b/crates/c-api/src/types/memory.rs
@@ -20,7 +20,7 @@ pub(crate) struct CMemoryType {
 impl wasm_memorytype_t {
     pub(crate) fn new(ty: MemoryType) -> wasm_memorytype_t {
         wasm_memorytype_t {
-            ext: wasm_externtype_t::new(ty.into()),
+            ext: wasm_externtype_t::from_extern_type(ty.into()),
         }
     }
 

--- a/crates/c-api/src/types/table.rs
+++ b/crates/c-api/src/types/table.rs
@@ -20,7 +20,7 @@ pub(crate) struct CTableType {
 impl wasm_tabletype_t {
     pub(crate) fn new(ty: TableType) -> wasm_tabletype_t {
         wasm_tabletype_t {
-            ext: wasm_externtype_t::new(ty.into()),
+            ext: wasm_externtype_t::from_extern_type(ty.into()),
         }
     }
 

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -114,7 +114,7 @@ mod tests {
     #[test]
     fn dummy_function_import() {
         let mut store = store();
-        let func_ty = FuncType::new(vec![ValType::I32], vec![ValType::I64]);
+        let func_ty = FuncType::new(store.engine(), vec![ValType::I32], vec![ValType::I64]);
         let func = dummy_func(&mut store, func_ty.clone());
         assert_eq!(func.ty(&store), func_ty);
     }

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1,4 +1,5 @@
 use crate::store::{StoreData, StoreOpaque, Stored};
+use crate::type_registry::RegisteredType;
 use crate::{
     AsContext, AsContextMut, CallHook, Engine, Extern, FuncType, Instance, Module, StoreContext,
     StoreContextMut, Val, ValRaw, ValType,
@@ -147,6 +148,7 @@ use wasmtime_runtime::{
 /// // Here we need to define the type signature of our `Double` function and
 /// // then wrap it up in a `Func`
 /// let double_type = wasmtime::FuncType::new(
+///     store.engine(),
 ///     [wasmtime::ValType::I32].iter().cloned(),
 ///     [wasmtime::ValType::I32].iter().cloned(),
 /// );
@@ -458,6 +460,7 @@ impl Func {
     ///     // ...
     /// });
     /// let get_row_count_type = wasmtime::FuncType::new(
+    ///     &engine,
     ///     None,
     ///     Some(wasmtime::ValType::I32),
     /// );
@@ -767,13 +770,7 @@ impl Func {
     /// Note that this is a somewhat expensive method since it requires taking a
     /// lock as well as cloning a type.
     fn load_ty(&self, store: &StoreOpaque) -> FuncType {
-        FuncType::from_wasm_func_type(
-            store
-                .engine()
-                .signatures()
-                .lookup_type(self.sig_index(store.store_data()))
-                .expect("signature should be registered"),
-        )
+        FuncType::from_shared_type_index(store.engine(), self.type_index(store.store_data()))
     }
 
     /// Gets a reference to the `FuncType` for this function.
@@ -794,7 +791,7 @@ impl Func {
         (store.store_data()[self.0].ty.as_ref().unwrap(), store)
     }
 
-    pub(crate) fn sig_index(&self, data: &StoreData) -> VMSharedTypeIndex {
+    pub(crate) fn type_index(&self, data: &StoreData) -> VMSharedTypeIndex {
         data[self.0].sig_index()
     }
 
@@ -1134,7 +1131,7 @@ impl Func {
                     // trampoline.
                     let _ = VMNativeCallHostFuncContext::from_opaque(f.as_ref().vmctx);
 
-                    let sig = self.sig_index(store.store_data());
+                    let sig = self.type_index(store.store_data());
                     module.runtime_info().wasm_to_native_trampoline(sig).expect(
                         "must have a wasm-to-native trampoline for this signature if the Wasm \
                          module is importing a function of this signature",
@@ -1488,7 +1485,7 @@ pub unsafe trait WasmRet {
     ) -> Result<Self::Abi>;
 
     #[doc(hidden)]
-    fn func_type(params: impl Iterator<Item = ValType>) -> FuncType;
+    fn func_type(engine: &Engine, params: impl Iterator<Item = ValType>) -> FuncType;
 
     #[doc(hidden)]
     unsafe fn wrap_trampoline(ptr: *mut ValRaw, f: impl FnOnce(Self::Retptr) -> Self::Abi);
@@ -1520,8 +1517,8 @@ where
         Ok(<Self as WasmTy>::into_abi(self, store))
     }
 
-    fn func_type(params: impl Iterator<Item = ValType>) -> FuncType {
-        FuncType::new(params, Some(<Self as WasmTy>::valtype()))
+    fn func_type(engine: &Engine, params: impl Iterator<Item = ValType>) -> FuncType {
+        FuncType::new(engine, params, Some(<Self as WasmTy>::valtype()))
     }
 
     unsafe fn wrap_trampoline(ptr: *mut ValRaw, f: impl FnOnce(Self::Retptr) -> Self::Abi) {
@@ -1560,8 +1557,8 @@ where
         self.and_then(|val| val.into_abi_for_ret(store, retptr))
     }
 
-    fn func_type(params: impl Iterator<Item = ValType>) -> FuncType {
-        T::func_type(params)
+    fn func_type(engine: &Engine, params: impl Iterator<Item = ValType>) -> FuncType {
+        T::func_type(engine, params)
     }
 
     unsafe fn wrap_trampoline(ptr: *mut ValRaw, f: impl FnOnce(Self::Retptr) -> Self::Abi) {
@@ -1602,8 +1599,9 @@ macro_rules! impl_wasm_host_results {
                 Ok(<($($t::Abi,)*) as HostAbi>::into_abi(abi, ptr))
             }
 
-            fn func_type(params: impl Iterator<Item = ValType>) -> FuncType {
+            fn func_type(engine: &Engine, params: impl Iterator<Item = ValType>) -> FuncType {
                 FuncType::new(
+                    engine,
                     params,
                     IntoIterator::into_iter([$($t::valtype(),)*]),
                 )
@@ -1893,6 +1891,17 @@ impl<T> AsContextMut for Caller<'_, T> {
     }
 }
 
+// State stored inside a `VMNativeCallHostFuncContext`.
+struct HostFuncState<F> {
+    // The actual host function.
+    func: F,
+
+    // NB: We have to keep our `VMSharedTypeIndex` registered in the engine for
+    // as long as this function exists.
+    #[allow(dead_code)]
+    ty: RegisteredType,
+}
+
 macro_rules! impl_into_func {
     ($num:tt $($args:ident)*) => {
         // Implement for functions without a leading `&Caller` parameter,
@@ -1961,8 +1970,9 @@ macro_rules! impl_into_func {
                         // Double-check ourselves in debug mode, but we control
                         // the `Any` here so an unsafe downcast should also
                         // work.
-                        debug_assert!(state.is::<F>());
-                        let func = &*(state as *const _ as *const F);
+                        debug_assert!(state.is::<HostFuncState<F>>());
+                        let state = &*(state as *const _ as *const HostFuncState<F>);
+                        let func = &state.func;
 
                         let ret = {
                             panic::catch_unwind(AssertUnwindSafe(|| {
@@ -2045,11 +2055,11 @@ macro_rules! impl_into_func {
                 }
 
                 let ty = R::func_type(
+                    engine,
                     None::<ValType>.into_iter()
                         $(.chain(Some($args::valtype())))*
                 );
-
-                let shared_signature_id = engine.signatures().register(ty.as_wasm_func_type());
+                let type_index = ty.type_index();
 
                 let array_call = array_call_trampoline::<T, F, $($args,)* R>;
                 let native_call = NonNull::new(native_call_shim::<T, F, $($args,)* R> as *mut _).unwrap();
@@ -2060,10 +2070,13 @@ macro_rules! impl_into_func {
                             native_call,
                             array_call,
                             wasm_call: None,
-                            type_index: shared_signature_id,
+                            type_index,
                             vmctx: ptr::null_mut(),
                         },
-                        Box::new(self),
+                        Box::new(HostFuncState {
+                            func: self,
+                            ty: ty.into_registered_type(),
+                        }),
                     )
                 };
 
@@ -2252,14 +2265,6 @@ impl HostFunc {
     fn export_func(&self) -> ExportFunction {
         ExportFunction {
             func_ref: NonNull::from(self.func_ref()),
-        }
-    }
-}
-
-impl Drop for HostFunc {
-    fn drop(&mut self) {
-        unsafe {
-            self.engine.signatures().unregister(self.sig_index());
         }
     }
 }

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -190,13 +190,7 @@ where
 
     /// Purely a debug-mode assertion, not actually used in release builds.
     fn debug_typecheck(store: &StoreOpaque, func: VMSharedTypeIndex) {
-        let ty = FuncType::from_wasm_func_type(
-            store
-                .engine()
-                .signatures()
-                .lookup_type(func)
-                .expect("signature should be registered"),
-        );
+        let ty = FuncType::from_shared_type_index(store.engine(), func);
         Params::typecheck(ty.params()).expect("params should match");
         Results::typecheck(ty.results()).expect("results should match");
     }

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -1366,7 +1366,7 @@ impl DefinitionType {
     pub(crate) fn from(store: &StoreOpaque, item: &Extern) -> DefinitionType {
         let data = store.store_data();
         match item {
-            Extern::Func(f) => DefinitionType::Func(f.sig_index(data)),
+            Extern::Func(f) => DefinitionType::Func(f.type_index(data)),
             Extern::Table(t) => DefinitionType::Table(*t.wasmtime_ty(data), t.internal_size(store)),
             Extern::Global(t) => DefinitionType::Global(*t.wasmtime_ty(data)),
             Extern::Memory(t) => {

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -736,9 +736,10 @@ impl Module {
     ) -> impl ExactSizeIterator<Item = ImportType<'module>> + 'module {
         let module = self.compiled_module().module();
         let types = self.types();
+        let engine = self.engine();
         module
             .imports()
-            .map(move |(module, field, ty)| ImportType::new(module, field, ty, types))
+            .map(move |(module, field, ty)| ImportType::new(module, field, ty, types, engine))
             .collect::<Vec<_>>()
             .into_iter()
     }
@@ -802,8 +803,9 @@ impl Module {
     ) -> impl ExactSizeIterator<Item = ExportType<'module>> + 'module {
         let module = self.compiled_module().module();
         let types = self.types();
+        let engine = self.engine();
         module.exports.iter().map(move |(name, entity_index)| {
-            ExportType::new(name, module.type_of(*entity_index), types)
+            ExportType::new(name, module.type_of(*entity_index), types, engine)
         })
     }
 
@@ -854,6 +856,7 @@ impl Module {
         let module = self.compiled_module().module();
         let entity_index = module.exports.get(name)?;
         Some(ExternType::from_wasmtime(
+            self.engine(),
             self.types(),
             &module.type_of(*entity_index),
         ))

--- a/crates/wasmtime/src/runtime/trampoline/func.rs
+++ b/crates/wasmtime/src/runtime/trampoline/func.rs
@@ -1,5 +1,6 @@
 //! Support for a calling of an imported function.
 
+use crate::type_registry::RegisteredType;
 use crate::{code_memory::CodeMemory, Engine, FuncType, ValRaw};
 use anyhow::Result;
 use std::panic::{self, AssertUnwindSafe};
@@ -12,6 +13,10 @@ struct TrampolineState<F> {
     func: F,
     #[allow(dead_code)]
     code_memory: CodeMemory,
+
+    // Need to keep our `VMSharedTypeIndex` registered in the engine.
+    #[allow(dead_code)]
+    sig: RegisteredType,
 }
 
 /// Shim to call a host-defined function that uses the array calling convention.
@@ -126,10 +131,14 @@ where
                 array_call,
                 wasm_call,
                 native_call,
-                type_index: sig,
+                type_index: sig.index(),
                 vmctx: ptr::null_mut(),
             },
-            Box::new(TrampolineState { func, code_memory }),
+            Box::new(TrampolineState {
+                func,
+                code_memory,
+                sig,
+            }),
         ))
     }
 }

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -30,7 +30,7 @@ impl MatchCx<'_> {
         }
         let msg = "function types incompatible";
         let expected = &self.types[expected];
-        let actual = match self.engine.signatures().lookup_type(actual) {
+        let actual = match self.engine.signatures().borrow(actual) {
             Some(ty) => ty,
             None => {
                 debug_assert!(false, "all signatures should be registered");

--- a/tests/all/call_hook.rs
+++ b/tests/all/call_hook.rs
@@ -32,9 +32,14 @@ fn call_wrapped_func() -> Result<(), Error> {
             assert_eq!(d, 4.0);
         },
     ));
+    let func_ty = FuncType::new(
+        store.engine(),
+        [ValType::I32, ValType::I64, ValType::F32, ValType::F64],
+        [],
+    );
     funcs.push(Func::new(
         &mut store,
-        FuncType::new([ValType::I32, ValType::I64, ValType::F32, ValType::F64], []),
+        func_ty,
         |caller: Caller<State>, params, results| {
             verify(caller.data());
 
@@ -47,20 +52,21 @@ fn call_wrapped_func() -> Result<(), Error> {
             Ok(())
         },
     ));
+    let func_ty = FuncType::new(
+        store.engine(),
+        [ValType::I32, ValType::I64, ValType::F32, ValType::F64],
+        [],
+    );
     funcs.push(unsafe {
-        Func::new_unchecked(
-            &mut store,
-            FuncType::new([ValType::I32, ValType::I64, ValType::F32, ValType::F64], []),
-            |caller: Caller<State>, space| {
-                verify(caller.data());
+        Func::new_unchecked(&mut store, func_ty, |caller: Caller<State>, space| {
+            verify(caller.data());
 
-                assert_eq!(space[0].get_i32(), 1i32);
-                assert_eq!(space[1].get_i64(), 2i64);
-                assert_eq!(space[2].get_f32(), 3.0f32.to_bits());
-                assert_eq!(space[3].get_f64(), 4.0f64.to_bits());
-                Ok(())
-            },
-        )
+            assert_eq!(space[0].get_i32(), 1i32);
+            assert_eq!(space[1].get_i64(), 2i64);
+            assert_eq!(space[2].get_f32(), 3.0f32.to_bits());
+            assert_eq!(space[3].get_f64(), 4.0f64.to_bits());
+            Ok(())
+        })
     });
 
     let mut n = 0;

--- a/tests/all/component_model/dynamic.rs
+++ b/tests/all/component_model/dynamic.rs
@@ -684,7 +684,7 @@ fn introspection() -> Result<()> {
 
     let component_ty = linker.substituted_component_type(&component)?;
 
-    let mut imports = component_ty.imports();
+    let mut imports = component_ty.imports(linker.engine());
     assert_eq!(imports.len(), 3);
     let (name, res_ty) = imports.next().unwrap();
     assert_eq!(name, "res");
@@ -698,24 +698,24 @@ fn introspection() -> Result<()> {
     let ComponentItem::ComponentInstance(ai_ty) = ai_ty else {
         panic!("`ai` import item of wrong type")
     };
-    assert_eq!(ai_ty.exports().len(), 0);
+    assert_eq!(ai_ty.exports(linker.engine()).len(), 0);
 
     let (name, bi_ty) = imports.next().unwrap();
     assert_eq!(name, "bi");
     let ComponentItem::ComponentInstance(bi_ty) = bi_ty else {
         panic!("`bi` import item of wrong type")
     };
-    let mut bi_exports = bi_ty.exports();
+    let mut bi_exports = bi_ty.exports(linker.engine());
     assert_eq!(bi_exports.len(), 1);
     let (name, bi_m_ty) = bi_exports.next().unwrap();
     assert_eq!(name, "m");
     let ComponentItem::Module(bi_m_ty) = bi_m_ty else {
         panic!("`bi.m` import item of wrong type")
     };
-    assert_eq!(bi_m_ty.imports().len(), 0);
-    assert_eq!(bi_m_ty.exports().len(), 0);
+    assert_eq!(bi_m_ty.imports(linker.engine()).len(), 0);
+    assert_eq!(bi_m_ty.exports(linker.engine()).len(), 0);
 
-    let mut exports = component_ty.exports();
+    let mut exports = component_ty.exports(linker.engine());
     assert_eq!(exports.len(), 11);
 
     let (name, run_ty) = exports.next().unwrap();
@@ -734,44 +734,44 @@ fn introspection() -> Result<()> {
     let ComponentItem::ComponentInstance(i_ty) = i_ty else {
         panic!("`i` export item of wrong type")
     };
-    let mut i_ty_exports = i_ty.exports();
+    let mut i_ty_exports = i_ty.exports(linker.engine());
     assert_eq!(i_ty_exports.len(), 1);
     let (name, i_i_ty) = i_ty_exports.next().unwrap();
     assert_eq!(name, "i");
     let ComponentItem::ComponentInstance(i_i_ty) = i_i_ty else {
         panic!("`i.i` import item of wrong type")
     };
-    let mut i_i_ty_exports = i_i_ty.exports();
+    let mut i_i_ty_exports = i_i_ty.exports(linker.engine());
     assert_eq!(i_i_ty_exports.len(), 1);
     let (name, i_i_m_ty) = i_i_ty_exports.next().unwrap();
     assert_eq!(name, "m");
     let ComponentItem::Module(i_i_m_ty) = i_i_m_ty else {
         panic!("`i.i.m` import item of wrong type")
     };
-    assert_eq!(i_i_m_ty.imports().len(), 0);
-    assert_eq!(i_i_m_ty.exports().len(), 0);
+    assert_eq!(i_i_m_ty.imports(linker.engine()).len(), 0);
+    assert_eq!(i_i_m_ty.exports(linker.engine()).len(), 0);
 
     let (name, r_ty) = exports.next().unwrap();
     assert_eq!(name, "r");
     let ComponentItem::ComponentInstance(r_ty) = r_ty else {
         panic!("`r` export item of wrong type")
     };
-    assert_eq!(r_ty.exports().len(), 0);
+    assert_eq!(r_ty.exports(linker.engine()).len(), 0);
 
     let (name, r2_ty) = exports.next().unwrap();
     assert_eq!(name, "r2");
     let ComponentItem::ComponentInstance(r2_ty) = r2_ty else {
         panic!("`r2` export item of wrong type")
     };
-    let mut r2_exports = r2_ty.exports();
+    let mut r2_exports = r2_ty.exports(linker.engine());
     assert_eq!(r2_exports.len(), 1);
     let (name, r2_m_ty) = r2_exports.next().unwrap();
     assert_eq!(name, "m");
     let ComponentItem::Module(r2_m_ty) = r2_m_ty else {
         panic!("`r2.m` export item of wrong type")
     };
-    assert_eq!(r2_m_ty.imports().len(), 0);
-    assert_eq!(r2_m_ty.exports().len(), 0);
+    assert_eq!(r2_m_ty.imports(linker.engine()).len(), 0);
+    assert_eq!(r2_m_ty.exports(linker.engine()).len(), 0);
 
     let (name, b_ty) = exports.next().unwrap();
     assert_eq!(name, "b");

--- a/tests/all/coredump.rs
+++ b/tests/all/coredump.rs
@@ -17,7 +17,7 @@ fn coredump_attached_to_error() -> Result<()> {
     "#;
 
     let module = Module::new(store.engine(), wat)?;
-    let hello_type = FuncType::new(None, None);
+    let hello_type = FuncType::new(store.engine(), None, None);
     let hello_func = Func::new(&mut store, hello_type, |_, _, _| bail!("test 123"));
 
     let instance = Instance::new(&mut store, &module, &[hello_func.into()])?;

--- a/tests/all/epoch_interruption.rs
+++ b/tests/all/epoch_interruption.rs
@@ -21,7 +21,7 @@ fn make_env<T>(engine: &Engine) -> Linker<T> {
         .func_new(
             "",
             "bump_epoch",
-            FuncType::new(None, None),
+            FuncType::new(&engine, None, None),
             move |_caller, _params, _results| {
                 engine.increment_epoch();
                 Ok(())
@@ -418,7 +418,7 @@ async fn drop_future_on_epoch_yield() {
         .func_new(
             "",
             "oops",
-            FuncType::new(None, None),
+            FuncType::new(&engine, None, None),
             move |_caller, _params, _results| {
                 panic!("Should not have reached this point!");
             },
@@ -428,7 +428,7 @@ async fn drop_future_on_epoch_yield() {
         .func_new(
             "",
             "im_alive",
-            FuncType::new(None, None),
+            FuncType::new(&engine, None, None),
             move |_caller, _params, _results| {
                 alive_flag_clone.store(true, Ordering::Release);
                 Ok(())

--- a/tests/all/funcref.rs
+++ b/tests/all/funcref.rs
@@ -141,14 +141,11 @@ fn func_new_returns_wrong_store() -> anyhow::Result<()> {
         let f1 = Func::wrap(&mut store1, move || {
             let _ = &set;
         });
-        let f2 = Func::new(
-            &mut store2,
-            FuncType::new(None, Some(ValType::FuncRef)),
-            move |_, _, results| {
-                results[0] = f1.clone().into();
-                Ok(())
-            },
-        );
+        let func_ty = FuncType::new(store2.engine(), None, Some(ValType::FuncRef));
+        let f2 = Func::new(&mut store2, func_ty, move |_, _, results| {
+            results[0] = f1.clone().into();
+            Ok(())
+        });
         assert!(f2.call(&mut store2, &[], &mut [Val::I32(0)]).is_err());
     }
     assert!(dropped.load(SeqCst));

--- a/tests/all/host_funcs.rs
+++ b/tests/all/host_funcs.rs
@@ -12,7 +12,7 @@ fn async_required() {
     drop(linker.func_new_async(
         "",
         "",
-        FuncType::new(None, None),
+        FuncType::new(&engine, None, None),
         move |_caller, _params, _results| Box::new(async { Ok(()) }),
     ));
 }
@@ -493,10 +493,10 @@ fn new_from_signature() -> Result<()> {
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);
 
-    let ty = FuncType::new(None, None);
+    let ty = FuncType::new(&engine, None, None);
     linker.func_new("", "f1", ty, |_, _, _| panic!())?;
 
-    let ty = FuncType::new(Some(ValType::I32), Some(ValType::F64));
+    let ty = FuncType::new(&engine, Some(ValType::I32), Some(ValType::F64));
     linker.func_new("", "f2", ty, |_, _, _| panic!())?;
 
     let mut store = Store::new(&engine, ());
@@ -603,7 +603,7 @@ fn call_wrapped_func() -> Result<()> {
 fn func_return_nothing() -> Result<()> {
     let engine = Engine::default();
     let mut linker = Linker::new(&engine);
-    let ty = FuncType::new(None, Some(ValType::I32));
+    let ty = FuncType::new(&engine, None, Some(ValType::I32));
     linker.func_new("", "", ty, |_, _, _| Ok(()))?;
 
     let mut store = Store::new(&engine, ());

--- a/tests/all/import_indexes.rs
+++ b/tests/all/import_indexes.rs
@@ -17,12 +17,13 @@ fn same_import_names_still_distinct() -> anyhow::Result<()> {
     "#;
 
     let mut store = Store::<()>::default();
-    let module = Module::new(store.engine(), WAT)?;
+    let engine = store.engine().clone();
+    let module = Module::new(&engine, WAT)?;
 
     let imports = [
         Func::new(
             &mut store,
-            FuncType::new(None, Some(ValType::I32)),
+            FuncType::new(&engine, None, Some(ValType::I32)),
             |_, params, results| {
                 assert!(params.is_empty());
                 assert_eq!(results.len(), 1);
@@ -33,7 +34,7 @@ fn same_import_names_still_distinct() -> anyhow::Result<()> {
         .into(),
         Func::new(
             &mut store,
-            FuncType::new(None, Some(ValType::F32)),
+            FuncType::new(&engine, None, Some(ValType::F32)),
             |_, params, results| {
                 assert!(params.is_empty());
                 assert_eq!(results.len(), 1);

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -966,7 +966,7 @@ async fn total_stacks_limit() -> Result<()> {
     linker.func_new_async(
         "async",
         "yield",
-        FuncType::new([], []),
+        FuncType::new(&engine, [], []),
         |_caller, _params, _results| {
             Box::new(async {
                 tokio::task::yield_now().await;

--- a/tests/all/stack_creator.rs
+++ b/tests/all/stack_creator.rs
@@ -135,7 +135,7 @@ async fn called_on_custom_heap_stack() -> Result<()> {
         "#,
     )?;
 
-    let ty = FuncType::new([], [ValType::I64]);
+    let ty = FuncType::new(store.engine(), [], [ValType::I64]);
     let host_func = Func::new(&mut store, ty, move |_caller, _params, results| {
         let foo = 42;
         // output an address on the stack


### PR DESCRIPTION
Rather than holding a copy of the type directly, it now holds a `RegisteredType` which internally is

* A `VMSharedTypeIndex` pointing into the engine's types registry.
* An `Arc` handle to the engine's type registry.
* An `Arc` handle to the actual type.

The last exists only to keep it so that accessing a `wasmtime::FuncType`'s parameters and results fast, avoiding any new locking on call hot paths.

This is helping set the stage for further types and `TypeRegistry` refactors needed for Wasm GC.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
