### PR TITLE
Shrink the size of int-to-float conversions

### DIFF
--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -170,7 +170,7 @@
 
 ;; Cranelift's `fcvt_from_{u,s}int` instructions are polymorphic over the input
 ;; type so remove any unnecessary `uextend` or `sextend` to give backends
-;; the chance to convert from the smallest integral type to the a float. This
+;; the chance to convert from the smallest integral type to the float. This
 ;; can help lowerings on x64 for example which has a less efficient u64-to-float
 ;; conversion than other bit widths.
 (rule (simplify (fcvt_from_uint ty (uextend _ val)))

--- a/cranelift/codegen/src/opts/arithmetic.isle
+++ b/cranelift/codegen/src/opts/arithmetic.isle
@@ -167,3 +167,13 @@
       (if-let $true (ty_equal half_ty (ty_half_width ty)))
       (if-let $true (u64_eq k (ty_bits_u64 half_ty)))
       (uextend ty (umulhi half_ty x y)))
+
+;; Cranelift's `fcvt_from_{u,s}int` instructions are polymorphic over the input
+;; type so remove any unnecessary `uextend` or `sextend` to give backends
+;; the chance to convert from the smallest integral type to the a float. This
+;; can help lowerings on x64 for example which has a less efficient u64-to-float
+;; conversion than other bit widths.
+(rule (simplify (fcvt_from_uint ty (uextend _ val)))
+      (fcvt_from_uint ty val))
+(rule (simplify (fcvt_from_sint ty (sextend _ val)))
+      (fcvt_from_sint ty val))

--- a/cranelift/filetests/filetests/egraph/fcvt.clif
+++ b/cranelift/filetests/filetests/egraph/fcvt.clif
@@ -1,0 +1,43 @@
+test optimize
+set opt_level=speed
+target x86_64
+
+function %u32_ext_to_f32(i32) -> f32 {
+block0(v0: i32):
+  v1 = uextend.i64 v0
+  v2 = fcvt_from_uint.f32 v1
+  return v2
+
+  ; check: v3 = fcvt_from_uint.f32 v0
+  ; check: return v3
+}
+
+function %u32_ext_to_f64(i32) -> f64 {
+block0(v0: i32):
+  v1 = uextend.i64 v0
+  v2 = fcvt_from_uint.f64 v1
+  return v2
+
+  ; check: v3 = fcvt_from_uint.f64 v0
+  ; check: return v3
+}
+
+function %i32_ext_to_f32(i32) -> f32 {
+block0(v0: i32):
+  v1 = sextend.i64 v0
+  v2 = fcvt_from_sint.f32 v1
+  return v2
+
+  ; check: v3 = fcvt_from_sint.f32 v0
+  ; check: return v3
+}
+
+function %i32_ext_to_f64(i32) -> f64 {
+block0(v0: i32):
+  v1 = sextend.i64 v0
+  v2 = fcvt_from_sint.f64 v1
+  return v2
+
+  ; check: v3 = fcvt_from_sint.f64 v0
+  ; check: return v3
+}

--- a/cranelift/filetests/filetests/egraph/vector.clif
+++ b/cranelift/filetests/filetests/egraph/vector.clif
@@ -18,10 +18,9 @@ block0(v0: i32):
   v2 = splat.i64x2 v1
   v3 = fcvt_from_uint.f64x2 v2
   return v3
-  ; check: v1 = uextend.i64 v0
-  ; check: v4 = fcvt_from_uint.f64 v1
-  ; check: v5 = splat.f64x2 v4
-  ; check: return v5
+  ; check: v5 = fcvt_from_uint.f64 v0
+  ; check: v7 = splat.f64x2 v5
+  ; check: return v7
 }
 
 function %f3(i32) -> f64x2 {


### PR DESCRIPTION
This commit adds egraph optimization rules to shrink the size of int-to-float conversions where possible. This helps backends like the x64 backend where the 64-bit-unsigned-integer-to-float conversions does not have a single instruction lowering unlike other types.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
