### PR TITLE
Rename `Func::{from_caller_checked_func_ref => from_vm_func_ref}`

### DIFF
--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -151,7 +151,7 @@ impl Table {
         unsafe {
             match (*table).get(index)? {
                 runtime::TableElement::FuncRef(f) => {
-                    let func = Func::from_caller_checked_func_ref(store, f);
+                    let func = Func::from_vm_func_ref(store, f);
                     Some(Val::FuncRef(func))
                 }
                 runtime::TableElement::ExternRef(None) => Some(Val::ExternRef(None)),

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -504,7 +504,7 @@ impl Func {
         })
     }
 
-    pub(crate) unsafe fn from_caller_checked_func_ref(
+    pub(crate) unsafe fn from_vm_func_ref(
         store: &mut StoreOpaque,
         raw: *mut VMFuncRef,
     ) -> Option<Func> {
@@ -931,7 +931,7 @@ impl Func {
     /// caller must guarantee that `raw` is owned by the `store` provided and is
     /// valid within the `store`.
     pub unsafe fn from_raw(mut store: impl AsContextMut, raw: *mut c_void) -> Option<Func> {
-        Func::from_caller_checked_func_ref(store.as_context_mut().0, raw.cast())
+        Func::from_vm_func_ref(store.as_context_mut().0, raw.cast())
     }
 
     /// Extracts the raw value of this `Func`, which is owned by `store`.

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -447,7 +447,7 @@ unsafe impl WasmTy for Option<Func> {
 
     #[inline]
     unsafe fn from_abi(abi: Self::Abi, store: &mut StoreOpaque) -> Self {
-        Func::from_caller_checked_func_ref(store, abi)
+        Func::from_vm_func_ref(store, abi)
     }
 }
 


### PR DESCRIPTION
This reflects the renaming of `VMCallerCheckedAnyFunc` to `VMFuncRef` from a while back.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
