### PR TITLE
Add Component::image_range

### DIFF
--- a/crates/c-api/include/wasmtime/module.h
+++ b/crates/c-api/include/wasmtime/module.h
@@ -145,8 +145,8 @@ wasmtime_module_deserialize_file(wasm_engine_t *engine, const char *path,
  * https://docs.wasmtime.dev/api/wasmtime/struct.Module.html#method.image_range
  */
 WASM_API_EXTERN void
-wasmtime_module_image_range(const wasmtime_module_t *module, size_t *start,
-                            size_t *end);
+wasmtime_module_image_range(const wasmtime_module_t *module, void **start,
+                            void **end);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/crates/c-api/src/module.rs
+++ b/crates/c-api/src/module.rs
@@ -186,8 +186,8 @@ pub extern "C" fn wasmtime_module_serialize(
 #[no_mangle]
 pub extern "C" fn wasmtime_module_image_range(
     module: &wasmtime_module_t,
-    start: &mut usize,
-    end: &mut usize,
+    start: &mut *const u8,
+    end: &mut *const u8,
 ) {
     let range = module.module.image_range();
     *start = range.start;

--- a/crates/runtime/src/mmap_vec.rs
+++ b/crates/runtime/src/mmap_vec.rs
@@ -122,6 +122,14 @@ impl MmapVec {
     pub fn original_offset(&self) -> usize {
         self.range.start
     }
+
+    /// Returns the bounds, in host memory, of where this mmap
+    /// image resides.
+    pub fn image_range(&self) -> Range<*const u8> {
+        let base = self.as_ptr();
+        let len = self.len();
+        base..base.wrapping_add(len)
+    }
 }
 
 impl Deref for MmapVec {

--- a/crates/wasmtime/src/runtime/component/component.rs
+++ b/crates/wasmtime/src/runtime/component/component.rs
@@ -5,6 +5,7 @@ use crate::{
 use anyhow::{bail, Context, Result};
 use std::fs;
 use std::mem;
+use std::ops::Range;
 use std::path::Path;
 use std::ptr::NonNull;
 use std::sync::Arc;
@@ -509,6 +510,15 @@ impl Component {
             }
         }
         Some(resources)
+    }
+
+    /// Returns the range, in the host's address space, that this module's
+    /// compiled code resides at.
+    ///
+    /// For more information see
+    /// [`Module;:image_range`](crate::Module::image_range).
+    pub fn image_range(&self) -> Range<*const u8> {
+        self.inner.code.code_memory().mmap().image_range()
     }
 }
 

--- a/crates/wasmtime/src/runtime/instantiate.rs
+++ b/crates/wasmtime/src/runtime/instantiate.rs
@@ -7,7 +7,6 @@ use crate::{code_memory::CodeMemory, profiling_agent::ProfilingAgent};
 use anyhow::{Error, Result};
 use object::write::WritableBuffer;
 use std::convert::TryFrom;
-use std::ops::Range;
 use std::str;
 use std::sync::Arc;
 use wasmtime_environ::{

--- a/crates/wasmtime/src/runtime/instantiate.rs
+++ b/crates/wasmtime/src/runtime/instantiate.rs
@@ -319,14 +319,6 @@ impl CompiledModule {
     pub fn has_address_map(&self) -> bool {
         !self.code_memory.address_map_data().is_empty()
     }
-
-    /// Returns the bounds, in host memory, of where this module's compiled
-    /// image resides.
-    pub fn image_range(&self) -> Range<usize> {
-        let base = self.mmap().as_ptr() as usize;
-        let len = self.mmap().len();
-        base..base + len
-    }
 }
 
 #[cfg(feature = "addr2line")]

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -981,8 +981,8 @@ impl Module {
     ///
     /// It is not safe to modify the memory in this range, nor is it safe to
     /// modify the protections of memory in this range.
-    pub fn image_range(&self) -> Range<usize> {
-        self.compiled_module().image_range()
+    pub fn image_range(&self) -> Range<*const u8> {
+        self.compiled_module().mmap().image_range()
     }
 
     /// Force initialization of copy-on-write images to happen here-and-now


### PR DESCRIPTION
This is the same as `Module::image_range` but for components. While I'm here additionally return a pointer instead of a `usize` to further emphasize that it's in the host's address space.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
