### PR TITLE
Make `RegisteredType` hold a whole `Engine`

### DIFF
--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -307,7 +307,7 @@ impl Component {
         // Create a signature registration with the `Engine` for all trampolines
         // and core wasm types found within this component, both for the
         // component and for all included core wasm modules.
-        let signatures = TypeCollection::new_for_module(engine.signatures(), types.module_types());
+        let signatures = TypeCollection::new_for_module(engine, types.module_types());
 
         // Assemble the `CodeObject` artifact which is shared by all core wasm
         // modules as well as the final component.

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -517,7 +517,7 @@ impl Module {
         // Note that the unsafety here should be ok since the `trampolines`
         // field should only point to valid trampoline function pointers
         // within the text section.
-        let signatures = TypeCollection::new_for_module(engine.signatures(), &types);
+        let signatures = TypeCollection::new_for_module(engine, &types);
 
         // Package up all our data into a `CodeObject` and delegate to the final
         // step of module compilation.

--- a/crates/wasmtime/src/runtime/trampoline/func.rs
+++ b/crates/wasmtime/src/runtime/trampoline/func.rs
@@ -123,7 +123,7 @@ where
     let native_call = text[native_call_range.start as usize..].as_ptr() as *mut _;
     let native_call = NonNull::new(native_call).unwrap();
 
-    let sig = engine.signatures().register(ft.as_wasm_func_type());
+    let sig = ft.clone().into_registered_type();
 
     unsafe {
         Ok(VMArrayCallHostFuncContext::new(

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -252,13 +252,13 @@ impl FuncType {
     }
 
     pub(crate) fn from_wasm_func_type(engine: &Engine, ty: &WasmFuncType) -> FuncType {
-        let ty = engine.signatures().register(ty);
+        let ty = RegisteredType::new(engine, ty);
         Self { ty }
     }
 
     pub(crate) fn from_shared_type_index(engine: &Engine, index: VMSharedTypeIndex) -> FuncType {
-        let ty = engine.signatures().root(index).expect(
-            "VMSharedTypeIndex is not registered in the Engine. Wrong \
+        let ty = RegisteredType::root(engine, index).expect(
+            "VMSharedTypeIndex is not registered in the Engine! Wrong \
              engine? Didn't root the index somewhere?",
         );
         Self { ty }


### PR DESCRIPTION
Rather than an `Arc<RwLock<TypeRegistryInner>>`.

This also removes the `Arc` inside `TypeRegistry` and we effectively reuse `Engine`'s internal `Arc` instead.

Also, to avoid various `TypeRegistry` methods needing to take an `Engine` to construct their `RegisteredType` results, but then needing to assert that the given engine is this registry's engine, I turned the methods into `TypeRegistry` constructors. These constructors take just an `&Engine` and then access the underlying `TypeRegistry` as needed, effectively making that property hold statically.

This is a minor clean up on its own, but is a big help for follow up work I am doing for Wasm GC and typed function references, where being able to grab a reference to the engine that a `FuncType` is registered within will prevent needing to thread in additional engine parameters to various places and then assert that the engine is the engine that the type is registered within, and etc...

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
