### PR TITLE
Wasmtime: Finish support for the typed function references proposal

### DIFF
--- a/benches/call.rs
+++ b/benches/call.rs
@@ -195,10 +195,9 @@ fn bench_host_to_wasm<Params, Results>(
                     .call_unchecked(&mut *store, space.as_mut_ptr(), space.len())
                     .unwrap();
                 for (i, expected) in results.iter().enumerate() {
-                    assert_vals_eq(
-                        expected,
-                        &Val::from_raw(&mut *store, space[i], expected.ty()),
-                    );
+                    let ty = expected.ty(&store);
+                    let actual = Val::from_raw(&mut *store, space[i], ty);
+                    assert_vals_eq(expected, &actual);
                 }
             })
         },

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -122,7 +122,7 @@ pub(crate) fn translate_args<'a>(
     let num_args = args.len();
     dst.reserve(args.len() + results_size);
     dst.extend(args);
-    dst.extend((0..results_size).map(|_| Val::null()));
+    dst.extend((0..results_size).map(|_| Val::null_func_ref()));
     let (a, b) = dst.split_at_mut(num_args);
     (a, b)
 }

--- a/crates/c-api/src/lib.rs
+++ b/crates/c-api/src/lib.rs
@@ -119,3 +119,8 @@ unsafe fn slice_from_raw_parts_mut<'a, T>(ptr: *mut T, len: usize) -> &'a mut [T
         std::slice::from_raw_parts_mut(ptr, len)
     }
 }
+
+pub(crate) fn abort(name: &str) -> ! {
+    eprintln!("`{}` is not implemented", name);
+    std::process::abort();
+}

--- a/crates/c-api/src/ref.rs
+++ b/crates/c-api/src/ref.rs
@@ -1,5 +1,6 @@
+use crate::abort;
 use std::os::raw::c_void;
-use wasmtime::{ExternRef, Func, Val};
+use wasmtime::{Ref, Val};
 
 /// `*mut wasm_ref_t` is a reference type (`externref` or `funcref`), as seen by
 /// the C API. Because we do not have a uniform representation for `funcref`s
@@ -15,34 +16,23 @@ use wasmtime::{ExternRef, Func, Val};
 /// regular, non-`repr(C)` `enum` to define `WasmRefInner`.
 #[derive(Clone)]
 pub struct wasm_ref_t {
-    pub(crate) r: WasmRefInner,
-}
-
-#[derive(Clone)]
-pub(crate) enum WasmRefInner {
-    ExternRef(ExternRef),
-    FuncRef(Func),
+    pub(crate) r: Ref,
 }
 
 wasmtime_c_api_macros::declare_own!(wasm_ref_t);
 
-pub(crate) fn ref_to_val(r: &wasm_ref_t) -> Val {
-    match &r.r {
-        WasmRefInner::ExternRef(x) => Val::ExternRef(Some(x.clone())),
-        WasmRefInner::FuncRef(f) => Val::FuncRef(Some(f.clone())),
+impl wasm_ref_t {
+    pub(crate) fn new(r: Ref) -> Option<Box<wasm_ref_t>> {
+        if r.is_null() {
+            None
+        } else {
+            Some(Box::new(wasm_ref_t { r }))
+        }
     }
 }
 
-pub(crate) fn val_into_ref(val: Val) -> Option<Box<wasm_ref_t>> {
-    match val {
-        Val::ExternRef(Some(x)) => Some(Box::new(wasm_ref_t {
-            r: WasmRefInner::ExternRef(x),
-        })),
-        Val::FuncRef(Some(f)) => Some(Box::new(wasm_ref_t {
-            r: WasmRefInner::FuncRef(f),
-        })),
-        _ => None,
-    }
+pub(crate) fn ref_to_val(r: &wasm_ref_t) -> Val {
+    Val::from(r.r.clone())
 }
 
 #[no_mangle]
@@ -50,15 +40,10 @@ pub extern "C" fn wasm_ref_copy(r: Option<&wasm_ref_t>) -> Option<Box<wasm_ref_t
     r.map(|r| Box::new(r.clone()))
 }
 
-fn abort(name: &str) -> ! {
-    eprintln!("`{}` is not implemented", name);
-    std::process::abort();
-}
-
 #[no_mangle]
 pub extern "C" fn wasm_ref_same(a: Option<&wasm_ref_t>, b: Option<&wasm_ref_t>) -> bool {
     match (a.map(|a| &a.r), b.map(|b| &b.r)) {
-        (Some(WasmRefInner::ExternRef(a)), Some(WasmRefInner::ExternRef(b))) => a.ptr_eq(b),
+        (Some(Ref::Extern(Some(a))), Some(Ref::Extern(Some(b)))) => a.ptr_eq(b),
         (None, None) => true,
         // Note: we don't support equality for `Func`, so we always return
         // `false` for `funcref`s.

--- a/crates/c-api/src/table.rs
+++ b/crates/c-api/src/table.rs
@@ -1,10 +1,10 @@
-use crate::r#ref::{ref_to_val, val_into_ref};
 use crate::{
     handle_result, wasm_extern_t, wasm_ref_t, wasm_store_t, wasm_tabletype_t, wasmtime_error_t,
     wasmtime_val_t, CStoreContext, CStoreContextMut,
 };
+use anyhow::anyhow;
 use std::mem::MaybeUninit;
-use wasmtime::{Extern, Table, TableType, Val, ValType};
+use wasmtime::{Extern, HeapType, Ref, Table, TableType};
 
 #[derive(Clone)]
 #[repr(transparent)]
@@ -32,15 +32,12 @@ impl wasm_table_t {
     }
 }
 
-fn ref_to_val_for_table(r: Option<&wasm_ref_t>, table_ty: &TableType) -> Val {
-    r.map_or_else(
-        || match table_ty.element() {
-            ValType::FuncRef => Val::FuncRef(None),
-            ValType::ExternRef => Val::ExternRef(None),
-            ty => panic!("unsupported table element type: {:?}", ty),
-        },
-        |r| ref_to_val(r),
-    )
+fn option_wasm_ref_t_to_ref(r: Option<&wasm_ref_t>, table_ty: &TableType) -> Ref {
+    match (r.map(|r| r.r.clone()), table_ty.element().heap_type()) {
+        (None, HeapType::NoFunc | HeapType::Func | HeapType::Concrete(_)) => Ref::Func(None),
+        (None, HeapType::Extern) => Ref::Extern(None),
+        (Some(r), _) => r,
+    }
 }
 
 #[no_mangle]
@@ -49,8 +46,9 @@ pub unsafe extern "C" fn wasm_table_new(
     tt: &wasm_tabletype_t,
     init: Option<&wasm_ref_t>,
 ) -> Option<Box<wasm_table_t>> {
-    let init = ref_to_val_for_table(init, &tt.ty().ty);
-    let table = Table::new(store.store.context_mut(), tt.ty().ty.clone(), init).ok()?;
+    let tt = tt.ty().ty.clone();
+    let init = option_wasm_ref_t_to_ref(init, &tt);
+    let table = Table::new(store.store.context_mut(), tt, init).ok()?;
     Some(Box::new(wasm_table_t {
         ext: wasm_extern_t {
             store: store.store.clone(),
@@ -72,8 +70,8 @@ pub unsafe extern "C" fn wasm_table_get(
     index: wasm_table_size_t,
 ) -> Option<Box<wasm_ref_t>> {
     let table = t.table();
-    let val = table.get(t.ext.store.context_mut(), index)?;
-    val_into_ref(val)
+    let r = table.get(t.ext.store.context_mut(), index)?;
+    wasm_ref_t::new(r)
 }
 
 #[no_mangle]
@@ -83,7 +81,7 @@ pub unsafe extern "C" fn wasm_table_set(
     r: Option<&wasm_ref_t>,
 ) -> bool {
     let table = t.table();
-    let val = ref_to_val_for_table(r, &table.ty(t.ext.store.context()));
+    let val = option_wasm_ref_t_to_ref(r, &table.ty(t.ext.store.context()));
     table.set(t.ext.store.context_mut(), index, val).is_ok()
 }
 
@@ -101,7 +99,7 @@ pub unsafe extern "C" fn wasm_table_grow(
     init: Option<&wasm_ref_t>,
 ) -> bool {
     let table = t.table();
-    let init = ref_to_val_for_table(init, &table.ty(t.ext.store.context()));
+    let init = option_wasm_ref_t_to_ref(init, &table.ty(t.ext.store.context()));
     table.grow(t.ext.store.context_mut(), delta, init).is_ok()
 }
 
@@ -123,7 +121,10 @@ pub unsafe extern "C" fn wasmtime_table_new(
     out: &mut Table,
 ) -> Option<Box<wasmtime_error_t>> {
     handle_result(
-        Table::new(store, tt.ty().ty.clone(), init.to_val()),
+        init.to_val()
+            .ref_()
+            .ok_or_else(|| anyhow!("wasmtime_table_new init value is not a reference"))
+            .and_then(|init| Table::new(store, tt.ty().ty.clone(), init)),
         |table| *out = table,
     )
 }
@@ -144,8 +145,8 @@ pub extern "C" fn wasmtime_table_get(
     ret: &mut MaybeUninit<wasmtime_val_t>,
 ) -> bool {
     match table.get(store, index) {
-        Some(val) => {
-            crate::initialize(ret, wasmtime_val_t::from_val(val));
+        Some(r) => {
+            crate::initialize(ret, wasmtime_val_t::from_val(r.into()));
             true
         }
         None => false,
@@ -159,7 +160,13 @@ pub unsafe extern "C" fn wasmtime_table_set(
     index: u32,
     val: &wasmtime_val_t,
 ) -> Option<Box<wasmtime_error_t>> {
-    handle_result(table.set(store, index, val.to_val()), |()| {})
+    handle_result(
+        val.to_val()
+            .ref_()
+            .ok_or_else(|| anyhow!("wasmtime_table_set value is not a reference"))
+            .and_then(|val| table.set(store, index, val)),
+        |()| {},
+    )
 }
 
 #[no_mangle]
@@ -175,7 +182,11 @@ pub unsafe extern "C" fn wasmtime_table_grow(
     val: &wasmtime_val_t,
     prev_size: &mut u32,
 ) -> Option<Box<wasmtime_error_t>> {
-    handle_result(table.grow(store, delta, val.to_val()), |prev| {
-        *prev_size = prev
-    })
+    handle_result(
+        val.to_val()
+            .ref_()
+            .ok_or_else(|| anyhow!("wasmtime_table_grow value is not a reference"))
+            .and_then(|val| table.grow(store, delta, val)),
+        |prev| *prev_size = prev,
+    )
 }

--- a/crates/c-api/src/types/table.rs
+++ b/crates/c-api/src/types/table.rs
@@ -1,6 +1,6 @@
 use crate::{wasm_externtype_t, wasm_limits_t, wasm_valtype_t, CExternType};
 use once_cell::unsync::OnceCell;
-use wasmtime::TableType;
+use wasmtime::{TableType, ValType};
 
 #[repr(transparent)]
 #[derive(Clone)]
@@ -53,19 +53,20 @@ impl CTableType {
 pub extern "C" fn wasm_tabletype_new(
     ty: Box<wasm_valtype_t>,
     limits: &wasm_limits_t,
-) -> Box<wasm_tabletype_t> {
-    Box::new(wasm_tabletype_t::new(TableType::new(
-        ty.ty,
+) -> Option<Box<wasm_tabletype_t>> {
+    let ty = ty.ty.as_ref()?.clone();
+    Some(Box::new(wasm_tabletype_t::new(TableType::new(
+        ty,
         limits.min,
         limits.max(),
-    )))
+    ))))
 }
 
 #[no_mangle]
 pub extern "C" fn wasm_tabletype_element(tt: &wasm_tabletype_t) -> &wasm_valtype_t {
     let tt = tt.ty();
     tt.element_cache.get_or_init(|| wasm_valtype_t {
-        ty: tt.ty.element().clone(),
+        ty: ValType::Ref(tt.ty.element().clone()),
     })
 }
 

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1320,7 +1320,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     ) -> WasmResult<ir::Value> {
         let (func_idx, func_sig) =
             match self.module.table_plans[table_index].table.wasm_ty.heap_type {
-                WasmHeapType::Func | WasmHeapType::Concrete(_) => (
+                WasmHeapType::Func | WasmHeapType::Concrete(_) | WasmHeapType::NoFunc => (
                     BuiltinFunctionIndex::table_grow_func_ref(),
                     self.builtin_function_signatures
                         .table_grow_func_ref(&mut pos.func),
@@ -1355,7 +1355,9 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
         let plan = &self.module.table_plans[table_index];
         match plan.table.wasm_ty.heap_type {
-            WasmHeapType::Func | WasmHeapType::Concrete(_) => match plan.style {
+            WasmHeapType::Func | WasmHeapType::Concrete(_) | WasmHeapType::NoFunc => match plan
+                .style
+            {
                 TableStyle::CallerChecksSignature => {
                     Ok(self.get_or_init_func_ref_table_elem(builder, table_index, table, index))
                 }
@@ -1490,7 +1492,9 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         let pointer_type = self.pointer_type();
         let plan = &self.module.table_plans[table_index];
         match plan.table.wasm_ty.heap_type {
-            WasmHeapType::Func | WasmHeapType::Concrete(_) => match plan.style {
+            WasmHeapType::Func | WasmHeapType::Concrete(_) | WasmHeapType::NoFunc => match plan
+                .style
+            {
                 TableStyle::CallerChecksSignature => {
                     let table_entry_addr = builder.ins().table_addr(pointer_type, table, index, 0);
                     // Set the "initialized bit". See doc-comment on
@@ -1650,7 +1654,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
     ) -> WasmResult<()> {
         let (builtin_idx, builtin_sig) =
             match self.module.table_plans[table_index].table.wasm_ty.heap_type {
-                WasmHeapType::Func | WasmHeapType::Concrete(_) => (
+                WasmHeapType::Func | WasmHeapType::Concrete(_) | WasmHeapType::NoFunc => (
                     BuiltinFunctionIndex::table_fill_func_ref(),
                     self.builtin_function_signatures
                         .table_fill_func_ref(&mut pos.func),
@@ -1681,7 +1685,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
         ht: WasmHeapType,
     ) -> WasmResult<ir::Value> {
         Ok(match ht {
-            WasmHeapType::Func | WasmHeapType::Concrete(_) => {
+            WasmHeapType::Func | WasmHeapType::Concrete(_) | WasmHeapType::NoFunc => {
                 pos.ins().iconst(self.pointer_type(), 0)
             }
             WasmHeapType::Extern => pos.ins().null(self.reference_type(ht)),
@@ -2033,7 +2037,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             // entire lifetime of the `Store` so there's no need for barriers.
             // This means that they can fall through to memory as well.
             WasmValType::Ref(WasmRefType {
-                heap_type: WasmHeapType::Func | WasmHeapType::Concrete(_),
+                heap_type: WasmHeapType::Func | WasmHeapType::Concrete(_) | WasmHeapType::NoFunc,
                 ..
             }) => {}
 

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -174,9 +174,9 @@ fn wasm_call_signature(
 /// Returns the reference type to use for the provided wasm type.
 fn reference_type(wasm_ht: cranelift_wasm::WasmHeapType, pointer_type: ir::Type) -> ir::Type {
     match wasm_ht {
-        cranelift_wasm::WasmHeapType::Func | cranelift_wasm::WasmHeapType::Concrete(_) => {
-            pointer_type
-        }
+        cranelift_wasm::WasmHeapType::Func
+        | cranelift_wasm::WasmHeapType::Concrete(_)
+        | cranelift_wasm::WasmHeapType::NoFunc => pointer_type,
         cranelift_wasm::WasmHeapType::Extern => match pointer_type {
             ir::types::I32 => ir::types::R32,
             ir::types::I64 => ir::types::R64,

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -474,7 +474,7 @@ impl ModuleTranslation<'_> {
                 .wasm_ty
                 .heap_type
             {
-                WasmHeapType::Func | WasmHeapType::Concrete(_) => {}
+                WasmHeapType::Func | WasmHeapType::Concrete(_) | WasmHeapType::NoFunc => {}
                 // If this is not a funcref table, then we can't support a
                 // pre-computed table of function indices. Technically this
                 // initializer won't trap so we could continue processing

--- a/crates/environ/src/module_types.rs
+++ b/crates/environ/src/module_types.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::ops::Index;
 use wasmparser::types::CoreTypeId;
 use wasmparser::UnpackedIndex;
-use wasmtime_types::{ModuleInternedTypeIndex, TypeIndex};
+use wasmtime_types::{EngineOrModuleTypeIndex, ModuleInternedTypeIndex, TypeIndex};
 
 /// All types used in a core wasm module.
 ///
@@ -106,13 +106,15 @@ impl TypeConvert for WasmparserTypeConverter<'_> {
         match index {
             UnpackedIndex::Id(id) => {
                 let signature = self.types.wasmparser_to_wasmtime[&id];
-                WasmHeapType::Concrete(signature)
+                WasmHeapType::Concrete(EngineOrModuleTypeIndex::Module(signature))
             }
             UnpackedIndex::RecGroup(_) => unreachable!(),
             UnpackedIndex::Module(i) => {
                 let i = TypeIndex::from_u32(i);
                 match self.module.types[i] {
-                    ModuleType::Function(sig) => WasmHeapType::Concrete(sig),
+                    ModuleType::Function(sig) => {
+                        WasmHeapType::Concrete(EngineOrModuleTypeIndex::Module(sig))
+                    }
                 }
             }
         }

--- a/crates/fuzzing/src/generators/value.rs
+++ b/crates/fuzzing/src/generators/value.rs
@@ -2,6 +2,7 @@
 
 use arbitrary::{Arbitrary, Unstructured};
 use std::hash::Hash;
+use wasmtime::HeapType;
 
 /// A value passed to and from evaluation. Note that reference types are not
 /// (yet) supported.
@@ -290,8 +291,11 @@ impl TryFrom<wasmtime::ValType> for DiffValueType {
             F32 => Ok(Self::F32),
             F64 => Ok(Self::F64),
             V128 => Ok(Self::V128),
-            FuncRef => Ok(Self::FuncRef),
-            ExternRef => Ok(Self::ExternRef),
+            Ref(r) => match (r.is_nullable(), r.heap_type()) {
+                (true, HeapType::Func) => Ok(Self::FuncRef),
+                (true, HeapType::Extern) => Ok(Self::ExternRef),
+                _ => Err("non-funcref and non-externref reference types are not suported yet"),
+            },
         }
     }
 }

--- a/crates/fuzzing/src/oracles.rs
+++ b/crates/fuzzing/src/oracles.rs
@@ -565,9 +565,10 @@ pub fn make_api_calls(api: generators::api::ApiCalls) {
                 let nth = nth % funcs.len();
                 let f = &funcs[nth];
                 let ty = f.ty(&store);
-                let params = dummy::dummy_values(ty.params());
-                let mut results = vec![Val::I32(0); ty.results().len()];
-                let _ = f.call(store, &params, &mut results);
+                if let Ok(params) = dummy::dummy_values(ty.params()) {
+                    let mut results = vec![Val::I32(0); ty.results().len()];
+                    let _ = f.call(store, &params, &mut results);
+                }
             }
         }
     }
@@ -625,7 +626,7 @@ pub fn table_ops(
         let func_ty = FuncType::new(
             store.engine(),
             vec![],
-            vec![ValType::ExternRef, ValType::ExternRef, ValType::ExternRef],
+            vec![ValType::EXTERNREF, ValType::EXTERNREF, ValType::EXTERNREF],
         );
         let func = Func::new(&mut store, func_ty, {
             let num_dropped = num_dropped.clone();
@@ -698,7 +699,7 @@ pub fn table_ops(
         let func_ty = FuncType::new(
             store.engine(),
             vec![],
-            vec![ValType::ExternRef, ValType::ExternRef, ValType::ExternRef],
+            vec![ValType::EXTERNREF, ValType::EXTERNREF, ValType::EXTERNREF],
         );
         let func = Func::new(&mut store, func_ty, {
             let num_dropped = num_dropped.clone();

--- a/crates/fuzzing/src/oracles/diff_wasmtime.rs
+++ b/crates/fuzzing/src/oracles/diff_wasmtime.rs
@@ -230,8 +230,8 @@ impl Into<DiffValue> for Val {
             Val::F32(n) => DiffValue::F32(n),
             Val::F64(n) => DiffValue::F64(n),
             Val::V128(n) => DiffValue::V128(n.into()),
-            Val::FuncRef(f) => DiffValue::FuncRef { null: f.is_none() },
-            Val::ExternRef(e) => DiffValue::ExternRef { null: e.is_none() },
+            Val::ExternRef(r) => DiffValue::ExternRef { null: r.is_none() },
+            Val::FuncRef(r) => DiffValue::FuncRef { null: r.is_none() },
         }
     }
 }

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -1,6 +1,6 @@
 //! Dummy implementations of things that a Wasm module can import.
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use wasmtime::*;
 
 /// Create a set of dummy functions/globals/etc for the given imports.
@@ -19,51 +19,55 @@ pub fn dummy_linker<'module, T>(store: &mut Store<T>, module: &Module) -> Result
 /// Construct a dummy `Extern` from its type signature
 pub fn dummy_extern<T>(store: &mut Store<T>, ty: ExternType) -> Result<Extern> {
     Ok(match ty {
-        ExternType::Func(func_ty) => Extern::Func(dummy_func(store, func_ty)),
-        ExternType::Global(global_ty) => Extern::Global(dummy_global(store, global_ty)),
+        ExternType::Func(func_ty) => Extern::Func(dummy_func(store, func_ty)?),
+        ExternType::Global(global_ty) => Extern::Global(dummy_global(store, global_ty)?),
         ExternType::Table(table_ty) => Extern::Table(dummy_table(store, table_ty)?),
         ExternType::Memory(mem_ty) => Extern::Memory(dummy_memory(store, mem_ty)?),
     })
 }
 
 /// Construct a dummy function for the given function type
-pub fn dummy_func<T>(store: &mut Store<T>, ty: FuncType) -> Func {
-    Func::new(store, ty.clone(), move |_, _, results| {
-        for (ret_ty, result) in ty.results().zip(results) {
-            *result = dummy_value(ret_ty);
+pub fn dummy_func<T>(store: &mut Store<T>, ty: FuncType) -> Result<Func> {
+    let dummy_results = ty.results().map(dummy_value).collect::<Result<Vec<_>>>()?;
+    Ok(Func::new(store, ty.clone(), move |_, _, results| {
+        for (slot, dummy) in results.iter_mut().zip(&dummy_results) {
+            *slot = dummy.clone();
         }
         Ok(())
-    })
+    }))
 }
 
 /// Construct a dummy value for the given value type.
-pub fn dummy_value(val_ty: ValType) -> Val {
-    match val_ty {
+pub fn dummy_value(val_ty: ValType) -> Result<Val> {
+    Ok(match val_ty {
         ValType::I32 => Val::I32(0),
         ValType::I64 => Val::I64(0),
         ValType::F32 => Val::F32(0),
         ValType::F64 => Val::F64(0),
         ValType::V128 => Val::V128(0.into()),
-        ValType::ExternRef => Val::ExternRef(None),
-        ValType::FuncRef => Val::FuncRef(None),
-    }
+        ValType::Ref(r) => match r.heap_type() {
+            _ if !r.is_nullable() => bail!("cannot construct a dummy value of type `{r}`"),
+            HeapType::Extern => Val::null_extern_ref(),
+            HeapType::NoFunc | HeapType::Func | HeapType::Concrete(_) => Val::null_func_ref(),
+        },
+    })
 }
 
 /// Construct a sequence of dummy values for the given types.
-pub fn dummy_values(val_tys: impl IntoIterator<Item = ValType>) -> Vec<Val> {
+pub fn dummy_values(val_tys: impl IntoIterator<Item = ValType>) -> Result<Vec<Val>> {
     val_tys.into_iter().map(dummy_value).collect()
 }
 
 /// Construct a dummy global for the given global type.
-pub fn dummy_global<T>(store: &mut Store<T>, ty: GlobalType) -> Global {
-    let val = dummy_value(ty.content().clone());
-    Global::new(store, ty, val).unwrap()
+pub fn dummy_global<T>(store: &mut Store<T>, ty: GlobalType) -> Result<Global> {
+    let val = dummy_value(ty.content().clone())?;
+    Global::new(store, ty, val)
 }
 
 /// Construct a dummy table for the given table type.
 pub fn dummy_table<T>(store: &mut Store<T>, ty: TableType) -> Result<Table> {
-    let init_val = dummy_value(ty.element().clone());
-    Table::new(store, ty, init_val)
+    let init_val = dummy_value(ty.element().clone().into())?;
+    Table::new(store, ty, init_val.ref_().unwrap())
 }
 
 /// Construct a dummy memory for the given memory type.
@@ -85,22 +89,19 @@ mod tests {
     #[test]
     fn dummy_table_import() {
         let mut store = store();
-        let table = dummy_table(&mut store, TableType::new(ValType::ExternRef, 10, None)).unwrap();
+        let table = dummy_table(&mut store, TableType::new(RefType::EXTERNREF, 10, None)).unwrap();
         assert_eq!(table.size(&store), 10);
         for i in 0..10 {
-            assert!(table
-                .get(&mut store, i)
-                .unwrap()
-                .unwrap_externref()
-                .is_none());
+            assert!(table.get(&mut store, i).unwrap().unwrap_extern().is_none());
         }
     }
 
     #[test]
     fn dummy_global_import() {
         let mut store = store();
-        let global = dummy_global(&mut store, GlobalType::new(ValType::I32, Mutability::Const));
-        assert_eq!(*global.ty(&store).content(), ValType::I32);
+        let global =
+            dummy_global(&mut store, GlobalType::new(ValType::I32, Mutability::Const)).unwrap();
+        assert!(global.ty(&store).content().is_i32());
         assert_eq!(global.ty(&store).mutability(), Mutability::Const);
     }
 
@@ -115,7 +116,9 @@ mod tests {
     fn dummy_function_import() {
         let mut store = store();
         let func_ty = FuncType::new(store.engine(), vec![ValType::I32], vec![ValType::I64]);
-        let func = dummy_func(&mut store, func_ty.clone());
-        assert_eq!(func.ty(&store), func_ty);
+        let func = dummy_func(&mut store, func_ty.clone()).unwrap();
+        let actual_ty = func.ty(&store);
+        assert!(actual_ty.matches(store.engine(), &func_ty));
+        assert!(func_ty.matches(store.engine(), &actual_ty));
     }
 }

--- a/crates/fuzzing/src/oracles/dummy.rs
+++ b/crates/fuzzing/src/oracles/dummy.rs
@@ -118,7 +118,6 @@ mod tests {
         let func_ty = FuncType::new(store.engine(), vec![ValType::I32], vec![ValType::I64]);
         let func = dummy_func(&mut store, func_ty.clone()).unwrap();
         let actual_ty = func.ty(&store);
-        assert!(actual_ty.matches(store.engine(), &func_ty));
-        assert!(func_ty.matches(store.engine(), &actual_ty));
+        assert!(FuncType::eq(&actual_ty, &func_ty));
     }
 }

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -1007,7 +1007,7 @@ pub union ValRaw {
     /// This value is always stored in a little-endian format.
     v128: u128,
 
-    /// A WebAssembly `funcref` value.
+    /// A WebAssembly `funcref` value (or one of its subtypes).
     ///
     /// The payload here is a pointer which is runtime-defined. This is one of
     /// the main points of unsafety about the `ValRaw` type as the validity of
@@ -1017,7 +1017,7 @@ pub union ValRaw {
     /// This value is always stored in a little-endian format.
     funcref: *mut c_void,
 
-    /// A WebAssembly `externref` value.
+    /// A WebAssembly `externref` value (or one of its subtypes).
     ///
     /// The payload here is a pointer which is runtime-defined. This is one of
     /// the main points of unsafety about the `ValRaw` type as the validity of

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -10,6 +10,26 @@ use std::fmt;
 mod error;
 pub use error::*;
 
+/// A trait for things that can trace all type-to-type edges, aka all type
+/// indices within this thing.
+pub trait TypeTrace {
+    /// Visit each edge.
+    ///
+    /// The function can break out of tracing by returning `Err(E)`.
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(EngineOrModuleTypeIndex) -> Result<(), E>;
+
+    /// Visit each edge, mutably.
+    ///
+    /// Allows updating edges.
+    ///
+    /// The function can break out of tracing by returning `Err(E)`.
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut EngineOrModuleTypeIndex) -> Result<(), E>;
+}
+
 /// WebAssembly value type -- equivalent of `wasmparser::ValType`.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum WasmValType {
@@ -40,11 +60,57 @@ impl fmt::Display for WasmValType {
     }
 }
 
+impl TypeTrace for WasmValType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(EngineOrModuleTypeIndex) -> Result<(), E>,
+    {
+        match self {
+            WasmValType::Ref(r) => r.trace(func),
+            WasmValType::I32
+            | WasmValType::I64
+            | WasmValType::F32
+            | WasmValType::F64
+            | WasmValType::V128 => Ok(()),
+        }
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut EngineOrModuleTypeIndex) -> Result<(), E>,
+    {
+        match self {
+            WasmValType::Ref(r) => r.trace_mut(func),
+            WasmValType::I32
+            | WasmValType::I64
+            | WasmValType::F32
+            | WasmValType::F64
+            | WasmValType::V128 => Ok(()),
+        }
+    }
+}
+
 /// WebAssembly reference type -- equivalent of `wasmparser`'s RefType
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct WasmRefType {
     pub nullable: bool,
     pub heap_type: WasmHeapType,
+}
+
+impl TypeTrace for WasmRefType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(EngineOrModuleTypeIndex) -> Result<(), E>,
+    {
+        self.heap_type.trace(func)
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut EngineOrModuleTypeIndex) -> Result<(), E>,
+    {
+        self.heap_type.trace_mut(func)
+    }
 }
 
 impl WasmRefType {
@@ -74,30 +140,67 @@ impl fmt::Display for WasmRefType {
     }
 }
 
+/// An interned type index, either at the module or engine level.
+///
+/// Roughly equivalent to `wasmparser::UnpackedIndex`, although doesn't have to
+/// concern itself with recursion-group-local indices.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum EngineOrModuleTypeIndex {
+    /// An index within a global namespace across all modules that can interact
+    /// with each other (in practice this is a `VMSharedTypeIndex` at the per
+    /// `wasmtime::Engine` level).
+    Engine(u32),
+    /// An index within the current Wasm module.
+    Module(ModuleInternedTypeIndex),
+}
+
+impl fmt::Display for EngineOrModuleTypeIndex {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Engine(i) => write!(f, "(engine {i})"),
+            Self::Module(i) => write!(f, "(module {})", i.as_u32()),
+        }
+    }
+}
+
 /// WebAssembly heap type -- equivalent of `wasmparser`'s HeapType
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum WasmHeapType {
-    Func,
     Extern,
-    // FIXME: the `TypeIndex` payload here is not suitable given all the
-    // contexts that this type is used within. For example the Engine in
-    // wasmtime hashes this index which is not appropriate because the index is
-    // not globally unique.
-    //
-    // This probably needs to become `WasmHeapType<T>` where all of translation
-    // uses `WasmHeapType<TypeIndex>` and all of engine-level "stuff"  uses
-    // `WasmHeapType<VMSharedTypeIndex>`. This `<T>` would need to be
-    // propagated to quite a few locations though so it's left for a future
-    // refactoring at this time.
-    Concrete(ModuleInternedTypeIndex),
+    Func,
+    Concrete(EngineOrModuleTypeIndex),
+    NoFunc,
 }
 
 impl fmt::Display for WasmHeapType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Func => write!(f, "func"),
             Self::Extern => write!(f, "extern"),
-            Self::Concrete(i) => write!(f, "func_sig{}", i.as_u32()),
+            Self::Func => write!(f, "func"),
+            Self::Concrete(i) => write!(f, "{i}"),
+            Self::NoFunc => write!(f, "nofunc"),
+        }
+    }
+}
+
+impl TypeTrace for WasmHeapType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(EngineOrModuleTypeIndex) -> Result<(), E>,
+    {
+        match *self {
+            Self::Concrete(i) => func(i),
+            Self::Func | Self::NoFunc | Self::Extern => Ok(()),
+        }
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut EngineOrModuleTypeIndex) -> Result<(), E>,
+    {
+        match self {
+            Self::Concrete(i) => func(i),
+            Self::Func | Self::NoFunc | Self::Extern => Ok(()),
         }
     }
 }
@@ -109,6 +212,34 @@ pub struct WasmFuncType {
     externref_params_count: usize,
     returns: Box<[WasmValType]>,
     externref_returns_count: usize,
+}
+
+impl TypeTrace for WasmFuncType {
+    fn trace<F, E>(&self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(EngineOrModuleTypeIndex) -> Result<(), E>,
+    {
+        for p in self.params.iter() {
+            p.trace(func)?;
+        }
+        for r in self.returns.iter() {
+            r.trace(func)?;
+        }
+        Ok(())
+    }
+
+    fn trace_mut<F, E>(&mut self, func: &mut F) -> Result<(), E>
+    where
+        F: FnMut(&mut EngineOrModuleTypeIndex) -> Result<(), E>,
+    {
+        for p in self.params.iter_mut() {
+            p.trace_mut(func)?;
+        }
+        for r in self.returns.iter_mut() {
+            r.trace_mut(func)?;
+        }
+        Ok(())
+    }
 }
 
 impl WasmFuncType {
@@ -485,15 +616,15 @@ pub trait TypeConvert {
     /// Converts a wasmparser heap type to a wasmtime type
     fn convert_heap_type(&self, ty: wasmparser::HeapType) -> WasmHeapType {
         match ty {
-            wasmparser::HeapType::Func => WasmHeapType::Func,
             wasmparser::HeapType::Extern => WasmHeapType::Extern,
+            wasmparser::HeapType::Func => WasmHeapType::Func,
+            wasmparser::HeapType::NoFunc => WasmHeapType::NoFunc,
             wasmparser::HeapType::Concrete(i) => self.lookup_heap_type(i),
 
             wasmparser::HeapType::Any
             | wasmparser::HeapType::Exn
             | wasmparser::HeapType::None
             | wasmparser::HeapType::NoExtern
-            | wasmparser::HeapType::NoFunc
             | wasmparser::HeapType::Eq
             | wasmparser::HeapType::Struct
             | wasmparser::HeapType::Array

--- a/crates/wasi-threads/src/lib.rs
+++ b/crates/wasi-threads/src/lib.rs
@@ -7,7 +7,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use std::thread;
-use wasmtime::{Caller, ExternType, InstancePre, Linker, Module, SharedMemory, Store, ValType};
+use wasmtime::{Caller, ExternType, InstancePre, Linker, Module, SharedMemory, Store};
 
 // This name is a function export designated by the wasi-threads specification:
 // https://github.com/WebAssembly/wasi-threads/#detailed-design-discussion
@@ -171,9 +171,13 @@ fn has_entry_point(module: &Module) -> bool {
 
 /// Check if the entry function has the correct signature `(i32, i32) -> ()`.
 fn has_correct_signature(module: &Module) -> bool {
-    use ValType::*;
     match module.get_export(WASI_ENTRY_POINT) {
-        Some(ExternType::Func(ty)) => ty.params().eq([I32, I32]) && ty.results().len() == 0,
+        Some(ExternType::Func(ty)) => {
+            ty.params().len() == 2
+                && ty.params().nth(0).unwrap().is_i32()
+                && ty.params().nth(1).unwrap().is_i32()
+                && ty.results().len() == 0
+        }
         _ => false,
     }
 }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1638,6 +1638,12 @@ impl Config {
         if self.features.threads && !self.features.bulk_memory {
             bail!("feature 'threads' requires 'bulk_memory' to be enabled");
         }
+        if self.features.function_references && !self.features.reference_types {
+            bail!("feature 'function_references' requires 'reference_types' to be enabled");
+        }
+        if self.features.gc && !self.features.function_references {
+            bail!("feature 'gc' requires 'function_references' to be enabled");
+        }
         #[cfg(feature = "async")]
         if self.async_support && self.max_wasm_stack > self.async_stack_size {
             bail!("max_wasm_stack size cannot exceed the async_stack_size");
@@ -1945,6 +1951,7 @@ impl fmt::Debug for Config {
                 "wasm_function_references",
                 &self.features.function_references,
             )
+            .field("wasm_gc", &self.features.gc)
             .field("wasm_bulk_memory", &self.features.bulk_memory)
             .field("wasm_simd", &self.features.simd)
             .field("wasm_relaxed_simd", &self.features.relaxed_simd)

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -734,19 +734,41 @@ impl Config {
         self
     }
 
-    /// Configures whether the [WebAssembly function references proposal][proposal]
-    /// will be enabled for compilation.
+    /// Configures whether the [WebAssembly function references
+    /// proposal][proposal] will be enabled for compilation.
     ///
     /// This feature gates non-nullable reference types, function reference
-    /// types, call_ref, ref.func, and non-nullable reference related instructions.
+    /// types, `call_ref`, `ref.func`, and non-nullable reference related
+    /// instructions.
     ///
-    /// Note that the function references proposal depends on the reference types proposal.
+    /// Note that the function references proposal depends on the reference
+    /// types proposal.
     ///
     /// This feature is `false` by default.
     ///
     /// [proposal]: https://github.com/WebAssembly/function-references
     pub fn wasm_function_references(&mut self, enable: bool) -> &mut Self {
         self.features.function_references = enable;
+        self
+    }
+
+    /// Configures whether the [WebAssembly Garbage Collection
+    /// proposal][proposal] will be enabled for compilation.
+    ///
+    /// This feature gates `struct` and `array` type definitions and references,
+    /// the `i31ref` type, and all related instructions.
+    ///
+    /// Note that the function references proposal depends on the typed function
+    /// references proposal.
+    ///
+    /// This feature is `false` by default.
+    ///
+    /// **Warning: Wasmtime's implementation of the GC proposal is still in
+    /// progress and generally not ready for primetime.**
+    ///
+    /// [proposal]: https://github.com/WebAssembly/gc
+    pub fn wasm_gc(&mut self, enable: bool) -> &mut Self {
+        self.features.gc = enable;
         self
     }
 

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -291,8 +291,9 @@ impl Engine {
             "use_colocated_libcalls" => *value == FlagValue::Bool(false),
             "use_pinned_reg_as_heap_base" => *value == FlagValue::Bool(false),
 
-            // If reference types are enabled this must be enabled, otherwise
-            // this setting can have any value.
+            // If reference types (or anything that depends on reference types,
+            // like typed function references and GC) are enabled this must be
+            // enabled, otherwise this setting can have any value.
             "enable_safepoints" => {
                 if self.config().features.reference_types {
                     *value == FlagValue::Bool(true)

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -168,6 +168,7 @@ impl Engine {
     }
 
     /// Returns whether the engine `a` and `b` refer to the same configuration.
+    #[inline]
     pub fn same(a: &Engine, b: &Engine) -> bool {
         Arc::ptr_eq(&a.inner, &b.inner)
     }

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -191,6 +191,7 @@ struct WasmFeatures {
     relaxed_simd: bool,
     extended_const: bool,
     function_references: bool,
+    gc: bool,
 }
 
 impl Metadata<'_> {
@@ -223,7 +224,6 @@ impl Metadata<'_> {
         } = engine.config().features;
 
         assert!(!memory_control);
-        assert!(!gc);
         assert!(!component_model_values);
         assert!(!component_model_nested_names);
 
@@ -246,6 +246,7 @@ impl Metadata<'_> {
                 relaxed_simd,
                 extended_const,
                 function_references,
+                gc,
             },
         }
     }
@@ -420,6 +421,7 @@ impl Metadata<'_> {
             relaxed_simd,
             extended_const,
             function_references,
+            gc,
         } = self.features;
 
         Self::check_bool(
@@ -475,6 +477,7 @@ impl Metadata<'_> {
             other.function_references,
             "WebAssembly function-references support",
         )?;
+        Self::check_bool(gc, other.gc, "WebAssembly garbage collection support")?;
 
         Ok(())
     }

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -2,7 +2,7 @@ use crate::component::matching::InstanceType;
 use crate::component::resources::{HostResourceData, HostResourceIndex, HostResourceTables};
 use crate::component::ResourceType;
 use crate::store::{StoreId, StoreOpaque};
-use crate::StoreContextMut;
+use crate::{FuncType, StoreContextMut, ValType};
 use anyhow::{bail, Result};
 use std::ptr::NonNull;
 use std::sync::Arc;
@@ -86,12 +86,18 @@ impl Options {
         self.store_id.assert_belongs_to(store.0.id());
 
         let realloc = self.realloc.unwrap();
+        let realloc_ty = FuncType::new(
+            store.engine(),
+            [ValType::I32, ValType::I32, ValType::I32, ValType::I32],
+            [ValType::I32],
+        );
 
         // Invoke the wasm malloc function using its raw and statically known
         // signature.
         let result = unsafe {
             crate::TypedFunc::<(u32, u32, u32, u32), u32>::call_raw(
                 store,
+                &realloc_ty,
                 realloc,
                 (
                     u32::try_from(old)?,

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -2,7 +2,7 @@ use crate::component::matching::InstanceType;
 use crate::component::resources::{HostResourceData, HostResourceIndex, HostResourceTables};
 use crate::component::ResourceType;
 use crate::store::{StoreId, StoreOpaque};
-use crate::{FuncType, StoreContextMut, ValType};
+use crate::{FuncType, StoreContextMut};
 use anyhow::{bail, Result};
 use std::ptr::NonNull;
 use std::sync::Arc;
@@ -86,11 +86,9 @@ impl Options {
         self.store_id.assert_belongs_to(store.0.id());
 
         let realloc = self.realloc.unwrap();
-        let realloc_ty = FuncType::new(
-            store.engine(),
-            [ValType::I32, ValType::I32, ValType::I32, ValType::I32],
-            [ValType::I32],
-        );
+        let realloc_ty = FuncType::from_shared_type_index(store.engine(), unsafe {
+            realloc.as_ref().type_index
+        });
 
         // Invoke the wasm malloc function using its raw and statically known
         // signature.

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -508,13 +508,9 @@ impl<'a> Instantiator<'a> {
 
         let val = unsafe { crate::Extern::from_wasmtime_export(export, store) };
         let ty = DefinitionType::from(store, &val);
-        crate::types::matching::MatchCx {
-            engine: store.engine(),
-            signatures: module.signatures(),
-            types: module.types(),
-        }
-        .definition(&expected, &ty)
-        .expect("unexpected typecheck failure");
+        crate::types::matching::MatchCx::new(module)
+            .definition(&expected, &ty)
+            .expect("unexpected typecheck failure");
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/types.rs
+++ b/crates/wasmtime/src/runtime/component/types.rs
@@ -940,9 +940,10 @@ impl ComponentItem {
             TypeDef::ComponentFunc(idx) => Self::ComponentFunc(ComponentFunc::from(*idx, ty)),
             TypeDef::Interface(iface_ty) => Self::Type(Type::from(iface_ty, ty)),
             TypeDef::Module(idx) => Self::Module(Module::from(*idx, ty)),
-            TypeDef::CoreFunc(idx) => {
-                Self::CoreFunc(FuncType::from_wasm_func_type(engine, &ty.types[*idx]))
-            }
+            TypeDef::CoreFunc(idx) => Self::CoreFunc(FuncType::from_wasm_func_type(
+                engine,
+                ty.types[*idx].clone(),
+            )),
             TypeDef::Resource(idx) => Self::Resource(ty.resources[ty.types[*idx].ty]),
         }
     }

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -73,8 +73,9 @@ impl Global {
     }
 
     fn _new(store: &mut StoreOpaque, ty: GlobalType, val: Val) -> Result<Global> {
-        val.ensure_matches_ty(store, ty.content())
-            .context("type mismatch: initial value provided does not match the type of this global")?;
+        val.ensure_matches_ty(store, ty.content()).context(
+            "type mismatch: initial value provided does not match the type of this global",
+        )?;
         unsafe {
             let wasmtime_export = generate_global_export(store, ty, val);
             Ok(Global::from_wasmtime_global(wasmtime_export, store))

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -149,7 +149,7 @@ impl Global {
             bail!("immutable global cannot be set");
         }
         val.ensure_matches_ty(store, global_ty.content())
-            .context("attempt to set global to value of wrong type")?;
+            .context("type mismatch: attempt to set global to value of wrong type")?;
         unsafe {
             let definition = &mut *store[self.0].definition;
             match val {

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -1,7 +1,9 @@
-use crate::store::{StoreData, StoreOpaque, Stored};
-use crate::trampoline::generate_global_export;
-use crate::{AsContext, AsContextMut, ExternRef, Func, GlobalType, Mutability, Val, ValType};
-use anyhow::{bail, Result};
+use crate::{
+    store::{StoreData, StoreOpaque, Stored},
+    trampoline::generate_global_export,
+    AsContext, AsContextMut, ExternRef, Func, GlobalType, HeapType, Mutability, Ref, Val, ValType,
+};
+use anyhow::{bail, Context, Result};
 use std::mem;
 use std::ptr;
 
@@ -71,12 +73,8 @@ impl Global {
     }
 
     fn _new(store: &mut StoreOpaque, ty: GlobalType, val: Val) -> Result<Global> {
-        if !val.comes_from_same_store(store) {
-            bail!("cross-`Store` globals are not supported");
-        }
-        if val.ty() != *ty.content() {
-            bail!("value provided does not match the type of this global");
-        }
+        val.ensure_matches_ty(store, ty.content())
+            .context("value provided does not match the type of this global")?;
         unsafe {
             let wasmtime_export = generate_global_export(store, ty, val);
             Ok(Global::from_wasmtime_global(wasmtime_export, store))
@@ -91,7 +89,7 @@ impl Global {
     pub fn ty(&self, store: impl AsContext) -> GlobalType {
         let store = store.as_context();
         let ty = &store[self.0].global;
-        GlobalType::from_wasmtime_global(&ty)
+        GlobalType::from_wasmtime_global(store.engine(), &ty)
     }
 
     /// Returns the current [`Val`] of this global.
@@ -108,16 +106,26 @@ impl Global {
                 ValType::I64 => Val::from(*definition.as_i64()),
                 ValType::F32 => Val::F32(*definition.as_u32()),
                 ValType::F64 => Val::F64(*definition.as_u64()),
-                ValType::ExternRef => Val::ExternRef(
-                    definition
-                        .as_externref()
-                        .clone()
-                        .map(|inner| ExternRef { inner }),
-                ),
-                ValType::FuncRef => {
-                    Val::FuncRef(Func::from_raw(store, definition.as_func_ref().cast()))
-                }
                 ValType::V128 => Val::V128((*definition.as_u128()).into()),
+                ValType::Ref(ref_ty) => {
+                    let reference = match ref_ty.heap_type() {
+                        HeapType::Extern => Ref::Extern(
+                            definition
+                                .as_externref()
+                                .clone()
+                                .map(|inner| ExternRef { inner }),
+                        ),
+                        HeapType::Func | HeapType::Concrete(_) => {
+                            Ref::Func(Func::from_raw(store, definition.as_func_ref().cast()))
+                        }
+                        HeapType::NoFunc => Ref::Func(None),
+                    };
+                    debug_assert!(
+                        ref_ty.is_nullable() || !reference.is_null(),
+                        "if the type is non-nullable, we better have a non-null reference"
+                    );
+                    reference.into()
+                }
             }
         }
     }
@@ -135,17 +143,12 @@ impl Global {
     /// Panics if `store` does not own this global.
     pub fn set(&self, mut store: impl AsContextMut, val: Val) -> Result<()> {
         let store = store.as_context_mut().0;
-        let ty = self.ty(&store);
-        if ty.mutability() != Mutability::Var {
+        let global_ty = self.ty(&store);
+        if global_ty.mutability() != Mutability::Var {
             bail!("immutable global cannot be set");
         }
-        let ty = ty.content();
-        if val.ty() != *ty {
-            bail!("global of type {:?} cannot be set to {:?}", ty, val.ty());
-        }
-        if !val.comes_from_same_store(store) {
-            bail!("cross-`Store` values are not supported");
-        }
+        val.ensure_matches_ty(store, global_ty.content())
+            .context("attempt to set global to value of wrong type")?;
         unsafe {
             let definition = &mut *store[self.0].definition;
             match val {
@@ -153,15 +156,17 @@ impl Global {
                 Val::I64(i) => *definition.as_i64_mut() = i,
                 Val::F32(f) => *definition.as_u32_mut() = f,
                 Val::F64(f) => *definition.as_u64_mut() = f,
+                Val::V128(i) => *definition.as_u128_mut() = i.into(),
                 Val::FuncRef(f) => {
                     *definition.as_func_ref_mut() =
                         f.map_or(ptr::null_mut(), |f| f.vm_func_ref(store).as_ptr().cast());
                 }
-                Val::ExternRef(x) => {
-                    let old = mem::replace(definition.as_externref_mut(), x.map(|x| x.inner));
+                Val::ExternRef(e) => {
+                    // Take care to invoke the `Drop` implementation of the
+                    // existing `ExternRef` so that it doesn't leak.
+                    let old = mem::replace(definition.as_externref_mut(), e.map(|e| e.inner));
                     drop(old);
                 }
-                Val::V128(i) => *definition.as_u128_mut() = i.into(),
             }
         }
         Ok(())

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -74,7 +74,7 @@ impl Global {
 
     fn _new(store: &mut StoreOpaque, ty: GlobalType, val: Val) -> Result<Global> {
         val.ensure_matches_ty(store, ty.content())
-            .context("value provided does not match the type of this global")?;
+            .context("type mismatch: initial value provided does not match the type of this global")?;
         unsafe {
             let wasmtime_export = generate_global_export(store, ty, val);
             Ok(Global::from_wasmtime_global(wasmtime_export, store))

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -292,10 +292,13 @@ impl Table {
 
         let dst_ty = dst_table.ty(&store);
         let src_ty = src_table.ty(&store);
-        dst_ty
+        src_ty
             .element()
-            .ensure_matches(store.engine(), src_ty.element())
-            .context("tables do not have the same element type")?;
+            .ensure_matches(store.engine(), dst_ty.element())
+            .context(
+                "type mismatch: source table's element type does not match \
+                 destination table's element type",
+            )?;
 
         let dst_table = dst_table.wasmtime_table(store, std::iter::empty());
         let src_range = src_index..(src_index.checked_add(len).unwrap_or(u32::MAX));

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -1,7 +1,7 @@
 use crate::store::{StoreData, StoreOpaque, Stored};
 use crate::trampoline::generate_table_export;
-use crate::{AsContext, AsContextMut, ExternRef, Func, TableType, Val};
-use anyhow::{anyhow, bail, Result};
+use crate::{AsContext, AsContextMut, ExternRef, Func, Ref, TableType};
+use anyhow::{anyhow, bail, Context, Result};
 use wasmtime_runtime::{self as runtime};
 
 /// A WebAssembly `table`, or an array of values.
@@ -51,8 +51,8 @@ impl Table {
     /// let engine = Engine::default();
     /// let mut store = Store::new(&engine, ());
     ///
-    /// let ty = TableType::new(ValType::FuncRef, 2, None);
-    /// let table = Table::new(&mut store, ty, Val::FuncRef(None))?;
+    /// let ty = TableType::new(RefType::FUNCREF, 2, None);
+    /// let table = Table::new(&mut store, ty, Ref::Func(None))?;
     ///
     /// let module = Module::new(
     ///     &engine,
@@ -69,7 +69,7 @@ impl Table {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn new(mut store: impl AsContextMut, ty: TableType, init: Val) -> Result<Table> {
+    pub fn new(mut store: impl AsContextMut, ty: TableType, init: Ref) -> Result<Table> {
         Table::_new(store.as_context_mut().0, ty, init)
     }
 
@@ -86,7 +86,7 @@ impl Table {
     pub async fn new_async<T>(
         mut store: impl AsContextMut<Data = T>,
         ty: TableType,
-        init: Val,
+        init: Ref,
     ) -> Result<Table>
     where
         T: Send,
@@ -101,7 +101,7 @@ impl Table {
             .await?
     }
 
-    fn _new(store: &mut StoreOpaque, ty: TableType, init: Val) -> Result<Table> {
+    fn _new(store: &mut StoreOpaque, ty: TableType, init: Ref) -> Result<Table> {
         let wasmtime_export = generate_table_export(store, &ty)?;
         let init = init.into_table_element(store, ty.element())?;
         unsafe {
@@ -121,7 +121,7 @@ impl Table {
     pub fn ty(&self, store: impl AsContext) -> TableType {
         let store = store.as_context();
         let ty = &store[self.0].table.table;
-        TableType::from_wasmtime_table(ty)
+        TableType::from_wasmtime_table(store.engine(), ty)
     }
 
     fn wasmtime_table(
@@ -145,18 +145,19 @@ impl Table {
     /// # Panics
     ///
     /// Panics if `store` does not own this table.
-    pub fn get(&self, mut store: impl AsContextMut, index: u32) -> Option<Val> {
+    pub fn get(&self, mut store: impl AsContextMut, index: u32) -> Option<Ref> {
         let store = store.as_context_mut().0;
         let table = self.wasmtime_table(store, std::iter::once(index));
         unsafe {
             match (*table).get(index)? {
                 runtime::TableElement::FuncRef(f) => {
                     let func = Func::from_vm_func_ref(store, f);
-                    Some(Val::FuncRef(func))
+                    Some(func.into())
                 }
-                runtime::TableElement::ExternRef(None) => Some(Val::ExternRef(None)),
+                runtime::TableElement::ExternRef(None) => Some(Ref::Extern(None)),
                 runtime::TableElement::ExternRef(Some(x)) => {
-                    Some(Val::ExternRef(Some(ExternRef { inner: x })))
+                    let x = ExternRef { inner: x };
+                    Some(x.into())
                 }
                 runtime::TableElement::UninitFunc => {
                     unreachable!("lazy init above should have converted UninitFunc")
@@ -176,10 +177,10 @@ impl Table {
     /// # Panics
     ///
     /// Panics if `store` does not own this table.
-    pub fn set(&self, mut store: impl AsContextMut, index: u32, val: Val) -> Result<()> {
+    pub fn set(&self, mut store: impl AsContextMut, index: u32, val: Ref) -> Result<()> {
         let store = store.as_context_mut().0;
-        let ty = self.ty(&store).element().clone();
-        let val = val.into_table_element(store, ty)?;
+        let ty = self.ty(&store);
+        let val = val.into_table_element(store, ty.element())?;
         let table = self.wasmtime_table(store, std::iter::empty());
         unsafe {
             (*table)
@@ -222,10 +223,10 @@ impl Table {
     /// (see also: [`Store::limiter_async`](`crate::Store::limiter_async`)).
     /// When using an async resource limiter, use [`Table::grow_async`]
     /// instead.
-    pub fn grow(&self, mut store: impl AsContextMut, delta: u32, init: Val) -> Result<u32> {
+    pub fn grow(&self, mut store: impl AsContextMut, delta: u32, init: Ref) -> Result<u32> {
         let store = store.as_context_mut().0;
-        let ty = self.ty(&store).element().clone();
-        let init = init.into_table_element(store, ty)?;
+        let ty = self.ty(&store);
+        let init = init.into_table_element(store, ty.element())?;
         let table = self.wasmtime_table(store, std::iter::empty());
         unsafe {
             match (*table).grow(delta, init, store)? {
@@ -252,7 +253,7 @@ impl Table {
         &self,
         mut store: impl AsContextMut<Data = T>,
         delta: u32,
-        init: Val,
+        init: Ref,
     ) -> Result<u32>
     where
         T: Send,
@@ -273,7 +274,8 @@ impl Table {
     /// # Errors
     ///
     /// Returns an error if the range is out of bounds of either the source or
-    /// destination tables.
+    /// destination tables, or if the source table's element type does not match
+    /// the destination table's element type.
     ///
     /// # Panics
     ///
@@ -287,9 +289,13 @@ impl Table {
         len: u32,
     ) -> Result<()> {
         let store = store.as_context_mut().0;
-        if dst_table.ty(&store).element() != src_table.ty(&store).element() {
-            bail!("tables do not have the same element type");
-        }
+
+        let dst_ty = dst_table.ty(&store);
+        let src_ty = src_table.ty(&store);
+        dst_ty
+            .element()
+            .ensure_matches(store.engine(), src_ty.element())
+            .context("tables do not have the same element type")?;
 
         let dst_table = dst_table.wasmtime_table(store, std::iter::empty());
         let src_range = src_index..(src_index.checked_add(len).unwrap_or(u32::MAX));
@@ -316,10 +322,10 @@ impl Table {
     /// # Panics
     ///
     /// Panics if `store` does not own either `dst_table` or `src_table`.
-    pub fn fill(&self, mut store: impl AsContextMut, dst: u32, val: Val, len: u32) -> Result<()> {
+    pub fn fill(&self, mut store: impl AsContextMut, dst: u32, val: Ref, len: u32) -> Result<()> {
         let store = store.as_context_mut().0;
-        let ty = self.ty(&store).element().clone();
-        let val = val.into_table_element(store, ty)?;
+        let ty = self.ty(&store);
+        let val = val.into_table_element(store, ty.element())?;
 
         let table = self.wasmtime_table(store, std::iter::empty());
         unsafe {
@@ -384,11 +390,11 @@ mod tests {
         let t2 = instance.get_table(&mut store, "t").unwrap();
 
         // That said, they really point to the same table.
-        assert!(t1.get(&mut store, 0).unwrap().unwrap_externref().is_none());
-        assert!(t2.get(&mut store, 0).unwrap().unwrap_externref().is_none());
-        t1.set(&mut store, 0, Val::ExternRef(Some(ExternRef::new(42))))?;
-        assert!(t1.get(&mut store, 0).unwrap().unwrap_externref().is_some());
-        assert!(t2.get(&mut store, 0).unwrap().unwrap_externref().is_some());
+        assert!(t1.get(&mut store, 0).unwrap().unwrap_extern().is_none());
+        assert!(t2.get(&mut store, 0).unwrap().unwrap_extern().is_none());
+        t1.set(&mut store, 0, Ref::Extern(Some(ExternRef::new(42))))?;
+        assert!(t1.get(&mut store, 0).unwrap().unwrap_extern().is_some());
+        assert!(t2.get(&mut store, 0).unwrap().unwrap_extern().is_some());
 
         // And therefore their hash keys are the same.
         assert!(t1.hash_key(&store.as_context().0) == t2.hash_key(&store.as_context().0));

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1,8 +1,8 @@
 use crate::store::{StoreData, StoreOpaque, Stored};
 use crate::type_registry::RegisteredType;
 use crate::{
-    AsContext, AsContextMut, CallHook, Engine, Extern, FuncType, Instance, Module, StoreContext,
-    StoreContextMut, Val, ValRaw, ValType,
+    AsContext, AsContextMut, CallHook, Engine, Extern, FuncType, Instance, Module, Ref,
+    StoreContext, StoreContextMut, Val, ValRaw, ValType,
 };
 use anyhow::{bail, Context as _, Error, Result};
 use std::ffi::c_void;
@@ -16,6 +16,90 @@ use wasmtime_runtime::{
     ExportFunction, SendSyncPtr, StoreBox, VMArrayCallHostFuncContext, VMContext, VMFuncRef,
     VMFunctionImport, VMNativeCallHostFuncContext, VMOpaqueContext, VMSharedTypeIndex,
 };
+
+/// A reference to the abstract `nofunc` heap value.
+///
+/// The are no instances of `(ref nofunc)`: it is an uninhabited type.
+///
+/// There is precisely one instance of `(ref null nofunc)`, aka `nullfuncref`:
+/// the null reference.
+///
+/// This `NoFunc` Rust type's sole purpose is for use with [`Func::wrap`]- and
+/// [`Func::typed`]-style APIs for statically typing a function as taking or
+/// returning a `(ref null nofunc)` (aka `Option<NoFunc>`) which is always
+/// `None`.
+///
+/// # Example
+///
+/// ```
+/// # use wasmtime::*;
+/// # fn _foo() -> Result<()> {
+/// let mut config = Config::new();
+/// config.wasm_function_references(true);
+/// let engine = Engine::new(&config)?;
+///
+/// let module = Module::new(
+///     &engine,
+///     r#"
+///         (module
+///             (func (export "f") (param (ref null nofunc))
+///                 ;; If the reference is null, return.
+///                 local.get 0
+///                 ref.is_null nofunc
+///                 br_if 0
+///
+///                 ;; If the reference was not null (which is impossible)
+///                 ;; then raise a trap.
+///                 unreachable
+///             )
+///         )
+///     "#,
+/// )?;
+///
+/// let mut store = Store::new(&engine, ());
+/// let instance = Instance::new(&mut store, &module, &[])?;
+/// let f = instance.get_func(&mut store, "f").unwrap();
+///
+/// // We can cast a `(ref null nofunc)`-taking function into a typed function that
+/// // takes an `Option<NoFunc>` via the `Func::typed` method.
+/// let f = f.typed::<Option<NoFunc>, ()>(&store)?;
+///
+/// // We can call the typed function, passing the null `nofunc` reference.
+/// let result = f.call(&mut store, NoFunc::null());
+///
+/// // The function should not have trapped, because the reference we gave it was
+/// // null (as it had to be, since `NoFunc` is uninhabited).
+/// assert!(result.is_ok());
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct NoFunc {
+    _inner: Uninhabited,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum Uninhabited {}
+
+impl NoFunc {
+    /// Get the null `(ref null nofunc)` (aka `nullfuncref`) reference.
+    #[inline]
+    pub fn null() -> Option<NoFunc> {
+        None
+    }
+
+    /// Get the null `(ref null nofunc)` (aka `nullfuncref`) reference as a
+    /// [`wasmtime::Ref`].
+    pub fn null_ref() -> Ref {
+        Ref::Func(None)
+    }
+
+    /// Get the null `(ref null nofunc)` (aka `nullfuncref`) reference as a
+    /// [`wasmtime::Val`].
+    pub fn null_val() -> Val {
+        Val::FuncRef(None)
+    }
+}
 
 /// A WebAssembly function which can be called.
 ///
@@ -356,6 +440,11 @@ impl Func {
     /// documentation.
     ///
     /// [`Trap`]: crate::Trap
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given function type is not associated with this store's
+    /// engine.
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "cranelift", feature = "winch"))))]
     pub fn new<T>(
@@ -363,6 +452,7 @@ impl Func {
         ty: FuncType,
         func: impl Fn(Caller<'_, T>, &[Val], &mut [Val]) -> Result<()> + Send + Sync + 'static,
     ) -> Self {
+        assert!(ty.comes_from_same_engine(store.as_context().engine()));
         let ty_clone = ty.clone();
         unsafe {
             Func::new_unchecked(store, ty, move |caller, values| {
@@ -394,6 +484,11 @@ impl Func {
     /// This function is not safe because it's not known at compile time that
     /// the `func` provided correctly interprets the argument types provided to
     /// it, or that the results it produces will be of the correct type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given function type is not associated with this store's
+    /// engine.
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "cranelift", feature = "winch"))))]
     pub unsafe fn new_unchecked<T>(
@@ -401,6 +496,7 @@ impl Func {
         ty: FuncType,
         func: impl Fn(Caller<'_, T>, &mut [ValRaw]) -> Result<()> + Send + Sync + 'static,
     ) -> Self {
+        assert!(ty.comes_from_same_engine(store.as_context().engine()));
         let store = store.as_context_mut().0;
         let host = HostFunc::new_unchecked(store.engine(), ty, func);
         host.into_func(store)
@@ -425,6 +521,9 @@ impl Func {
     ///
     /// This function will panic if `store` is not associated with an [async
     /// config](crate::Config::async_support).
+    ///
+    /// Panics if the given function type is not associated with this store's
+    /// engine.
     ///
     /// # Errors
     ///
@@ -492,6 +591,7 @@ impl Func {
             store.as_context().async_support(),
             "cannot use `new_async` without enabling async support in the config"
         );
+        assert!(ty.comes_from_same_engine(store.as_context().engine()));
         Func::new(store, ty, move |mut caller, params, results| {
             let async_cx = caller
                 .store
@@ -524,17 +624,21 @@ impl Func {
     /// function being called is known statically so the type signature can
     /// be inferred. Rust types will map to WebAssembly types as follows:
     ///
-    /// | Rust Argument Type  | WebAssembly Type |
-    /// |---------------------|------------------|
-    /// | `i32`               | `i32`            |
-    /// | `u32`               | `i32`            |
-    /// | `i64`               | `i64`            |
-    /// | `u64`               | `i64`            |
-    /// | `f32`               | `f32`            |
-    /// | `f64`               | `f64`            |
-    /// | (not supported)     | `v128`           |
-    /// | `Option<Func>`      | `funcref`        |
-    /// | `Option<ExternRef>` | `externref`      |
+    /// | Rust Argument Type                | WebAssembly Type                      |
+    /// |-----------------------------------|---------------------------------------|
+    /// | `i32`                             | `i32`                                 |
+    /// | `u32`                             | `i32`                                 |
+    /// | `i64`                             | `i64`                                 |
+    /// | `u64`                             | `i64`                                 |
+    /// | `f32`                             | `f32`                                 |
+    /// | `f64`                             | `f64`                                 |
+    /// | `V128` on x86-64 and aarch64 only | `v128`                                |
+    /// | `Option<Func>`                    | `funcref` aka `(ref null func)`       |
+    /// | `Func`                            | `(ref func)`                          |
+    /// | `Option<Nofunc>`                  | `nullfuncref` aka `(ref null nofunc)` |
+    /// | `NoFunc`                          | `(ref nofunc)`                        |
+    /// | `Option<ExternRef>`               | `externref` aka `(ref null extern)`   |
+    /// | `ExternRef`                       | `(ref extern)`                        |
     ///
     /// Any of the Rust types can be returned from the closure as well, in
     /// addition to some extra types
@@ -769,8 +873,33 @@ impl Func {
     ///
     /// Note that this is a somewhat expensive method since it requires taking a
     /// lock as well as cloning a type.
-    fn load_ty(&self, store: &StoreOpaque) -> FuncType {
+    pub(crate) fn load_ty(&self, store: &StoreOpaque) -> FuncType {
+        assert!(self.comes_from_same_store(store));
         FuncType::from_shared_type_index(store.engine(), self.type_index(store.store_data()))
+    }
+
+    /// Does this function match the given type?
+    ///
+    /// That is, is this function's type a subtype of the given type?
+    pub fn matches_ty(&self, store: impl AsContext, func_ty: &FuncType) -> bool {
+        self._matches_ty(store.as_context().0, func_ty)
+    }
+
+    pub(crate) fn _matches_ty(&self, store: &StoreOpaque, func_ty: &FuncType) -> bool {
+        let actual_ty = self.load_ty(store);
+        actual_ty.matches(store.engine(), func_ty)
+    }
+
+    pub(crate) fn ensure_matches_ty(&self, store: &StoreOpaque, func_ty: &FuncType) -> Result<()> {
+        if !self.comes_from_same_store(store) {
+            bail!("function used with wrong store");
+        }
+        if self._matches_ty(store, func_ty) {
+            Ok(())
+        } else {
+            let actual_ty = self.load_ty(store);
+            bail!("type mismatch: expected {func_ty}, found {actual_ty}")
+        }
     }
 
     /// Gets a reference to the `FuncType` for this function.
@@ -1020,13 +1149,8 @@ impl Func {
             );
         }
         for (ty, arg) in ty.params().zip(params) {
-            if arg.ty() != ty {
-                bail!(
-                    "argument type mismatch: found {} but expected {}",
-                    arg.ty(),
-                    ty
-                );
-            }
+            arg.ensure_matches_ty(opaque, &ty)
+                .context("argument type mismatch")?;
             if !arg.comes_from_same_store(opaque) {
                 bail!("cross-`Store` values are not currently supported");
             }
@@ -1171,7 +1295,7 @@ impl Func {
             val_vec.push(unsafe { Val::from_raw(&mut caller.store, values_vec[i], ty) })
         }
 
-        val_vec.extend((0..ty.results().len()).map(|_| Val::null()));
+        val_vec.extend((0..ty.results().len()).map(|_| Val::null_func_ref()));
         let (params, results) = val_vec.split_at_mut(nparams);
         func(caller.sub_caller(), params, results)?;
 
@@ -1191,12 +1315,8 @@ impl Func {
         // produces the wrong number, wrong types, or wrong stores of
         // values, and we need to catch that here.
         for (i, (ret, ty)) in results.iter().zip(ty.results()).enumerate() {
-            if ret.ty() != ty {
-                bail!("function attempted to return an incompatible value");
-            }
-            if !ret.comes_from_same_store(caller.store.0) {
-                bail!("cross-`Store` values are not currently supported");
-            }
+            ret.ensure_matches_ty(caller.store.0, &ty)
+                .context("function attempted to return an incompatible value")?;
             unsafe {
                 values_vec[i] = ret.to_raw(&mut caller.store);
             }
@@ -1235,19 +1355,27 @@ impl Func {
     /// function. This behaves the same way as `Params`, but just for the
     /// results of the function.
     ///
+    /// # Translating Between WebAssembly and Rust Types
+    ///
     /// Translation between Rust types and WebAssembly types looks like:
     ///
-    /// | WebAssembly | Rust                |
-    /// |-------------|---------------------|
-    /// | `i32`       | `i32` or `u32`      |
-    /// | `i64`       | `i64` or `u64`      |
-    /// | `f32`       | `f32`               |
-    /// | `f64`       | `f64`               |
-    /// | `externref` | `Option<ExternRef>` |
-    /// | `funcref`   | `Option<Func>`      |
-    /// | `v128`      | not supported       |
+    /// | WebAssembly                           | Rust                                  |
+    /// |---------------------------------------|---------------------------------------|
+    /// | `i32`                                 | `i32` or `u32`                        |
+    /// | `i64`                                 | `i64` or `u64`                        |
+    /// | `f32`                                 | `f32`                                 |
+    /// | `f64`                                 | `f64`                                 |
+    /// | `externref` aka `(ref null extern)`   | `Option<ExternRef>`                   |
+    /// | `(ref extern)`                        | `ExternRef`                           |
+    /// | `funcref` aka `(ref null func)`       | `Option<Func>`                        |
+    /// | `(ref func)`                          | `Func`                                |
+    /// | `(ref null <func type index>)`        | `Option<Func>`                        |
+    /// | `(ref <func type index>)`             | `Func`                                |
+    /// | `nullfuncref` aka `(ref null nofunc)` | `Option<NoFunc>`                      |
+    /// | `(ref nofunc)`                        | `NoFunc`                              |
+    /// | `v128`                                | `V128` on `x86-64` and `aarch64` only |
     ///
-    /// (note that this mapping is the same as that of [`Func::wrap`]).
+    /// (Note that this mapping is the same as that of [`Func::wrap`]).
     ///
     /// Note that once the [`TypedFunc`] return value is acquired you'll use either
     /// [`TypedFunc::call`] or [`TypedFunc::call_async`] as necessary to actually invoke
@@ -1258,6 +1386,39 @@ impl Func {
     /// [`Instance::get_typed_func`](crate::Instance::get_typed_func) to
     /// directly get a typed function value from an
     /// [`Instance`](crate::Instance).
+    ///
+    /// ## Subtyping
+    ///
+    /// For result types, you can always use a supertype of the WebAssembly
+    /// function's actual declared result type. For example, if the WebAssembly
+    /// function was declared with type `(func (result nullfuncref))` you could
+    /// successfully call `f.typed::<(), Option<Func>>()` because `Option<Func>`
+    /// corresponds to `funcref`, which is a supertype of `nullfuncref`.
+    ///
+    /// For parameter types, you can always use a subtype of the WebAssembly
+    /// function's actual declared parameter type. For example, if the
+    /// WebAssembly function was declared with type `(func (param (ref null
+    /// func)))` you could successfully call `f.typed::<Func, ()>()` because
+    /// `Func` corresponds to `(ref func)`, which is a subtype of `(ref null
+    /// func)`.
+    ///
+    /// Additionally, for functions which take a reference to a concrete type as
+    /// a parameter, you can also use the concrete type's supertype. Consider a
+    /// WebAssembly function that takes a reference to a function with a
+    /// concrete type: `(ref null <func type index>)`. In this scenario, there
+    /// is no static `wasmtime::Foo` Rust type that corresponds to that
+    /// particular Wasm-defined concrete reference type because Wasm modules are
+    /// loaded dynamically at runtime. You *could* do `f.typed::<Option<NoFunc>,
+    /// ()>()`, and while that is correctly typed and valid, it is often overly
+    /// restrictive. The only value you could call the resulting typed function
+    /// with is the null function reference, but we'd like to call it with
+    /// non-null function references that happen to be of the correct
+    /// type. Therefore, `f.typed<Option<Func>, ()>()` is also allowed in this
+    /// case, even though `Option<Func>` represents `(ref null func)` which is
+    /// the supertype, not subtype, of `(ref null <func type index>)`. This does
+    /// imply some minimal dynamic type checks in this case, but it is supported
+    /// for better ergonomics, to enable passing non-null references into the
+    /// function.
     ///
     /// # Errors
     ///
@@ -1325,13 +1486,16 @@ impl Func {
         Results: WasmResults,
     {
         // Type-check that the params/results are all valid
-        let ty = self.ty(store);
-        Params::typecheck(ty.params()).context("type mismatch with parameters")?;
-        Results::typecheck(ty.results()).context("type mismatch with results")?;
+        let store = store.as_context().0;
+        let ty = self.load_ty(store);
+        Params::typecheck(store.engine(), ty.params(), TypeCheckPosition::Param)
+            .context("type mismatch with parameters")?;
+        Results::typecheck(store.engine(), ty.results(), TypeCheckPosition::Result)
+            .context("type mismatch with results")?;
 
         // and then we can construct the typed version of this function
         // (unsafely), which should be safe since we just did the type check above.
-        unsafe { Ok(TypedFunc::new_unchecked(*self)) }
+        unsafe { Ok(TypedFunc::_new_unchecked(store, *self)) }
     }
 
     /// Get a stable hash key for this function.
@@ -2126,12 +2290,18 @@ pub(crate) struct HostFunc {
 
 impl HostFunc {
     /// Analog of [`Func::new`]
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given function type is not associated with the given
+    /// engine.
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub fn new<T>(
         engine: &Engine,
         ty: FuncType,
         func: impl Fn(Caller<'_, T>, &[Val], &mut [Val]) -> Result<()> + Send + Sync + 'static,
     ) -> Self {
+        assert!(ty.comes_from_same_engine(engine));
         let ty_clone = ty.clone();
         unsafe {
             HostFunc::new_unchecked(engine, ty, move |caller, values| {
@@ -2141,12 +2311,18 @@ impl HostFunc {
     }
 
     /// Analog of [`Func::new_unchecked`]
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given function type is not associated with the given
+    /// engine.
     #[cfg(any(feature = "cranelift", feature = "winch"))]
     pub unsafe fn new_unchecked<T>(
         engine: &Engine,
         ty: FuncType,
         func: impl Fn(Caller<'_, T>, &mut [ValRaw]) -> Result<()> + Send + Sync + 'static,
     ) -> Self {
+        assert!(ty.comes_from_same_engine(engine));
         let func = move |caller_vmctx, values: &mut [ValRaw]| {
             Caller::<T>::with(caller_vmctx, |mut caller| {
                 caller.store.0.call_hook(CallHook::CallingHost)?;

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -887,7 +887,7 @@ impl Func {
 
     pub(crate) fn _matches_ty(&self, store: &StoreOpaque, func_ty: &FuncType) -> bool {
         let actual_ty = self.load_ty(store);
-        actual_ty.matches(store.engine(), func_ty)
+        actual_ty.matches(func_ty)
     }
 
     pub(crate) fn ensure_matches_ty(&self, store: &StoreOpaque, func_ty: &FuncType) -> Result<()> {

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -89,13 +89,13 @@ impl NoFunc {
     }
 
     /// Get the null `(ref null nofunc)` (aka `nullfuncref`) reference as a
-    /// [`wasmtime::Ref`].
+    /// [`Ref`].
     pub fn null_ref() -> Ref {
         Ref::Func(None)
     }
 
     /// Get the null `(ref null nofunc)` (aka `nullfuncref`) reference as a
-    /// [`wasmtime::Val`].
+    /// [`Val`].
     pub fn null_val() -> Val {
         Val::FuncRef(None)
     }

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -570,17 +570,17 @@ unsafe impl WasmTy for NoFunc {
 
     #[inline]
     fn compatible_with_store(&self, _store: &StoreOpaque) -> bool {
-        unreachable!("NoFunc is uninhabited")
+        match self._inner {}
     }
 
     #[inline]
     fn dynamic_concrete_type_check(&self, _: &StoreOpaque, _: bool, _: &FuncType) -> Result<()> {
-        unreachable!("NoFunc is uninhabited")
+        match self._inner {}
     }
 
     #[inline]
     fn is_externref(&self) -> bool {
-        unreachable!("NoFunc is uninhabited")
+        match self._inner {}
     }
 
     #[inline]

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -1,9 +1,13 @@
 use super::{invoke_wasm_and_catch_traps, HostAbi};
 use crate::store::{AutoAssertNoGc, StoreOpaque};
-use crate::{AsContextMut, ExternRef, Func, FuncType, StoreContextMut, ValRaw, ValType};
-use anyhow::{bail, Result};
+use crate::{
+    AsContext, AsContextMut, Engine, ExternRef, Func, FuncType, HeapType, NoFunc, RefType,
+    StoreContextMut, ValRaw, ValType,
+};
+use anyhow::{bail, Context, Result};
 use std::marker;
 use std::mem::{self, MaybeUninit};
+use std::os::raw::c_void;
 use std::ptr::{self, NonNull};
 use wasmtime_runtime::{
     VMContext, VMFuncRef, VMNativeCallFunction, VMOpaqueContext, VMSharedTypeIndex,
@@ -17,17 +21,19 @@ use wasmtime_runtime::{
 ///
 /// This structure is created via [`Func::typed`] or [`TypedFunc::new_unchecked`].
 /// For more documentation about this see those methods.
-#[repr(transparent)] // here for the C API
 pub struct TypedFunc<Params, Results> {
     _a: marker::PhantomData<fn(Params) -> Results>,
+    ty: FuncType,
     func: Func,
 }
 
-impl<Params, Results> Copy for TypedFunc<Params, Results> {}
-
 impl<Params, Results> Clone for TypedFunc<Params, Results> {
     fn clone(&self) -> TypedFunc<Params, Results> {
-        *self
+        Self {
+            _a: marker::PhantomData,
+            ty: self.ty.clone(),
+            func: self.func,
+        }
     }
 }
 
@@ -48,9 +54,19 @@ where
     /// This function only safe to call if `typed` would otherwise return `Ok`
     /// for the same `Params` and `Results` specified. If `typed` would return
     /// an error then the returned `TypedFunc` is memory unsafe to invoke.
-    pub unsafe fn new_unchecked(func: Func) -> TypedFunc<Params, Results> {
+    pub unsafe fn new_unchecked(store: impl AsContext, func: Func) -> TypedFunc<Params, Results> {
+        let store = store.as_context().0;
+        Self::_new_unchecked(store, func)
+    }
+
+    pub(crate) unsafe fn _new_unchecked(
+        store: &StoreOpaque,
+        func: Func,
+    ) -> TypedFunc<Params, Results> {
+        let ty = func.load_ty(store);
         TypedFunc {
             _a: marker::PhantomData,
+            ty,
             func,
         }
     }
@@ -85,7 +101,7 @@ where
             "must use `call_async` with async stores"
         );
         let func = self.func.vm_func_ref(store.0);
-        unsafe { Self::call_raw(&mut store, func, params) }
+        unsafe { Self::call_raw(&mut store, &self.ty, func, params) }
     }
 
     /// Invokes this WebAssembly function with the specified parameters.
@@ -123,13 +139,14 @@ where
         store
             .on_fiber(|store| {
                 let func = self.func.vm_func_ref(store.0);
-                unsafe { Self::call_raw(store, func, params) }
+                unsafe { Self::call_raw(store, &self.ty, func, params) }
             })
             .await?
     }
 
     pub(crate) unsafe fn call_raw<T>(
         store: &mut StoreContextMut<'_, T>,
+        ty: &FuncType,
         func: ptr::NonNull<VMFuncRef>,
         params: Params,
     ) -> Result<Results> {
@@ -159,12 +176,7 @@ where
             // the Wasm frame and they get referenced from the stack maps.
             let mut store = AutoAssertNoGc::new(&mut **store.as_context_mut().0);
 
-            match params.into_abi(&mut store) {
-                Some(abi) => abi,
-                None => {
-                    bail!("attempt to pass cross-`Store` value to Wasm as function argument")
-                }
-            }
+            params.into_abi(&mut store, ty.params())?
         };
 
         // Try to capture only a single variable (a tuple) in the closure below.
@@ -191,9 +203,18 @@ where
     /// Purely a debug-mode assertion, not actually used in release builds.
     fn debug_typecheck(store: &StoreOpaque, func: VMSharedTypeIndex) {
         let ty = FuncType::from_shared_type_index(store.engine(), func);
-        Params::typecheck(ty.params()).expect("params should match");
-        Results::typecheck(ty.results()).expect("results should match");
+        Params::typecheck(store.engine(), ty.params(), TypeCheckPosition::Param)
+            .expect("params should match");
+        Results::typecheck(store.engine(), ty.results(), TypeCheckPosition::Result)
+            .expect("results should match");
     }
+}
+
+#[doc(hidden)]
+#[derive(Copy, Clone)]
+pub enum TypeCheckPosition {
+    Param,
+    Result,
 }
 
 /// A trait implemented for types which can be arguments and results for
@@ -205,29 +226,107 @@ where
 ///
 /// For more information see [`Func::wrap`] and [`Func::typed`]
 pub unsafe trait WasmTy: Send {
+    // The raw ABI type that values of this type can be converted to and passed
+    // to Wasm, or given from Wasm and converted back from.
     #[doc(hidden)]
     type Abi: Copy;
+
+    // Do a "static" (aka at time of `func.typed::<P, R>()`) ahead-of-time type
+    // check for this type at the given position. You probably don't need to
+    // override this trait method.
     #[doc(hidden)]
     #[inline]
-    fn typecheck(ty: crate::ValType) -> Result<()> {
-        if ty == Self::valtype() {
-            Ok(())
-        } else {
-            bail!("expected {} found {}", Self::valtype(), ty)
+    fn typecheck(engine: &Engine, actual: ValType, position: TypeCheckPosition) -> Result<()> {
+        let expected = Self::valtype();
+        debug_assert!(expected.comes_from_same_engine(engine));
+        debug_assert!(actual.comes_from_same_engine(engine));
+        match position {
+            // The caller is expecting to receive a `T` and the callee is
+            // actually returning a `U`, so ensure that `U <: T`.
+            TypeCheckPosition::Result => actual.ensure_matches(engine, &expected),
+            // The caller is expecting to pass a `T` and the callee is expecting
+            // to receive a `U`, so ensure that `T <: U`.
+            TypeCheckPosition::Param => match (expected.as_ref(), actual.as_ref()) {
+                // ... except that this technically-correct check would overly
+                // restrict the usefulness of our typed function APIs for the
+                // specific case of concrete reference types. Let's work through
+                // an example.
+                //
+                // Consider functions that take a `(ref param $some_func_type)`
+                // parameter:
+                //
+                // * We cannot have a static `wasmtime::SomeFuncTypeRef` type
+                //   that implements `WasmTy` specifically for `(ref null
+                //   $some_func_type)` because Wasm modules, and their types,
+                //   are loaded dynamically at runtime.
+                //
+                // * Therefore the embedder's only option for `T <: (ref null
+                //   $some_func_type)` is `T = (ref null nofunc)` aka
+                //   `Option<wasmtime::NoFunc>`.
+                //
+                // * But that static type means they can *only* pass in the null
+                //   function reference as an argument to the typed function.
+                //   This is way too restrictive! For ergonomics, we want them
+                //   to be able to pass in a `wasmtime::Func` whose type is
+                //   `$some_func_type`!
+                //
+                // To lift this constraint and enable better ergonomics for
+                // embedders, we allow `top(T) <: top(U)` -- i.e. they are part
+                // of the same type hierarchy and a dynamic cast could possibly
+                // succeed -- for the specific case of concrete heap type
+                // parameters, and fall back to dynamic type checks on the
+                // arguments passed to each invocation, as necessary.
+                (Some(expected_ref), Some(actual_ref)) if actual_ref.heap_type().is_concrete() => {
+                    expected_ref
+                        .heap_type()
+                        .top(engine)
+                        .ensure_matches(engine, &actual_ref.heap_type().top(engine))
+                }
+                _ => expected.ensure_matches(engine, &actual),
+            },
         }
     }
+
+    // The value type that this Type represents.
     #[doc(hidden)]
     fn valtype() -> ValType;
+
+    // Dynamic checks that this value is being used with the correct store
+    // context.
     #[doc(hidden)]
     fn compatible_with_store(&self, store: &StoreOpaque) -> bool;
+
+    // Dynamic checks that `self <: actual` for concrete type arguments. See the
+    // comment above in `WasmTy::typecheck`.
+    //
+    // Only ever called for concrete reference type arguments, so any type which
+    // is not in a type hierarchy with concrete reference types can implement
+    // this with `unreachable!()`.
+    #[doc(hidden)]
+    fn dynamic_concrete_type_check(
+        &self,
+        store: &StoreOpaque,
+        nullable: bool,
+        actual: &FuncType,
+    ) -> Result<()>;
+
+    // Is this an externref?
     #[doc(hidden)]
     fn is_externref(&self) -> bool;
+
+    // Construct a `Self::Abi` from the given `ValRaw`.
     #[doc(hidden)]
     unsafe fn abi_from_raw(raw: *mut ValRaw) -> Self::Abi;
+
+    // Stuff our given `Self::Abi` into a `ValRaw`.
     #[doc(hidden)]
     unsafe fn abi_into_raw(abi: Self::Abi, raw: *mut ValRaw);
+
+    // Convert `self` into `Self::Abi`.
     #[doc(hidden)]
     fn into_abi(self, store: &mut StoreOpaque) -> Self::Abi;
+
+    // Convert back from `Self::Abi` into `Self`.
     #[doc(hidden)]
     unsafe fn from_abi(abi: Self::Abi, store: &mut StoreOpaque) -> Self;
 }
@@ -243,6 +342,10 @@ macro_rules! integers {
             #[inline]
             fn compatible_with_store(&self, _: &StoreOpaque) -> bool {
                 true
+            }
+            #[inline]
+            fn dynamic_concrete_type_check(&self, _: &StoreOpaque, _: bool, _: &FuncType) -> Result<()> {
+                unreachable!()
             }
             #[inline]
             fn is_externref(&self) -> bool {
@@ -288,6 +391,10 @@ macro_rules! floats {
                 true
             }
             #[inline]
+            fn dynamic_concrete_type_check(&self, _: &StoreOpaque, _: bool, _: &FuncType) -> Result<()> {
+                unreachable!()
+            }
+            #[inline]
             fn is_externref(&self) -> bool {
                 false
             }
@@ -316,17 +423,105 @@ floats! {
     f64/u64/get_f64 => F64
 }
 
-unsafe impl WasmTy for Option<ExternRef> {
-    type Abi = *mut u8;
+unsafe impl WasmTy for ExternRef {
+    type Abi = NonNull<u8>;
 
     #[inline]
     fn valtype() -> ValType {
-        ValType::ExternRef
+        ValType::Ref(RefType::new(false, HeapType::Extern))
     }
 
     #[inline]
     fn compatible_with_store(&self, _store: &StoreOpaque) -> bool {
         true
+    }
+
+    #[inline]
+    fn dynamic_concrete_type_check(&self, _: &StoreOpaque, _: bool, _: &FuncType) -> Result<()> {
+        unreachable!()
+    }
+
+    #[inline]
+    fn is_externref(&self) -> bool {
+        true
+    }
+
+    #[inline]
+    unsafe fn abi_from_raw(raw: *mut ValRaw) -> Self::Abi {
+        let p = (*raw).get_externref().cast::<u8>();
+        debug_assert!(!p.is_null());
+        NonNull::new_unchecked(p)
+    }
+
+    #[inline]
+    unsafe fn abi_into_raw(abi: NonNull<u8>, raw: *mut ValRaw) {
+        *raw = ValRaw::externref(abi.cast::<c_void>().as_ptr());
+    }
+
+    #[inline]
+    fn into_abi(self, store: &mut StoreOpaque) -> Self::Abi {
+        let abi = self.inner.as_raw();
+        unsafe {
+            // NB: We _must not_ trigger a GC when passing refs from host
+            // code into Wasm (e.g. returned from a host function or passed
+            // as arguments to a Wasm function). After insertion into the
+            // table, this reference is no longer rooted. If multiple
+            // references are being sent from the host into Wasm and we
+            // allowed GCs during insertion, then the following events could
+            // happen:
+            //
+            // * Reference A is inserted into the activations
+            //   table. This does not trigger a GC, but does fill the table
+            //   to capacity.
+            //
+            // * The caller's reference to A is removed. Now the only
+            //   reference to A is from the activations table.
+            //
+            // * Reference B is inserted into the activations table. Because
+            //   the table is at capacity, a GC is triggered.
+            //
+            // * A is reclaimed because the only reference keeping it alive
+            //   was the activation table's reference (it isn't inside any
+            //   Wasm frames on the stack yet, so stack scanning and stack
+            //   maps don't increment its reference count).
+            //
+            // * We transfer control to Wasm, giving it A and B. Wasm uses
+            //   A. That's a use after free.
+            //
+            // In conclusion, to prevent uses after free, we cannot GC
+            // during this insertion.
+            let mut store = AutoAssertNoGc::new(store);
+            store.insert_vmexternref_without_gc(self.inner);
+
+            debug_assert!(!abi.is_null());
+            NonNull::new_unchecked(abi)
+        }
+    }
+
+    #[inline]
+    unsafe fn from_abi(abi: Self::Abi, _store: &mut StoreOpaque) -> Self {
+        ExternRef {
+            inner: wasmtime_runtime::VMExternRef::clone_from_raw(abi.as_ptr()),
+        }
+    }
+}
+
+unsafe impl WasmTy for Option<ExternRef> {
+    type Abi = *mut u8;
+
+    #[inline]
+    fn valtype() -> ValType {
+        ValType::EXTERNREF
+    }
+
+    #[inline]
+    fn compatible_with_store(&self, _store: &StoreOpaque) -> bool {
+        true
+    }
+
+    #[inline]
+    fn dynamic_concrete_type_check(&self, _: &StoreOpaque, _: bool, _: &FuncType) -> Result<()> {
+        unreachable!()
     }
 
     #[inline]
@@ -347,40 +542,7 @@ unsafe impl WasmTy for Option<ExternRef> {
     #[inline]
     fn into_abi(self, store: &mut StoreOpaque) -> Self::Abi {
         if let Some(x) = self {
-            let abi = x.inner.as_raw();
-            unsafe {
-                // NB: We _must not_ trigger a GC when passing refs from host
-                // code into Wasm (e.g. returned from a host function or passed
-                // as arguments to a Wasm function). After insertion into the
-                // table, this reference is no longer rooted. If multiple
-                // references are being sent from the host into Wasm and we
-                // allowed GCs during insertion, then the following events could
-                // happen:
-                //
-                // * Reference A is inserted into the activations
-                //   table. This does not trigger a GC, but does fill the table
-                //   to capacity.
-                //
-                // * The caller's reference to A is removed. Now the only
-                //   reference to A is from the activations table.
-                //
-                // * Reference B is inserted into the activations table. Because
-                //   the table is at capacity, a GC is triggered.
-                //
-                // * A is reclaimed because the only reference keeping it alive
-                //   was the activation table's reference (it isn't inside any
-                //   Wasm frames on the stack yet, so stack scanning and stack
-                //   maps don't increment its reference count).
-                //
-                // * We transfer control to Wasm, giving it A and B. Wasm uses
-                //   A. That's a use after free.
-                //
-                // In conclusion, to prevent uses after free, we cannot GC
-                // during this insertion.
-                let mut store = AutoAssertNoGc::new(store);
-                store.insert_vmexternref_without_gc(x.inner);
-            }
-            abi
+            <ExternRef as WasmTy>::into_abi(x, store).as_ptr()
         } else {
             ptr::null_mut()
         }
@@ -398,12 +560,162 @@ unsafe impl WasmTy for Option<ExternRef> {
     }
 }
 
+unsafe impl WasmTy for NoFunc {
+    type Abi = NoFunc;
+
+    #[inline]
+    fn valtype() -> ValType {
+        ValType::Ref(RefType::new(false, HeapType::NoFunc))
+    }
+
+    #[inline]
+    fn compatible_with_store(&self, _store: &StoreOpaque) -> bool {
+        unreachable!("NoFunc is uninhabited")
+    }
+
+    #[inline]
+    fn dynamic_concrete_type_check(&self, _: &StoreOpaque, _: bool, _: &FuncType) -> Result<()> {
+        unreachable!("NoFunc is uninhabited")
+    }
+
+    #[inline]
+    fn is_externref(&self) -> bool {
+        unreachable!("NoFunc is uninhabited")
+    }
+
+    #[inline]
+    unsafe fn abi_from_raw(_raw: *mut ValRaw) -> Self::Abi {
+        unreachable!("NoFunc is uninhabited")
+    }
+
+    #[inline]
+    unsafe fn abi_into_raw(_abi: Self::Abi, _raw: *mut ValRaw) {
+        unreachable!("NoFunc is uninhabited")
+    }
+
+    #[inline]
+    fn into_abi(self, _store: &mut StoreOpaque) -> Self::Abi {
+        unreachable!("NoFunc is uninhabited")
+    }
+
+    #[inline]
+    unsafe fn from_abi(_abi: Self::Abi, _store: &mut StoreOpaque) -> Self {
+        unreachable!("NoFunc is uninhabited")
+    }
+}
+
+unsafe impl WasmTy for Option<NoFunc> {
+    type Abi = *mut NoFunc;
+
+    #[inline]
+    fn valtype() -> ValType {
+        ValType::Ref(RefType::new(true, HeapType::NoFunc))
+    }
+
+    #[inline]
+    fn compatible_with_store(&self, _store: &StoreOpaque) -> bool {
+        true
+    }
+
+    #[inline]
+    fn dynamic_concrete_type_check(
+        &self,
+        _: &StoreOpaque,
+        nullable: bool,
+        func_ty: &FuncType,
+    ) -> Result<()> {
+        if nullable {
+            // `(ref null nofunc) <: (ref null $f)` for all function types `$f`.
+            Ok(())
+        } else {
+            bail!("argument type mismatch: expected (ref {func_ty}), found null reference")
+        }
+    }
+
+    #[inline]
+    fn is_externref(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    unsafe fn abi_from_raw(_raw: *mut ValRaw) -> Self::Abi {
+        ptr::null_mut()
+    }
+
+    #[inline]
+    unsafe fn abi_into_raw(_abi: Self::Abi, raw: *mut ValRaw) {
+        *raw = ValRaw::funcref(ptr::null_mut());
+    }
+
+    #[inline]
+    fn into_abi(self, _store: &mut StoreOpaque) -> Self::Abi {
+        ptr::null_mut()
+    }
+
+    #[inline]
+    unsafe fn from_abi(_abi: Self::Abi, _store: &mut StoreOpaque) -> Self {
+        None
+    }
+}
+
+unsafe impl WasmTy for Func {
+    type Abi = NonNull<wasmtime_runtime::VMFuncRef>;
+
+    #[inline]
+    fn valtype() -> ValType {
+        ValType::Ref(RefType::new(false, HeapType::Func))
+    }
+
+    #[inline]
+    fn compatible_with_store<'a>(&self, store: &StoreOpaque) -> bool {
+        store.store_data().contains(self.0)
+    }
+
+    #[inline]
+    fn dynamic_concrete_type_check(
+        &self,
+        store: &StoreOpaque,
+        _nullable: bool,
+        actual: &FuncType,
+    ) -> Result<()> {
+        self.ensure_matches_ty(store, actual)
+            .context("argument type mismatch for reference to concrete type")
+    }
+
+    #[inline]
+    fn is_externref(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    unsafe fn abi_from_raw(raw: *mut ValRaw) -> Self::Abi {
+        let p = (*raw).get_funcref();
+        debug_assert!(!p.is_null());
+        NonNull::new_unchecked(p.cast::<wasmtime_runtime::VMFuncRef>())
+    }
+
+    #[inline]
+    unsafe fn abi_into_raw(abi: Self::Abi, raw: *mut ValRaw) {
+        *raw = ValRaw::funcref(abi.cast::<c_void>().as_ptr());
+    }
+
+    #[inline]
+    fn into_abi(self, store: &mut StoreOpaque) -> Self::Abi {
+        self.vm_func_ref(store)
+    }
+
+    #[inline]
+    unsafe fn from_abi(abi: Self::Abi, store: &mut StoreOpaque) -> Self {
+        Func::from_vm_func_ref(store, abi.as_ptr()).unwrap()
+    }
+}
+
 unsafe impl WasmTy for Option<Func> {
     type Abi = *mut wasmtime_runtime::VMFuncRef;
 
     #[inline]
     fn valtype() -> ValType {
-        ValType::FuncRef
+        ValType::FUNCREF
     }
 
     #[inline]
@@ -412,6 +724,22 @@ unsafe impl WasmTy for Option<Func> {
             store.store_data().contains(f.0)
         } else {
             true
+        }
+    }
+
+    fn dynamic_concrete_type_check(
+        &self,
+        store: &StoreOpaque,
+        nullable: bool,
+        func_ty: &FuncType,
+    ) -> Result<()> {
+        if let Some(f) = self {
+            f.ensure_matches_ty(store, func_ty)
+                .context("argument type mismatch for reference to concrete type")
+        } else if nullable {
+            Ok(())
+        } else {
+            bail!("argument type mismatch: expected (ref {func_ty}), found null reference")
         }
     }
 
@@ -455,13 +783,21 @@ pub unsafe trait WasmParams: Send {
     type Abi: Copy;
 
     #[doc(hidden)]
-    fn typecheck(params: impl ExactSizeIterator<Item = crate::ValType>) -> Result<()>;
+    fn typecheck(
+        engine: &Engine,
+        params: impl ExactSizeIterator<Item = crate::ValType>,
+        position: TypeCheckPosition,
+    ) -> Result<()>;
 
     #[doc(hidden)]
     fn externrefs_count(&self) -> usize;
 
     #[doc(hidden)]
-    fn into_abi(self, store: &mut StoreOpaque) -> Option<Self::Abi>;
+    fn into_abi(
+        self,
+        store: &mut StoreOpaque,
+        params: impl ExactSizeIterator<Item = crate::ValType>,
+    ) -> Result<Self::Abi>;
 
     #[doc(hidden)]
     unsafe fn invoke<R: WasmResults>(
@@ -480,8 +816,12 @@ where
 {
     type Abi = <(T,) as WasmParams>::Abi;
 
-    fn typecheck(params: impl ExactSizeIterator<Item = crate::ValType>) -> Result<()> {
-        <(T,) as WasmParams>::typecheck(params)
+    fn typecheck(
+        engine: &Engine,
+        params: impl ExactSizeIterator<Item = crate::ValType>,
+        position: TypeCheckPosition,
+    ) -> Result<()> {
+        <(T,) as WasmParams>::typecheck(engine, params, position)
     }
 
     #[inline]
@@ -490,8 +830,12 @@ where
     }
 
     #[inline]
-    fn into_abi(self, store: &mut StoreOpaque) -> Option<Self::Abi> {
-        <(T,) as WasmParams>::into_abi((self,), store)
+    fn into_abi(
+        self,
+        store: &mut StoreOpaque,
+        params: impl ExactSizeIterator<Item = crate::ValType>,
+    ) -> Result<Self::Abi> {
+        <(T,) as WasmParams>::into_abi((self,), store, params)
     }
 
     unsafe fn invoke<R: WasmResults>(
@@ -510,14 +854,18 @@ macro_rules! impl_wasm_params {
         unsafe impl<$($t: WasmTy,)*> WasmParams for ($($t,)*) {
             type Abi = ($($t::Abi,)*);
 
-            fn typecheck(mut params: impl ExactSizeIterator<Item = crate::ValType>) -> Result<()> {
+            fn typecheck(
+                _engine: &Engine,
+                mut params: impl ExactSizeIterator<Item = crate::ValType>,
+                _position: TypeCheckPosition,
+            ) -> Result<()> {
                 let mut _n = 0;
 
                 $(
                     match params.next() {
                         Some(t) => {
                             _n += 1;
-                            $t::typecheck(t)?
+                            $t::typecheck(_engine, t, _position)?
                         },
                         None => bail!("expected {} types, found {}", $n, params.len() + _n),
                     }
@@ -542,16 +890,24 @@ macro_rules! impl_wasm_params {
 
 
             #[inline]
-            fn into_abi(self, _store: &mut StoreOpaque) -> Option<Self::Abi> {
+            fn into_abi(
+                self,
+                _store: &mut StoreOpaque,
+                mut _params: impl ExactSizeIterator<Item = ValType>,
+            ) -> Result<Self::Abi> {
                 let ($($t,)*) = self;
                 $(
-                    let $t = if $t.compatible_with_store(_store) {
-                        $t.into_abi(_store)
-                    } else {
-                        return None;
-                    };
+                    if !$t.compatible_with_store(_store) {
+                        bail!("attempt to pass cross-`Store` value to Wasm as function argument");
+                    }
+                    if let ValType::Ref(r) = _params.next().unwrap() {
+                        if let Some(c) = r.heap_type().as_concrete() {
+                            $t.dynamic_concrete_type_check(_store, r.is_nullable(), c)?;
+                        }
+                    }
+                    let $t = $t.into_abi(_store);
                 )*
-                Some(($($t,)*))
+                Ok(($($t,)*))
             }
 
             unsafe fn invoke<R: WasmResults>(
@@ -589,13 +945,10 @@ for_each_function_signature!(impl_wasm_params);
 
 /// A trait used for [`Func::typed`] and with [`TypedFunc`] to represent the set of
 /// results for wasm functions.
-///
-/// This is currently only implemented for `()` and for bare types that can be
-/// returned. This is not yet implemented for tuples because a multi-value
-/// `TypedFunc` is not currently supported.
 pub unsafe trait WasmResults: WasmParams {
     #[doc(hidden)]
     type ResultAbi: HostAbi;
+
     #[doc(hidden)]
     unsafe fn from_abi(store: &mut StoreOpaque, abi: Self::ResultAbi) -> Self;
 }

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -809,8 +809,8 @@ impl<T> InstancePre<T> {
                 Definition::HostFunc(f) => {
                     host_funcs += 1;
                     if f.func_ref().wasm_call.is_none() {
-                        // `f` needs its `VMFuncRef::wasm_call`
-                        // patched with a Wasm-to-native trampoline.
+                        // `f` needs its `VMFuncRef::wasm_call` patched with a
+                        // Wasm-to-native trampoline.
                         debug_assert!(matches!(f.host_ctx(), crate::HostContext::Native(_)));
                         func_refs.push(VMFuncRef {
                             wasm_call: module
@@ -972,11 +972,7 @@ fn typecheck<I>(
     if expected != imports.len() {
         bail!("expected {} imports, found {}", expected, imports.len());
     }
-    let cx = matching::MatchCx {
-        signatures: module.signatures(),
-        types: module.types(),
-        engine: module.engine(),
-    };
+    let cx = matching::MatchCx::new(module);
     for ((name, field, expected_ty), actual) in env_module.imports().zip(imports) {
         check(&cx, &expected_ty, actual)
             .with_context(|| format!("incompatible import type for `{name}::{field}`"))?;

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -1,6 +1,8 @@
-use std::fmt;
+use anyhow::{bail, Result};
+use std::fmt::{self, Display};
 use wasmtime_environ::{
-    EntityType, Global, Memory, ModuleTypes, Table, WasmFuncType, WasmRefType, WasmValType,
+    EngineOrModuleTypeIndex, EntityType, Global, Memory, ModuleTypes, Table, WasmFuncType,
+    WasmHeapType, WasmRefType, WasmValType,
 };
 use wasmtime_runtime::VMSharedTypeIndex;
 
@@ -24,10 +26,21 @@ pub enum Mutability {
 // Value Types
 
 /// A list of all possible value types in WebAssembly.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+///
+/// # Subtyping and Equality
+///
+/// `ValType` does not implement `Eq`, because reference types have a subtyping
+/// relationship, and so 99.99% of the time you actually want to check whether
+/// one type matches (i.e. is a subtype of) another type. You can use the
+/// [`ValType::matches`] and [`Val::matches_ty`] methods to perform these types
+/// of checks. If, however, you are in that 0.01% scenario where you need to
+/// check precise equality between types, you can use the [`ValType::eq`]
+/// method.
+#[derive(Clone, Hash)]
 pub enum ValType {
-    // NB: the ordering here is intended to match the ordering in
+    // NB: the ordering of variants here is intended to match the ordering in
     // `wasmtime_types::WasmType` to help improve codegen when converting.
+    //
     /// Signed 32 bit integer.
     I32,
     /// Signed 64 bit integer.
@@ -38,13 +51,17 @@ pub enum ValType {
     F64,
     /// A 128 bit number.
     V128,
-    /// A reference to a Wasm function.
-    FuncRef,
-    /// A reference to opaque data in the Wasm instance.
-    ExternRef,
+    /// An opaque reference to some type on the heap.
+    Ref(RefType),
 }
 
-impl fmt::Display for ValType {
+impl fmt::Debug for ValType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(self, f)
+    }
+}
+
+impl Display for ValType {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ValType::I32 => write!(f, "i32"),
@@ -52,13 +69,28 @@ impl fmt::Display for ValType {
             ValType::F32 => write!(f, "f32"),
             ValType::F64 => write!(f, "f64"),
             ValType::V128 => write!(f, "v128"),
-            ValType::ExternRef => write!(f, "externref"),
-            ValType::FuncRef => write!(f, "funcref"),
+            ValType::Ref(r) => Display::fmt(r, f),
         }
     }
 }
 
+impl From<RefType> for ValType {
+    #[inline]
+    fn from(r: RefType) -> Self {
+        ValType::Ref(r)
+    }
+}
+
 impl ValType {
+    /// The `externref` type, aka `(ref null extern)`.
+    pub const EXTERNREF: Self = ValType::Ref(RefType::EXTERNREF);
+
+    /// The `funcref` type, aka `(ref null func)`.
+    pub const FUNCREF: Self = ValType::Ref(RefType::FUNCREF);
+
+    /// The `nullfuncref` type, aka `(ref null nofunc)`.
+    pub const NULLFUNCREF: Self = ValType::Ref(RefType::NULLFUNCREF);
+
     /// Returns true if `ValType` matches any of the numeric types. (e.g. `I32`,
     /// `I64`, `F32`, `F64`).
     pub fn is_num(&self) -> bool {
@@ -68,11 +100,122 @@ impl ValType {
         }
     }
 
-    /// Returns true if `ValType` matches either of the reference types.
+    /// Is this the `i32` type?
+    pub fn is_i32(&self) -> bool {
+        matches!(self, ValType::I32)
+    }
+
+    /// Is this the `i64` type?
+    pub fn is_i64(&self) -> bool {
+        matches!(self, ValType::I64)
+    }
+
+    /// Is this the `f32` type?
+    pub fn is_f32(&self) -> bool {
+        matches!(self, ValType::F32)
+    }
+
+    /// Is this the `f64` type?
+    pub fn is_f64(&self) -> bool {
+        matches!(self, ValType::F64)
+    }
+
+    /// Returns true if `ValType` is any kind of reference type.
     pub fn is_ref(&self) -> bool {
+        matches!(self, ValType::Ref(_))
+    }
+
+    /// Is this the `funcref` (aka `(ref null func)`) type?
+    pub fn is_funcref(&self) -> bool {
+        matches!(
+            self,
+            ValType::Ref(RefType {
+                is_nullable: true,
+                heap_type: HeapType::Func
+            })
+        )
+    }
+
+    /// Is this the `externref` (aka `(ref null extern)`) type?
+    pub fn is_externref(&self) -> bool {
+        matches!(
+            self,
+            ValType::Ref(RefType {
+                is_nullable: true,
+                heap_type: HeapType::Extern
+            })
+        )
+    }
+
+    /// Get the underlying reference type, if this value type is a reference
+    /// type.
+    pub fn as_ref(&self) -> Option<&RefType> {
         match self {
-            ValType::ExternRef | ValType::FuncRef => true,
-            _ => false,
+            ValType::Ref(r) => Some(r),
+            _ => None,
+        }
+    }
+
+    /// Get the underlying reference type, panicking if this value type is not a
+    /// reference type.
+    pub fn unwrap_ref(&self) -> &RefType {
+        self.as_ref()
+            .expect("ValType::unwrap_ref on a non-reference type")
+    }
+
+    /// Does this value type match the other type?
+    ///
+    /// That is, is this value type a subtype of the other?
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine.
+    pub fn matches(&self, engine: &Engine, other: &ValType) -> bool {
+        assert!(self.comes_from_same_engine(engine));
+        assert!(other.comes_from_same_engine(engine));
+        match (self, other) {
+            (Self::I32, Self::I32) => true,
+            (Self::I64, Self::I64) => true,
+            (Self::F32, Self::F32) => true,
+            (Self::F64, Self::F64) => true,
+            (Self::V128, Self::V128) => true,
+            (Self::Ref(a), Self::Ref(b)) => a.matches(engine, b),
+            (Self::I32, _)
+            | (Self::I64, _)
+            | (Self::F32, _)
+            | (Self::F64, _)
+            | (Self::V128, _)
+            | (Self::Ref(_), _) => false,
+        }
+    }
+
+    /// Is value type `a` precisely equal to value type `b`?
+    ///
+    /// Returns `false` even if `a` is a subtype of `b` or vice versa, if they
+    /// are not exactly the same value type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine.
+    pub fn eq(engine: &Engine, a: &Self, b: &Self) -> bool {
+        a.matches(engine, b) && b.matches(engine, a)
+    }
+
+    pub(crate) fn ensure_matches(&self, engine: &Engine, other: &ValType) -> Result<()> {
+        if !self.comes_from_same_engine(engine) || !other.comes_from_same_engine(engine) {
+            bail!("type used with wrong engine");
+        }
+        if self.matches(engine, other) {
+            Ok(())
+        } else {
+            bail!("type mismatch: expected {other}, found {self}")
+        }
+    }
+
+    pub(crate) fn comes_from_same_engine(&self, engine: &Engine) -> bool {
+        match self {
+            Self::I32 | Self::I64 | Self::F32 | Self::F64 | Self::V128 => true,
+            Self::Ref(r) => r.comes_from_same_engine(engine),
         }
     }
 
@@ -83,28 +226,336 @@ impl ValType {
             Self::F32 => WasmValType::F32,
             Self::F64 => WasmValType::F64,
             Self::V128 => WasmValType::V128,
-            Self::FuncRef => WasmValType::Ref(WasmRefType::FUNCREF),
-            Self::ExternRef => WasmValType::Ref(WasmRefType::EXTERNREF),
+            Self::Ref(r) => WasmValType::Ref(r.to_wasm_type()),
         }
     }
 
-    pub(crate) fn from_wasm_type(ty: &WasmValType) -> Self {
+    pub(crate) fn from_wasm_type(engine: &Engine, ty: &WasmValType) -> Self {
         match ty {
             WasmValType::I32 => Self::I32,
             WasmValType::I64 => Self::I64,
             WasmValType::F32 => Self::F32,
             WasmValType::F64 => Self::F64,
             WasmValType::V128 => Self::V128,
-            WasmValType::Ref(WasmRefType::FUNCREF) => Self::FuncRef,
-            WasmValType::Ref(WasmRefType::EXTERNREF) => Self::ExternRef,
-            // FIXME: exposing the full function-references (and beyond)
-            // proposals will require redesigning the embedder API for `ValType`
-            // and types in Wasmtime. That is a large undertaking which is
-            // deferred for later. The intention for now is that
-            // function-references types can't show up in the "public API" of a
-            // core wasm module but it can use everything internally still.
-            WasmValType::Ref(_) => {
-                unimplemented!("typed function references are not exposed in the public API yet")
+            WasmValType::Ref(r) => Self::Ref(RefType::from_wasm_type(engine, r)),
+        }
+    }
+}
+
+/// Opaque references to data in the Wasm heap or to host data.
+///
+/// # Subtyping and Equality
+///
+/// `RefType` does not implement `Eq`, because reference types have a subtyping
+/// relationship, and so 99.99% of the time you actually want to check whether
+/// one type matches (i.e. is a subtype of) another type. You can use the
+/// [`RefType::matches`] and [`Ref::matches_ty`] methods to perform these types
+/// of checks. If, however, you are in that 0.01% scenario where you need to
+/// check precise equality between types, you can use the [`RefType::eq`]
+/// method.
+#[derive(Clone, Hash)]
+pub struct RefType {
+    is_nullable: bool,
+    heap_type: HeapType,
+}
+
+impl fmt::Debug for RefType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(self, f)
+    }
+}
+
+impl fmt::Display for RefType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(ref ")?;
+        if self.is_nullable() {
+            write!(f, "null ")?;
+        }
+        write!(f, "{})", self.heap_type())
+    }
+}
+
+impl RefType {
+    /// The `externref` type, aka `(ref null extern)`.
+    pub const EXTERNREF: Self = RefType {
+        is_nullable: true,
+        heap_type: HeapType::Extern,
+    };
+
+    /// The `funcref` type, aka `(ref null func)`.
+    pub const FUNCREF: Self = RefType {
+        is_nullable: true,
+        heap_type: HeapType::Func,
+    };
+
+    /// The `nullfuncref` type, aka `(ref null nofunc)`.
+    pub const NULLFUNCREF: Self = RefType {
+        is_nullable: true,
+        heap_type: HeapType::NoFunc,
+    };
+
+    /// Construct a new reference type.
+    pub fn new(is_nullable: bool, heap_type: HeapType) -> RefType {
+        RefType {
+            is_nullable,
+            heap_type,
+        }
+    }
+
+    /// Can this type of reference be null?
+    pub fn is_nullable(&self) -> bool {
+        self.is_nullable
+    }
+
+    /// The heap type that this is a reference to.
+    pub fn heap_type(&self) -> &HeapType {
+        &self.heap_type
+    }
+
+    /// Does this reference type match the other?
+    ///
+    /// That is, is this reference type a subtype of the other?
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine.
+    pub fn matches(&self, engine: &Engine, other: &RefType) -> bool {
+        assert!(self.comes_from_same_engine(engine));
+        assert!(other.comes_from_same_engine(engine));
+        if self.is_nullable() && !other.is_nullable() {
+            return false;
+        }
+        self.heap_type().matches(engine, other.heap_type())
+    }
+
+    /// Is reference type `a` precisely equal to reference type `b`?
+    ///
+    /// Returns `false` even if `a` is a subtype of `b` or vice versa, if they
+    /// are not exactly the same reference type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine.
+    pub fn eq(engine: &Engine, a: &RefType, b: &RefType) -> bool {
+        a.matches(engine, b) && b.matches(engine, a)
+    }
+
+    pub(crate) fn ensure_matches(&self, engine: &Engine, other: &RefType) -> Result<()> {
+        if !self.comes_from_same_engine(engine) || !other.comes_from_same_engine(engine) {
+            bail!("type used with wrong engine");
+        }
+        if self.matches(engine, other) {
+            Ok(())
+        } else {
+            bail!("type mismatch: expected {other}, found {self}")
+        }
+    }
+
+    pub(crate) fn comes_from_same_engine(&self, engine: &Engine) -> bool {
+        self.heap_type().comes_from_same_engine(engine)
+    }
+
+    pub(crate) fn to_wasm_type(&self) -> WasmRefType {
+        WasmRefType {
+            nullable: self.is_nullable(),
+            heap_type: self.heap_type().to_wasm_type(),
+        }
+    }
+
+    pub(crate) fn from_wasm_type(engine: &Engine, ty: &WasmRefType) -> RefType {
+        RefType {
+            is_nullable: ty.nullable,
+            heap_type: HeapType::from_wasm_type(engine, &ty.heap_type),
+        }
+    }
+}
+
+/// The heap types that can Wasm can have references to.
+///
+/// # Subtyping and Equality
+///
+/// `HeapType` does not implement `Eq`, because heap types have a subtyping
+/// relationship, and so 99.99% of the time you actually want to check whether
+/// one type matches (i.e. is a subtype of) another type. You can use the
+/// [`HeapType::matches`] and [`Ref::matches_ty`] methods to perform these types
+/// of checks. If, however, you are in that 0.01% scenario where you need to
+/// check precise equality between types, you can use the [`HeapType::eq`]
+/// method.
+#[derive(Debug, Clone, Hash)]
+pub enum HeapType {
+    /// The `extern` heap type represents external host data.
+    Extern,
+
+    /// The `func` heap type represents a reference to any kind of function.
+    ///
+    /// This is the top type for the function references type hierarchy, and is
+    /// therefore a supertype of every function reference.
+    Func,
+
+    /// The concrete heap type represents a reference to a function of a
+    /// specific, concrete type.
+    ///
+    /// This is a subtype of `func` and a supertype of `nofunc`.
+    Concrete(FuncType),
+
+    /// The `nofunc` heap type represents the null function reference.
+    ///
+    /// This is the bottom type for the function references type hierarchy, and
+    /// therefore `nofunc` is a subtype of all function reference types.
+    NoFunc,
+}
+
+impl Display for HeapType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            HeapType::Extern => write!(f, "extern"),
+            HeapType::Func => write!(f, "func"),
+            HeapType::NoFunc => write!(f, "nofunc"),
+            HeapType::Concrete(ty) => write!(f, "(concrete {:?})", ty.type_index()),
+        }
+    }
+}
+
+impl HeapType {
+    /// Is this the abstract `extern` heap type?
+    pub fn is_extern(&self) -> bool {
+        matches!(self, HeapType::Extern)
+    }
+
+    /// Is this the abstract `func` heap type?
+    pub fn is_func(&self) -> bool {
+        matches!(self, HeapType::Func)
+    }
+
+    /// Is this the abstract `nofunc` heap type?
+    pub fn is_no_func(&self) -> bool {
+        matches!(self, HeapType::NoFunc)
+    }
+
+    /// Is this an abstract type?
+    ///
+    /// Types that are not abstract are concrete, user-defined types.
+    pub fn is_abstract(&self) -> bool {
+        !self.is_concrete()
+    }
+
+    /// Is this a concrete, user-defined heap type?
+    ///
+    /// Types that are not concrete, user-defined types are abstract types.
+    pub fn is_concrete(&self) -> bool {
+        matches!(self, HeapType::Concrete(_))
+    }
+
+    /// Get the underlying concrete, user-defined type, if any.
+    ///
+    /// Returns `None` for abstract types.
+    pub fn as_concrete(&self) -> Option<&FuncType> {
+        match self {
+            HeapType::Concrete(f) => Some(f),
+            _ => None,
+        }
+    }
+
+    /// Get the underlying concrete, user-defined type, panicking if this heap
+    /// type is not concrete.
+    pub fn unwrap_concrete(&self) -> &FuncType {
+        self.as_concrete()
+            .expect("HeapType::unwrap_concrete on non-concrete heap type")
+    }
+
+    /// Get the top type of this heap type's type hierarchy.
+    ///
+    /// The returned heap type is a supertype of all types in this heap type's
+    /// type hierarchy.
+    pub fn top(&self, engine: &Engine) -> HeapType {
+        // The engine isn't used yet, but will be once we support Wasm GC, so
+        // future-proof our API.
+        let _ = engine;
+
+        match self {
+            HeapType::Func | HeapType::Concrete(_) | HeapType::NoFunc => HeapType::Func,
+            HeapType::Extern => HeapType::Extern,
+        }
+    }
+
+    /// Does this heap type match the other heap type?
+    ///
+    /// That is, is this heap type a subtype of the other?
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine.
+    pub fn matches(&self, engine: &Engine, other: &HeapType) -> bool {
+        assert!(self.comes_from_same_engine(engine));
+        assert!(other.comes_from_same_engine(engine));
+        match (self, other) {
+            (HeapType::Extern, HeapType::Extern) => true,
+            (HeapType::Extern, _) => false,
+
+            (HeapType::NoFunc, HeapType::NoFunc | HeapType::Concrete(_) | HeapType::Func) => true,
+            (HeapType::NoFunc, _) => false,
+
+            (HeapType::Concrete(_), HeapType::Func) => true,
+            (HeapType::Concrete(a), HeapType::Concrete(b)) => a.matches(engine, b),
+            (HeapType::Concrete(_), _) => false,
+
+            (HeapType::Func, HeapType::Func) => true,
+            (HeapType::Func, _) => false,
+        }
+    }
+
+    /// Is heap type `a` precisely equal to heap type `b`?
+    ///
+    /// Returns `false` even if `a` is a subtype of `b` or vice versa, if they
+    /// are not exactly the same heap type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine.
+    pub fn eq(engine: &Engine, a: &HeapType, b: &HeapType) -> bool {
+        a.matches(engine, b) && b.matches(engine, a)
+    }
+
+    pub(crate) fn ensure_matches(&self, engine: &Engine, other: &HeapType) -> Result<()> {
+        if !self.comes_from_same_engine(engine) || !other.comes_from_same_engine(engine) {
+            bail!("type used with wrong engine");
+        }
+        if self.matches(engine, other) {
+            Ok(())
+        } else {
+            bail!("type mismatch: expected {other}, found {self}");
+        }
+    }
+
+    pub(crate) fn comes_from_same_engine(&self, engine: &Engine) -> bool {
+        match self {
+            HeapType::Extern | HeapType::Func | HeapType::NoFunc => true,
+            HeapType::Concrete(ty) => ty.comes_from_same_engine(engine),
+        }
+    }
+
+    pub(crate) fn to_wasm_type(&self) -> WasmHeapType {
+        match self {
+            HeapType::Extern => WasmHeapType::Extern,
+            HeapType::Func => WasmHeapType::Func,
+            HeapType::NoFunc => WasmHeapType::NoFunc,
+            HeapType::Concrete(f) => {
+                WasmHeapType::Concrete(EngineOrModuleTypeIndex::Engine(f.type_index().bits()))
+            }
+        }
+    }
+
+    pub(crate) fn from_wasm_type(engine: &Engine, ty: &WasmHeapType) -> HeapType {
+        match ty {
+            WasmHeapType::Extern => HeapType::Extern,
+            WasmHeapType::Func => HeapType::Func,
+            WasmHeapType::NoFunc => HeapType::NoFunc,
+            WasmHeapType::Concrete(EngineOrModuleTypeIndex::Engine(idx)) => {
+                let idx = VMSharedTypeIndex::new(*idx);
+                HeapType::Concrete(FuncType::from_shared_type_index(engine, idx))
+            }
+            WasmHeapType::Concrete(EngineOrModuleTypeIndex::Module(_)) => {
+                panic!("HeapType::from_wasm_type on non-canonical heap type")
             }
         }
     }
@@ -129,7 +580,7 @@ pub enum ExternType {
     Memory(MemoryType),
 }
 
-macro_rules! accessors {
+macro_rules! extern_type_accessors {
     ($(($variant:ident($ty:ty) $get:ident $unwrap:ident))*) => ($(
         /// Attempt to return the underlying type of this external type,
         /// returning `None` if it is a different type.
@@ -154,7 +605,7 @@ macro_rules! accessors {
 }
 
 impl ExternType {
-    accessors! {
+    extern_type_accessors! {
         (Func(FuncType) func unwrap_func)
         (Global(GlobalType) global unwrap_global)
         (Table(TableType) table unwrap_table)
@@ -167,10 +618,12 @@ impl ExternType {
         ty: &EntityType,
     ) -> ExternType {
         match ty {
-            EntityType::Function(idx) => FuncType::from_wasm_func_type(engine, &types[*idx]).into(),
-            EntityType::Global(ty) => GlobalType::from_wasmtime_global(ty).into(),
+            EntityType::Function(idx) => {
+                FuncType::from_wasm_func_type(engine, types[*idx].clone()).into()
+            }
+            EntityType::Global(ty) => GlobalType::from_wasmtime_global(engine, ty).into(),
             EntityType::Memory(ty) => MemoryType::from_wasmtime_memory(ty).into(),
-            EntityType::Table(ty) => TableType::from_wasmtime_table(ty).into(),
+            EntityType::Table(ty) => TableType::from_wasmtime_table(engine, ty).into(),
             EntityType::Tag(_) => unimplemented!("wasm tag support"),
         }
     }
@@ -200,12 +653,43 @@ impl From<TableType> for ExternType {
     }
 }
 
-/// A descriptor for a function in a WebAssembly module.
+/// The type of a WebAssembly function.
 ///
 /// WebAssembly functions can have 0 or more parameters and results.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+///
+/// # Subtyping and Equality
+///
+/// `FuncType` does not implement `Eq`, because reference types have a subtyping
+/// relationship, and so 99.99% of the time you actually want to check whether
+/// one type matches (i.e. is a subtype of) another type. You can use the
+/// [`FuncType::matches`] and [`Val::matches_ty`] methods to perform these types
+/// of checks. If, however, you are in that 0.01% scenario where you need to
+/// check precise equality between types, you can use the [`FuncType::eq`]
+/// method.
+#[derive(Debug, Clone, Hash)]
 pub struct FuncType {
-    ty: RegisteredType,
+    registered_type: RegisteredType,
+}
+
+impl Display for FuncType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(type (func")?;
+        if self.params().len() > 0 {
+            write!(f, " (param")?;
+            for p in self.params() {
+                write!(f, " {p}")?;
+            }
+            write!(f, ")")?;
+        }
+        if self.results().len() > 0 {
+            write!(f, " (result")?;
+            for r in self.results() {
+                write!(f, " {r}")?;
+            }
+            write!(f, ")")?;
+        }
+        write!(f, "))")
+    }
 }
 
 impl FuncType {
@@ -218,42 +702,124 @@ impl FuncType {
         params: impl IntoIterator<Item = ValType>,
         results: impl IntoIterator<Item = ValType>,
     ) -> FuncType {
+        // Keep any of our parameters' and results' `RegisteredType`s alive
+        // across `Self::from_wasm_func_type`. If one of our given `ValType`s is
+        // the only thing keeping a type in the registry, we don't want to
+        // unregister it when we convert the `ValType` into a `WasmValType` just
+        // before we register our new `WasmFuncType` that will reference it.
+        let mut registrations = vec![];
+
+        let mut to_wasm_type = |ty: ValType| {
+            if let Some(r) = ty.as_ref() {
+                if let Some(c) = r.heap_type().as_concrete() {
+                    registrations.push(c.registered_type.clone());
+                }
+            }
+            ty.to_wasm_type()
+        };
+
         Self::from_wasm_func_type(
             engine,
-            &WasmFuncType::new(
-                params.into_iter().map(|t| t.to_wasm_type()).collect(),
-                results.into_iter().map(|t| t.to_wasm_type()).collect(),
+            WasmFuncType::new(
+                params.into_iter().map(&mut to_wasm_type).collect(),
+                results.into_iter().map(&mut to_wasm_type).collect(),
             ),
         )
+    }
+
+    /// Get the engine that this function type is associated with.
+    pub fn engine(&self) -> &Engine {
+        self.registered_type.engine()
     }
 
     /// Returns the list of parameter types for this function.
     #[inline]
     pub fn params(&self) -> impl ExactSizeIterator<Item = ValType> + '_ {
-        self.ty.params().iter().map(ValType::from_wasm_type)
+        let engine = self.engine();
+        self.registered_type
+            .params()
+            .iter()
+            .map(|ty| ValType::from_wasm_type(engine, ty))
     }
 
     /// Returns the list of result types for this function.
     #[inline]
     pub fn results(&self) -> impl ExactSizeIterator<Item = ValType> + '_ {
-        self.ty.returns().iter().map(ValType::from_wasm_type)
+        let engine = self.engine();
+        self.registered_type
+            .returns()
+            .iter()
+            .map(|ty| ValType::from_wasm_type(engine, ty))
+    }
+
+    /// Does this function type match the other function type?
+    ///
+    /// That is, is this function type a subtype of the other function type?
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine.
+    pub fn matches(&self, engine: &Engine, other: &FuncType) -> bool {
+        assert!(self.comes_from_same_engine(engine));
+        assert!(other.comes_from_same_engine(engine));
+        self.params().len() == other.params().len()
+            && self.results().len() == other.results().len()
+            // Params are contravariant and results are covariant. For more
+            // details and a refresher on variance, read
+            // https://github.com/bytecodealliance/wasm-tools/blob/f1d89a4/crates/wasmparser/src/readers/core/types/matches.rs#L137-L174
+            && self
+                .params()
+                .zip(other.params())
+                .all(|(a, b)| b.matches(engine, &a))
+            && self
+                .results()
+                .zip(other.results())
+                .all(|(a, b)| a.matches(engine, &b))
+    }
+
+    /// Is function type `a` precisely equal to function type `b`?
+    ///
+    /// Returns `false` even if `a` is a subtype of `b` or vice versa, if they
+    /// are not exactly the same function type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if either type is associated with a different engine.
+    pub fn eq(engine: &Engine, a: &FuncType, b: &FuncType) -> bool {
+        a.matches(engine, b) && b.matches(engine, a)
+    }
+
+    pub(crate) fn comes_from_same_engine(&self, engine: &Engine) -> bool {
+        Engine::same(self.registered_type.engine(), engine)
     }
 
     pub(crate) fn type_index(&self) -> VMSharedTypeIndex {
-        self.ty.index()
+        self.registered_type.index()
     }
 
     pub(crate) fn as_wasm_func_type(&self) -> &WasmFuncType {
-        &self.ty
+        &self.registered_type
     }
 
     pub(crate) fn into_registered_type(self) -> RegisteredType {
-        self.ty
+        self.registered_type
     }
 
-    pub(crate) fn from_wasm_func_type(engine: &Engine, ty: &WasmFuncType) -> FuncType {
+    /// Construct a `FuncType` from a `WasmFuncType`.
+    ///
+    /// This method should only be used when something has already registered --
+    /// and is *keeping registered* -- any other concrete Wasm types referenced
+    /// by the given `WasmFuncType`.
+    ///
+    /// For example, this method may be called to convert a function type from
+    /// within a Wasm module's `ModuleTypes` since the Wasm module itself is
+    /// holding a strong reference to all of its types, including any `(ref null
+    /// <index>)` types used in the function's parameters and results.
+    pub(crate) fn from_wasm_func_type(engine: &Engine, ty: WasmFuncType) -> FuncType {
         let ty = RegisteredType::new(engine, ty);
-        Self { ty }
+        Self {
+            registered_type: ty,
+        }
     }
 
     pub(crate) fn from_shared_type_index(engine: &Engine, index: VMSharedTypeIndex) -> FuncType {
@@ -261,7 +827,9 @@ impl FuncType {
             "VMSharedTypeIndex is not registered in the Engine! Wrong \
              engine? Didn't root the index somewhere?",
         );
-        Self { ty }
+        Self {
+            registered_type: ty,
+        }
     }
 }
 
@@ -272,7 +840,7 @@ impl FuncType {
 /// This type describes an instance of a global in a WebAssembly module. Globals
 /// are local to an [`Instance`](crate::Instance) and are either immutable or
 /// mutable.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash)]
 pub struct GlobalType {
     content: ValType,
     mutability: Mutability,
@@ -309,8 +877,8 @@ impl GlobalType {
 
     /// Returns `None` if the wasmtime global has a type that we can't
     /// represent, but that should only very rarely happen and indicate a bug.
-    pub(crate) fn from_wasmtime_global(global: &Global) -> GlobalType {
-        let ty = ValType::from_wasm_type(&global.wasm_ty);
+    pub(crate) fn from_wasmtime_global(engine: &Engine, global: &Global) -> GlobalType {
+        let ty = ValType::from_wasm_type(engine, &global.wasm_ty);
         let mutability = if global.mutability {
             Mutability::Var
         } else {
@@ -327,28 +895,23 @@ impl GlobalType {
 /// Tables are contiguous chunks of a specific element, typically a `funcref` or
 /// an `externref`. The most common use for tables is a function table through
 /// which `call_indirect` can invoke other functions.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
+#[derive(Debug, Clone, Hash)]
 pub struct TableType {
+    // Keep a `wasmtime::RefType` so that `TableType::element` doesn't need to
+    // take an `&Engine`.
+    element: RefType,
     ty: Table,
 }
 
 impl TableType {
     /// Creates a new table descriptor which will contain the specified
     /// `element` and have the `limits` applied to its length.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the `element` type provided is not a reference type.
-    pub fn new(element: ValType, min: u32, max: Option<u32>) -> TableType {
+    pub fn new(element: RefType, min: u32, max: Option<u32>) -> TableType {
+        let wasm_ty = element.to_wasm_type();
         TableType {
+            element,
             ty: Table {
-                // FIXME: the `ValType` API should be redesigned and the
-                // argument to this constructor should be `RefType`.
-                wasm_ty: match element {
-                    ValType::FuncRef => WasmRefType::FUNCREF,
-                    ValType::ExternRef => WasmRefType::EXTERNREF,
-                    _ => panic!("Attempt to convert non-reference type to a reference type"),
-                },
+                wasm_ty,
                 minimum: min,
                 maximum: max,
             },
@@ -356,8 +919,8 @@ impl TableType {
     }
 
     /// Returns the element value type of this table.
-    pub fn element(&self) -> ValType {
-        ValType::from_wasm_type(&WasmValType::Ref(self.ty.wasm_ty))
+    pub fn element(&self) -> &RefType {
+        &self.element
     }
 
     /// Returns minimum number of elements this table must have
@@ -373,8 +936,12 @@ impl TableType {
         self.ty.maximum
     }
 
-    pub(crate) fn from_wasmtime_table(table: &Table) -> TableType {
-        TableType { ty: table.clone() }
+    pub(crate) fn from_wasmtime_table(engine: &Engine, table: &Table) -> TableType {
+        let element = RefType::from_wasm_type(engine, &table.wasm_ty);
+        TableType {
+            element,
+            ty: table.clone(),
+        }
     }
 
     pub(crate) fn wasmtime_table(&self) -> &Table {

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -765,6 +765,13 @@ impl FuncType {
     /// other.
     pub fn matches(&self, other: &FuncType) -> bool {
         assert!(self.comes_from_same_engine(other.engine()));
+
+        // Avoid matching on structure for subtyping checks when we have
+        // precisely the same type.
+        if self.type_index() == other.type_index() {
+            return true;
+        }
+
         self.params().len() == other.params().len()
             && self.results().len() == other.results().len()
             // Params are contravariant and results are covariant. For more
@@ -787,9 +794,11 @@ impl FuncType {
     ///
     /// # Panics
     ///
-    /// Panics if either type is associated with a different engine.
+    /// Panics if either type is associated with a different engine from the
+    /// other.
     pub fn eq(a: &FuncType, b: &FuncType) -> bool {
-        a.matches(b) && b.matches(a)
+        assert!(a.comes_from_same_engine(b.engine()));
+        a.type_index() == b.type_index()
     }
 
     pub(crate) fn comes_from_same_engine(&self, engine: &Engine) -> bool {

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -120,6 +120,11 @@ impl ValType {
         matches!(self, ValType::F64)
     }
 
+    /// Is this the `v128` type?
+    pub fn is_v128(&self) -> bool {
+        matches!(self, ValType::V128)
+    }
+
     /// Returns true if `ValType` is any kind of reference type.
     pub fn is_ref(&self) -> bool {
         matches!(self, ValType::Ref(_))

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -93,6 +93,7 @@ impl ValType {
 
     /// Returns true if `ValType` matches any of the numeric types. (e.g. `I32`,
     /// `I64`, `F32`, `F64`).
+    #[inline]
     pub fn is_num(&self) -> bool {
         match self {
             ValType::I32 | ValType::I64 | ValType::F32 | ValType::F64 => true,
@@ -101,36 +102,43 @@ impl ValType {
     }
 
     /// Is this the `i32` type?
+    #[inline]
     pub fn is_i32(&self) -> bool {
         matches!(self, ValType::I32)
     }
 
     /// Is this the `i64` type?
+    #[inline]
     pub fn is_i64(&self) -> bool {
         matches!(self, ValType::I64)
     }
 
     /// Is this the `f32` type?
+    #[inline]
     pub fn is_f32(&self) -> bool {
         matches!(self, ValType::F32)
     }
 
     /// Is this the `f64` type?
+    #[inline]
     pub fn is_f64(&self) -> bool {
         matches!(self, ValType::F64)
     }
 
     /// Is this the `v128` type?
+    #[inline]
     pub fn is_v128(&self) -> bool {
         matches!(self, ValType::V128)
     }
 
     /// Returns true if `ValType` is any kind of reference type.
+    #[inline]
     pub fn is_ref(&self) -> bool {
         matches!(self, ValType::Ref(_))
     }
 
     /// Is this the `funcref` (aka `(ref null func)`) type?
+    #[inline]
     pub fn is_funcref(&self) -> bool {
         matches!(
             self,
@@ -142,6 +150,7 @@ impl ValType {
     }
 
     /// Is this the `externref` (aka `(ref null extern)`) type?
+    #[inline]
     pub fn is_externref(&self) -> bool {
         matches!(
             self,
@@ -154,6 +163,7 @@ impl ValType {
 
     /// Get the underlying reference type, if this value type is a reference
     /// type.
+    #[inline]
     pub fn as_ref(&self) -> Option<&RefType> {
         match self {
             ValType::Ref(r) => Some(r),
@@ -163,6 +173,7 @@ impl ValType {
 
     /// Get the underlying reference type, panicking if this value type is not a
     /// reference type.
+    #[inline]
     pub fn unwrap_ref(&self) -> &RefType {
         self.as_ref()
             .expect("ValType::unwrap_ref on a non-reference type")
@@ -234,6 +245,7 @@ impl ValType {
         }
     }
 
+    #[inline]
     pub(crate) fn from_wasm_type(engine: &Engine, ty: &WasmValType) -> Self {
         match ty {
             WasmValType::I32 => Self::I32,
@@ -742,6 +754,17 @@ impl FuncType {
         self.registered_type.engine()
     }
 
+    /// Get the `i`th parameter type.
+    ///
+    /// Returns `None` if `i` is out of bounds.
+    pub fn param(&self, i: usize) -> Option<ValType> {
+        let engine = self.engine();
+        self.registered_type
+            .params()
+            .get(i)
+            .map(|ty| ValType::from_wasm_type(engine, ty))
+    }
+
     /// Returns the list of parameter types for this function.
     #[inline]
     pub fn params(&self) -> impl ExactSizeIterator<Item = ValType> + '_ {
@@ -749,6 +772,17 @@ impl FuncType {
         self.registered_type
             .params()
             .iter()
+            .map(|ty| ValType::from_wasm_type(engine, ty))
+    }
+
+    /// Get the `i`th result type.
+    ///
+    /// Returns `None` if `i` is out of bounds.
+    pub fn result(&self, i: usize) -> Option<ValType> {
+        let engine = self.engine();
+        self.registered_type
+            .returns()
+            .get(i)
             .map(|ty| ValType::from_wasm_type(engine, ty))
     }
 

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -419,6 +419,13 @@ impl Display for HeapType {
     }
 }
 
+impl From<FuncType> for HeapType {
+    #[inline]
+    fn from(f: FuncType) -> Self {
+        HeapType::Concrete(f)
+    }
+}
+
 impl HeapType {
     /// Is this the abstract `extern` heap type?
     pub fn is_extern(&self) -> bool {

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -32,10 +32,10 @@ pub enum Mutability {
 /// `ValType` does not implement `Eq`, because reference types have a subtyping
 /// relationship, and so 99.99% of the time you actually want to check whether
 /// one type matches (i.e. is a subtype of) another type. You can use the
-/// [`ValType::matches`] and [`Val::matches_ty`] methods to perform these types
-/// of checks. If, however, you are in that 0.01% scenario where you need to
-/// check precise equality between types, you can use the [`ValType::eq`]
-/// method.
+/// [`ValType::matches`] and [`Val::matches_ty`][crate::Val::matches_ty] methods
+/// to perform these types of checks. If, however, you are in that 0.01%
+/// scenario where you need to check precise equality between types, you can use
+/// the [`ValType::eq`] method.
 #[derive(Clone, Hash)]
 pub enum ValType {
     // NB: the ordering of variants here is intended to match the ordering in
@@ -265,10 +265,10 @@ impl ValType {
 /// `RefType` does not implement `Eq`, because reference types have a subtyping
 /// relationship, and so 99.99% of the time you actually want to check whether
 /// one type matches (i.e. is a subtype of) another type. You can use the
-/// [`RefType::matches`] and [`Ref::matches_ty`] methods to perform these types
-/// of checks. If, however, you are in that 0.01% scenario where you need to
-/// check precise equality between types, you can use the [`RefType::eq`]
-/// method.
+/// [`RefType::matches`] and [`Ref::matches_ty`][crate::Ref::matches_ty] methods
+/// to perform these types of checks. If, however, you are in that 0.01%
+/// scenario where you need to check precise equality between types, you can use
+/// the [`RefType::eq`] method.
 #[derive(Clone, Hash)]
 pub struct RefType {
     is_nullable: bool,
@@ -392,10 +392,9 @@ impl RefType {
 /// `HeapType` does not implement `Eq`, because heap types have a subtyping
 /// relationship, and so 99.99% of the time you actually want to check whether
 /// one type matches (i.e. is a subtype of) another type. You can use the
-/// [`HeapType::matches`] and [`Ref::matches_ty`] methods to perform these types
-/// of checks. If, however, you are in that 0.01% scenario where you need to
-/// check precise equality between types, you can use the [`HeapType::eq`]
-/// method.
+/// [`HeapType::matches`] method to perform these types of checks. If, however,
+/// you are in that 0.01% scenario where you need to check precise equality
+/// between types, you can use the [`HeapType::eq`] method.
 #[derive(Debug, Clone, Hash)]
 pub enum HeapType {
     /// The `extern` heap type represents external host data.
@@ -684,10 +683,10 @@ impl From<TableType> for ExternType {
 /// `FuncType` does not implement `Eq`, because reference types have a subtyping
 /// relationship, and so 99.99% of the time you actually want to check whether
 /// one type matches (i.e. is a subtype of) another type. You can use the
-/// [`FuncType::matches`] and [`Val::matches_ty`] methods to perform these types
-/// of checks. If, however, you are in that 0.01% scenario where you need to
-/// check precise equality between types, you can use the [`FuncType::eq`]
-/// method.
+/// [`FuncType::matches`] and [`Func::matches_ty`][crate::Func::matches_ty]
+/// methods to perform these types of checks. If, however, you are in that 0.01%
+/// scenario where you need to check precise equality between types, you can use
+/// the [`FuncType::eq`] method.
 #[derive(Debug, Clone, Hash)]
 pub struct FuncType {
     registered_type: RegisteredType,

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -34,9 +34,13 @@ impl MatchCx<'_> {
             // that `actual` can match it.
             None => false,
             Some(expected) => {
-                let expected = FuncType::from_shared_type_index(self.engine, expected);
-                let actual = FuncType::from_shared_type_index(self.engine, actual);
-                actual.matches(&expected)
+                // Avoid matching on structure for subtyping checks when we have
+                // precisely the same type.
+                expected == actual || {
+                    let expected = FuncType::from_shared_type_index(self.engine, expected);
+                    let actual = FuncType::from_shared_type_index(self.engine, actual);
+                    actual.matches(&expected)
+                }
             }
         };
         if matches {

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -1,5 +1,6 @@
 use crate::linker::DefinitionType;
 use crate::{type_registry::TypeCollection, Engine};
+use crate::{FuncType, Module};
 use anyhow::{anyhow, bail, Result};
 use wasmtime_environ::{
     EntityType, Global, Memory, ModuleInternedTypeIndex, ModuleTypes, Table, WasmFuncType,
@@ -8,22 +9,35 @@ use wasmtime_environ::{
 use wasmtime_runtime::VMSharedTypeIndex;
 
 pub struct MatchCx<'a> {
-    pub signatures: &'a TypeCollection,
-    pub types: &'a ModuleTypes,
-    pub engine: &'a Engine,
+    signatures: &'a TypeCollection,
+    types: &'a ModuleTypes,
+    engine: &'a Engine,
 }
 
 impl MatchCx<'_> {
-    pub fn vmshared_signature_index(
+    /// Construct a new matching context for the given module.
+    pub fn new(module: &Module) -> MatchCx<'_> {
+        MatchCx {
+            signatures: module.signatures(),
+            types: module.types(),
+            engine: module.engine(),
+        }
+    }
+
+    fn type_reference(
         &self,
         expected: ModuleInternedTypeIndex,
         actual: VMSharedTypeIndex,
     ) -> Result<()> {
         let matches = match self.signatures.shared_type(expected) {
-            Some(idx) => actual == idx,
             // If our expected signature isn't registered, then there's no way
             // that `actual` can match it.
             None => false,
+            Some(expected) => {
+                let expected = FuncType::from_shared_type_index(self.engine, expected);
+                let actual = FuncType::from_shared_type_index(self.engine, actual);
+                actual.matches(self.engine, &expected)
+            }
         };
         if matches {
             return Ok(());
@@ -32,10 +46,7 @@ impl MatchCx<'_> {
         let expected = &self.types[expected];
         let actual = match self.engine.signatures().borrow(actual) {
             Some(ty) => ty,
-            None => {
-                debug_assert!(false, "all signatures should be registered");
-                bail!("{}", msg);
-            }
+            None => panic!("{actual:?} is not registered"),
         };
 
         Err(func_ty_mismatch(msg, expected, &actual))
@@ -61,7 +72,7 @@ impl MatchCx<'_> {
                 _ => bail!("expected memory, but found {}", actual.desc()),
             },
             EntityType::Function(expected) => match actual {
-                DefinitionType::Func(actual) => self.vmshared_signature_index(*expected, *actual),
+                DefinitionType::Func(actual) => self.type_reference(*expected, *actual),
                 _ => bail!("expected func, but found {}", actual.desc()),
             },
             EntityType::Tag(_) => unimplemented!(),
@@ -193,17 +204,24 @@ fn memory_ty(expected: &Memory, actual: &Memory, actual_runtime_size: Option<u64
 }
 
 fn match_heap(expected: WasmHeapType, actual: WasmHeapType, desc: &str) -> Result<()> {
+    use WasmHeapType as H;
     let result = match (actual, expected) {
-        (WasmHeapType::Concrete(actual), WasmHeapType::Concrete(expected)) => {
+        (H::Concrete(actual), H::Concrete(expected)) => {
             // TODO(dhil): we need either canonicalised types or a context here.
             actual == expected
         }
-        (WasmHeapType::Concrete(_), WasmHeapType::Func)
-        | (WasmHeapType::Func, WasmHeapType::Func)
-        | (WasmHeapType::Extern, WasmHeapType::Extern) => true,
-        (WasmHeapType::Func, _) | (WasmHeapType::Extern, _) | (WasmHeapType::Concrete(_), _) => {
-            false
-        }
+
+        (H::NoFunc, H::NoFunc) => true,
+        (_, H::NoFunc) => false,
+
+        (H::NoFunc, H::Concrete(_)) => true,
+        (_, H::Concrete(_)) => false,
+
+        (H::NoFunc | H::Concrete(_) | H::Func, H::Func) => true,
+        (_, H::Func) => false,
+
+        (H::Extern, H::Extern) => true,
+        (_, H::Extern) => false,
     };
     if result {
         Ok(())

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -36,7 +36,7 @@ impl MatchCx<'_> {
             Some(expected) => {
                 let expected = FuncType::from_shared_type_index(self.engine, expected);
                 let actual = FuncType::from_shared_type_index(self.engine, actual);
-                actual.matches(self.engine, &expected)
+                actual.matches(&expected)
             }
         };
         if matches {

--- a/crates/wasmtime/src/runtime/v128.rs
+++ b/crates/wasmtime/src/runtime/v128.rs
@@ -95,6 +95,15 @@ unsafe impl WasmTy for V128 {
         true
     }
 
+    fn dynamic_concrete_type_check(
+        &self,
+        _: &StoreOpaque,
+        _: bool,
+        _: &crate::FuncType,
+    ) -> anyhow::Result<()> {
+        unreachable!()
+    }
+
     #[inline]
     fn is_externref(&self) -> bool {
         false

--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -709,7 +709,20 @@ mod tests {
     fn size_of_val() {
         // Try to keep tabs on the size of `Val` and make sure we don't grow its
         // size.
-        assert_eq!(std::mem::size_of::<Val>(), 32);
+        assert_eq!(
+            std::mem::size_of::<Val>(),
+            if cfg!(any(
+                target_arch = "x86_64",
+                target_arch = "aarch64",
+                target_arch = "riscv64"
+            )) {
+                32
+            } else if cfg!(target_arch = "s390x") {
+                24
+            } else {
+                panic!("unsupported architecture")
+            }
+        );
     }
 
     #[test]

--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -9,10 +9,14 @@ pub use wasmtime_runtime::ValRaw;
 
 /// Possible runtime values that a WebAssembly module can either consume or
 /// produce.
+///
+/// Note that we inline the `enum Ref { ... }` variants into `enum Val { ... }`
+/// here as a size optimization.
 #[derive(Debug, Clone)]
 pub enum Val {
     // NB: the ordering here is intended to match the ordering in
     // `ValType` to improve codegen when learning the type of a value.
+    //
     /// A 32-bit integer.
     I32(i32),
 
@@ -34,10 +38,6 @@ pub enum Val {
     /// A 128-bit number.
     V128(V128),
 
-    // NB: We inline the `enum Ref { ... }` variants into `enum Val { ... }`
-    // here for performance and as a size optimization. This removes 8 bytes of
-    // additional enum discriminant from `Val`.
-    //
     /// A function reference.
     FuncRef(Option<Func>),
 

--- a/crates/wasmtime/src/runtime/values.rs
+++ b/crates/wasmtime/src/runtime/values.rs
@@ -520,6 +520,12 @@ impl Ref {
         }
     }
 
+    /// Is this a non-null reference?
+    #[inline]
+    pub fn is_non_null(&self) -> bool {
+        !self.is_null()
+    }
+
     /// Is this an `extern` reference?
     #[inline]
     pub fn is_extern(&self) -> bool {
@@ -670,7 +676,7 @@ impl Ref {
         ty: &RefType,
     ) -> Result<TableElement> {
         self.ensure_matches_ty(store, &ty)
-            .context("value does not match table element type")?;
+            .context("type mismatch: value does not match table element type")?;
         match (self, ty.heap_type()) {
             (Ref::Func(None), HeapType::NoFunc | HeapType::Func | HeapType::Concrete(_)) => {
                 assert!(ty.is_nullable());

--- a/crates/wast/src/spectest.rs
+++ b/crates/wast/src/spectest.rs
@@ -38,8 +38,8 @@ pub fn link_spectest<T>(
     let g = Global::new(&mut *store, ty, Val::F64(0x4084_d000_0000_0000))?;
     linker.define(&mut *store, "spectest", "global_f64", g)?;
 
-    let ty = TableType::new(ValType::FuncRef, 10, Some(20));
-    let table = Table::new(&mut *store, ty, Val::FuncRef(None))?;
+    let ty = TableType::new(RefType::FUNCREF, 10, Some(20));
+    let table = Table::new(&mut *store, ty, Ref::Func(None))?;
     linker.define(&mut *store, "spectest", "table", table)?;
 
     let ty = MemoryType::new(1, Some(2));

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -178,7 +178,7 @@ where
                     })
                     .collect::<Result<Vec<_>>>()?;
 
-                let mut results = vec![Val::null(); func.ty(&self.store).results().len()];
+                let mut results = vec![Val::null_func_ref(); func.ty(&self.store).results().len()];
                 Ok(match func.call(&mut self.store, &values, &mut results) {
                     Ok(()) => Outcome::Ok(Results::Core(results.into())),
                     Err(e) => Outcome::Trap(e),

--- a/examples/externref.rs
+++ b/examples/externref.rs
@@ -32,14 +32,15 @@ fn main() -> Result<()> {
     let elem = table
         .get(&mut store, 3)
         .unwrap() // assert in bounds
-        .unwrap_externref() // assert it's an externref table
+        .unwrap_extern() // assert it's an externref table
+        .cloned()
         .unwrap(); // assert the externref isn't null
     assert!(elem.ptr_eq(&externref));
 
     println!("Touching `externref` global...");
     let global = instance.get_global(&mut store, "global").unwrap();
     global.set(&mut store, Some(externref.clone()).into())?;
-    let global_val = global.get(&mut store).unwrap_externref().unwrap();
+    let global_val = global.get(&mut store).unwrap_externref().cloned().unwrap();
     assert!(global_val.ptr_eq(&externref));
 
     println!("Calling `externref` func...");

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -533,7 +533,7 @@ impl RunCommand {
 
         // Invoke the function and then afterwards print all the results that came
         // out, if there are any.
-        let mut results = vec![Val::null(); ty.results().len()];
+        let mut results = vec![Val::null_func_ref(); ty.results().len()];
         let invoke_res = func
             .call(&mut *store, &values, &mut results)
             .with_context(|| {
@@ -561,9 +561,11 @@ impl RunCommand {
                 Val::I64(i) => println!("{}", i),
                 Val::F32(f) => println!("{}", f32::from_bits(f)),
                 Val::F64(f) => println!("{}", f64::from_bits(f)),
-                Val::ExternRef(_) => println!("<externref>"),
-                Val::FuncRef(_) => println!("<funcref>"),
                 Val::V128(i) => println!("{}", i.as_u128()),
+                Val::ExternRef(None) => println!("<null externref>"),
+                Val::ExternRef(Some(_)) => println!("<externref>"),
+                Val::FuncRef(None) => println!("<null funcref>"),
+                Val::FuncRef(Some(_)) => println!("<funcref>"),
             }
         }
 

--- a/tests/all/externals.rs
+++ b/tests/all/externals.rs
@@ -203,8 +203,7 @@ fn get_set_funcref_globals_via_api() -> anyhow::Result<()> {
 
     global.set(&mut store, Val::FuncRef(Some(f.clone())))?;
     let f2 = global.get(&mut store).unwrap_funcref().cloned().unwrap();
-    assert!(f.ty(&store).matches(store.engine(), &f2.ty(&store)));
-    assert!(f2.ty(&store).matches(store.engine(), &f.ty(&store)));
+    assert!(FuncType::eq(&f.ty(&store), &f2.ty(&store)));
 
     // Initialize with a non-null funcref.
 
@@ -214,8 +213,7 @@ fn get_set_funcref_globals_via_api() -> anyhow::Result<()> {
         Val::FuncRef(Some(f.clone())),
     )?;
     let f2 = global.get(&mut store).unwrap_funcref().cloned().unwrap();
-    assert!(f.ty(&store).matches(store.engine(), &f2.ty(&store)));
-    assert!(f2.ty(&store).matches(store.engine(), &f.ty(&store)));
+    assert!(FuncType::eq(&f.ty(&store), &f2.ty(&store)));
 
     Ok(())
 }

--- a/tests/all/externals.rs
+++ b/tests/all/externals.rs
@@ -18,49 +18,37 @@ fn bad_globals() {
 }
 
 #[test]
-#[should_panic]
-fn bad_tables_i32() {
-    // NOTE(dhil): The below test does not make sense after the
-    // implementation of the function-references proposal, since the
-    // type component of a TableType is now a reference type (I32 is
-    // not a reference type constructor).
-
-    // i32 not supported yet
-    TableType::new(ValType::I32, 0, Some(1));
-}
-
-#[test]
 fn bad_tables() {
     let mut store = Store::<()>::default();
 
     // mismatched initializer
-    let ty = TableType::new(ValType::FuncRef, 0, Some(1));
-    assert!(Table::new(&mut store, ty.clone(), Val::I32(0)).is_err());
+    let ty = TableType::new(RefType::FUNCREF, 0, Some(1));
+    assert!(Table::new(&mut store, ty.clone(), Ref::Extern(None)).is_err());
 
     // get out of bounds
-    let ty = TableType::new(ValType::FuncRef, 0, Some(1));
-    let t = Table::new(&mut store, ty.clone(), Val::FuncRef(None)).unwrap();
+    let ty = TableType::new(RefType::FUNCREF, 0, Some(1));
+    let t = Table::new(&mut store, ty.clone(), Ref::Func(None)).unwrap();
     assert!(t.get(&mut store, 0).is_none());
     assert!(t.get(&mut store, u32::max_value()).is_none());
 
     // set out of bounds or wrong type
-    let ty = TableType::new(ValType::FuncRef, 1, Some(1));
-    let t = Table::new(&mut store, ty.clone(), Val::FuncRef(None)).unwrap();
-    assert!(t.set(&mut store, 0, Val::I32(0)).is_err());
-    assert!(t.set(&mut store, 0, Val::FuncRef(None)).is_ok());
-    assert!(t.set(&mut store, 1, Val::FuncRef(None)).is_err());
+    let ty = TableType::new(RefType::FUNCREF, 1, Some(1));
+    let t = Table::new(&mut store, ty.clone(), Ref::Func(None)).unwrap();
+    assert!(t.set(&mut store, 0, Ref::Extern(None)).is_err());
+    assert!(t.set(&mut store, 0, Ref::Func(None)).is_ok());
+    assert!(t.set(&mut store, 1, Ref::Func(None)).is_err());
 
     // grow beyond max
-    let ty = TableType::new(ValType::FuncRef, 1, Some(1));
-    let t = Table::new(&mut store, ty.clone(), Val::FuncRef(None)).unwrap();
-    assert!(t.grow(&mut store, 0, Val::FuncRef(None)).is_ok());
-    assert!(t.grow(&mut store, 1, Val::FuncRef(None)).is_err());
+    let ty = TableType::new(RefType::FUNCREF, 1, Some(1));
+    let t = Table::new(&mut store, ty.clone(), Ref::Func(None)).unwrap();
+    assert!(t.grow(&mut store, 0, Ref::Func(None)).is_ok());
+    assert!(t.grow(&mut store, 1, Ref::Func(None)).is_err());
     assert_eq!(t.size(&store), 1);
 
     // grow wrong type
-    let ty = TableType::new(ValType::FuncRef, 1, Some(2));
-    let t = Table::new(&mut store, ty.clone(), Val::FuncRef(None)).unwrap();
-    assert!(t.grow(&mut store, 1, Val::I32(0)).is_err());
+    let ty = TableType::new(RefType::FUNCREF, 1, Some(2));
+    let t = Table::new(&mut store, ty.clone(), Ref::Func(None)).unwrap();
+    assert!(t.grow(&mut store, 1, Ref::Extern(None)).is_err());
     assert_eq!(t.size(&store), 1);
 }
 
@@ -73,15 +61,15 @@ fn cross_store() -> anyhow::Result<()> {
     let mut store1 = Store::new(&engine, ());
     let mut store2 = Store::new(&engine, ());
 
-    // ============ Cross-store instantiation ==============
+    eprintln!("============ Cross-store instantiation ==============");
 
     let func = Func::wrap(&mut store2, || {});
     let ty = GlobalType::new(ValType::I32, Mutability::Const);
     let global = Global::new(&mut store2, ty, Val::I32(0))?;
     let ty = MemoryType::new(1, None);
     let memory = Memory::new(&mut store2, ty)?;
-    let ty = TableType::new(ValType::FuncRef, 1, None);
-    let table = Table::new(&mut store2, ty, Val::FuncRef(None))?;
+    let ty = TableType::new(RefType::FUNCREF, 1, None);
+    let table = Table::new(&mut store2, ty, Ref::Func(None))?;
 
     let need_func = Module::new(&engine, r#"(module (import "" "" (func)))"#)?;
     assert!(Instance::new(&mut store1, &need_func, &[func.into()]).is_err());
@@ -95,27 +83,29 @@ fn cross_store() -> anyhow::Result<()> {
     let need_memory = Module::new(&engine, r#"(module (import "" "" (memory 1)))"#)?;
     assert!(Instance::new(&mut store1, &need_memory, &[memory.into()]).is_err());
 
-    // ============ Cross-store globals ==============
+    eprintln!("============ Cross-store globals ==============");
 
     let store1val = Val::FuncRef(Some(Func::wrap(&mut store1, || {})));
+    let store1ref = store1val.clone().ref_().unwrap();
     let store2val = Val::FuncRef(Some(Func::wrap(&mut store2, || {})));
+    let store2ref = store2val.clone().ref_().unwrap();
 
-    let ty = GlobalType::new(ValType::FuncRef, Mutability::Var);
+    let ty = GlobalType::new(ValType::FUNCREF, Mutability::Var);
     assert!(Global::new(&mut store2, ty.clone(), store1val.clone()).is_err());
     if let Ok(g) = Global::new(&mut store2, ty.clone(), store2val.clone()) {
         assert!(g.set(&mut store2, store1val.clone()).is_err());
     }
 
-    // ============ Cross-store tables ==============
+    eprintln!("============ Cross-store tables ==============");
 
-    let ty = TableType::new(ValType::FuncRef, 1, None);
-    assert!(Table::new(&mut store2, ty.clone(), store1val.clone()).is_err());
-    let t1 = Table::new(&mut store2, ty.clone(), store2val.clone())?;
-    assert!(t1.set(&mut store2, 0, store1val.clone()).is_err());
-    assert!(t1.grow(&mut store2, 0, store1val.clone()).is_err());
-    assert!(t1.fill(&mut store2, 0, store1val.clone(), 1).is_err());
+    let ty = TableType::new(RefType::FUNCREF, 1, None);
+    assert!(Table::new(&mut store2, ty.clone(), store1ref.clone()).is_err());
+    let t1 = Table::new(&mut store2, ty.clone(), store2ref.clone())?;
+    assert!(t1.set(&mut store2, 0, store1ref.clone()).is_err());
+    assert!(t1.grow(&mut store2, 0, store1ref.clone()).is_err());
+    assert!(t1.fill(&mut store2, 0, store1ref.clone(), 1).is_err());
 
-    // ============ Cross-store funcs ==============
+    eprintln!("============ Cross-store funcs ==============");
 
     let module = Module::new(&engine, r#"(module (func (export "f") (param funcref)))"#)?;
     let s1_inst = Instance::new(&mut store1, &module, &[])?;
@@ -166,7 +156,7 @@ fn get_set_externref_globals_via_api() -> anyhow::Result<()> {
 
     let global = Global::new(
         &mut store,
-        GlobalType::new(ValType::ExternRef, Mutability::Var),
+        GlobalType::new(ValType::EXTERNREF, Mutability::Var),
         Val::ExternRef(None),
     )?;
     assert!(global.get(&mut store).unwrap_externref().is_none());
@@ -175,7 +165,7 @@ fn get_set_externref_globals_via_api() -> anyhow::Result<()> {
         &mut store,
         Val::ExternRef(Some(ExternRef::new("hello".to_string()))),
     )?;
-    let r = global.get(&mut store).unwrap_externref().unwrap();
+    let r = global.get(&mut store).unwrap_externref().cloned().unwrap();
     assert!(r.data().is::<String>());
     assert_eq!(r.data().downcast_ref::<String>().unwrap(), "hello");
 
@@ -183,10 +173,10 @@ fn get_set_externref_globals_via_api() -> anyhow::Result<()> {
 
     let global = Global::new(
         &mut store,
-        GlobalType::new(ValType::ExternRef, Mutability::Const),
+        GlobalType::new(ValType::EXTERNREF, Mutability::Const),
         Val::ExternRef(Some(ExternRef::new(42_i32))),
     )?;
-    let r = global.get(&mut store).unwrap_externref().unwrap();
+    let r = global.get(&mut store).unwrap_externref().cloned().unwrap();
     assert!(r.data().is::<i32>());
     assert_eq!(r.data().downcast_ref::<i32>().copied().unwrap(), 42);
 
@@ -206,24 +196,26 @@ fn get_set_funcref_globals_via_api() -> anyhow::Result<()> {
 
     let global = Global::new(
         &mut store,
-        GlobalType::new(ValType::FuncRef, Mutability::Var),
+        GlobalType::new(ValType::FUNCREF, Mutability::Var),
         Val::FuncRef(None),
     )?;
     assert!(global.get(&mut store).unwrap_funcref().is_none());
 
     global.set(&mut store, Val::FuncRef(Some(f.clone())))?;
     let f2 = global.get(&mut store).unwrap_funcref().cloned().unwrap();
-    assert_eq!(f.ty(&store), f2.ty(&store));
+    assert!(f.ty(&store).matches(store.engine(), &f2.ty(&store)));
+    assert!(f2.ty(&store).matches(store.engine(), &f.ty(&store)));
 
     // Initialize with a non-null funcref.
 
     let global = Global::new(
         &mut store,
-        GlobalType::new(ValType::FuncRef, Mutability::Var),
+        GlobalType::new(ValType::FUNCREF, Mutability::Var),
         Val::FuncRef(Some(f.clone())),
     )?;
     let f2 = global.get(&mut store).unwrap_funcref().cloned().unwrap();
-    assert_eq!(f.ty(&store), f2.ty(&store));
+    assert!(f.ty(&store).matches(store.engine(), &f2.ty(&store)));
+    assert!(f2.ty(&store).matches(store.engine(), &f.ty(&store)));
 
     Ok(())
 }
@@ -235,13 +227,13 @@ fn create_get_set_funcref_tables_via_api() -> anyhow::Result<()> {
     let engine = Engine::new(&cfg)?;
     let mut store = Store::new(&engine, ());
 
-    let table_ty = TableType::new(ValType::FuncRef, 10, None);
-    let init = Val::FuncRef(Some(Func::wrap(&mut store, || {})));
+    let table_ty = TableType::new(RefType::FUNCREF, 10, None);
+    let init = Ref::Func(Some(Func::wrap(&mut store, || {})));
     let table = Table::new(&mut store, table_ty, init)?;
 
-    assert!(table.get(&mut store, 5).unwrap().unwrap_funcref().is_some());
-    table.set(&mut store, 5, Val::FuncRef(None))?;
-    assert!(table.get(&mut store, 5).unwrap().unwrap_funcref().is_none());
+    assert!(table.get(&mut store, 5).unwrap().unwrap_func().is_some());
+    table.set(&mut store, 5, Ref::Func(None))?;
+    assert!(table.get(&mut store, 5).unwrap().unwrap_func().is_none());
 
     Ok(())
 }
@@ -253,21 +245,21 @@ fn fill_funcref_tables_via_api() -> anyhow::Result<()> {
     let engine = Engine::new(&cfg)?;
     let mut store = Store::new(&engine, ());
 
-    let table_ty = TableType::new(ValType::FuncRef, 10, None);
-    let table = Table::new(&mut store, table_ty, Val::FuncRef(None))?;
+    let table_ty = TableType::new(RefType::FUNCREF, 10, None);
+    let table = Table::new(&mut store, table_ty, Ref::Func(None))?;
 
     for i in 0..10 {
-        assert!(table.get(&mut store, i).unwrap().unwrap_funcref().is_none());
+        assert!(table.get(&mut store, i).unwrap().unwrap_func().is_none());
     }
 
-    let fill = Val::FuncRef(Some(Func::wrap(&mut store, || {})));
+    let fill = Ref::Func(Some(Func::wrap(&mut store, || {})));
     table.fill(&mut store, 2, fill, 4)?;
 
     for i in (0..2).chain(7..10) {
-        assert!(table.get(&mut store, i).unwrap().unwrap_funcref().is_none());
+        assert!(table.get(&mut store, i).unwrap().unwrap_func().is_none());
     }
     for i in 2..6 {
-        assert!(table.get(&mut store, i).unwrap().unwrap_funcref().is_some());
+        assert!(table.get(&mut store, i).unwrap().unwrap_func().is_some());
     }
 
     Ok(())
@@ -280,11 +272,11 @@ fn grow_funcref_tables_via_api() -> anyhow::Result<()> {
     let engine = Engine::new(&cfg)?;
     let mut store = Store::new(&engine, ());
 
-    let table_ty = TableType::new(ValType::FuncRef, 10, None);
-    let table = Table::new(&mut store, table_ty, Val::FuncRef(None))?;
+    let table_ty = TableType::new(RefType::FUNCREF, 10, None);
+    let table = Table::new(&mut store, table_ty, Ref::Func(None))?;
 
     assert_eq!(table.size(&store), 10);
-    table.grow(&mut store, 3, Val::FuncRef(None))?;
+    table.grow(&mut store, 3, Ref::Func(None))?;
     assert_eq!(table.size(&store), 13);
 
     Ok(())
@@ -297,30 +289,26 @@ fn create_get_set_externref_tables_via_api() -> anyhow::Result<()> {
     let engine = Engine::new(&cfg)?;
     let mut store = Store::new(&engine, ());
 
-    let table_ty = TableType::new(ValType::ExternRef, 10, None);
+    let table_ty = TableType::new(RefType::EXTERNREF, 10, None);
     let table = Table::new(
         &mut store,
         table_ty,
-        Val::ExternRef(Some(ExternRef::new(42_usize))),
+        Ref::Extern(Some(ExternRef::new(42_usize))),
     )?;
 
     assert_eq!(
         *table
             .get(&mut store, 5)
             .unwrap()
-            .unwrap_externref()
+            .unwrap_extern()
             .unwrap()
             .data()
             .downcast_ref::<usize>()
             .unwrap(),
         42
     );
-    table.set(&mut store, 5, Val::ExternRef(None))?;
-    assert!(table
-        .get(&mut store, 5)
-        .unwrap()
-        .unwrap_externref()
-        .is_none());
+    table.set(&mut store, 5, Ref::Extern(None))?;
+    assert!(table.get(&mut store, 5).unwrap().unwrap_extern().is_none());
 
     Ok(())
 }
@@ -332,37 +320,29 @@ fn fill_externref_tables_via_api() -> anyhow::Result<()> {
     let engine = Engine::new(&cfg)?;
     let mut store = Store::new(&engine, ());
 
-    let table_ty = TableType::new(ValType::ExternRef, 10, None);
-    let table = Table::new(&mut store, table_ty, Val::ExternRef(None))?;
+    let table_ty = TableType::new(RefType::EXTERNREF, 10, None);
+    let table = Table::new(&mut store, table_ty, Ref::Extern(None))?;
 
     for i in 0..10 {
-        assert!(table
-            .get(&mut store, i)
-            .unwrap()
-            .unwrap_externref()
-            .is_none());
+        assert!(table.get(&mut store, i).unwrap().unwrap_extern().is_none());
     }
 
     table.fill(
         &mut store,
         2,
-        Val::ExternRef(Some(ExternRef::new(42_usize))),
+        Ref::Extern(Some(ExternRef::new(42_usize))),
         4,
     )?;
 
     for i in (0..2).chain(7..10) {
-        assert!(table
-            .get(&mut store, i)
-            .unwrap()
-            .unwrap_externref()
-            .is_none());
+        assert!(table.get(&mut store, i).unwrap().unwrap_extern().is_none());
     }
     for i in 2..6 {
         assert_eq!(
             *table
                 .get(&mut store, i)
                 .unwrap()
-                .unwrap_externref()
+                .unwrap_extern()
                 .unwrap()
                 .data()
                 .downcast_ref::<usize>()
@@ -381,11 +361,11 @@ fn grow_externref_tables_via_api() -> anyhow::Result<()> {
     let engine = Engine::new(&cfg)?;
     let mut store = Store::new(&engine, ());
 
-    let table_ty = TableType::new(ValType::ExternRef, 10, None);
-    let table = Table::new(&mut store, table_ty, Val::ExternRef(None))?;
+    let table_ty = TableType::new(RefType::EXTERNREF, 10, None);
+    let table = Table::new(&mut store, table_ty, Ref::Extern(None))?;
 
     assert_eq!(table.size(&store), 10);
-    table.grow(&mut store, 3, Val::ExternRef(None))?;
+    table.grow(&mut store, 3, Ref::Extern(None))?;
     assert_eq!(table.size(&store), 13);
 
     Ok(())

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -1615,14 +1615,15 @@ fn call_wasm_passing_subtype_func_param() -> anyhow::Result<()> {
             (module
                 (type $ty (func (result funcref)))
                 (func (export "f") (param (ref null $ty)) (result funcref)
-                    local.get 0
-
                     ;; Return null if the funcref is null.
+                    ref.null func
                     local.get 0
                     ref.is_null
                     br_if 0
+                    drop
 
                     ;; Otherwise, call it.
+                    local.get 0
                     call_ref $ty
                 )
             )

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -249,7 +249,7 @@ fn call_indirect_native_from_wasm_import_global() -> Result<()> {
     let func = Func::wrap(&mut store, || -> (i32, i32, i32) { (10, 20, 30) });
     let global = Global::new(
         &mut store,
-        GlobalType::new(ValType::FuncRef, Mutability::Const),
+        GlobalType::new(ValType::FUNCREF, Mutability::Const),
         Val::FuncRef(Some(func)),
     )?;
     let instance = Instance::new(&mut store, &module, &[global.into()])?;
@@ -278,8 +278,8 @@ fn call_indirect_native_from_wasm_import_table() -> Result<()> {
     let func = Func::wrap(&mut store, || -> (i32, i32, i32) { (10, 20, 30) });
     let table = Table::new(
         &mut store,
-        TableType::new(ValType::FuncRef, 1, Some(1)),
-        Val::FuncRef(Some(func)),
+        TableType::new(RefType::FUNCREF, 1, Some(1)),
+        Ref::Func(Some(func)),
     )?;
     let instance = Instance::new(&mut store, &module, &[table.into()])?;
     let func = instance.get_typed_func::<(), (i32, i32, i32)>(&mut store, "run")?;
@@ -385,16 +385,24 @@ fn func_constructors() {
     Func::wrap(&mut store, || -> i64 { 0 });
     Func::wrap(&mut store, || -> f32 { 0.0 });
     Func::wrap(&mut store, || -> f64 { 0.0 });
+    Func::wrap(&mut store, || -> ExternRef { loop {} });
     Func::wrap(&mut store, || -> Option<ExternRef> { None });
+    Func::wrap(&mut store, || -> Func { loop {} });
     Func::wrap(&mut store, || -> Option<Func> { None });
+    Func::wrap(&mut store, || -> NoFunc { loop {} });
+    Func::wrap(&mut store, || -> Option<NoFunc> { None });
 
     Func::wrap(&mut store, || -> Result<()> { loop {} });
     Func::wrap(&mut store, || -> Result<i32> { loop {} });
     Func::wrap(&mut store, || -> Result<i64> { loop {} });
     Func::wrap(&mut store, || -> Result<f32> { loop {} });
     Func::wrap(&mut store, || -> Result<f64> { loop {} });
+    Func::wrap(&mut store, || -> Result<ExternRef> { loop {} });
     Func::wrap(&mut store, || -> Result<Option<ExternRef>> { loop {} });
+    Func::wrap(&mut store, || -> Result<Func> { loop {} });
     Func::wrap(&mut store, || -> Result<Option<Func>> { loop {} });
+    Func::wrap(&mut store, || -> Result<NoFunc> { loop {} });
+    Func::wrap(&mut store, || -> Result<Option<NoFunc>> { loop {} });
 }
 
 #[test]
@@ -452,24 +460,28 @@ fn signatures_match() {
     let mut store = Store::<()>::default();
 
     let f = Func::wrap(&mut store, || {});
-    assert_eq!(f.ty(&store).params().collect::<Vec<_>>(), &[]);
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.ty(&store).params().len(), 0);
+    assert_eq!(f.ty(&store).results().len(), 0);
 
     let f = Func::wrap(&mut store, || -> i32 { loop {} });
-    assert_eq!(f.ty(&store).params().collect::<Vec<_>>(), &[]);
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[ValType::I32]);
+    assert_eq!(f.ty(&store).params().len(), 0);
+    assert_eq!(f.ty(&store).results().len(), 1);
+    assert!(f.ty(&store).results().nth(0).unwrap().is_i32());
 
     let f = Func::wrap(&mut store, || -> i64 { loop {} });
-    assert_eq!(f.ty(&store).params().collect::<Vec<_>>(), &[]);
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[ValType::I64]);
+    assert_eq!(f.ty(&store).params().len(), 0);
+    assert_eq!(f.ty(&store).results().len(), 1);
+    assert!(f.ty(&store).results().nth(0).unwrap().is_i64());
 
     let f = Func::wrap(&mut store, || -> f32 { loop {} });
-    assert_eq!(f.ty(&store).params().collect::<Vec<_>>(), &[]);
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[ValType::F32]);
+    assert_eq!(f.ty(&store).params().len(), 0);
+    assert_eq!(f.ty(&store).results().len(), 1);
+    assert!(f.ty(&store).results().nth(0).unwrap().is_f32());
 
     let f = Func::wrap(&mut store, || -> f64 { loop {} });
-    assert_eq!(f.ty(&store).params().collect::<Vec<_>>(), &[]);
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[ValType::F64]);
+    assert_eq!(f.ty(&store).params().len(), 0);
+    assert_eq!(f.ty(&store).results().len(), 1);
+    assert!(f.ty(&store).results().nth(0).unwrap().is_f64());
 
     let f = Func::wrap(
         &mut store,
@@ -477,19 +489,18 @@ fn signatures_match() {
             loop {}
         },
     );
-    assert_eq!(
-        f.ty(&store).params().collect::<Vec<_>>(),
-        &[
-            ValType::F32,
-            ValType::F64,
-            ValType::I32,
-            ValType::I64,
-            ValType::I32,
-            ValType::ExternRef,
-            ValType::FuncRef,
-        ]
-    );
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[ValType::F64]);
+
+    assert_eq!(f.ty(&store).params().len(), 7);
+    assert!(f.ty(&store).params().nth(0).unwrap().is_f32());
+    assert!(f.ty(&store).params().nth(1).unwrap().is_f64());
+    assert!(f.ty(&store).params().nth(2).unwrap().is_i32());
+    assert!(f.ty(&store).params().nth(3).unwrap().is_i64());
+    assert!(f.ty(&store).params().nth(4).unwrap().is_i32());
+    assert!(f.ty(&store).params().nth(5).unwrap().is_externref());
+    assert!(f.ty(&store).params().nth(6).unwrap().is_funcref());
+
+    assert_eq!(f.ty(&store).results().len(), 1);
+    assert!(f.ty(&store).results().nth(0).unwrap().is_f64());
 }
 
 #[test]
@@ -901,8 +912,8 @@ fn externref_signature_no_reference_types() -> anyhow::Result<()> {
     Func::wrap(&mut store, |_: Option<Func>| {});
     let func_ty = FuncType::new(
         store.engine(),
-        [ValType::FuncRef, ValType::ExternRef].iter().cloned(),
-        [ValType::FuncRef, ValType::ExternRef].iter().cloned(),
+        [ValType::FUNCREF, ValType::EXTERNREF].iter().cloned(),
+        [ValType::FUNCREF, ValType::EXTERNREF].iter().cloned(),
     );
     Func::new(&mut store, func_ty, |_, _, _| Ok(()));
     Ok(())
@@ -1398,7 +1409,7 @@ fn calls_with_funcref_and_externref() -> anyhow::Result<()> {
         ],
         &mut results,
     )?;
-    assert_my_externref(results[0].unwrap_externref().as_ref());
+    assert_my_externref(results[0].unwrap_externref());
     assert!(results[1].unwrap_funcref().is_none());
 
     // funcref=Some, externref=Some
@@ -1413,8 +1424,330 @@ fn calls_with_funcref_and_externref() -> anyhow::Result<()> {
         ],
         &mut results,
     )?;
-    assert_my_externref(results[0].unwrap_externref().as_ref());
+    assert_my_externref(results[0].unwrap_externref());
     assert_my_funcref(&mut store, results[1].unwrap_funcref())?;
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn typed_concrete_param() -> anyhow::Result<()> {
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (type $t (func))
+                (func (export "f") (param (ref null $t)))
+            )
+        "#,
+    )?;
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[])?;
+
+    let nop = Func::new(
+        &mut store,
+        FuncType::new(&engine, None, None),
+        |_caller, _params, _results| Ok(()),
+    );
+
+    let f = instance.get_func(&mut store, "f").unwrap();
+
+    // Can type with a subtype, which should avoid all dynamic type checks after
+    // successful construction.
+    let a = f.typed::<Option<NoFunc>, ()>(&store)?;
+    a.call(&mut store, None)?;
+    // NB: Cannot call with Some(_) as `NoFunc` is uninhabited.
+
+    // Can call `typed` with a supertype, falling back to dynamic type checks on
+    // each call.
+    let a = f.typed::<Option<Func>, ()>(&store)?;
+    a.call(&mut store, None)?;
+    a.call(&mut store, Some(nop.clone()))?;
+    let e = a.call(&mut store, Some(f.clone())).expect_err(
+        "should return an error because while we did pass an instance of \
+         `Option<Func>`, it was not an instance of `(ref null $t)`",
+    );
+    let e = format!("{e:?}");
+    assert!(e.contains("argument type mismatch for reference to concrete type"));
+    assert!(e.contains(
+        "type mismatch: expected (type (func)), \
+         found (type (func (param (ref null (concrete VMSharedTypeIndex(0))))))"
+    ));
+
+    // And dynamic checks also work with a non-nullable super type.
+    let a = f.typed::<Func, ()>(&store)?;
+    a.call(&mut store, nop.clone())?;
+    let e = a.call(&mut store, f.clone()).expect_err(
+        "should return an error because while we did pass an instance of \
+         `Func`, it was not an instance of `(ref null $t)`",
+    );
+    let e = format!("{e:?}");
+    assert!(e.contains("argument type mismatch for reference to concrete type"));
+    assert!(e.contains(
+        "type mismatch: expected (type (func)), \
+         found (type (func (param (ref null (concrete VMSharedTypeIndex(0))))))"
+    ));
+
+    // Calling `typed` with a type that is not a supertype nor a subtype fails
+    // the initial type check.
+    let e = f.typed::<Option<ExternRef>, ()>(&store).err().unwrap();
+    let e = format!("{e:?}");
+    assert!(e.contains("type mismatch with parameters"));
+    assert!(e.contains("type mismatch: expected func, found extern"));
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn typed_concrete_result() -> anyhow::Result<()> {
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    let engine = Engine::new(&config)?;
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (type $t (func))
+                (func $nop)
+                (elem declare func $nop)
+                (func (export "f") (result (ref $t))
+                    ref.func $nop
+                )
+            )
+        "#,
+    )?;
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[])?;
+
+    let f = instance.get_func(&mut store, "f").unwrap();
+
+    // Can type `f` with a supertype of the declared result type, and we get the
+    // expected return value.
+    let a = f.typed::<(), Func>(&store)?;
+    let g = a.call(&mut store, ())?;
+    g.typed::<(), ()>(&store)?.call(&mut store, ())?;
+
+    // Also works with a nullable supertype.
+    let a = f.typed::<(), Option<Func>>(&store)?;
+    let g = a.call(&mut store, ())?;
+    g.unwrap().typed::<(), ()>(&store)?.call(&mut store, ())?;
+
+    // But we can't claim that `f` returns a particular subtype of its actual
+    // return type.
+    let e = f.typed::<(), NoFunc>(&store).err().unwrap();
+    let e = format!("{e:?}");
+    assert!(e.contains("type mismatch with results"));
+    assert!(e.contains(
+        "type mismatch: expected (ref nofunc), found (ref (concrete VMSharedTypeIndex(0)))"
+    ));
+
+    // Nor some unrelated type that it is neither a subtype or supertype of.
+    let e = f.typed::<(), ExternRef>(&store).err().unwrap();
+    let e = format!("{e:?}");
+    assert!(e.contains("type mismatch with results"));
+    assert!(e.contains(
+        "type mismatch: expected (ref extern), found (ref (concrete VMSharedTypeIndex(0)))"
+    ));
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn wrap_subtype_param() -> anyhow::Result<()> {
+    let mut store = Store::<()>::default();
+    let f = Func::wrap(&mut store, |_caller: Caller<'_, ()>, _: Option<Func>| {
+        // No-op.
+    });
+
+    // Precise type.
+    let a = f.typed::<Option<Func>, ()>(&store)?;
+    a.call(&mut store, None)?;
+    a.call(&mut store, Some(f.clone()))?;
+
+    // Subtype via heap type.
+    let a = f.typed::<Option<NoFunc>, ()>(&store)?;
+    a.call(&mut store, None)?;
+
+    // Subtype via non-null.
+    let a = f.typed::<Func, ()>(&store)?;
+    a.call(&mut store, f.clone())?;
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn wrap_supertype_result() -> anyhow::Result<()> {
+    let mut store = Store::<()>::default();
+    let f = Func::wrap(&mut store, |_caller: Caller<'_, ()>| -> NoFunc {
+        unreachable!()
+    });
+
+    // Precise type.
+    let _ = f.typed::<(), NoFunc>(&store)?;
+
+    // Supertype via heap type.
+    let _ = f.typed::<(), Func>(&store)?;
+
+    // Supertype via nullability.
+    let _ = f.typed::<(), Option<NoFunc>>(&store)?;
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn call_wasm_passing_subtype_func_param() -> anyhow::Result<()> {
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (type $ty (func (result funcref)))
+                (func (export "f") (param (ref null $ty)) (result funcref)
+                    local.get 0
+
+                    ;; Return null if the funcref is null.
+                    local.get 0
+                    ref.is_null
+                    br_if 0
+
+                    ;; Otherwise, call it.
+                    call_ref $ty
+                )
+            )
+        "#,
+    )?;
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let f = instance.get_func(&mut store, "f").unwrap();
+
+    let g_ty = FuncType::new(&engine, None, Some(ValType::I32));
+    let g = Func::new(&mut store, g_ty.clone(), |_caller, _params, results| {
+        results[0] = Val::I32(0x1234_5678);
+        Ok(())
+    });
+
+    // h's type is a subtype of the Wasm-defined `$ty`:
+    //
+    //     (func (result (ref null g_ty))) <: (func (result funcref))
+    let h_ty = FuncType::new(
+        &engine,
+        None,
+        Some(ValType::Ref(RefType::new(true, HeapType::Concrete(g_ty)))),
+    );
+    let h = Func::new(&mut store, h_ty, move |_caller, _params, results| {
+        results[0] = Val::FuncRef(Some(g.clone()));
+        Ok(())
+    });
+
+    // Array call, passing in a subtype of the expected parameter.
+
+    let mut results = vec![Val::I32(0)];
+    f.call(&mut store, &[Val::null_func_ref()], &mut results)?;
+    assert!(results[0].unwrap_func_ref().is_none());
+
+    f.call(&mut store, &[h.clone().into()], &mut results)?;
+    let g = results[0].clone();
+    let g = g.unwrap_func_ref().unwrap();
+    g.call(&mut store, &[], &mut results)?;
+    assert_eq!(results[0].unwrap_i32(), 0x1234_5678);
+
+    // Native call, passing in a subtype of the expected parameter.
+
+    let f = f.typed::<Option<Func>, Option<Func>>(&store)?;
+    let r = f.call(&mut store, None)?;
+    assert!(r.is_none());
+
+    let g = f.call(&mut store, Some(h))?;
+    let g = g.unwrap().typed::<(), u32>(&mut store)?;
+    let x = g.call(&mut store, ())?;
+    assert_eq!(x, 0x1234_5678);
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn call_wasm_getting_subtype_func_return() -> anyhow::Result<()> {
+    let mut config = Config::new();
+    config.wasm_gc(true);
+    config.wasm_function_references(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (type $ty (func (result funcref)))
+
+                (func $a (result i32)
+                    i32.const 0x12345678
+                )
+
+                (func $b (result funcref)
+                    ref.func $a
+                )
+
+                (elem declare func $a $b)
+
+                ;; Returns a `(ref null nofunc)` if called with `0`, otherwise
+                ;; returns `(ref null $ty)`, both of which are subtypes of
+                ;; `funcref`.
+                (func (export "f") (param i32) (result funcref)
+                    block
+                        local.get 0
+                        br_if 0
+                        ref.null nofunc
+                        return
+                    end
+                    ref.func $b
+                )
+            )
+        "#,
+    )?;
+
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let f = instance.get_func(&mut store, "f").unwrap();
+
+    // Array call, receiving a subtype of the expected result.
+
+    let mut results = vec![Val::I32(0)];
+    f.call(&mut store, &[Val::I32(0)], &mut results)?;
+    assert!(results[0].unwrap_func_ref().is_none());
+
+    f.call(&mut store, &[Val::I32(1)], &mut results)?;
+    let b = results[0].clone();
+    let b = b.unwrap_func_ref().unwrap();
+    b.call(&mut store, &[], &mut results)?;
+    let a = results[0].clone();
+    let a = a.unwrap_func_ref().unwrap();
+    a.call(&mut store, &[], &mut results)?;
+    assert_eq!(results[0].unwrap_i32(), 0x1234_5678);
+
+    // Native call, receiving a subtype of the expected result.
+
+    let f = f.typed::<u32, Option<Func>>(&store)?;
+    let r = f.call(&mut store, 0)?;
+    assert!(r.is_none());
+
+    let b = f.call(&mut store, 1)?;
+    let b = b.unwrap().typed::<(), Option<Func>>(&store)?;
+    let a = b.call(&mut store, ())?;
+    let a = a.unwrap().typed::<(), u32>(&store)?;
+    let x = a.call(&mut store, ())?;
+    assert_eq!(x, 0x1234_5678);
 
     Ok(())
 }

--- a/tests/all/funcref.rs
+++ b/tests/all/funcref.rs
@@ -31,12 +31,7 @@ fn pass_funcref_in_and_out_of_wasm() -> anyhow::Result<()> {
 
         // Can't compare `Func` for equality, so this is the best we can do here.
         let result_func = results[0].unwrap_funcref().unwrap();
-        assert!(func
-            .ty(&store)
-            .matches(store.engine(), &result_func.ty(&store)));
-        assert!(result_func
-            .ty(&store)
-            .matches(store.engine(), &func.ty(&store)));
+        assert!(FuncType::eq(&func.ty(&store), &result_func.ty(&store)));
     }
 
     // Pass in a null funcref.
@@ -62,12 +57,10 @@ fn pass_funcref_in_and_out_of_wasm() -> anyhow::Result<()> {
 
         // Can't compare `Func` for equality, so this is the best we can do here.
         let result_func = results[0].unwrap_funcref().unwrap();
-        assert!(other_instance_func
-            .ty(&store)
-            .matches(store.engine(), &result_func.ty(&store)));
-        assert!(result_func
-            .ty(&store)
-            .matches(store.engine(), &other_instance_func.ty(&store)));
+        assert!(FuncType::eq(
+            &other_instance_func.ty(&store),
+            &result_func.ty(&store),
+        ));
     }
 
     // Passing in a `funcref` from another store fails.

--- a/tests/all/funcref.rs
+++ b/tests/all/funcref.rs
@@ -31,7 +31,12 @@ fn pass_funcref_in_and_out_of_wasm() -> anyhow::Result<()> {
 
         // Can't compare `Func` for equality, so this is the best we can do here.
         let result_func = results[0].unwrap_funcref().unwrap();
-        assert_eq!(func.ty(&store), result_func.ty(&store));
+        assert!(func
+            .ty(&store)
+            .matches(store.engine(), &result_func.ty(&store)));
+        assert!(result_func
+            .ty(&store)
+            .matches(store.engine(), &func.ty(&store)));
     }
 
     // Pass in a null funcref.
@@ -57,7 +62,12 @@ fn pass_funcref_in_and_out_of_wasm() -> anyhow::Result<()> {
 
         // Can't compare `Func` for equality, so this is the best we can do here.
         let result_func = results[0].unwrap_funcref().unwrap();
-        assert_eq!(other_instance_func.ty(&store), result_func.ty(&store));
+        assert!(other_instance_func
+            .ty(&store)
+            .matches(store.engine(), &result_func.ty(&store)));
+        assert!(result_func
+            .ty(&store)
+            .matches(store.engine(), &other_instance_func.ty(&store)));
     }
 
     // Passing in a `funcref` from another store fails.
@@ -141,7 +151,7 @@ fn func_new_returns_wrong_store() -> anyhow::Result<()> {
         let f1 = Func::wrap(&mut store1, move || {
             let _ = &set;
         });
-        let func_ty = FuncType::new(store2.engine(), None, Some(ValType::FuncRef));
+        let func_ty = FuncType::new(store2.engine(), None, Some(ValType::FUNCREF));
         let f2 = Func::new(&mut store2, func_ty, move |_, _, results| {
             results[0] = f1.clone().into();
             Ok(())

--- a/tests/all/gc.rs
+++ b/tests/all/gc.rs
@@ -270,7 +270,7 @@ fn global_drops_externref() -> anyhow::Result<()> {
         let externref = ExternRef::new(SetFlagOnDrop(flag.clone()));
         Global::new(
             &mut store,
-            GlobalType::new(ValType::ExternRef, Mutability::Const),
+            GlobalType::new(ValType::EXTERNREF, Mutability::Const),
             externref.into(),
         )?;
         drop(store);
@@ -320,7 +320,7 @@ fn table_drops_externref() -> anyhow::Result<()> {
         let externref = ExternRef::new(SetFlagOnDrop(flag.clone()));
         Table::new(
             &mut store,
-            TableType::new(ValType::ExternRef, 1, None),
+            TableType::new(RefType::EXTERNREF, 1, None),
             externref.into(),
         )?;
         drop(store);
@@ -432,7 +432,7 @@ fn global_init_no_leak() -> anyhow::Result<()> {
     let externref = ExternRef::new(());
     let global = Global::new(
         &mut store,
-        GlobalType::new(ValType::ExternRef, Mutability::Const),
+        GlobalType::new(ValType::EXTERNREF, Mutability::Const),
         externref.clone().into(),
     )?;
     Instance::new(&mut store, &module, &[global.into()])?;

--- a/tests/all/host_funcs.rs
+++ b/tests/all/host_funcs.rs
@@ -154,59 +154,62 @@ fn signatures_match() -> Result<()> {
         .unwrap()
         .into_func()
         .unwrap();
-    assert_eq!(f.ty(&store).params().collect::<Vec<_>>(), &[]);
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[]);
+    assert_eq!(f.ty(&store).params().len(), 0);
+    assert_eq!(f.ty(&store).results().len(), 0);
 
     let f = linker
         .get(&mut store, "", "f2")
         .unwrap()
         .into_func()
         .unwrap();
-    assert_eq!(f.ty(&store).params().collect::<Vec<_>>(), &[]);
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[ValType::I32]);
+    assert_eq!(f.ty(&store).params().len(), 0);
+    assert_eq!(f.ty(&store).results().len(), 1);
+    assert!(f.ty(&store).results().nth(0).unwrap().is_i32());
 
     let f = linker
         .get(&mut store, "", "f3")
         .unwrap()
         .into_func()
         .unwrap();
-    assert_eq!(f.ty(&store).params().collect::<Vec<_>>(), &[]);
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[ValType::I64]);
+    assert_eq!(f.ty(&store).params().len(), 0);
+    assert_eq!(f.ty(&store).results().len(), 1);
+    assert!(f.ty(&store).results().nth(0).unwrap().is_i64());
 
     let f = linker
         .get(&mut store, "", "f4")
         .unwrap()
         .into_func()
         .unwrap();
-    assert_eq!(f.ty(&store).params().collect::<Vec<_>>(), &[]);
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[ValType::F32]);
+    assert_eq!(f.ty(&store).params().len(), 0);
+    assert_eq!(f.ty(&store).results().len(), 1);
+    assert!(f.ty(&store).results().nth(0).unwrap().is_f32());
 
     let f = linker
         .get(&mut store, "", "f5")
         .unwrap()
         .into_func()
         .unwrap();
-    assert_eq!(f.ty(&store).params().collect::<Vec<_>>(), &[]);
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[ValType::F64]);
+    assert_eq!(f.ty(&store).params().len(), 0);
+    assert_eq!(f.ty(&store).results().len(), 1);
+    assert!(f.ty(&store).results().nth(0).unwrap().is_f64());
 
     let f = linker
         .get(&mut store, "", "f6")
         .unwrap()
         .into_func()
         .unwrap();
-    assert_eq!(
-        f.ty(&store).params().collect::<Vec<_>>(),
-        &[
-            ValType::F32,
-            ValType::F64,
-            ValType::I32,
-            ValType::I64,
-            ValType::I32,
-            ValType::ExternRef,
-            ValType::FuncRef,
-        ]
-    );
-    assert_eq!(f.ty(&store).results().collect::<Vec<_>>(), &[ValType::F64]);
+
+    assert_eq!(f.ty(&store).params().len(), 7);
+    assert!(f.ty(&store).params().nth(0).unwrap().is_f32());
+    assert!(f.ty(&store).params().nth(1).unwrap().is_f64());
+    assert!(f.ty(&store).params().nth(2).unwrap().is_i32());
+    assert!(f.ty(&store).params().nth(3).unwrap().is_i64());
+    assert!(f.ty(&store).params().nth(4).unwrap().is_i32());
+    assert!(f.ty(&store).params().nth(5).unwrap().is_externref());
+    assert!(f.ty(&store).params().nth(6).unwrap().is_funcref());
+
+    assert_eq!(f.ty(&store).results().len(), 1);
+    assert!(f.ty(&store).results().nth(0).unwrap().is_f64());
 
     Ok(())
 }

--- a/tests/all/invoke_func_via_table.rs
+++ b/tests/all/invoke_func_via_table.rs
@@ -24,8 +24,7 @@ fn test_invoke_func_via_table() -> Result<()> {
         .unwrap()
         .get(&mut store, 0)
         .unwrap()
-        .funcref()
-        .unwrap()
+        .unwrap_func()
         .unwrap()
         .clone();
     let mut results = [Val::I32(0)];

--- a/tests/all/limits.rs
+++ b/tests/all/limits.rs
@@ -52,17 +52,17 @@ fn test_limits() -> Result<()> {
         instance.get_table(&mut store, "t").unwrap(),
         Table::new(
             &mut store,
-            TableType::new(ValType::FuncRef, 0, None),
-            Val::FuncRef(None),
+            TableType::new(RefType::FUNCREF, 0, None),
+            Ref::Func(None),
         )?,
     ]) {
-        table.grow(&mut store, 2, Val::FuncRef(None))?;
-        table.grow(&mut store, 1, Val::FuncRef(None))?;
-        table.grow(&mut store, 2, Val::FuncRef(None))?;
+        table.grow(&mut store, 2, Ref::Func(None))?;
+        table.grow(&mut store, 1, Ref::Func(None))?;
+        table.grow(&mut store, 2, Ref::Func(None))?;
 
         assert_eq!(
             table
-                .grow(&mut store, 1, Val::FuncRef(None))
+                .grow(&mut store, 1, Ref::Func(None))
                 .map_err(|e| e.to_string())
                 .unwrap_err(),
             "failed to grow table by `1`"
@@ -163,18 +163,18 @@ async fn test_limits_async() -> Result<()> {
         instance.get_table(&mut store, "t").unwrap(),
         Table::new_async(
             &mut store,
-            TableType::new(ValType::FuncRef, 0, None),
-            Val::FuncRef(None),
+            TableType::new(RefType::FUNCREF, 0, None),
+            Ref::Func(None),
         )
         .await?,
     ]) {
-        table.grow_async(&mut store, 2, Val::FuncRef(None)).await?;
-        table.grow_async(&mut store, 1, Val::FuncRef(None)).await?;
-        table.grow_async(&mut store, 2, Val::FuncRef(None)).await?;
+        table.grow_async(&mut store, 2, Ref::Func(None)).await?;
+        table.grow_async(&mut store, 1, Ref::Func(None)).await?;
+        table.grow_async(&mut store, 2, Ref::Func(None)).await?;
 
         assert_eq!(
             table
-                .grow_async(&mut store, 1, Val::FuncRef(None))
+                .grow_async(&mut store, 1, Ref::Func(None))
                 .await
                 .map_err(|e| e.to_string())
                 .unwrap_err(),
@@ -226,14 +226,14 @@ fn test_limits_memory_only() -> Result<()> {
         instance.get_table(&mut store, "t").unwrap(),
         Table::new(
             &mut store,
-            TableType::new(ValType::FuncRef, 0, None),
-            Val::FuncRef(None),
+            TableType::new(RefType::FUNCREF, 0, None),
+            Ref::Func(None),
         )?,
     ]) {
-        table.grow(&mut store, 2, Val::FuncRef(None))?;
-        table.grow(&mut store, 1, Val::FuncRef(None))?;
-        table.grow(&mut store, 2, Val::FuncRef(None))?;
-        table.grow(&mut store, 1, Val::FuncRef(None))?;
+        table.grow(&mut store, 2, Ref::Func(None))?;
+        table.grow(&mut store, 1, Ref::Func(None))?;
+        table.grow(&mut store, 2, Ref::Func(None))?;
+        table.grow(&mut store, 1, Ref::Func(None))?;
     }
 
     Ok(())
@@ -300,17 +300,17 @@ fn test_limits_table_only() -> Result<()> {
         instance.get_table(&mut store, "t").unwrap(),
         Table::new(
             &mut store,
-            TableType::new(ValType::FuncRef, 0, None),
-            Val::FuncRef(None),
+            TableType::new(RefType::FUNCREF, 0, None),
+            Ref::Func(None),
         )?,
     ]) {
-        table.grow(&mut store, 2, Val::FuncRef(None))?;
-        table.grow(&mut store, 1, Val::FuncRef(None))?;
-        table.grow(&mut store, 2, Val::FuncRef(None))?;
+        table.grow(&mut store, 2, Ref::Func(None))?;
+        table.grow(&mut store, 1, Ref::Func(None))?;
+        table.grow(&mut store, 2, Ref::Func(None))?;
 
         assert_eq!(
             table
-                .grow(&mut store, 1, Val::FuncRef(None))
+                .grow(&mut store, 1, Ref::Func(None))
                 .map_err(|e| e.to_string())
                 .unwrap_err(),
             "failed to grow table by `1`"
@@ -338,8 +338,8 @@ fn test_initial_table_limits_exceeded() -> Result<()> {
 
     match Table::new(
         &mut store,
-        TableType::new(ValType::FuncRef, 99, None),
-        Val::FuncRef(None),
+        TableType::new(RefType::FUNCREF, 99, None),
+        Ref::Func(None),
     ) {
         Ok(_) => unreachable!(),
         Err(e) => assert_eq!(
@@ -675,9 +675,9 @@ fn test_custom_table_limiter() -> Result<()> {
     let table = instance.get_table(&mut store, "t").unwrap();
 
     // Grow the table by 10 elements
-    table.grow(&mut store, 3, Val::FuncRef(None))?;
-    table.grow(&mut store, 5, Val::FuncRef(None))?;
-    table.grow(&mut store, 2, Val::FuncRef(None))?;
+    table.grow(&mut store, 3, Ref::Func(None))?;
+    table.grow(&mut store, 5, Ref::Func(None))?;
+    table.grow(&mut store, 2, Ref::Func(None))?;
 
     assert!(!store.data().limit_exceeded);
 
@@ -687,7 +687,7 @@ fn test_custom_table_limiter() -> Result<()> {
     // Try to grow the memory again
     assert_eq!(
         table
-            .grow(&mut store, 1, Val::FuncRef(None))
+            .grow(&mut store, 1, Ref::Func(None))
             .map_err(|e| e.to_string())
             .unwrap_err(),
         "failed to grow table by `1`"
@@ -785,7 +785,7 @@ fn custom_limiter_detect_grow_failure() -> Result<()> {
 
     let table = instance.get_table(&mut store, "t").unwrap();
     // Grow the table 10 elements
-    table.grow(&mut store, 10, Val::FuncRef(None))?;
+    table.grow(&mut store, 10, Ref::Func(None))?;
 
     assert!(store.data().table_error.is_none());
     assert_eq!(store.data().table_current, 0);
@@ -795,7 +795,7 @@ fn custom_limiter_detect_grow_failure() -> Result<()> {
     // The ResourceLimiter will permit this, but the grow will fail.
     assert_eq!(
         table
-            .grow(&mut store, 1, Val::FuncRef(None))
+            .grow(&mut store, 1, Ref::Func(None))
             .unwrap_err()
             .to_string(),
         "failed to grow table by `1`"
@@ -901,7 +901,7 @@ async fn custom_limiter_async_detect_grow_failure() -> Result<()> {
 
     let table = instance.get_table(&mut store, "t").unwrap();
     // Grow the table 10 elements
-    table.grow_async(&mut store, 10, Val::FuncRef(None)).await?;
+    table.grow_async(&mut store, 10, Ref::Func(None)).await?;
 
     assert!(store.data().table_error.is_none());
     assert_eq!(store.data().table_current, 0);
@@ -911,7 +911,7 @@ async fn custom_limiter_async_detect_grow_failure() -> Result<()> {
     // The ResourceLimiter will permit this, but the grow will fail.
     assert_eq!(
         table
-            .grow_async(&mut store, 1, Val::FuncRef(None))
+            .grow_async(&mut store, 1, Ref::Func(None))
             .await
             .unwrap_err()
             .to_string(),
@@ -1031,7 +1031,7 @@ fn panic_in_table_limiter() {
     let table = instance.get_table(&mut store, "t").unwrap();
 
     // Grow the table, which should panic
-    table.grow(&mut store, 3, Val::FuncRef(None)).unwrap();
+    table.grow(&mut store, 3, Ref::Func(None)).unwrap();
 }
 
 #[tokio::test]
@@ -1104,7 +1104,7 @@ async fn panic_in_async_table_limiter() {
 
     // Grow the table, which should panic
     table
-        .grow_async(&mut store, 3, Val::FuncRef(None))
+        .grow_async(&mut store, 3, Ref::Func(None))
         .await
         .unwrap();
 }
@@ -1149,12 +1149,12 @@ fn growth_trap() -> Result<()> {
         instance.get_table(&mut store, "t").unwrap(),
         Table::new(
             &mut store,
-            TableType::new(ValType::FuncRef, 0, None),
-            Val::FuncRef(None),
+            TableType::new(RefType::FUNCREF, 0, None),
+            Ref::Func(None),
         )?,
     ] {
-        table.grow(&mut store, 1, Val::FuncRef(None))?;
-        assert!(table.grow(&mut store, 1, Val::FuncRef(None)).is_err());
+        table.grow(&mut store, 1, Ref::Func(None))?;
+        assert!(table.grow(&mut store, 1, Ref::Func(None)).is_err());
     }
 
     let mut store = Store::new(&engine, store.data().clone());

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -523,6 +523,7 @@ fn linker_instantiate_with_concrete_func_refs() -> Result<()> {
 #[cfg_attr(miri, ignore)]
 fn linker_defines_func_subtype() -> Result<()> {
     let mut config = Config::new();
+    config.wasm_function_references(true);
     config.wasm_gc(true);
     let engine = Engine::new(&config)?;
 
@@ -604,6 +605,7 @@ fn linker_defines_global_subtype_const_ok() -> Result<()> {
 #[cfg_attr(miri, ignore)]
 fn linker_defines_global_subtype_const_err() -> Result<()> {
     let mut config = Config::new();
+    config.wasm_function_references(true);
     config.wasm_gc(true);
     let engine = Engine::new(&config)?;
     let mut store = Store::new(&engine, ());

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -730,18 +730,5 @@ fn linker_defines_table_subtype_err() -> Result<()> {
     let e = linker.instantiate(&mut store, &module).unwrap_err();
     assert_eq!(e.to_string(), "incompatible import type for `env::t`");
 
-    // Not mutable.
-    let mut linker = Linker::new(&engine);
-    let nop = FuncType::new(&engine, None, None);
-    let ref_null_nop = RefType::new(true, HeapType::Concrete(nop));
-    let t = Table::new(
-        &mut store,
-        TableType::new(ref_null_nop, 0, None),
-        Ref::Func(None),
-    )?;
-    linker.define(&store, "env", "t", t)?;
-    let e = linker.instantiate(&mut store, &module).unwrap_err();
-    assert_eq!(e.to_string(), "incompatible import type for `env::t`");
-
     Ok(())
 }

--- a/tests/all/linker.rs
+++ b/tests/all/linker.rs
@@ -79,12 +79,12 @@ fn link_twice_bad() -> Result<()> {
     assert!(linker.define(&mut store, "m", "", memory.clone()).is_err());
 
     // tables
-    let ty = TableType::new(ValType::FuncRef, 1, None);
-    let table = Table::new(&mut store, ty, Val::FuncRef(None))?;
+    let ty = TableType::new(RefType::FUNCREF, 1, None);
+    let table = Table::new(&mut store, ty, Ref::Func(None))?;
     linker.define(&mut store, "t", "", table.clone())?;
     assert!(linker.define(&mut store, "t", "", table.clone()).is_err());
-    let ty = TableType::new(ValType::FuncRef, 2, None);
-    let table = Table::new(&mut store, ty, Val::FuncRef(None))?;
+    let ty = TableType::new(RefType::FUNCREF, 2, None);
+    let table = Table::new(&mut store, ty, Ref::Func(None))?;
     assert!(linker.define(&mut store, "t", "", table.clone()).is_err());
     Ok(())
 }
@@ -433,6 +433,313 @@ fn test_default_value_unknown_import() -> Result<()> {
     assert_eq!(results[0].i64(), Some(0));
     assert_eq!(results[1].f32(), Some(0.0));
     assert!(results[2].externref().unwrap().is_none());
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn linker_instantiate_with_concrete_func_refs() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    let engine = Engine::new(&config)?;
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (type $a (func (result i32)))
+                (type $b (func (result (ref null $a))))
+                (type $c (func (result (ref null $b))))
+
+                (import "env" "f" (func $f (result (ref null $c))))
+
+                (func (export "g") (result funcref)
+                    call $f
+                )
+            )
+        "#,
+    )?;
+
+    let a = FuncType::new(&engine, None, Some(ValType::I32));
+    let ref_null_a = ValType::from(RefType::new(true, HeapType::Concrete(a.clone())));
+
+    let b = FuncType::new(&engine, None, Some(ref_null_a));
+    let ref_null_b = ValType::from(RefType::new(true, HeapType::Concrete(b.clone())));
+
+    let c = FuncType::new(&engine, None, Some(ref_null_b));
+    let ref_null_c = ValType::from(RefType::new(true, HeapType::Concrete(c.clone())));
+
+    let mut store = Store::new(&engine, ());
+    let a_func = Func::new(&mut store, a, |_caller, _args, results| {
+        results[0] = Val::I32(0x1234_5678);
+        Ok(())
+    });
+
+    let b_func = Func::new(&mut store, b, move |_caller, _args, results| {
+        results[0] = Val::FuncRef(Some(a_func.clone()));
+        Ok(())
+    });
+
+    let c_func = Func::new(&mut store, c, move |_caller, _args, results| {
+        results[0] = Val::FuncRef(Some(b_func.clone()));
+        Ok(())
+    });
+
+    let mut linker = Linker::new(&engine);
+    linker.func_new(
+        "env",
+        "f",
+        FuncType::new(&engine, None, Some(ref_null_c)),
+        move |_caller, _args, results| {
+            results[0] = Val::FuncRef(Some(c_func.clone()));
+            Ok(())
+        },
+    )?;
+
+    let instance = linker.instantiate(&mut store, &module)?;
+
+    let g = instance.get_typed_func::<(), Option<Func>>(&mut store, "g")?;
+
+    let c = g.call(&mut store, ())?;
+    let c = c.expect("func ref c is non null");
+    let c = c.typed::<(), Option<Func>>(&mut store)?;
+
+    let b = c.call(&mut store, ())?;
+    let b = b.expect("func ref b is non null");
+    let b = b.typed::<(), Option<Func>>(&mut store)?;
+
+    let a = b.call(&mut store, ())?;
+    let a = a.expect("func ref a is non null");
+    let a = a.typed::<(), u32>(&mut store)?;
+
+    let x = a.call(&mut store, ())?;
+    assert_eq!(x, 0x1234_5678);
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn linker_defines_func_subtype() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_gc(true);
+    let engine = Engine::new(&config)?;
+
+    let mut linker = Linker::new(&engine);
+    linker.func_new(
+        "env",
+        "f",
+        FuncType::new(&engine, Some(ValType::FUNCREF), None),
+        |_caller, _args, _results| Ok(()),
+    )?;
+    linker.func_new(
+        "env",
+        "g",
+        FuncType::new(&engine, None, Some(ValType::NULLFUNCREF)),
+        |_caller, _args, _results| Ok(()),
+    )?;
+    let nop_ty = FuncType::new(&engine, None, None);
+    let ref_null_nop = ValType::from(RefType::new(true, HeapType::Concrete(nop_ty)));
+    linker.func_new(
+        "env",
+        "h",
+        FuncType::new(&engine, Some(ref_null_nop.clone()), Some(ref_null_nop)),
+        |_caller, _args, _results| Ok(()),
+    )?;
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                ;; wasm's declared nullfuncref <: f's actual funcref
+                (import "env" "f" (func (param nullfuncref)))
+
+                ;; g's actual nullfuncref <: wasm's declared funcref
+                (import "env" "g" (func (result funcref)))
+
+                ;; wasm's declared nullfuncref param <: h's actual (ref null $nop) param, and
+                ;; h's actual (ref null $nop) result <: wasm's declared funcref result
+                (import "env" "h" (func (param nullfuncref) (result funcref)))
+            )
+        "#,
+    )?;
+
+    let mut store = Store::new(&engine, ());
+    let _ = linker.instantiate(&mut store, &module)?;
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn linker_defines_global_subtype_const_ok() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+    let mut linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (import "env" "g" (global funcref))
+            )
+        "#,
+    )?;
+
+    let g = Global::new(
+        &mut store,
+        GlobalType::new(ValType::NULLFUNCREF, Mutability::Const),
+        Val::FuncRef(None),
+    )?;
+    linker.define(&store, "env", "g", g)?;
+
+    let _ = linker.instantiate(&mut store, &module)?;
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn linker_defines_global_subtype_const_err() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_gc(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+    let mut linker = Linker::new(&engine);
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (import "env" "g" (global nullfuncref))
+            )
+        "#,
+    )?;
+
+    // funcref </: nullfuncref
+    let g = Global::new(
+        &mut store,
+        GlobalType::new(ValType::FUNCREF, Mutability::Const),
+        Val::FuncRef(None),
+    )?;
+    linker.define(&store, "env", "g", g)?;
+
+    let e = linker.instantiate(&mut store, &module).unwrap_err();
+    assert_eq!(e.to_string(), "incompatible import type for `env::g`");
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn linker_defines_global_subtype_mut_err() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (type $nop (func))
+                (import "env" "g" (global (mut (ref null $nop))))
+            )
+        "#,
+    )?;
+
+    // Supertype, not precise type.
+    let mut linker = Linker::new(&engine);
+    let g = Global::new(
+        &mut store,
+        GlobalType::new(ValType::FUNCREF, Mutability::Var),
+        Val::FuncRef(None),
+    )?;
+    linker.define(&store, "env", "g", g)?;
+    let e = linker.instantiate(&mut store, &module).unwrap_err();
+    assert_eq!(e.to_string(), "incompatible import type for `env::g`");
+
+    // Subtype, not precise type.
+    let mut linker = Linker::new(&engine);
+    let g = Global::new(
+        &mut store,
+        GlobalType::new(ValType::NULLFUNCREF, Mutability::Var),
+        Val::FuncRef(None),
+    )?;
+    linker.define(&store, "env", "g", g)?;
+    let e = linker.instantiate(&mut store, &module).unwrap_err();
+    assert_eq!(e.to_string(), "incompatible import type for `env::g`");
+
+    // Not mutable.
+    let mut linker = Linker::new(&engine);
+    let nop = FuncType::new(&engine, None, None);
+    let ref_null_nop = ValType::from(RefType::new(true, HeapType::Concrete(nop)));
+    let g = Global::new(
+        &mut store,
+        GlobalType::new(ref_null_nop, Mutability::Const),
+        Val::FuncRef(None),
+    )?;
+    linker.define(&store, "env", "g", g)?;
+    let e = linker.instantiate(&mut store, &module).unwrap_err();
+    assert_eq!(e.to_string(), "incompatible import type for `env::g`");
+
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn linker_defines_table_subtype_err() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (type $nop (func))
+                (import "env" "t" (table 0 (ref null $nop)))
+            )
+        "#,
+    )?;
+
+    // Supertype, not precise type.
+    let mut linker = Linker::new(&engine);
+    let t = Table::new(
+        &mut store,
+        TableType::new(RefType::FUNCREF, 0, None),
+        Ref::Func(None),
+    )?;
+    linker.define(&store, "env", "t", t)?;
+    let e = linker.instantiate(&mut store, &module).unwrap_err();
+    assert_eq!(e.to_string(), "incompatible import type for `env::t`");
+
+    // Subtype, not precise type.
+    let mut linker = Linker::new(&engine);
+    let t = Table::new(
+        &mut store,
+        TableType::new(RefType::NULLFUNCREF, 0, None),
+        Ref::Func(None),
+    )?;
+    linker.define(&store, "env", "t", t)?;
+    let e = linker.instantiate(&mut store, &module).unwrap_err();
+    assert_eq!(e.to_string(), "incompatible import type for `env::t`");
+
+    // Not mutable.
+    let mut linker = Linker::new(&engine);
+    let nop = FuncType::new(&engine, None, None);
+    let ref_null_nop = RefType::new(true, HeapType::Concrete(nop));
+    let t = Table::new(
+        &mut store,
+        TableType::new(ref_null_nop, 0, None),
+        Ref::Func(None),
+    )?;
+    linker.define(&store, "env", "t", t)?;
+    let e = linker.instantiate(&mut store, &module).unwrap_err();
+    assert_eq!(e.to_string(), "incompatible import type for `env::t`");
 
     Ok(())
 }

--- a/tests/all/pooling_allocator.rs
+++ b/tests/all/pooling_allocator.rs
@@ -304,14 +304,14 @@ fn table_limit() -> Result<()> {
         assert_eq!(table.size(&store), i);
         assert_eq!(
             table
-                .grow(&mut store, 1, Val::FuncRef(None))
+                .grow(&mut store, 1, Ref::Func(None))
                 .expect("table should grow"),
             i
         );
     }
 
     assert_eq!(table.size(&store), TABLE_ELEMENTS);
-    assert!(table.grow(&mut store, 1, Val::FuncRef(None)).is_err());
+    assert!(table.grow(&mut store, 1, Ref::Func(None)).is_err());
 
     Ok(())
 }
@@ -349,7 +349,7 @@ fn table_init() -> Result<()> {
     for i in 0..5 {
         let v = table.get(&mut store, i).expect("table should have entry");
         let f = v
-            .funcref()
+            .as_func()
             .expect("expected funcref")
             .expect("expected non-null value");
         assert_eq!(f.ty(&store).params().len(), i as usize);
@@ -359,7 +359,7 @@ fn table_init() -> Result<()> {
         table
             .get(&mut store, 5)
             .expect("table should have entry")
-            .funcref()
+            .as_func()
             .expect("expected funcref")
             .is_none(),
         "funcref should be null"
@@ -396,11 +396,11 @@ fn table_zeroed() -> Result<()> {
 
         for i in 0..10 {
             match table.get(&mut store, i).unwrap() {
-                Val::FuncRef(r) => assert!(r.is_none()),
+                Ref::Func(r) => assert!(r.is_none()),
                 _ => panic!("expected a funcref"),
             }
             table
-                .set(&mut store, i, Val::FuncRef(Some(f.clone())))
+                .set(&mut store, i, Ref::Func(Some(f.clone())))
                 .unwrap();
         }
     }

--- a/tests/all/table.rs
+++ b/tests/all/table.rs
@@ -4,10 +4,10 @@ use wasmtime::*;
 #[test]
 fn get_none() {
     let mut store = Store::<()>::default();
-    let ty = TableType::new(ValType::FuncRef, 1, None);
-    let table = Table::new(&mut store, ty, Val::FuncRef(None)).unwrap();
+    let ty = TableType::new(RefType::FUNCREF, 1, None);
+    let table = Table::new(&mut store, ty, Ref::Func(None)).unwrap();
     match table.get(&mut store, 0) {
-        Some(Val::FuncRef(None)) => {}
+        Some(Ref::Func(None)) => {}
         _ => panic!(),
     }
     assert!(table.get(&mut store, 1).is_none());
@@ -16,21 +16,21 @@ fn get_none() {
 #[test]
 fn fill_wrong() {
     let mut store = Store::<()>::default();
-    let ty = TableType::new(ValType::FuncRef, 1, None);
-    let table = Table::new(&mut store, ty, Val::FuncRef(None)).unwrap();
+    let ty = TableType::new(RefType::FUNCREF, 1, None);
+    let table = Table::new(&mut store, ty, Ref::Func(None)).unwrap();
     assert_eq!(
         table
-            .fill(&mut store, 0, Val::ExternRef(None), 1)
+            .fill(&mut store, 0, Ref::Extern(None), 1)
             .map_err(|e| e.to_string())
             .unwrap_err(),
         "value does not match table element type"
     );
 
-    let ty = TableType::new(ValType::ExternRef, 1, None);
-    let table = Table::new(&mut store, ty, Val::ExternRef(None)).unwrap();
+    let ty = TableType::new(RefType::EXTERNREF, 1, None);
+    let table = Table::new(&mut store, ty, Ref::Extern(None)).unwrap();
     assert_eq!(
         table
-            .fill(&mut store, 0, Val::FuncRef(None), 1)
+            .fill(&mut store, 0, Ref::Func(None), 1)
             .map_err(|e| e.to_string())
             .unwrap_err(),
         "value does not match table element type"
@@ -40,10 +40,10 @@ fn fill_wrong() {
 #[test]
 fn copy_wrong() {
     let mut store = Store::<()>::default();
-    let ty = TableType::new(ValType::FuncRef, 1, None);
-    let table1 = Table::new(&mut store, ty, Val::FuncRef(None)).unwrap();
-    let ty = TableType::new(ValType::ExternRef, 1, None);
-    let table2 = Table::new(&mut store, ty, Val::ExternRef(None)).unwrap();
+    let ty = TableType::new(RefType::FUNCREF, 1, None);
+    let table1 = Table::new(&mut store, ty, Ref::Func(None)).unwrap();
+    let ty = TableType::new(RefType::EXTERNREF, 1, None);
+    let table2 = Table::new(&mut store, ty, Ref::Extern(None)).unwrap();
     assert_eq!(
         Table::copy(&mut store, &table1, 0, &table2, 0, 1)
             .map_err(|e| e.to_string())
@@ -56,8 +56,8 @@ fn copy_wrong() {
 #[cfg_attr(miri, ignore)]
 fn null_elem_segment_works_with_imported_table() -> Result<()> {
     let mut store = Store::<()>::default();
-    let ty = TableType::new(ValType::FuncRef, 1, None);
-    let table = Table::new(&mut store, ty, Val::FuncRef(None))?;
+    let ty = TableType::new(RefType::FUNCREF, 1, None);
+    let table = Table::new(&mut store, ty, Ref::Func(None))?;
     let module = Module::new(
         store.engine(),
         r#"

--- a/tests/all/table.rs
+++ b/tests/all/table.rs
@@ -23,7 +23,7 @@ fn fill_wrong() {
             .fill(&mut store, 0, Ref::Extern(None), 1)
             .map_err(|e| e.to_string())
             .unwrap_err(),
-        "value does not match table element type"
+        "type mismatch: value does not match table element type"
     );
 
     let ty = TableType::new(RefType::EXTERNREF, 1, None);
@@ -33,7 +33,7 @@ fn fill_wrong() {
             .fill(&mut store, 0, Ref::Func(None), 1)
             .map_err(|e| e.to_string())
             .unwrap_err(),
-        "value does not match table element type"
+        "type mismatch: value does not match table element type"
     );
 }
 
@@ -48,7 +48,7 @@ fn copy_wrong() {
         Table::copy(&mut store, &table1, 0, &table2, 0, 1)
             .map_err(|e| e.to_string())
             .unwrap_err(),
-        "tables do not have the same element type"
+        "type mismatch: source table's element type does not match destination table's element type"
     );
 }
 

--- a/tests/all/traps.rs
+++ b/tests/all/traps.rs
@@ -531,12 +531,10 @@ fn mismatched_arguments() -> Result<()> {
         func.call(&mut store, &[], &mut []).unwrap_err().to_string(),
         "expected 1 arguments, got 0"
     );
-    assert_eq!(
-        func.call(&mut store, &[Val::F32(0)], &mut [])
-            .unwrap_err()
-            .to_string(),
-        "argument type mismatch: found f32 but expected i32",
-    );
+    let e = func.call(&mut store, &[Val::F32(0)], &mut []).unwrap_err();
+    let e = format!("{e:?}");
+    assert!(e.contains("argument type mismatch"));
+    assert!(e.contains("expected i32, found f32"));
     assert_eq!(
         func.call(&mut store, &[Val::I32(0), Val::I32(1)], &mut [])
             .unwrap_err()

--- a/tests/all/winch.rs
+++ b/tests/all/winch.rs
@@ -86,7 +86,7 @@ fn array_to_wasm() -> Result<()> {
     let constant = instance
         .get_func(&mut store, "42")
         .ok_or(anyhow::anyhow!("test function not found"))?;
-    let mut returns = vec![Val::null(); 1];
+    let mut returns = vec![Val::null_func_ref(); 1];
     constant.call(&mut store, &[], &mut returns)?;
 
     assert_eq!(returns.len(), 1);
@@ -95,7 +95,7 @@ fn array_to_wasm() -> Result<()> {
     let sum = instance
         .get_func(&mut store, "sum10")
         .ok_or(anyhow::anyhow!("sum10 function not found"))?;
-    let mut returns = vec![Val::null(); 1];
+    let mut returns = vec![Val::null_func_ref(); 1];
     let args = vec![Val::I32(1); 10];
     sum.call(&mut store, &args, &mut returns)?;
 


### PR DESCRIPTION
While we supported the function references proposal inside Wasm, we didn't support it on the "outside" in the Wasmtime embedder APIs. So much of the work here is exposing typed function references, and their type system updates, in the embedder API. These changes include:

* `ValType::FuncRef` and `ValType::ExternRef` are gone, replaced with the introduction of the `RefType` and `HeapType` types and a `ValType::Ref(RefType)` variant.

* `ValType` and `FuncType` no longer implement `Eq` and `PartialEq`. Instead there are `ValType::matches` and `FuncType::matches` methods which check directional subtyping. I also added `ValType::eq` and `FuncType::eq` static methods for the rare case where someone needs to check precise equality, but that is almost never actually the case, 99.99% of the time you want to check subtyping.

* There are also public `Val::matches_ty` predicates for checking if a value is an instance of a type, as well as internal helpers like `Val::ensure_matches_ty` that return a formatted error if the value does not match the given type. These helpers are used throughout Wasmtime internals now.

* There is now a dedicated `wasmtime::Ref` type that represents reference values. Table operations have been updated to take and return `Ref`s rather than `Val`s.

Furthermore, this commit also includes type registry changes to correctly manage lifetimes of types that reference other types. This wasn't previously an issue because the only thing that could reference types that reference other types was a Wasm module that added all the types that could reference each other at the same time and removed them all at the same time. But now that the previously discussed work to expose these things in the embedder API is done, type lifetime management in the registry becomes a little trickier because the embedder might grab a reference to a type that references another type, and then unload the Wasm module that originally defined that type, but then the user should still be able use that type and the other types it transtively references. Before, we were refcounting individual registry entries. Now, we still are refcounting individual entries, but now we are also accounting for type-to-type references and adding a new type to the registry will increment the refcounts of each of the types that it references, and removing a type from the registry will decrement the refcounts of each of the types it references, and then recursively (logically, not literally) remove any types whose refcount has now reached zero.

Additionally, this PR adds support for subtyping to `Func::typed`- and `Func::wrap`-style APIs. For result types, you can always use a supertype of the WebAssembly function's actual declared return type in `Func::typed`. And for param types, you can always use a subtype of the Wasm function's actual declared param type. Doing these things essentially erases information but is always correct. But additionally, for functions which take a reference to a concrete type as a parameter, you can also use the concrete type's supertype. Consider a WebAssembly function that takes a reference to a function with a concrete type: `(ref null <func type index>)`. In this scenario, there is no static `wasmtime::Foo` Rust type that corresponds to that particular Wasm-defined concrete reference type because Wasm modules are loaded dynamically at runtime. You *could* do `f.typed::<Option<NoFunc>, ()>()`, and while that is correctly typed and valid, it is often overly restrictive. The only value you could call the resulting typed function with is the null function reference, but we'd like to call it with non-null function references that happen to be of the correct type. Therefore, `f.typed<Option<Func>, ()>()` is also allowed in this case, even though `Option<Func>` represents `(ref null func)` which is the supertype, not subtype, of `(ref null <func type index>)`. This does imply some minimal dynamic type checks in this case, but it is supported for better ergonomics, to enable passing non-null references into the function.

We can investigate whether it is possible to use generic type parameters and combinators to define Rust types that precisely match concrete reference types in future, follow-up pull requests. But for now, we've made things usable, at least.

Finally, this also takes the first baby step towards adding support for the Wasm GC proposal. Right now the only thing that is supported is `nofunc` references, and this was mainly to make testing function reference subtyping easier. But that does mean that supporting `nofunc` references entailed also adding a `wasmtime::NoFunc` type as well as the `Config::wasm_gc(enabled)` knob. So we officially have an in-progress implementation of Wasm GC in Wasmtime after this PR lands!

Fixes https://github.com/bytecodealliance/wasmtime/issues/6455

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
