### PR TITLE
Fix assertion locations in memflags after #7903

### DIFF
--- a/cranelift/codegen/src/ir/memflags.rs
+++ b/cranelift/codegen/src/ir/memflags.rs
@@ -127,15 +127,16 @@ impl MemFlags {
     /// Set endianness of the memory access.
     pub fn set_endianness(&mut self, endianness: Endianness) {
         *self = self.with_endianness(endianness);
-        assert!(!(self.read(FlagBit::LittleEndian) && self.read(FlagBit::BigEndian)));
     }
 
     /// Set endianness of the memory access, returning new flags.
     pub const fn with_endianness(self, endianness: Endianness) -> Self {
-        match endianness {
+        let res = match endianness {
             Endianness::Little => self.with(FlagBit::LittleEndian),
             Endianness::Big => self.with(FlagBit::BigEndian),
-        }
+        };
+        assert!(!(res.read(FlagBit::LittleEndian) && res.read(FlagBit::BigEndian)));
+        res
     }
 
     /// Test if the `notrap` flag is set.
@@ -214,12 +215,12 @@ impl MemFlags {
     /// Set the `heap` bit. See the notes about mutual exclusion with
     /// other bits in `heap()`.
     pub fn set_heap(&mut self) {
-        assert!(!self.table() && !self.vmctx());
         *self = self.with_heap();
     }
 
     /// Set the `heap` bit, returning new flags.
     pub const fn with_heap(self) -> Self {
+        assert!(!self.table() && !self.vmctx());
         self.with(FlagBit::Heap)
     }
 
@@ -238,12 +239,12 @@ impl MemFlags {
     /// Set the `table` bit. See the notes about mutual exclusion with
     /// other bits in `table()`.
     pub fn set_table(&mut self) {
-        assert!(!self.heap() && !self.vmctx());
         *self = self.with_table();
     }
 
     /// Set the `table` bit, returning new flags.
     pub const fn with_table(self) -> Self {
+        assert!(!self.heap() && !self.vmctx());
         self.with(FlagBit::Table)
     }
 
@@ -262,12 +263,12 @@ impl MemFlags {
     /// Set the `vmctx` bit. See the notes about mutual exclusion with
     /// other bits in `vmctx()`.
     pub fn set_vmctx(&mut self) {
-        assert!(!self.heap() && !self.table());
         *self = self.with_vmctx();
     }
 
     /// Set the `vmctx` bit, returning new flags.
     pub const fn with_vmctx(self) -> Self {
+        assert!(!self.heap() && !self.table());
         self.with(FlagBit::Vmctx)
     }
 


### PR DESCRIPTION
In #7903 I reworked the `set` and `with` functions on `MemFlags` to use the `with` variant internally, to enable further use of `const`. However, I didn't move the assertions from the `set` to the `with` methods, meaning that there was now a path that would avoid them. This follow-up fixes that mistake by moving the assertions into the `with` functions.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
