### PR TITLE
Test with aarch64 macOS on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -514,7 +514,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
     - name: CPU information
       run: sysctl hw
-      if: matrix.os == 'macos-latest'
+      if: contains(matrix.os, 'macos')
     - name: CPU information
       run: wmic cpu list /format:list
       shell: pwsh

--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -36,7 +36,7 @@ const array = [
   },
   {
     "build": "aarch64-macos",
-    "os": "macos-latest",
+    "os": "macos-14",
     "target": "aarch64-apple-darwin",
   },
   {

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -60,6 +60,12 @@ const array = [
     "filter": "macos-x64"
   },
   {
+    "os": "macos-14",
+    "name": "Test macOS arm64",
+    "filter": "macos-arm64"
+    "target": "aarch64-apple-darwin",
+  },
+  {
     "os": "windows-latest",
     "name": "Test Windows MSVC x86_64",
     "filter": "windows-x64"

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -62,8 +62,8 @@ const array = [
   {
     "os": "macos-14",
     "name": "Test macOS arm64",
-    "filter": "macos-arm64"
-    "target": "aarch64-apple-darwin",
+    "filter": "macos-arm64",
+    "target": "aarch64-apple-darwin"
   },
   {
     "os": "windows-latest",


### PR DESCRIPTION
Rebase of #7129 with the `macos-14` string which GitHub indicates should now work for public repos.



<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
