### PR TITLE
Return correct fs errors on the proxy adapter

### DIFF
--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -20,6 +20,8 @@ impl bindings::exports::wasi::http::incoming_handler::Guest for T {
         assert!(request.authority().is_some());
         assert!(request.path_with_query().is_some());
 
+        test_filesystem();
+
         let header = String::from("custom-forbidden-header");
         let req_hdrs = request.headers();
 
@@ -60,3 +62,7 @@ impl bindings::exports::wasi::http::incoming_handler::Guest for T {
 // Technically this should not be here for a proxy, but given the current
 // framework for tests it's required since this file is built as a `bin`
 fn main() {}
+
+fn test_filesystem() {
+    assert!(std::fs::File::open(".").is_err());
+}

--- a/crates/wasi-preview1-component-adapter/src/lib.rs
+++ b/crates/wasi-preview1-component-adapter/src/lib.rs
@@ -908,6 +908,13 @@ pub unsafe extern "C" fn fd_prestat_get(fd: Fd, buf: *mut Prestat) -> Errno {
         return ERRNO_BADF;
     }
 
+    // For the proxy adapter don't return `ERRNO_NOTSUP` through below, instead
+    // always return `ERRNO_BADF` which is the indicator that prestats aren't
+    // available.
+    if cfg!(feature = "proxy") {
+        return ERRNO_BADF;
+    }
+
     cfg_filesystem_available! {
         State::with(|state| {
             let ds = state.descriptors();


### PR DESCRIPTION
This commit fixes an issue with the proxy adapter where if the proxy program attempted to look at prestat items, which wasi-libc always does on startup, it would invoke `fd_prestat_get` and receive `ERRNO_NOTSUP` in response (the standard response when using the
`cfg_filesystem_available!` macro). This error code is unexpected by wasi-libc and causes wasi-libc to abort. The PR here is to instead return `ERRNO_BADF` which is indeed expected by wasi-libc and is recognized as meaning "that prestat isn't available".

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
