### PR TITLE
Rename `WasmHeapType::TypedFunc` to `WasmHeapType::Concrete`

### DIFF
--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1320,7 +1320,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     ) -> WasmResult<ir::Value> {
         let (func_idx, func_sig) =
             match self.module.table_plans[table_index].table.wasm_ty.heap_type {
-                WasmHeapType::Func | WasmHeapType::TypedFunc(_) => (
+                WasmHeapType::Func | WasmHeapType::Concrete(_) => (
                     BuiltinFunctionIndex::table_grow_func_ref(),
                     self.builtin_function_signatures
                         .table_grow_func_ref(&mut pos.func),
@@ -1355,7 +1355,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
         let plan = &self.module.table_plans[table_index];
         match plan.table.wasm_ty.heap_type {
-            WasmHeapType::Func | WasmHeapType::TypedFunc(_) => match plan.style {
+            WasmHeapType::Func | WasmHeapType::Concrete(_) => match plan.style {
                 TableStyle::CallerChecksSignature => {
                     Ok(self.get_or_init_func_ref_table_elem(builder, table_index, table, index))
                 }
@@ -1490,7 +1490,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         let pointer_type = self.pointer_type();
         let plan = &self.module.table_plans[table_index];
         match plan.table.wasm_ty.heap_type {
-            WasmHeapType::Func | WasmHeapType::TypedFunc(_) => match plan.style {
+            WasmHeapType::Func | WasmHeapType::Concrete(_) => match plan.style {
                 TableStyle::CallerChecksSignature => {
                     let table_entry_addr = builder.ins().table_addr(pointer_type, table, index, 0);
                     // Set the "initialized bit". See doc-comment on
@@ -1650,7 +1650,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     ) -> WasmResult<()> {
         let (builtin_idx, builtin_sig) =
             match self.module.table_plans[table_index].table.wasm_ty.heap_type {
-                WasmHeapType::Func | WasmHeapType::TypedFunc(_) => (
+                WasmHeapType::Func | WasmHeapType::Concrete(_) => (
                     BuiltinFunctionIndex::table_fill_func_ref(),
                     self.builtin_function_signatures
                         .table_fill_func_ref(&mut pos.func),
@@ -1681,7 +1681,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         ht: WasmHeapType,
     ) -> WasmResult<ir::Value> {
         Ok(match ht {
-            WasmHeapType::Func | WasmHeapType::TypedFunc(_) => {
+            WasmHeapType::Func | WasmHeapType::Concrete(_) => {
                 pos.ins().iconst(self.pointer_type(), 0)
             }
             WasmHeapType::Extern => pos.ins().null(self.reference_type(ht)),
@@ -2033,7 +2033,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             // entire lifetime of the `Store` so there's no need for barriers.
             // This means that they can fall through to memory as well.
             WasmValType::Ref(WasmRefType {
-                heap_type: WasmHeapType::Func | WasmHeapType::TypedFunc(_),
+                heap_type: WasmHeapType::Func | WasmHeapType::Concrete(_),
                 ..
             }) => {}
 

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -174,7 +174,7 @@ fn wasm_call_signature(
 /// Returns the reference type to use for the provided wasm type.
 fn reference_type(wasm_ht: cranelift_wasm::WasmHeapType, pointer_type: ir::Type) -> ir::Type {
     match wasm_ht {
-        cranelift_wasm::WasmHeapType::Func | cranelift_wasm::WasmHeapType::TypedFunc(_) => {
+        cranelift_wasm::WasmHeapType::Func | cranelift_wasm::WasmHeapType::Concrete(_) => {
             pointer_type
         }
         cranelift_wasm::WasmHeapType::Extern => match pointer_type {

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -474,7 +474,7 @@ impl ModuleTranslation<'_> {
                 .wasm_ty
                 .heap_type
             {
-                WasmHeapType::Func | WasmHeapType::TypedFunc(_) => {}
+                WasmHeapType::Func | WasmHeapType::Concrete(_) => {}
                 // If this is not a funcref table, then we can't support a
                 // pre-computed table of function indices. Technically this
                 // initializer won't trap so we could continue processing

--- a/crates/environ/src/module_types.rs
+++ b/crates/environ/src/module_types.rs
@@ -106,13 +106,13 @@ impl TypeConvert for WasmparserTypeConverter<'_> {
         match index {
             UnpackedIndex::Id(id) => {
                 let signature = self.types.wasmparser_to_wasmtime[&id];
-                WasmHeapType::TypedFunc(signature)
+                WasmHeapType::Concrete(signature)
             }
             UnpackedIndex::RecGroup(_) => unreachable!(),
             UnpackedIndex::Module(i) => {
                 let i = TypeIndex::from_u32(i);
                 match self.module.types[i] {
-                    ModuleType::Function(sig) => WasmHeapType::TypedFunc(sig),
+                    ModuleType::Function(sig) => WasmHeapType::Concrete(sig),
                 }
             }
         }

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -178,7 +178,7 @@ fn wasm_to_table_type(ty: WasmRefType) -> Result<TableElementType> {
     match ty.heap_type {
         WasmHeapType::Func => Ok(TableElementType::Func),
         WasmHeapType::Extern => Ok(TableElementType::Extern),
-        WasmHeapType::TypedFunc(_) => Ok(TableElementType::Func),
+        WasmHeapType::Concrete(_) => Ok(TableElementType::Func),
     }
 }
 

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -89,7 +89,7 @@ pub enum WasmHeapType {
     // `WasmHeapType<VMSharedTypeIndex>`. This `<T>` would need to be
     // propagated to quite a few locations though so it's left for a future
     // refactoring at this time.
-    TypedFunc(ModuleInternedTypeIndex),
+    Concrete(ModuleInternedTypeIndex),
 }
 
 impl fmt::Display for WasmHeapType {
@@ -97,7 +97,7 @@ impl fmt::Display for WasmHeapType {
         match self {
             Self::Func => write!(f, "func"),
             Self::Extern => write!(f, "extern"),
-            Self::TypedFunc(i) => write!(f, "func_sig{}", i.as_u32()),
+            Self::Concrete(i) => write!(f, "func_sig{}", i.as_u32()),
         }
     }
 }

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -194,14 +194,14 @@ fn memory_ty(expected: &Memory, actual: &Memory, actual_runtime_size: Option<u64
 
 fn match_heap(expected: WasmHeapType, actual: WasmHeapType, desc: &str) -> Result<()> {
     let result = match (actual, expected) {
-        (WasmHeapType::TypedFunc(actual), WasmHeapType::TypedFunc(expected)) => {
+        (WasmHeapType::Concrete(actual), WasmHeapType::Concrete(expected)) => {
             // TODO(dhil): we need either canonicalised types or a context here.
             actual == expected
         }
-        (WasmHeapType::TypedFunc(_), WasmHeapType::Func)
+        (WasmHeapType::Concrete(_), WasmHeapType::Func)
         | (WasmHeapType::Func, WasmHeapType::Func)
         | (WasmHeapType::Extern, WasmHeapType::Extern) => true,
-        (WasmHeapType::Func, _) | (WasmHeapType::Extern, _) | (WasmHeapType::TypedFunc(_), _) => {
+        (WasmHeapType::Func, _) | (WasmHeapType::Extern, _) | (WasmHeapType::Concrete(_), _) => {
             false
         }
     };


### PR DESCRIPTION
Purely mechanical, not functional changes.

This better matches the wording of the spec and of `wasmparser`, especially as we prepare to implement Wasm GC, where there can be references to concrete types that are not functions (and are structs or arrays instead).

Splitting this out from other work I am doing to make subsequent PRs that much easier to review.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
