### PR TITLE
vet: prune lockfile

### DIFF
--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -2,392 +2,192 @@
 # cargo-vet imports lock
 
 [[unpublished.cranelift]]
-version = "0.105.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-bforest]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-bforest]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-codegen]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-codegen]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-codegen-meta]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-codegen-meta]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-codegen-shared]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-control]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-control]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-entity]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-entity]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-frontend]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-frontend]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-interpreter]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-isle]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-isle]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-jit]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-jit]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-module]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-module]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-native]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-native]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-object]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-object]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-reader]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-reader]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-serde]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-serde]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.cranelift-wasm]]
-version = "0.105.0"
-audited_as = "0.104.0"
+audited_as = "0.104.1"
 
 [[unpublished.cranelift-wasm]]
 version = "0.106.0"
-audited_as = "0.104.0"
-
-[[unpublished.wasi-cap-std-sync]]
-version = "18.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasi-cap-std-sync]]
-version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasi-common]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "0.104.1"
 
 [[unpublished.wasi-common]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasi-tokio]]
-version = "18.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasi-tokio]]
-version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-asm-macros]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-asm-macros]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-cache]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-cache]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-cli]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-cli]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-cli-flags]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-component-macro]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-component-macro]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-component-util]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-component-util]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-cranelift]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-cranelift]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-cranelift-shared]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-environ]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-environ]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-explorer]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-explorer]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-fiber]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-fiber]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-jit-debug]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-jit-icache-coherence]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-runtime]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-runtime]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-types]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-types]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-wasi]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-wasi-http]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-wasi-http]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-wasi-nn]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-wasi-threads]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-wasi-threads]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-wast]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-winch]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-winch]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-wit-bindgen]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wasmtime-wmemcheck]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wasmtime-wmemcheck]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wiggle]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wiggle]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wiggle-generate]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wiggle-generate]]
 version = "19.0.0"
-audited_as = "17.0.0"
-
-[[unpublished.wiggle-macro]]
-version = "18.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wiggle-macro]]
 version = "19.0.0"
-audited_as = "17.0.0"
+audited_as = "17.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
 audited_as = "0.1.0"
 
 [[unpublished.winch-codegen]]
-version = "0.16.0"
-audited_as = "0.15.0"
-
-[[unpublished.winch-codegen]]
 version = "0.17.0"
-audited_as = "0.15.0"
+audited_as = "0.15.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -481,22 +281,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.cap-fs-ext]]
-version = "2.0.1"
-when = "2024-01-02"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
-[[publisher.cap-fs-ext]]
 version = "3.0.0"
 when = "2024-01-11"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
-[[publisher.cap-net-ext]]
-version = "2.0.1"
-when = "2024-01-02"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -509,22 +295,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.cap-primitives]]
-version = "2.0.1"
-when = "2024-01-02"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
-[[publisher.cap-primitives]]
 version = "3.0.0"
 when = "2024-01-11"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
-[[publisher.cap-rand]]
-version = "2.0.1"
-when = "2024-01-02"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -537,22 +309,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.cap-std]]
-version = "2.0.1"
-when = "2024-01-02"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
-[[publisher.cap-std]]
 version = "3.0.0"
 when = "2024-01-11"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
-[[publisher.cap-time-ext]]
-version = "2.0.1"
-when = "2024-01-02"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -600,104 +358,104 @@ user-login = "jrmuizel"
 user-name = "Jeff Muizelaar"
 
 [[publisher.cranelift]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-shared]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-entity]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-interpreter]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-jit]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-native]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-reader]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-serde]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.cranelift-wasm]]
-version = "0.104.0"
-when = "2024-01-25"
+version = "0.104.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -767,13 +525,6 @@ user-name = "Josh Stone"
 [[publisher.io-extras]]
 version = "0.18.1"
 when = "2023-12-01"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
-[[publisher.io-lifetimes]]
-version = "2.0.2"
-when = "2023-06-30"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -884,13 +635,6 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.rustix]]
-version = "0.38.28"
-when = "2023-12-09"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
-[[publisher.rustix]]
 version = "0.38.31"
 when = "2024-02-01"
 user-id = 6825
@@ -967,22 +711,8 @@ user-login = "dtolnay"
 user-name = "David Tolnay"
 
 [[publisher.system-interface]]
-version = "0.26.1"
-when = "2024-01-02"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
-[[publisher.system-interface]]
 version = "0.27.1"
 when = "2024-02-13"
-user-id = 6825
-user-login = "sunfishcode"
-user-name = "Dan Gohman"
-
-[[publisher.target-lexicon]]
-version = "0.12.12"
-when = "2023-10-19"
 user-id = 6825
 user-login = "sunfishcode"
 user-name = "Dan Gohman"
@@ -1065,8 +795,8 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.wasi-common]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1106,29 +836,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-encoder]]
-version = "0.38.1"
-when = "2023-11-29"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-encoder]]
-version = "0.41.0"
-when = "2024-01-29"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-encoder]]
 version = "0.41.2"
 when = "2024-02-12"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-metadata]]
-version = "0.10.17"
-when = "2024-01-29"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1141,22 +850,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasm-mutate]]
-version = "0.2.46"
-when = "2024-01-29"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-mutate]]
 version = "0.2.48"
 when = "2024-02-12"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasm-smith]]
-version = "0.15.1"
-when = "2024-01-29"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1169,29 +864,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasmparser]]
-version = "0.118.1"
-when = "2023-11-29"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasmparser]]
-version = "0.121.0"
-when = "2024-01-29"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasmparser]]
 version = "0.121.2"
 when = "2024-02-12"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wasmprinter]]
-version = "0.2.78"
-when = "2024-01-29"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1204,166 +878,152 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wasmtime]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-asm-macros]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cache]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli-flags]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-macro]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-util]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift-shared]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-explorer]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-fiber]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-debug]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-icache-coherence]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-runtime]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-types]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-nn]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wast]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-winch]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wit-bindgen]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wmemcheck]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wast]]
-version = "70.0.2"
-when = "2024-01-29"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wast]]
 version = "71.0.1"
 when = "2024-02-12"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wat]]
-version = "1.0.85"
-when = "2024-01-29"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1376,20 +1036,20 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wiggle]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-generate]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
-version = "17.0.0"
-when = "2024-01-25"
+version = "17.0.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1408,19 +1068,12 @@ user-login = "BurntSushi"
 user-name = "Andrew Gallant"
 
 [[publisher.winch-codegen]]
-version = "0.15.0"
-when = "2024-01-25"
+version = "0.15.1"
+when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.windows-core]]
-version = "0.51.1"
-when = "2023-08-17"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows-core]]
 version = "0.52.0"
 when = "2023-11-15"
 user-id = 64539
@@ -1449,13 +1102,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows-targets]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows-targets]]
 version = "0.52.0"
 when = "2023-11-15"
 user-id = 64539
@@ -1470,13 +1116,6 @@ user-login = "kennykerr"
 user-name = "Kenny Kerr"
 
 [[publisher.windows_aarch64_gnullvm]]
-version = "0.48.5"
-when = "2023-08-18"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_aarch64_gnullvm]]
 version = "0.52.0"
 when = "2023-11-15"
 user-id = 64539
@@ -1486,13 +1125,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_aarch64_msvc]]
 version = "0.48.0"
 when = "2023-03-31"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_aarch64_msvc]]
-version = "0.48.5"
-when = "2023-08-18"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -1507,13 +1139,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_i686_gnu]]
 version = "0.48.0"
 when = "2023-03-31"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_i686_gnu]]
-version = "0.48.5"
-when = "2023-08-18"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -1528,13 +1153,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_i686_msvc]]
 version = "0.48.0"
 when = "2023-03-31"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_i686_msvc]]
-version = "0.48.5"
-when = "2023-08-18"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -1549,13 +1167,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_x86_64_gnu]]
 version = "0.48.0"
 when = "2023-03-31"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_gnu]]
-version = "0.48.5"
-when = "2023-08-18"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -1570,13 +1181,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_x86_64_gnullvm]]
 version = "0.48.0"
 when = "2023-03-31"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_gnullvm]]
-version = "0.48.5"
-when = "2023-08-18"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -1591,13 +1195,6 @@ user-name = "Kenny Kerr"
 [[publisher.windows_x86_64_msvc]]
 version = "0.48.0"
 when = "2023-03-31"
-user-id = 64539
-user-login = "kennykerr"
-user-name = "Kenny Kerr"
-
-[[publisher.windows_x86_64_msvc]]
-version = "0.48.5"
-when = "2023-08-18"
 user-id = 64539
 user-login = "kennykerr"
 user-name = "Kenny Kerr"
@@ -1624,22 +1221,8 @@ user-login = "sunfishcode"
 user-name = "Dan Gohman"
 
 [[publisher.wit-bindgen]]
-version = "0.15.0"
-when = "2023-11-27"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wit-bindgen]]
 version = "0.17.0"
 when = "2024-02-05"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wit-bindgen-core]]
-version = "0.15.0"
-when = "2023-11-27"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -1652,13 +1235,6 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wit-bindgen-rust]]
-version = "0.15.0"
-when = "2023-11-27"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wit-bindgen-rust]]
 version = "0.17.0"
 when = "2024-02-05"
 user-id = 1
@@ -1666,22 +1242,8 @@ user-login = "alexcrichton"
 user-name = "Alex Crichton"
 
 [[publisher.wit-bindgen-rust-macro]]
-version = "0.15.0"
-when = "2023-11-27"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wit-bindgen-rust-macro]]
 version = "0.17.0"
 when = "2024-02-05"
-user-id = 1
-user-login = "alexcrichton"
-user-name = "Alex Crichton"
-
-[[publisher.wit-component]]
-version = "0.18.2"
-when = "2023-11-20"
 user-id = 1
 user-login = "alexcrichton"
 user-name = "Alex Crichton"
@@ -2316,12 +1878,6 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "3.6.0 -> 3.8.0"
-aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
-
-[[audits.mozilla.audits.toml]]
-who = "Bobby Holley <bobbyholley@gmail.com>"
-criteria = "safe-to-deploy"
-delta = "0.5.7 -> 0.5.9"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.unicode-normalization]]


### PR DESCRIPTION
This is a retry of #7910 to fix some `cargo vet` warnings; it is the result of running `cargo vet prune`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
