### PR TITLE
Extend C API with interfaces needed to use threads

### DIFF
--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -195,6 +195,7 @@
 #include <wasmtime/memory.h>
 #include <wasmtime/module.h>
 #include <wasmtime/profiling.h>
+#include <wasmtime/sharedmemory.h>
 #include <wasmtime/store.h>
 #include <wasmtime/table.h>
 #include <wasmtime/trap.h>

--- a/crates/c-api/include/wasmtime/extern.h
+++ b/crates/c-api/include/wasmtime/extern.h
@@ -85,6 +85,11 @@ typedef uint8_t wasmtime_extern_kind_t;
 /// \brief Value of #wasmtime_extern_kind_t meaning that #wasmtime_extern_t is a
 /// memory
 #define WASMTIME_EXTERN_MEMORY 3
+/// \brief Value of #wasmtime_extern_kind_t meaning that #wasmtime_extern_t is a
+/// shared memory
+#define WASMTIME_EXTERN_SHAREDMEMORY 4
+
+struct wasmtime_sharedmemory;
 
 /**
  * \typedef wasmtime_extern_union_t
@@ -105,6 +110,8 @@ typedef union wasmtime_extern_union {
   wasmtime_table_t table;
   /// Field used if #wasmtime_extern_t::kind is #WASMTIME_EXTERN_MEMORY
   wasmtime_memory_t memory;
+  /// Field used if #wasmtime_extern_t::kind is #WASMTIME_EXTERN_SHAREDMEMORY
+  struct wasmtime_sharedmemory *sharedmemory;
 } wasmtime_extern_union_t;
 
 /**

--- a/crates/c-api/include/wasmtime/linker.h
+++ b/crates/c-api/include/wasmtime/linker.h
@@ -43,6 +43,15 @@ typedef struct wasmtime_linker wasmtime_linker_t;
 WASM_API_EXTERN wasmtime_linker_t *wasmtime_linker_new(wasm_engine_t *engine);
 
 /**
+ * \brief Clones existing linker.
+ *
+ * This function does not take ownership of the linker argument, and the caller
+ * is expected to delete the returned linker.
+ */
+WASM_API_EXTERN wasmtime_linker_t *
+wasmtime_linker_clone(wasmtime_linker_t *linker);
+
+/**
  * \brief Deletes a linker
  */
 WASM_API_EXTERN void wasmtime_linker_delete(wasmtime_linker_t *linker);

--- a/crates/c-api/include/wasmtime/memory.h
+++ b/crates/c-api/include/wasmtime/memory.h
@@ -55,6 +55,11 @@ WASM_API_EXTERN bool wasmtime_memorytype_maximum(const wasm_memorytype_t *ty,
 WASM_API_EXTERN bool wasmtime_memorytype_is64(const wasm_memorytype_t *ty);
 
 /**
+ * \brief Returns whether this type of memory represents a shared memory.
+ */
+WASM_API_EXTERN bool wasmtime_memorytype_isshared(const wasm_memorytype_t *ty);
+
+/**
  * \brief Creates a new WebAssembly linear memory
  *
  * \param store the store to create the memory within

--- a/crates/c-api/include/wasmtime/sharedmemory.h
+++ b/crates/c-api/include/wasmtime/sharedmemory.h
@@ -1,0 +1,115 @@
+/**
+ * \file wasmtime/sharedmemory.h
+ *
+ * Wasmtime API for interacting with wasm shared memories.
+ */
+
+#ifndef WASMTIME_SHAREDMEMORY_H
+#define WASMTIME_SHAREDMEMORY_H
+
+#include <wasm.h>
+#include <wasmtime/error.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief Interface for shared memories.
+ *
+ * For more information see the Rust documentation at:
+ * https://docs.wasmtime.dev/api/wasmtime/struct.SharedMemory.html
+ */
+typedef struct wasmtime_sharedmemory wasmtime_sharedmemory_t;
+
+/**
+ * \brief Creates a new WebAssembly shared linear memory
+ *
+ * \param engine engine that created shared memory is associated with
+ * \param ty the type of the memory to create
+ * \param ret where to store the returned memory
+ *
+ * If an error happens when creating the memory it's returned and owned by the
+ * caller. If an error happens then `ret` is not filled in.
+ */
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_sharedmemory_new(const wasm_engine_t *engine,
+                          const wasm_memorytype_t *ty,
+                          wasmtime_sharedmemory_t **ret);
+
+/**
+ * \brief Deletes shared linear memory
+ *
+ * \param memory memory to be deleted
+ */
+WASM_API_EXTERN void
+wasmtime_sharedmemory_delete(wasmtime_sharedmemory_t *memory);
+
+/**
+ * \brief Clones shared linear memory
+ *
+ * \param memory memory to be cloned
+ *
+ * This function makes shallow clone, ie. copy of reference counted
+ * memory handle.
+ */
+WASM_API_EXTERN wasmtime_sharedmemory_t *
+wasmtime_sharedmemory_clone(const wasmtime_sharedmemory_t *memory);
+
+/**
+ * \brief Moves shared linear memory into wasmtime_extern_t object
+ *
+ * \param memory memory to be moved
+ * \param out where to store resulting `wasmtime_extern_t`
+ *
+ * This function moves ownership of `memory` into resulting `wasmtime_extern_t`.
+ */
+WASM_API_EXTERN void
+wasmtime_sharedmemory_into_extern(wasmtime_sharedmemory_t *memory,
+                                  wasmtime_extern_t *out);
+
+/**
+ * \brief Returns the type of the shared memory specified
+ */
+WASM_API_EXTERN wasm_memorytype_t *
+wasmtime_sharedmemory_type(const wasmtime_sharedmemory_t *memory);
+
+/**
+ * \brief Returns the base pointer in memory where
+          the shared linear memory starts.
+ */
+WASM_API_EXTERN uint8_t *
+wasmtime_sharedmemory_data(const wasmtime_sharedmemory_t *memory);
+
+/**
+ * \brief Returns the byte length of this shared linear memory.
+ */
+WASM_API_EXTERN size_t
+wasmtime_sharedmemory_data_size(const wasmtime_sharedmemory_t *memory);
+
+/**
+ * \brief Returns the length, in WebAssembly pages, of this shared linear memory
+ */
+WASM_API_EXTERN uint64_t
+wasmtime_sharedmemory_size(const wasmtime_sharedmemory_t *memory);
+
+/**
+ * \brief Attempts to grow the specified shared memory by `delta` pages.
+ *
+ * \param memory the memory to grow
+ * \param delta the number of pages to grow by
+ * \param prev_size where to store the previous size of memory
+ *
+ * If memory cannot be grown then `prev_size` is left unchanged and an error is
+ * returned. Otherwise `prev_size` is set to the previous size of the memory, in
+ * WebAssembly pages, and `NULL` is returned.
+ */
+WASM_API_EXTERN wasmtime_error_t *
+wasmtime_sharedmemory_grow(const wasmtime_sharedmemory_t *memory,
+                           uint64_t delta, uint64_t *prev_size);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // WASMTIME_SHAREDMEMORY_H

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -29,6 +29,7 @@ mod module;
 #[cfg(feature = "profiling")]
 mod profiling;
 mod r#ref;
+mod sharedmemory;
 mod store;
 mod table;
 mod trap;

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -22,6 +22,13 @@ pub extern "C" fn wasmtime_linker_new(engine: &wasm_engine_t) -> Box<wasmtime_li
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_linker_clone(linker: &wasmtime_linker_t) -> Box<wasmtime_linker_t> {
+    Box::new(wasmtime_linker_t {
+        linker: linker.linker.clone(),
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_linker_allow_shadowing(
     linker: &mut wasmtime_linker_t,
     allow_shadowing: bool,

--- a/crates/c-api/src/types/memory.rs
+++ b/crates/c-api/src/types/memory.rs
@@ -109,6 +109,11 @@ pub extern "C" fn wasmtime_memorytype_is64(mt: &wasm_memorytype_t) -> bool {
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_memorytype_isshared(mt: &wasm_memorytype_t) -> bool {
+    mt.ty().ty.is_shared()
+}
+
+#[no_mangle]
 pub extern "C" fn wasm_memorytype_as_externtype(ty: &wasm_memorytype_t) -> &wasm_externtype_t {
     &ty.ext
 }


### PR DESCRIPTION
I'm not sure how to handle SharedMemory here. Possibly it could use Extern interfaces, but I had some trouble with it. Extern seem to assume that it's associated with Store, but shared memories aren't. Instead I added dedicated `wasmtime_linker_define_sharedmemory`. Is this acceptable or I need to fight with Extern more to get it to work?