### PR TITLE
wasi-sockets: (TCP) Use tokio's built in methods to perform the state changes

### DIFF
--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -487,11 +487,12 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get_mut(&this)?;
-        let view = &*socket.as_std_view()?;
-
         let duration = Duration::from_nanos(value);
+        {
+            let view = &*socket.as_std_view()?;
 
-        util::set_tcp_keepidle(view, duration)?;
+            util::set_tcp_keepidle(view, duration)?;
+        }
 
         #[cfg(target_os = "macos")]
         {
@@ -553,11 +554,13 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     fn set_hop_limit(&mut self, this: Resource<tcp::TcpSocket>, value: u8) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get_mut(&this)?;
-        let view = &*socket.as_std_view()?;
+        {
+            let view = &*socket.as_std_view()?;
 
-        match socket.family {
-            SocketAddressFamily::Ipv4 => util::set_ip_ttl(view, value)?,
-            SocketAddressFamily::Ipv6 => util::set_ipv6_unicast_hops(view, value)?,
+            match socket.family {
+                SocketAddressFamily::Ipv4 => util::set_ip_ttl(view, value)?,
+                SocketAddressFamily::Ipv6 => util::set_ipv6_unicast_hops(view, value)?,
+            }
         }
 
         #[cfg(target_os = "macos")]
@@ -584,10 +587,12 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get_mut(&this)?;
-        let view = &*socket.as_std_view()?;
         let value = value.try_into().unwrap_or(usize::MAX);
+        {
+            let view = &*socket.as_std_view()?;
 
-        util::set_socket_recv_buffer_size(view, value)?;
+            util::set_socket_recv_buffer_size(view, value)?;
+        }
 
         #[cfg(target_os = "macos")]
         {
@@ -613,10 +618,12 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get_mut(&this)?;
-        let view = &*socket.as_std_view()?;
         let value = value.try_into().unwrap_or(usize::MAX);
+        {
+            let view = &*socket.as_std_view()?;
 
-        util::set_socket_send_buffer_size(view, value)?;
+            util::set_socket_send_buffer_size(view, value)?;
+        }
 
         #[cfg(target_os = "macos")]
         {

--- a/crates/wasi/src/preview2/host/tcp.rs
+++ b/crates/wasi/src/preview2/host/tcp.rs
@@ -1,6 +1,6 @@
 use crate::preview2::host::network::util;
 use crate::preview2::network::SocketAddrUse;
-use crate::preview2::tcp::{TcpSocket, TcpState};
+use crate::preview2::tcp::{TcpReadStream, TcpSocket, TcpState, TcpWriteStream};
 use crate::preview2::{
     bindings::{
         io::streams::{InputStream, OutputStream},
@@ -10,13 +10,13 @@ use crate::preview2::{
     network::SocketAddressFamily,
 };
 use crate::preview2::{Pollable, SocketResult, WasiView};
-use cap_net_ext::Blocking;
 use io_lifetimes::AsSocketlike;
 use rustix::io::Errno;
 use rustix::net::sockopt;
 use std::net::SocketAddr;
+use std::sync::Arc;
+use std::task::Poll;
 use std::time::Duration;
-use tokio::io::Interest;
 use wasmtime::component::Resource;
 
 impl<T: WasiView> tcp::Host for T {}
@@ -34,11 +34,11 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         let network = table.get(&network)?;
         let local_address: SocketAddr = local_address.into();
 
-        match socket.tcp_state {
-            TcpState::Default => {}
-            TcpState::BindStarted => return Err(ErrorCode::ConcurrencyConflict.into()),
+        let tokio_socket = match &socket.tcp_state {
+            TcpState::Default(socket) => socket,
+            TcpState::BindStarted(..) => return Err(ErrorCode::ConcurrencyConflict.into()),
             _ => return Err(ErrorCode::InvalidState.into()),
-        }
+        };
 
         util::validate_unicast(&local_address)?;
         util::validate_address_family(&local_address, &socket.family)?;
@@ -54,10 +54,10 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
             // Unconditionally (re)set SO_REUSEADDR, even when the value is false.
             // This ensures we're not accidentally affected by any socket option
             // state left behind by a previous failed call to this method (start_bind).
-            util::set_tcp_reuseaddr(socket.tcp_socket(), reuse_addr)?;
+            util::set_tcp_reuseaddr(&tokio_socket, reuse_addr)?;
 
             // Perform the OS bind call.
-            util::tcp_bind(socket.tcp_socket(), &local_address).map_err(|error| match error {
+            tokio_socket.bind(local_address).map_err(|error| match Errno::from_io_error(&error) {
                 // From https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html:
                 // > [EAFNOSUPPORT] The specified address is not a valid address for the address family of the specified socket
                 //
@@ -65,13 +65,23 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
                 // been handled by our own validation slightly higher up in this
                 // function. This error mapping is here just in case there is
                 // an edge case we didn't catch.
-                Errno::AFNOSUPPORT => ErrorCode::InvalidArgument,
+                Some(Errno::AFNOSUPPORT) => ErrorCode::InvalidArgument,
+
+                // See: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-bind#:~:text=WSAENOBUFS
+                // Windows returns WSAENOBUFS when the ephemeral ports have been exhausted.
+                #[cfg(windows)]
+                Some(Errno::NOBUFS) => ErrorCode::AddressInUse,
+
                 _ => ErrorCode::from(error),
             })?;
         }
 
         let socket = table.get_mut(&this)?;
-        socket.tcp_state = TcpState::BindStarted;
+
+        socket.tcp_state = match std::mem::replace(&mut socket.tcp_state, TcpState::Closed) {
+            TcpState::Default(socket) => TcpState::BindStarted(socket),
+            _ => unreachable!(),
+        };
 
         Ok(())
     }
@@ -81,11 +91,14 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         let socket = table.get_mut(&this)?;
 
         match socket.tcp_state {
-            TcpState::BindStarted => {}
+            TcpState::BindStarted(..) => {}
             _ => return Err(ErrorCode::NotInProgress.into()),
         }
 
-        socket.tcp_state = TcpState::Bound;
+        socket.tcp_state = match std::mem::replace(&mut socket.tcp_state, TcpState::Closed) {
+            TcpState::BindStarted(socket) => TcpState::Bound(socket),
+            _ => unreachable!(),
+        };
 
         Ok(())
     }
@@ -98,54 +111,37 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         self.ctx().allowed_network_uses.check_allowed_tcp()?;
         let table = self.table();
-        let r = {
-            let socket = table.get(&this)?;
-            let network = table.get(&network)?;
-            let remote_address: SocketAddr = remote_address.into();
+        let socket = table.get(&this)?;
+        let network = table.get(&network)?;
+        let remote_address: SocketAddr = remote_address.into();
 
-            match socket.tcp_state {
-                TcpState::Default => {}
-                TcpState::Bound
-                | TcpState::Connected
-                | TcpState::ConnectFailed
-                | TcpState::Listening => return Err(ErrorCode::InvalidState.into()),
-                TcpState::Connecting
-                | TcpState::ConnectReady
-                | TcpState::ListenStarted
-                | TcpState::BindStarted => return Err(ErrorCode::ConcurrencyConflict.into()),
+        match socket.tcp_state {
+            TcpState::Default(..) => {}
+
+            TcpState::Connecting(..) | TcpState::ConnectReady(..) => {
+                return Err(ErrorCode::ConcurrencyConflict.into())
             }
 
-            util::validate_unicast(&remote_address)?;
-            util::validate_remote_address(&remote_address)?;
-            util::validate_address_family(&remote_address, &socket.family)?;
-
-            // Ensure that we're allowed to connect to this address.
-            network.check_socket_addr(&remote_address, SocketAddrUse::TcpConnect)?;
-
-            // Do an OS `connect`. Our socket is non-blocking, so it'll either...
-            util::tcp_connect(socket.tcp_socket(), &remote_address)
+            _ => return Err(ErrorCode::InvalidState.into()),
         };
 
-        match r {
-            // succeed immediately,
-            Ok(()) => {
-                let socket = table.get_mut(&this)?;
-                socket.tcp_state = TcpState::ConnectReady;
-                return Ok(());
-            }
-            // continue in progress,
-            Err(err) if err == Errno::INPROGRESS => {}
-            // or fail immediately.
-            Err(err) => {
-                return Err(match err {
-                    Errno::AFNOSUPPORT => ErrorCode::InvalidArgument.into(), // See `bind` implementation.
-                    _ => err.into(),
-                });
-            }
-        }
+        util::validate_unicast(&remote_address)?;
+        util::validate_remote_address(&remote_address)?;
+        util::validate_address_family(&remote_address, &socket.family)?;
+
+        // Ensure that we're allowed to connect to this address.
+        network.check_socket_addr(&remote_address, SocketAddrUse::TcpConnect)?;
 
         let socket = table.get_mut(&this)?;
-        socket.tcp_state = TcpState::Connecting;
+        let TcpState::Default(tokio_socket) =
+            std::mem::replace(&mut socket.tcp_state, TcpState::Closed)
+        else {
+            unreachable!();
+        };
+
+        let future = TcpSocket::connect(tokio_socket, remote_address);
+
+        socket.tcp_state = TcpState::Connecting(Box::pin(future));
 
         Ok(())
     }
@@ -157,41 +153,45 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         let table = self.table();
         let socket = table.get_mut(&this)?;
 
-        match socket.tcp_state {
-            TcpState::ConnectReady => {}
-            TcpState::Connecting => {
-                // Do a `poll` to test for completion, using a timeout of zero
-                // to avoid blocking.
-                match rustix::event::poll(
-                    &mut [rustix::event::PollFd::new(
-                        socket.tcp_socket(),
-                        rustix::event::PollFlags::OUT,
-                    )],
-                    0,
-                ) {
-                    Ok(0) => return Err(ErrorCode::WouldBlock.into()),
-                    Ok(_) => (),
-                    Err(err) => Err(err).unwrap(),
-                }
-
-                // Check whether the connect succeeded.
-                match sockopt::get_socket_error(socket.tcp_socket()) {
-                    Ok(Ok(())) => {}
-                    Err(err) | Ok(Err(err)) => {
-                        socket.tcp_state = TcpState::ConnectFailed;
-                        return Err(err.into());
+        let previous_state = std::mem::replace(&mut socket.tcp_state, TcpState::Closed);
+        let result = match previous_state {
+            TcpState::ConnectReady(result) => result,
+            TcpState::Connecting(mut future) => {
+                let mut cx = std::task::Context::from_waker(futures::task::noop_waker_ref());
+                match future.as_mut().poll(&mut cx) {
+                    Poll::Ready(result) => result,
+                    Poll::Pending => {
+                        socket.tcp_state = TcpState::Connecting(future);
+                        return Err(ErrorCode::WouldBlock.into());
                     }
                 }
             }
-            _ => return Err(ErrorCode::NotInProgress.into()),
+            previous_state => {
+                socket.tcp_state = previous_state;
+                return Err(ErrorCode::NotInProgress.into());
+            }
         };
 
-        socket.tcp_state = TcpState::Connected;
-        let (input, output) = socket.as_split();
-        let input_stream = self.table().push_child(input, &this)?;
-        let output_stream = self.table().push_child(output, &this)?;
+        match result {
+            Ok(stream) => {
+                let stream = Arc::new(stream);
 
-        Ok((input_stream, output_stream))
+                let input: InputStream =
+                    InputStream::Host(Box::new(TcpReadStream::new(stream.clone())));
+                let output: OutputStream = Box::new(TcpWriteStream::new(stream.clone()));
+
+                let input_stream = self.table().push_child(input, &this)?;
+                let output_stream = self.table().push_child(output, &this)?;
+
+                let socket = self.table().get_mut(&this)?;
+                socket.tcp_state = TcpState::Connected(stream);
+                Ok((input_stream, output_stream))
+            }
+            Err(err) => {
+                socket.tcp_state = TcpState::Closed;
+                Err(err.into())
+            }
+        }
     }
 
     fn start_listen(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<()> {
@@ -199,37 +199,62 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         let table = self.table();
         let socket = table.get_mut(&this)?;
 
-        match socket.tcp_state {
-            TcpState::Bound => {}
-            TcpState::Default
-            | TcpState::Connected
-            | TcpState::ConnectFailed
-            | TcpState::Listening => return Err(ErrorCode::InvalidState.into()),
-            TcpState::ListenStarted
-            | TcpState::Connecting
-            | TcpState::ConnectReady
-            | TcpState::BindStarted => return Err(ErrorCode::ConcurrencyConflict.into()),
+        match std::mem::replace(&mut socket.tcp_state, TcpState::Closed) {
+            TcpState::Bound(tokio_socket) => {
+                socket.tcp_state = TcpState::ListenStarted(tokio_socket);
+                Ok(())
+            }
+            TcpState::ListenStarted(tokio_socket) => {
+                socket.tcp_state = TcpState::ListenStarted(tokio_socket);
+                Err(ErrorCode::ConcurrencyConflict.into())
+            }
+            previous_state => {
+                socket.tcp_state = previous_state;
+                Err(ErrorCode::InvalidState.into())
+            }
         }
-
-        util::tcp_listen(socket.tcp_socket(), socket.listen_backlog_size)?;
-
-        socket.tcp_state = TcpState::ListenStarted;
-
-        Ok(())
     }
 
     fn finish_listen(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get_mut(&this)?;
 
-        match socket.tcp_state {
-            TcpState::ListenStarted => {}
-            _ => return Err(ErrorCode::NotInProgress.into()),
+        let tokio_socket = match std::mem::replace(&mut socket.tcp_state, TcpState::Closed) {
+            TcpState::ListenStarted(tokio_socket) => tokio_socket,
+            previous_state => {
+                socket.tcp_state = previous_state;
+                return Err(ErrorCode::NotInProgress.into());
+            }
+        };
+
+        match TcpSocket::listen(tokio_socket, socket.listen_backlog_size) {
+            Ok(listener) => {
+                socket.tcp_state = TcpState::Listening {
+                    listener,
+                    pending_accept: None,
+                };
+                Ok(())
+            }
+            Err(err) => {
+                socket.tcp_state = TcpState::Closed;
+
+                Err(match Errno::from_io_error(&err) {
+                    // See: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-listen#:~:text=WSAEMFILE
+                    // According to the docs, `listen` can return EMFILE on Windows.
+                    // This is odd, because we're not trying to create a new socket
+                    // or file descriptor of any kind. So we rewrite it to less
+                    // surprising error code.
+                    //
+                    // At the time of writing, this behavior has never been experimentally
+                    // observed by any of the wasmtime authors, so we're relying fully
+                    // on Microsoft's documentation here.
+                    #[cfg(windows)]
+                    Some(Errno::MFILE) => Errno::NOBUFS.into(),
+
+                    _ => err.into(),
+                })
+            }
         }
-
-        socket.tcp_state = TcpState::Listening;
-
-        Ok(())
     }
 
     fn accept(
@@ -242,17 +267,59 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     )> {
         self.ctx().allowed_network_uses.check_allowed_tcp()?;
         let table = self.table();
-        let socket = table.get(&this)?;
+        let socket = table.get_mut(&this)?;
 
-        match socket.tcp_state {
-            TcpState::Listening => {}
-            _ => return Err(ErrorCode::InvalidState.into()),
-        }
+        let TcpState::Listening {
+            listener,
+            pending_accept,
+        } = &mut socket.tcp_state
+        else {
+            return Err(ErrorCode::InvalidState.into());
+        };
 
-        // Do the OS accept call.
-        let tcp_socket = socket.tcp_socket();
-        let (client_fd, _addr) = tcp_socket.try_io(Interest::READABLE, || {
-            util::tcp_accept(tcp_socket, Blocking::No)
+        let result = match pending_accept.take() {
+            Some(result) => result,
+            None => {
+                let mut cx = std::task::Context::from_waker(futures::task::noop_waker_ref());
+                match TcpSocket::poll_accept(listener, &mut cx) {
+                    Poll::Ready(result) => result,
+                    Poll::Pending => Err(Errno::WOULDBLOCK.into()),
+                }
+            }
+        };
+
+        let client = result.map_err(|err| match Errno::from_io_error(&err) {
+            // From: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept#:~:text=WSAEINPROGRESS
+            // > WSAEINPROGRESS: A blocking Windows Sockets 1.1 call is in progress,
+            // > or the service provider is still processing a callback function.
+            //
+            // wasi-sockets doesn't have an equivalent to the EINPROGRESS error,
+            // because in POSIX this error is only returned by a non-blocking
+            // `connect` and wasi-sockets has a different solution for that.
+            #[cfg(windows)]
+            Some(Errno::INPROGRESS) => Errno::INTR.into(),
+
+            // Normalize Linux' non-standard behavior.
+            //
+            // From https://man7.org/linux/man-pages/man2/accept.2.html:
+            // > Linux accept() passes already-pending network errors on the
+            // > new socket as an error code from accept(). This behavior
+            // > differs from other BSD socket implementations. (...)
+            #[cfg(target_os = "linux")]
+            Some(
+                Errno::CONNRESET
+                | Errno::NETRESET
+                | Errno::HOSTUNREACH
+                | Errno::HOSTDOWN
+                | Errno::NETDOWN
+                | Errno::NETUNREACH
+                | Errno::PROTO
+                | Errno::NOPROTOOPT
+                | Errno::NONET
+                | Errno::OPNOTSUPP,
+            ) => Errno::CONNABORTED.into(),
+
+            _ => err,
         })?;
 
         #[cfg(target_os = "macos")]
@@ -262,30 +329,28 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
             // and only if a specific value was explicitly set on the listener.
 
             if let Some(size) = socket.receive_buffer_size {
-                _ = util::set_socket_recv_buffer_size(&client_fd, size); // Ignore potential error.
+                _ = util::set_socket_recv_buffer_size(&client, size); // Ignore potential error.
             }
 
             if let Some(size) = socket.send_buffer_size {
-                _ = util::set_socket_send_buffer_size(&client_fd, size); // Ignore potential error.
+                _ = util::set_socket_send_buffer_size(&client, size); // Ignore potential error.
             }
 
             // For some reason, IP_TTL is inherited, but IPV6_UNICAST_HOPS isn't.
             if let (SocketAddressFamily::Ipv6, Some(ttl)) = (socket.family, socket.hop_limit) {
-                _ = util::set_ipv6_unicast_hops(&client_fd, ttl); // Ignore potential error.
+                _ = util::set_ipv6_unicast_hops(&client, ttl); // Ignore potential error.
             }
 
             if let Some(value) = socket.keep_alive_idle_time {
-                _ = util::set_tcp_keepidle(&client_fd, value); // Ignore potential error.
+                _ = util::set_tcp_keepidle(&client, value); // Ignore potential error.
             }
         }
 
-        let mut tcp_socket = TcpSocket::from_fd(client_fd, socket.family)?;
+        let client = Arc::new(client);
 
-        // Mark the socket as connected so that we can exit early from methods like `start-bind`.
-        tcp_socket.tcp_state = TcpState::Connected;
-
-        let (input, output) = tcp_socket.as_split();
-        let output: OutputStream = output;
+        let input: InputStream = InputStream::Host(Box::new(TcpReadStream::new(client.clone())));
+        let output: OutputStream = Box::new(TcpWriteStream::new(client.clone()));
+        let tcp_socket = TcpSocket::from_state(TcpState::Connected(client), socket.family)?;
 
         let tcp_socket = self.table().push(tcp_socket)?;
         let input_stream = self.table().push_child(input, &tcp_socket)?;
@@ -298,36 +363,28 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         let table = self.table();
         let socket = table.get(&this)?;
 
-        match socket.tcp_state {
-            TcpState::Default => return Err(ErrorCode::InvalidState.into()),
-            TcpState::BindStarted => return Err(ErrorCode::ConcurrencyConflict.into()),
-            _ => {}
-        }
+        let view = match socket.tcp_state {
+            TcpState::Default(..) => return Err(ErrorCode::InvalidState.into()),
+            TcpState::BindStarted(..) => return Err(ErrorCode::ConcurrencyConflict.into()),
+            _ => socket.as_std_view()?,
+        };
 
-        let addr = socket
-            .tcp_socket()
-            .as_socketlike_view::<std::net::TcpStream>()
-            .local_addr()?;
-        Ok(addr.into())
+        Ok(view.local_addr()?.into())
     }
 
     fn remote_address(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<IpSocketAddress> {
         let table = self.table();
         let socket = table.get(&this)?;
 
-        match socket.tcp_state {
-            TcpState::Connected => {}
-            TcpState::Connecting | TcpState::ConnectReady => {
+        let view = match socket.tcp_state {
+            TcpState::Connected(..) => socket.as_std_view()?,
+            TcpState::Connecting(..) | TcpState::ConnectReady(..) => {
                 return Err(ErrorCode::ConcurrencyConflict.into())
             }
             _ => return Err(ErrorCode::InvalidState.into()),
-        }
+        };
 
-        let addr = socket
-            .tcp_socket()
-            .as_socketlike_view::<std::net::TcpStream>()
-            .peer_addr()?;
-        Ok(addr.into())
+        Ok(view.peer_addr()?.into())
     }
 
     fn is_listening(&mut self, this: Resource<tcp::TcpSocket>) -> Result<bool, anyhow::Error> {
@@ -335,7 +392,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         let socket = table.get(&this)?;
 
         match socket.tcp_state {
-            TcpState::Listening => Ok(true),
+            TcpState::Listening { .. } => Ok(true),
             _ => Ok(false),
         }
     }
@@ -358,8 +415,8 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         this: Resource<tcp::TcpSocket>,
         value: u64,
     ) -> SocketResult<()> {
-        const MIN_BACKLOG: i32 = 1;
-        const MAX_BACKLOG: i32 = i32::MAX; // OS'es will most likely limit it down even further.
+        const MIN_BACKLOG: u32 = 1;
+        const MAX_BACKLOG: u32 = i32::MAX as u32; // OS'es will most likely limit it down even further.
 
         let table = self.table();
         let socket = table.get_mut(&this)?;
@@ -371,38 +428,36 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         // Silently clamp backlog size. This is OK for us to do, because operating systems do this too.
         let value = value
             .try_into()
-            .unwrap_or(i32::MAX)
+            .unwrap_or(u32::MAX)
             .clamp(MIN_BACKLOG, MAX_BACKLOG);
 
-        match socket.tcp_state {
-            TcpState::Default | TcpState::BindStarted | TcpState::Bound => {
+        match &socket.tcp_state {
+            TcpState::Default(..) | TcpState::Bound(..) => {
                 // Socket not listening yet. Stash value for first invocation to `listen`.
-                socket.listen_backlog_size = Some(value);
+                socket.listen_backlog_size = value;
 
                 Ok(())
             }
-            TcpState::Listening => {
+            TcpState::Listening { listener, .. } => {
                 // Try to update the backlog by calling `listen` again.
                 // Not all platforms support this. We'll only update our own value if the OS supports changing the backlog size after the fact.
 
-                rustix::net::listen(socket.tcp_socket(), value)
+                rustix::net::listen(&listener, value.try_into().unwrap())
                     .map_err(|_| ErrorCode::NotSupported)?;
 
-                socket.listen_backlog_size = Some(value);
+                socket.listen_backlog_size = value;
 
                 Ok(())
             }
-            TcpState::Connected | TcpState::ConnectFailed => Err(ErrorCode::InvalidState.into()),
-            TcpState::Connecting | TcpState::ConnectReady | TcpState::ListenStarted => {
-                Err(ErrorCode::ConcurrencyConflict.into())
-            }
+            _ => Err(ErrorCode::InvalidState.into()),
         }
     }
 
     fn keep_alive_enabled(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<bool> {
         let table = self.table();
         let socket = table.get(&this)?;
-        Ok(sockopt::get_socket_keepalive(socket.tcp_socket())?)
+        let view = &*socket.as_std_view()?;
+        Ok(sockopt::get_socket_keepalive(view)?)
     }
 
     fn set_keep_alive_enabled(
@@ -412,13 +467,15 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get(&this)?;
-        Ok(sockopt::set_socket_keepalive(socket.tcp_socket(), value)?)
+        let view = &*socket.as_std_view()?;
+        Ok(sockopt::set_socket_keepalive(view, value)?)
     }
 
     fn keep_alive_idle_time(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u64> {
         let table = self.table();
         let socket = table.get(&this)?;
-        Ok(sockopt::get_tcp_keepidle(socket.tcp_socket())?.as_nanos() as u64)
+        let view = &*socket.as_std_view()?;
+        Ok(sockopt::get_tcp_keepidle(view)?.as_nanos() as u64)
     }
 
     fn set_keep_alive_idle_time(
@@ -428,10 +485,11 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get_mut(&this)?;
+        let view = &*socket.as_std_view()?;
 
         let duration = Duration::from_nanos(value);
 
-        util::set_tcp_keepidle(socket.tcp_socket(), duration)?;
+        util::set_tcp_keepidle(view, duration)?;
 
         #[cfg(target_os = "macos")]
         {
@@ -444,7 +502,8 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     fn keep_alive_interval(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u64> {
         let table = self.table();
         let socket = table.get(&this)?;
-        Ok(sockopt::get_tcp_keepintvl(socket.tcp_socket())?.as_nanos() as u64)
+        let view = &*socket.as_std_view()?;
+        Ok(sockopt::get_tcp_keepintvl(view)?.as_nanos() as u64)
     }
 
     fn set_keep_alive_interval(
@@ -454,16 +513,15 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get(&this)?;
-        Ok(util::set_tcp_keepintvl(
-            socket.tcp_socket(),
-            Duration::from_nanos(value),
-        )?)
+        let view = &*socket.as_std_view()?;
+        Ok(util::set_tcp_keepintvl(view, Duration::from_nanos(value))?)
     }
 
     fn keep_alive_count(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u32> {
         let table = self.table();
         let socket = table.get(&this)?;
-        Ok(sockopt::get_tcp_keepcnt(socket.tcp_socket())?)
+        let view = &*socket.as_std_view()?;
+        Ok(sockopt::get_tcp_keepcnt(view)?)
     }
 
     fn set_keep_alive_count(
@@ -473,16 +531,18 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get(&this)?;
-        Ok(util::set_tcp_keepcnt(socket.tcp_socket(), value)?)
+        let view = &*socket.as_std_view()?;
+        Ok(util::set_tcp_keepcnt(view, value)?)
     }
 
     fn hop_limit(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u8> {
         let table = self.table();
         let socket = table.get(&this)?;
+        let view = &*socket.as_std_view()?;
 
         let ttl = match socket.family {
-            SocketAddressFamily::Ipv4 => util::get_ip_ttl(socket.tcp_socket())?,
-            SocketAddressFamily::Ipv6 => util::get_ipv6_unicast_hops(socket.tcp_socket())?,
+            SocketAddressFamily::Ipv4 => util::get_ip_ttl(view)?,
+            SocketAddressFamily::Ipv6 => util::get_ipv6_unicast_hops(view)?,
         };
 
         Ok(ttl)
@@ -491,10 +551,11 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     fn set_hop_limit(&mut self, this: Resource<tcp::TcpSocket>, value: u8) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get_mut(&this)?;
+        let view = &*socket.as_std_view()?;
 
         match socket.family {
-            SocketAddressFamily::Ipv4 => util::set_ip_ttl(socket.tcp_socket(), value)?,
-            SocketAddressFamily::Ipv6 => util::set_ipv6_unicast_hops(socket.tcp_socket(), value)?,
+            SocketAddressFamily::Ipv4 => util::set_ip_ttl(view, value)?,
+            SocketAddressFamily::Ipv6 => util::set_ipv6_unicast_hops(view, value)?,
         }
 
         #[cfg(target_os = "macos")]
@@ -508,8 +569,9 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     fn receive_buffer_size(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u64> {
         let table = self.table();
         let socket = table.get(&this)?;
+        let view = &*socket.as_std_view()?;
 
-        let value = util::get_socket_recv_buffer_size(socket.tcp_socket())?;
+        let value = util::get_socket_recv_buffer_size(view)?;
         Ok(value as u64)
     }
 
@@ -520,9 +582,10 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get_mut(&this)?;
+        let view = &*socket.as_std_view()?;
         let value = value.try_into().unwrap_or(usize::MAX);
 
-        util::set_socket_recv_buffer_size(socket.tcp_socket(), value)?;
+        util::set_socket_recv_buffer_size(view, value)?;
 
         #[cfg(target_os = "macos")]
         {
@@ -535,8 +598,9 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     fn send_buffer_size(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u64> {
         let table = self.table();
         let socket = table.get(&this)?;
+        let view = &*socket.as_std_view()?;
 
-        let value = util::get_socket_send_buffer_size(socket.tcp_socket())?;
+        let value = util::get_socket_send_buffer_size(view)?;
         Ok(value as u64)
     }
 
@@ -547,9 +611,10 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get_mut(&this)?;
+        let view = &*socket.as_std_view()?;
         let value = value.try_into().unwrap_or(usize::MAX);
 
-        util::set_socket_send_buffer_size(socket.tcp_socket(), value)?;
+        util::set_socket_send_buffer_size(view, value)?;
 
         #[cfg(target_os = "macos")]
         {
@@ -571,13 +636,10 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
         let table = self.table();
         let socket = table.get(&this)?;
 
-        match socket.tcp_state {
-            TcpState::Connected => {}
-            TcpState::Connecting | TcpState::ConnectReady => {
-                return Err(ErrorCode::ConcurrencyConflict.into())
-            }
+        let stream = match &socket.tcp_state {
+            TcpState::Connected(stream) => stream,
             _ => return Err(ErrorCode::InvalidState.into()),
-        }
+        };
 
         let how = match shutdown_type {
             ShutdownType::Receive => std::net::Shutdown::Read,
@@ -585,8 +647,7 @@ impl<T: WasiView> crate::preview2::host::tcp::tcp::HostTcpSocket for T {
             ShutdownType::Both => std::net::Shutdown::Both,
         };
 
-        socket
-            .tcp_socket()
+        stream
             .as_socketlike_view::<std::net::TcpStream>()
             .shutdown(how)?;
         Ok(())

--- a/crates/wasi/src/preview2/tcp.rs
+++ b/crates/wasi/src/preview2/tcp.rs
@@ -1,5 +1,7 @@
 use super::network::SocketAddressFamily;
-use super::{with_ambient_tokio_runtime, HostInputStream, HostOutputStream, SocketResult, StreamError};
+use super::{
+    with_ambient_tokio_runtime, HostInputStream, HostOutputStream, SocketResult, StreamError,
+};
 use crate::preview2::{AbortOnDropJoinHandle, Subscribe};
 use anyhow::{Error, Result};
 use cap_net_ext::AddressFamily;
@@ -313,15 +315,24 @@ impl TcpSocket {
         }
     }
 
-    pub(crate) fn connect(socket: tokio::net::TcpSocket, addr: std::net::SocketAddr) -> impl Future<Output = io::Result<tokio::net::TcpStream>> + Send {
+    pub(crate) fn connect(
+        socket: tokio::net::TcpSocket,
+        addr: std::net::SocketAddr,
+    ) -> impl Future<Output = io::Result<tokio::net::TcpStream>> + Send {
         crate::preview2::spawn(socket.connect(addr))
     }
 
-    pub(crate) fn listen(socket: tokio::net::TcpSocket, backlog: u32) -> io::Result<tokio::net::TcpListener> {
+    pub(crate) fn listen(
+        socket: tokio::net::TcpSocket,
+        backlog: u32,
+    ) -> io::Result<tokio::net::TcpListener> {
         with_ambient_tokio_runtime(|| socket.listen(backlog))
     }
 
-    pub(crate) fn poll_accept(listener: &tokio::net::TcpListener, cx: &mut std::task::Context) -> std::task::Poll<io::Result<tokio::net::TcpStream>> {
+    pub(crate) fn poll_accept(
+        listener: &tokio::net::TcpListener,
+        cx: &mut std::task::Context,
+    ) -> std::task::Poll<io::Result<tokio::net::TcpStream>> {
         with_ambient_tokio_runtime(|| listener.poll_accept(cx).map_ok(|(stream, _)| stream))
     }
 }
@@ -348,7 +359,8 @@ impl Subscribe for TcpSocket {
             } => match pending_accept {
                 Some(_) => {}
                 None => {
-                    let result = futures::future::poll_fn(|cx| TcpSocket::poll_accept(listener, cx)).await;
+                    let result =
+                        futures::future::poll_fn(|cx| TcpSocket::poll_accept(listener, cx)).await;
                     *pending_accept = Some(result);
                 }
             },

--- a/crates/wasi/src/preview2/tcp.rs
+++ b/crates/wasi/src/preview2/tcp.rs
@@ -1,17 +1,19 @@
 use super::network::SocketAddressFamily;
-use super::{HostInputStream, HostOutputStream, StreamError};
-use crate::preview2::host::network::util;
-use crate::preview2::{
-    with_ambient_tokio_runtime, AbortOnDropJoinHandle, InputStream, OutputStream, Subscribe,
-};
+use super::{with_ambient_tokio_runtime, HostInputStream, HostOutputStream, SocketResult, StreamError};
+use crate::preview2::{AbortOnDropJoinHandle, Subscribe};
 use anyhow::{Error, Result};
-use cap_net_ext::{AddressFamily, Blocking};
-use io_lifetimes::raw::{FromRawSocketlike, IntoRawSocketlike};
+use cap_net_ext::AddressFamily;
+use futures::Future;
+use io_lifetimes::views::SocketlikeView;
+use io_lifetimes::AsSocketlike;
 use rustix::net::sockopt;
 use std::io;
 use std::mem;
+use std::pin::Pin;
 use std::sync::Arc;
-use tokio::io::Interest;
+
+/// Value taken from rust std library.
+const DEFAULT_BACKLOG: u32 = 128;
 
 /// The state of a TCP socket.
 ///
@@ -19,32 +21,34 @@ use tokio::io::Interest;
 /// activities of binding, listening, accepting, and connecting.
 pub(crate) enum TcpState {
     /// The initial state for a newly-created socket.
-    Default,
+    Default(tokio::net::TcpSocket),
 
     /// Binding started via `start_bind`.
-    BindStarted,
+    BindStarted(tokio::net::TcpSocket),
 
     /// Binding finished via `finish_bind`. The socket has an address but
     /// is not yet listening for connections.
-    Bound,
+    Bound(tokio::net::TcpSocket),
 
     /// Listening started via `listen_start`.
-    ListenStarted,
+    ListenStarted(tokio::net::TcpSocket),
 
     /// The socket is now listening and waiting for an incoming connection.
-    Listening,
+    Listening {
+        listener: tokio::net::TcpListener,
+        pending_accept: Option<io::Result<tokio::net::TcpStream>>,
+    },
 
     /// An outgoing connection is started via `start_connect`.
-    Connecting,
+    Connecting(Pin<Box<dyn Future<Output = io::Result<tokio::net::TcpStream>> + Send>>),
 
     /// An outgoing connection is ready to be established.
-    ConnectReady,
-
-    /// An outgoing connection was attempted but failed.
-    ConnectFailed,
+    ConnectReady(io::Result<tokio::net::TcpStream>),
 
     /// An outgoing connection has been established.
-    Connected,
+    Connected(Arc<tokio::net::TcpStream>),
+
+    Closed,
 }
 
 /// A host TCP socket, plus associated bookkeeping.
@@ -52,15 +56,11 @@ pub(crate) enum TcpState {
 /// The inner state is wrapped in an Arc because the same underlying socket is
 /// used for implementing the stream types.
 pub struct TcpSocket {
-    /// The part of a `TcpSocket` which is reference-counted so that we
-    /// can pass it to async tasks.
-    pub(crate) inner: Arc<tokio::net::TcpStream>,
-
     /// The current state in the bind/listen/accept/connect progression.
     pub(crate) tcp_state: TcpState,
 
-    /// The desired listen queue size. Set to None to use the system's default.
-    pub(crate) listen_backlog_size: Option<i32>,
+    /// The desired listen queue size.
+    pub(crate) listen_backlog_size: u32,
 
     pub(crate) family: SocketAddressFamily,
 
@@ -83,7 +83,7 @@ pub(crate) struct TcpReadStream {
 }
 
 impl TcpReadStream {
-    fn new(stream: Arc<tokio::net::TcpStream>) -> Self {
+    pub(crate) fn new(stream: Arc<tokio::net::TcpStream>) -> Self {
         Self {
             stream,
             closed: false,
@@ -259,34 +259,28 @@ impl Subscribe for TcpWriteStream {
 impl TcpSocket {
     /// Create a new socket in the given family.
     pub fn new(family: AddressFamily) -> io::Result<Self> {
-        // Create a new host socket and set it to non-blocking, which is needed
-        // by our async implementation.
-        let fd = util::tcp_socket(family, Blocking::No)?;
+        with_ambient_tokio_runtime(|| {
+            let (socket, family) = match family {
+                AddressFamily::Ipv4 => {
+                    let socket = tokio::net::TcpSocket::new_v4()?;
+                    (socket, SocketAddressFamily::Ipv4)
+                }
+                AddressFamily::Ipv6 => {
+                    let socket = tokio::net::TcpSocket::new_v6()?;
+                    sockopt::set_ipv6_v6only(&socket, true)?;
+                    (socket, SocketAddressFamily::Ipv6)
+                }
+            };
 
-        let socket_address_family = match family {
-            AddressFamily::Ipv4 => SocketAddressFamily::Ipv4,
-            AddressFamily::Ipv6 => {
-                sockopt::set_ipv6_v6only(&fd, true)?;
-                SocketAddressFamily::Ipv6
-            }
-        };
-
-        Self::from_fd(fd, socket_address_family)
+            Self::from_state(TcpState::Default(socket), family)
+        })
     }
 
     /// Create a `TcpSocket` from an existing socket.
-    ///
-    /// The socket must be in non-blocking mode.
-    pub(crate) fn from_fd(
-        fd: rustix::fd::OwnedFd,
-        family: SocketAddressFamily,
-    ) -> io::Result<Self> {
-        let stream = Self::setup_tokio_tcp_stream(fd)?;
-
+    pub(crate) fn from_state(state: TcpState, family: SocketAddressFamily) -> io::Result<Self> {
         Ok(Self {
-            inner: Arc::new(stream),
-            tcp_state: TcpState::Default,
-            listen_backlog_size: None,
+            tcp_state: state,
+            listen_backlog_size: DEFAULT_BACKLOG,
             family,
             #[cfg(target_os = "macos")]
             receive_buffer_size: None,
@@ -299,37 +293,65 @@ impl TcpSocket {
         })
     }
 
-    fn setup_tokio_tcp_stream(fd: rustix::fd::OwnedFd) -> io::Result<tokio::net::TcpStream> {
-        let std_stream =
-            unsafe { std::net::TcpStream::from_raw_socketlike(fd.into_raw_socketlike()) };
-        with_ambient_tokio_runtime(|| tokio::net::TcpStream::try_from(std_stream))
+    pub(crate) fn as_std_view(&self) -> SocketResult<SocketlikeView<'_, std::net::TcpStream>> {
+        use crate::preview2::bindings::sockets::network::ErrorCode;
+
+        match &self.tcp_state {
+            TcpState::Default(socket) | TcpState::Bound(socket) => {
+                Ok(socket.as_socketlike_view::<std::net::TcpStream>())
+            }
+            TcpState::Connected(stream) => Ok(stream.as_socketlike_view::<std::net::TcpStream>()),
+            TcpState::Listening { listener, .. } => {
+                Ok(listener.as_socketlike_view::<std::net::TcpStream>())
+            }
+
+            TcpState::BindStarted(..)
+            | TcpState::ListenStarted(..)
+            | TcpState::Connecting(..)
+            | TcpState::ConnectReady(..)
+            | TcpState::Closed => Err(ErrorCode::InvalidState.into()),
+        }
     }
 
-    pub fn tcp_socket(&self) -> &tokio::net::TcpStream {
-        &self.inner
+    pub(crate) fn connect(socket: tokio::net::TcpSocket, addr: std::net::SocketAddr) -> impl Future<Output = io::Result<tokio::net::TcpStream>> + Send {
+        crate::preview2::spawn(socket.connect(addr))
     }
 
-    /// Create the input/output stream pair for a tcp socket.
-    pub fn as_split(&self) -> (InputStream, OutputStream) {
-        let input = Box::new(TcpReadStream::new(self.inner.clone()));
-        let output = Box::new(TcpWriteStream::new(self.inner.clone()));
-        (InputStream::Host(input), output)
+    pub(crate) fn listen(socket: tokio::net::TcpSocket, backlog: u32) -> io::Result<tokio::net::TcpListener> {
+        with_ambient_tokio_runtime(|| socket.listen(backlog))
+    }
+
+    pub(crate) fn poll_accept(listener: &tokio::net::TcpListener, cx: &mut std::task::Context) -> std::task::Poll<io::Result<tokio::net::TcpStream>> {
+        with_ambient_tokio_runtime(|| listener.poll_accept(cx).map_ok(|(stream, _)| stream))
     }
 }
 
 #[async_trait::async_trait]
 impl Subscribe for TcpSocket {
     async fn ready(&mut self) {
-        // Some states are ready immediately.
-        match self.tcp_state {
-            TcpState::BindStarted | TcpState::ListenStarted | TcpState::ConnectReady => return,
-            _ => {}
+        match &mut self.tcp_state {
+            TcpState::Default(..)
+            | TcpState::BindStarted(..)
+            | TcpState::Bound(..)
+            | TcpState::ListenStarted(..)
+            | TcpState::ConnectReady(..)
+            | TcpState::Closed
+            | TcpState::Connected(..) => {
+                // No async operation in progress.
+            }
+            TcpState::Connecting(future) => {
+                self.tcp_state = TcpState::ConnectReady(future.as_mut().await);
+            }
+            TcpState::Listening {
+                listener,
+                pending_accept,
+            } => match pending_accept {
+                Some(_) => {}
+                None => {
+                    let result = futures::future::poll_fn(|cx| TcpSocket::poll_accept(listener, cx)).await;
+                    *pending_accept = Some(result);
+                }
+            },
         }
-
-        // FIXME: Add `Interest::ERROR` when we update to tokio 1.32.
-        self.inner
-            .ready(Interest::READABLE | Interest::WRITABLE)
-            .await
-            .unwrap();
     }
 }


### PR DESCRIPTION
Full discussion: https://bytecodealliance.zulipchat.com/#narrow/stream/217126-wasmtime/topic/tokio.20always.20reports.20readiness

TLDR: Our implementation was flawed. It called `tokio::net::TcpStream::try_from(...)` directly after creating the socket. That triggers Tokio to call `epoll_ctl` to add it to the poll list. Linux sees that the socket is not connected (yet) and emits EPOLLHUP. Tokio interprets that to be a "final" state and never recovers from it. All future attempts to await I/O readiness immediately succeed.

This PR moves away from rustix and uses Tokio's own methods for constructing, binding, connecting, listening & accepting sockets. It still uses rustix for socket options