### PR TITLE
winch: Optimize calls

### DIFF
--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -506,17 +506,17 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             Writable::from_reg(regs::rax()),
         ));
         insts.push(Inst::CallKnown {
+            opcode: Opcode::Call,
             dest: ExternalName::LibCall(LibCall::Probestack),
-            info: Box::new(CallInfo {
+            info: Some(Box::new(CallInfo {
                 // No need to include arg here: we are post-regalloc
                 // so no constraints will be seen anyway.
                 uses: smallvec![],
                 defs: smallvec![],
                 clobbers: PRegSet::empty(),
-                opcode: Opcode::Call,
                 callee_pop_size: 0,
                 callee_conv: CallConv::Probestack,
-            }),
+            })),
         });
     }
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -525,10 +525,12 @@
 
        ;; Direct call: call simm32.
        (CallKnown (dest ExternalName)
+                  (opcode Opcode)
                   (info BoxCallInfo))
 
        ;; Indirect call: callq (reg mem)
        (CallUnknown (dest RegMem)
+                    (opcode Opcode)
                     (info BoxCallInfo))
 
        ;; Tail call to a direct destination.

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -41,8 +41,6 @@ pub struct CallInfo {
     pub defs: CallRetList,
     /// Registers clobbered by this call, as per its calling convention.
     pub clobbers: PRegSet,
-    /// The opcode of this call.
-    pub opcode: Opcode,
     /// The number of bytes that the callee will pop from the stack for the
     /// caller, if any. (Used for popping stack arguments with the `tail`
     /// calling convention.)
@@ -556,14 +554,14 @@ impl Inst {
     ) -> Inst {
         Inst::CallKnown {
             dest,
-            info: Box::new(CallInfo {
+            opcode,
+            info: Some(Box::new(CallInfo {
                 uses,
                 defs,
                 clobbers,
-                opcode,
                 callee_pop_size,
                 callee_conv,
-            }),
+            })),
         }
     }
 
@@ -579,14 +577,14 @@ impl Inst {
         dest.assert_regclass_is(RegClass::Int);
         Inst::CallUnknown {
             dest,
-            info: Box::new(CallInfo {
+            opcode,
+            info: Some(Box::new(CallInfo {
                 uses,
                 defs,
                 clobbers,
-                opcode,
                 callee_pop_size,
                 callee_conv,
-            }),
+            })),
         }
     }
 
@@ -2348,37 +2346,41 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             collector.reg_early_def(*tmp);
         }
 
-        Inst::CallKnown { dest, ref info, .. } => {
+        Inst::CallKnown { dest, info, .. } => {
             // Probestack is special and is only inserted after
             // regalloc, so we do not need to represent its ABI to the
             // register allocator. Assert that we don't alter that
             // arrangement.
-            debug_assert_ne!(*dest, ExternalName::LibCall(LibCall::Probestack));
-            for u in &info.uses {
-                collector.reg_fixed_use(u.vreg, u.preg);
+            if let Some(info) = info {
+                debug_assert_ne!(*dest, ExternalName::LibCall(LibCall::Probestack));
+                for u in &info.uses {
+                    collector.reg_fixed_use(u.vreg, u.preg);
+                }
+                for d in &info.defs {
+                    collector.reg_fixed_def(d.vreg, d.preg);
+                }
+                collector.reg_clobbers(info.clobbers);
             }
-            for d in &info.defs {
-                collector.reg_fixed_def(d.vreg, d.preg);
-            }
-            collector.reg_clobbers(info.clobbers);
         }
 
-        Inst::CallUnknown { ref info, dest, .. } => {
-            match dest {
-                RegMem::Reg { reg } if info.callee_conv == CallConv::Tail => {
-                    // TODO(https://github.com/bytecodealliance/regalloc2/issues/145):
-                    // This shouldn't be a fixed register constraint.
-                    collector.reg_fixed_use(*reg, regs::r15())
+        Inst::CallUnknown { info, dest, .. } => {
+            if let Some(info) = info {
+                match dest {
+                    RegMem::Reg { reg } if info.callee_conv == CallConv::Tail => {
+                        // TODO(https://github.com/bytecodealliance/regalloc2/issues/145):
+                        // This shouldn't be a fixed register constraint.
+                        collector.reg_fixed_use(*reg, regs::r15())
+                    }
+                    _ => dest.get_operands(collector),
                 }
-                _ => dest.get_operands(collector),
+                for u in &info.uses {
+                    collector.reg_fixed_use(u.vreg, u.preg);
+                }
+                for d in &info.defs {
+                    collector.reg_fixed_def(d.vreg, d.preg);
+                }
+                collector.reg_clobbers(info.clobbers);
             }
-            for u in &info.uses {
-                collector.reg_fixed_use(u.vreg, u.preg);
-            }
-            for d in &info.defs {
-                collector.reg_fixed_def(d.vreg, d.preg);
-            }
-            collector.reg_clobbers(info.clobbers);
         }
 
         Inst::ReturnCallKnown { callee, info } => {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -33,7 +33,7 @@ use regalloc2::PReg;
 use std::boxed::Box;
 use std::convert::TryFrom;
 
-type BoxCallInfo = Box<CallInfo>;
+type BoxCallInfo = Option<Box<CallInfo>>;
 type BoxReturnCallInfo = Box<ReturnCallInfo>;
 type VecArgPair = Vec<ArgPair>;
 

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -33,6 +33,10 @@ use regalloc2::PReg;
 use std::boxed::Box;
 use std::convert::TryFrom;
 
+/// Type representing out-of-line data for calls. This type optional because the
+/// call instruction is also used by Winch to emit calls, but the
+/// `Box<CallInfo>` field is not used, it's only used by Cranelift. By making it
+/// optional, we reduce the number of heap allocations in Winch.
 type BoxCallInfo = Option<Box<CallInfo>>;
 type BoxReturnCallInfo = Box<ReturnCallInfo>;
 type VecArgPair = Vec<ArgPair>;

--- a/winch/codegen/src/codegen/context.rs
+++ b/winch/codegen/src/codegen/context.rs
@@ -3,7 +3,6 @@ use wasmtime_environ::{VMOffsets, WasmHeapType, WasmValType};
 use super::ControlStackFrame;
 use crate::{
     abi::{ABIOperand, ABIResults, RetArea, ABI},
-    codegen::BuiltinFunctions,
     frame::Frame,
     isa::reg::RegClass,
     masm::{MacroAssembler, OperandSize, RegImm, SPOffset, StackSlot},
@@ -27,7 +26,7 @@ use crate::{
 /// generation process. The code generation context should
 /// be generally used as the single entry point to access
 /// the compound functionality provided by its elements.
-pub(crate) struct CodeGenContext<'a, 'builtins: 'a> {
+pub(crate) struct CodeGenContext<'a> {
     /// The register allocator.
     pub regalloc: RegAlloc,
     /// The value stack.
@@ -36,19 +35,16 @@ pub(crate) struct CodeGenContext<'a, 'builtins: 'a> {
     pub frame: Frame,
     /// Reachability state.
     pub reachable: bool,
-    /// The built-in functions available to the JIT code.
-    pub builtins: &'builtins mut BuiltinFunctions,
     /// A reference to the VMOffsets.
     pub vmoffsets: &'a VMOffsets<u8>,
 }
 
-impl<'a, 'builtins> CodeGenContext<'a, 'builtins> {
+impl<'a> CodeGenContext<'a> {
     /// Create a new code generation context.
     pub fn new(
         regalloc: RegAlloc,
         stack: Stack,
         frame: Frame,
-        builtins: &'builtins mut BuiltinFunctions,
         vmoffsets: &'a VMOffsets<u8>,
     ) -> Self {
         Self {
@@ -56,7 +52,6 @@ impl<'a, 'builtins> CodeGenContext<'a, 'builtins> {
             stack,
             frame,
             reachable: true,
-            builtins,
             vmoffsets,
         }
     }

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -87,9 +87,9 @@ pub(crate) enum Callee<'a> {
     Builtin(BuiltinFunction),
 }
 
-impl<'a> Callee<'a> {
+impl Callee<'_> {
     /// Returns the [ABISig] of the [Callee].
-    pub(crate) fn sig(&'a self) -> &'a ABISig {
+    pub(crate) fn sig(&self) -> &ABISig {
         match self {
             Self::Local(info) | Self::Import(info) => &info.sig,
             Self::FuncRef(sig) => sig,

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -37,7 +37,7 @@ where
     pub sig: ABISig,
 
     /// The code generation context.
-    pub context: CodeGenContext<'a, 'translation>,
+    pub context: CodeGenContext<'a>,
 
     /// A reference to the function compilation environment.
     pub env: FuncEnv<'a, 'translation, 'data, M::Ptr>,
@@ -57,7 +57,7 @@ where
 {
     pub fn new(
         masm: &'a mut M,
-        context: CodeGenContext<'a, 'translation>,
+        context: CodeGenContext<'a>,
         env: FuncEnv<'a, 'translation, 'data, M::Ptr>,
         sig: ABISig,
     ) -> Self {
@@ -368,7 +368,7 @@ where
         let table_data = self.env.resolve_table_data(table_index);
         let ptr_type = self.env.ptr_type();
         let builtin = self
-            .context
+            .env
             .builtins
             .table_get_lazy_init_func_ref::<M::ABI, M::Ptr>();
 
@@ -416,9 +416,11 @@ where
         // This is safe since the FnCall::emit call below, will ensure
         // that the result register is placed on the value stack.
         self.context.free_reg(elem_value);
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |_| {
-            Callee::Builtin(builtin.clone())
-        });
+        FnCall::emit::<M, M::Ptr>(
+            self.masm,
+            &mut self.context,
+            Callee::Builtin(builtin.clone()),
+        );
 
         // We know the signature of the libcall in this case, so we assert that there's
         // one element in the stack and that it's  the ABI signature's result register.

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -1,7 +1,7 @@
 use super::{abi::Aarch64ABI, address::Address, asm::Assembler, regs};
 use crate::{
     abi::{self, local::LocalSlot},
-    codegen::{ptr_type_from_ptr_size, CodeGenContext, HeapData, TableData},
+    codegen::{ptr_type_from_ptr_size, CodeGenContext, FuncEnv, HeapData, TableData},
     isa::reg::Reg,
     masm::{
         CalleeKind, DivKind, ExtendKind, FloatCmpKind, Imm as I, IntCmpKind,
@@ -328,11 +328,13 @@ impl Masm for MacroAssembler {
         todo!()
     }
 
-    fn float_round(
+    fn float_round<F: FnMut(&mut FuncEnv<Self::Ptr>, &mut CodeGenContext, &mut Self)>(
         &mut self,
         _mode: RoundingMode,
+        _env: &mut FuncEnv<Self::Ptr>,
         _context: &mut CodeGenContext,
         _size: OperandSize,
+        _fallback: F,
     ) {
         todo!();
     }

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -98,7 +98,7 @@ impl TargetIsa for Aarch64 {
         let stack = Stack::new();
         let abi_sig = abi::Aarch64ABI::sig(sig, &CallingConvention::Default);
 
-        let env = FuncEnv::new(&vmoffsets, translation, types, self);
+        let env = FuncEnv::new(&vmoffsets, translation, types, builtins, self);
         let defined_locals = DefinedLocals::new::<abi::Aarch64ABI>(&env, &mut body, validator)?;
         let frame = Frame::new::<abi::Aarch64ABI>(&abi_sig, &defined_locals)?;
         let gpr = RegBitSet::int(
@@ -109,7 +109,7 @@ impl TargetIsa for Aarch64 {
         // TODO: Add floating point bitmask
         let fpr = RegBitSet::float(0, 0, usize::try_from(MAX_FPR).unwrap());
         let regalloc = RegAlloc::from(gpr, fpr);
-        let codegen_context = CodeGenContext::new(regalloc, stack, frame, builtins, &vmoffsets);
+        let codegen_context = CodeGenContext::new(regalloc, stack, frame, &vmoffsets);
         let mut codegen = CodeGen::new(&mut masm, codegen_context, env, abi_sig);
 
         codegen.emit(&mut body, validator)?;

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -18,16 +18,15 @@ use cranelift_codegen::{
                 ShiftKind as CraneliftShiftKind, SseOpcode, SyntheticAmode, WritableGpr,
                 WritableXmm, Xmm, XmmMem, XmmMemAligned, CC,
             },
-            settings as x64_settings, CallInfo, EmitInfo, EmitState, Inst,
+            settings as x64_settings, EmitInfo, EmitState, Inst,
         },
-        CallConv,
     },
     settings, Final, MachBuffer, MachBufferFinalized, MachInstEmit, MachInstEmitState, MachLabel,
     VCodeConstantData, VCodeConstants, Writable,
 };
 
 use super::address::Address;
-use smallvec::{smallvec, SmallVec};
+use smallvec::SmallVec;
 
 // Conversions between winch-codegen x64 types and cranelift-codegen x64 types.
 
@@ -1246,14 +1245,8 @@ impl Assembler {
     pub fn call_with_reg(&mut self, callee: Reg) {
         self.emit(Inst::CallUnknown {
             dest: RegMem::reg(callee.into()),
-            info: Box::new(CallInfo {
-                uses: smallvec![],
-                defs: smallvec![],
-                clobbers: Default::default(),
-                opcode: Opcode::Call,
-                callee_pop_size: 0,
-                callee_conv: CallConv::SystemV,
-            }),
+            opcode: Opcode::Call,
+            info: None,
         });
     }
 
@@ -1262,14 +1255,8 @@ impl Assembler {
         let dest = ExternalName::user(UserExternalNameRef::new(index as usize));
         self.emit(Inst::CallKnown {
             dest,
-            info: Box::new(CallInfo {
-                uses: smallvec![],
-                defs: smallvec![],
-                clobbers: Default::default(),
-                opcode: Opcode::Call,
-                callee_pop_size: 0,
-                callee_conv: CallConv::SystemV,
-            }),
+            opcode: Opcode::Call,
+            info: None,
         });
     }
 
@@ -1278,14 +1265,8 @@ impl Assembler {
         let dest = ExternalName::LibCall(lib);
         self.emit(Inst::CallKnown {
             dest,
-            info: Box::new(CallInfo {
-                uses: smallvec![],
-                defs: smallvec![],
-                clobbers: Default::default(),
-                opcode: Opcode::Call,
-                callee_pop_size: 0,
-                callee_conv: CallConv::SystemV,
-            }),
+            opcode: Opcode::Call,
+            info: None,
         });
     }
 

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -107,7 +107,7 @@ impl TargetIsa for X64 {
         let stack = Stack::new();
         let abi_sig = abi::X64ABI::sig(sig, &CallingConvention::Default);
 
-        let env = FuncEnv::new(&vmoffsets, translation, types, self);
+        let env = FuncEnv::new(&vmoffsets, translation, types, builtins, self);
         let defined_locals = DefinedLocals::new::<abi::X64ABI>(&env, &mut body, validator)?;
         let frame = Frame::new::<abi::X64ABI>(&abi_sig, &defined_locals)?;
         let gpr = RegBitSet::int(
@@ -122,7 +122,7 @@ impl TargetIsa for X64 {
         );
 
         let regalloc = RegAlloc::from(gpr, fpr);
-        let codegen_context = CodeGenContext::new(regalloc, stack, frame, builtins, &vmoffsets);
+        let codegen_context = CodeGenContext::new(regalloc, stack, frame, &vmoffsets);
         let mut codegen = CodeGen::new(&mut masm, codegen_context, env, abi_sig);
 
         codegen.emit(&mut body, validator)?;

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -1,5 +1,5 @@
 use crate::abi::{self, align_to, LocalSlot};
-use crate::codegen::{CodeGenContext, HeapData, TableData};
+use crate::codegen::{CodeGenContext, FuncEnv, HeapData, TableData};
 use crate::isa::reg::Reg;
 use cranelift_codegen::{
     ir::{Endianness, LibCall, MemFlags},
@@ -603,7 +603,14 @@ pub(crate) trait MacroAssembler {
     fn float_neg(&mut self, dst: Reg, size: OperandSize);
 
     /// Perform a floating point floor operation.
-    fn float_round(&mut self, mode: RoundingMode, context: &mut CodeGenContext, size: OperandSize);
+    fn float_round<F: FnMut(&mut FuncEnv<Self::Ptr>, &mut CodeGenContext, &mut Self)>(
+        &mut self,
+        mode: RoundingMode,
+        env: &mut FuncEnv<Self::Ptr>,
+        context: &mut CodeGenContext,
+        size: OperandSize,
+        fallback: F,
+    );
 
     /// Perform a floating point square root operation.
     fn float_sqrt(&mut self, dst: Reg, src: Reg, size: OperandSize);

--- a/winch/codegen/src/regalloc.rs
+++ b/winch/codegen/src/regalloc.rs
@@ -54,7 +54,7 @@ impl RegAlloc {
             spill(self);
             self.regset
                 .reg(named)
-                .expect(&format!("register {:?} to be available", named))
+                .unwrap_or_else(|| panic!("Exepected register {:?} to be available", named))
         })
     }
 

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -453,7 +453,7 @@ where
     }
 
     fn visit_f32_floor(&mut self) {
-        self.masm.float_round::<_>(
+        self.masm.float_round(
             RoundingMode::Down,
             &mut self.env,
             &mut self.context,

--- a/winch/codegen/src/visitor.rs
+++ b/winch/codegen/src/visitor.rs
@@ -453,43 +453,107 @@ where
     }
 
     fn visit_f32_floor(&mut self) {
-        self.masm
-            .float_round(RoundingMode::Down, &mut self.context, OperandSize::S32);
+        self.masm.float_round::<_>(
+            RoundingMode::Down,
+            &mut self.env,
+            &mut self.context,
+            OperandSize::S32,
+            |env, cx, masm| {
+                let builtin = env.builtins.floor_f32::<M::ABI>();
+                FnCall::emit::<M, M::Ptr>(masm, cx, Callee::Builtin(builtin));
+            },
+        );
     }
 
     fn visit_f64_floor(&mut self) {
-        self.masm
-            .float_round(RoundingMode::Down, &mut self.context, OperandSize::S64);
+        self.masm.float_round(
+            RoundingMode::Down,
+            &mut self.env,
+            &mut self.context,
+            OperandSize::S64,
+            |env, cx, masm| {
+                let builtin = env.builtins.floor_f64::<M::ABI>();
+                FnCall::emit::<M, M::Ptr>(masm, cx, Callee::Builtin(builtin));
+            },
+        );
     }
 
     fn visit_f32_ceil(&mut self) {
-        self.masm
-            .float_round(RoundingMode::Up, &mut self.context, OperandSize::S32);
+        self.masm.float_round(
+            RoundingMode::Up,
+            &mut self.env,
+            &mut self.context,
+            OperandSize::S32,
+            |env, cx, masm| {
+                let builtin = env.builtins.ceil_f32::<M::ABI>();
+                FnCall::emit::<M, M::Ptr>(masm, cx, Callee::Builtin(builtin));
+            },
+        );
     }
 
     fn visit_f64_ceil(&mut self) {
-        self.masm
-            .float_round(RoundingMode::Up, &mut self.context, OperandSize::S64);
+        self.masm.float_round(
+            RoundingMode::Up,
+            &mut self.env,
+            &mut self.context,
+            OperandSize::S64,
+            |env, cx, masm| {
+                let builtin = env.builtins.ceil_f64::<M::ABI>();
+                FnCall::emit::<M, M::Ptr>(masm, cx, Callee::Builtin(builtin));
+            },
+        );
     }
 
     fn visit_f32_nearest(&mut self) {
-        self.masm
-            .float_round(RoundingMode::Nearest, &mut self.context, OperandSize::S32);
+        self.masm.float_round(
+            RoundingMode::Nearest,
+            &mut self.env,
+            &mut self.context,
+            OperandSize::S32,
+            |env, cx, masm| {
+                let builtin = env.builtins.nearest_f32::<M::ABI>();
+                FnCall::emit::<M, M::Ptr>(masm, cx, Callee::Builtin(builtin))
+            },
+        );
     }
 
     fn visit_f64_nearest(&mut self) {
-        self.masm
-            .float_round(RoundingMode::Nearest, &mut self.context, OperandSize::S64);
+        self.masm.float_round(
+            RoundingMode::Nearest,
+            &mut self.env,
+            &mut self.context,
+            OperandSize::S64,
+            |env, cx, masm| {
+                let builtin = env.builtins.nearest_f64::<M::ABI>();
+                FnCall::emit::<M, M::Ptr>(masm, cx, Callee::Builtin(builtin));
+            },
+        );
     }
 
     fn visit_f32_trunc(&mut self) {
-        self.masm
-            .float_round(RoundingMode::Zero, &mut self.context, OperandSize::S32);
+        self.masm.float_round(
+            RoundingMode::Zero,
+            &mut self.env,
+            &mut self.context,
+            OperandSize::S32,
+            |env, cx, masm| {
+                let builtin = env.builtins.trunc_f32::<M::ABI>();
+                FnCall::emit::<M, M::Ptr>(masm, cx, Callee::Builtin(builtin));
+            },
+        );
     }
 
     fn visit_f64_trunc(&mut self) {
-        self.masm
-            .float_round(RoundingMode::Zero, &mut self.context, OperandSize::S64);
+        self.masm.float_round(
+            RoundingMode::Zero,
+            &mut self.env,
+            &mut self.context,
+            OperandSize::S64,
+            |env, cx, masm| {
+                let builtin = env.builtins.trunc_f64::<M::ABI>();
+                FnCall::emit::<M, M::Ptr>(masm, cx, Callee::Builtin(builtin));
+            },
+        );
     }
 
     fn visit_f32_sqrt(&mut self) {
@@ -1291,8 +1355,12 @@ where
     }
 
     fn visit_call(&mut self, index: u32) {
-        let callee = self.env.callee_from_index(FuncIndex::from_u32(index));
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |_| callee.clone());
+        FnCall::emit::<M, M::Ptr>(
+            self.masm,
+            &mut self.context,
+            self.env
+                .callee_from_index::<M::ABI>(FuncIndex::from_u32(index)),
+        )
     }
 
     fn visit_call_indirect(&mut self, type_index: u32, table_index: u32, _: u8) {
@@ -1321,9 +1389,11 @@ where
             }
         }
 
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |_| {
-            self.env.funcref(type_index)
-        })
+        FnCall::emit::<M, M::Ptr>(
+            self.masm,
+            &mut self.context,
+            self.env.funcref::<M::ABI>(type_index),
+        )
     }
 
     fn visit_table_init(&mut self, elem: u32, table: u32) {
@@ -1335,15 +1405,19 @@ where
 
         self.context.stack.insert_many(
             at,
-            [
+            &[
                 vmctx.into(),
                 table.try_into().unwrap(),
                 elem.try_into().unwrap(),
             ],
         );
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |cx| {
-            Callee::Builtin(cx.builtins.table_init::<M::ABI, M::Ptr>())
-        });
+
+        let builtin = self.env.builtins.table_init::<M::ABI, M::Ptr>();
+        FnCall::emit::<M, M::Ptr>(
+            self.masm,
+            &mut self.context,
+            Callee::Builtin(builtin.clone()),
+        )
     }
 
     fn visit_table_copy(&mut self, dst: u32, src: u32) {
@@ -1353,16 +1427,15 @@ where
         let at = self.context.stack.len() - 3;
         self.context.stack.insert_many(
             at,
-            [
+            &[
                 vmctx.into(),
                 dst.try_into().unwrap(),
                 src.try_into().unwrap(),
             ],
         );
 
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |context| {
-            Callee::Builtin(context.builtins.table_copy::<M::ABI, M::Ptr>())
-        });
+        let builtin = self.env.builtins.table_copy::<M::ABI, M::Ptr>();
+        FnCall::emit::<M, M::Ptr>(self.masm, &mut self.context, Callee::Builtin(builtin))
     }
 
     fn visit_table_get(&mut self, table: u32) {
@@ -1385,10 +1458,7 @@ where
         let table_index = TableIndex::from_u32(table);
         let table_plan = self.env.table_plan(table_index);
         let builtin = match table_plan.table.wasm_ty.heap_type {
-            WasmHeapType::Func => self
-                .context
-                .builtins
-                .table_grow_func_ref::<M::ABI, M::Ptr>(),
+            WasmHeapType::Func => self.env.builtins.table_grow_func_ref::<M::ABI, M::Ptr>(),
             ty => unimplemented!("Support for HeapType: {ty}"),
         };
 
@@ -1406,11 +1476,13 @@ where
         self.context.stack.inner_mut().swap(len - 1, len - 2);
         self.context
             .stack
-            .insert_many(at, [vmctx.into(), table.try_into().unwrap()]);
+            .insert_many(at, &[vmctx.into(), table.try_into().unwrap()]);
 
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |_| {
-            Callee::Builtin(builtin.clone())
-        });
+        FnCall::emit::<M, M::Ptr>(
+            self.masm,
+            &mut self.context,
+            Callee::Builtin(builtin.clone()),
+        )
     }
 
     fn visit_table_size(&mut self, table: u32) {
@@ -1425,10 +1497,7 @@ where
         let table_index = TableIndex::from_u32(table);
         let table_plan = self.env.table_plan(table_index);
         let builtin = match table_plan.table.wasm_ty.heap_type {
-            WasmHeapType::Func => self
-                .context
-                .builtins
-                .table_fill_func_ref::<M::ABI, M::Ptr>(),
+            WasmHeapType::Func => self.env.builtins.table_fill_func_ref::<M::ABI, M::Ptr>(),
             ty => unimplemented!("Support for heap type: {ty}"),
         };
 
@@ -1437,10 +1506,12 @@ where
         let at = len - 3;
         self.context
             .stack
-            .insert_many(at, [vmctx.into(), table.try_into().unwrap()]);
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |_| {
-            Callee::Builtin(builtin.clone())
-        })
+            .insert_many(at, &[vmctx.into(), table.try_into().unwrap()]);
+        FnCall::emit::<M, M::Ptr>(
+            self.masm,
+            &mut self.context,
+            Callee::Builtin(builtin.clone()),
+        )
     }
 
     fn visit_table_set(&mut self, table: u32) {
@@ -1482,14 +1553,12 @@ where
 
     fn visit_elem_drop(&mut self, index: u32) {
         let ptr_type = self.env.ptr_type();
-        let elem_drop = self.context.builtins.elem_drop::<M::ABI, M::Ptr>();
+        let elem_drop = self.env.builtins.elem_drop::<M::ABI, M::Ptr>();
         let vmctx = TypedReg::new(ptr_type, <M::ABI as ABI>::vmctx_reg());
         self.context
             .stack
             .extend([vmctx.into(), index.try_into().unwrap()]);
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |_| {
-            Callee::Builtin(elem_drop.clone())
-        });
+        FnCall::emit::<M, M::Ptr>(self.masm, &mut self.context, Callee::Builtin(elem_drop))
     }
 
     fn visit_memory_init(&mut self, data_index: u32, mem: u32) {
@@ -1499,15 +1568,14 @@ where
         let vmctx = TypedReg::new(ptr_type, <M::ABI as ABI>::vmctx_reg());
         self.context.stack.insert_many(
             at,
-            [
+            &[
                 vmctx.into(),
                 mem.try_into().unwrap(),
                 data_index.try_into().unwrap(),
             ],
         );
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |cx| {
-            Callee::Builtin(cx.builtins.memory_init::<M::ABI, M::Ptr>())
-        });
+        let builtin = self.env.builtins.memory_init::<M::ABI, M::Ptr>();
+        FnCall::emit::<M, M::Ptr>(self.masm, &mut self.context, Callee::Builtin(builtin))
     }
 
     fn visit_memory_copy(&mut self, dst_mem: u32, src_mem: u32) {
@@ -1522,17 +1590,17 @@ where
         let at = self.context.stack.len() - 2;
         self.context
             .stack
-            .insert_many(at, [src_mem.try_into().unwrap()]);
+            .insert_many(at, &[src_mem.try_into().unwrap()]);
 
         // One element was inserted above, so instead of 3, we use 4.
         let at = self.context.stack.len() - 4;
         self.context
             .stack
-            .insert_many(at, [vmctx.into(), dst_mem.try_into().unwrap()]);
+            .insert_many(at, &[vmctx.into(), dst_mem.try_into().unwrap()]);
 
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |cx| {
-            Callee::Builtin(cx.builtins.memory_copy::<M::ABI, M::Ptr>())
-        });
+        let builtin = self.env.builtins.memory_copy::<M::ABI, M::Ptr>();
+
+        FnCall::emit::<M, M::Ptr>(self.masm, &mut self.context, Callee::Builtin(builtin))
     }
 
     fn visit_memory_fill(&mut self, mem: u32) {
@@ -1543,11 +1611,10 @@ where
 
         self.context
             .stack
-            .insert_many(at, [vmctx.into(), mem.try_into().unwrap()]);
+            .insert_many(at, &[vmctx.into(), mem.try_into().unwrap()]);
 
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |cx| {
-            Callee::Builtin(cx.builtins.memory_fill::<M::ABI, M::Ptr>())
-        });
+        let builtin = self.env.builtins.memory_fill::<M::ABI, M::Ptr>();
+        FnCall::emit::<M, M::Ptr>(self.masm, &mut self.context, Callee::Builtin(builtin))
     }
 
     fn visit_memory_size(&mut self, mem: u32, _: u8) {
@@ -1563,12 +1630,11 @@ where
         // The stack at this point contains: [ delta ]
         // The desired state is
         //   [ vmctx, delta, index ]
-        self.context.stack.insert_many(at, [vmctx.into()]);
+        self.context.stack.insert_many(at, &[vmctx.into()]);
         self.context.stack.extend([mem.try_into().unwrap()]);
 
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |cx| {
-            Callee::Builtin(cx.builtins.memory32_grow::<M::ABI, M::Ptr>())
-        });
+        let builtin = self.env.builtins.memory32_grow::<M::ABI, M::Ptr>();
+        FnCall::emit::<M, M::Ptr>(self.masm, &mut self.context, Callee::Builtin(builtin))
     }
 
     fn visit_data_drop(&mut self, data_index: u32) {
@@ -1578,9 +1644,8 @@ where
             .stack
             .extend([vmctx.into(), data_index.try_into().unwrap()]);
 
-        FnCall::emit::<M, M::Ptr, _>(self.masm, &mut self.context, |cx| {
-            Callee::Builtin(cx.builtins.data_drop::<M::ABI, M::Ptr>())
-        });
+        let builtin = self.env.builtins.data_drop::<M::ABI, M::Ptr>();
+        FnCall::emit::<M, M::Ptr>(self.masm, &mut self.context, Callee::Builtin(builtin))
     }
 
     fn visit_nop(&mut self) {}


### PR DESCRIPTION
This commit introduces several optimizations to speed up the compilation of function calls:

* Keep track of previously resolved function signatures for local or imported callees to avoid computing the `ABISig` on every function call.
* Keep track of previously resolved type signatures for indirect calls to avoid computing the `ABISig` on every function call.
* Refactor `CallKnown` and `CallUnknown` instructions to make the `BoxCallInfo` field in the struct optional. Prior to this change, from Winch's perspective each call lowering involved a heap allocation, using the default values for `BoxCallInfo`, which in the end are not used by Winch.
* Switch Winch's internal `Stack` to use a `SmallVec` rather than a `Vec`. Many of the operations involving builtin function calls require inserting elements at arbitrary offsets in the stack and using a `SmallVec` makes this process more efficient.

With the changes mentioned above, I observed ~30% improvement in compilation times for modules that are call-heavy.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
