### PR TITLE
Perform stronger typechecks of host-owned resources

### DIFF
--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -692,7 +692,7 @@ impl Func {
             // of the component.
             flags.set_may_enter(true);
 
-            let (calls, host_table) = store.0.component_calls_and_host_table();
+            let (calls, host_table, _) = store.0.component_resource_state();
             ResourceTables {
                 calls,
                 host_table: Some(host_table),

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -1,4 +1,5 @@
 use crate::component::matching::InstanceType;
+use crate::component::resources::HostResourceTables;
 use crate::component::ResourceType;
 use crate::store::{StoreId, StoreOpaque};
 use crate::StoreContextMut;
@@ -278,7 +279,7 @@ impl<'a, T> LowerContext<'a, T> {
     ///
     /// The `ty` provided is which table to put this into.
     pub fn guest_resource_lower_own(&mut self, ty: TypeResourceTableIndex, rep: u32) -> u32 {
-        self.resource_tables().resource_lower_own(Some(ty), rep)
+        self.resource_tables().guest_resource_lower_own(rep, ty)
     }
 
     /// Lowers a `borrow` resource into the guest, converting the `rep` to a
@@ -298,19 +299,20 @@ impl<'a, T> LowerContext<'a, T> {
         if unsafe { (*self.instance).resource_owned_by_own_instance(ty) } {
             return rep;
         }
-        self.resource_tables().resource_lower_borrow(Some(ty), rep)
+        self.resource_tables().guest_resource_lower_borrow(rep, ty)
     }
 
     /// Lifts a host-owned `own` resource at the `idx` specified into the
     /// representation of that resource.
-    pub fn host_resource_lift_own(&mut self, idx: u32) -> Result<u32> {
-        self.resource_tables().resource_lift_own(None, idx)
+    pub fn host_resource_lift_own(&mut self, idx: u32, expected: ResourceType) -> Result<u32> {
+        self.resource_tables().host_resource_lift_own(idx, expected)
     }
 
     /// Lifts a host-owned `borrow` resource at the `idx` specified into the
     /// representation of that resource.
-    pub fn host_resource_lift_borrow(&mut self, idx: u32) -> Result<u32> {
-        self.resource_tables().resource_lift_borrow(None, idx)
+    pub fn host_resource_lift_borrow(&mut self, idx: u32, expected: ResourceType) -> Result<u32> {
+        self.resource_tables()
+            .host_resource_lift_borrow(idx, expected)
     }
 
     /// Lowers a resource into the host-owned table, returning the index it was
@@ -318,8 +320,8 @@ impl<'a, T> LowerContext<'a, T> {
     ///
     /// Note that this is a special case for `Resource<T>`. Most of the time a
     /// host value shouldn't be lowered with a lowering context.
-    pub fn host_resource_lower_own(&mut self, rep: u32) -> u32 {
-        self.resource_tables().resource_lower_own(None, rep)
+    pub fn host_resource_lower_own(&mut self, rep: u32, ty: ResourceType) -> u32 {
+        self.resource_tables().host_resource_lower_own(rep, ty)
     }
 
     /// Returns the underlying resource type for the `ty` table specified.
@@ -335,26 +337,27 @@ impl<'a, T> LowerContext<'a, T> {
         InstanceType::new(unsafe { &*self.instance })
     }
 
-    fn resource_tables(&mut self) -> ResourceTables<'_> {
-        let (calls, host_table) = self.store.0.component_calls_and_host_table();
-        ResourceTables {
-            host_table: Some(host_table),
-            calls,
-            // Note that the unsafety here should be valid given the contract of
-            // `LowerContext::new`.
-            tables: Some(unsafe { (*self.instance).component_resource_tables() }),
-        }
+    fn resource_tables(&mut self) -> HostResourceTables<'_> {
+        let (calls, host_table, host_resource_types) = self.store.0.component_resource_state();
+        HostResourceTables::from_parts(
+            ResourceTables {
+                host_table: Some(host_table),
+                calls,
+                // Note that the unsafety here should be valid given the contract of
+                // `LowerContext::new`.
+                tables: Some(unsafe { (*self.instance).component_resource_tables() }),
+            },
+            host_resource_types,
+        )
     }
 
-    /// Begins a call into the component instance, starting recording of
-    /// metadata related to resource borrowing.
+    /// See [`HostResourceTables::enter_call`].
     #[inline]
     pub fn enter_call(&mut self) {
         self.resource_tables().enter_call()
     }
 
-    /// Completes a call into the component instance, validating that it's ok to
-    /// complete by ensuring the are no remaining active borrows.
+    /// See [`HostResourceTables::exit_call`].
     #[inline]
     pub fn exit_call(&mut self) -> Result<()> {
         self.resource_tables().exit_call()
@@ -379,6 +382,7 @@ pub struct LiftContext<'a> {
     instance: *mut ComponentInstance,
 
     host_table: &'a mut ResourceTable,
+    host_resource_types: &'a mut Vec<ResourceType>,
 
     calls: &'a mut CallContexts,
 }
@@ -404,8 +408,8 @@ impl<'a> LiftContext<'a> {
         // so it's hacked around a bit. This unsafe pointer cast could be fixed
         // with more methods in more places, but it doesn't seem worth doing it
         // at this time.
-        let (calls, host_table) =
-            (&mut *(store as *mut StoreOpaque)).component_calls_and_host_table();
+        let (calls, host_table, host_resource_types) =
+            (&mut *(store as *mut StoreOpaque)).component_resource_state();
         let memory = options.memory.map(|_| options.memory(store));
 
         LiftContext {
@@ -415,6 +419,7 @@ impl<'a> LiftContext<'a> {
             instance,
             calls,
             host_table,
+            host_resource_types,
         }
     }
 
@@ -450,7 +455,7 @@ impl<'a> LiftContext<'a> {
         ty: TypeResourceTableIndex,
         idx: u32,
     ) -> Result<(u32, Option<NonNull<VMFuncRef>>, Option<InstanceFlags>)> {
-        let idx = self.resource_tables().resource_lift_own(Some(ty), idx)?;
+        let idx = self.resource_tables().guest_resource_lift_own(idx, ty)?;
         // Note that the unsafety here should be valid given the contract of
         // `LiftContext::new`.
         let (dtor, flags) = unsafe { (*self.instance).dtor_and_flags(ty) };
@@ -463,19 +468,19 @@ impl<'a> LiftContext<'a> {
         ty: TypeResourceTableIndex,
         idx: u32,
     ) -> Result<u32> {
-        self.resource_tables().resource_lift_borrow(Some(ty), idx)
+        self.resource_tables().guest_resource_lift_borrow(idx, ty)
     }
 
     /// Lowers a resource into the host-owned table, returning the index it was
     /// inserted at.
-    pub fn host_resource_lower_own(&mut self, rep: u32) -> u32 {
-        self.resource_tables().resource_lower_own(None, rep)
+    pub fn host_resource_lower_own(&mut self, rep: u32, ty: ResourceType) -> u32 {
+        self.resource_tables().host_resource_lower_own(rep, ty)
     }
 
     /// Lowers a resource into the host-owned table, returning the index it was
     /// inserted at.
-    pub fn host_resource_lower_borrow(&mut self, rep: u32) -> u32 {
-        self.resource_tables().resource_lower_borrow(None, rep)
+    pub fn host_resource_lower_borrow(&mut self, rep: u32, ty: ResourceType) -> u32 {
+        self.resource_tables().host_resource_lower_borrow(rep, ty)
     }
 
     /// Returns the underlying type of the resource table specified by `ty`.
@@ -491,23 +496,26 @@ impl<'a> LiftContext<'a> {
         InstanceType::new(unsafe { &*self.instance })
     }
 
-    fn resource_tables(&mut self) -> ResourceTables<'_> {
-        ResourceTables {
-            host_table: Some(self.host_table),
-            calls: self.calls,
-            // Note that the unsafety here should be valid given the contract of
-            // `LiftContext::new`.
-            tables: Some(unsafe { (*self.instance).component_resource_tables() }),
-        }
+    fn resource_tables(&mut self) -> HostResourceTables<'_> {
+        HostResourceTables::from_parts(
+            ResourceTables {
+                host_table: Some(self.host_table),
+                calls: self.calls,
+                // Note that the unsafety here should be valid given the contract of
+                // `LiftContext::new`.
+                tables: Some(unsafe { (*self.instance).component_resource_tables() }),
+            },
+            self.host_resource_types,
+        )
     }
 
-    /// Same as `LowerContext::enter_call`
+    /// See [`HostResourceTables::enter_call`].
     #[inline]
     pub fn enter_call(&mut self) {
         self.resource_tables().enter_call()
     }
 
-    /// Same as `LiftContext::enter_call`
+    /// See [`HostResourceTables::exit_call`].
     #[inline]
     pub fn exit_call(&mut self) -> Result<()> {
         self.resource_tables().exit_call()

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -63,6 +63,8 @@ pub use self::resources::{Resource, ResourceAny};
 pub use self::types::{ResourceType, Type};
 pub use self::values::{Enum, Flags, List, OptionVal, Record, ResultVal, Tuple, Val, Variant};
 
+pub(crate) use self::resources::HostResourceData;
+
 // These items are expected to be used by an eventual
 // `#[derive(ComponentType)]`, they are not part of Wasmtime's API stability
 // guarantees

--- a/crates/wasmtime/src/runtime/component/resources.rs
+++ b/crates/wasmtime/src/runtime/component/resources.rs
@@ -336,10 +336,11 @@ impl HostResourceIndex {
     }
 
     fn index(&self) -> u32 {
-        self.0 as u32
+        u32::try_from(self.0 & 0xffffffff).unwrap()
     }
+
     fn gen(&self) -> u32 {
-        (self.0 >> 32) as u32
+        u32::try_from(self.0 >> 32).unwrap()
     }
 }
 

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -369,6 +369,8 @@ pub struct StoreOpaque {
     component_host_table: wasmtime_runtime::component::ResourceTable,
     #[cfg(feature = "component-model")]
     component_calls: wasmtime_runtime::component::CallContexts,
+    #[cfg(feature = "component-model")]
+    host_resource_types: Vec<crate::component::ResourceType>,
 }
 
 #[cfg(feature = "async")]
@@ -520,6 +522,8 @@ impl<T> Store<T> {
                 component_host_table: Default::default(),
                 #[cfg(feature = "component-model")]
                 component_calls: Default::default(),
+                #[cfg(feature = "component-model")]
+                host_resource_types: Vec::new(),
             },
             limiter: None,
             call_hook: None,
@@ -1627,13 +1631,18 @@ at https://bytecodealliance.org/security.
 
     #[inline]
     #[cfg(feature = "component-model")]
-    pub(crate) fn component_calls_and_host_table(
+    pub(crate) fn component_resource_state(
         &mut self,
     ) -> (
         &mut wasmtime_runtime::component::CallContexts,
         &mut wasmtime_runtime::component::ResourceTable,
+        &mut Vec<crate::component::ResourceType>,
     ) {
-        (&mut self.component_calls, &mut self.component_host_table)
+        (
+            &mut self.component_calls,
+            &mut self.component_host_table,
+            &mut self.host_resource_types,
+        )
     }
 
     #[cfg(feature = "component-model")]

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -370,7 +370,7 @@ pub struct StoreOpaque {
     #[cfg(feature = "component-model")]
     component_calls: wasmtime_runtime::component::CallContexts,
     #[cfg(feature = "component-model")]
-    host_resource_types: Vec<crate::component::ResourceType>,
+    host_resource_data: crate::component::HostResourceData,
 }
 
 #[cfg(feature = "async")]
@@ -523,7 +523,7 @@ impl<T> Store<T> {
                 #[cfg(feature = "component-model")]
                 component_calls: Default::default(),
                 #[cfg(feature = "component-model")]
-                host_resource_types: Vec::new(),
+                host_resource_data: Default::default(),
             },
             limiter: None,
             call_hook: None,
@@ -1636,12 +1636,12 @@ at https://bytecodealliance.org/security.
     ) -> (
         &mut wasmtime_runtime::component::CallContexts,
         &mut wasmtime_runtime::component::ResourceTable,
-        &mut Vec<crate::component::ResourceType>,
+        &mut crate::component::HostResourceData,
     ) {
         (
             &mut self.component_calls,
             &mut self.component_host_table,
-            &mut self.host_resource_types,
+            &mut self.host_resource_data,
         )
     }
 

--- a/tests/all/component_model/resources.rs
+++ b/tests/all/component_model/resources.rs
@@ -137,44 +137,70 @@ fn resource_any() -> Result<()> {
         "#,
     )?;
 
-    let mut store = Store::new(&engine, ());
     let linker = Linker::new(&engine);
-    let i = linker.instantiate(&mut store, &c)?;
-    let t = i.get_resource(&mut store, "t").unwrap();
-    let u = i.get_resource(&mut store, "u").unwrap();
+    {
+        let mut store = Store::new(&engine, ());
+        let i = linker.instantiate(&mut store, &c)?;
+        let t = i.get_resource(&mut store, "t").unwrap();
+        let u = i.get_resource(&mut store, "u").unwrap();
 
-    assert_ne!(t, u);
+        assert_ne!(t, u);
 
-    let t_ctor = i.get_typed_func::<(u32,), (ResourceAny,)>(&mut store, "[constructor]t")?;
-    let u_ctor = i.get_typed_func::<(u32,), (ResourceAny,)>(&mut store, "[constructor]u")?;
-    let t_dtor = i.get_typed_func::<(ResourceAny,), ()>(&mut store, "drop-t")?;
-    let u_dtor = i.get_typed_func::<(ResourceAny,), ()>(&mut store, "drop-u")?;
+        let t_ctor = i.get_typed_func::<(u32,), (ResourceAny,)>(&mut store, "[constructor]t")?;
+        let u_ctor = i.get_typed_func::<(u32,), (ResourceAny,)>(&mut store, "[constructor]u")?;
+        let t_dtor = i.get_typed_func::<(ResourceAny,), ()>(&mut store, "drop-t")?;
+        let u_dtor = i.get_typed_func::<(ResourceAny,), ()>(&mut store, "drop-u")?;
 
-    let (t1,) = t_ctor.call(&mut store, (100,))?;
-    t_ctor.post_return(&mut store)?;
-    let (t2,) = t_ctor.call(&mut store, (200,))?;
-    t_ctor.post_return(&mut store)?;
-    let (u1,) = u_ctor.call(&mut store, (300,))?;
-    u_ctor.post_return(&mut store)?;
-    let (u2,) = u_ctor.call(&mut store, (400,))?;
-    u_ctor.post_return(&mut store)?;
+        let (t1,) = t_ctor.call(&mut store, (100,))?;
+        t_ctor.post_return(&mut store)?;
+        let (t2,) = t_ctor.call(&mut store, (200,))?;
+        t_ctor.post_return(&mut store)?;
+        let (u1,) = u_ctor.call(&mut store, (300,))?;
+        u_ctor.post_return(&mut store)?;
+        let (u2,) = u_ctor.call(&mut store, (400,))?;
+        u_ctor.post_return(&mut store)?;
 
-    assert_eq!(t1.ty(), t);
-    assert_eq!(t2.ty(), t);
-    assert_eq!(u1.ty(), u);
-    assert_eq!(u2.ty(), u);
+        assert_eq!(t1.ty(), t);
+        assert_eq!(t2.ty(), t);
+        assert_eq!(u1.ty(), u);
+        assert_eq!(u2.ty(), u);
 
-    u_dtor.call(&mut store, (u2,))?;
-    u_dtor.post_return(&mut store)?;
+        u_dtor.call(&mut store, (u2,))?;
+        u_dtor.post_return(&mut store)?;
 
-    u_dtor.call(&mut store, (u1,))?;
-    u_dtor.post_return(&mut store)?;
+        u_dtor.call(&mut store, (u1,))?;
+        u_dtor.post_return(&mut store)?;
 
-    t_dtor.call(&mut store, (t1,))?;
-    t_dtor.post_return(&mut store)?;
+        t_dtor.call(&mut store, (t1,))?;
+        t_dtor.post_return(&mut store)?;
 
-    t_dtor.call(&mut store, (t2,))?;
-    t_dtor.post_return(&mut store)?;
+        t_dtor.call(&mut store, (t2,))?;
+        t_dtor.post_return(&mut store)?;
+    }
+
+    {
+        let mut store = Store::new(&engine, ());
+        let i = linker.instantiate(&mut store, &c)?;
+        let t_ctor = i.get_typed_func::<(u32,), (ResourceAny,)>(&mut store, "[constructor]t")?;
+        let u_ctor = i.get_typed_func::<(u32,), (ResourceAny,)>(&mut store, "[constructor]u")?;
+        let t_dtor = i.get_typed_func::<(ResourceAny,), ()>(&mut store, "drop-t")?;
+
+        // `t` is placed at host index 0
+        let (t,) = t_ctor.call(&mut store, (100,))?;
+        t_ctor.post_return(&mut store)?;
+        t_dtor.call(&mut store, (t1,))?;
+        t_dtor.post_return(&mut store)?;
+
+        // `u` is also placed at host index 0 since `t` was deallocated
+        let (u,) = u_ctor.call(&mut store, (100,))?;
+        u_ctor.post_return(&mut store)?;
+
+        // reuse of `t` should fail, despite it pointing to a valid resource
+        assert_eq!(
+            t_dtor.call(&mut store, (t1,)).unwrap_err().to_string(),
+            "host-owned resource is being used with the wrong type"
+        );
+    }
 
     Ok(())
 }

--- a/tests/all/component_model/resources.rs
+++ b/tests/all/component_model/resources.rs
@@ -188,16 +188,16 @@ fn resource_any() -> Result<()> {
         // `t` is placed at host index 0
         let (t,) = t_ctor.call(&mut store, (100,))?;
         t_ctor.post_return(&mut store)?;
-        t_dtor.call(&mut store, (t1,))?;
+        t_dtor.call(&mut store, (t,))?;
         t_dtor.post_return(&mut store)?;
 
         // `u` is also placed at host index 0 since `t` was deallocated
-        let (u,) = u_ctor.call(&mut store, (100,))?;
+        let (_u,) = u_ctor.call(&mut store, (100,))?;
         u_ctor.post_return(&mut store)?;
 
         // reuse of `t` should fail, despite it pointing to a valid resource
         assert_eq!(
-            t_dtor.call(&mut store, (t1,)).unwrap_err().to_string(),
+            t_dtor.call(&mut store, (t,)).unwrap_err().to_string(),
             "host-owned resource is being used with the wrong type"
         );
     }


### PR DESCRIPTION
Right now the abstraction for host-owned resources in Wasmtime is quite simple, it's "just an index". This can be error prone because the host can suffer both from use-after-free and ABA-style problems. While there's not much that can be done about use-after-free the previous implementation would accidentally enable "AB" style problems where if a host-owned resource index was deallocated and then reallocated with another type the original handle would still work. While not a major bug this can be confusing and additionally violate's our guarantees as a component runtime to guests to ensure that resources always have valid `rep`s going into components.

This commit adds a new layer of storage which keeps track of the `ResourceType` for all host-owned resources. This means that resources going into a host-owned table now record their type and coming out of a host-owned table a typecheck is always performed. Note that guests can continue to skip this logic as they already have per-type tables and so won't suffer the same issue.

This change is inspired by my taking a look at #7883. The crux of the issue was a typo where a resource was reused by accident which led to confusing behavior due to the reuse. This change instead makes it return an error more quickly and doesn't allow the component to see any invalid state.

Closes #7883

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
