### PR TITLE
x64: Add `fcvt_from_uint` lowering for i64x2

### DIFF
--- a/cranelift/codegen/src/isa/x64/lower.isle
+++ b/cranelift/codegen/src/isa/x64/lower.isle
@@ -3417,6 +3417,45 @@
 (rule (lower (has_type ty (fcvt_from_uint val @ (value_type $I64))))
       (cvt_u64_to_float_seq ty val))
 
+;; Base case of u64x2 being converted to f64x2. No native instruction for this
+;; is available so it's emulated through a series of instructions that exploit
+;; the binary representation of 64-bit floats. This sequence of instructions is
+;; copied from LLVM and my understanding of the general idea is to roughly:
+;;
+;; * For each bullet below operate in parallel on the left and right lanes.
+;; * Move the low 32 bits of the input into one register and the upper
+;;   32-bits into a different register, where both have all 0s for the upper
+;;   32-bits. (e.g. split the 64-bit input into two locations)
+;; * For the low bits, create `1.<twenty-zeros><low32>p52` via bit tricks.
+;; * For the high bits, create `1.<twenty-zeros><high32>p84` via bit tricks.
+;; * Create the constant `1.0p84 + 1.0p52`
+;; * Add the two high halves and subtract the constant.
+;;
+;; Apply some math and this should produce the same result as the native
+;; conversion.
+;;
+;; As for the bit tricks a float is represented where the low 53 bits are the
+;; decimal of the float, basically:
+;;
+;;  f = 1.<fraction> ^ (<exponent> - 1023)
+;;
+;; where `<fraction>` is the low 53 bits. By placing the 32-bit halves from
+;; the original integer into the low 53 bits and setting the exponent right it
+;; means that each 32-bit half can become part of a 64-bit floating point
+;; number. The final step in combining via float arithmetic will chop off the
+;; leading `1.` at the start of the float that we constructed, one for the low
+;; half and one for the upper half.
+(rule -1 (lower (has_type $F64X2 (fcvt_from_uint val @ (value_type $I64X2))))
+  (let ((low32_mask XmmMem (emit_u128_le_const 0x00000000ffffffff_00000000ffffffff))
+        (float_1p52 XmmMem (emit_u128_le_const 0x4330000000000000_4330000000000000))
+        (float_1p84 XmmMem (emit_u128_le_const 0x4530000000000000_4530000000000000))
+        (float_1p84_plus_1p52 XmmMem (emit_u128_le_const 0x4530000000100000_4530000000100000))
+        (low32 Xmm (x64_pand val low32_mask))
+        (low32_as_float Xmm (x64_por low32 float_1p52))
+        (high32 Xmm (x64_psrlq val (xmi_imm 32)))
+        (high32_as_float Xmm (x64_por high32 float_1p84)))
+    (x64_addpd low32_as_float (x64_subpd high32_as_float float_1p84_plus_1p52))))
+
 ;; Algorithm uses unpcklps to help create a float that is equivalent
 ;; 0x1.0p52 + double(src). 0x1.0p52 is unique because at this exponent
 ;; every value of the mantissa represents a corresponding uint32 number.

--- a/cranelift/filetests/filetests/isa/x64/fcvt-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt-avx.clif
@@ -113,3 +113,45 @@ block0(v0: i64):
 ;   popq %rbp
 ;   retq
 
+function %u64x2_to_f64x2(i64x2) -> f64x2 {
+block0(v0: i64x2):
+  v1 = fcvt_from_uint.f64x2 v0
+  return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   vpand   %xmm0, const(0), %xmm2
+;   vpor    %xmm2, const(1), %xmm4
+;   vpsrlq  %xmm0, $32, %xmm6
+;   vpor    %xmm6, const(2), %xmm0
+;   vsubpd  %xmm0, const(3), %xmm2
+;   vaddpd  %xmm4, %xmm2, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   vpand 0x34(%rip), %xmm0, %xmm2
+;   vpor 0x3c(%rip), %xmm2, %xmm4
+;   vpsrlq $0x20, %xmm0, %xmm6
+;   vpor 0x3f(%rip), %xmm6, %xmm0
+;   vsubpd 0x47(%rip), %xmm0, %xmm2
+;   vaddpd %xmm2, %xmm4, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+

--- a/cranelift/filetests/filetests/isa/x64/fcvt.clif
+++ b/cranelift/filetests/filetests/isa/x64/fcvt.clif
@@ -1146,3 +1146,53 @@ block0(v0: f32x4):
 ;   popq %rbp
 ;   retq
 
+function %u64x2_to_f64x2(i64x2) -> f64x2 {
+block0(v0: i64x2):
+  v1 = fcvt_from_uint.f64x2 v0
+  return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movdqa  %xmm0, %xmm7
+;   pand    %xmm7, const(0), %xmm7
+;   movdqa  %xmm7, %xmm1
+;   por     %xmm1, const(1), %xmm1
+;   movdqa  %xmm1, %xmm7
+;   psrlq   %xmm0, $32, %xmm0
+;   por     %xmm0, const(2), %xmm0
+;   subpd   %xmm0, const(3), %xmm0
+;   movdqa  %xmm0, %xmm1
+;   movdqa  %xmm7, %xmm0
+;   addpd   %xmm0, %xmm1, %xmm0
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movdqa %xmm0, %xmm7
+;   pand 0x40(%rip), %xmm7
+;   movdqa %xmm7, %xmm1
+;   por 0x44(%rip), %xmm1
+;   movdqa %xmm1, %xmm7
+;   psrlq $0x20, %xmm0
+;   por 0x43(%rip), %xmm0
+;   subpd 0x4b(%rip), %xmm0
+;   movdqa %xmm0, %xmm1
+;   movdqa %xmm7, %xmm0
+;   addpd %xmm1, %xmm0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+

--- a/cranelift/filetests/filetests/runtests/simd-fcvt-from-uint.clif
+++ b/cranelift/filetests/filetests/runtests/simd-fcvt-from-uint.clif
@@ -6,14 +6,25 @@ target x86_64
 target x86_64 sse41
 target x86_64 sse42
 target x86_64 sse42 has_avx
+target x86_64 sse42 has_avx has_avx512vl has_avx512f
 target riscv64 has_v
 target riscv64 has_v has_c has_zcb
 
-function %fcvt_from_uint(i32x4) -> f32x4 {
+function %fcvt_from_uint32(i32x4) -> f32x4 {
 block0(v0: i32x4):
     v1 = fcvt_from_uint.f32x4 v0
     return v1
 }
-; run: %fcvt_from_uint([0 0 0 0]) == [0x0.0 0x0.0 0x0.0 0x0.0]
-; run: %fcvt_from_uint([0xFFFFFFFF 0 1 123456789]) == [0x100000000.0 0.0 0x1.0 0x75bcd18.0]
+; run: %fcvt_from_uint32([0 0 0 0]) == [0x0.0 0x0.0 0x0.0 0x0.0]
+; run: %fcvt_from_uint32([0xFFFFFFFF 0 1 123456789]) == [0x100000000.0 0.0 0x1.0 0x75bcd18.0]
 ; Note that 0xFFFFFFFF is decimal 4,294,967,295 and is rounded up 1 to 4,294,967,296 in f32x4.
+
+function %fcvt_from_uint64(i64x2) -> f64x2 {
+block0(v0: i64x2):
+    v1 = fcvt_from_uint.f64x2 v0
+    return v1
+}
+; run: %fcvt_from_uint64([0 0]) == [0x0.0 0x0.0]
+; run: %fcvt_from_uint64([0xFFFFFFFF 0]) == [0xffffffff.0 0.0]
+; run: %fcvt_from_uint64([1 123456789]) == [0x1.0 0x75bcd15.0]
+; run: %fcvt_from_uint64([-1 0x20]) == [0x1.0p64 0x20.0]


### PR DESCRIPTION
This commit adds a general purpose lowering for the `fcvt_from_uint` instruction in addition to the previously specialized lowering for what the wasm frontend produces. This is unlikely to get triggered much from the wasm frontend except when intermediate optimizations change the shape of code. The goal of this commit is to address issues such as those identified in #7915 and historically by ensuring that there's a lowering for the instruction for all input types instead of trying to massage the input into the right form.

This instruction lowering was crafted by studying LLVM's output and I've put commentary to the best of my ability as to what's going on.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
