### PR TITLE
winch: Move the stack overflow check to the function prologue

### DIFF
--- a/cranelift/codegen/src/isa/x64/encoding/rex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/rex.rs
@@ -67,28 +67,31 @@ pub(crate) fn reg_enc(reg: impl Into<Reg>) -> u8 {
 /// - bit 1 set to 1 indicates the REX prefix must always be emitted.
 #[repr(transparent)]
 #[derive(Clone, Copy)]
-pub(crate) struct RexFlags(u8);
+pub struct RexFlags(u8);
 
 impl RexFlags {
     /// By default, set the W field, and don't always emit.
     #[inline(always)]
-    pub(crate) fn set_w() -> Self {
+    pub fn set_w() -> Self {
         Self(0)
     }
+
     /// Creates a new RexPrefix for which the REX.W bit will be cleared.
     #[inline(always)]
-    pub(crate) fn clear_w() -> Self {
+    pub fn clear_w() -> Self {
         Self(1)
     }
 
+    /// Require that the REX prefix is emitted.
     #[inline(always)]
-    pub(crate) fn always_emit(&mut self) -> &mut Self {
+    pub fn always_emit(&mut self) -> &mut Self {
         self.0 = self.0 | 2;
         self
     }
 
+    /// Emit the rex prefix if the referenced register would require it for 8-bit operations.
     #[inline(always)]
-    pub(crate) fn always_emit_if_8bit_needed(&mut self, reg: Reg) -> &mut Self {
+    pub fn always_emit_if_8bit_needed(&mut self, reg: Reg) -> &mut Self {
         let enc_reg = int_reg_enc(reg);
         if enc_reg >= 4 && enc_reg <= 7 {
             self.always_emit();
@@ -96,17 +99,21 @@ impl RexFlags {
         self
     }
 
+    /// True if 64-bit operands are used.
     #[inline(always)]
-    pub(crate) fn must_clear_w(&self) -> bool {
+    pub fn must_clear_w(&self) -> bool {
         (self.0 & 1) != 0
     }
+
+    /// True if the REX prefix must always be emitted.
     #[inline(always)]
-    pub(crate) fn must_always_emit(&self) -> bool {
+    pub fn must_always_emit(&self) -> bool {
         (self.0 & 2) != 0
     }
 
+    /// Emit a unary instruction.
     #[inline(always)]
-    pub(crate) fn emit_one_op(&self, sink: &mut MachBuffer<Inst>, enc_e: u8) {
+    pub fn emit_one_op(&self, sink: &mut MachBuffer<Inst>, enc_e: u8) {
         // Register Operand coded in Opcode Byte
         // REX.R and REX.X unused
         // REX.B == 1 accesses r8-r15
@@ -120,8 +127,9 @@ impl RexFlags {
         }
     }
 
+    /// Emit a binary instruction.
     #[inline(always)]
-    pub(crate) fn emit_two_op(&self, sink: &mut MachBuffer<Inst>, enc_g: u8, enc_e: u8) {
+    pub fn emit_two_op(&self, sink: &mut MachBuffer<Inst>, enc_g: u8, enc_e: u8) {
         let w = if self.must_clear_w() { 0 } else { 1 };
         let r = (enc_g >> 3) & 1;
         let x = 0;
@@ -132,6 +140,7 @@ impl RexFlags {
         }
     }
 
+    /// Emit a ternary instruction.
     #[inline(always)]
     pub fn emit_three_op(
         &self,

--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -55,7 +55,7 @@ pub mod write;
 pub use crate::entity::packed_option;
 pub use crate::machinst::buffer::{
     FinalizedMachReloc, FinalizedRelocTarget, MachCallSite, MachSrcLoc, MachStackMap,
-    MachTextSectionBuilder, MachTrap,
+    MachTextSectionBuilder, MachTrap, OpenPatchRegion, PatchRegion,
 };
 pub use crate::machinst::{
     CompiledCode, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit,

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -542,11 +542,12 @@ impl<I: VCodeInst> MachBuffer<I> {
         // Post-invariant: as for `put1()`.
     }
 
-    /// Begin a region of patchable code. There are some requirements for the
-    /// code that is emitted:
-    ///
-    /// 1. It must not introduce any instructions that could be chomped
-    ///    (branches are an example of this)
+    /// Begin a region of patchable code. There is one requirement for the
+    /// code that is emitted: It must not introduce any instructions that
+    /// could be chomped (branches are an example of this). In other words,
+    /// you must not call [`MachBuffer::add_cond_branch`] or
+    /// [`MachBuffer::add_uncond_branch`] between calls to this method and
+    /// [`MachBuffer::end_patchable`].
     pub fn start_patchable(&mut self) -> OpenPatchRegion {
         assert!(!self.open_patchable, "Patchable regions may not be nested");
         self.open_patchable = true;
@@ -554,11 +555,11 @@ impl<I: VCodeInst> MachBuffer<I> {
     }
 
     /// End a region of patchable code, yielding a [`PatchRegion`] value that
-    /// can be consumed later to produce a one-off mutable slice to the associated
-    /// region of the data buffer.
+    /// can be consumed later to produce a one-off mutable slice to the
+    /// associated region of the data buffer.
     pub fn end_patchable(&mut self, open: OpenPatchRegion) -> PatchRegion {
-        // No need to assert the state of `open_patchable` here, as we take ownership
-        // of the only `OpenPatchable` value.
+        // No need to assert the state of `open_patchable` here, as we take
+        // ownership of the only `OpenPatchable` value.
         self.open_patchable = false;
         let end = usize::try_from(self.cur_offset()).unwrap();
         PatchRegion { range: open.0..end }

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -41,7 +41,7 @@ pub(crate) struct MacroAssembler {
     sp_offset: u32,
     /// This value represents the maximum stack size seen while compiling the function. While the
     /// function is still being compiled its value will not be valid (the stack will grow and
-    /// shrink as space is reserved and freed during compilstion), but once all instructions have
+    /// shrink as space is reserved and freed during compilation), but once all instructions have
     /// been seen this value will be the maximum stack usage seen.
     sp_max: u32,
     /// Add instructions that are used to add the constant stack max to a register.

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -39,7 +39,10 @@ use wasmtime_environ::{PtrSize, WasmValType, WASM_PAGE_SIZE};
 pub(crate) struct MacroAssembler {
     /// Stack pointer offset.
     sp_offset: u32,
-    /// Stack high-water mark.
+    /// This value represents the maximum stack size seen while compiling the function. While the
+    /// function is still being compiled its value will not be valid (the stack will grow and
+    /// shrink as space is reserved and freed during compilstion), but once all instructions have
+    /// been seen this value will be the maximum stack usage seen.
     sp_max: u32,
     /// Add instructions that are used to add the constant stack max to a register.
     stack_max_use_add: Option<PatchableAddToReg>,
@@ -1193,6 +1196,10 @@ impl MacroAssembler {
 
     fn increment_sp(&mut self, bytes: u32) {
         self.sp_offset += bytes;
+
+        // NOTE: we use `max` here to track the largest stack allocation in `sp_max`. Once we have
+        // seen the entire function, this value will represent the maximum size for the stack
+        // frame.
         self.sp_max = self.sp_max.max(self.sp_offset);
     }
 

--- a/winch/codegen/src/trampoline.rs
+++ b/winch/codegen/src/trampoline.rs
@@ -694,6 +694,7 @@ where
     /// The trampoline's prologue.
     fn prologue(&mut self) {
         self.masm.prologue();
+        // TODO: emit a stack check
         self.masm.save_clobbers(&[]);
     }
 
@@ -701,6 +702,7 @@ where
     /// callee-saved registers.
     fn prologue_with_callee_saved(&mut self) {
         self.masm.prologue();
+        // TODO: emit a stack check
         // Save any callee-saved registers.
         self.masm.save_clobbers(&self.callee_saved_regs);
     }

--- a/winch/filetests/filetests/x64/block/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/block/as_if_cond.wat
@@ -9,32 +9,34 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840d000000         	je	0x36
-;;   29:	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x32
+;;      	 0f840d000000         	je	0x3d
+;;   30:	 4883ec08             	sub	rsp, 8
+;;      	 e800000000           	call	0x39
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/block/as_if_else.wat
+++ b/winch/filetests/filetests/x64/block/as_if_else.wat
@@ -6,19 +6,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x33
-;;   29:	 b802000000           	mov	eax, 2
-;;      	 e905000000           	jmp	0x38
-;;   33:	 b801000000           	mov	eax, 1
+;;      	 0f840a000000         	je	0x3a
+;;   30:	 b802000000           	mov	eax, 2
+;;      	 e905000000           	jmp	0x3f
+;;   3a:	 b801000000           	mov	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
+;;   45:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/block/as_if_then.wat
+++ b/winch/filetests/filetests/x64/block/as_if_then.wat
@@ -6,19 +6,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x33
-;;   29:	 b801000000           	mov	eax, 1
-;;      	 e905000000           	jmp	0x38
-;;   33:	 b802000000           	mov	eax, 2
+;;      	 0f840a000000         	je	0x3a
+;;   30:	 b801000000           	mov	eax, 1
+;;      	 e905000000           	jmp	0x3f
+;;   3a:	 b802000000           	mov	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
+;;   45:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/block/deep.wat
+++ b/winch/filetests/filetests/x64/block/deep.wat
@@ -46,30 +46,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b896000000           	mov	eax, 0x96
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/block/empty.wat
+++ b/winch/filetests/filetests/x64/block/empty.wat
@@ -10,26 +10,28 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/block/get_and_set.wat
+++ b/winch/filetests/filetests/x64/block/get_and_set.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
+;;   45:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/block/get_and_tee.wat
+++ b/winch/filetests/filetests/x64/block/get_and_tee.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
+;;   45:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/block/nested.wat
+++ b/winch/filetests/filetests/x64/block/nested.wat
@@ -11,33 +11,35 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x32
+;;      	 e800000000           	call	0x39
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b809000000           	mov	eax, 9
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/block/singular.wat
+++ b/winch/filetests/filetests/x64/block/singular.wat
@@ -8,14 +8,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b807000000           	mov	eax, 7
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/block/with_local_float.wat
+++ b/winch/filetests/filetests/x64/block/with_local_float.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f3440f107c240c       	movss	xmm15, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_block_first.wat
+++ b/winch/filetests/filetests/x64/br/as_block_first.wat
@@ -8,26 +8,28 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_block_last.wat
+++ b/winch/filetests/filetests/x64/br/as_block_last.wat
@@ -8,29 +8,31 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8717000000         	ja	0x2f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2f:	 0f0b                 	ud2	
+;;   36:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_block_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_block_mid.wat
@@ -8,29 +8,31 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8717000000         	ja	0x2f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2f:	 0f0b                 	ud2	
+;;   36:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_block_value.wat
+++ b/winch/filetests/filetests/x64/br/as_block_value.wat
@@ -8,30 +8,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/br/as_br_if_cond.wat
@@ -6,13 +6,14 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_br_value.wat
+++ b/winch/filetests/filetests/x64/br/as_br_value.wat
@@ -6,14 +6,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b809000000           	mov	eax, 9
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_call_all.wat
+++ b/winch/filetests/filetests/x64/br/as_call_all.wat
@@ -7,12 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -20,18 +21,19 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80f000000           	mov	eax, 0xf
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_call_first.wat
+++ b/winch/filetests/filetests/x64/br/as_call_first.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -23,18 +24,19 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80c000000           	mov	eax, 0xc
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_call_last.wat
+++ b/winch/filetests/filetests/x64/br/as_call_last.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -22,18 +23,19 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80e000000           	mov	eax, 0xe
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_call_mid.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -23,18 +24,19 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80d000000           	mov	eax, 0xd
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/br/as_if_cond.wat
@@ -11,14 +11,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_if_else.wat
+++ b/winch/filetests/filetests/x64/br/as_if_else.wat
@@ -11,21 +11,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8409000000         	je	0x39
-;;   30:	 8b442408             	mov	eax, dword ptr [rsp + 8]
-;;      	 e905000000           	jmp	0x3e
-;;   39:	 b804000000           	mov	eax, 4
+;;      	 0f8409000000         	je	0x40
+;;   37:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;      	 e905000000           	jmp	0x45
+;;   40:	 b804000000           	mov	eax, 4
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_if_then.wat
+++ b/winch/filetests/filetests/x64/br/as_if_then.wat
@@ -11,21 +11,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x3a
-;;   30:	 b803000000           	mov	eax, 3
-;;      	 e904000000           	jmp	0x3e
-;;   3a:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;      	 0f840a000000         	je	0x41
+;;   37:	 b803000000           	mov	eax, 3
+;;      	 e904000000           	jmp	0x45
+;;   41:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_loop_first.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_first.wat
@@ -7,14 +7,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b803000000           	mov	eax, 3
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_last.wat
@@ -9,30 +9,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b805000000           	mov	eax, 5
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/as_loop_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_mid.wat
@@ -10,30 +10,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b804000000           	mov	eax, 4
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br/br_jump.wat
+++ b/winch/filetests/filetests/x64/br/br_jump.wat
@@ -14,12 +14,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8736000000         	ja	0x4e
-;;   18:	 48c744240800000000   	
+;;      	 0f873a000000         	ja	0x55
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
@@ -29,8 +30,8 @@
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 44891c24             	mov	dword ptr [rsp], r11d
 ;;      	 4883c404             	add	rsp, 4
-;;      	 e9eaffffff           	jmp	0x32
-;;   48:	 4883c410             	add	rsp, 0x10
+;;      	 e9eaffffff           	jmp	0x39
+;;   4f:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4e:	 0f0b                 	ud2	
+;;   55:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_block_last.wat
+++ b/winch/filetests/filetests/x64/br_if/as_block_last.wat
@@ -7,32 +7,34 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 e800000000           	call	0x25
-;;      	 e800000000           	call	0x2a
+;;      	 e800000000           	call	0x2c
+;;      	 e800000000           	call	0x31
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8500000000         	jne	0x36
-;;   36:	 4883c410             	add	rsp, 0x10
+;;      	 0f8500000000         	jne	0x3d
+;;   3d:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_block_last_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_block_last_value.wat
@@ -9,33 +9,35 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 e800000000           	call	0x25
-;;      	 e800000000           	call	0x2a
+;;      	 e800000000           	call	0x2c
+;;      	 e800000000           	call	0x31
 ;;      	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;      	 b80b000000           	mov	eax, 0xb
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8500000000         	jne	0x3b
-;;   3b:	 4883c410             	add	rsp, 0x10
+;;      	 0f8500000000         	jne	0x42
+;;   42:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/br_if/as_br_if_cond.wat
@@ -6,19 +6,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f850d000000         	jne	0x36
-;;   29:	 b801000000           	mov	eax, 1
+;;      	 0f850d000000         	jne	0x3d
+;;   30:	 b801000000           	mov	eax, 1
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8500000000         	jne	0x36
-;;   36:	 4883c408             	add	rsp, 8
+;;      	 0f8500000000         	jne	0x3d
+;;   3d:	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_br_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_br_value.wat
@@ -6,17 +6,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b902000000           	mov	ecx, 2
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8500000000         	jne	0x2e
-;;   2e:	 4883c408             	add	rsp, 8
+;;      	 0f8500000000         	jne	0x35
+;;   35:	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_call_first.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_first.wat
@@ -11,12 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -24,30 +25,31 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b901000000           	mov	ecx, 1
 ;;      	 b80c000000           	mov	eax, 0xc
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8526000000         	jne	0x54
-;;   2e:	 4883ec04             	sub	rsp, 4
+;;      	 0f8526000000         	jne	0x5b
+;;   35:	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 8b7c2404             	mov	edi, dword ptr [rsp + 4]
 ;;      	 be02000000           	mov	esi, 2
 ;;      	 ba03000000           	mov	edx, 3
-;;      	 e800000000           	call	0x4c
+;;      	 e800000000           	call	0x53
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
+;;   61:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_call_last.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_last.wat
@@ -11,12 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -24,30 +25,31 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b901000000           	mov	ecx, 1
 ;;      	 b80e000000           	mov	eax, 0xe
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8526000000         	jne	0x54
-;;   2e:	 4883ec04             	sub	rsp, 4
+;;      	 0f8526000000         	jne	0x5b
+;;   35:	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 bf01000000           	mov	edi, 1
 ;;      	 be02000000           	mov	esi, 2
 ;;      	 8b542404             	mov	edx, dword ptr [rsp + 4]
-;;      	 e800000000           	call	0x4c
+;;      	 e800000000           	call	0x53
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
+;;   61:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_mid.wat
@@ -11,12 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -24,30 +25,31 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b901000000           	mov	ecx, 1
 ;;      	 b80d000000           	mov	eax, 0xd
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8526000000         	jne	0x54
-;;   2e:	 4883ec04             	sub	rsp, 4
+;;      	 0f8526000000         	jne	0x5b
+;;   35:	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 bf01000000           	mov	edi, 1
 ;;      	 8b742404             	mov	esi, dword ptr [rsp + 4]
 ;;      	 ba03000000           	mov	edx, 3
-;;      	 e800000000           	call	0x4c
+;;      	 e800000000           	call	0x53
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
+;;   61:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/br_if/as_if_cond.wat
@@ -12,23 +12,24 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8736000000         	ja	0x4e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f873a000000         	ja	0x55
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8517000000         	jne	0x48
-;;   31:	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x43
-;;   39:	 b802000000           	mov	eax, 2
-;;      	 e905000000           	jmp	0x48
-;;   43:	 b803000000           	mov	eax, 3
+;;      	 0f8517000000         	jne	0x4f
+;;   38:	 85c0                 	test	eax, eax
+;;      	 0f840a000000         	je	0x4a
+;;   40:	 b802000000           	mov	eax, 2
+;;      	 e905000000           	jmp	0x4f
+;;   4a:	 b803000000           	mov	eax, 3
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4e:	 0f0b                 	ud2	
+;;   55:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_if_else.wat
+++ b/winch/filetests/filetests/x64/br_if/as_if_else.wat
@@ -10,36 +10,38 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x4c
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x3a
-;;   30:	 e800000000           	call	0x35
-;;      	 e90c000000           	jmp	0x46
-;;   3a:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;      	 0f840a000000         	je	0x41
+;;   37:	 e800000000           	call	0x3c
+;;      	 e90c000000           	jmp	0x4d
+;;   41:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8500000000         	jne	0x46
-;;   46:	 4883c410             	add	rsp, 0x10
+;;      	 0f8500000000         	jne	0x4d
+;;   4d:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4c:	 0f0b                 	ud2	
+;;   53:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_if_then.wat
+++ b/winch/filetests/filetests/x64/br_if/as_if_then.wat
@@ -9,36 +9,38 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x4c
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8411000000         	je	0x41
-;;   30:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;      	 0f8411000000         	je	0x48
+;;   37:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f850a000000         	jne	0x46
-;;      	 e905000000           	jmp	0x46
-;;   41:	 e800000000           	call	0x46
+;;      	 0f850a000000         	jne	0x4d
+;;      	 e905000000           	jmp	0x4d
+;;   48:	 e800000000           	call	0x4d
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4c:	 0f0b                 	ud2	
+;;   53:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
@@ -10,22 +10,23 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x4b
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 c744240800000000     	mov	dword ptr [rsp + 8], 0
 ;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;      	 b811000000           	mov	eax, 0x11
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8509000000         	jne	0x45
-;;   3c:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
+;;      	 0f8509000000         	jne	0x4c
+;;   43:	 8944240c             	mov	dword ptr [rsp + 0xc], eax
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4b:	 0f0b                 	ud2	
+;;   52:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/br_if/as_loop_last.wat
@@ -7,31 +7,33 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x37
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8500000000         	jne	0x31
-;;   31:	 4883c410             	add	rsp, 0x10
+;;      	 0f8500000000         	jne	0x38
+;;   38:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   37:	 0f0b                 	ud2	
+;;   3e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_if/with_machine_stack_entry.wat
+++ b/winch/filetests/filetests/x64/br_if/with_machine_stack_entry.wat
@@ -13,40 +13,42 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x58
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
 ;;      	 4883ec04             	sub	rsp, 4
-;;      	 e800000000           	call	0x39
+;;      	 e800000000           	call	0x40
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8409000000         	je	0x4e
-;;   45:	 4883c404             	add	rsp, 4
-;;      	 e904000000           	jmp	0x52
-;;   4e:	 4883c404             	add	rsp, 4
+;;      	 0f8409000000         	je	0x55
+;;   4c:	 4883c404             	add	rsp, 4
+;;      	 e904000000           	jmp	0x59
+;;   55:	 4883c404             	add	rsp, 4
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   58:	 0f0b                 	ud2	
+;;   5f:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_table/ensure_sp_state.wat
+++ b/winch/filetests/filetests/x64/br_table/ensure_sp_state.wat
@@ -12,12 +12,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c30c000000       	add	r11, 0xc
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8743000000         	ja	0x5b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8747000000         	ja	0x62
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
@@ -30,10 +31,10 @@
 ;;      	 4963148b             	movsxd	rdx, dword ptr [r11 + rcx*4]
 ;;      	 4901d3               	add	r11, rdx
 ;;      	 41ffe3               	jmp	r11
-;;   4d:	 0400                 	add	al, 0
+;;   54:	 0400                 	add	al, 0
 ;;      	 0000                 	add	byte ptr [rax], al
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5b:	 0f0b                 	ud2	
+;;   62:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_table/large.wat
+++ b/winch/filetests/filetests/x64/br_table/large.wat
@@ -739,12 +739,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87dc800100         	ja	0x180f4
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f87e0800100         	ja	0x180fb
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 b927600000           	mov	ecx, 0x6027
@@ -754,7 +755,7 @@
 ;;      	 49630c83             	movsxd	rcx, dword ptr [r11 + rax*4]
 ;;      	 4901cb               	add	r11, rcx
 ;;      	 41ffe3               	jmp	r11
-;;   3f:	 a0800100aa800100a0   	
+;;   46:	 a0800100aa800100a0   	
 ;; 				movabs	al, byte ptr [0xa0000180aa000180]
 ;;      	 800100               	add	byte ptr [rcx], 0
 ;;      	 aa                   	stosb	byte ptr [rdi], al
@@ -31525,9 +31526,9 @@
 ;;      	 aa                   	stosb	byte ptr [rdi], al
 ;;      	 800100               	add	byte ptr [rcx], 0
 ;;      	 b800000000           	mov	eax, 0
-;;      	 e905000000           	jmp	0x180ee
-;; 180e9:	 b801000000           	mov	eax, 1
+;;      	 e905000000           	jmp	0x180f5
+;; 180f0:	 b801000000           	mov	eax, 1
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;; 180f4:	 0f0b                 	ud2	
+;; 180fb:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/br_table/nested_br_table_loop_block.wat
+++ b/winch/filetests/filetests/x64/br_table/nested_br_table_loop_block.wat
@@ -19,12 +19,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8777000000         	ja	0x8f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f877b000000         	ja	0x96
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 b902000000           	mov	ecx, 2
@@ -34,4 +35,4 @@
 ;;      	 49630c83             	movsxd	rcx, dword ptr [r11 + rax*4]
 ;;      	 4901cb               	add	r11, rcx
 ;;      	 41ffe3               	jmp	r11
-;;   3f:	 e1ff                 	loope	0x40
+;;   46:	 e1ff                 	loope	0x47

--- a/winch/filetests/filetests/x64/br_table/stack_handling.wat
+++ b/winch/filetests/filetests/x64/br_table/stack_handling.wat
@@ -12,12 +12,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8759000000         	ja	0x71
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f875d000000         	ja	0x78
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
@@ -30,17 +31,17 @@
 ;;      	 49630c83             	movsxd	rcx, dword ptr [r11 + rax*4]
 ;;      	 4901cb               	add	r11, rcx
 ;;      	 41ffe3               	jmp	r11
-;;   4d:	 1a00                 	sbb	al, byte ptr [rax]
+;;   54:	 1a00                 	sbb	al, byte ptr [rax]
 ;;      	 0000                 	add	byte ptr [rax], al
 ;;      	 1100                 	adc	dword ptr [rax], eax
 ;;      	 0000                 	add	byte ptr [rax], al
 ;;      	 1a00                 	sbb	al, byte ptr [rax]
 ;;      	 0000                 	add	byte ptr [rax], al
-;;      	 e909000000           	jmp	0x67
-;;   5e:	 4883c404             	add	rsp, 4
-;;      	 e904000000           	jmp	0x6b
-;;   67:	 4883c404             	add	rsp, 4
+;;      	 e909000000           	jmp	0x6e
+;;   65:	 4883c404             	add	rsp, 4
+;;      	 e904000000           	jmp	0x72
+;;   6e:	 4883c404             	add	rsp, 4
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   71:	 0f0b                 	ud2	
+;;   78:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/call/params.wat
+++ b/winch/filetests/filetests/x64/call/params.wat
@@ -37,12 +37,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c340000000       	add	r11, 0x40
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87fe000000         	ja	0x116
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8702010000         	ja	0x11d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
@@ -64,7 +65,7 @@
 ;;      	 44895c2408           	mov	dword ptr [rsp + 8], r11d
 ;;      	 41bb08000000         	mov	r11d, 8
 ;;      	 44895c2410           	mov	dword ptr [rsp + 0x10], r11d
-;;      	 e800000000           	call	0x7f
+;;      	 e800000000           	call	0x86
 ;;      	 4883c42c             	add	rsp, 0x2c
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883ec04             	sub	rsp, 4
@@ -96,22 +97,23 @@
 ;;      	 44895c2408           	mov	dword ptr [rsp + 8], r11d
 ;;      	 41bb08000000         	mov	r11d, 8
 ;;      	 44895c2410           	mov	dword ptr [rsp + 0x10], r11d
-;;      	 e800000000           	call	0x108
+;;      	 e800000000           	call	0x10f
 ;;      	 4883c428             	add	rsp, 0x28
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;  116:	 0f0b                 	ud2	
+;;  11d:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8757000000         	ja	0x6f
-;;   18:	 897c241c             	mov	dword ptr [rsp + 0x1c], edi
+;;      	 0f875b000000         	ja	0x76
+;;   1b:	 4883ec20             	sub	rsp, 0x20
+;;      	 897c241c             	mov	dword ptr [rsp + 0x1c], edi
 ;;      	 89742418             	mov	dword ptr [rsp + 0x18], esi
 ;;      	 89542414             	mov	dword ptr [rsp + 0x14], edx
 ;;      	 894c2410             	mov	dword ptr [rsp + 0x10], ecx
@@ -139,4 +141,4 @@
 ;;      	 4883c420             	add	rsp, 0x20
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6f:	 0f0b                 	ud2	
+;;   76:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/call/recursive.wat
+++ b/winch/filetests/filetests/x64/call/recursive.wat
@@ -24,28 +24,29 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8787000000         	ja	0x9f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f878b000000         	ja	0xa6
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 83f801               	cmp	eax, 1
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f9ec0             	setle	al
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8409000000         	je	0x41
-;;   38:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
-;;      	 e958000000           	jmp	0x99
-;;   41:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;      	 0f8409000000         	je	0x48
+;;   3f:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;      	 e958000000           	jmp	0xa0
+;;   48:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 83e801               	sub	eax, 1
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
 ;;      	 4883ec0c             	sub	rsp, 0xc
 ;;      	 8b7c240c             	mov	edi, dword ptr [rsp + 0xc]
-;;      	 e800000000           	call	0x5c
+;;      	 e800000000           	call	0x63
 ;;      	 4883c40c             	add	rsp, 0xc
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
@@ -56,7 +57,7 @@
 ;;      	 890c24               	mov	dword ptr [rsp], ecx
 ;;      	 4883ec08             	sub	rsp, 8
 ;;      	 8b7c2408             	mov	edi, dword ptr [rsp + 8]
-;;      	 e800000000           	call	0x86
+;;      	 e800000000           	call	0x8d
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 8b0c24               	mov	ecx, dword ptr [rsp]
@@ -66,4 +67,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   9f:	 0f0b                 	ud2	
+;;   a6:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/call/reg_on_stack.wat
+++ b/winch/filetests/filetests/x64/call/reg_on_stack.wat
@@ -12,25 +12,26 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876e000000         	ja	0x86
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8772000000         	ja	0x8d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 44891c24             	mov	dword ptr [rsp], r11d
 ;;      	 4883ec0c             	sub	rsp, 0xc
 ;;      	 bf01000000           	mov	edi, 1
-;;      	 e800000000           	call	0x3b
+;;      	 e800000000           	call	0x42
 ;;      	 4883c40c             	add	rsp, 0xc
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
 ;;      	 4883ec08             	sub	rsp, 8
 ;;      	 bf01000000           	mov	edi, 1
-;;      	 e800000000           	call	0x54
+;;      	 e800000000           	call	0x5b
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
@@ -39,11 +40,11 @@
 ;;      	 8b0424               	mov	eax, dword ptr [rsp]
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8409000000         	je	0x7e
-;;   75:	 4883c404             	add	rsp, 4
-;;      	 e902000000           	jmp	0x80
-;;   7e:	 0f0b                 	ud2	
+;;      	 0f8409000000         	je	0x85
+;;   7c:	 4883c404             	add	rsp, 4
+;;      	 e902000000           	jmp	0x87
+;;   85:	 0f0b                 	ud2	
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   86:	 0f0b                 	ud2	
+;;   8d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/call/simple.wat
+++ b/winch/filetests/filetests/x64/call/simple.wat
@@ -15,17 +15,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8751000000         	ja	0x69
-;;   18:	 48c744240800000000   	
+;;      	 0f8755000000         	ja	0x70
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 bf14000000           	mov	edi, 0x14
 ;;      	 be50000000           	mov	esi, 0x50
-;;      	 e800000000           	call	0x34
+;;      	 e800000000           	call	0x3b
 ;;      	 b902000000           	mov	ecx, 2
 ;;      	 894c240c             	mov	dword ptr [rsp + 0xc], ecx
 ;;      	 4883ec04             	sub	rsp, 4
@@ -42,16 +43,17 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   69:	 0f0b                 	ud2	
+;;   70:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x37
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -61,4 +63,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   37:	 0f0b                 	ud2	
+;;   3e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/call_indirect/call_indirect.wat
+++ b/winch/filetests/filetests/x64/call_indirect/call_indirect.wat
@@ -31,22 +31,23 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c330000000       	add	r11, 0x30
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8793010000         	ja	0x1ab
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8797010000         	ja	0x1b2
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 83f801               	cmp	eax, 1
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f96c0             	setbe	al
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x42
-;;   38:	 b801000000           	mov	eax, 1
-;;      	 e963010000           	jmp	0x1a5
-;;   42:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;      	 0f840a000000         	je	0x49
+;;   3f:	 b801000000           	mov	eax, 1
+;;      	 e963010000           	jmp	0x1ac
+;;   49:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 83e802               	sub	eax, 2
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
@@ -54,8 +55,8 @@
 ;;      	 4c89f2               	mov	rdx, r14
 ;;      	 8b5a50               	mov	ebx, dword ptr [rdx + 0x50]
 ;;      	 39d9                 	cmp	ecx, ebx
-;;      	 0f834a010000         	jae	0x1ad
-;;   63:	 4189cb               	mov	r11d, ecx
+;;      	 0f834a010000         	jae	0x1b4
+;;   6a:	 4189cb               	mov	r11d, ecx
 ;;      	 4d6bdb08             	imul	r11, r11, 8
 ;;      	 488b5248             	mov	rdx, qword ptr [rdx + 0x48]
 ;;      	 4889d6               	mov	rsi, rdx
@@ -64,8 +65,8 @@
 ;;      	 480f43d6             	cmovae	rdx, rsi
 ;;      	 488b02               	mov	rax, qword ptr [rdx]
 ;;      	 4885c0               	test	rax, rax
-;;      	 0f8529000000         	jne	0xaf
-;;   86:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
+;;      	 0f8529000000         	jne	0xb6
+;;   8d:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
 ;;      	 498b5b48             	mov	rbx, qword ptr [r11 + 0x48]
 ;;      	 4156                 	push	r14
 ;;      	 4883ec04             	sub	rsp, 4
@@ -75,16 +76,16 @@
 ;;      	 8b1424               	mov	edx, dword ptr [rsp]
 ;;      	 ffd3                 	call	rbx
 ;;      	 4883c40c             	add	rsp, 0xc
-;;      	 e904000000           	jmp	0xb3
-;;   af:	 4883e0fe             	and	rax, 0xfffffffffffffffe
+;;      	 e904000000           	jmp	0xba
+;;   b6:	 4883e0fe             	and	rax, 0xfffffffffffffffe
 ;;      	 4885c0               	test	rax, rax
-;;      	 0f84f3000000         	je	0x1af
-;;   bc:	 4d8b5e40             	mov	r11, qword ptr [r14 + 0x40]
+;;      	 0f84f3000000         	je	0x1b6
+;;   c3:	 4d8b5e40             	mov	r11, qword ptr [r14 + 0x40]
 ;;      	 418b0b               	mov	ecx, dword ptr [r11]
 ;;      	 8b5018               	mov	edx, dword ptr [rax + 0x18]
 ;;      	 39d1                 	cmp	ecx, edx
-;;      	 0f85e3000000         	jne	0x1b1
-;;   ce:	 50                   	push	rax
+;;      	 0f85e3000000         	jne	0x1b8
+;;   d5:	 50                   	push	rax
 ;;      	 59                   	pop	rcx
 ;;      	 488b5110             	mov	rdx, qword ptr [rcx + 0x10]
 ;;      	 4883ec0c             	sub	rsp, 0xc
@@ -102,8 +103,8 @@
 ;;      	 4c89f2               	mov	rdx, r14
 ;;      	 8b5a50               	mov	ebx, dword ptr [rdx + 0x50]
 ;;      	 39d9                 	cmp	ecx, ebx
-;;      	 0f83a5000000         	jae	0x1b3
-;;  10e:	 4189cb               	mov	r11d, ecx
+;;      	 0f83a5000000         	jae	0x1ba
+;;  115:	 4189cb               	mov	r11d, ecx
 ;;      	 4d6bdb08             	imul	r11, r11, 8
 ;;      	 488b5248             	mov	rdx, qword ptr [rdx + 0x48]
 ;;      	 4889d6               	mov	rsi, rdx
@@ -112,8 +113,8 @@
 ;;      	 480f43d6             	cmovae	rdx, rsi
 ;;      	 488b02               	mov	rax, qword ptr [rdx]
 ;;      	 4885c0               	test	rax, rax
-;;      	 0f8532000000         	jne	0x163
-;;  131:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
+;;      	 0f8532000000         	jne	0x16a
+;;  138:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
 ;;      	 498b5b48             	mov	rbx, qword ptr [r11 + 0x48]
 ;;      	 4156                 	push	r14
 ;;      	 4883ec04             	sub	rsp, 4
@@ -125,16 +126,16 @@
 ;;      	 ffd3                 	call	rbx
 ;;      	 4883c40c             	add	rsp, 0xc
 ;;      	 4883c40c             	add	rsp, 0xc
-;;      	 e904000000           	jmp	0x167
-;;  163:	 4883e0fe             	and	rax, 0xfffffffffffffffe
+;;      	 e904000000           	jmp	0x16e
+;;  16a:	 4883e0fe             	and	rax, 0xfffffffffffffffe
 ;;      	 4885c0               	test	rax, rax
-;;      	 0f8445000000         	je	0x1b5
-;;  170:	 4d8b5e40             	mov	r11, qword ptr [r14 + 0x40]
+;;      	 0f8445000000         	je	0x1bc
+;;  177:	 4d8b5e40             	mov	r11, qword ptr [r14 + 0x40]
 ;;      	 418b0b               	mov	ecx, dword ptr [r11]
 ;;      	 8b5018               	mov	edx, dword ptr [rax + 0x18]
 ;;      	 39d1                 	cmp	ecx, edx
-;;      	 0f8535000000         	jne	0x1b7
-;;  182:	 50                   	push	rax
+;;      	 0f8535000000         	jne	0x1be
+;;  189:	 50                   	push	rax
 ;;      	 59                   	pop	rcx
 ;;      	 488b5110             	mov	rdx, qword ptr [rcx + 0x10]
 ;;      	 4883ec08             	sub	rsp, 8
@@ -149,10 +150,10 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;  1ab:	 0f0b                 	ud2	
-;;  1ad:	 0f0b                 	ud2	
-;;  1af:	 0f0b                 	ud2	
-;;  1b1:	 0f0b                 	ud2	
-;;  1b3:	 0f0b                 	ud2	
-;;  1b5:	 0f0b                 	ud2	
-;;  1b7:	 0f0b                 	ud2	
+;;  1b2:	 0f0b                 	ud2	
+;;  1b4:	 0f0b                 	ud2	
+;;  1b6:	 0f0b                 	ud2	
+;;  1b8:	 0f0b                 	ud2	
+;;  1ba:	 0f0b                 	ud2	
+;;  1bc:	 0f0b                 	ud2	
+;;  1be:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/call_indirect/local_arg.wat
+++ b/winch/filetests/filetests/x64/call_indirect/local_arg.wat
@@ -76,26 +76,28 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870e000000         	ja	0x26
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8712000000         	ja	0x2d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   26:	 0f0b                 	ud2	
+;;   2d:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87b4000000         	ja	0xcc
-;;   18:	 48c744240800000000   	
+;;      	 0f87b8000000         	ja	0xd3
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
@@ -105,8 +107,8 @@
 ;;      	 4c89f2               	mov	rdx, r14
 ;;      	 8b5a50               	mov	ebx, dword ptr [rdx + 0x50]
 ;;      	 39d9                 	cmp	ecx, ebx
-;;      	 0f8389000000         	jae	0xce
-;;   45:	 4189cb               	mov	r11d, ecx
+;;      	 0f8389000000         	jae	0xd5
+;;   4c:	 4189cb               	mov	r11d, ecx
 ;;      	 4d6bdb08             	imul	r11, r11, 8
 ;;      	 488b5248             	mov	rdx, qword ptr [rdx + 0x48]
 ;;      	 4889d6               	mov	rsi, rdx
@@ -115,8 +117,8 @@
 ;;      	 480f43d6             	cmovae	rdx, rsi
 ;;      	 488b02               	mov	rax, qword ptr [rdx]
 ;;      	 4885c0               	test	rax, rax
-;;      	 0f8529000000         	jne	0x91
-;;   68:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
+;;      	 0f8529000000         	jne	0x98
+;;   6f:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
 ;;      	 498b5b48             	mov	rbx, qword ptr [r11 + 0x48]
 ;;      	 4156                 	push	r14
 ;;      	 4883ec04             	sub	rsp, 4
@@ -126,16 +128,16 @@
 ;;      	 8b1424               	mov	edx, dword ptr [rsp]
 ;;      	 ffd3                 	call	rbx
 ;;      	 4883c40c             	add	rsp, 0xc
-;;      	 e904000000           	jmp	0x95
-;;   91:	 4883e0fe             	and	rax, 0xfffffffffffffffe
+;;      	 e904000000           	jmp	0x9c
+;;   98:	 4883e0fe             	and	rax, 0xfffffffffffffffe
 ;;      	 4885c0               	test	rax, rax
-;;      	 0f8432000000         	je	0xd0
-;;   9e:	 4d8b5e40             	mov	r11, qword ptr [r14 + 0x40]
+;;      	 0f8432000000         	je	0xd7
+;;   a5:	 4d8b5e40             	mov	r11, qword ptr [r14 + 0x40]
 ;;      	 418b0b               	mov	ecx, dword ptr [r11]
 ;;      	 8b5018               	mov	edx, dword ptr [rax + 0x18]
 ;;      	 39d1                 	cmp	ecx, edx
-;;      	 0f8522000000         	jne	0xd2
-;;   b0:	 488b4810             	mov	rcx, qword ptr [rax + 0x10]
+;;      	 0f8522000000         	jne	0xd9
+;;   b7:	 488b4810             	mov	rcx, qword ptr [rax + 0x10]
 ;;      	 4883ec0c             	sub	rsp, 0xc
 ;;      	 8b7c240c             	mov	edi, dword ptr [rsp + 0xc]
 ;;      	 ffd1                 	call	rcx
@@ -144,7 +146,7 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   cc:	 0f0b                 	ud2	
-;;   ce:	 0f0b                 	ud2	
-;;   d0:	 0f0b                 	ud2	
-;;   d2:	 0f0b                 	ud2	
+;;   d3:	 0f0b                 	ud2	
+;;   d5:	 0f0b                 	ud2	
+;;   d7:	 0f0b                 	ud2	
+;;   d9:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_abs/f32_abs_const.wat
+++ b/winch/filetests/filetests/x64/f32_abs/f32_abs_const.wat
@@ -8,22 +8,24 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10051c000000     	movss	xmm0, dword ptr [rip + 0x1c]
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]
 ;;      	 41bbffffff7f         	mov	r11d, 0x7fffffff
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f54c7             	andps	xmm0, xmm15
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
-;;   3b:	 0000                 	add	byte ptr [rax], al
-;;   3d:	 0000                 	add	byte ptr [rax], al
-;;   3f:	 00c3                 	add	bl, al
-;;   41:	 f5                   	cmc	
-;;   42:	 a8bf                 	test	al, 0xbf
+;;   40:	 0f0b                 	ud2	
+;;   42:	 0000                 	add	byte ptr [rax], al
+;;   44:	 0000                 	add	byte ptr [rax], al
+;;   46:	 0000                 	add	byte ptr [rax], al
+;;   48:	 c3                   	ret	
+;;   49:	 f5                   	cmc	
+;;   4a:	 a8bf                 	test	al, 0xbf

--- a/winch/filetests/filetests/x64/f32_abs/f32_abs_param.wat
+++ b/winch/filetests/filetests/x64/f32_abs/f32_abs_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x3d
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 41bbffffff7f         	mov	r11d, 0x7fffffff
@@ -22,4 +23,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3d:	 0f0b                 	ud2	
+;;   44:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_add/const.wat
+++ b/winch/filetests/filetests/x64/f32_add/const.wat
@@ -9,25 +9,26 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10051c000000     	movss	xmm0, dword ptr [rip + 0x1c]
-;;      	 f30f100d1c000000     	movss	xmm1, dword ptr [rip + 0x1c]
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]
+;;      	 f30f100d1d000000     	movss	xmm1, dword ptr [rip + 0x1d]
 ;;      	 f30f58c8             	addss	xmm1, xmm0
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
-;;   3b:	 0000                 	add	byte ptr [rax], al
-;;   3d:	 0000                 	add	byte ptr [rax], al
-;;   3f:	 00cd                 	add	ch, cl
-;;   41:	 cc                   	int3	
-;;   42:	 0c40                 	or	al, 0x40
+;;   40:	 0f0b                 	ud2	
+;;   42:	 0000                 	add	byte ptr [rax], al
 ;;   44:	 0000                 	add	byte ptr [rax], al
 ;;   46:	 0000                 	add	byte ptr [rax], al
 ;;   48:	 cdcc                 	int	0xcc
+;;   4a:	 0c40                 	or	al, 0x40
+;;   4c:	 0000                 	add	byte ptr [rax], al
+;;   4e:	 0000                 	add	byte ptr [rax], al
+;;   50:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_add/locals.wat
+++ b/winch/filetests/filetests/x64/f32_add/locals.wat
@@ -18,17 +18,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 48c744240800000000   	
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100533000000     	movss	xmm0, dword ptr [rip + 0x33]
+;;      	 f30f100534000000     	movss	xmm0, dword ptr [rip + 0x34]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]
+;;      	 f30f10052e000000     	movss	xmm0, dword ptr [rip + 0x2e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
@@ -37,7 +38,8 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
-;;   5c:	 0000                 	add	byte ptr [rax], al
-;;   5e:	 0000                 	add	byte ptr [rax], al
-;;   60:	 cdcc                 	int	0xcc
+;;   61:	 0f0b                 	ud2	
+;;   63:	 0000                 	add	byte ptr [rax], al
+;;   65:	 0000                 	add	byte ptr [rax], al
+;;   67:	 00cd                 	add	ch, cl
+;;   69:	 cc                   	int3	

--- a/winch/filetests/filetests/x64/f32_add/params.wat
+++ b/winch/filetests/filetests/x64/f32_add/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_ceil/f32_ceil_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_ceil/f32_ceil_const_sse41.wat
@@ -9,21 +9,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100514000000     	movss	xmm0, dword ptr [rip + 0x14]
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f100515000000     	movss	xmm0, dword ptr [rip + 0x15]
 ;;      	 660f3a0ac002         	roundss	xmm0, xmm0, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
-;;   32:	 0000                 	add	byte ptr [rax], al
-;;   34:	 0000                 	add	byte ptr [rax], al
-;;   36:	 0000                 	add	byte ptr [rax], al
-;;   38:	 c3                   	ret	
-;;   39:	 f5                   	cmc	
-;;   3a:	 a8bf                 	test	al, 0xbf
+;;   37:	 0f0b                 	ud2	
+;;   39:	 0000                 	add	byte ptr [rax], al
+;;   3b:	 0000                 	add	byte ptr [rax], al
+;;   3d:	 0000                 	add	byte ptr [rax], al
+;;   3f:	 00c3                 	add	bl, al
+;;   41:	 f5                   	cmc	
+;;   42:	 a8bf                 	test	al, 0xbf

--- a/winch/filetests/filetests/x64/f32_ceil/f32_ceil_param.wat
+++ b/winch/filetests/filetests/x64/f32_ceil/f32_ceil_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x58
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f3440f107c240c       	movss	xmm15, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   58:	 0f0b                 	ud2	
+;;   5f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_ceil/f32_ceil_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_ceil/f32_ceil_param_sse41.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 660f3a0ac002         	roundss	xmm0, xmm0, 2
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_const/call_id.wat
+++ b/winch/filetests/filetests/x64/f32_const/call_id.wat
@@ -6,38 +6,37 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x37
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 f30f100518000000     	movss	xmm0, dword ptr [rip + 0x18]
-;;      	 e800000000           	call	0x2d
+;;      	 f30f100511000000     	movss	xmm0, dword ptr [rip + 0x11]
+;;      	 e800000000           	call	0x34
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   37:	 0f0b                 	ud2	
-;;   39:	 0000                 	add	byte ptr [rax], al
-;;   3b:	 0000                 	add	byte ptr [rax], al
-;;   3d:	 0000                 	add	byte ptr [rax], al
-;;   3f:	 00c3                 	add	bl, al
+;;   3e:	 0f0b                 	ud2	
+;;   40:	 c3                   	ret	
 ;;   41:	 f5                   	cmc	
 ;;   42:	 a83f                 	test	al, 0x3f

--- a/winch/filetests/filetests/x64/f32_const/id.wat
+++ b/winch/filetests/filetests/x64/f32_const/id.wat
@@ -5,15 +5,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i32_s/const.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_s/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x2b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8717000000         	ja	0x32
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 f30f2ac0             	cvtsi2ss	xmm0, eax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2b:	 0f0b                 	ud2	
+;;   32:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i32_s/locals.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_s/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 48c744240800000000   	
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i32_s/params.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_s/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 f30f2ac0             	cvtsi2ss	xmm0, eax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i32_s/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_s/spilled.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c30c000000       	add	r11, 0xc
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x3d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 f30f2ac0             	cvtsi2ss	xmm0, eax
 ;;      	 4883ec04             	sub	rsp, 4
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3d:	 0f0b                 	ud2	
+;;   44:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i32_u/const.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_u/const.wat
@@ -8,19 +8,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x57
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b901000000           	mov	ecx, 1
 ;;      	 8bc9                 	mov	ecx, ecx
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x37
-;;   2d:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
-;;      	 e91a000000           	jmp	0x51
-;;   37:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x3e
+;;   34:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
+;;      	 e91a000000           	jmp	0x58
+;;   3e:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -30,4 +31,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   57:	 0f0b                 	ud2	
+;;   5e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i32_u/locals.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_u/locals.wat
@@ -10,21 +10,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 48c744240800000000   	
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;      	 8bc9                 	mov	ecx, ecx
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x3f
-;;   35:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
-;;      	 e91a000000           	jmp	0x59
-;;   3f:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x46
+;;   3c:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
+;;      	 e91a000000           	jmp	0x60
+;;   46:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -34,4 +35,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i32_u/params.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_u/params.wat
@@ -8,20 +8,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;      	 8bc9                 	mov	ecx, ecx
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x3a
-;;   30:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
-;;      	 e91a000000           	jmp	0x54
-;;   3a:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x41
+;;   37:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
+;;      	 e91a000000           	jmp	0x5b
+;;   41:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -31,4 +32,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
+;;   61:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i32_u/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_u/spilled.wat
@@ -10,19 +10,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c30c000000       	add	r11, 0xc
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8751000000         	ja	0x69
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8755000000         	ja	0x70
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b901000000           	mov	ecx, 1
 ;;      	 8bc9                 	mov	ecx, ecx
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x37
-;;   2d:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
-;;      	 e91a000000           	jmp	0x51
-;;   37:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x3e
+;;   34:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
+;;      	 e91a000000           	jmp	0x58
+;;   3e:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -36,4 +37,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   69:	 0f0b                 	ud2	
+;;   70:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i64_s/const.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_s/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 f3480f2ac0           	cvtsi2ss	xmm0, rax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i64_s/locals.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_s/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871d000000         	ja	0x35
-;;   18:	 48c744240800000000   	
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   35:	 0f0b                 	ud2	
+;;   3c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i64_s/params.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_s/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 f3480f2ac0           	cvtsi2ss	xmm0, rax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i64_s/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_s/spilled.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c30c000000       	add	r11, 0xc
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x40
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 f3480f2ac0           	cvtsi2ss	xmm0, rax
 ;;      	 4883ec04             	sub	rsp, 4
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   40:	 0f0b                 	ud2	
+;;   47:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i64_u/const.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_u/const.wat
@@ -8,18 +8,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x57
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c101000000       	mov	rcx, 1
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x37
-;;   2d:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
-;;      	 e91a000000           	jmp	0x51
-;;   37:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x3e
+;;   34:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
+;;      	 e91a000000           	jmp	0x58
+;;   3e:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -29,4 +30,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   57:	 0f0b                 	ud2	
+;;   5e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i64_u/locals.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_u/locals.wat
@@ -10,20 +10,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8746000000         	ja	0x5e
-;;   18:	 48c744240800000000   	
+;;      	 0f874a000000         	ja	0x65
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x3e
-;;   34:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
-;;      	 e91a000000           	jmp	0x58
-;;   3e:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x45
+;;   3b:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
+;;      	 e91a000000           	jmp	0x5f
+;;   45:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -33,4 +34,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5e:	 0f0b                 	ud2	
+;;   65:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i64_u/params.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_u/params.wat
@@ -8,19 +8,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x3a
-;;   30:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
-;;      	 e91a000000           	jmp	0x54
-;;   3a:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x41
+;;   37:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
+;;      	 e91a000000           	jmp	0x5b
+;;   41:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -30,4 +31,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
+;;   61:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_convert_i64_u/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_u/spilled.wat
@@ -10,18 +10,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c30c000000       	add	r11, 0xc
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8751000000         	ja	0x69
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8755000000         	ja	0x70
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c101000000       	mov	rcx, 1
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x37
-;;   2d:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
-;;      	 e91a000000           	jmp	0x51
-;;   37:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x3e
+;;   34:	 f3480f2ac1           	cvtsi2ss	xmm0, rcx
+;;      	 e91a000000           	jmp	0x58
+;;   3e:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -35,4 +36,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   69:	 0f0b                 	ud2	
+;;   70:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_copysign/const.wat
+++ b/winch/filetests/filetests/x64/f32_copysign/const.wat
@@ -9,14 +9,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8737000000         	ja	0x4f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100534000000     	movss	xmm0, dword ptr [rip + 0x34]
-;;      	 f30f100d34000000     	movss	xmm1, dword ptr [rip + 0x34]
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]
+;;      	 f30f100d2d000000     	movss	xmm1, dword ptr [rip + 0x2d]
 ;;      	 41bb00000080         	mov	r11d, 0x80000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f54c7             	andps	xmm0, xmm15
@@ -27,12 +28,8 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4f:	 0f0b                 	ud2	
-;;   51:	 0000                 	add	byte ptr [rax], al
-;;   53:	 0000                 	add	byte ptr [rax], al
-;;   55:	 0000                 	add	byte ptr [rax], al
-;;   57:	 00cd                 	add	ch, cl
-;;   59:	 cc                   	int3	
+;;   56:	 0f0b                 	ud2	
+;;   58:	 cdcc                 	int	0xcc
 ;;   5a:	 0c40                 	or	al, 0x40
 ;;   5c:	 0000                 	add	byte ptr [rax], al
 ;;   5e:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f32_copysign/locals.wat
+++ b/winch/filetests/filetests/x64/f32_copysign/locals.wat
@@ -18,17 +18,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8758000000         	ja	0x70
-;;   18:	 48c744240800000000   	
+;;      	 0f875c000000         	ja	0x77
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10054b000000     	movss	xmm0, dword ptr [rip + 0x4b]
+;;      	 f30f10054c000000     	movss	xmm0, dword ptr [rip + 0x4c]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f100545000000     	movss	xmm0, dword ptr [rip + 0x45]
+;;      	 f30f100546000000     	movss	xmm0, dword ptr [rip + 0x46]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
@@ -42,8 +43,9 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   70:	 0f0b                 	ud2	
-;;   72:	 0000                 	add	byte ptr [rax], al
-;;   74:	 0000                 	add	byte ptr [rax], al
-;;   76:	 0000                 	add	byte ptr [rax], al
-;;   78:	 cdcc                 	int	0xcc
+;;   77:	 0f0b                 	ud2	
+;;   79:	 0000                 	add	byte ptr [rax], al
+;;   7b:	 0000                 	add	byte ptr [rax], al
+;;   7d:	 0000                 	add	byte ptr [rax], al
+;;   7f:	 00cd                 	add	ch, cl
+;;   81:	 cc                   	int3	

--- a/winch/filetests/filetests/x64/f32_copysign/params.wat
+++ b/winch/filetests/filetests/x64/f32_copysign/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x57
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
@@ -29,4 +30,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   57:	 0f0b                 	ud2	
+;;   5e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_demote_f64/const.wat
+++ b/winch/filetests/filetests/x64/f32_demote_f64/const.wat
@@ -8,18 +8,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10050c000000     	movsd	xmm0, qword ptr [rip + 0xc]
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10050d000000     	movsd	xmm0, qword ptr [rip + 0xd]
 ;;      	 f20f5ac0             	cvtsd2ss	xmm0, xmm0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
-;;   30:	 0000                 	add	byte ptr [rax], al
-;;   32:	 0000                 	add	byte ptr [rax], al
-;;   34:	 0000                 	add	byte ptr [rax], al
+;;   35:	 0f0b                 	ud2	
+;;   37:	 0000                 	add	byte ptr [rax], al
+;;   39:	 0000                 	add	byte ptr [rax], al
+;;   3b:	 0000                 	add	byte ptr [rax], al
+;;   3d:	 00f0                 	add	al, dh

--- a/winch/filetests/filetests/x64/f32_demote_f64/locals.wat
+++ b/winch/filetests/filetests/x64/f32_demote_f64/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871d000000         	ja	0x35
-;;   18:	 48c744240800000000   	
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   35:	 0f0b                 	ud2	
+;;   3c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_demote_f64/params.wat
+++ b/winch/filetests/filetests/x64/f32_demote_f64/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f5ac0             	cvtsd2ss	xmm0, xmm0
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_demote_f64/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_demote_f64/spilled.wat
@@ -10,13 +10,14 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c30c000000       	add	r11, 0xc
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x40
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100524000000     	movsd	xmm0, qword ptr [rip + 0x24]
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f100525000000     	movsd	xmm0, qword ptr [rip + 0x25]
 ;;      	 f20f5ac0             	cvtsd2ss	xmm0, xmm0
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 f30f110424           	movss	dword ptr [rsp], xmm0
@@ -25,10 +26,11 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   40:	 0f0b                 	ud2	
-;;   42:	 0000                 	add	byte ptr [rax], al
-;;   44:	 0000                 	add	byte ptr [rax], al
-;;   46:	 0000                 	add	byte ptr [rax], al
-;;   48:	 0000                 	add	byte ptr [rax], al
-;;   4a:	 0000                 	add	byte ptr [rax], al
-;;   4c:	 0000                 	add	byte ptr [rax], al
+;;   47:	 0f0b                 	ud2	
+;;   49:	 0000                 	add	byte ptr [rax], al
+;;   4b:	 0000                 	add	byte ptr [rax], al
+;;   4d:	 0000                 	add	byte ptr [rax], al
+;;   4f:	 0000                 	add	byte ptr [rax], al
+;;   51:	 0000                 	add	byte ptr [rax], al
+;;   53:	 0000                 	add	byte ptr [rax], al
+;;   55:	 00f0                 	add	al, dh

--- a/winch/filetests/filetests/x64/f32_div/const.wat
+++ b/winch/filetests/filetests/x64/f32_div/const.wat
@@ -9,25 +9,26 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10051c000000     	movss	xmm0, dword ptr [rip + 0x1c]
-;;      	 f30f100d1c000000     	movss	xmm1, dword ptr [rip + 0x1c]
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]
+;;      	 f30f100d1d000000     	movss	xmm1, dword ptr [rip + 0x1d]
 ;;      	 f30f5ec8             	divss	xmm1, xmm0
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
-;;   3b:	 0000                 	add	byte ptr [rax], al
-;;   3d:	 0000                 	add	byte ptr [rax], al
-;;   3f:	 00cd                 	add	ch, cl
-;;   41:	 cc                   	int3	
-;;   42:	 0c40                 	or	al, 0x40
+;;   40:	 0f0b                 	ud2	
+;;   42:	 0000                 	add	byte ptr [rax], al
 ;;   44:	 0000                 	add	byte ptr [rax], al
 ;;   46:	 0000                 	add	byte ptr [rax], al
 ;;   48:	 cdcc                 	int	0xcc
+;;   4a:	 0c40                 	or	al, 0x40
+;;   4c:	 0000                 	add	byte ptr [rax], al
+;;   4e:	 0000                 	add	byte ptr [rax], al
+;;   50:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_div/locals.wat
+++ b/winch/filetests/filetests/x64/f32_div/locals.wat
@@ -18,17 +18,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 48c744240800000000   	
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100533000000     	movss	xmm0, dword ptr [rip + 0x33]
+;;      	 f30f100534000000     	movss	xmm0, dword ptr [rip + 0x34]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]
+;;      	 f30f10052e000000     	movss	xmm0, dword ptr [rip + 0x2e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
@@ -37,7 +38,8 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
-;;   5c:	 0000                 	add	byte ptr [rax], al
-;;   5e:	 0000                 	add	byte ptr [rax], al
-;;   60:	 cdcc                 	int	0xcc
+;;   61:	 0f0b                 	ud2	
+;;   63:	 0000                 	add	byte ptr [rax], al
+;;   65:	 0000                 	add	byte ptr [rax], al
+;;   67:	 00cd                 	add	ch, cl
+;;   69:	 cc                   	int3	

--- a/winch/filetests/filetests/x64/f32_div/params.wat
+++ b/winch/filetests/filetests/x64/f32_div/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_eq/const.wat
+++ b/winch/filetests/filetests/x64/f32_eq/const.wat
@@ -9,14 +9,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x4b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10052c000000     	movss	xmm0, dword ptr [rip + 0x2c]
-;;      	 f30f100d2c000000     	movss	xmm1, dword ptr [rip + 0x2c]
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]
+;;      	 f30f100d2d000000     	movss	xmm1, dword ptr [rip + 0x2d]
 ;;      	 0f2ec8               	ucomiss	xmm1, xmm0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f94c0             	sete	al
@@ -26,11 +27,11 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4b:	 0f0b                 	ud2	
-;;   4d:	 0000                 	add	byte ptr [rax], al
-;;   4f:	 00cd                 	add	ch, cl
-;;   51:	 cc                   	int3	
-;;   52:	 0c40                 	or	al, 0x40
+;;   52:	 0f0b                 	ud2	
 ;;   54:	 0000                 	add	byte ptr [rax], al
 ;;   56:	 0000                 	add	byte ptr [rax], al
 ;;   58:	 cdcc                 	int	0xcc
+;;   5a:	 0c40                 	or	al, 0x40
+;;   5c:	 0000                 	add	byte ptr [rax], al
+;;   5e:	 0000                 	add	byte ptr [rax], al
+;;   60:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_eq/locals.wat
+++ b/winch/filetests/filetests/x64/f32_eq/locals.wat
@@ -18,17 +18,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8754000000         	ja	0x6c
-;;   18:	 48c744240800000000   	
+;;      	 0f8758000000         	ja	0x73
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100543000000     	movss	xmm0, dword ptr [rip + 0x43]
+;;      	 f30f100544000000     	movss	xmm0, dword ptr [rip + 0x44]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f10053d000000     	movss	xmm0, dword ptr [rip + 0x3d]
+;;      	 f30f10053e000000     	movss	xmm0, dword ptr [rip + 0x3e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
@@ -41,6 +42,7 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6c:	 0f0b                 	ud2	
-;;   6e:	 0000                 	add	byte ptr [rax], al
-;;   70:	 cdcc                 	int	0xcc
+;;   73:	 0f0b                 	ud2	
+;;   75:	 0000                 	add	byte ptr [rax], al
+;;   77:	 00cd                 	add	ch, cl
+;;   79:	 cc                   	int3	

--- a/winch/filetests/filetests/x64/f32_eq/params.wat
+++ b/winch/filetests/filetests/x64/f32_eq/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873b000000         	ja	0x53
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f873f000000         	ja	0x5a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   53:	 0f0b                 	ud2	
+;;   5a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_floor/f32_floor_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_floor/f32_floor_const_sse41.wat
@@ -9,21 +9,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100514000000     	movss	xmm0, dword ptr [rip + 0x14]
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f100515000000     	movss	xmm0, dword ptr [rip + 0x15]
 ;;      	 660f3a0ac001         	roundss	xmm0, xmm0, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
-;;   32:	 0000                 	add	byte ptr [rax], al
-;;   34:	 0000                 	add	byte ptr [rax], al
-;;   36:	 0000                 	add	byte ptr [rax], al
-;;   38:	 c3                   	ret	
-;;   39:	 f5                   	cmc	
-;;   3a:	 a8bf                 	test	al, 0xbf
+;;   37:	 0f0b                 	ud2	
+;;   39:	 0000                 	add	byte ptr [rax], al
+;;   3b:	 0000                 	add	byte ptr [rax], al
+;;   3d:	 0000                 	add	byte ptr [rax], al
+;;   3f:	 00c3                 	add	bl, al
+;;   41:	 f5                   	cmc	
+;;   42:	 a8bf                 	test	al, 0xbf

--- a/winch/filetests/filetests/x64/f32_floor/f32_floor_param.wat
+++ b/winch/filetests/filetests/x64/f32_floor/f32_floor_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x58
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f3440f107c240c       	movss	xmm15, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   58:	 0f0b                 	ud2	
+;;   5f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_floor/f32_floor_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_floor/f32_floor_param_sse41.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 660f3a0ac001         	roundss	xmm0, xmm0, 1
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_ge/const.wat
+++ b/winch/filetests/filetests/x64/f32_ge/const.wat
@@ -9,14 +9,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x4b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10052c000000     	movss	xmm0, dword ptr [rip + 0x2c]
-;;      	 f30f100d2c000000     	movss	xmm1, dword ptr [rip + 0x2c]
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]
+;;      	 f30f100d2d000000     	movss	xmm1, dword ptr [rip + 0x2d]
 ;;      	 0f2ec8               	ucomiss	xmm1, xmm0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f93c0             	setae	al
@@ -26,11 +27,11 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4b:	 0f0b                 	ud2	
-;;   4d:	 0000                 	add	byte ptr [rax], al
-;;   4f:	 00cd                 	add	ch, cl
-;;   51:	 cc                   	int3	
-;;   52:	 0c40                 	or	al, 0x40
+;;   52:	 0f0b                 	ud2	
 ;;   54:	 0000                 	add	byte ptr [rax], al
 ;;   56:	 0000                 	add	byte ptr [rax], al
 ;;   58:	 cdcc                 	int	0xcc
+;;   5a:	 0c40                 	or	al, 0x40
+;;   5c:	 0000                 	add	byte ptr [rax], al
+;;   5e:	 0000                 	add	byte ptr [rax], al
+;;   60:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_ge/locals.wat
+++ b/winch/filetests/filetests/x64/f32_ge/locals.wat
@@ -18,17 +18,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8754000000         	ja	0x6c
-;;   18:	 48c744240800000000   	
+;;      	 0f8758000000         	ja	0x73
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100543000000     	movss	xmm0, dword ptr [rip + 0x43]
+;;      	 f30f100544000000     	movss	xmm0, dword ptr [rip + 0x44]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f10053d000000     	movss	xmm0, dword ptr [rip + 0x3d]
+;;      	 f30f10053e000000     	movss	xmm0, dword ptr [rip + 0x3e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
@@ -41,6 +42,7 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6c:	 0f0b                 	ud2	
-;;   6e:	 0000                 	add	byte ptr [rax], al
-;;   70:	 cdcc                 	int	0xcc
+;;   73:	 0f0b                 	ud2	
+;;   75:	 0000                 	add	byte ptr [rax], al
+;;   77:	 00cd                 	add	ch, cl
+;;   79:	 cc                   	int3	

--- a/winch/filetests/filetests/x64/f32_ge/params.wat
+++ b/winch/filetests/filetests/x64/f32_ge/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873b000000         	ja	0x53
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f873f000000         	ja	0x5a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   53:	 0f0b                 	ud2	
+;;   5a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_gt/const.wat
+++ b/winch/filetests/filetests/x64/f32_gt/const.wat
@@ -9,14 +9,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x4b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10052c000000     	movss	xmm0, dword ptr [rip + 0x2c]
-;;      	 f30f100d2c000000     	movss	xmm1, dword ptr [rip + 0x2c]
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]
+;;      	 f30f100d2d000000     	movss	xmm1, dword ptr [rip + 0x2d]
 ;;      	 0f2ec8               	ucomiss	xmm1, xmm0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f97c0             	seta	al
@@ -26,11 +27,11 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4b:	 0f0b                 	ud2	
-;;   4d:	 0000                 	add	byte ptr [rax], al
-;;   4f:	 00cd                 	add	ch, cl
-;;   51:	 cc                   	int3	
-;;   52:	 0c40                 	or	al, 0x40
+;;   52:	 0f0b                 	ud2	
 ;;   54:	 0000                 	add	byte ptr [rax], al
 ;;   56:	 0000                 	add	byte ptr [rax], al
 ;;   58:	 cdcc                 	int	0xcc
+;;   5a:	 0c40                 	or	al, 0x40
+;;   5c:	 0000                 	add	byte ptr [rax], al
+;;   5e:	 0000                 	add	byte ptr [rax], al
+;;   60:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_gt/locals.wat
+++ b/winch/filetests/filetests/x64/f32_gt/locals.wat
@@ -18,17 +18,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8754000000         	ja	0x6c
-;;   18:	 48c744240800000000   	
+;;      	 0f8758000000         	ja	0x73
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100543000000     	movss	xmm0, dword ptr [rip + 0x43]
+;;      	 f30f100544000000     	movss	xmm0, dword ptr [rip + 0x44]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f10053d000000     	movss	xmm0, dword ptr [rip + 0x3d]
+;;      	 f30f10053e000000     	movss	xmm0, dword ptr [rip + 0x3e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
@@ -41,6 +42,7 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6c:	 0f0b                 	ud2	
-;;   6e:	 0000                 	add	byte ptr [rax], al
-;;   70:	 cdcc                 	int	0xcc
+;;   73:	 0f0b                 	ud2	
+;;   75:	 0000                 	add	byte ptr [rax], al
+;;   77:	 00cd                 	add	ch, cl
+;;   79:	 cc                   	int3	

--- a/winch/filetests/filetests/x64/f32_gt/params.wat
+++ b/winch/filetests/filetests/x64/f32_gt/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873b000000         	ja	0x53
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f873f000000         	ja	0x5a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   53:	 0f0b                 	ud2	
+;;   5a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_le/const.wat
+++ b/winch/filetests/filetests/x64/f32_le/const.wat
@@ -9,23 +9,25 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10051c000000     	movss	xmm0, dword ptr [rip + 0x1c]
-;;      	 f30f100d1c000000     	movss	xmm1, dword ptr [rip + 0x1c]
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]
+;;      	 f30f100d1d000000     	movss	xmm1, dword ptr [rip + 0x1d]
 ;;      	 0f2ec1               	ucomiss	xmm0, xmm1
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f93c0             	setae	al
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
-;;   40:	 cdcc                 	int	0xcc
-;;   42:	 0c40                 	or	al, 0x40
-;;   44:	 0000                 	add	byte ptr [rax], al
-;;   46:	 0000                 	add	byte ptr [rax], al
-;;   48:	 cdcc                 	int	0xcc
+;;   45:	 0f0b                 	ud2	
+;;   47:	 00cd                 	add	ch, cl
+;;   49:	 cc                   	int3	
+;;   4a:	 0c40                 	or	al, 0x40
+;;   4c:	 0000                 	add	byte ptr [rax], al
+;;   4e:	 0000                 	add	byte ptr [rax], al
+;;   50:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_le/locals.wat
+++ b/winch/filetests/filetests/x64/f32_le/locals.wat
@@ -18,17 +18,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 48c744240800000000   	
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10053b000000     	movss	xmm0, dword ptr [rip + 0x3b]
+;;      	 f30f100534000000     	movss	xmm0, dword ptr [rip + 0x34]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f100535000000     	movss	xmm0, dword ptr [rip + 0x35]
+;;      	 f30f10052e000000     	movss	xmm0, dword ptr [rip + 0x2e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
@@ -38,9 +39,5 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
-;;   61:	 0000                 	add	byte ptr [rax], al
-;;   63:	 0000                 	add	byte ptr [rax], al
-;;   65:	 0000                 	add	byte ptr [rax], al
-;;   67:	 00cd                 	add	ch, cl
-;;   69:	 cc                   	int3	
+;;   66:	 0f0b                 	ud2	
+;;   68:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_le/params.wat
+++ b/winch/filetests/filetests/x64/f32_le/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872e000000         	ja	0x46
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
@@ -25,4 +26,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   46:	 0f0b                 	ud2	
+;;   4d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_lt/const.wat
+++ b/winch/filetests/filetests/x64/f32_lt/const.wat
@@ -9,23 +9,25 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10051c000000     	movss	xmm0, dword ptr [rip + 0x1c]
-;;      	 f30f100d1c000000     	movss	xmm1, dword ptr [rip + 0x1c]
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]
+;;      	 f30f100d1d000000     	movss	xmm1, dword ptr [rip + 0x1d]
 ;;      	 0f2ec1               	ucomiss	xmm0, xmm1
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f97c0             	seta	al
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
-;;   40:	 cdcc                 	int	0xcc
-;;   42:	 0c40                 	or	al, 0x40
-;;   44:	 0000                 	add	byte ptr [rax], al
-;;   46:	 0000                 	add	byte ptr [rax], al
-;;   48:	 cdcc                 	int	0xcc
+;;   45:	 0f0b                 	ud2	
+;;   47:	 00cd                 	add	ch, cl
+;;   49:	 cc                   	int3	
+;;   4a:	 0c40                 	or	al, 0x40
+;;   4c:	 0000                 	add	byte ptr [rax], al
+;;   4e:	 0000                 	add	byte ptr [rax], al
+;;   50:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_lt/locals.wat
+++ b/winch/filetests/filetests/x64/f32_lt/locals.wat
@@ -18,17 +18,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 48c744240800000000   	
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10053b000000     	movss	xmm0, dword ptr [rip + 0x3b]
+;;      	 f30f100534000000     	movss	xmm0, dword ptr [rip + 0x34]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f100535000000     	movss	xmm0, dword ptr [rip + 0x35]
+;;      	 f30f10052e000000     	movss	xmm0, dword ptr [rip + 0x2e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
@@ -38,9 +39,5 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
-;;   61:	 0000                 	add	byte ptr [rax], al
-;;   63:	 0000                 	add	byte ptr [rax], al
-;;   65:	 0000                 	add	byte ptr [rax], al
-;;   67:	 00cd                 	add	ch, cl
-;;   69:	 cc                   	int3	
+;;   66:	 0f0b                 	ud2	
+;;   68:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_lt/params.wat
+++ b/winch/filetests/filetests/x64/f32_lt/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872e000000         	ja	0x46
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
@@ -25,4 +26,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   46:	 0f0b                 	ud2	
+;;   4d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_max/const.wat
+++ b/winch/filetests/filetests/x64/f32_max/const.wat
@@ -9,31 +9,33 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10053c000000     	movss	xmm0, dword ptr [rip + 0x3c]
-;;      	 f30f100d3c000000     	movss	xmm1, dword ptr [rip + 0x3c]
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10053d000000     	movss	xmm0, dword ptr [rip + 0x3d]
+;;      	 f30f100d3d000000     	movss	xmm1, dword ptr [rip + 0x3d]
 ;;      	 0f2ec8               	ucomiss	xmm1, xmm0
-;;      	 0f8518000000         	jne	0x4d
-;;      	 0f8a08000000         	jp	0x43
-;;   3b:	 0f54c8               	andps	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x51
-;;   43:	 f30f58c8             	addss	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x51
-;;   4d:	 f30f5fc8             	maxss	xmm1, xmm0
+;;      	 0f8518000000         	jne	0x54
+;;      	 0f8a08000000         	jp	0x4a
+;;   42:	 0f54c8               	andps	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x58
+;;   4a:	 f30f58c8             	addss	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x58
+;;   54:	 f30f5fc8             	maxss	xmm1, xmm0
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
-;;   5c:	 0000                 	add	byte ptr [rax], al
-;;   5e:	 0000                 	add	byte ptr [rax], al
-;;   60:	 cdcc                 	int	0xcc
-;;   62:	 0c40                 	or	al, 0x40
-;;   64:	 0000                 	add	byte ptr [rax], al
-;;   66:	 0000                 	add	byte ptr [rax], al
-;;   68:	 cdcc                 	int	0xcc
+;;   61:	 0f0b                 	ud2	
+;;   63:	 0000                 	add	byte ptr [rax], al
+;;   65:	 0000                 	add	byte ptr [rax], al
+;;   67:	 00cd                 	add	ch, cl
+;;   69:	 cc                   	int3	
+;;   6a:	 0c40                 	or	al, 0x40
+;;   6c:	 0000                 	add	byte ptr [rax], al
+;;   6e:	 0000                 	add	byte ptr [rax], al
+;;   70:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_max/locals.wat
+++ b/winch/filetests/filetests/x64/f32_max/locals.wat
@@ -18,33 +18,34 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8763000000         	ja	0x7b
-;;   18:	 48c744240800000000   	
+;;      	 0f8767000000         	ja	0x82
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100553000000     	movss	xmm0, dword ptr [rip + 0x53]
+;;      	 f30f100554000000     	movss	xmm0, dword ptr [rip + 0x54]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f10054d000000     	movss	xmm0, dword ptr [rip + 0x4d]
+;;      	 f30f10054e000000     	movss	xmm0, dword ptr [rip + 0x4e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
 ;;      	 0f2ec8               	ucomiss	xmm1, xmm0
-;;      	 0f8518000000         	jne	0x6e
-;;      	 0f8a08000000         	jp	0x64
-;;   5c:	 0f54c8               	andps	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x72
-;;   64:	 f30f58c8             	addss	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x72
-;;   6e:	 f30f5fc8             	maxss	xmm1, xmm0
+;;      	 0f8518000000         	jne	0x75
+;;      	 0f8a08000000         	jp	0x6b
+;;   63:	 0f54c8               	andps	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x79
+;;   6b:	 f30f58c8             	addss	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x79
+;;   75:	 f30f5fc8             	maxss	xmm1, xmm0
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   7b:	 0f0b                 	ud2	
-;;   7d:	 0000                 	add	byte ptr [rax], al
-;;   7f:	 00cd                 	add	ch, cl
-;;   81:	 cc                   	int3	
+;;   82:	 0f0b                 	ud2	
+;;   84:	 0000                 	add	byte ptr [rax], al
+;;   86:	 0000                 	add	byte ptr [rax], al
+;;   88:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_max/params.wat
+++ b/winch/filetests/filetests/x64/f32_max/params.wat
@@ -9,26 +9,27 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874a000000         	ja	0x62
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f874e000000         	ja	0x69
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
 ;;      	 0f2ec8               	ucomiss	xmm1, xmm0
-;;      	 0f8518000000         	jne	0x55
-;;      	 0f8a08000000         	jp	0x4b
-;;   43:	 0f54c8               	andps	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x59
-;;   4b:	 f30f58c8             	addss	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x59
-;;   55:	 f30f5fc8             	maxss	xmm1, xmm0
+;;      	 0f8518000000         	jne	0x5c
+;;      	 0f8a08000000         	jp	0x52
+;;   4a:	 0f54c8               	andps	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x60
+;;   52:	 f30f58c8             	addss	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x60
+;;   5c:	 f30f5fc8             	maxss	xmm1, xmm0
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   62:	 0f0b                 	ud2	
+;;   69:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_min/const.wat
+++ b/winch/filetests/filetests/x64/f32_min/const.wat
@@ -9,31 +9,33 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10053c000000     	movss	xmm0, dword ptr [rip + 0x3c]
-;;      	 f30f100d3c000000     	movss	xmm1, dword ptr [rip + 0x3c]
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10053d000000     	movss	xmm0, dword ptr [rip + 0x3d]
+;;      	 f30f100d3d000000     	movss	xmm1, dword ptr [rip + 0x3d]
 ;;      	 0f2ec8               	ucomiss	xmm1, xmm0
-;;      	 0f8518000000         	jne	0x4d
-;;      	 0f8a08000000         	jp	0x43
-;;   3b:	 0f56c8               	orps	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x51
-;;   43:	 f30f58c8             	addss	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x51
-;;   4d:	 f30f5dc8             	minss	xmm1, xmm0
+;;      	 0f8518000000         	jne	0x54
+;;      	 0f8a08000000         	jp	0x4a
+;;   42:	 0f56c8               	orps	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x58
+;;   4a:	 f30f58c8             	addss	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x58
+;;   54:	 f30f5dc8             	minss	xmm1, xmm0
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
-;;   5c:	 0000                 	add	byte ptr [rax], al
-;;   5e:	 0000                 	add	byte ptr [rax], al
-;;   60:	 cdcc                 	int	0xcc
-;;   62:	 0c40                 	or	al, 0x40
-;;   64:	 0000                 	add	byte ptr [rax], al
-;;   66:	 0000                 	add	byte ptr [rax], al
-;;   68:	 cdcc                 	int	0xcc
+;;   61:	 0f0b                 	ud2	
+;;   63:	 0000                 	add	byte ptr [rax], al
+;;   65:	 0000                 	add	byte ptr [rax], al
+;;   67:	 00cd                 	add	ch, cl
+;;   69:	 cc                   	int3	
+;;   6a:	 0c40                 	or	al, 0x40
+;;   6c:	 0000                 	add	byte ptr [rax], al
+;;   6e:	 0000                 	add	byte ptr [rax], al
+;;   70:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_min/locals.wat
+++ b/winch/filetests/filetests/x64/f32_min/locals.wat
@@ -18,33 +18,34 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8763000000         	ja	0x7b
-;;   18:	 48c744240800000000   	
+;;      	 0f8767000000         	ja	0x82
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100553000000     	movss	xmm0, dword ptr [rip + 0x53]
+;;      	 f30f100554000000     	movss	xmm0, dword ptr [rip + 0x54]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f10054d000000     	movss	xmm0, dword ptr [rip + 0x4d]
+;;      	 f30f10054e000000     	movss	xmm0, dword ptr [rip + 0x4e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
 ;;      	 0f2ec8               	ucomiss	xmm1, xmm0
-;;      	 0f8518000000         	jne	0x6e
-;;      	 0f8a08000000         	jp	0x64
-;;   5c:	 0f56c8               	orps	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x72
-;;   64:	 f30f58c8             	addss	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x72
-;;   6e:	 f30f5dc8             	minss	xmm1, xmm0
+;;      	 0f8518000000         	jne	0x75
+;;      	 0f8a08000000         	jp	0x6b
+;;   63:	 0f56c8               	orps	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x79
+;;   6b:	 f30f58c8             	addss	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x79
+;;   75:	 f30f5dc8             	minss	xmm1, xmm0
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   7b:	 0f0b                 	ud2	
-;;   7d:	 0000                 	add	byte ptr [rax], al
-;;   7f:	 00cd                 	add	ch, cl
-;;   81:	 cc                   	int3	
+;;   82:	 0f0b                 	ud2	
+;;   84:	 0000                 	add	byte ptr [rax], al
+;;   86:	 0000                 	add	byte ptr [rax], al
+;;   88:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_min/params.wat
+++ b/winch/filetests/filetests/x64/f32_min/params.wat
@@ -9,26 +9,27 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874a000000         	ja	0x62
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f874e000000         	ja	0x69
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
 ;;      	 0f2ec8               	ucomiss	xmm1, xmm0
-;;      	 0f8518000000         	jne	0x55
-;;      	 0f8a08000000         	jp	0x4b
-;;   43:	 0f56c8               	orps	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x59
-;;   4b:	 f30f58c8             	addss	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x59
-;;   55:	 f30f5dc8             	minss	xmm1, xmm0
+;;      	 0f8518000000         	jne	0x5c
+;;      	 0f8a08000000         	jp	0x52
+;;   4a:	 0f56c8               	orps	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x60
+;;   52:	 f30f58c8             	addss	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x60
+;;   5c:	 f30f5dc8             	minss	xmm1, xmm0
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   62:	 0f0b                 	ud2	
+;;   69:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_mul/const.wat
+++ b/winch/filetests/filetests/x64/f32_mul/const.wat
@@ -9,25 +9,26 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10051c000000     	movss	xmm0, dword ptr [rip + 0x1c]
-;;      	 f30f100d1c000000     	movss	xmm1, dword ptr [rip + 0x1c]
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]
+;;      	 f30f100d1d000000     	movss	xmm1, dword ptr [rip + 0x1d]
 ;;      	 f30f59c8             	mulss	xmm1, xmm0
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
-;;   3b:	 0000                 	add	byte ptr [rax], al
-;;   3d:	 0000                 	add	byte ptr [rax], al
-;;   3f:	 00cd                 	add	ch, cl
-;;   41:	 cc                   	int3	
-;;   42:	 0c40                 	or	al, 0x40
+;;   40:	 0f0b                 	ud2	
+;;   42:	 0000                 	add	byte ptr [rax], al
 ;;   44:	 0000                 	add	byte ptr [rax], al
 ;;   46:	 0000                 	add	byte ptr [rax], al
 ;;   48:	 cdcc                 	int	0xcc
+;;   4a:	 0c40                 	or	al, 0x40
+;;   4c:	 0000                 	add	byte ptr [rax], al
+;;   4e:	 0000                 	add	byte ptr [rax], al
+;;   50:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_mul/locals.wat
+++ b/winch/filetests/filetests/x64/f32_mul/locals.wat
@@ -18,17 +18,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 48c744240800000000   	
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100533000000     	movss	xmm0, dword ptr [rip + 0x33]
+;;      	 f30f100534000000     	movss	xmm0, dword ptr [rip + 0x34]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]
+;;      	 f30f10052e000000     	movss	xmm0, dword ptr [rip + 0x2e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
@@ -37,7 +38,8 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
-;;   5c:	 0000                 	add	byte ptr [rax], al
-;;   5e:	 0000                 	add	byte ptr [rax], al
-;;   60:	 cdcc                 	int	0xcc
+;;   61:	 0f0b                 	ud2	
+;;   63:	 0000                 	add	byte ptr [rax], al
+;;   65:	 0000                 	add	byte ptr [rax], al
+;;   67:	 00cd                 	add	ch, cl
+;;   69:	 cc                   	int3	

--- a/winch/filetests/filetests/x64/f32_mul/params.wat
+++ b/winch/filetests/filetests/x64/f32_mul/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_ne/const.wat
+++ b/winch/filetests/filetests/x64/f32_ne/const.wat
@@ -9,14 +9,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x4b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10052c000000     	movss	xmm0, dword ptr [rip + 0x2c]
-;;      	 f30f100d2c000000     	movss	xmm1, dword ptr [rip + 0x2c]
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]
+;;      	 f30f100d2d000000     	movss	xmm1, dword ptr [rip + 0x2d]
 ;;      	 0f2ec8               	ucomiss	xmm1, xmm0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f95c0             	setne	al
@@ -26,11 +27,11 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4b:	 0f0b                 	ud2	
-;;   4d:	 0000                 	add	byte ptr [rax], al
-;;   4f:	 00cd                 	add	ch, cl
-;;   51:	 cc                   	int3	
-;;   52:	 0c40                 	or	al, 0x40
+;;   52:	 0f0b                 	ud2	
 ;;   54:	 0000                 	add	byte ptr [rax], al
 ;;   56:	 0000                 	add	byte ptr [rax], al
 ;;   58:	 cdcc                 	int	0xcc
+;;   5a:	 0c40                 	or	al, 0x40
+;;   5c:	 0000                 	add	byte ptr [rax], al
+;;   5e:	 0000                 	add	byte ptr [rax], al
+;;   60:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_ne/locals.wat
+++ b/winch/filetests/filetests/x64/f32_ne/locals.wat
@@ -18,17 +18,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8754000000         	ja	0x6c
-;;   18:	 48c744240800000000   	
+;;      	 0f8758000000         	ja	0x73
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100543000000     	movss	xmm0, dword ptr [rip + 0x43]
+;;      	 f30f100544000000     	movss	xmm0, dword ptr [rip + 0x44]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f10053d000000     	movss	xmm0, dword ptr [rip + 0x3d]
+;;      	 f30f10053e000000     	movss	xmm0, dword ptr [rip + 0x3e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
@@ -41,6 +42,7 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6c:	 0f0b                 	ud2	
-;;   6e:	 0000                 	add	byte ptr [rax], al
-;;   70:	 cdcc                 	int	0xcc
+;;   73:	 0f0b                 	ud2	
+;;   75:	 0000                 	add	byte ptr [rax], al
+;;   77:	 00cd                 	add	ch, cl
+;;   79:	 cc                   	int3	

--- a/winch/filetests/filetests/x64/f32_ne/params.wat
+++ b/winch/filetests/filetests/x64/f32_ne/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873b000000         	ja	0x53
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f873f000000         	ja	0x5a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   53:	 0f0b                 	ud2	
+;;   5a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_nearest/f32_floor_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_nearest/f32_floor_const_sse41.wat
@@ -9,21 +9,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100514000000     	movss	xmm0, dword ptr [rip + 0x14]
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f100515000000     	movss	xmm0, dword ptr [rip + 0x15]
 ;;      	 660f3a0ac000         	roundss	xmm0, xmm0, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
-;;   32:	 0000                 	add	byte ptr [rax], al
-;;   34:	 0000                 	add	byte ptr [rax], al
-;;   36:	 0000                 	add	byte ptr [rax], al
-;;   38:	 c3                   	ret	
-;;   39:	 f5                   	cmc	
-;;   3a:	 a8bf                 	test	al, 0xbf
+;;   37:	 0f0b                 	ud2	
+;;   39:	 0000                 	add	byte ptr [rax], al
+;;   3b:	 0000                 	add	byte ptr [rax], al
+;;   3d:	 0000                 	add	byte ptr [rax], al
+;;   3f:	 00c3                 	add	bl, al
+;;   41:	 f5                   	cmc	
+;;   42:	 a8bf                 	test	al, 0xbf

--- a/winch/filetests/filetests/x64/f32_nearest/f32_floor_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_nearest/f32_floor_param_sse41.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 660f3a0ac000         	roundss	xmm0, xmm0, 0
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_nearest/f32_nearest_param.wat
+++ b/winch/filetests/filetests/x64/f32_nearest/f32_nearest_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x58
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f3440f107c240c       	movss	xmm15, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   58:	 0f0b                 	ud2	
+;;   5f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_neg/f32_neg_const.wat
+++ b/winch/filetests/filetests/x64/f32_neg/f32_neg_const.wat
@@ -8,22 +8,24 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10051c000000     	movss	xmm0, dword ptr [rip + 0x1c]
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]
 ;;      	 41bb00000080         	mov	r11d, 0x80000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f57c7             	xorps	xmm0, xmm15
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
-;;   3b:	 0000                 	add	byte ptr [rax], al
-;;   3d:	 0000                 	add	byte ptr [rax], al
-;;   3f:	 00c3                 	add	bl, al
-;;   41:	 f5                   	cmc	
-;;   42:	 a8bf                 	test	al, 0xbf
+;;   40:	 0f0b                 	ud2	
+;;   42:	 0000                 	add	byte ptr [rax], al
+;;   44:	 0000                 	add	byte ptr [rax], al
+;;   46:	 0000                 	add	byte ptr [rax], al
+;;   48:	 c3                   	ret	
+;;   49:	 f5                   	cmc	
+;;   4a:	 a8bf                 	test	al, 0xbf

--- a/winch/filetests/filetests/x64/f32_neg/f32_neg_param.wat
+++ b/winch/filetests/filetests/x64/f32_neg/f32_neg_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x3d
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 41bb00000080         	mov	r11d, 0x80000000
@@ -22,4 +23,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3d:	 0f0b                 	ud2	
+;;   44:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_reinterpret_i32/const.wat
+++ b/winch/filetests/filetests/x64/f32_reinterpret_i32/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x2b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8717000000         	ja	0x32
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 660f6ec0             	movd	xmm0, eax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2b:	 0f0b                 	ud2	
+;;   32:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_reinterpret_i32/locals.wat
+++ b/winch/filetests/filetests/x64/f32_reinterpret_i32/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 48c744240800000000   	
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_reinterpret_i32/params.wat
+++ b/winch/filetests/filetests/x64/f32_reinterpret_i32/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 660f6ec0             	movd	xmm0, eax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_reinterpret_i32/ret_int.wat
+++ b/winch/filetests/filetests/x64/f32_reinterpret_i32/ret_int.wat
@@ -10,16 +10,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 660f6ec0             	movd	xmm0, eax
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_reinterpret_i32/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_reinterpret_i32/spilled.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c30c000000       	add	r11, 0xc
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x3d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 660f6ec0             	movd	xmm0, eax
 ;;      	 4883ec04             	sub	rsp, 4
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3d:	 0f0b                 	ud2	
+;;   44:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_sqrt/f32_sqrt_const.wat
+++ b/winch/filetests/filetests/x64/f32_sqrt/f32_sqrt_const.wat
@@ -8,18 +8,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10050c000000     	movss	xmm0, dword ptr [rip + 0xc]
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10050d000000     	movss	xmm0, dword ptr [rip + 0xd]
 ;;      	 f30f51c0             	sqrtss	xmm0, xmm0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
-;;   30:	 c3                   	ret	
-;;   31:	 f5                   	cmc	
-;;   32:	 a83f                 	test	al, 0x3f
+;;   35:	 0f0b                 	ud2	
+;;   37:	 00c3                 	add	bl, al
+;;   39:	 f5                   	cmc	
+;;   3a:	 a83f                 	test	al, 0x3f

--- a/winch/filetests/filetests/x64/f32_sqrt/f32_sqrt_param.wat
+++ b/winch/filetests/filetests/x64/f32_sqrt/f32_sqrt_param.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 f30f51c0             	sqrtss	xmm0, xmm0
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_sub/const.wat
+++ b/winch/filetests/filetests/x64/f32_sub/const.wat
@@ -9,25 +9,26 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10051c000000     	movss	xmm0, dword ptr [rip + 0x1c]
-;;      	 f30f100d1c000000     	movss	xmm1, dword ptr [rip + 0x1c]
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]
+;;      	 f30f100d1d000000     	movss	xmm1, dword ptr [rip + 0x1d]
 ;;      	 f30f5cc8             	subss	xmm1, xmm0
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
-;;   3b:	 0000                 	add	byte ptr [rax], al
-;;   3d:	 0000                 	add	byte ptr [rax], al
-;;   3f:	 00cd                 	add	ch, cl
-;;   41:	 cc                   	int3	
-;;   42:	 0c40                 	or	al, 0x40
+;;   40:	 0f0b                 	ud2	
+;;   42:	 0000                 	add	byte ptr [rax], al
 ;;   44:	 0000                 	add	byte ptr [rax], al
 ;;   46:	 0000                 	add	byte ptr [rax], al
 ;;   48:	 cdcc                 	int	0xcc
+;;   4a:	 0c40                 	or	al, 0x40
+;;   4c:	 0000                 	add	byte ptr [rax], al
+;;   4e:	 0000                 	add	byte ptr [rax], al
+;;   50:	 cdcc                 	int	0xcc

--- a/winch/filetests/filetests/x64/f32_sub/locals.wat
+++ b/winch/filetests/filetests/x64/f32_sub/locals.wat
@@ -18,17 +18,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 48c744240800000000   	
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100533000000     	movss	xmm0, dword ptr [rip + 0x33]
+;;      	 f30f100534000000     	movss	xmm0, dword ptr [rip + 0x34]
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
-;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]
+;;      	 f30f10052e000000     	movss	xmm0, dword ptr [rip + 0x2e]
 ;;      	 f30f11442408         	movss	dword ptr [rsp + 8], xmm0
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
@@ -37,7 +38,8 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
-;;   5c:	 0000                 	add	byte ptr [rax], al
-;;   5e:	 0000                 	add	byte ptr [rax], al
-;;   60:	 cdcc                 	int	0xcc
+;;   61:	 0f0b                 	ud2	
+;;   63:	 0000                 	add	byte ptr [rax], al
+;;   65:	 0000                 	add	byte ptr [rax], al
+;;   67:	 00cd                 	add	ch, cl
+;;   69:	 cc                   	int3	

--- a/winch/filetests/filetests/x64/f32_sub/params.wat
+++ b/winch/filetests/filetests/x64/f32_sub/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 f30f114c2408         	movss	dword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f10442408         	movss	xmm0, dword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_trunc/f32_trunc_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_trunc/f32_trunc_const_sse41.wat
@@ -9,21 +9,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100514000000     	movss	xmm0, dword ptr [rip + 0x14]
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f100515000000     	movss	xmm0, dword ptr [rip + 0x15]
 ;;      	 660f3a0ac003         	roundss	xmm0, xmm0, 3
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
-;;   32:	 0000                 	add	byte ptr [rax], al
-;;   34:	 0000                 	add	byte ptr [rax], al
-;;   36:	 0000                 	add	byte ptr [rax], al
-;;   38:	 c3                   	ret	
-;;   39:	 f5                   	cmc	
-;;   3a:	 a8bf                 	test	al, 0xbf
+;;   37:	 0f0b                 	ud2	
+;;   39:	 0000                 	add	byte ptr [rax], al
+;;   3b:	 0000                 	add	byte ptr [rax], al
+;;   3d:	 0000                 	add	byte ptr [rax], al
+;;   3f:	 00c3                 	add	bl, al
+;;   41:	 f5                   	cmc	
+;;   42:	 a8bf                 	test	al, 0xbf

--- a/winch/filetests/filetests/x64/f32_trunc/f32_trunc_param.wat
+++ b/winch/filetests/filetests/x64/f32_trunc/f32_trunc_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x58
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f3440f107c240c       	movss	xmm15, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   58:	 0f0b                 	ud2	
+;;   5f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_trunc/f32_trunc_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_trunc/f32_trunc_param_sse41.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 660f3a0ac003         	roundss	xmm0, xmm0, 3
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_abs/f64_abs_const.wat
+++ b/winch/filetests/filetests/x64/f64_abs/f64_abs_const.wat
@@ -8,13 +8,14 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10051c000000     	movsd	xmm0, qword ptr [rip + 0x1c]
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]
 ;;      	 49bbffffffffffffff7f 	
 ;; 				movabs	r11, 0x7fffffffffffffff
 ;;      	 664d0f6efb           	movq	xmm15, r11
@@ -22,4 +23,7 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
+;;   45:	 0f0b                 	ud2	
+;;   47:	 001f                 	add	byte ptr [rdi], bl
+;;   49:	 85eb                 	test	ebx, ebp
+;;   4b:	 51                   	push	rcx

--- a/winch/filetests/filetests/x64/f64_abs/f64_abs_param.wat
+++ b/winch/filetests/filetests/x64/f64_abs/f64_abs_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 49bbffffffffffffff7f 	
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_add/const.wat
+++ b/winch/filetests/filetests/x64/f64_add/const.wat
@@ -9,19 +9,29 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8722000000         	ja	0x3a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10051c000000     	movsd	xmm0, qword ptr [rip + 0x1c]
-;;      	 f20f100d1c000000     	movsd	xmm1, qword ptr [rip + 0x1c]
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]
+;;      	 f20f100d1d000000     	movsd	xmm1, qword ptr [rip + 0x1d]
 ;;      	 f20f58c8             	addsd	xmm1, xmm0
 ;;      	 660f28c1             	movapd	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3a:	 0f0b                 	ud2	
-;;   3c:	 0000                 	add	byte ptr [rax], al
-;;   3e:	 0000                 	add	byte ptr [rax], al
+;;   41:	 0f0b                 	ud2	
+;;   43:	 0000                 	add	byte ptr [rax], al
+;;   45:	 0000                 	add	byte ptr [rax], al
+;;   47:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   4d:	 99                   	cdq	
+;;   4e:	 01409a               	add	dword ptr [rax - 0x66], eax
+;;   51:	 99                   	cdq	
+;;   52:	 99                   	cdq	
+;;   53:	 99                   	cdq	
+;;   54:	 99                   	cdq	
+;;   55:	 99                   	cdq	
+;;   56:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_add/locals.wat
+++ b/winch/filetests/filetests/x64/f64_add/locals.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100537000000     	movsd	xmm0, qword ptr [rip + 0x37]
+;;      	 f20f100530000000     	movsd	xmm0, qword ptr [rip + 0x30]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100531000000     	movsd	xmm0, qword ptr [rip + 0x31]
+;;      	 f20f10052a000000     	movsd	xmm0, qword ptr [rip + 0x2a]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -38,10 +39,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
-;;   61:	 0000                 	add	byte ptr [rax], al
-;;   63:	 0000                 	add	byte ptr [rax], al
-;;   65:	 0000                 	add	byte ptr [rax], al
-;;   67:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   6d:	 99                   	cdq	
-;;   6e:	 f1                   	int1	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_add/params.wat
+++ b/winch/filetests/filetests/x64/f64_add/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_ceil/f64_ceil_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_ceil/f64_ceil_const_sse41.wat
@@ -9,18 +9,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100514000000     	movsd	xmm0, qword ptr [rip + 0x14]
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f100515000000     	movsd	xmm0, qword ptr [rip + 0x15]
 ;;      	 660f3a0bc002         	roundsd	xmm0, xmm0, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
-;;   32:	 0000                 	add	byte ptr [rax], al
-;;   34:	 0000                 	add	byte ptr [rax], al
-;;   36:	 0000                 	add	byte ptr [rax], al
+;;   37:	 0f0b                 	ud2	
+;;   39:	 0000                 	add	byte ptr [rax], al
+;;   3b:	 0000                 	add	byte ptr [rax], al
+;;   3d:	 0000                 	add	byte ptr [rax], al
+;;   3f:	 001f                 	add	byte ptr [rdi], bl
+;;   41:	 85eb                 	test	ebx, ebp
+;;   43:	 51                   	push	rcx

--- a/winch/filetests/filetests/x64/f64_ceil/f64_ceil_param.wat
+++ b/winch/filetests/filetests/x64/f64_ceil/f64_ceil_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x58
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f2440f107c2408       	movsd	xmm15, qword ptr [rsp + 8]
 ;;      	 4883ec08             	sub	rsp, 8
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   58:	 0f0b                 	ud2	
+;;   5f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_ceil/f64_ceil_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_ceil/f64_ceil_param_sse41.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 660f3a0bc002         	roundsd	xmm0, xmm0, 2
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_const/call_id.wat
+++ b/winch/filetests/filetests/x64/f64_const/call_id.wat
@@ -6,38 +6,34 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x37
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 f20f100518000000     	movsd	xmm0, qword ptr [rip + 0x18]
-;;      	 e800000000           	call	0x2d
+;;      	 f20f100511000000     	movsd	xmm0, qword ptr [rip + 0x11]
+;;      	 e800000000           	call	0x34
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   37:	 0f0b                 	ud2	
-;;   39:	 0000                 	add	byte ptr [rax], al
-;;   3b:	 0000                 	add	byte ptr [rax], al
-;;   3d:	 0000                 	add	byte ptr [rax], al
-;;   3f:	 001f                 	add	byte ptr [rdi], bl
-;;   41:	 85eb                 	test	ebx, ebp
-;;   43:	 51                   	push	rcx
+;;   3e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_const/id.wat
+++ b/winch/filetests/filetests/x64/f64_const/id.wat
@@ -5,15 +5,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i32_s/const.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_s/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x2b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8717000000         	ja	0x32
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 f20f2ac0             	cvtsi2sd	xmm0, eax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2b:	 0f0b                 	ud2	
+;;   32:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i32_s/locals.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_s/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 48c744240800000000   	
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i32_s/params.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_s/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 f20f2ac0             	cvtsi2sd	xmm0, eax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i32_s/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_s/spilled.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x3d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 f20f2ac0             	cvtsi2sd	xmm0, eax
 ;;      	 4883ec08             	sub	rsp, 8
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3d:	 0f0b                 	ud2	
+;;   44:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i32_u/const.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_u/const.wat
@@ -8,19 +8,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x57
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b901000000           	mov	ecx, 1
 ;;      	 8bc9                 	mov	ecx, ecx
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x37
-;;   2d:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
-;;      	 e91a000000           	jmp	0x51
-;;   37:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x3e
+;;   34:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
+;;      	 e91a000000           	jmp	0x58
+;;   3e:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -30,4 +31,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   57:	 0f0b                 	ud2	
+;;   5e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i32_u/locals.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_u/locals.wat
@@ -10,21 +10,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 48c744240800000000   	
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;      	 8bc9                 	mov	ecx, ecx
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x3f
-;;   35:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
-;;      	 e91a000000           	jmp	0x59
-;;   3f:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x46
+;;   3c:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
+;;      	 e91a000000           	jmp	0x60
+;;   46:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -34,4 +35,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i32_u/params.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_u/params.wat
@@ -8,20 +8,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;      	 8bc9                 	mov	ecx, ecx
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x3a
-;;   30:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
-;;      	 e91a000000           	jmp	0x54
-;;   3a:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x41
+;;   37:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
+;;      	 e91a000000           	jmp	0x5b
+;;   41:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -31,4 +32,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
+;;   61:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i32_u/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_u/spilled.wat
@@ -10,19 +10,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8751000000         	ja	0x69
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8755000000         	ja	0x70
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b901000000           	mov	ecx, 1
 ;;      	 8bc9                 	mov	ecx, ecx
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x37
-;;   2d:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
-;;      	 e91a000000           	jmp	0x51
-;;   37:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x3e
+;;   34:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
+;;      	 e91a000000           	jmp	0x58
+;;   3e:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -36,4 +37,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   69:	 0f0b                 	ud2	
+;;   70:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i64_s/const.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_s/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 f2480f2ac0           	cvtsi2sd	xmm0, rax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i64_s/locals.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_s/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871d000000         	ja	0x35
-;;   18:	 48c744240800000000   	
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   35:	 0f0b                 	ud2	
+;;   3c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i64_s/params.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_s/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 f2480f2ac0           	cvtsi2sd	xmm0, rax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i64_s/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_s/spilled.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x40
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 f2480f2ac0           	cvtsi2sd	xmm0, rax
 ;;      	 4883ec08             	sub	rsp, 8
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   40:	 0f0b                 	ud2	
+;;   47:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i64_u/const.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_u/const.wat
@@ -8,18 +8,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x57
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c101000000       	mov	rcx, 1
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x37
-;;   2d:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
-;;      	 e91a000000           	jmp	0x51
-;;   37:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x3e
+;;   34:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
+;;      	 e91a000000           	jmp	0x58
+;;   3e:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -29,4 +30,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   57:	 0f0b                 	ud2	
+;;   5e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i64_u/locals.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_u/locals.wat
@@ -10,20 +10,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8746000000         	ja	0x5e
-;;   18:	 48c744240800000000   	
+;;      	 0f874a000000         	ja	0x65
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x3e
-;;   34:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
-;;      	 e91a000000           	jmp	0x58
-;;   3e:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x45
+;;   3b:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
+;;      	 e91a000000           	jmp	0x5f
+;;   45:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -33,4 +34,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5e:	 0f0b                 	ud2	
+;;   65:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i64_u/params.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_u/params.wat
@@ -8,19 +8,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x5a
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x3a
-;;   30:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
-;;      	 e91a000000           	jmp	0x54
-;;   3a:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x41
+;;   37:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
+;;      	 e91a000000           	jmp	0x5b
+;;   41:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -30,4 +31,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5a:	 0f0b                 	ud2	
+;;   61:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_convert_i64_u/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_u/spilled.wat
@@ -10,18 +10,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8751000000         	ja	0x69
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8755000000         	ja	0x70
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c101000000       	mov	rcx, 1
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f8c0a000000         	jl	0x37
-;;   2d:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
-;;      	 e91a000000           	jmp	0x51
-;;   37:	 4989cb               	mov	r11, rcx
+;;      	 0f8c0a000000         	jl	0x3e
+;;   34:	 f2480f2ac1           	cvtsi2sd	xmm0, rcx
+;;      	 e91a000000           	jmp	0x58
+;;   3e:	 4989cb               	mov	r11, rcx
 ;;      	 49c1eb01             	shr	r11, 1
 ;;      	 4889c8               	mov	rax, rcx
 ;;      	 4883e001             	and	rax, 1
@@ -35,4 +36,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   69:	 0f0b                 	ud2	
+;;   70:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_copysign/const.wat
+++ b/winch/filetests/filetests/x64/f64_copysign/const.wat
@@ -9,14 +9,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x58
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10053c000000     	movsd	xmm0, qword ptr [rip + 0x3c]
-;;      	 f20f100d3c000000     	movsd	xmm1, qword ptr [rip + 0x3c]
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10053d000000     	movsd	xmm0, qword ptr [rip + 0x3d]
+;;      	 f20f100d3d000000     	movsd	xmm1, qword ptr [rip + 0x3d]
 ;;      	 49bb0000000000000080 	
 ;; 				movabs	r11, 0x8000000000000000
 ;;      	 664d0f6efb           	movq	xmm15, r11
@@ -28,7 +29,16 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   58:	 0f0b                 	ud2	
-;;   5a:	 0000                 	add	byte ptr [rax], al
-;;   5c:	 0000                 	add	byte ptr [rax], al
-;;   5e:	 0000                 	add	byte ptr [rax], al
+;;   5f:	 0f0b                 	ud2	
+;;   61:	 0000                 	add	byte ptr [rax], al
+;;   63:	 0000                 	add	byte ptr [rax], al
+;;   65:	 0000                 	add	byte ptr [rax], al
+;;   67:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   6d:	 99                   	cdq	
+;;   6e:	 01409a               	add	dword ptr [rax - 0x66], eax
+;;   71:	 99                   	cdq	
+;;   72:	 99                   	cdq	
+;;   73:	 99                   	cdq	
+;;   74:	 99                   	cdq	
+;;   75:	 99                   	cdq	
+;;   76:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_copysign/locals.wat
+++ b/winch/filetests/filetests/x64/f64_copysign/locals.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8765000000         	ja	0x7d
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8769000000         	ja	0x84
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10054f000000     	movsd	xmm0, qword ptr [rip + 0x4f]
+;;      	 f20f100550000000     	movsd	xmm0, qword ptr [rip + 0x50]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100549000000     	movsd	xmm0, qword ptr [rip + 0x49]
+;;      	 f20f10054a000000     	movsd	xmm0, qword ptr [rip + 0x4a]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -44,10 +45,5 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   7d:	 0f0b                 	ud2	
-;;   7f:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   85:	 99                   	cdq	
-;;   86:	 f1                   	int1	
-;;   87:	 bf9a999999           	mov	edi, 0x9999999a
-;;   8c:	 99                   	cdq	
-;;   8d:	 99                   	cdq	
+;;   84:	 0f0b                 	ud2	
+;;   86:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f64_copysign/params.wat
+++ b/winch/filetests/filetests/x64/f64_copysign/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8748000000         	ja	0x60
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f874c000000         	ja	0x67
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -30,4 +31,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   60:	 0f0b                 	ud2	
+;;   67:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_div/const.wat
+++ b/winch/filetests/filetests/x64/f64_div/const.wat
@@ -9,19 +9,29 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8722000000         	ja	0x3a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10051c000000     	movsd	xmm0, qword ptr [rip + 0x1c]
-;;      	 f20f100d1c000000     	movsd	xmm1, qword ptr [rip + 0x1c]
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]
+;;      	 f20f100d1d000000     	movsd	xmm1, qword ptr [rip + 0x1d]
 ;;      	 f20f5ec8             	divsd	xmm1, xmm0
 ;;      	 660f28c1             	movapd	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3a:	 0f0b                 	ud2	
-;;   3c:	 0000                 	add	byte ptr [rax], al
-;;   3e:	 0000                 	add	byte ptr [rax], al
+;;   41:	 0f0b                 	ud2	
+;;   43:	 0000                 	add	byte ptr [rax], al
+;;   45:	 0000                 	add	byte ptr [rax], al
+;;   47:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   4d:	 99                   	cdq	
+;;   4e:	 01409a               	add	dword ptr [rax - 0x66], eax
+;;   51:	 99                   	cdq	
+;;   52:	 99                   	cdq	
+;;   53:	 99                   	cdq	
+;;   54:	 99                   	cdq	
+;;   55:	 99                   	cdq	
+;;   56:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_div/locals.wat
+++ b/winch/filetests/filetests/x64/f64_div/locals.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100537000000     	movsd	xmm0, qword ptr [rip + 0x37]
+;;      	 f20f100530000000     	movsd	xmm0, qword ptr [rip + 0x30]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100531000000     	movsd	xmm0, qword ptr [rip + 0x31]
+;;      	 f20f10052a000000     	movsd	xmm0, qword ptr [rip + 0x2a]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -38,10 +39,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
-;;   61:	 0000                 	add	byte ptr [rax], al
-;;   63:	 0000                 	add	byte ptr [rax], al
-;;   65:	 0000                 	add	byte ptr [rax], al
-;;   67:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   6d:	 99                   	cdq	
-;;   6e:	 f1                   	int1	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_div/params.wat
+++ b/winch/filetests/filetests/x64/f64_div/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_eq/const.wat
+++ b/winch/filetests/filetests/x64/f64_eq/const.wat
@@ -9,14 +9,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x4c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10052c000000     	movsd	xmm0, qword ptr [rip + 0x2c]
-;;      	 f20f100d2c000000     	movsd	xmm1, qword ptr [rip + 0x2c]
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10052d000000     	movsd	xmm0, qword ptr [rip + 0x2d]
+;;      	 f20f100d2d000000     	movsd	xmm1, qword ptr [rip + 0x2d]
 ;;      	 660f2ec8             	ucomisd	xmm1, xmm0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f94c0             	sete	al
@@ -26,5 +27,14 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4c:	 0f0b                 	ud2	
-;;   4e:	 0000                 	add	byte ptr [rax], al
+;;   53:	 0f0b                 	ud2	
+;;   55:	 0000                 	add	byte ptr [rax], al
+;;   57:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   5d:	 99                   	cdq	
+;;   5e:	 01409a               	add	dword ptr [rax - 0x66], eax
+;;   61:	 99                   	cdq	
+;;   62:	 99                   	cdq	
+;;   63:	 99                   	cdq	
+;;   64:	 99                   	cdq	
+;;   65:	 99                   	cdq	
+;;   66:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_eq/locals.wat
+++ b/winch/filetests/filetests/x64/f64_eq/locals.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8759000000         	ja	0x71
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f875d000000         	ja	0x78
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100547000000     	movsd	xmm0, qword ptr [rip + 0x47]
+;;      	 f20f100548000000     	movsd	xmm0, qword ptr [rip + 0x48]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100541000000     	movsd	xmm0, qword ptr [rip + 0x41]
+;;      	 f20f100542000000     	movsd	xmm0, qword ptr [rip + 0x42]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -42,9 +43,7 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   71:	 0f0b                 	ud2	
-;;   73:	 0000                 	add	byte ptr [rax], al
-;;   75:	 0000                 	add	byte ptr [rax], al
-;;   77:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   7d:	 99                   	cdq	
-;;   7e:	 f1                   	int1	
+;;   78:	 0f0b                 	ud2	
+;;   7a:	 0000                 	add	byte ptr [rax], al
+;;   7c:	 0000                 	add	byte ptr [rax], al
+;;   7e:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f64_eq/params.wat
+++ b/winch/filetests/filetests/x64/f64_eq/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x54
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -28,4 +29,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   54:	 0f0b                 	ud2	
+;;   5b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_floor/f64_floor_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_floor/f64_floor_const_sse41.wat
@@ -9,18 +9,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100514000000     	movsd	xmm0, qword ptr [rip + 0x14]
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f100515000000     	movsd	xmm0, qword ptr [rip + 0x15]
 ;;      	 660f3a0bc001         	roundsd	xmm0, xmm0, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
-;;   32:	 0000                 	add	byte ptr [rax], al
-;;   34:	 0000                 	add	byte ptr [rax], al
-;;   36:	 0000                 	add	byte ptr [rax], al
+;;   37:	 0f0b                 	ud2	
+;;   39:	 0000                 	add	byte ptr [rax], al
+;;   3b:	 0000                 	add	byte ptr [rax], al
+;;   3d:	 0000                 	add	byte ptr [rax], al
+;;   3f:	 001f                 	add	byte ptr [rdi], bl
+;;   41:	 85eb                 	test	ebx, ebp
+;;   43:	 51                   	push	rcx

--- a/winch/filetests/filetests/x64/f64_floor/f64_floor_param.wat
+++ b/winch/filetests/filetests/x64/f64_floor/f64_floor_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x58
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f2440f107c2408       	movsd	xmm15, qword ptr [rsp + 8]
 ;;      	 4883ec08             	sub	rsp, 8
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   58:	 0f0b                 	ud2	
+;;   5f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_floor/f64_floor_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_floor/f64_floor_param_sse41.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 660f3a0bc001         	roundsd	xmm0, xmm0, 1
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_ge/const.wat
+++ b/winch/filetests/filetests/x64/f64_ge/const.wat
@@ -9,14 +9,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x4c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10052c000000     	movsd	xmm0, qword ptr [rip + 0x2c]
-;;      	 f20f100d2c000000     	movsd	xmm1, qword ptr [rip + 0x2c]
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10052d000000     	movsd	xmm0, qword ptr [rip + 0x2d]
+;;      	 f20f100d2d000000     	movsd	xmm1, qword ptr [rip + 0x2d]
 ;;      	 660f2ec8             	ucomisd	xmm1, xmm0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f93c0             	setae	al
@@ -26,5 +27,14 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4c:	 0f0b                 	ud2	
-;;   4e:	 0000                 	add	byte ptr [rax], al
+;;   53:	 0f0b                 	ud2	
+;;   55:	 0000                 	add	byte ptr [rax], al
+;;   57:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   5d:	 99                   	cdq	
+;;   5e:	 01409a               	add	dword ptr [rax - 0x66], eax
+;;   61:	 99                   	cdq	
+;;   62:	 99                   	cdq	
+;;   63:	 99                   	cdq	
+;;   64:	 99                   	cdq	
+;;   65:	 99                   	cdq	
+;;   66:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_ge/locals.wat
+++ b/winch/filetests/filetests/x64/f64_ge/locals.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8759000000         	ja	0x71
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f875d000000         	ja	0x78
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100547000000     	movsd	xmm0, qword ptr [rip + 0x47]
+;;      	 f20f100548000000     	movsd	xmm0, qword ptr [rip + 0x48]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100541000000     	movsd	xmm0, qword ptr [rip + 0x41]
+;;      	 f20f100542000000     	movsd	xmm0, qword ptr [rip + 0x42]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -42,9 +43,7 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   71:	 0f0b                 	ud2	
-;;   73:	 0000                 	add	byte ptr [rax], al
-;;   75:	 0000                 	add	byte ptr [rax], al
-;;   77:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   7d:	 99                   	cdq	
-;;   7e:	 f1                   	int1	
+;;   78:	 0f0b                 	ud2	
+;;   7a:	 0000                 	add	byte ptr [rax], al
+;;   7c:	 0000                 	add	byte ptr [rax], al
+;;   7e:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f64_ge/params.wat
+++ b/winch/filetests/filetests/x64/f64_ge/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x54
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -28,4 +29,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   54:	 0f0b                 	ud2	
+;;   5b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_gt/const.wat
+++ b/winch/filetests/filetests/x64/f64_gt/const.wat
@@ -9,14 +9,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x4c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10052c000000     	movsd	xmm0, qword ptr [rip + 0x2c]
-;;      	 f20f100d2c000000     	movsd	xmm1, qword ptr [rip + 0x2c]
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10052d000000     	movsd	xmm0, qword ptr [rip + 0x2d]
+;;      	 f20f100d2d000000     	movsd	xmm1, qword ptr [rip + 0x2d]
 ;;      	 660f2ec8             	ucomisd	xmm1, xmm0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f97c0             	seta	al
@@ -26,5 +27,14 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4c:	 0f0b                 	ud2	
-;;   4e:	 0000                 	add	byte ptr [rax], al
+;;   53:	 0f0b                 	ud2	
+;;   55:	 0000                 	add	byte ptr [rax], al
+;;   57:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   5d:	 99                   	cdq	
+;;   5e:	 01409a               	add	dword ptr [rax - 0x66], eax
+;;   61:	 99                   	cdq	
+;;   62:	 99                   	cdq	
+;;   63:	 99                   	cdq	
+;;   64:	 99                   	cdq	
+;;   65:	 99                   	cdq	
+;;   66:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_gt/locals.wat
+++ b/winch/filetests/filetests/x64/f64_gt/locals.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8759000000         	ja	0x71
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f875d000000         	ja	0x78
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100547000000     	movsd	xmm0, qword ptr [rip + 0x47]
+;;      	 f20f100548000000     	movsd	xmm0, qword ptr [rip + 0x48]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100541000000     	movsd	xmm0, qword ptr [rip + 0x41]
+;;      	 f20f100542000000     	movsd	xmm0, qword ptr [rip + 0x42]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -42,9 +43,7 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   71:	 0f0b                 	ud2	
-;;   73:	 0000                 	add	byte ptr [rax], al
-;;   75:	 0000                 	add	byte ptr [rax], al
-;;   77:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   7d:	 99                   	cdq	
-;;   7e:	 f1                   	int1	
+;;   78:	 0f0b                 	ud2	
+;;   7a:	 0000                 	add	byte ptr [rax], al
+;;   7c:	 0000                 	add	byte ptr [rax], al
+;;   7e:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f64_gt/params.wat
+++ b/winch/filetests/filetests/x64/f64_gt/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x54
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -28,4 +29,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   54:	 0f0b                 	ud2	
+;;   5b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_le/const.wat
+++ b/winch/filetests/filetests/x64/f64_le/const.wat
@@ -9,30 +9,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100524000000     	movsd	xmm0, qword ptr [rip + 0x24]
-;;      	 f20f100d24000000     	movsd	xmm1, qword ptr [rip + 0x24]
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]
+;;      	 f20f100d1d000000     	movsd	xmm1, qword ptr [rip + 0x1d]
 ;;      	 660f2ec1             	ucomisd	xmm0, xmm1
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f93c0             	setae	al
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
-;;   41:	 0000                 	add	byte ptr [rax], al
-;;   43:	 0000                 	add	byte ptr [rax], al
-;;   45:	 0000                 	add	byte ptr [rax], al
-;;   47:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   4d:	 99                   	cdq	
-;;   4e:	 01409a               	add	dword ptr [rax - 0x66], eax
-;;   51:	 99                   	cdq	
-;;   52:	 99                   	cdq	
-;;   53:	 99                   	cdq	
-;;   54:	 99                   	cdq	
-;;   55:	 99                   	cdq	
-;;   56:	 f1                   	int1	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_le/locals.wat
+++ b/winch/filetests/filetests/x64/f64_le/locals.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874c000000         	ja	0x64
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8750000000         	ja	0x6b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100537000000     	movsd	xmm0, qword ptr [rip + 0x37]
+;;      	 f20f100538000000     	movsd	xmm0, qword ptr [rip + 0x38]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100531000000     	movsd	xmm0, qword ptr [rip + 0x31]
+;;      	 f20f100532000000     	movsd	xmm0, qword ptr [rip + 0x32]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -39,5 +40,8 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   64:	 0f0b                 	ud2	
-;;   66:	 0000                 	add	byte ptr [rax], al
+;;   6b:	 0f0b                 	ud2	
+;;   6d:	 0000                 	add	byte ptr [rax], al
+;;   6f:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   75:	 99                   	cdq	
+;;   76:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_le/params.wat
+++ b/winch/filetests/filetests/x64/f64_le/params.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874c000000         	ja	0x64
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8750000000         	ja	0x6b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100537000000     	movsd	xmm0, qword ptr [rip + 0x37]
+;;      	 f20f100538000000     	movsd	xmm0, qword ptr [rip + 0x38]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100531000000     	movsd	xmm0, qword ptr [rip + 0x31]
+;;      	 f20f100532000000     	movsd	xmm0, qword ptr [rip + 0x32]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -39,5 +40,8 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   64:	 0f0b                 	ud2	
-;;   66:	 0000                 	add	byte ptr [rax], al
+;;   6b:	 0f0b                 	ud2	
+;;   6d:	 0000                 	add	byte ptr [rax], al
+;;   6f:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   75:	 99                   	cdq	
+;;   76:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_lt/const.wat
+++ b/winch/filetests/filetests/x64/f64_lt/const.wat
@@ -9,30 +9,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100524000000     	movsd	xmm0, qword ptr [rip + 0x24]
-;;      	 f20f100d24000000     	movsd	xmm1, qword ptr [rip + 0x24]
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]
+;;      	 f20f100d1d000000     	movsd	xmm1, qword ptr [rip + 0x1d]
 ;;      	 660f2ec1             	ucomisd	xmm0, xmm1
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f97c0             	seta	al
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
-;;   41:	 0000                 	add	byte ptr [rax], al
-;;   43:	 0000                 	add	byte ptr [rax], al
-;;   45:	 0000                 	add	byte ptr [rax], al
-;;   47:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   4d:	 99                   	cdq	
-;;   4e:	 01409a               	add	dword ptr [rax - 0x66], eax
-;;   51:	 99                   	cdq	
-;;   52:	 99                   	cdq	
-;;   53:	 99                   	cdq	
-;;   54:	 99                   	cdq	
-;;   55:	 99                   	cdq	
-;;   56:	 f1                   	int1	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_lt/locals.wat
+++ b/winch/filetests/filetests/x64/f64_lt/locals.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874c000000         	ja	0x64
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8750000000         	ja	0x6b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100537000000     	movsd	xmm0, qword ptr [rip + 0x37]
+;;      	 f20f100538000000     	movsd	xmm0, qword ptr [rip + 0x38]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100531000000     	movsd	xmm0, qword ptr [rip + 0x31]
+;;      	 f20f100532000000     	movsd	xmm0, qword ptr [rip + 0x32]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -39,5 +40,8 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   64:	 0f0b                 	ud2	
-;;   66:	 0000                 	add	byte ptr [rax], al
+;;   6b:	 0f0b                 	ud2	
+;;   6d:	 0000                 	add	byte ptr [rax], al
+;;   6f:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   75:	 99                   	cdq	
+;;   76:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_lt/params.wat
+++ b/winch/filetests/filetests/x64/f64_lt/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x47
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -25,4 +26,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   47:	 0f0b                 	ud2	
+;;   4e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_max/const.wat
+++ b/winch/filetests/filetests/x64/f64_max/const.wat
@@ -9,33 +9,26 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8745000000         	ja	0x5d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10053c000000     	movsd	xmm0, qword ptr [rip + 0x3c]
-;;      	 f20f100d3c000000     	movsd	xmm1, qword ptr [rip + 0x3c]
+;;      	 0f8749000000         	ja	0x64
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10053d000000     	movsd	xmm0, qword ptr [rip + 0x3d]
+;;      	 f20f100d3d000000     	movsd	xmm1, qword ptr [rip + 0x3d]
 ;;      	 660f2ec8             	ucomisd	xmm1, xmm0
-;;      	 0f8519000000         	jne	0x4f
-;;      	 0f8a09000000         	jp	0x45
-;;   3c:	 660f54c8             	andpd	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x53
-;;   45:	 f20f58c8             	addsd	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x53
-;;   4f:	 f20f5fc8             	maxsd	xmm1, xmm0
+;;      	 0f8519000000         	jne	0x56
+;;      	 0f8a09000000         	jp	0x4c
+;;   43:	 660f54c8             	andpd	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x5a
+;;   4c:	 f20f58c8             	addsd	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x5a
+;;   56:	 f20f5fc8             	maxsd	xmm1, xmm0
 ;;      	 660f28c1             	movapd	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5d:	 0f0b                 	ud2	
-;;   5f:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   65:	 99                   	cdq	
-;;   66:	 01409a               	add	dword ptr [rax - 0x66], eax
-;;   69:	 99                   	cdq	
-;;   6a:	 99                   	cdq	
-;;   6b:	 99                   	cdq	
-;;   6c:	 99                   	cdq	
-;;   6d:	 99                   	cdq	
-;;   6e:	 f1                   	int1	
+;;   64:	 0f0b                 	ud2	
+;;   66:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f64_max/locals.wat
+++ b/winch/filetests/filetests/x64/f64_max/locals.wat
@@ -18,33 +18,37 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876a000000         	ja	0x82
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f876e000000         	ja	0x89
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100557000000     	movsd	xmm0, qword ptr [rip + 0x57]
+;;      	 f20f100558000000     	movsd	xmm0, qword ptr [rip + 0x58]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100551000000     	movsd	xmm0, qword ptr [rip + 0x51]
+;;      	 f20f100552000000     	movsd	xmm0, qword ptr [rip + 0x52]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
 ;;      	 660f2ec8             	ucomisd	xmm1, xmm0
-;;      	 0f8519000000         	jne	0x74
-;;      	 0f8a09000000         	jp	0x6a
-;;   61:	 660f54c8             	andpd	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x78
-;;   6a:	 f20f58c8             	addsd	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x78
-;;   74:	 f20f5fc8             	maxsd	xmm1, xmm0
+;;      	 0f8519000000         	jne	0x7b
+;;      	 0f8a09000000         	jp	0x71
+;;   68:	 660f54c8             	andpd	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x7f
+;;   71:	 f20f58c8             	addsd	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x7f
+;;   7b:	 f20f5fc8             	maxsd	xmm1, xmm0
 ;;      	 660f28c1             	movapd	xmm0, xmm1
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   82:	 0f0b                 	ud2	
-;;   84:	 0000                 	add	byte ptr [rax], al
-;;   86:	 0000                 	add	byte ptr [rax], al
+;;   89:	 0f0b                 	ud2	
+;;   8b:	 0000                 	add	byte ptr [rax], al
+;;   8d:	 0000                 	add	byte ptr [rax], al
+;;   8f:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   95:	 99                   	cdq	
+;;   96:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_max/params.wat
+++ b/winch/filetests/filetests/x64/f64_max/params.wat
@@ -9,26 +9,27 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874d000000         	ja	0x65
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
 ;;      	 660f2ec8             	ucomisd	xmm1, xmm0
-;;      	 0f8519000000         	jne	0x57
-;;      	 0f8a09000000         	jp	0x4d
-;;   44:	 660f54c8             	andpd	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x5b
-;;   4d:	 f20f58c8             	addsd	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x5b
-;;   57:	 f20f5fc8             	maxsd	xmm1, xmm0
+;;      	 0f8519000000         	jne	0x5e
+;;      	 0f8a09000000         	jp	0x54
+;;   4b:	 660f54c8             	andpd	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x62
+;;   54:	 f20f58c8             	addsd	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x62
+;;   5e:	 f20f5fc8             	maxsd	xmm1, xmm0
 ;;      	 660f28c1             	movapd	xmm0, xmm1
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   65:	 0f0b                 	ud2	
+;;   6c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_min/const.wat
+++ b/winch/filetests/filetests/x64/f64_min/const.wat
@@ -9,33 +9,26 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8745000000         	ja	0x5d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10053c000000     	movsd	xmm0, qword ptr [rip + 0x3c]
-;;      	 f20f100d3c000000     	movsd	xmm1, qword ptr [rip + 0x3c]
+;;      	 0f8749000000         	ja	0x64
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10053d000000     	movsd	xmm0, qword ptr [rip + 0x3d]
+;;      	 f20f100d3d000000     	movsd	xmm1, qword ptr [rip + 0x3d]
 ;;      	 660f2ec8             	ucomisd	xmm1, xmm0
-;;      	 0f8519000000         	jne	0x4f
-;;      	 0f8a09000000         	jp	0x45
-;;   3c:	 660f56c8             	orpd	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x53
-;;   45:	 f20f58c8             	addsd	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x53
-;;   4f:	 f20f5dc8             	minsd	xmm1, xmm0
+;;      	 0f8519000000         	jne	0x56
+;;      	 0f8a09000000         	jp	0x4c
+;;   43:	 660f56c8             	orpd	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x5a
+;;   4c:	 f20f58c8             	addsd	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x5a
+;;   56:	 f20f5dc8             	minsd	xmm1, xmm0
 ;;      	 660f28c1             	movapd	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5d:	 0f0b                 	ud2	
-;;   5f:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   65:	 99                   	cdq	
-;;   66:	 01409a               	add	dword ptr [rax - 0x66], eax
-;;   69:	 99                   	cdq	
-;;   6a:	 99                   	cdq	
-;;   6b:	 99                   	cdq	
-;;   6c:	 99                   	cdq	
-;;   6d:	 99                   	cdq	
-;;   6e:	 f1                   	int1	
+;;   64:	 0f0b                 	ud2	
+;;   66:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f64_min/locals.wat
+++ b/winch/filetests/filetests/x64/f64_min/locals.wat
@@ -18,33 +18,37 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876a000000         	ja	0x82
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f876e000000         	ja	0x89
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100557000000     	movsd	xmm0, qword ptr [rip + 0x57]
+;;      	 f20f100558000000     	movsd	xmm0, qword ptr [rip + 0x58]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100551000000     	movsd	xmm0, qword ptr [rip + 0x51]
+;;      	 f20f100552000000     	movsd	xmm0, qword ptr [rip + 0x52]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
 ;;      	 660f2ec8             	ucomisd	xmm1, xmm0
-;;      	 0f8519000000         	jne	0x74
-;;      	 0f8a09000000         	jp	0x6a
-;;   61:	 660f56c8             	orpd	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x78
-;;   6a:	 f20f58c8             	addsd	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x78
-;;   74:	 f20f5dc8             	minsd	xmm1, xmm0
+;;      	 0f8519000000         	jne	0x7b
+;;      	 0f8a09000000         	jp	0x71
+;;   68:	 660f56c8             	orpd	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x7f
+;;   71:	 f20f58c8             	addsd	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x7f
+;;   7b:	 f20f5dc8             	minsd	xmm1, xmm0
 ;;      	 660f28c1             	movapd	xmm0, xmm1
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   82:	 0f0b                 	ud2	
-;;   84:	 0000                 	add	byte ptr [rax], al
-;;   86:	 0000                 	add	byte ptr [rax], al
+;;   89:	 0f0b                 	ud2	
+;;   8b:	 0000                 	add	byte ptr [rax], al
+;;   8d:	 0000                 	add	byte ptr [rax], al
+;;   8f:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   95:	 99                   	cdq	
+;;   96:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_min/params.wat
+++ b/winch/filetests/filetests/x64/f64_min/params.wat
@@ -9,26 +9,27 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874d000000         	ja	0x65
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
 ;;      	 660f2ec8             	ucomisd	xmm1, xmm0
-;;      	 0f8519000000         	jne	0x57
-;;      	 0f8a09000000         	jp	0x4d
-;;   44:	 660f56c8             	orpd	xmm1, xmm0
-;;      	 e90e000000           	jmp	0x5b
-;;   4d:	 f20f58c8             	addsd	xmm1, xmm0
-;;      	 0f8a04000000         	jp	0x5b
-;;   57:	 f20f5dc8             	minsd	xmm1, xmm0
+;;      	 0f8519000000         	jne	0x5e
+;;      	 0f8a09000000         	jp	0x54
+;;   4b:	 660f56c8             	orpd	xmm1, xmm0
+;;      	 e90e000000           	jmp	0x62
+;;   54:	 f20f58c8             	addsd	xmm1, xmm0
+;;      	 0f8a04000000         	jp	0x62
+;;   5e:	 f20f5dc8             	minsd	xmm1, xmm0
 ;;      	 660f28c1             	movapd	xmm0, xmm1
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   65:	 0f0b                 	ud2	
+;;   6c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_mul/const.wat
+++ b/winch/filetests/filetests/x64/f64_mul/const.wat
@@ -9,19 +9,29 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8722000000         	ja	0x3a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10051c000000     	movsd	xmm0, qword ptr [rip + 0x1c]
-;;      	 f20f100d1c000000     	movsd	xmm1, qword ptr [rip + 0x1c]
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]
+;;      	 f20f100d1d000000     	movsd	xmm1, qword ptr [rip + 0x1d]
 ;;      	 f20f59c8             	mulsd	xmm1, xmm0
 ;;      	 660f28c1             	movapd	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3a:	 0f0b                 	ud2	
-;;   3c:	 0000                 	add	byte ptr [rax], al
-;;   3e:	 0000                 	add	byte ptr [rax], al
+;;   41:	 0f0b                 	ud2	
+;;   43:	 0000                 	add	byte ptr [rax], al
+;;   45:	 0000                 	add	byte ptr [rax], al
+;;   47:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   4d:	 99                   	cdq	
+;;   4e:	 01409a               	add	dword ptr [rax - 0x66], eax
+;;   51:	 99                   	cdq	
+;;   52:	 99                   	cdq	
+;;   53:	 99                   	cdq	
+;;   54:	 99                   	cdq	
+;;   55:	 99                   	cdq	
+;;   56:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_mul/locals.wat
+++ b/winch/filetests/filetests/x64/f64_mul/locals.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100537000000     	movsd	xmm0, qword ptr [rip + 0x37]
+;;      	 f20f100530000000     	movsd	xmm0, qword ptr [rip + 0x30]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100531000000     	movsd	xmm0, qword ptr [rip + 0x31]
+;;      	 f20f10052a000000     	movsd	xmm0, qword ptr [rip + 0x2a]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -38,10 +39,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
-;;   61:	 0000                 	add	byte ptr [rax], al
-;;   63:	 0000                 	add	byte ptr [rax], al
-;;   65:	 0000                 	add	byte ptr [rax], al
-;;   67:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   6d:	 99                   	cdq	
-;;   6e:	 f1                   	int1	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_mul/params.wat
+++ b/winch/filetests/filetests/x64/f64_mul/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_ne/const.wat
+++ b/winch/filetests/filetests/x64/f64_ne/const.wat
@@ -9,14 +9,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x4c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10052c000000     	movsd	xmm0, qword ptr [rip + 0x2c]
-;;      	 f20f100d2c000000     	movsd	xmm1, qword ptr [rip + 0x2c]
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10052d000000     	movsd	xmm0, qword ptr [rip + 0x2d]
+;;      	 f20f100d2d000000     	movsd	xmm1, qword ptr [rip + 0x2d]
 ;;      	 660f2ec8             	ucomisd	xmm1, xmm0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f95c0             	setne	al
@@ -26,5 +27,14 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4c:	 0f0b                 	ud2	
-;;   4e:	 0000                 	add	byte ptr [rax], al
+;;   53:	 0f0b                 	ud2	
+;;   55:	 0000                 	add	byte ptr [rax], al
+;;   57:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   5d:	 99                   	cdq	
+;;   5e:	 01409a               	add	dword ptr [rax - 0x66], eax
+;;   61:	 99                   	cdq	
+;;   62:	 99                   	cdq	
+;;   63:	 99                   	cdq	
+;;   64:	 99                   	cdq	
+;;   65:	 99                   	cdq	
+;;   66:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_ne/locals.wat
+++ b/winch/filetests/filetests/x64/f64_ne/locals.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8759000000         	ja	0x71
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f875d000000         	ja	0x78
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100547000000     	movsd	xmm0, qword ptr [rip + 0x47]
+;;      	 f20f100548000000     	movsd	xmm0, qword ptr [rip + 0x48]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100541000000     	movsd	xmm0, qword ptr [rip + 0x41]
+;;      	 f20f100542000000     	movsd	xmm0, qword ptr [rip + 0x42]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -42,9 +43,7 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   71:	 0f0b                 	ud2	
-;;   73:	 0000                 	add	byte ptr [rax], al
-;;   75:	 0000                 	add	byte ptr [rax], al
-;;   77:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   7d:	 99                   	cdq	
-;;   7e:	 f1                   	int1	
+;;   78:	 0f0b                 	ud2	
+;;   7a:	 0000                 	add	byte ptr [rax], al
+;;   7c:	 0000                 	add	byte ptr [rax], al
+;;   7e:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f64_ne/params.wat
+++ b/winch/filetests/filetests/x64/f64_ne/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x54
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -28,4 +29,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   54:	 0f0b                 	ud2	
+;;   5b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_nearest/f64_nearest_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_nearest/f64_nearest_const_sse41.wat
@@ -9,18 +9,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100514000000     	movsd	xmm0, qword ptr [rip + 0x14]
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f100515000000     	movsd	xmm0, qword ptr [rip + 0x15]
 ;;      	 660f3a0bc000         	roundsd	xmm0, xmm0, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
-;;   32:	 0000                 	add	byte ptr [rax], al
-;;   34:	 0000                 	add	byte ptr [rax], al
-;;   36:	 0000                 	add	byte ptr [rax], al
+;;   37:	 0f0b                 	ud2	
+;;   39:	 0000                 	add	byte ptr [rax], al
+;;   3b:	 0000                 	add	byte ptr [rax], al
+;;   3d:	 0000                 	add	byte ptr [rax], al
+;;   3f:	 001f                 	add	byte ptr [rdi], bl
+;;   41:	 85eb                 	test	ebx, ebp
+;;   43:	 51                   	push	rcx

--- a/winch/filetests/filetests/x64/f64_nearest/f64_nearest_param.wat
+++ b/winch/filetests/filetests/x64/f64_nearest/f64_nearest_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x58
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f2440f107c2408       	movsd	xmm15, qword ptr [rsp + 8]
 ;;      	 4883ec08             	sub	rsp, 8
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   58:	 0f0b                 	ud2	
+;;   5f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_nearest/f64_nearest_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_nearest/f64_nearest_param_sse41.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 660f3a0bc000         	roundsd	xmm0, xmm0, 0
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_neg/f64_neg_const.wat
+++ b/winch/filetests/filetests/x64/f64_neg/f64_neg_const.wat
@@ -8,13 +8,14 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10051c000000     	movsd	xmm0, qword ptr [rip + 0x1c]
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]
 ;;      	 49bb0000000000000080 	
 ;; 				movabs	r11, 0x8000000000000000
 ;;      	 664d0f6efb           	movq	xmm15, r11
@@ -22,4 +23,7 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
+;;   45:	 0f0b                 	ud2	
+;;   47:	 001f                 	add	byte ptr [rdi], bl
+;;   49:	 85eb                 	test	ebx, ebp
+;;   4b:	 51                   	push	rcx

--- a/winch/filetests/filetests/x64/f64_neg/f64_neg_param.wat
+++ b/winch/filetests/filetests/x64/f64_neg/f64_neg_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 49bb0000000000000080 	
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_promote_f32/const.wat
+++ b/winch/filetests/filetests/x64/f64_promote_f32/const.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10050c000000     	movss	xmm0, dword ptr [rip + 0xc]
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10050d000000     	movss	xmm0, dword ptr [rip + 0xd]
 ;;      	 f30f5ac0             	cvtss2sd	xmm0, xmm0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
-;;   30:	 0000                 	add	byte ptr [rax], al
+;;   35:	 0f0b                 	ud2	
+;;   37:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f64_promote_f32/locals.wat
+++ b/winch/filetests/filetests/x64/f64_promote_f32/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871d000000         	ja	0x35
-;;   18:	 48c744240800000000   	
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   35:	 0f0b                 	ud2	
+;;   3c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_promote_f32/params.wat
+++ b/winch/filetests/filetests/x64/f64_promote_f32/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 f30f5ac0             	cvtss2sd	xmm0, xmm0
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_promote_f32/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_promote_f32/spilled.wat
@@ -10,13 +10,14 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x40
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100524000000     	movss	xmm0, dword ptr [rip + 0x24]
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f100525000000     	movss	xmm0, dword ptr [rip + 0x25]
 ;;      	 f30f5ac0             	cvtss2sd	xmm0, xmm0
 ;;      	 4883ec08             	sub	rsp, 8
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0
@@ -25,8 +26,8 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   40:	 0f0b                 	ud2	
-;;   42:	 0000                 	add	byte ptr [rax], al
-;;   44:	 0000                 	add	byte ptr [rax], al
-;;   46:	 0000                 	add	byte ptr [rax], al
-;;   48:	 0000                 	add	byte ptr [rax], al
+;;   47:	 0f0b                 	ud2	
+;;   49:	 0000                 	add	byte ptr [rax], al
+;;   4b:	 0000                 	add	byte ptr [rax], al
+;;   4d:	 0000                 	add	byte ptr [rax], al
+;;   4f:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/f64_reinterpret_i64/const.wat
+++ b/winch/filetests/filetests/x64/f64_reinterpret_i64/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 66480f6ec0           	movq	xmm0, rax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_reinterpret_i64/locals.wat
+++ b/winch/filetests/filetests/x64/f64_reinterpret_i64/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871d000000         	ja	0x35
-;;   18:	 48c744240800000000   	
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   35:	 0f0b                 	ud2	
+;;   3c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_reinterpret_i64/params.wat
+++ b/winch/filetests/filetests/x64/f64_reinterpret_i64/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 66480f6ec0           	movq	xmm0, rax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_reinterpret_i64/ret_int.wat
+++ b/winch/filetests/filetests/x64/f64_reinterpret_i64/ret_int.wat
@@ -10,16 +10,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871d000000         	ja	0x35
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 66480f6ec0           	movq	xmm0, rax
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   35:	 0f0b                 	ud2	
+;;   3c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_reinterpret_i64/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_reinterpret_i64/spilled.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x40
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 66480f6ec0           	movq	xmm0, rax
 ;;      	 4883ec08             	sub	rsp, 8
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   40:	 0f0b                 	ud2	
+;;   47:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_sqrt/f64_sqrt_const.wat
+++ b/winch/filetests/filetests/x64/f64_sqrt/f64_sqrt_const.wat
@@ -8,15 +8,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10050c000000     	movsd	xmm0, qword ptr [rip + 0xc]
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10050d000000     	movsd	xmm0, qword ptr [rip + 0xd]
 ;;      	 f20f51c0             	sqrtsd	xmm0, xmm0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	
+;;   37:	 001f                 	add	byte ptr [rdi], bl
+;;   39:	 85eb                 	test	ebx, ebp
+;;   3b:	 51                   	push	rcx

--- a/winch/filetests/filetests/x64/f64_sqrt/f64_sqrt_param.wat
+++ b/winch/filetests/filetests/x64/f64_sqrt/f64_sqrt_param.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f51c0             	sqrtsd	xmm0, xmm0
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_sub/const.wat
+++ b/winch/filetests/filetests/x64/f64_sub/const.wat
@@ -9,19 +9,29 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8722000000         	ja	0x3a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10051c000000     	movsd	xmm0, qword ptr [rip + 0x1c]
-;;      	 f20f100d1c000000     	movsd	xmm1, qword ptr [rip + 0x1c]
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]
+;;      	 f20f100d1d000000     	movsd	xmm1, qword ptr [rip + 0x1d]
 ;;      	 f20f5cc8             	subsd	xmm1, xmm0
 ;;      	 660f28c1             	movapd	xmm0, xmm1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3a:	 0f0b                 	ud2	
-;;   3c:	 0000                 	add	byte ptr [rax], al
-;;   3e:	 0000                 	add	byte ptr [rax], al
+;;   41:	 0f0b                 	ud2	
+;;   43:	 0000                 	add	byte ptr [rax], al
+;;   45:	 0000                 	add	byte ptr [rax], al
+;;   47:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
+;;   4d:	 99                   	cdq	
+;;   4e:	 01409a               	add	dword ptr [rax - 0x66], eax
+;;   51:	 99                   	cdq	
+;;   52:	 99                   	cdq	
+;;   53:	 99                   	cdq	
+;;   54:	 99                   	cdq	
+;;   55:	 99                   	cdq	
+;;   56:	 f1                   	int1	

--- a/winch/filetests/filetests/x64/f64_sub/locals.wat
+++ b/winch/filetests/filetests/x64/f64_sub/locals.wat
@@ -18,18 +18,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100537000000     	movsd	xmm0, qword ptr [rip + 0x37]
+;;      	 f20f100530000000     	movsd	xmm0, qword ptr [rip + 0x30]
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
-;;      	 f20f100531000000     	movsd	xmm0, qword ptr [rip + 0x31]
+;;      	 f20f10052a000000     	movsd	xmm0, qword ptr [rip + 0x2a]
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f104c2410         	movsd	xmm1, qword ptr [rsp + 0x10]
@@ -38,10 +39,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
-;;   61:	 0000                 	add	byte ptr [rax], al
-;;   63:	 0000                 	add	byte ptr [rax], al
-;;   65:	 0000                 	add	byte ptr [rax], al
-;;   67:	 009a99999999         	add	byte ptr [rdx - 0x66666667], bl
-;;   6d:	 99                   	cdq	
-;;   6e:	 f1                   	int1	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_sub/params.wat
+++ b/winch/filetests/filetests/x64/f64_sub/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0
 ;;      	 f20f114c2408         	movsd	qword ptr [rsp + 8], xmm1
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_trunc/f64_trunc_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_trunc/f64_trunc_const_sse41.wat
@@ -9,18 +9,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100514000000     	movsd	xmm0, qword ptr [rip + 0x14]
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f100515000000     	movsd	xmm0, qword ptr [rip + 0x15]
 ;;      	 660f3a0bc003         	roundsd	xmm0, xmm0, 3
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
-;;   32:	 0000                 	add	byte ptr [rax], al
-;;   34:	 0000                 	add	byte ptr [rax], al
-;;   36:	 0000                 	add	byte ptr [rax], al
+;;   37:	 0f0b                 	ud2	
+;;   39:	 0000                 	add	byte ptr [rax], al
+;;   3b:	 0000                 	add	byte ptr [rax], al
+;;   3d:	 0000                 	add	byte ptr [rax], al
+;;   3f:	 001f                 	add	byte ptr [rdi], bl
+;;   41:	 85eb                 	test	ebx, ebp
+;;   43:	 51                   	push	rcx

--- a/winch/filetests/filetests/x64/f64_trunc/f64_trunc_param.wat
+++ b/winch/filetests/filetests/x64/f64_trunc/f64_trunc_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x58
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f2440f107c2408       	movsd	xmm15, qword ptr [rsp + 8]
 ;;      	 4883ec08             	sub	rsp, 8
@@ -28,4 +29,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   58:	 0f0b                 	ud2	
+;;   5f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_trunc/f64_trunc_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_trunc/f64_trunc_param_sse41.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 660f3a0bc003         	roundsd	xmm0, xmm0, 3
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_add/const.wat
+++ b/winch/filetests/filetests/x64/i32_add/const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80a000000           	mov	eax, 0xa
 ;;      	 83c014               	add	eax, 0x14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_add/locals.wat
+++ b/winch/filetests/filetests/x64/i32_add/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x49
-;;   18:	 48c744240800000000   	
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80a000000           	mov	eax, 0xa
@@ -37,4 +38,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   49:	 0f0b                 	ud2	
+;;   50:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_add/max.wat
+++ b/winch/filetests/filetests/x64/i32_add/max.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b8ffffff7f           	mov	eax, 0x7fffffff
 ;;      	 83c001               	add	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_add/max_one.wat
+++ b/winch/filetests/filetests/x64/i32_add/max_one.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b800000080           	mov	eax, 0x80000000
 ;;      	 83c0ff               	add	eax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_add/mixed.wat
+++ b/winch/filetests/filetests/x64/i32_add/mixed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff
 ;;      	 83c001               	add	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_add/params.wat
+++ b/winch/filetests/filetests/x64/i32_add/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_add/signed.wat
+++ b/winch/filetests/filetests/x64/i32_add/signed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff
 ;;      	 83c0ff               	add	eax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_add/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i32_add/unsigned_with_zero.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 83c000               	add	eax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_and/const.wat
+++ b/winch/filetests/filetests/x64/i32_and/const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 83e002               	and	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_and/locals.wat
+++ b/winch/filetests/filetests/x64/i32_and/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x49
-;;   18:	 48c744240800000000   	
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
@@ -37,4 +38,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   49:	 0f0b                 	ud2	
+;;   50:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_and/params.wat
+++ b/winch/filetests/filetests/x64/i32_and/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_clz/lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i32_clz/lzcnt_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x2b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8717000000         	ja	0x32
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 f30fbdc0             	lzcnt	eax, eax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2b:	 0f0b                 	ud2	
+;;   32:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_clz/lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i32_clz/lzcnt_local.wat
@@ -14,12 +14,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 48c744240800000000   	
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -29,4 +30,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_clz/lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i32_clz/lzcnt_param.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 f30fbdc0             	lzcnt	eax, eax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_clz/no_lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i32_clz/no_lzcnt_const.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 0fbdc0               	bsr	eax, eax
 ;;      	 41bb00000000         	mov	r11d, 0
@@ -24,4 +25,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_clz/no_lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i32_clz/no_lzcnt_local.wat
@@ -13,12 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8735000000         	ja	0x4d
-;;   18:	 48c744240800000000   	
+;;      	 0f8739000000         	ja	0x54
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -33,4 +34,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4d:	 0f0b                 	ud2	
+;;   54:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_clz/no_lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i32_clz/no_lzcnt_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 0fbdc0               	bsr	eax, eax
@@ -25,4 +26,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ctz/bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/bmi1_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x2b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8717000000         	ja	0x32
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 f30fbcc0             	tzcnt	eax, eax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2b:	 0f0b                 	ud2	
+;;   32:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ctz/bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/bmi1_local.wat
@@ -15,12 +15,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 48c744240800000000   	
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -30,4 +31,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ctz/bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/bmi1_param.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 f30fbcc0             	tzcnt	eax, eax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ctz/no_bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/no_bmi1_const.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x3b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 0fbcc0               	bsf	eax, eax
 ;;      	 41bb00000000         	mov	r11d, 0
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3b:	 0f0b                 	ud2	
+;;   42:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ctz/no_bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/no_bmi1_local.wat
@@ -13,12 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x4c
-;;   18:	 48c744240800000000   	
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -32,4 +33,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4c:	 0f0b                 	ud2	
+;;   53:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ctz/no_bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/no_bmi1_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 0fbcc0               	bsf	eax, eax
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
+;;   45:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_divs/const.wat
+++ b/winch/filetests/filetests/x64/i32_divs/const.wat
@@ -9,20 +9,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x38
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b90a000000           	mov	ecx, 0xa
 ;;      	 b814000000           	mov	eax, 0x14
 ;;      	 83f900               	cmp	ecx, 0
-;;      	 0f840b000000         	je	0x3a
-;;   2f:	 99                   	cdq	
+;;      	 0f840b000000         	je	0x41
+;;   36:	 99                   	cdq	
 ;;      	 f7f9                 	idiv	ecx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   38:	 0f0b                 	ud2	
-;;   3a:	 0f0b                 	ud2	
+;;   3f:	 0f0b                 	ud2	
+;;   41:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_divs/one_zero.wat
+++ b/winch/filetests/filetests/x64/i32_divs/one_zero.wat
@@ -9,20 +9,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x38
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b900000000           	mov	ecx, 0
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 83f900               	cmp	ecx, 0
-;;      	 0f840b000000         	je	0x3a
-;;   2f:	 99                   	cdq	
+;;      	 0f840b000000         	je	0x41
+;;   36:	 99                   	cdq	
 ;;      	 f7f9                 	idiv	ecx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   38:	 0f0b                 	ud2	
-;;   3a:	 0f0b                 	ud2	
+;;   3f:	 0f0b                 	ud2	
+;;   41:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_divs/overflow.wat
+++ b/winch/filetests/filetests/x64/i32_divs/overflow.wat
@@ -9,20 +9,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x38
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b9ffffffff           	mov	ecx, 0xffffffff
 ;;      	 b800000080           	mov	eax, 0x80000000
 ;;      	 83f900               	cmp	ecx, 0
-;;      	 0f840b000000         	je	0x3a
-;;   2f:	 99                   	cdq	
+;;      	 0f840b000000         	je	0x41
+;;   36:	 99                   	cdq	
 ;;      	 f7f9                 	idiv	ecx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   38:	 0f0b                 	ud2	
-;;   3a:	 0f0b                 	ud2	
+;;   3f:	 0f0b                 	ud2	
+;;   41:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_divs/params.wat
+++ b/winch/filetests/filetests/x64/i32_divs/params.wat
@@ -9,22 +9,23 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 83f900               	cmp	ecx, 0
-;;      	 0f840b000000         	je	0x40
-;;   35:	 99                   	cdq	
+;;      	 0f840b000000         	je	0x47
+;;   3c:	 99                   	cdq	
 ;;      	 f7f9                 	idiv	ecx
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
-;;   40:	 0f0b                 	ud2	
+;;   45:	 0f0b                 	ud2	
+;;   47:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_divs/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i32_divs/zero_zero.wat
@@ -9,20 +9,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x38
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b900000000           	mov	ecx, 0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 83f900               	cmp	ecx, 0
-;;      	 0f840b000000         	je	0x3a
-;;   2f:	 99                   	cdq	
+;;      	 0f840b000000         	je	0x41
+;;   36:	 99                   	cdq	
 ;;      	 f7f9                 	idiv	ecx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   38:	 0f0b                 	ud2	
-;;   3a:	 0f0b                 	ud2	
+;;   3f:	 0f0b                 	ud2	
+;;   41:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_divu/const.wat
+++ b/winch/filetests/filetests/x64/i32_divu/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b90a000000           	mov	ecx, 0xa
 ;;      	 b814000000           	mov	eax, 0x14
 ;;      	 31d2                 	xor	edx, edx
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_divu/one_zero.wat
+++ b/winch/filetests/filetests/x64/i32_divu/one_zero.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b900000000           	mov	ecx, 0
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 31d2                 	xor	edx, edx
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_divu/params.wat
+++ b/winch/filetests/filetests/x64/i32_divu/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_divu/signed.wat
+++ b/winch/filetests/filetests/x64/i32_divu/signed.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b9ffffffff           	mov	ecx, 0xffffffff
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff
 ;;      	 31d2                 	xor	edx, edx
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_divu/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i32_divu/zero_zero.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b900000000           	mov	ecx, 0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 31d2                 	xor	edx, edx
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_eq/const.wat
+++ b/winch/filetests/filetests/x64/i32_eq/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 83f803               	cmp	eax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_eq/locals.wat
+++ b/winch/filetests/filetests/x64/i32_eq/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x52
-;;   18:	 48c744240800000000   	
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -38,4 +39,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   52:	 0f0b                 	ud2	
+;;   59:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_eq/params.wat
+++ b/winch/filetests/filetests/x64/i32_eq/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_eqz/const.wat
+++ b/winch/filetests/filetests/x64/i32_eqz/const.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 83f800               	cmp	eax, 0
 ;;      	 b800000000           	mov	eax, 0
@@ -21,4 +22,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_eqz/local.wat
+++ b/winch/filetests/filetests/x64/i32_eqz/local.wat
@@ -13,12 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48c744240800000000   	
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -30,4 +31,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_eqz/param.wat
+++ b/winch/filetests/filetests/x64/i32_eqz/param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 83f800               	cmp	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_extend_16_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_extend_16_s/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 0fbfc0               	movsx	eax, ax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_extend_16_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_extend_16_s/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 48c744240800000000   	
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_extend_16_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_extend_16_s/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 0fbfc0               	movsx	eax, ax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_extend_8_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_extend_8_s/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 0fbec0               	movsx	eax, al
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_extend_8_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_extend_8_s/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 48c744240800000000   	
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_extend_8_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_extend_8_s/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 0fbec0               	movsx	eax, al
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ge_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_ge_s/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 83f803               	cmp	eax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ge_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ge_s/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x52
-;;   18:	 48c744240800000000   	
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -38,4 +39,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   52:	 0f0b                 	ud2	
+;;   59:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ge_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_ge_s/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ge_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_ge_u/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 83f803               	cmp	eax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ge_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ge_u/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x52
-;;   18:	 48c744240800000000   	
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -38,4 +39,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   52:	 0f0b                 	ud2	
+;;   59:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ge_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_ge_u/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_gt_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_gt_s/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 83f803               	cmp	eax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_gt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_gt_s/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x52
-;;   18:	 48c744240800000000   	
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -38,4 +39,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   52:	 0f0b                 	ud2	
+;;   59:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_gt_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_gt_s/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_gt_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_gt_u/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 83f803               	cmp	eax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_gt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_gt_u/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x52
-;;   18:	 48c744240800000000   	
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -38,4 +39,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   52:	 0f0b                 	ud2	
+;;   59:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_gt_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_gt_u/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_le_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_le_s/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 83f803               	cmp	eax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_le_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_le_s/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x52
-;;   18:	 48c744240800000000   	
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -38,4 +39,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   52:	 0f0b                 	ud2	
+;;   59:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_le_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_le_s/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_le_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_le_u/const.wat
@@ -10,12 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 83f803               	cmp	eax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_le_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_le_u/locals.wat
@@ -18,12 +18,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x52
-;;   18:	 48c744240800000000   	
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -39,4 +40,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   52:	 0f0b                 	ud2	
+;;   59:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_le_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_le_u/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_lt_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_lt_s/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 83f803               	cmp	eax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_lt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_lt_s/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x52
-;;   18:	 48c744240800000000   	
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -38,4 +39,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   52:	 0f0b                 	ud2	
+;;   59:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_lt_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_lt_s/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_lt_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_lt_u/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 83f803               	cmp	eax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_lt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_lt_u/locals.wat
@@ -18,12 +18,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x52
-;;   18:	 48c744240800000000   	
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -39,4 +40,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   52:	 0f0b                 	ud2	
+;;   59:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_lt_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_lt_u/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_mul/const.wat
+++ b/winch/filetests/filetests/x64/i32_mul/const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80a000000           	mov	eax, 0xa
 ;;      	 6bc014               	imul	eax, eax, 0x14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_mul/locals.wat
+++ b/winch/filetests/filetests/x64/i32_mul/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8732000000         	ja	0x4a
-;;   18:	 48c744240800000000   	
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80a000000           	mov	eax, 0xa
@@ -37,4 +38,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4a:	 0f0b                 	ud2	
+;;   51:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_mul/max.wat
+++ b/winch/filetests/filetests/x64/i32_mul/max.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b8ffffff7f           	mov	eax, 0x7fffffff
 ;;      	 6bc0ff               	imul	eax, eax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_mul/max_one.wat
+++ b/winch/filetests/filetests/x64/i32_mul/max_one.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b800000080           	mov	eax, 0x80000000
 ;;      	 6bc0ff               	imul	eax, eax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_mul/mixed.wat
+++ b/winch/filetests/filetests/x64/i32_mul/mixed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff
 ;;      	 6bc001               	imul	eax, eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_mul/params.wat
+++ b/winch/filetests/filetests/x64/i32_mul/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x37
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   37:	 0f0b                 	ud2	
+;;   3e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_mul/signed.wat
+++ b/winch/filetests/filetests/x64/i32_mul/signed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff
 ;;      	 6bc0ff               	imul	eax, eax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_mul/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i32_mul/unsigned_with_zero.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 6bc000               	imul	eax, eax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ne/const.wat
+++ b/winch/filetests/filetests/x64/i32_ne/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 83f803               	cmp	eax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ne/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ne/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x52
-;;   18:	 48c744240800000000   	
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
@@ -38,4 +39,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   52:	 0f0b                 	ud2	
+;;   59:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_ne/params.wat
+++ b/winch/filetests/filetests/x64/i32_ne/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_or/const.wat
+++ b/winch/filetests/filetests/x64/i32_or/const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 83c802               	or	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_or/locals.wat
+++ b/winch/filetests/filetests/x64/i32_or/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x49
-;;   18:	 48c744240800000000   	
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
@@ -37,4 +38,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   49:	 0f0b                 	ud2	
+;;   50:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_or/params.wat
+++ b/winch/filetests/filetests/x64/i32_or/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_popcnt/const.wat
+++ b/winch/filetests/filetests/x64/i32_popcnt/const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x2b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8717000000         	ja	0x32
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b803000000           	mov	eax, 3
 ;;      	 f30fb8c0             	popcnt	eax, eax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2b:	 0f0b                 	ud2	
+;;   32:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_popcnt/fallback.wat
+++ b/winch/filetests/filetests/x64/i32_popcnt/fallback.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8745000000         	ja	0x5d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8749000000         	ja	0x64
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80f000000           	mov	eax, 0xf
 ;;      	 89c1                 	mov	ecx, eax
 ;;      	 c1e801               	shr	eax, 1
@@ -34,4 +35,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5d:	 0f0b                 	ud2	
+;;   64:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_popcnt/no_sse42.wat
+++ b/winch/filetests/filetests/x64/i32_popcnt/no_sse42.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8745000000         	ja	0x5d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8749000000         	ja	0x64
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b803000000           	mov	eax, 3
 ;;      	 89c1                 	mov	ecx, eax
 ;;      	 c1e801               	shr	eax, 1
@@ -35,4 +36,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5d:	 0f0b                 	ud2	
+;;   64:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_popcnt/reg.wat
+++ b/winch/filetests/filetests/x64/i32_popcnt/reg.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 f30fb8c0             	popcnt	eax, eax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_reinterpret_f32/const.wat
+++ b/winch/filetests/filetests/x64/i32_reinterpret_f32/const.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10050c000000     	movss	xmm0, dword ptr [rip + 0xc]
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10050d000000     	movss	xmm0, dword ptr [rip + 0xd]
 ;;      	 660f7ec0             	movd	eax, xmm0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
-;;   30:	 0000                 	add	byte ptr [rax], al
+;;   35:	 0f0b                 	ud2	
+;;   37:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/i32_reinterpret_f32/locals.wat
+++ b/winch/filetests/filetests/x64/i32_reinterpret_f32/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871d000000         	ja	0x35
-;;   18:	 48c744240800000000   	
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   35:	 0f0b                 	ud2	
+;;   3c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_reinterpret_f32/params.wat
+++ b/winch/filetests/filetests/x64/i32_reinterpret_f32/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 660f7ec0             	movd	eax, xmm0
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_reinterpret_f32/ret_float.wat
+++ b/winch/filetests/filetests/x64/i32_reinterpret_f32/ret_float.wat
@@ -10,17 +10,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100514000000     	movss	xmm0, dword ptr [rip + 0x14]
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f100515000000     	movss	xmm0, dword ptr [rip + 0x15]
 ;;      	 660f7ec0             	movd	eax, xmm0
-;;      	 f30f100508000000     	movss	xmm0, dword ptr [rip + 8]
+;;      	 f30f100509000000     	movss	xmm0, dword ptr [rip + 9]
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
-;;   38:	 0000                 	add	byte ptr [rax], al
+;;   3d:	 0f0b                 	ud2	
+;;   3f:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/i32_rems/const.wat
+++ b/winch/filetests/filetests/x64/i32_rems/const.wat
@@ -9,22 +9,23 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b905000000           	mov	ecx, 5
 ;;      	 b807000000           	mov	eax, 7
 ;;      	 99                   	cdq	
 ;;      	 83f9ff               	cmp	ecx, -1
-;;      	 0f850a000000         	jne	0x3a
-;;   30:	 ba00000000           	mov	edx, 0
-;;      	 e902000000           	jmp	0x3c
-;;   3a:	 f7f9                 	idiv	ecx
+;;      	 0f850a000000         	jne	0x41
+;;   37:	 ba00000000           	mov	edx, 0
+;;      	 e902000000           	jmp	0x43
+;;   41:	 f7f9                 	idiv	ecx
 ;;      	 89d0                 	mov	eax, edx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rems/one_zero.wat
+++ b/winch/filetests/filetests/x64/i32_rems/one_zero.wat
@@ -9,22 +9,23 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b900000000           	mov	ecx, 0
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 99                   	cdq	
 ;;      	 83f9ff               	cmp	ecx, -1
-;;      	 0f850a000000         	jne	0x3a
-;;   30:	 ba00000000           	mov	edx, 0
-;;      	 e902000000           	jmp	0x3c
-;;   3a:	 f7f9                 	idiv	ecx
+;;      	 0f850a000000         	jne	0x41
+;;   37:	 ba00000000           	mov	edx, 0
+;;      	 e902000000           	jmp	0x43
+;;   41:	 f7f9                 	idiv	ecx
 ;;      	 89d0                 	mov	eax, edx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rems/overflow.wat
+++ b/winch/filetests/filetests/x64/i32_rems/overflow.wat
@@ -9,22 +9,23 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b9ffffffff           	mov	ecx, 0xffffffff
 ;;      	 b800000080           	mov	eax, 0x80000000
 ;;      	 99                   	cdq	
 ;;      	 83f9ff               	cmp	ecx, -1
-;;      	 0f850a000000         	jne	0x3a
-;;   30:	 ba00000000           	mov	edx, 0
-;;      	 e902000000           	jmp	0x3c
-;;   3a:	 f7f9                 	idiv	ecx
+;;      	 0f850a000000         	jne	0x41
+;;   37:	 ba00000000           	mov	edx, 0
+;;      	 e902000000           	jmp	0x43
+;;   41:	 f7f9                 	idiv	ecx
 ;;      	 89d0                 	mov	eax, edx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rems/params.wat
+++ b/winch/filetests/filetests/x64/i32_rems/params.wat
@@ -9,24 +9,25 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8732000000         	ja	0x4a
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 99                   	cdq	
 ;;      	 83f9ff               	cmp	ecx, -1
-;;      	 0f850a000000         	jne	0x40
-;;   36:	 ba00000000           	mov	edx, 0
-;;      	 e902000000           	jmp	0x42
-;;   40:	 f7f9                 	idiv	ecx
+;;      	 0f850a000000         	jne	0x47
+;;   3d:	 ba00000000           	mov	edx, 0
+;;      	 e902000000           	jmp	0x49
+;;   47:	 f7f9                 	idiv	ecx
 ;;      	 89d0                 	mov	eax, edx
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4a:	 0f0b                 	ud2	
+;;   51:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rems/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i32_rems/zero_zero.wat
@@ -9,22 +9,23 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b900000000           	mov	ecx, 0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 99                   	cdq	
 ;;      	 83f9ff               	cmp	ecx, -1
-;;      	 0f850a000000         	jne	0x3a
-;;   30:	 ba00000000           	mov	edx, 0
-;;      	 e902000000           	jmp	0x3c
-;;   3a:	 f7f9                 	idiv	ecx
+;;      	 0f850a000000         	jne	0x41
+;;   37:	 ba00000000           	mov	edx, 0
+;;      	 e902000000           	jmp	0x43
+;;   41:	 f7f9                 	idiv	ecx
 ;;      	 89d0                 	mov	eax, edx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_remu/const.wat
+++ b/winch/filetests/filetests/x64/i32_remu/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b905000000           	mov	ecx, 5
 ;;      	 b807000000           	mov	eax, 7
 ;;      	 31d2                 	xor	edx, edx
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_remu/one_zero.wat
+++ b/winch/filetests/filetests/x64/i32_remu/one_zero.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b900000000           	mov	ecx, 0
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 31d2                 	xor	edx, edx
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_remu/params.wat
+++ b/winch/filetests/filetests/x64/i32_remu/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x38
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
@@ -25,4 +26,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   38:	 0f0b                 	ud2	
+;;   3f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_remu/signed.wat
+++ b/winch/filetests/filetests/x64/i32_remu/signed.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b9ffffffff           	mov	ecx, 0xffffffff
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff
 ;;      	 31d2                 	xor	edx, edx
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_remu/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i32_remu/zero_zero.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b900000000           	mov	ecx, 0
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 31d2                 	xor	edx, edx
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rotl/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/16_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 c1c000               	rol	eax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rotl/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/8_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 c1c002               	rol	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rotl/locals.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x47
-;;   18:	 48c744240800000000   	
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
@@ -36,4 +37,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   47:	 0f0b                 	ud2	
+;;   4e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rotl/params.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rotr/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/16_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 c1c800               	ror	eax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rotr/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/8_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 c1c802               	ror	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rotr/locals.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x47
-;;   18:	 48c744240800000000   	
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
@@ -36,4 +37,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   47:	 0f0b                 	ud2	
+;;   4e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_rotr/params.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shl/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_shl/16_const.wat
@@ -10,15 +10,16 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 c1e000               	shl	eax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shl/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_shl/8_const.wat
@@ -10,15 +10,16 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 c1e002               	shl	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shl/locals.wat
+++ b/winch/filetests/filetests/x64/i32_shl/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x47
-;;   18:	 48c744240800000000   	
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
@@ -36,4 +37,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   47:	 0f0b                 	ud2	
+;;   4e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shl/params.wat
+++ b/winch/filetests/filetests/x64/i32_shl/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shr_s/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/16_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 c1f800               	sar	eax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shr_s/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/8_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 c1f802               	sar	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shr_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x47
-;;   18:	 48c744240800000000   	
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
@@ -36,4 +37,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   47:	 0f0b                 	ud2	
+;;   4e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shr_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shr_u/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/16_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 c1e800               	shr	eax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shr_u/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/8_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 c1e802               	shr	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shr_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x47
-;;   18:	 48c744240800000000   	
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
@@ -36,4 +37,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   47:	 0f0b                 	ud2	
+;;   4e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_shr_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_sub/const.wat
+++ b/winch/filetests/filetests/x64/i32_sub/const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80a000000           	mov	eax, 0xa
 ;;      	 83e814               	sub	eax, 0x14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_sub/locals.wat
+++ b/winch/filetests/filetests/x64/i32_sub/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x49
-;;   18:	 48c744240800000000   	
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80a000000           	mov	eax, 0xa
@@ -37,4 +38,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   49:	 0f0b                 	ud2	
+;;   50:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_sub/max.wat
+++ b/winch/filetests/filetests/x64/i32_sub/max.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b8ffffff7f           	mov	eax, 0x7fffffff
 ;;      	 83e8ff               	sub	eax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_sub/max_one.wat
+++ b/winch/filetests/filetests/x64/i32_sub/max_one.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b800000080           	mov	eax, 0x80000000
 ;;      	 83e801               	sub	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_sub/mixed.wat
+++ b/winch/filetests/filetests/x64/i32_sub/mixed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff
 ;;      	 83e801               	sub	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_sub/params.wat
+++ b/winch/filetests/filetests/x64/i32_sub/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_sub/signed.wat
+++ b/winch/filetests/filetests/x64/i32_sub/signed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff
 ;;      	 83e8ff               	sub	eax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_sub/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i32_sub/unsigned_with_zero.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 83e800               	sub	eax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_trunc_f32_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_s/const.wat
@@ -8,32 +8,33 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874c000000         	ja	0x64
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10054c000000     	movss	xmm0, dword ptr [rip + 0x4c]
+;;      	 0f8750000000         	ja	0x6b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10054d000000     	movss	xmm0, dword ptr [rip + 0x4d]
 ;;      	 f30f2cc0             	cvttss2si	eax, xmm0
 ;;      	 83f801               	cmp	eax, 1
-;;      	 0f812d000000         	jno	0x5e
-;;   31:	 0f2ec0               	ucomiss	xmm0, xmm0
-;;      	 0f8a2c000000         	jp	0x66
-;;   3a:	 41bb000000cf         	mov	r11d, 0xcf000000
+;;      	 0f812d000000         	jno	0x65
+;;   38:	 0f2ec0               	ucomiss	xmm0, xmm0
+;;      	 0f8a2c000000         	jp	0x6d
+;;   41:	 41bb000000cf         	mov	r11d, 0xcf000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ec7             	ucomiss	xmm0, xmm15
-;;      	 0f8219000000         	jb	0x68
-;;   4f:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f8219000000         	jb	0x6f
+;;   56:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 440f2ef8             	ucomiss	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x6a
-;;   5e:	 4883c408             	add	rsp, 8
+;;      	 0f820c000000         	jb	0x71
+;;   65:	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   64:	 0f0b                 	ud2	
-;;   66:	 0f0b                 	ud2	
-;;   68:	 0f0b                 	ud2	
-;;   6a:	 0f0b                 	ud2	
-;;   6c:	 0000                 	add	byte ptr [rax], al
-;;   6e:	 0000                 	add	byte ptr [rax], al
-;;   70:	 0000                 	add	byte ptr [rax], al
+;;   6b:	 0f0b                 	ud2	
+;;   6d:	 0f0b                 	ud2	
+;;   6f:	 0f0b                 	ud2	
+;;   71:	 0f0b                 	ud2	
+;;   73:	 0000                 	add	byte ptr [rax], al
+;;   75:	 0000                 	add	byte ptr [rax], al
+;;   77:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/i32_trunc_f32_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_s/locals.wat
@@ -10,31 +10,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8753000000         	ja	0x6b
-;;   18:	 48c744240800000000   	
+;;      	 0f8757000000         	ja	0x72
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 f30f2cc0             	cvttss2si	eax, xmm0
 ;;      	 83f801               	cmp	eax, 1
-;;      	 0f812d000000         	jno	0x65
-;;   38:	 0f2ec0               	ucomiss	xmm0, xmm0
-;;      	 0f8a2c000000         	jp	0x6d
-;;   41:	 41bb000000cf         	mov	r11d, 0xcf000000
+;;      	 0f812d000000         	jno	0x6c
+;;   3f:	 0f2ec0               	ucomiss	xmm0, xmm0
+;;      	 0f8a2c000000         	jp	0x74
+;;   48:	 41bb000000cf         	mov	r11d, 0xcf000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ec7             	ucomiss	xmm0, xmm15
-;;      	 0f8219000000         	jb	0x6f
-;;   56:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f8219000000         	jb	0x76
+;;   5d:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 440f2ef8             	ucomiss	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x71
-;;   65:	 4883c410             	add	rsp, 0x10
+;;      	 0f820c000000         	jb	0x78
+;;   6c:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6b:	 0f0b                 	ud2	
-;;   6d:	 0f0b                 	ud2	
-;;   6f:	 0f0b                 	ud2	
-;;   71:	 0f0b                 	ud2	
+;;   72:	 0f0b                 	ud2	
+;;   74:	 0f0b                 	ud2	
+;;   76:	 0f0b                 	ud2	
+;;   78:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_trunc_f32_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_s/params.wat
@@ -8,30 +8,31 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8750000000         	ja	0x68
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8754000000         	ja	0x6f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 f30f2cc0             	cvttss2si	eax, xmm0
 ;;      	 83f801               	cmp	eax, 1
-;;      	 0f812d000000         	jno	0x62
-;;   35:	 0f2ec0               	ucomiss	xmm0, xmm0
-;;      	 0f8a2c000000         	jp	0x6a
-;;   3e:	 41bb000000cf         	mov	r11d, 0xcf000000
+;;      	 0f812d000000         	jno	0x69
+;;   3c:	 0f2ec0               	ucomiss	xmm0, xmm0
+;;      	 0f8a2c000000         	jp	0x71
+;;   45:	 41bb000000cf         	mov	r11d, 0xcf000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ec7             	ucomiss	xmm0, xmm15
-;;      	 0f8219000000         	jb	0x6c
-;;   53:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f8219000000         	jb	0x73
+;;   5a:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 440f2ef8             	ucomiss	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x6e
-;;   62:	 4883c410             	add	rsp, 0x10
+;;      	 0f820c000000         	jb	0x75
+;;   69:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   68:	 0f0b                 	ud2	
-;;   6a:	 0f0b                 	ud2	
-;;   6c:	 0f0b                 	ud2	
-;;   6e:	 0f0b                 	ud2	
+;;   6f:	 0f0b                 	ud2	
+;;   71:	 0f0b                 	ud2	
+;;   73:	 0f0b                 	ud2	
+;;   75:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_trunc_f32_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_u/const.wat
@@ -8,33 +8,35 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8757000000         	ja	0x6f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100d54000000     	movss	xmm1, dword ptr [rip + 0x54]
+;;      	 0f875b000000         	ja	0x76
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f100d55000000     	movss	xmm1, dword ptr [rip + 0x55]
 ;;      	 41bb0000004f         	mov	r11d, 0x4f000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ecf             	ucomiss	xmm1, xmm15
-;;      	 0f8315000000         	jae	0x4e
-;;      	 0f8a32000000         	jp	0x71
-;;   3f:	 f30f2cc1             	cvttss2si	eax, xmm1
+;;      	 0f8315000000         	jae	0x55
+;;      	 0f8a32000000         	jp	0x78
+;;   46:	 f30f2cc1             	cvttss2si	eax, xmm1
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8d1d000000         	jge	0x69
-;;   4c:	 0f0b                 	ud2	
+;;      	 0f8d1d000000         	jge	0x70
+;;   53:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f3410f5cc7           	subss	xmm0, xmm15
 ;;      	 f30f2cc0             	cvttss2si	eax, xmm0
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8c10000000         	jl	0x73
-;;   63:	 81c000000080         	add	eax, 0x80000000
+;;      	 0f8c10000000         	jl	0x7a
+;;   6a:	 81c000000080         	add	eax, 0x80000000
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6f:	 0f0b                 	ud2	
-;;   71:	 0f0b                 	ud2	
-;;   73:	 0f0b                 	ud2	
-;;   75:	 0000                 	add	byte ptr [rax], al
-;;   77:	 0000                 	add	byte ptr [rax], al
+;;   76:	 0f0b                 	ud2	
+;;   78:	 0f0b                 	ud2	
+;;   7a:	 0f0b                 	ud2	
+;;   7c:	 0000                 	add	byte ptr [rax], al
+;;   7e:	 0000                 	add	byte ptr [rax], al
+;;   80:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/i32_trunc_f32_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_u/locals.wat
@@ -10,33 +10,34 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875e000000         	ja	0x76
-;;   18:	 48c744240800000000   	
+;;      	 0f8762000000         	ja	0x7d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
 ;;      	 41bb0000004f         	mov	r11d, 0x4f000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ecf             	ucomiss	xmm1, xmm15
-;;      	 0f8315000000         	jae	0x55
-;;      	 0f8a32000000         	jp	0x78
-;;   46:	 f30f2cc1             	cvttss2si	eax, xmm1
+;;      	 0f8315000000         	jae	0x5c
+;;      	 0f8a32000000         	jp	0x7f
+;;   4d:	 f30f2cc1             	cvttss2si	eax, xmm1
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8d1d000000         	jge	0x70
-;;   53:	 0f0b                 	ud2	
+;;      	 0f8d1d000000         	jge	0x77
+;;   5a:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f3410f5cc7           	subss	xmm0, xmm15
 ;;      	 f30f2cc0             	cvttss2si	eax, xmm0
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8c10000000         	jl	0x7a
-;;   6a:	 81c000000080         	add	eax, 0x80000000
+;;      	 0f8c10000000         	jl	0x81
+;;   71:	 81c000000080         	add	eax, 0x80000000
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   76:	 0f0b                 	ud2	
-;;   78:	 0f0b                 	ud2	
-;;   7a:	 0f0b                 	ud2	
+;;   7d:	 0f0b                 	ud2	
+;;   7f:	 0f0b                 	ud2	
+;;   81:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_trunc_f32_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_u/params.wat
@@ -8,32 +8,33 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875b000000         	ja	0x73
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f875f000000         	ja	0x7a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
 ;;      	 41bb0000004f         	mov	r11d, 0x4f000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ecf             	ucomiss	xmm1, xmm15
-;;      	 0f8315000000         	jae	0x52
-;;      	 0f8a32000000         	jp	0x75
-;;   43:	 f30f2cc1             	cvttss2si	eax, xmm1
+;;      	 0f8315000000         	jae	0x59
+;;      	 0f8a32000000         	jp	0x7c
+;;   4a:	 f30f2cc1             	cvttss2si	eax, xmm1
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8d1d000000         	jge	0x6d
-;;   50:	 0f0b                 	ud2	
+;;      	 0f8d1d000000         	jge	0x74
+;;   57:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f3410f5cc7           	subss	xmm0, xmm15
 ;;      	 f30f2cc0             	cvttss2si	eax, xmm0
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8c10000000         	jl	0x77
-;;   67:	 81c000000080         	add	eax, 0x80000000
+;;      	 0f8c10000000         	jl	0x7e
+;;   6e:	 81c000000080         	add	eax, 0x80000000
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   73:	 0f0b                 	ud2	
-;;   75:	 0f0b                 	ud2	
-;;   77:	 0f0b                 	ud2	
+;;   7a:	 0f0b                 	ud2	
+;;   7c:	 0f0b                 	ud2	
+;;   7e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_trunc_f64_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_s/const.wat
@@ -8,36 +8,37 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8753000000         	ja	0x6b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100554000000     	movsd	xmm0, qword ptr [rip + 0x54]
+;;      	 0f8757000000         	ja	0x72
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f100555000000     	movsd	xmm0, qword ptr [rip + 0x55]
 ;;      	 f20f2cc0             	cvttsd2si	eax, xmm0
 ;;      	 83f801               	cmp	eax, 1
-;;      	 0f8134000000         	jno	0x65
-;;   31:	 660f2ec0             	ucomisd	xmm0, xmm0
-;;      	 0f8a32000000         	jp	0x6d
-;;   3b:	 49bb000020000000e0c1 	
+;;      	 0f8134000000         	jno	0x6c
+;;   38:	 660f2ec0             	ucomisd	xmm0, xmm0
+;;      	 0f8a32000000         	jp	0x74
+;;   42:	 49bb000020000000e0c1 	
 ;; 				movabs	r11, 0xc1e0000000200000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ec7           	ucomisd	xmm0, xmm15
-;;      	 0f861a000000         	jbe	0x6f
-;;   55:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f861a000000         	jbe	0x76
+;;   5c:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 66440f2ef8           	ucomisd	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x71
-;;   65:	 4883c408             	add	rsp, 8
+;;      	 0f820c000000         	jb	0x78
+;;   6c:	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6b:	 0f0b                 	ud2	
-;;   6d:	 0f0b                 	ud2	
-;;   6f:	 0f0b                 	ud2	
-;;   71:	 0f0b                 	ud2	
-;;   73:	 0000                 	add	byte ptr [rax], al
-;;   75:	 0000                 	add	byte ptr [rax], al
-;;   77:	 0000                 	add	byte ptr [rax], al
-;;   79:	 0000                 	add	byte ptr [rax], al
-;;   7b:	 0000                 	add	byte ptr [rax], al
-;;   7d:	 00f0                 	add	al, dh
+;;   72:	 0f0b                 	ud2	
+;;   74:	 0f0b                 	ud2	
+;;   76:	 0f0b                 	ud2	
+;;   78:	 0f0b                 	ud2	
+;;   7a:	 0000                 	add	byte ptr [rax], al
+;;   7c:	 0000                 	add	byte ptr [rax], al
+;;   7e:	 0000                 	add	byte ptr [rax], al
+;;   80:	 0000                 	add	byte ptr [rax], al
+;;   82:	 0000                 	add	byte ptr [rax], al
+;;   84:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/i32_trunc_f64_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_s/locals.wat
@@ -10,32 +10,33 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875a000000         	ja	0x72
-;;   18:	 48c744240800000000   	
+;;      	 0f875e000000         	ja	0x79
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f2cc0             	cvttsd2si	eax, xmm0
 ;;      	 83f801               	cmp	eax, 1
-;;      	 0f8134000000         	jno	0x6c
-;;   38:	 660f2ec0             	ucomisd	xmm0, xmm0
-;;      	 0f8a32000000         	jp	0x74
-;;   42:	 49bb000020000000e0c1 	
+;;      	 0f8134000000         	jno	0x73
+;;   3f:	 660f2ec0             	ucomisd	xmm0, xmm0
+;;      	 0f8a32000000         	jp	0x7b
+;;   49:	 49bb000020000000e0c1 	
 ;; 				movabs	r11, 0xc1e0000000200000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ec7           	ucomisd	xmm0, xmm15
-;;      	 0f861a000000         	jbe	0x76
-;;   5c:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f861a000000         	jbe	0x7d
+;;   63:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 66440f2ef8           	ucomisd	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x78
-;;   6c:	 4883c410             	add	rsp, 0x10
+;;      	 0f820c000000         	jb	0x7f
+;;   73:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   72:	 0f0b                 	ud2	
-;;   74:	 0f0b                 	ud2	
-;;   76:	 0f0b                 	ud2	
-;;   78:	 0f0b                 	ud2	
+;;   79:	 0f0b                 	ud2	
+;;   7b:	 0f0b                 	ud2	
+;;   7d:	 0f0b                 	ud2	
+;;   7f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_trunc_f64_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_s/params.wat
@@ -8,31 +8,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8757000000         	ja	0x6f
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f875b000000         	ja	0x76
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f20f2cc0             	cvttsd2si	eax, xmm0
 ;;      	 83f801               	cmp	eax, 1
-;;      	 0f8134000000         	jno	0x69
-;;   35:	 660f2ec0             	ucomisd	xmm0, xmm0
-;;      	 0f8a32000000         	jp	0x71
-;;   3f:	 49bb000020000000e0c1 	
+;;      	 0f8134000000         	jno	0x70
+;;   3c:	 660f2ec0             	ucomisd	xmm0, xmm0
+;;      	 0f8a32000000         	jp	0x78
+;;   46:	 49bb000020000000e0c1 	
 ;; 				movabs	r11, 0xc1e0000000200000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ec7           	ucomisd	xmm0, xmm15
-;;      	 0f861a000000         	jbe	0x73
-;;   59:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f861a000000         	jbe	0x7a
+;;   60:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 66440f2ef8           	ucomisd	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x75
-;;   69:	 4883c410             	add	rsp, 0x10
+;;      	 0f820c000000         	jb	0x7c
+;;   70:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6f:	 0f0b                 	ud2	
-;;   71:	 0f0b                 	ud2	
-;;   73:	 0f0b                 	ud2	
-;;   75:	 0f0b                 	ud2	
+;;   76:	 0f0b                 	ud2	
+;;   78:	 0f0b                 	ud2	
+;;   7a:	 0f0b                 	ud2	
+;;   7c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_trunc_f64_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_u/const.wat
@@ -8,38 +8,40 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875c000000         	ja	0x74
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100d5c000000     	movsd	xmm1, qword ptr [rip + 0x5c]
+;;      	 0f8760000000         	ja	0x7b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f100d5d000000     	movsd	xmm1, qword ptr [rip + 0x5d]
 ;;      	 49bb000000000000e041 	
 ;; 				movabs	r11, 0x41e0000000000000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ecf           	ucomisd	xmm1, xmm15
-;;      	 0f8315000000         	jae	0x53
-;;      	 0f8a32000000         	jp	0x76
-;;   44:	 f20f2cc1             	cvttsd2si	eax, xmm1
+;;      	 0f8315000000         	jae	0x5a
+;;      	 0f8a32000000         	jp	0x7d
+;;   4b:	 f20f2cc1             	cvttsd2si	eax, xmm1
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8d1d000000         	jge	0x6e
-;;   51:	 0f0b                 	ud2	
+;;      	 0f8d1d000000         	jge	0x75
+;;   58:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f2410f5cc7           	subsd	xmm0, xmm15
 ;;      	 f20f2cc0             	cvttsd2si	eax, xmm0
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8c10000000         	jl	0x78
-;;   68:	 81c000000080         	add	eax, 0x80000000
+;;      	 0f8c10000000         	jl	0x7f
+;;   6f:	 81c000000080         	add	eax, 0x80000000
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   74:	 0f0b                 	ud2	
-;;   76:	 0f0b                 	ud2	
-;;   78:	 0f0b                 	ud2	
-;;   7a:	 0000                 	add	byte ptr [rax], al
-;;   7c:	 0000                 	add	byte ptr [rax], al
-;;   7e:	 0000                 	add	byte ptr [rax], al
-;;   80:	 0000                 	add	byte ptr [rax], al
-;;   82:	 0000                 	add	byte ptr [rax], al
-;;   84:	 0000                 	add	byte ptr [rax], al
+;;   7b:	 0f0b                 	ud2	
+;;   7d:	 0f0b                 	ud2	
+;;   7f:	 0f0b                 	ud2	
+;;   81:	 0000                 	add	byte ptr [rax], al
+;;   83:	 0000                 	add	byte ptr [rax], al
+;;   85:	 0000                 	add	byte ptr [rax], al
+;;   87:	 0000                 	add	byte ptr [rax], al
+;;   89:	 0000                 	add	byte ptr [rax], al
+;;   8b:	 0000                 	add	byte ptr [rax], al
+;;   8d:	 00f0                 	add	al, dh

--- a/winch/filetests/filetests/x64/i32_trunc_f64_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_u/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8763000000         	ja	0x7b
-;;   18:	 48c744240800000000   	
+;;      	 0f8767000000         	ja	0x82
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f104c2408         	movsd	xmm1, qword ptr [rsp + 8]
@@ -23,21 +24,21 @@
 ;; 				movabs	r11, 0x41e0000000000000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ecf           	ucomisd	xmm1, xmm15
-;;      	 0f8315000000         	jae	0x5a
-;;      	 0f8a32000000         	jp	0x7d
-;;   4b:	 f20f2cc1             	cvttsd2si	eax, xmm1
+;;      	 0f8315000000         	jae	0x61
+;;      	 0f8a32000000         	jp	0x84
+;;   52:	 f20f2cc1             	cvttsd2si	eax, xmm1
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8d1d000000         	jge	0x75
-;;   58:	 0f0b                 	ud2	
+;;      	 0f8d1d000000         	jge	0x7c
+;;   5f:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f2410f5cc7           	subsd	xmm0, xmm15
 ;;      	 f20f2cc0             	cvttsd2si	eax, xmm0
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8c10000000         	jl	0x7f
-;;   6f:	 81c000000080         	add	eax, 0x80000000
+;;      	 0f8c10000000         	jl	0x86
+;;   76:	 81c000000080         	add	eax, 0x80000000
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   7b:	 0f0b                 	ud2	
-;;   7d:	 0f0b                 	ud2	
-;;   7f:	 0f0b                 	ud2	
+;;   82:	 0f0b                 	ud2	
+;;   84:	 0f0b                 	ud2	
+;;   86:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_trunc_f64_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_u/params.wat
@@ -8,33 +8,34 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8760000000         	ja	0x78
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f8764000000         	ja	0x7f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f104c2408         	movsd	xmm1, qword ptr [rsp + 8]
 ;;      	 49bb000000000000e041 	
 ;; 				movabs	r11, 0x41e0000000000000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ecf           	ucomisd	xmm1, xmm15
-;;      	 0f8315000000         	jae	0x57
-;;      	 0f8a32000000         	jp	0x7a
-;;   48:	 f20f2cc1             	cvttsd2si	eax, xmm1
+;;      	 0f8315000000         	jae	0x5e
+;;      	 0f8a32000000         	jp	0x81
+;;   4f:	 f20f2cc1             	cvttsd2si	eax, xmm1
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8d1d000000         	jge	0x72
-;;   55:	 0f0b                 	ud2	
+;;      	 0f8d1d000000         	jge	0x79
+;;   5c:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f2410f5cc7           	subsd	xmm0, xmm15
 ;;      	 f20f2cc0             	cvttsd2si	eax, xmm0
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8c10000000         	jl	0x7c
-;;   6c:	 81c000000080         	add	eax, 0x80000000
+;;      	 0f8c10000000         	jl	0x83
+;;   73:	 81c000000080         	add	eax, 0x80000000
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   78:	 0f0b                 	ud2	
-;;   7a:	 0f0b                 	ud2	
-;;   7c:	 0f0b                 	ud2	
+;;   7f:	 0f0b                 	ud2	
+;;   81:	 0f0b                 	ud2	
+;;   83:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_wrap_i64/const.wat
+++ b/winch/filetests/filetests/x64/i32_wrap_i64/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x2b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8717000000         	ja	0x32
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 89c0                 	mov	eax, eax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2b:	 0f0b                 	ud2	
+;;   32:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_wrap_i64/locals.wat
+++ b/winch/filetests/filetests/x64/i32_wrap_i64/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 48c744240800000000   	
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_wrap_i64/params.wat
+++ b/winch/filetests/filetests/x64/i32_wrap_i64/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 89c0                 	mov	eax, eax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_wrap_i64/spilled.wat
+++ b/winch/filetests/filetests/x64/i32_wrap_i64/spilled.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c30c000000       	add	r11, 0xc
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 89c0                 	mov	eax, eax
 ;;      	 4883ec04             	sub	rsp, 4
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_xor/const.wat
+++ b/winch/filetests/filetests/x64/i32_xor/const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 83f002               	xor	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_xor/locals.wat
+++ b/winch/filetests/filetests/x64/i32_xor/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x49
-;;   18:	 48c744240800000000   	
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
@@ -37,4 +38,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   49:	 0f0b                 	ud2	
+;;   50:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i32_xor/params.wat
+++ b/winch/filetests/filetests/x64/i32_xor/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_add/const.wat
+++ b/winch/filetests/filetests/x64/i64_add/const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c00a000000       	mov	rax, 0xa
 ;;      	 4883c014             	add	rax, 0x14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_add/locals.wat
+++ b/winch/filetests/filetests/x64/i64_add/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x57
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -38,4 +39,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   57:	 0f0b                 	ud2	
+;;   5e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_add/max.wat
+++ b/winch/filetests/filetests/x64/i64_add/max.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 49bbffffffffffffff7f 	
 ;; 				movabs	r11, 0x7fffffffffffffff
@@ -21,4 +22,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_add/max_one.wat
+++ b/winch/filetests/filetests/x64/i64_add/max_one.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b80000000000000080 	
 ;; 				movabs	rax, 0x8000000000000000
 ;;      	 4883c0ff             	add	rax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_add/mixed.wat
+++ b/winch/filetests/filetests/x64/i64_add/mixed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
 ;;      	 4883c001             	add	rax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_add/params.wat
+++ b/winch/filetests/filetests/x64/i64_add/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_add/signed.wat
+++ b/winch/filetests/filetests/x64/i64_add/signed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
 ;;      	 4883c0ff             	add	rax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_add/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i64_add/unsigned_with_zero.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 4883c000             	add	rax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_and/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_and/32_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883e003             	and	rax, 3
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_and/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_and/64_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_and/locals.wat
+++ b/winch/filetests/filetests/x64/i64_and/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x57
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -37,4 +38,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   57:	 0f0b                 	ud2	
+;;   5e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_and/params.wat
+++ b/winch/filetests/filetests/x64/i64_and/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_clz/lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i64_clz/lzcnt_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 f3480fbdc0           	lzcnt	rax, rax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_clz/lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i64_clz/lzcnt_local.wat
@@ -14,12 +14,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 48c744240800000000   	
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
@@ -29,4 +30,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_clz/lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i64_clz/lzcnt_param.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 f3480fbdc0           	lzcnt	rax, rax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_clz/no_lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i64_clz/no_lzcnt_const.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 480fbdc0             	bsr	rax, rax
 ;;      	 41bb00000000         	mov	r11d, 0
@@ -24,4 +25,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_clz/no_lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i64_clz/no_lzcnt_local.wat
@@ -13,12 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x54
-;;   18:	 48c744240800000000   	
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
@@ -33,4 +34,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   54:	 0f0b                 	ud2	
+;;   5b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_clz/no_lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i64_clz/no_lzcnt_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 480fbdc0             	bsr	rax, rax
@@ -25,4 +26,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ctz/bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/bmi1_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 f3480fbcc0           	tzcnt	rax, rax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ctz/bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/bmi1_local.wat
@@ -14,12 +14,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 48c744240800000000   	
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
@@ -29,4 +30,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ctz/bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/bmi1_param.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 f3480fbcc0           	tzcnt	rax, rax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ctz/no_bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/no_bmi1_const.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 480fbcc0             	bsf	rax, rax
 ;;      	 41bb00000000         	mov	r11d, 0
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
+;;   45:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ctz/no_bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/no_bmi1_local.wat
@@ -13,12 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8739000000         	ja	0x51
-;;   18:	 48c744240800000000   	
+;;      	 0f873d000000         	ja	0x58
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
@@ -32,4 +33,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   51:	 0f0b                 	ud2	
+;;   58:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ctz/no_bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/no_bmi1_param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 480fbcc0             	bsf	rax, rax
@@ -24,4 +25,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_divs/const.wat
+++ b/winch/filetests/filetests/x64/i64_divs/const.wat
@@ -9,20 +9,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c10a000000       	mov	rcx, 0xa
 ;;      	 48c7c014000000       	mov	rax, 0x14
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f840d000000         	je	0x41
-;;   34:	 4899                 	cqo	
+;;      	 0f840d000000         	je	0x48
+;;   3b:	 4899                 	cqo	
 ;;      	 48f7f9               	idiv	rcx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
-;;   41:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_divs/one_zero.wat
+++ b/winch/filetests/filetests/x64/i64_divs/one_zero.wat
@@ -9,20 +9,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c100000000       	mov	rcx, 0
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f840d000000         	je	0x41
-;;   34:	 4899                 	cqo	
+;;      	 0f840d000000         	je	0x48
+;;   3b:	 4899                 	cqo	
 ;;      	 48f7f9               	idiv	rcx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
-;;   41:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_divs/overflow.wat
+++ b/winch/filetests/filetests/x64/i64_divs/overflow.wat
@@ -9,21 +9,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c1ffffffff       	mov	rcx, 0xffffffffffffffff
 ;;      	 48b80000000000000080 	
 ;; 				movabs	rax, 0x8000000000000000
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f840d000000         	je	0x44
-;;   37:	 4899                 	cqo	
+;;      	 0f840d000000         	je	0x4b
+;;   3e:	 4899                 	cqo	
 ;;      	 48f7f9               	idiv	rcx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
-;;   44:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_divs/params.wat
+++ b/winch/filetests/filetests/x64/i64_divs/params.wat
@@ -9,22 +9,23 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872d000000         	ja	0x45
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8731000000         	ja	0x4c
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
 ;;      	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f840d000000         	je	0x47
-;;   3a:	 4899                 	cqo	
+;;      	 0f840d000000         	je	0x4e
+;;   41:	 4899                 	cqo	
 ;;      	 48f7f9               	idiv	rcx
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   45:	 0f0b                 	ud2	
-;;   47:	 0f0b                 	ud2	
+;;   4c:	 0f0b                 	ud2	
+;;   4e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_divs/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i64_divs/zero_zero.wat
@@ -9,20 +9,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c100000000       	mov	rcx, 0
 ;;      	 48c7c000000000       	mov	rax, 0
 ;;      	 4883f900             	cmp	rcx, 0
-;;      	 0f840d000000         	je	0x41
-;;   34:	 4899                 	cqo	
+;;      	 0f840d000000         	je	0x48
+;;   3b:	 4899                 	cqo	
 ;;      	 48f7f9               	idiv	rcx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
-;;   41:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_divu/const.wat
+++ b/winch/filetests/filetests/x64/i64_divu/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c10a000000       	mov	rcx, 0xa
 ;;      	 48c7c014000000       	mov	rax, 0x14
 ;;      	 4831d2               	xor	rdx, rdx
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_divu/one_zero.wat
+++ b/winch/filetests/filetests/x64/i64_divu/one_zero.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c100000000       	mov	rcx, 0
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 4831d2               	xor	rdx, rdx
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_divu/params.wat
+++ b/winch/filetests/filetests/x64/i64_divu/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_divu/signed.wat
+++ b/winch/filetests/filetests/x64/i64_divu/signed.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c1ffffffff       	mov	rcx, 0xffffffffffffffff
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
 ;;      	 4831d2               	xor	rdx, rdx
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_divu/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i64_divu/zero_zero.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c100000000       	mov	rcx, 0
 ;;      	 48c7c000000000       	mov	rax, 0
 ;;      	 4831d2               	xor	rdx, rdx
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_eq/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_eq/32_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883f803             	cmp	rax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_eq/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_eq/64_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_eq/locals.wat
+++ b/winch/filetests/filetests/x64/i64_eq/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -39,4 +40,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_eq/params.wat
+++ b/winch/filetests/filetests/x64/i64_eq/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_eqz/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_eqz/32_const.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 4883f800             	cmp	rax, 0
 ;;      	 b800000000           	mov	eax, 0
@@ -21,4 +22,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_eqz/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_eqz/64_const.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8ffffffffffffff7f 	
 ;; 				movabs	rax, 0x7fffffffffffffff
 ;;      	 4883f800             	cmp	rax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_eqz/local.wat
+++ b/winch/filetests/filetests/x64/i64_eqz/local.wat
@@ -13,12 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x49
-;;   18:	 48c744240800000000   	
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
@@ -30,4 +31,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   49:	 0f0b                 	ud2	
+;;   50:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_eqz/param.wat
+++ b/winch/filetests/filetests/x64/i64_eqz/param.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 4883f800             	cmp	rax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_eqz/spilled.wat
+++ b/winch/filetests/filetests/x64/i64_eqz/spilled.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c30c000000       	add	r11, 0xc
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 4883f800             	cmp	rax, 0
 ;;      	 b800000000           	mov	eax, 0
@@ -27,4 +28,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_16_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_extend_16_s/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 480fbfc0             	movsx	rax, ax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_16_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_extend_16_s/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 48c744240800000000   	
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_16_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_extend_16_s/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 480fbfc0             	movsx	rax, ax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_32_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_extend_32_s/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8714000000         	ja	0x2c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 4863c0               	movsxd	rax, eax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2c:	 0f0b                 	ud2	
+;;   33:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_32_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_extend_32_s/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 48c744240800000000   	
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_32_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_extend_32_s/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8717000000         	ja	0x2f
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 4863c0               	movsxd	rax, eax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2f:	 0f0b                 	ud2	
+;;   36:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_8_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_extend_8_s/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 480fbec0             	movsx	rax, al
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_8_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_extend_8_s/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 48c744240800000000   	
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_8_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_extend_8_s/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 480fbec0             	movsx	rax, al
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_i32_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_s/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 4863c0               	movsxd	rax, eax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_i32_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_s/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 48c744240800000000   	
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_i32_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_s/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 4863c0               	movsxd	rax, eax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_i32_s/spilled.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_s/spilled.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8714000000         	ja	0x2c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 4863c0               	movsxd	rax, eax
 ;;      	 50                   	push	rax
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2c:	 0f0b                 	ud2	
+;;   33:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_i32_u/const.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_u/const.wat
@@ -8,15 +8,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8711000000         	ja	0x29
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8715000000         	ja	0x30
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 8bc0                 	mov	eax, eax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   29:	 0f0b                 	ud2	
+;;   30:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_i32_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_u/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 48c744240800000000   	
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_i32_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_u/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8714000000         	ja	0x2c
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 8bc0                 	mov	eax, eax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2c:	 0f0b                 	ud2	
+;;   33:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_extend_i32_u/spilled.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_u/spilled.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x2b
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8717000000         	ja	0x32
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 8bc0                 	mov	eax, eax
 ;;      	 50                   	push	rax
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2b:	 0f0b                 	ud2	
+;;   32:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ge_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/32_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883f803             	cmp	rax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ge_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/64_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ge_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -39,4 +40,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ge_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ge_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/32_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883f803             	cmp	rax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ge_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/64_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ge_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -39,4 +40,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ge_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_gt_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/32_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883f803             	cmp	rax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_gt_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/64_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_gt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -39,4 +40,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_gt_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_gt_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/32_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883f803             	cmp	rax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_gt_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/64_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_gt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -39,4 +40,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_gt_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_le_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/32_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883f803             	cmp	rax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_le_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/64_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_le_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -39,4 +40,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_le_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_le_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/32_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883f803             	cmp	rax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_le_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/64_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_le_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -39,4 +40,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_le_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_lt_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/32_const.wat
@@ -10,12 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883f803             	cmp	rax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_lt_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/64_const.wat
@@ -10,12 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -26,4 +27,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_lt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/locals.wat
@@ -18,12 +18,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -40,4 +41,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_lt_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/params.wat
@@ -10,12 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -27,4 +28,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_lt_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/32_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883f803             	cmp	rax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_lt_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/64_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -25,4 +26,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_lt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -39,4 +40,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_lt_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -26,4 +27,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_mul/const.wat
+++ b/winch/filetests/filetests/x64/i64_mul/const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c00a000000       	mov	rax, 0xa
 ;;      	 486bc014             	imul	rax, rax, 0x14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_mul/locals.wat
+++ b/winch/filetests/filetests/x64/i64_mul/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x58
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -38,4 +39,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   58:	 0f0b                 	ud2	
+;;   5f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_mul/max.wat
+++ b/winch/filetests/filetests/x64/i64_mul/max.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8ffffffffffffff7f 	
 ;; 				movabs	rax, 0x7fffffffffffffff
 ;;      	 486bc0ff             	imul	rax, rax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_mul/max_one.wat
+++ b/winch/filetests/filetests/x64/i64_mul/max_one.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b80000000000000080 	
 ;; 				movabs	rax, 0x8000000000000000
 ;;      	 486bc0ff             	imul	rax, rax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_mul/mixed.wat
+++ b/winch/filetests/filetests/x64/i64_mul/mixed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
 ;;      	 486bc001             	imul	rax, rax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_mul/params.wat
+++ b/winch/filetests/filetests/x64/i64_mul/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x3d
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3d:	 0f0b                 	ud2	
+;;   44:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_mul/signed.wat
+++ b/winch/filetests/filetests/x64/i64_mul/signed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
 ;;      	 486bc0ff             	imul	rax, rax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_mul/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i64_mul/unsigned_with_zero.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 486bc000             	imul	rax, rax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ne/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_ne/32_const.wat
@@ -10,12 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883f803             	cmp	rax, 3
 ;;      	 b800000000           	mov	eax, 0
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ne/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_ne/64_const.wat
@@ -10,12 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -26,4 +27,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ne/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ne/locals.wat
@@ -18,12 +18,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x5f
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -40,4 +41,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5f:	 0f0b                 	ud2	
+;;   66:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_ne/params.wat
+++ b/winch/filetests/filetests/x64/i64_ne/params.wat
@@ -10,12 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -27,4 +28,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_or/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_or/32_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883c803             	or	rax, 3
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_or/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_or/64_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_or/locals.wat
+++ b/winch/filetests/filetests/x64/i64_or/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x57
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -37,4 +38,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   57:	 0f0b                 	ud2	
+;;   5e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_or/params.wat
+++ b/winch/filetests/filetests/x64/i64_or/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_popcnt/const.wat
+++ b/winch/filetests/filetests/x64/i64_popcnt/const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c003000000       	mov	rax, 3
 ;;      	 f3480fb8c0           	popcnt	rax, rax
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_popcnt/fallback.wat
+++ b/winch/filetests/filetests/x64/i64_popcnt/fallback.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876b000000         	ja	0x83
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f876f000000         	ja	0x8a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c00f000000       	mov	rax, 0xf
 ;;      	 4889c1               	mov	rcx, rax
 ;;      	 48c1e801             	shr	rax, 1
@@ -41,4 +42,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   83:	 0f0b                 	ud2	
+;;   8a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_popcnt/no_sse42.wat
+++ b/winch/filetests/filetests/x64/i64_popcnt/no_sse42.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876b000000         	ja	0x83
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f876f000000         	ja	0x8a
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c003000000       	mov	rax, 3
 ;;      	 4889c1               	mov	rcx, rax
 ;;      	 48c1e801             	shr	rax, 1
@@ -42,4 +43,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   83:	 0f0b                 	ud2	
+;;   8a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_popcnt/reg.wat
+++ b/winch/filetests/filetests/x64/i64_popcnt/reg.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 f3480fb8c0           	popcnt	rax, rax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_reinterpret_f64/const.wat
+++ b/winch/filetests/filetests/x64/i64_reinterpret_f64/const.wat
@@ -8,22 +8,19 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8717000000         	ja	0x2f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100514000000     	movsd	xmm0, qword ptr [rip + 0x14]
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10050d000000     	movsd	xmm0, qword ptr [rip + 0xd]
 ;;      	 66480f7ec0           	movq	rax, xmm0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2f:	 0f0b                 	ud2	
-;;   31:	 0000                 	add	byte ptr [rax], al
-;;   33:	 0000                 	add	byte ptr [rax], al
-;;   35:	 0000                 	add	byte ptr [rax], al
-;;   37:	 0000                 	add	byte ptr [rax], al
-;;   39:	 0000                 	add	byte ptr [rax], al
-;;   3b:	 0000                 	add	byte ptr [rax], al
-;;   3d:	 00f0                 	add	al, dh
+;;   36:	 0f0b                 	ud2	
+;;   38:	 0000                 	add	byte ptr [rax], al
+;;   3a:	 0000                 	add	byte ptr [rax], al
+;;   3c:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/i64_reinterpret_f64/locals.wat
+++ b/winch/filetests/filetests/x64/i64_reinterpret_f64/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x36
-;;   18:	 48c744240800000000   	
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   36:	 0f0b                 	ud2	
+;;   3d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_reinterpret_f64/params.wat
+++ b/winch/filetests/filetests/x64/i64_reinterpret_f64/params.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 66480f7ec0           	movq	rax, xmm0
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_reinterpret_f64/ret_float.wat
+++ b/winch/filetests/filetests/x64/i64_reinterpret_f64/ret_float.wat
@@ -10,23 +10,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x37
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10051c000000     	movsd	xmm0, qword ptr [rip + 0x1c]
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f100515000000     	movsd	xmm0, qword ptr [rip + 0x15]
 ;;      	 66480f7ec0           	movq	rax, xmm0
-;;      	 f20f10050f000000     	movsd	xmm0, qword ptr [rip + 0xf]
+;;      	 f20f100508000000     	movsd	xmm0, qword ptr [rip + 8]
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   37:	 0f0b                 	ud2	
-;;   39:	 0000                 	add	byte ptr [rax], al
-;;   3b:	 0000                 	add	byte ptr [rax], al
-;;   3d:	 0000                 	add	byte ptr [rax], al
-;;   3f:	 0000                 	add	byte ptr [rax], al
-;;   41:	 0000                 	add	byte ptr [rax], al
-;;   43:	 0000                 	add	byte ptr [rax], al
-;;   45:	 00f0                 	add	al, dh
+;;   3e:	 0f0b                 	ud2	
+;;   40:	 0000                 	add	byte ptr [rax], al
+;;   42:	 0000                 	add	byte ptr [rax], al
+;;   44:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/i64_rems/const.wat
+++ b/winch/filetests/filetests/x64/i64_rems/const.wat
@@ -9,22 +9,23 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x4c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c105000000       	mov	rcx, 5
 ;;      	 48c7c007000000       	mov	rax, 7
 ;;      	 4899                 	cqo	
 ;;      	 4883f9ff             	cmp	rcx, -1
-;;      	 0f850a000000         	jne	0x40
-;;   36:	 ba00000000           	mov	edx, 0
-;;      	 e903000000           	jmp	0x43
-;;   40:	 48f7f9               	idiv	rcx
+;;      	 0f850a000000         	jne	0x47
+;;   3d:	 ba00000000           	mov	edx, 0
+;;      	 e903000000           	jmp	0x4a
+;;   47:	 48f7f9               	idiv	rcx
 ;;      	 4889d0               	mov	rax, rdx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4c:	 0f0b                 	ud2	
+;;   53:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rems/one_zero.wat
+++ b/winch/filetests/filetests/x64/i64_rems/one_zero.wat
@@ -9,22 +9,23 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x4c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c100000000       	mov	rcx, 0
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 4899                 	cqo	
 ;;      	 4883f9ff             	cmp	rcx, -1
-;;      	 0f850a000000         	jne	0x40
-;;   36:	 ba00000000           	mov	edx, 0
-;;      	 e903000000           	jmp	0x43
-;;   40:	 48f7f9               	idiv	rcx
+;;      	 0f850a000000         	jne	0x47
+;;   3d:	 ba00000000           	mov	edx, 0
+;;      	 e903000000           	jmp	0x4a
+;;   47:	 48f7f9               	idiv	rcx
 ;;      	 4889d0               	mov	rax, rdx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4c:	 0f0b                 	ud2	
+;;   53:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rems/overflow.wat
+++ b/winch/filetests/filetests/x64/i64_rems/overflow.wat
@@ -9,23 +9,24 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8737000000         	ja	0x4f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c1ffffffff       	mov	rcx, 0xffffffffffffffff
 ;;      	 48b80000000000000080 	
 ;; 				movabs	rax, 0x8000000000000000
 ;;      	 4899                 	cqo	
 ;;      	 4883f9ff             	cmp	rcx, -1
-;;      	 0f850a000000         	jne	0x43
-;;   39:	 ba00000000           	mov	edx, 0
-;;      	 e903000000           	jmp	0x46
-;;   43:	 48f7f9               	idiv	rcx
+;;      	 0f850a000000         	jne	0x4a
+;;   40:	 ba00000000           	mov	edx, 0
+;;      	 e903000000           	jmp	0x4d
+;;   4a:	 48f7f9               	idiv	rcx
 ;;      	 4889d0               	mov	rax, rdx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4f:	 0f0b                 	ud2	
+;;   56:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rems/params.wat
+++ b/winch/filetests/filetests/x64/i64_rems/params.wat
@@ -9,24 +9,25 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x52
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
 ;;      	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
 ;;      	 4899                 	cqo	
 ;;      	 4883f9ff             	cmp	rcx, -1
-;;      	 0f850a000000         	jne	0x46
-;;   3c:	 ba00000000           	mov	edx, 0
-;;      	 e903000000           	jmp	0x49
-;;   46:	 48f7f9               	idiv	rcx
+;;      	 0f850a000000         	jne	0x4d
+;;   43:	 ba00000000           	mov	edx, 0
+;;      	 e903000000           	jmp	0x50
+;;   4d:	 48f7f9               	idiv	rcx
 ;;      	 4889d0               	mov	rax, rdx
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   52:	 0f0b                 	ud2	
+;;   59:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rems/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i64_rems/zero_zero.wat
@@ -9,22 +9,23 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x4c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c100000000       	mov	rcx, 0
 ;;      	 48c7c000000000       	mov	rax, 0
 ;;      	 4899                 	cqo	
 ;;      	 4883f9ff             	cmp	rcx, -1
-;;      	 0f850a000000         	jne	0x40
-;;   36:	 ba00000000           	mov	edx, 0
-;;      	 e903000000           	jmp	0x43
-;;   40:	 48f7f9               	idiv	rcx
+;;      	 0f850a000000         	jne	0x47
+;;   3d:	 ba00000000           	mov	edx, 0
+;;      	 e903000000           	jmp	0x4a
+;;   47:	 48f7f9               	idiv	rcx
 ;;      	 4889d0               	mov	rax, rdx
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4c:	 0f0b                 	ud2	
+;;   53:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_remu/const.wat
+++ b/winch/filetests/filetests/x64/i64_remu/const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c105000000       	mov	rcx, 5
 ;;      	 48c7c007000000       	mov	rax, 7
 ;;      	 4831d2               	xor	rdx, rdx
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_remu/one_zero.wat
+++ b/winch/filetests/filetests/x64/i64_remu/one_zero.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c100000000       	mov	rcx, 0
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 4831d2               	xor	rdx, rdx
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_remu/params.wat
+++ b/winch/filetests/filetests/x64/i64_remu/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x3f
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
@@ -25,4 +26,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3f:	 0f0b                 	ud2	
+;;   46:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_remu/signed.wat
+++ b/winch/filetests/filetests/x64/i64_remu/signed.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c1ffffffff       	mov	rcx, 0xffffffffffffffff
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
 ;;      	 4831d2               	xor	rdx, rdx
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_remu/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i64_remu/zero_zero.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c100000000       	mov	rcx, 0
 ;;      	 48c7c000000000       	mov	rax, 0
 ;;      	 4831d2               	xor	rdx, rdx
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rotl/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/16_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 48c1c000             	rol	rax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rotl/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/8_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 48c1c002             	rol	rax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rotl/locals.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x54
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -37,4 +38,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   54:	 0f0b                 	ud2	
+;;   5b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rotl/params.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rotr/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/16_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 48c1c800             	ror	rax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rotr/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/8_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 48c1c802             	ror	rax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rotr/locals.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x54
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -37,4 +38,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   54:	 0f0b                 	ud2	
+;;   5b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_rotr/params.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shl/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_shl/16_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 48c1e000             	shl	rax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shl/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_shl/8_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 48c1e002             	shl	rax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shl/locals.wat
+++ b/winch/filetests/filetests/x64/i64_shl/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x54
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -37,4 +38,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   54:	 0f0b                 	ud2	
+;;   5b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shl/params.wat
+++ b/winch/filetests/filetests/x64/i64_shl/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shr_s/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/16_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 48c1f800             	sar	rax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shr_s/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/8_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 48c1f802             	sar	rax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shr_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x54
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -37,4 +38,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   54:	 0f0b                 	ud2	
+;;   5b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shr_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shr_u/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/16_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 48c1e800             	shr	rax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shr_u/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/8_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 48c1e802             	shr	rax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shr_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x54
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -37,4 +38,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   54:	 0f0b                 	ud2	
+;;   5b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_shr_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b4c2408           	mov	rcx, qword ptr [rsp + 8]
@@ -23,4 +24,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_sub/const.wat
+++ b/winch/filetests/filetests/x64/i64_sub/const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c00a000000       	mov	rax, 0xa
 ;;      	 4883e814             	sub	rax, 0x14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_sub/locals.wat
+++ b/winch/filetests/filetests/x64/i64_sub/locals.wat
@@ -18,12 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x57
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -38,4 +39,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   57:	 0f0b                 	ud2	
+;;   5e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_sub/max.wat
+++ b/winch/filetests/filetests/x64/i64_sub/max.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8ffffffffffffff7f 	
 ;; 				movabs	rax, 0x7fffffffffffffff
 ;;      	 4883e8ff             	sub	rax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_sub/max_one.wat
+++ b/winch/filetests/filetests/x64/i64_sub/max_one.wat
@@ -9,16 +9,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b80000000000000080 	
 ;; 				movabs	rax, 0x8000000000000000
 ;;      	 4883e801             	sub	rax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_sub/mixed.wat
+++ b/winch/filetests/filetests/x64/i64_sub/mixed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
 ;;      	 4883e801             	sub	rax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_sub/params.wat
+++ b/winch/filetests/filetests/x64/i64_sub/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_sub/signed.wat
+++ b/winch/filetests/filetests/x64/i64_sub/signed.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff
 ;;      	 4883e8ff             	sub	rax, -1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_sub/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i64_sub/unsigned_with_zero.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c001000000       	mov	rax, 1
 ;;      	 4883e800             	sub	rax, 0
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_trunc_f32_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_s/const.wat
@@ -8,31 +8,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x66
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10054c000000     	movss	xmm0, dword ptr [rip + 0x4c]
+;;      	 0f8752000000         	ja	0x6d
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10054d000000     	movss	xmm0, dword ptr [rip + 0x4d]
 ;;      	 f3480f2cc0           	cvttss2si	rax, xmm0
 ;;      	 4883f801             	cmp	rax, 1
-;;      	 0f812d000000         	jno	0x60
-;;   33:	 0f2ec0               	ucomiss	xmm0, xmm0
-;;      	 0f8a2c000000         	jp	0x68
-;;   3c:	 41bb000000df         	mov	r11d, 0xdf000000
+;;      	 0f812d000000         	jno	0x67
+;;   3a:	 0f2ec0               	ucomiss	xmm0, xmm0
+;;      	 0f8a2c000000         	jp	0x6f
+;;   43:	 41bb000000df         	mov	r11d, 0xdf000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ec7             	ucomiss	xmm0, xmm15
-;;      	 0f8219000000         	jb	0x6a
-;;   51:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f8219000000         	jb	0x71
+;;   58:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 440f2ef8             	ucomiss	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x6c
-;;   60:	 4883c408             	add	rsp, 8
+;;      	 0f820c000000         	jb	0x73
+;;   67:	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   66:	 0f0b                 	ud2	
-;;   68:	 0f0b                 	ud2	
-;;   6a:	 0f0b                 	ud2	
-;;   6c:	 0f0b                 	ud2	
-;;   6e:	 0000                 	add	byte ptr [rax], al
-;;   70:	 0000                 	add	byte ptr [rax], al
+;;   6d:	 0f0b                 	ud2	
+;;   6f:	 0f0b                 	ud2	
+;;   71:	 0f0b                 	ud2	
+;;   73:	 0f0b                 	ud2	
+;;   75:	 0000                 	add	byte ptr [rax], al
+;;   77:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/i64_trunc_f32_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_s/locals.wat
@@ -10,31 +10,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8755000000         	ja	0x6d
-;;   18:	 48c744240800000000   	
+;;      	 0f8759000000         	ja	0x74
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 f3480f2cc0           	cvttss2si	rax, xmm0
 ;;      	 4883f801             	cmp	rax, 1
-;;      	 0f812d000000         	jno	0x67
-;;   3a:	 0f2ec0               	ucomiss	xmm0, xmm0
-;;      	 0f8a2c000000         	jp	0x6f
-;;   43:	 41bb000000df         	mov	r11d, 0xdf000000
+;;      	 0f812d000000         	jno	0x6e
+;;   41:	 0f2ec0               	ucomiss	xmm0, xmm0
+;;      	 0f8a2c000000         	jp	0x76
+;;   4a:	 41bb000000df         	mov	r11d, 0xdf000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ec7             	ucomiss	xmm0, xmm15
-;;      	 0f8219000000         	jb	0x71
-;;   58:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f8219000000         	jb	0x78
+;;   5f:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 440f2ef8             	ucomiss	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x73
-;;   67:	 4883c410             	add	rsp, 0x10
+;;      	 0f820c000000         	jb	0x7a
+;;   6e:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6d:	 0f0b                 	ud2	
-;;   6f:	 0f0b                 	ud2	
-;;   71:	 0f0b                 	ud2	
-;;   73:	 0f0b                 	ud2	
+;;   74:	 0f0b                 	ud2	
+;;   76:	 0f0b                 	ud2	
+;;   78:	 0f0b                 	ud2	
+;;   7a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_trunc_f32_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_s/params.wat
@@ -8,30 +8,31 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8752000000         	ja	0x6a
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f8756000000         	ja	0x71
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
 ;;      	 f3480f2cc0           	cvttss2si	rax, xmm0
 ;;      	 4883f801             	cmp	rax, 1
-;;      	 0f812d000000         	jno	0x64
-;;   37:	 0f2ec0               	ucomiss	xmm0, xmm0
-;;      	 0f8a2c000000         	jp	0x6c
-;;   40:	 41bb000000df         	mov	r11d, 0xdf000000
+;;      	 0f812d000000         	jno	0x6b
+;;   3e:	 0f2ec0               	ucomiss	xmm0, xmm0
+;;      	 0f8a2c000000         	jp	0x73
+;;   47:	 41bb000000df         	mov	r11d, 0xdf000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ec7             	ucomiss	xmm0, xmm15
-;;      	 0f8219000000         	jb	0x6e
-;;   55:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f8219000000         	jb	0x75
+;;   5c:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 440f2ef8             	ucomiss	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x70
-;;   64:	 4883c410             	add	rsp, 0x10
+;;      	 0f820c000000         	jb	0x77
+;;   6b:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6a:	 0f0b                 	ud2	
-;;   6c:	 0f0b                 	ud2	
-;;   6e:	 0f0b                 	ud2	
-;;   70:	 0f0b                 	ud2	
+;;   71:	 0f0b                 	ud2	
+;;   73:	 0f0b                 	ud2	
+;;   75:	 0f0b                 	ud2	
+;;   77:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_trunc_f32_u/const.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_u/const.wat
@@ -8,34 +8,35 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8762000000         	ja	0x7a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f100d5c000000     	movss	xmm1, dword ptr [rip + 0x5c]
+;;      	 0f8766000000         	ja	0x81
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f100d5d000000     	movss	xmm1, dword ptr [rip + 0x5d]
 ;;      	 41bb0000005f         	mov	r11d, 0x5f000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ecf             	ucomiss	xmm1, xmm15
-;;      	 0f8317000000         	jae	0x50
-;;      	 0f8a3d000000         	jp	0x7c
-;;   3f:	 f3480f2cc1           	cvttss2si	rax, xmm1
+;;      	 0f8317000000         	jae	0x57
+;;      	 0f8a3d000000         	jp	0x83
+;;   46:	 f3480f2cc1           	cvttss2si	rax, xmm1
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8d26000000         	jge	0x74
-;;   4e:	 0f0b                 	ud2	
+;;      	 0f8d26000000         	jge	0x7b
+;;   55:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f3410f5cc7           	subss	xmm0, xmm15
 ;;      	 f3480f2cc0           	cvttss2si	rax, xmm0
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8c17000000         	jl	0x7e
-;;   67:	 49bb0000000000000080 	
+;;      	 0f8c17000000         	jl	0x85
+;;   6e:	 49bb0000000000000080 	
 ;; 				movabs	r11, 0x8000000000000000
 ;;      	 4c01d8               	add	rax, r11
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   7a:	 0f0b                 	ud2	
-;;   7c:	 0f0b                 	ud2	
-;;   7e:	 0f0b                 	ud2	
-;;   80:	 0000                 	add	byte ptr [rax], al
+;;   81:	 0f0b                 	ud2	
+;;   83:	 0f0b                 	ud2	
+;;   85:	 0f0b                 	ud2	
+;;   87:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/i64_trunc_f32_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_u/locals.wat
@@ -10,35 +10,36 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8769000000         	ja	0x81
-;;   18:	 48c744240800000000   	
+;;      	 0f876d000000         	ja	0x88
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
 ;;      	 41bb0000005f         	mov	r11d, 0x5f000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ecf             	ucomiss	xmm1, xmm15
-;;      	 0f8317000000         	jae	0x57
-;;      	 0f8a3d000000         	jp	0x83
-;;   46:	 f3480f2cc1           	cvttss2si	rax, xmm1
+;;      	 0f8317000000         	jae	0x5e
+;;      	 0f8a3d000000         	jp	0x8a
+;;   4d:	 f3480f2cc1           	cvttss2si	rax, xmm1
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8d26000000         	jge	0x7b
-;;   55:	 0f0b                 	ud2	
+;;      	 0f8d26000000         	jge	0x82
+;;   5c:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f3410f5cc7           	subss	xmm0, xmm15
 ;;      	 f3480f2cc0           	cvttss2si	rax, xmm0
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8c17000000         	jl	0x85
-;;   6e:	 49bb0000000000000080 	
+;;      	 0f8c17000000         	jl	0x8c
+;;   75:	 49bb0000000000000080 	
 ;; 				movabs	r11, 0x8000000000000000
 ;;      	 4c01d8               	add	rax, r11
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   81:	 0f0b                 	ud2	
-;;   83:	 0f0b                 	ud2	
-;;   85:	 0f0b                 	ud2	
+;;   88:	 0f0b                 	ud2	
+;;   8a:	 0f0b                 	ud2	
+;;   8c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_trunc_f32_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_u/params.wat
@@ -8,34 +8,35 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8766000000         	ja	0x7e
-;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
+;;      	 0f876a000000         	ja	0x85
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f30f104c240c         	movss	xmm1, dword ptr [rsp + 0xc]
 ;;      	 41bb0000005f         	mov	r11d, 0x5f000000
 ;;      	 66450f6efb           	movd	xmm15, r11d
 ;;      	 410f2ecf             	ucomiss	xmm1, xmm15
-;;      	 0f8317000000         	jae	0x54
-;;      	 0f8a3d000000         	jp	0x80
-;;   43:	 f3480f2cc1           	cvttss2si	rax, xmm1
+;;      	 0f8317000000         	jae	0x5b
+;;      	 0f8a3d000000         	jp	0x87
+;;   4a:	 f3480f2cc1           	cvttss2si	rax, xmm1
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8d26000000         	jge	0x78
-;;   52:	 0f0b                 	ud2	
+;;      	 0f8d26000000         	jge	0x7f
+;;   59:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f3410f5cc7           	subss	xmm0, xmm15
 ;;      	 f3480f2cc0           	cvttss2si	rax, xmm0
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8c17000000         	jl	0x82
-;;   6b:	 49bb0000000000000080 	
+;;      	 0f8c17000000         	jl	0x89
+;;   72:	 49bb0000000000000080 	
 ;; 				movabs	r11, 0x8000000000000000
 ;;      	 4c01d8               	add	rax, r11
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   7e:	 0f0b                 	ud2	
-;;   80:	 0f0b                 	ud2	
-;;   82:	 0f0b                 	ud2	
+;;   85:	 0f0b                 	ud2	
+;;   87:	 0f0b                 	ud2	
+;;   89:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_trunc_f64_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_s/const.wat
@@ -8,35 +8,36 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8755000000         	ja	0x6d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100554000000     	movsd	xmm0, qword ptr [rip + 0x54]
+;;      	 0f8759000000         	ja	0x74
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f100555000000     	movsd	xmm0, qword ptr [rip + 0x55]
 ;;      	 f2480f2cc0           	cvttsd2si	rax, xmm0
 ;;      	 4883f801             	cmp	rax, 1
-;;      	 0f8134000000         	jno	0x67
-;;   33:	 660f2ec0             	ucomisd	xmm0, xmm0
-;;      	 0f8a32000000         	jp	0x6f
-;;   3d:	 49bb000000000000e0c3 	
+;;      	 0f8134000000         	jno	0x6e
+;;   3a:	 660f2ec0             	ucomisd	xmm0, xmm0
+;;      	 0f8a32000000         	jp	0x76
+;;   44:	 49bb000000000000e0c3 	
 ;; 				movabs	r11, 0xc3e0000000000000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ec7           	ucomisd	xmm0, xmm15
-;;      	 0f821a000000         	jb	0x71
-;;   57:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f821a000000         	jb	0x78
+;;   5e:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 66440f2ef8           	ucomisd	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x73
-;;   67:	 4883c408             	add	rsp, 8
+;;      	 0f820c000000         	jb	0x7a
+;;   6e:	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   6d:	 0f0b                 	ud2	
-;;   6f:	 0f0b                 	ud2	
-;;   71:	 0f0b                 	ud2	
-;;   73:	 0f0b                 	ud2	
-;;   75:	 0000                 	add	byte ptr [rax], al
-;;   77:	 0000                 	add	byte ptr [rax], al
-;;   79:	 0000                 	add	byte ptr [rax], al
-;;   7b:	 0000                 	add	byte ptr [rax], al
-;;   7d:	 00f0                 	add	al, dh
+;;   74:	 0f0b                 	ud2	
+;;   76:	 0f0b                 	ud2	
+;;   78:	 0f0b                 	ud2	
+;;   7a:	 0f0b                 	ud2	
+;;   7c:	 0000                 	add	byte ptr [rax], al
+;;   7e:	 0000                 	add	byte ptr [rax], al
+;;   80:	 0000                 	add	byte ptr [rax], al
+;;   82:	 0000                 	add	byte ptr [rax], al
+;;   84:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/i64_trunc_f64_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_s/locals.wat
@@ -10,32 +10,33 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875c000000         	ja	0x74
-;;   18:	 48c744240800000000   	
+;;      	 0f8760000000         	ja	0x7b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f2480f2cc0           	cvttsd2si	rax, xmm0
 ;;      	 4883f801             	cmp	rax, 1
-;;      	 0f8134000000         	jno	0x6e
-;;   3a:	 660f2ec0             	ucomisd	xmm0, xmm0
-;;      	 0f8a32000000         	jp	0x76
-;;   44:	 49bb000000000000e0c3 	
+;;      	 0f8134000000         	jno	0x75
+;;   41:	 660f2ec0             	ucomisd	xmm0, xmm0
+;;      	 0f8a32000000         	jp	0x7d
+;;   4b:	 49bb000000000000e0c3 	
 ;; 				movabs	r11, 0xc3e0000000000000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ec7           	ucomisd	xmm0, xmm15
-;;      	 0f821a000000         	jb	0x78
-;;   5e:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f821a000000         	jb	0x7f
+;;   65:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 66440f2ef8           	ucomisd	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x7a
-;;   6e:	 4883c410             	add	rsp, 0x10
+;;      	 0f820c000000         	jb	0x81
+;;   75:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   74:	 0f0b                 	ud2	
-;;   76:	 0f0b                 	ud2	
-;;   78:	 0f0b                 	ud2	
-;;   7a:	 0f0b                 	ud2	
+;;   7b:	 0f0b                 	ud2	
+;;   7d:	 0f0b                 	ud2	
+;;   7f:	 0f0b                 	ud2	
+;;   81:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_trunc_f64_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_s/params.wat
@@ -8,31 +8,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8759000000         	ja	0x71
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f875d000000         	ja	0x78
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
 ;;      	 f2480f2cc0           	cvttsd2si	rax, xmm0
 ;;      	 4883f801             	cmp	rax, 1
-;;      	 0f8134000000         	jno	0x6b
-;;   37:	 660f2ec0             	ucomisd	xmm0, xmm0
-;;      	 0f8a32000000         	jp	0x73
-;;   41:	 49bb000000000000e0c3 	
+;;      	 0f8134000000         	jno	0x72
+;;   3e:	 660f2ec0             	ucomisd	xmm0, xmm0
+;;      	 0f8a32000000         	jp	0x7a
+;;   48:	 49bb000000000000e0c3 	
 ;; 				movabs	r11, 0xc3e0000000000000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ec7           	ucomisd	xmm0, xmm15
-;;      	 0f821a000000         	jb	0x75
-;;   5b:	 66450f57ff           	xorpd	xmm15, xmm15
+;;      	 0f821a000000         	jb	0x7c
+;;   62:	 66450f57ff           	xorpd	xmm15, xmm15
 ;;      	 66440f2ef8           	ucomisd	xmm15, xmm0
-;;      	 0f820c000000         	jb	0x77
-;;   6b:	 4883c410             	add	rsp, 0x10
+;;      	 0f820c000000         	jb	0x7e
+;;   72:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   71:	 0f0b                 	ud2	
-;;   73:	 0f0b                 	ud2	
-;;   75:	 0f0b                 	ud2	
-;;   77:	 0f0b                 	ud2	
+;;   78:	 0f0b                 	ud2	
+;;   7a:	 0f0b                 	ud2	
+;;   7c:	 0f0b                 	ud2	
+;;   7e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_trunc_f64_u/const.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_u/const.wat
@@ -8,39 +8,40 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8767000000         	ja	0x7f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f100d64000000     	movsd	xmm1, qword ptr [rip + 0x64]
+;;      	 0f876b000000         	ja	0x86
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f100d65000000     	movsd	xmm1, qword ptr [rip + 0x65]
 ;;      	 49bb000000000000e043 	
 ;; 				movabs	r11, 0x43e0000000000000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ecf           	ucomisd	xmm1, xmm15
-;;      	 0f8317000000         	jae	0x55
-;;      	 0f8a3d000000         	jp	0x81
-;;   44:	 f2480f2cc1           	cvttsd2si	rax, xmm1
+;;      	 0f8317000000         	jae	0x5c
+;;      	 0f8a3d000000         	jp	0x88
+;;   4b:	 f2480f2cc1           	cvttsd2si	rax, xmm1
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8d26000000         	jge	0x79
-;;   53:	 0f0b                 	ud2	
+;;      	 0f8d26000000         	jge	0x80
+;;   5a:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f2410f5cc7           	subsd	xmm0, xmm15
 ;;      	 f2480f2cc0           	cvttsd2si	rax, xmm0
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8c17000000         	jl	0x83
-;;   6c:	 49bb0000000000000080 	
+;;      	 0f8c17000000         	jl	0x8a
+;;   73:	 49bb0000000000000080 	
 ;; 				movabs	r11, 0x8000000000000000
 ;;      	 4c01d8               	add	rax, r11
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   7f:	 0f0b                 	ud2	
-;;   81:	 0f0b                 	ud2	
-;;   83:	 0f0b                 	ud2	
-;;   85:	 0000                 	add	byte ptr [rax], al
-;;   87:	 0000                 	add	byte ptr [rax], al
-;;   89:	 0000                 	add	byte ptr [rax], al
-;;   8b:	 0000                 	add	byte ptr [rax], al
-;;   8d:	 00f0                 	add	al, dh
+;;   86:	 0f0b                 	ud2	
+;;   88:	 0f0b                 	ud2	
+;;   8a:	 0f0b                 	ud2	
+;;   8c:	 0000                 	add	byte ptr [rax], al
+;;   8e:	 0000                 	add	byte ptr [rax], al
+;;   90:	 0000                 	add	byte ptr [rax], al
+;;   92:	 0000                 	add	byte ptr [rax], al
+;;   94:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/i64_trunc_f64_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_u/locals.wat
@@ -10,12 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876e000000         	ja	0x86
-;;   18:	 48c744240800000000   	
+;;      	 0f8772000000         	ja	0x8d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f104c2408         	movsd	xmm1, qword ptr [rsp + 8]
@@ -23,23 +24,23 @@
 ;; 				movabs	r11, 0x43e0000000000000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ecf           	ucomisd	xmm1, xmm15
-;;      	 0f8317000000         	jae	0x5c
-;;      	 0f8a3d000000         	jp	0x88
-;;   4b:	 f2480f2cc1           	cvttsd2si	rax, xmm1
+;;      	 0f8317000000         	jae	0x63
+;;      	 0f8a3d000000         	jp	0x8f
+;;   52:	 f2480f2cc1           	cvttsd2si	rax, xmm1
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8d26000000         	jge	0x80
-;;   5a:	 0f0b                 	ud2	
+;;      	 0f8d26000000         	jge	0x87
+;;   61:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f2410f5cc7           	subsd	xmm0, xmm15
 ;;      	 f2480f2cc0           	cvttsd2si	rax, xmm0
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8c17000000         	jl	0x8a
-;;   73:	 49bb0000000000000080 	
+;;      	 0f8c17000000         	jl	0x91
+;;   7a:	 49bb0000000000000080 	
 ;; 				movabs	r11, 0x8000000000000000
 ;;      	 4c01d8               	add	rax, r11
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   86:	 0f0b                 	ud2	
-;;   88:	 0f0b                 	ud2	
-;;   8a:	 0f0b                 	ud2	
+;;   8d:	 0f0b                 	ud2	
+;;   8f:	 0f0b                 	ud2	
+;;   91:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_trunc_f64_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_u/params.wat
@@ -8,35 +8,36 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876b000000         	ja	0x83
-;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
+;;      	 0f876f000000         	ja	0x8a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f20f104c2408         	movsd	xmm1, qword ptr [rsp + 8]
 ;;      	 49bb000000000000e043 	
 ;; 				movabs	r11, 0x43e0000000000000
 ;;      	 664d0f6efb           	movq	xmm15, r11
 ;;      	 66410f2ecf           	ucomisd	xmm1, xmm15
-;;      	 0f8317000000         	jae	0x59
-;;      	 0f8a3d000000         	jp	0x85
-;;   48:	 f2480f2cc1           	cvttsd2si	rax, xmm1
+;;      	 0f8317000000         	jae	0x60
+;;      	 0f8a3d000000         	jp	0x8c
+;;   4f:	 f2480f2cc1           	cvttsd2si	rax, xmm1
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8d26000000         	jge	0x7d
-;;   57:	 0f0b                 	ud2	
+;;      	 0f8d26000000         	jge	0x84
+;;   5e:	 0f0b                 	ud2	
 ;;      	 0f28c1               	movaps	xmm0, xmm1
 ;;      	 f2410f5cc7           	subsd	xmm0, xmm15
 ;;      	 f2480f2cc0           	cvttsd2si	rax, xmm0
 ;;      	 4883f800             	cmp	rax, 0
-;;      	 0f8c17000000         	jl	0x87
-;;   70:	 49bb0000000000000080 	
+;;      	 0f8c17000000         	jl	0x8e
+;;   77:	 49bb0000000000000080 	
 ;; 				movabs	r11, 0x8000000000000000
 ;;      	 4c01d8               	add	rax, r11
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   83:	 0f0b                 	ud2	
-;;   85:	 0f0b                 	ud2	
-;;   87:	 0f0b                 	ud2	
+;;   8a:	 0f0b                 	ud2	
+;;   8c:	 0f0b                 	ud2	
+;;   8e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_xor/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_xor/32_const.wat
@@ -9,15 +9,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x2d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8719000000         	ja	0x34
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48c7c002000000       	mov	rax, 2
 ;;      	 4883f003             	xor	rax, 3
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2d:	 0f0b                 	ud2	
+;;   34:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_xor/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_xor/64_const.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x39
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 48b8feffffffffffff7f 	
 ;; 				movabs	rax, 0x7ffffffffffffffe
 ;;      	 49bbffffffffffffff7f 	
@@ -23,4 +24,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   39:	 0f0b                 	ud2	
+;;   40:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_xor/locals.wat
+++ b/winch/filetests/filetests/x64/i64_xor/locals.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x57
-;;   18:	 4531db               	xor	r11d, r11d
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -37,4 +38,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   57:	 0f0b                 	ud2	
+;;   5e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/i64_xor/params.wat
+++ b/winch/filetests/filetests/x64/i64_xor/params.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -24,4 +25,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/if/as_binop.wat
+++ b/winch/filetests/filetests/x64/if/as_binop.wat
@@ -17,47 +17,49 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f877f000000         	ja	0x97
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8783000000         	ja	0x9e
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840f000000         	je	0x3f
-;;   30:	 e800000000           	call	0x35
+;;      	 0f840f000000         	je	0x46
+;;   37:	 e800000000           	call	0x3c
 ;;      	 b803000000           	mov	eax, 3
-;;      	 e90a000000           	jmp	0x49
-;;   3f:	 e800000000           	call	0x44
+;;      	 e90a000000           	jmp	0x50
+;;   46:	 e800000000           	call	0x4b
 ;;      	 b8fdffffff           	mov	eax, 0xfffffffd
 ;;      	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8417000000         	je	0x73
-;;   5c:	 4883ec0c             	sub	rsp, 0xc
-;;      	 e800000000           	call	0x65
+;;      	 0f8417000000         	je	0x7a
+;;   63:	 4883ec0c             	sub	rsp, 0xc
+;;      	 e800000000           	call	0x6c
 ;;      	 4883c40c             	add	rsp, 0xc
 ;;      	 b804000000           	mov	eax, 4
-;;      	 e912000000           	jmp	0x85
-;;   73:	 4883ec0c             	sub	rsp, 0xc
-;;      	 e800000000           	call	0x7c
+;;      	 e912000000           	jmp	0x8c
+;;   7a:	 4883ec0c             	sub	rsp, 0xc
+;;      	 e800000000           	call	0x83
 ;;      	 4883c40c             	add	rsp, 0xc
 ;;      	 b8fbffffff           	mov	eax, 0xfffffffb
 ;;      	 8b0c24               	mov	ecx, dword ptr [rsp]
@@ -67,4 +69,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   97:	 0f0b                 	ud2	
+;;   9e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/if/as_br_if_last.wat
+++ b/winch/filetests/filetests/x64/if/as_br_if_last.wat
@@ -16,33 +16,35 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875e000000         	ja	0x76
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8762000000         	ja	0x7d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840f000000         	je	0x3b
-;;   2c:	 e800000000           	call	0x31
+;;      	 0f840f000000         	je	0x42
+;;   33:	 e800000000           	call	0x38
 ;;      	 b801000000           	mov	eax, 1
-;;      	 e90a000000           	jmp	0x45
-;;   3b:	 e800000000           	call	0x40
+;;      	 e90a000000           	jmp	0x4c
+;;   42:	 e800000000           	call	0x47
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
@@ -50,12 +52,12 @@
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8510000000         	jne	0x70
-;;   60:	 4883ec04             	sub	rsp, 4
+;;      	 0f8510000000         	jne	0x77
+;;   67:	 4883ec04             	sub	rsp, 4
 ;;      	 890424               	mov	dword ptr [rsp], eax
 ;;      	 b803000000           	mov	eax, 3
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   76:	 0f0b                 	ud2	
+;;   7d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/if/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/if/as_if_cond.wat
@@ -14,40 +14,42 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874a000000         	ja	0x62
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f874e000000         	ja	0x69
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x36
-;;   2c:	 b801000000           	mov	eax, 1
-;;      	 e905000000           	jmp	0x3b
-;;   36:	 b800000000           	mov	eax, 0
+;;      	 0f840a000000         	je	0x3d
+;;   33:	 b801000000           	mov	eax, 1
+;;      	 e905000000           	jmp	0x42
+;;   3d:	 b800000000           	mov	eax, 0
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840f000000         	je	0x52
-;;   43:	 e800000000           	call	0x48
+;;      	 0f840f000000         	je	0x59
+;;   4a:	 e800000000           	call	0x4f
 ;;      	 b802000000           	mov	eax, 2
-;;      	 e90a000000           	jmp	0x5c
-;;   52:	 e800000000           	call	0x57
+;;      	 e90a000000           	jmp	0x63
+;;   59:	 e800000000           	call	0x5e
 ;;      	 b803000000           	mov	eax, 3
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   62:	 0f0b                 	ud2	
+;;   69:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/if/as_testop.wat
+++ b/winch/filetests/filetests/x64/if/as_testop.wat
@@ -12,33 +12,35 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x57
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840f000000         	je	0x3b
-;;   2c:	 e800000000           	call	0x31
+;;      	 0f840f000000         	je	0x42
+;;   33:	 e800000000           	call	0x38
 ;;      	 b80d000000           	mov	eax, 0xd
-;;      	 e90a000000           	jmp	0x45
-;;   3b:	 e800000000           	call	0x40
+;;      	 e90a000000           	jmp	0x4c
+;;   42:	 e800000000           	call	0x47
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 83f800               	cmp	eax, 0
 ;;      	 b800000000           	mov	eax, 0
@@ -46,4 +48,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   57:	 0f0b                 	ud2	
+;;   5e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/if/break_value.wat
+++ b/winch/filetests/filetests/x64/if/break_value.wat
@@ -10,20 +10,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x36
-;;   2c:	 b812000000           	mov	eax, 0x12
-;;      	 e905000000           	jmp	0x3b
-;;   36:	 b815000000           	mov	eax, 0x15
+;;      	 0f840a000000         	je	0x3d
+;;   33:	 b812000000           	mov	eax, 0x12
+;;      	 e905000000           	jmp	0x42
+;;   3d:	 b815000000           	mov	eax, 0x15
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/if/nested.wat
+++ b/winch/filetests/filetests/x64/if/nested.wat
@@ -24,66 +24,68 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87bb000000         	ja	0xd3
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f87bf000000         	ja	0xda
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8451000000         	je	0x81
-;;   30:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;      	 0f8451000000         	je	0x88
+;;   37:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8405000000         	je	0x41
-;;   3c:	 e800000000           	call	0x41
+;;      	 0f8405000000         	je	0x48
+;;   43:	 e800000000           	call	0x48
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8405000000         	je	0x52
-;;      	 e905000000           	jmp	0x57
-;;   52:	 e800000000           	call	0x57
+;;      	 0f8405000000         	je	0x59
+;;      	 e905000000           	jmp	0x5e
+;;   59:	 e800000000           	call	0x5e
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840f000000         	je	0x72
-;;   63:	 e800000000           	call	0x68
+;;      	 0f840f000000         	je	0x79
+;;   6a:	 e800000000           	call	0x6f
 ;;      	 b809000000           	mov	eax, 9
-;;      	 e95b000000           	jmp	0xcd
-;;   72:	 e800000000           	call	0x77
+;;      	 e95b000000           	jmp	0xd4
+;;   79:	 e800000000           	call	0x7e
 ;;      	 b80a000000           	mov	eax, 0xa
-;;      	 e94c000000           	jmp	0xcd
-;;   81:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;      	 e94c000000           	jmp	0xd4
+;;   88:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8405000000         	je	0x92
-;;   8d:	 e800000000           	call	0x92
+;;      	 0f8405000000         	je	0x99
+;;   94:	 e800000000           	call	0x99
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8405000000         	je	0xa3
-;;      	 e905000000           	jmp	0xa8
-;;   a3:	 e800000000           	call	0xa8
+;;      	 0f8405000000         	je	0xaa
+;;      	 e905000000           	jmp	0xaf
+;;   aa:	 e800000000           	call	0xaf
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840f000000         	je	0xc3
-;;   b4:	 e800000000           	call	0xb9
+;;      	 0f840f000000         	je	0xca
+;;   bb:	 e800000000           	call	0xc0
 ;;      	 b80a000000           	mov	eax, 0xa
-;;      	 e90a000000           	jmp	0xcd
-;;   c3:	 e800000000           	call	0xc8
+;;      	 e90a000000           	jmp	0xd4
+;;   ca:	 e800000000           	call	0xcf
 ;;      	 b80b000000           	mov	eax, 0xb
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   d3:	 0f0b                 	ud2	
+;;   da:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/if/reachability.wat
+++ b/winch/filetests/filetests/x64/if/reachability.wat
@@ -15,23 +15,24 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8745000000         	ja	0x5d
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8749000000         	ja	0x64
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 44891c24             	mov	dword ptr [rsp], r11d
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840e000000         	je	0x47
-;;   39:	 b801000000           	mov	eax, 1
+;;      	 0f840e000000         	je	0x4e
+;;   40:	 b801000000           	mov	eax, 1
 ;;      	 4883c404             	add	rsp, 4
-;;      	 e910000000           	jmp	0x57
-;;   47:	 b802000000           	mov	eax, 2
+;;      	 e910000000           	jmp	0x5e
+;;   4e:	 b802000000           	mov	eax, 2
 ;;      	 8b0c24               	mov	ecx, dword ptr [rsp]
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 29c1                 	sub	ecx, eax
@@ -39,4 +40,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   5d:	 0f0b                 	ud2	
+;;   64:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/if/singular.wat
+++ b/winch/filetests/filetests/x64/if/singular.wat
@@ -10,39 +10,41 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x59
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8745000000         	ja	0x60
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8400000000         	je	0x2c
-;;   2c:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;      	 0f8400000000         	je	0x33
+;;   33:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8400000000         	je	0x38
-;;   38:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
+;;      	 0f8400000000         	je	0x3f
+;;   3f:	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x4e
-;;   44:	 b807000000           	mov	eax, 7
-;;      	 e905000000           	jmp	0x53
-;;   4e:	 b808000000           	mov	eax, 8
+;;      	 0f840a000000         	je	0x55
+;;   4b:	 b807000000           	mov	eax, 7
+;;      	 e905000000           	jmp	0x5a
+;;   55:	 b808000000           	mov	eax, 8
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   59:	 0f0b                 	ud2	
+;;   60:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/load/f32.wat
+++ b/winch/filetests/filetests/x64/load/f32.wat
@@ -7,12 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 498b4e50             	mov	rcx, qword ptr [r14 + 0x50]
 ;;      	 4801c1               	add	rcx, rax
@@ -20,4 +21,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/load/f64.wat
+++ b/winch/filetests/filetests/x64/load/f64.wat
@@ -6,12 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x32
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 498b4e50             	mov	rcx, qword ptr [r14 + 0x50]
 ;;      	 4801c1               	add	rcx, rax
@@ -19,4 +20,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   32:	 0f0b                 	ud2	
+;;   39:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/load/i32.wat
+++ b/winch/filetests/filetests/x64/load/i32.wat
@@ -7,12 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x30
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871c000000         	ja	0x37
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 498b4e50             	mov	rcx, qword ptr [r14 + 0x50]
 ;;      	 4801c1               	add	rcx, rax
@@ -20,4 +21,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   30:	 0f0b                 	ud2	
+;;   37:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/load/i64.wat
+++ b/winch/filetests/filetests/x64/load/i64.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8732000000         	ja	0x4a
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 b908000000           	mov	ecx, 8
@@ -27,4 +28,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4a:	 0f0b                 	ud2	
+;;   51:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/local/latent.wat
+++ b/winch/filetests/filetests/x64/local/latent.wat
@@ -9,12 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872b000000         	ja	0x43
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872f000000         	ja	0x4a
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   43:	 0f0b                 	ud2	
+;;   4a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/local/materialized.wat
+++ b/winch/filetests/filetests/x64/local/materialized.wat
@@ -8,16 +8,17 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 8944240c             	mov	dword ptr [rsp + 0xc], eax
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/as_binary_operand.wat
+++ b/winch/filetests/filetests/x64/loop/as_binary_operand.wat
@@ -10,34 +10,36 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x32
+;;      	 e800000000           	call	0x39
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b803000000           	mov	eax, 3
 ;;      	 6bc004               	imul	eax, eax, 4
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/as_br_if_first.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_if_first.wat
@@ -6,17 +6,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b902000000           	mov	ecx, 2
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8500000000         	jne	0x2e
-;;   2e:	 4883c408             	add	rsp, 8
+;;      	 0f8500000000         	jne	0x35
+;;   35:	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/as_br_if_last.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_if_last.wat
@@ -6,17 +6,18 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b901000000           	mov	ecx, 1
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8500000000         	jne	0x2e
-;;   2e:	 4883c408             	add	rsp, 8
+;;      	 0f8500000000         	jne	0x35
+;;   35:	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/as_br_value.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_value.wat
@@ -6,14 +6,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/as_call_value.wat
+++ b/winch/filetests/filetests/x64/loop/as_call_value.wat
@@ -7,32 +7,34 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8712000000         	ja	0x2a
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2a:	 0f0b                 	ud2	
+;;   31:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
 ;;      	 bf01000000           	mov	edi, 1
-;;      	 e800000000           	call	0x2a
+;;      	 e800000000           	call	0x31
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/as_if_condition.wat
+++ b/winch/filetests/filetests/x64/loop/as_if_condition.wat
@@ -7,32 +7,34 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840d000000         	je	0x36
-;;   29:	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x32
+;;      	 0f840d000000         	je	0x3d
+;;   30:	 4883ec08             	sub	rsp, 8
+;;      	 e800000000           	call	0x39
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/as_if_else.wat
+++ b/winch/filetests/filetests/x64/loop/as_if_else.wat
@@ -6,19 +6,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x33
-;;   29:	 b802000000           	mov	eax, 2
-;;      	 e905000000           	jmp	0x38
-;;   33:	 b801000000           	mov	eax, 1
+;;      	 0f840a000000         	je	0x3a
+;;   30:	 b802000000           	mov	eax, 2
+;;      	 e905000000           	jmp	0x3f
+;;   3a:	 b801000000           	mov	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
+;;   45:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/as_if_then.wat
+++ b/winch/filetests/filetests/x64/loop/as_if_then.wat
@@ -6,19 +6,20 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x3e
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x33
-;;   29:	 b801000000           	mov	eax, 1
-;;      	 e905000000           	jmp	0x38
-;;   33:	 b802000000           	mov	eax, 2
+;;      	 0f840a000000         	je	0x3a
+;;   30:	 b801000000           	mov	eax, 1
+;;      	 e905000000           	jmp	0x3f
+;;   3a:	 b802000000           	mov	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3e:	 0f0b                 	ud2	
+;;   45:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/as_local_set_value.wat
+++ b/winch/filetests/filetests/x64/loop/as_local_set_value.wat
@@ -6,12 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x38
-;;   18:	 48c744240800000000   	
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
@@ -20,4 +21,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   38:	 0f0b                 	ud2	
+;;   3f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/as_test_operand.wat
+++ b/winch/filetests/filetests/x64/loop/as_test_operand.wat
@@ -7,27 +7,29 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x40
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b80d000000           	mov	eax, 0xd
 ;;      	 83f800               	cmp	eax, 0
@@ -36,4 +38,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   40:	 0f0b                 	ud2	
+;;   47:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/as_unary_operand.wat
+++ b/winch/filetests/filetests/x64/loop/as_unary_operand.wat
@@ -7,27 +7,29 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x48
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b80d000000           	mov	eax, 0xd
 ;;      	 0fbcc0               	bsf	eax, eax
@@ -38,4 +40,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   48:	 0f0b                 	ud2	
+;;   4f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/break_inner.wat
+++ b/winch/filetests/filetests/x64/loop/break_inner.wat
@@ -13,12 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87bb000000         	ja	0xd3
-;;   18:	 48c744240800000000   	
+;;      	 0f87bf000000         	ja	0xda
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b800000000           	mov	eax, 0
@@ -67,4 +68,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   d3:	 0f0b                 	ud2	
+;;   da:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/cont_inner.wat
+++ b/winch/filetests/filetests/x64/loop/cont_inner.wat
@@ -11,12 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872e000000         	ja	0x46
-;;   18:	 48c744240800000000   	
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b800000000           	mov	eax, 0
@@ -24,8 +25,8 @@
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 44891c24             	mov	dword ptr [rsp], r11d
-;;      	 e9fbffffff           	jmp	0x3b
-;;   40:	 4883c410             	add	rsp, 0x10
+;;      	 e9fbffffff           	jmp	0x42
+;;   47:	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   46:	 0f0b                 	ud2	
+;;   4d:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/deep.wat
+++ b/winch/filetests/filetests/x64/loop/deep.wat
@@ -48,30 +48,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b896000000           	mov	eax, 0x96
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/effects.wat
+++ b/winch/filetests/filetests/x64/loop/effects.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874d000000         	ja	0x65
-;;   18:	 48c744240800000000   	
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
@@ -43,4 +44,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   65:	 0f0b                 	ud2	
+;;   6c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/empty.wat
+++ b/winch/filetests/filetests/x64/loop/empty.wat
@@ -8,13 +8,14 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/for.wat
+++ b/winch/filetests/filetests/x64/loop/for.wat
@@ -17,12 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f877d000000         	ja	0x95
-;;   18:	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
+;;      	 0f8781000000         	ja	0x9c
+;;   1b:	 4883ec20             	sub	rsp, 0x20
+;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4531db               	xor	r11d, r11d
 ;;      	 4c895c2410           	mov	qword ptr [rsp + 0x10], r11
 ;;      	 4c895c2408           	mov	qword ptr [rsp + 8], r11
@@ -37,17 +38,17 @@
 ;;      	 b900000000           	mov	ecx, 0
 ;;      	 400f97c1             	seta	cl
 ;;      	 85c9                 	test	ecx, ecx
-;;      	 0f8526000000         	jne	0x8a
-;;   64:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;      	 0f8526000000         	jne	0x91
+;;   6b:	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
 ;;      	 480fafc8             	imul	rcx, rax
 ;;      	 48894c2410           	mov	qword ptr [rsp + 0x10], rcx
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 4883c001             	add	rax, 1
 ;;      	 4889442408           	mov	qword ptr [rsp + 8], rax
-;;      	 e9bcffffff           	jmp	0x46
-;;   8a:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
+;;      	 e9bcffffff           	jmp	0x4d
+;;   91:	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
 ;;      	 4883c420             	add	rsp, 0x20
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   95:	 0f0b                 	ud2	
+;;   9c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/multi.wat
+++ b/winch/filetests/filetests/x64/loop/multi.wat
@@ -9,48 +9,50 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876a000000         	ja	0x82
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f876e000000         	ja	0x89
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x32
+;;      	 e800000000           	call	0x39
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x3f
+;;      	 e800000000           	call	0x46
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x4c
+;;      	 e800000000           	call	0x53
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x59
+;;      	 e800000000           	call	0x60
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x66
+;;      	 e800000000           	call	0x6d
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x73
+;;      	 e800000000           	call	0x7a
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b808000000           	mov	eax, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   82:	 0f0b                 	ud2	
+;;   89:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/nested.wat
+++ b/winch/filetests/filetests/x64/loop/nested.wat
@@ -10,33 +10,35 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x32
+;;      	 e800000000           	call	0x39
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b809000000           	mov	eax, 9
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/singular.wat
+++ b/winch/filetests/filetests/x64/loop/singular.wat
@@ -8,14 +8,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b807000000           	mov	eax, 7
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/loop/while.wat
+++ b/winch/filetests/filetests/x64/loop/while.wat
@@ -16,12 +16,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8769000000         	ja	0x81
-;;   18:	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
+;;      	 0f876d000000         	ja	0x88
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -32,17 +33,17 @@
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 400f94c0             	sete	al
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8526000000         	jne	0x76
-;;   50:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;      	 0f8526000000         	jne	0x7d
+;;   57:	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 488b4c2410           	mov	rcx, qword ptr [rsp + 0x10]
 ;;      	 480fafc8             	imul	rcx, rax
 ;;      	 48894c2408           	mov	qword ptr [rsp + 8], rcx
 ;;      	 488b442410           	mov	rax, qword ptr [rsp + 0x10]
 ;;      	 4883e801             	sub	rax, 1
 ;;      	 4889442410           	mov	qword ptr [rsp + 0x10], rax
-;;      	 e9c0ffffff           	jmp	0x36
-;;   76:	 488b442408           	mov	rax, qword ptr [rsp + 8]
+;;      	 e9c0ffffff           	jmp	0x3d
+;;   7d:	 488b442408           	mov	rax, qword ptr [rsp + 8]
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   81:	 0f0b                 	ud2	
+;;   88:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/nop/nop.wat
+++ b/winch/filetests/filetests/x64/nop/nop.wat
@@ -8,13 +8,14 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_block_first.wat
+++ b/winch/filetests/filetests/x64/return/as_block_first.wat
@@ -8,26 +8,28 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_block_last.wat
+++ b/winch/filetests/filetests/x64/return/as_block_last.wat
@@ -8,29 +8,31 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8717000000         	ja	0x2f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2f:	 0f0b                 	ud2	
+;;   36:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_block_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_block_mid.wat
@@ -8,29 +8,31 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8717000000         	ja	0x2f
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2f:	 0f0b                 	ud2	
+;;   36:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_block_value.wat
+++ b/winch/filetests/filetests/x64/return/as_block_value.wat
@@ -8,30 +8,32 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/return/as_br_if_cond.wat
@@ -8,26 +8,28 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_br_value.wat
+++ b/winch/filetests/filetests/x64/return/as_br_value.wat
@@ -8,27 +8,29 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b809000000           	mov	eax, 9
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_call_fist.wat
+++ b/winch/filetests/filetests/x64/return/as_call_fist.wat
@@ -8,12 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -21,18 +22,19 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80c000000           	mov	eax, 0xc
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_call_last.wat
+++ b/winch/filetests/filetests/x64/return/as_call_last.wat
@@ -8,12 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -21,18 +22,19 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80e000000           	mov	eax, 0xe
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_call_mid.wat
@@ -8,12 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x33
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -21,18 +22,19 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   33:	 0f0b                 	ud2	
+;;   3a:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b80d000000           	mov	eax, 0xd
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_func_first.wat
+++ b/winch/filetests/filetests/x64/return/as_func_first.wat
@@ -8,27 +8,29 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_func_last.wat
+++ b/winch/filetests/filetests/x64/return/as_func_last.wat
@@ -5,13 +5,14 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_func_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_func_mid.wat
@@ -8,30 +8,32 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_func_value.wat
+++ b/winch/filetests/filetests/x64/return/as_func_value.wat
@@ -8,30 +8,32 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b803000000           	mov	eax, 3
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/return/as_if_cond.wat
@@ -10,27 +10,29 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b802000000           	mov	eax, 2
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_if_else.wat
+++ b/winch/filetests/filetests/x64/return/as_if_else.wat
@@ -11,34 +11,36 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8409000000         	je	0x39
-;;   30:	 8b442408             	mov	eax, dword ptr [rsp + 8]
-;;      	 e905000000           	jmp	0x3e
-;;   39:	 b804000000           	mov	eax, 4
+;;      	 0f8409000000         	je	0x40
+;;   37:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;      	 e905000000           	jmp	0x45
+;;   40:	 b804000000           	mov	eax, 4
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_if_then.wat
+++ b/winch/filetests/filetests/x64/return/as_if_then.wat
@@ -11,34 +11,36 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x44
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840a000000         	je	0x3a
-;;   30:	 b803000000           	mov	eax, 3
-;;      	 e904000000           	jmp	0x3e
-;;   3a:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;      	 0f840a000000         	je	0x41
+;;   37:	 b803000000           	mov	eax, 3
+;;      	 e904000000           	jmp	0x45
+;;   41:	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   44:	 0f0b                 	ud2	
+;;   4b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_loop_first.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_first.wat
@@ -8,27 +8,29 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b803000000           	mov	eax, 3
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_last.wat
@@ -8,30 +8,32 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b805000000           	mov	eax, 5
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_loop_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_mid.wat
@@ -8,30 +8,32 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b804000000           	mov	eax, 4
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/as_return_value.wat
+++ b/winch/filetests/filetests/x64/return/as_return_value.wat
@@ -8,27 +8,29 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 4883c408             	add	rsp, 8
-;;      	 5d                   	pop	rbp
-;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
-;;
-;;      	 55                   	push	rbp
-;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
-;;      	 4d8b1b               	mov	r11, qword ptr [r11]
-;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8711000000         	ja	0x29
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 48c7c007000000       	mov	rax, 7
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
 ;;   29:	 0f0b                 	ud2	
+;;
+;;      	 55                   	push	rbp
+;;      	 4889e5               	mov	rbp, rsp
+;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
+;;      	 4939e3               	cmp	r11, rsp
+;;      	 0f8715000000         	ja	0x30
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 48c7c007000000       	mov	rax, 7
+;;      	 4883c408             	add	rsp, 8
+;;      	 5d                   	pop	rbp
+;;      	 c3                   	ret	
+;;   30:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/nullary.wat
+++ b/winch/filetests/filetests/x64/return/nullary.wat
@@ -6,26 +6,28 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/type_i32.wat
+++ b/winch/filetests/filetests/x64/return/type_i32.wat
@@ -9,27 +9,29 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/return/type_i64_value.wat
+++ b/winch/filetests/filetests/x64/return/type_i64_value.wat
@@ -9,27 +9,29 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 4883c408             	add	rsp, 8
-;;      	 5d                   	pop	rbp
-;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
-;;
-;;      	 55                   	push	rbp
-;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
-;;      	 4d8b1b               	mov	r11, qword ptr [r11]
-;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8711000000         	ja	0x29
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 48c7c002000000       	mov	rax, 2
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
 ;;   29:	 0f0b                 	ud2	
+;;
+;;      	 55                   	push	rbp
+;;      	 4889e5               	mov	rbp, rsp
+;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
+;;      	 4939e3               	cmp	r11, rsp
+;;      	 0f8715000000         	ja	0x30
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 48c7c002000000       	mov	rax, 2
+;;      	 4883c408             	add	rsp, 8
+;;      	 5d                   	pop	rbp
+;;      	 c3                   	ret	
+;;   30:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/select/f32.wat
+++ b/winch/filetests/filetests/x64/select/f32.wat
@@ -8,12 +8,13 @@
  
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8737000000         	ja	0x4f
-;;   18:	 f30f11442414         	movss	dword ptr [rsp + 0x14], xmm0
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 f30f11442414         	movss	dword ptr [rsp + 0x14], xmm0
 ;;      	 f30f114c2410         	movss	dword ptr [rsp + 0x10], xmm1
 ;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -21,9 +22,9 @@
 ;;      	 f30f10442410         	movss	xmm0, dword ptr [rsp + 0x10]
 ;;      	 f30f104c2414         	movss	xmm1, dword ptr [rsp + 0x14]
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8404000000         	je	0x49
-;;   45:	 f20f10c1             	movsd	xmm0, xmm1
+;;      	 0f8404000000         	je	0x50
+;;   4c:	 f20f10c1             	movsd	xmm0, xmm1
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4f:	 0f0b                 	ud2	
+;;   56:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/select/f64.wat
+++ b/winch/filetests/filetests/x64/select/f64.wat
@@ -8,12 +8,13 @@
  
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8737000000         	ja	0x4f
-;;   18:	 f20f11442418         	movsd	qword ptr [rsp + 0x18], xmm0
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4883ec20             	sub	rsp, 0x20
+;;      	 f20f11442418         	movsd	qword ptr [rsp + 0x18], xmm0
 ;;      	 f20f114c2410         	movsd	qword ptr [rsp + 0x10], xmm1
 ;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -21,9 +22,9 @@
 ;;      	 f20f10442410         	movsd	xmm0, qword ptr [rsp + 0x10]
 ;;      	 f20f104c2418         	movsd	xmm1, qword ptr [rsp + 0x18]
 ;;      	 83f800               	cmp	eax, 0
-;;      	 0f8404000000         	je	0x49
-;;   45:	 f20f10c1             	movsd	xmm0, xmm1
+;;      	 0f8404000000         	je	0x50
+;;   4c:	 f20f10c1             	movsd	xmm0, xmm1
 ;;      	 4883c420             	add	rsp, 0x20
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   4f:	 0f0b                 	ud2	
+;;   56:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/select/i32.wat
+++ b/winch/filetests/filetests/x64/select/i32.wat
@@ -7,12 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x42
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -25,4 +26,4 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   42:	 0f0b                 	ud2	
+;;   49:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/select/i64.wat
+++ b/winch/filetests/filetests/x64/select/i64.wat
@@ -8,12 +8,13 @@
  
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x48
-;;   18:	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4883ec20             	sub	rsp, 0x20
+;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
@@ -26,4 +27,4 @@
 ;;      	 4883c420             	add	rsp, 0x20
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   48:	 0f0b                 	ud2	
+;;   4f:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/store/f32.wat
+++ b/winch/filetests/filetests/x64/store/f32.wat
@@ -6,13 +6,14 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8722000000         	ja	0x3a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f30f10051c000000     	movss	xmm0, dword ptr [rip + 0x1c]
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 498b4e50             	mov	rcx, qword ptr [r14 + 0x50]
 ;;      	 4801c1               	add	rcx, rax
@@ -20,7 +21,7 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3a:	 0f0b                 	ud2	
-;;   3c:	 0000                 	add	byte ptr [rax], al
-;;   3e:	 0000                 	add	byte ptr [rax], al
-;;   40:	 0000                 	add	byte ptr [rax], al
+;;   41:	 0f0b                 	ud2	
+;;   43:	 0000                 	add	byte ptr [rax], al
+;;   45:	 0000                 	add	byte ptr [rax], al
+;;   47:	 0000                 	add	byte ptr [rax], al

--- a/winch/filetests/filetests/x64/store/f64.wat
+++ b/winch/filetests/filetests/x64/store/f64.wat
@@ -7,13 +7,14 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8722000000         	ja	0x3a
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
-;;      	 f20f10051c000000     	movsd	xmm0, qword ptr [rip + 0x1c]
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]
 ;;      	 b800000000           	mov	eax, 0
 ;;      	 498b4e50             	mov	rcx, qword ptr [r14 + 0x50]
 ;;      	 4801c1               	add	rcx, rax
@@ -21,10 +22,10 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3a:	 0f0b                 	ud2	
-;;   3c:	 0000                 	add	byte ptr [rax], al
-;;   3e:	 0000                 	add	byte ptr [rax], al
-;;   40:	 0000                 	add	byte ptr [rax], al
-;;   42:	 0000                 	add	byte ptr [rax], al
-;;   44:	 0000                 	add	byte ptr [rax], al
-;;   46:	 f4                   	hlt	
+;;   41:	 0f0b                 	ud2	
+;;   43:	 0000                 	add	byte ptr [rax], al
+;;   45:	 0000                 	add	byte ptr [rax], al
+;;   47:	 0000                 	add	byte ptr [rax], al
+;;   49:	 0000                 	add	byte ptr [rax], al
+;;   4b:	 0000                 	add	byte ptr [rax], al
+;;   4d:	 00f4                 	add	ah, dh

--- a/winch/filetests/filetests/x64/store/i32.wat
+++ b/winch/filetests/filetests/x64/store/i32.wat
@@ -8,12 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871d000000         	ja	0x35
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 b900000000           	mov	ecx, 0
 ;;      	 498b5650             	mov	rdx, qword ptr [r14 + 0x50]
@@ -22,4 +23,4 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   35:	 0f0b                 	ud2	
+;;   3c:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/store/i64.wat
+++ b/winch/filetests/filetests/x64/store/i64.wat
@@ -9,14 +9,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b820000000           	mov	eax, 0x20
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/table/fill.wat
+++ b/winch/filetests/filetests/x64/table/fill.wat
@@ -21,51 +21,55 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c340000000       	add	r11, 0x40
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87e8000000         	ja	0x100
-;;   18:	 897c241c             	mov	dword ptr [rsp + 0x1c], edi
+;;      	 0f87ec000000         	ja	0x107
+;;   1b:	 4883ec20             	sub	rsp, 0x20
+;;      	 897c241c             	mov	dword ptr [rsp + 0x1c], edi
 ;;      	 89742418             	mov	dword ptr [rsp + 0x18], esi
 ;;      	 89542414             	mov	dword ptr [rsp + 0x14], edx
 ;;      	 c744241000000000     	mov	dword ptr [rsp + 0x10], 0
@@ -76,8 +80,8 @@
 ;;      	 4c89f2               	mov	rdx, r14
 ;;      	 8b5a50               	mov	ebx, dword ptr [rdx + 0x50]
 ;;      	 39d9                 	cmp	ecx, ebx
-;;      	 0f83b7000000         	jae	0x102
-;;   4b:	 4189cb               	mov	r11d, ecx
+;;      	 0f83b7000000         	jae	0x109
+;;   52:	 4189cb               	mov	r11d, ecx
 ;;      	 4d6bdb08             	imul	r11, r11, 8
 ;;      	 488b5248             	mov	rdx, qword ptr [rdx + 0x48]
 ;;      	 4889d6               	mov	rsi, rdx
@@ -86,8 +90,8 @@
 ;;      	 480f43d6             	cmovae	rdx, rsi
 ;;      	 488b02               	mov	rax, qword ptr [rdx]
 ;;      	 4885c0               	test	rax, rax
-;;      	 0f8532000000         	jne	0xa0
-;;   6e:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
+;;      	 0f8532000000         	jne	0xa7
+;;   75:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
 ;;      	 498b5b48             	mov	rbx, qword ptr [r11 + 0x48]
 ;;      	 4156                 	push	r14
 ;;      	 4883ec04             	sub	rsp, 4
@@ -99,8 +103,8 @@
 ;;      	 ffd3                 	call	rbx
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c40c             	add	rsp, 0xc
-;;      	 e904000000           	jmp	0xa4
-;;   a0:	 4883e0fe             	and	rax, 0xfffffffffffffffe
+;;      	 e904000000           	jmp	0xab
+;;   a7:	 4883e0fe             	and	rax, 0xfffffffffffffffe
 ;;      	 488944240c           	mov	qword ptr [rsp + 0xc], rax
 ;;      	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
 ;;      	 498b4368             	mov	rax, qword ptr [r11 + 0x68]
@@ -125,5 +129,5 @@
 ;;      	 4883c420             	add	rsp, 0x20
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;  100:	 0f0b                 	ud2	
-;;  102:	 0f0b                 	ud2	
+;;  107:	 0f0b                 	ud2	
+;;  109:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/table/get.wat
+++ b/winch/filetests/filetests/x64/table/get.wat
@@ -11,32 +11,34 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8779000000         	ja	0x91
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f877d000000         	ja	0x98
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c240c             	mov	ecx, dword ptr [rsp + 0xc]
 ;;      	 4c89f2               	mov	rdx, r14
 ;;      	 8b5a50               	mov	ebx, dword ptr [rdx + 0x50]
 ;;      	 39d9                 	cmp	ecx, ebx
-;;      	 0f8361000000         	jae	0x93
-;;   32:	 4189cb               	mov	r11d, ecx
+;;      	 0f8361000000         	jae	0x9a
+;;   39:	 4189cb               	mov	r11d, ecx
 ;;      	 4d6bdb08             	imul	r11, r11, 8
 ;;      	 488b5248             	mov	rdx, qword ptr [rdx + 0x48]
 ;;      	 4889d6               	mov	rsi, rdx
@@ -45,8 +47,8 @@
 ;;      	 480f43d6             	cmovae	rdx, rsi
 ;;      	 488b02               	mov	rax, qword ptr [rdx]
 ;;      	 4885c0               	test	rax, rax
-;;      	 0f8532000000         	jne	0x87
-;;   55:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
+;;      	 0f8532000000         	jne	0x8e
+;;   5c:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
 ;;      	 498b5b48             	mov	rbx, qword ptr [r11 + 0x48]
 ;;      	 4156                 	push	r14
 ;;      	 4883ec04             	sub	rsp, 4
@@ -58,10 +60,10 @@
 ;;      	 ffd3                 	call	rbx
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c40c             	add	rsp, 0xc
-;;      	 e904000000           	jmp	0x8b
-;;   87:	 4883e0fe             	and	rax, 0xfffffffffffffffe
+;;      	 e904000000           	jmp	0x92
+;;   8e:	 4883e0fe             	and	rax, 0xfffffffffffffffe
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   91:	 0f0b                 	ud2	
-;;   93:	 0f0b                 	ud2	
+;;   98:	 0f0b                 	ud2	
+;;   9a:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/table/grow.wat
+++ b/winch/filetests/filetests/x64/table/grow.wat
@@ -11,12 +11,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8739000000         	ja	0x51
-;;   18:	 48897c2408           	mov	qword ptr [rsp + 8], rdi
+;;      	 0f873d000000         	ja	0x58
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
 ;;      	 498b5b50             	mov	rbx, qword ptr [r11 + 0x50]
@@ -32,4 +33,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   51:	 0f0b                 	ud2	
+;;   58:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/table/init_copy_drop.wat
+++ b/winch/filetests/filetests/x64/table/init_copy_drop.wat
@@ -35,82 +35,88 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b805000000           	mov	eax, 5
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b806000000           	mov	eax, 6
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b807000000           	mov	eax, 7
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b808000000           	mov	eax, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870f000000         	ja	0x27
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8713000000         	ja	0x2e
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 b809000000           	mov	eax, 9
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   27:	 0f0b                 	ud2	
+;;   2e:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8785010000         	ja	0x19d
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8789010000         	ja	0x1a4
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
 ;;      	 498b4310             	mov	rax, qword ptr [r11 + 0x10]
 ;;      	 4156                 	push	r14
@@ -205,16 +211,17 @@
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;  19d:	 0f0b                 	ud2	
+;;  1a4:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87b2000000         	ja	0xca
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f87b6000000         	ja	0xd1
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
@@ -224,8 +231,8 @@
 ;;      	 4c89f2               	mov	rdx, r14
 ;;      	 8b9af0000000         	mov	ebx, dword ptr [rdx + 0xf0]
 ;;      	 39d9                 	cmp	ecx, ebx
-;;      	 0f8387000000         	jae	0xcc
-;;   45:	 4189cb               	mov	r11d, ecx
+;;      	 0f8387000000         	jae	0xd3
+;;   4c:	 4189cb               	mov	r11d, ecx
 ;;      	 4d6bdb08             	imul	r11, r11, 8
 ;;      	 488b92e8000000       	mov	rdx, qword ptr [rdx + 0xe8]
 ;;      	 4889d6               	mov	rsi, rdx
@@ -234,8 +241,8 @@
 ;;      	 480f43d6             	cmovae	rdx, rsi
 ;;      	 488b02               	mov	rax, qword ptr [rdx]
 ;;      	 4885c0               	test	rax, rax
-;;      	 0f8532000000         	jne	0x9d
-;;   6b:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
+;;      	 0f8532000000         	jne	0xa4
+;;   72:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
 ;;      	 498b5b48             	mov	rbx, qword ptr [r11 + 0x48]
 ;;      	 4156                 	push	r14
 ;;      	 4883ec04             	sub	rsp, 4
@@ -247,23 +254,23 @@
 ;;      	 ffd3                 	call	rbx
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c40c             	add	rsp, 0xc
-;;      	 e904000000           	jmp	0xa1
-;;   9d:	 4883e0fe             	and	rax, 0xfffffffffffffffe
+;;      	 e904000000           	jmp	0xa8
+;;   a4:	 4883e0fe             	and	rax, 0xfffffffffffffffe
 ;;      	 4885c0               	test	rax, rax
-;;      	 0f8424000000         	je	0xce
-;;   aa:	 4d8b5e40             	mov	r11, qword ptr [r14 + 0x40]
+;;      	 0f8424000000         	je	0xd5
+;;   b1:	 4d8b5e40             	mov	r11, qword ptr [r14 + 0x40]
 ;;      	 418b0b               	mov	ecx, dword ptr [r11]
 ;;      	 8b5018               	mov	edx, dword ptr [rax + 0x18]
 ;;      	 39d1                 	cmp	ecx, edx
-;;      	 0f8514000000         	jne	0xd0
-;;   bc:	 50                   	push	rax
+;;      	 0f8514000000         	jne	0xd7
+;;   c3:	 50                   	push	rax
 ;;      	 59                   	pop	rcx
 ;;      	 488b5110             	mov	rdx, qword ptr [rcx + 0x10]
 ;;      	 ffd2                 	call	rdx
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   ca:	 0f0b                 	ud2	
-;;   cc:	 0f0b                 	ud2	
-;;   ce:	 0f0b                 	ud2	
-;;   d0:	 0f0b                 	ud2	
+;;   d1:	 0f0b                 	ud2	
+;;   d3:	 0f0b                 	ud2	
+;;   d5:	 0f0b                 	ud2	
+;;   d7:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/table/set.wat
+++ b/winch/filetests/filetests/x64/table/set.wat
@@ -16,25 +16,27 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8748000000         	ja	0x60
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f874c000000         	ja	0x67
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 488b442408           	mov	rax, qword ptr [rsp + 8]
@@ -42,8 +44,8 @@
 ;;      	 4c89f2               	mov	rdx, r14
 ;;      	 8b5a50               	mov	ebx, dword ptr [rdx + 0x50]
 ;;      	 39d9                 	cmp	ecx, ebx
-;;      	 0f8326000000         	jae	0x62
-;;   3c:	 4189cb               	mov	r11d, ecx
+;;      	 0f8326000000         	jae	0x69
+;;   43:	 4189cb               	mov	r11d, ecx
 ;;      	 4d6bdb08             	imul	r11, r11, 8
 ;;      	 488b5248             	mov	rdx, qword ptr [rdx + 0x48]
 ;;      	 4889d6               	mov	rsi, rdx
@@ -55,25 +57,26 @@
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   60:	 0f0b                 	ud2	
-;;   62:	 0f0b                 	ud2	
+;;   67:	 0f0b                 	ud2	
+;;   69:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87b4000000         	ja	0xcc
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f87b8000000         	ja	0xd3
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b4c2408             	mov	ecx, dword ptr [rsp + 8]
 ;;      	 4c89f2               	mov	rdx, r14
 ;;      	 8b5a50               	mov	ebx, dword ptr [rdx + 0x50]
 ;;      	 39d9                 	cmp	ecx, ebx
-;;      	 0f8398000000         	jae	0xce
-;;   36:	 4189cb               	mov	r11d, ecx
+;;      	 0f8398000000         	jae	0xd5
+;;   3d:	 4189cb               	mov	r11d, ecx
 ;;      	 4d6bdb08             	imul	r11, r11, 8
 ;;      	 488b5248             	mov	rdx, qword ptr [rdx + 0x48]
 ;;      	 4889d6               	mov	rsi, rdx
@@ -82,8 +85,8 @@
 ;;      	 480f43d6             	cmovae	rdx, rsi
 ;;      	 488b02               	mov	rax, qword ptr [rdx]
 ;;      	 4885c0               	test	rax, rax
-;;      	 0f8536000000         	jne	0x8f
-;;   59:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
+;;      	 0f8536000000         	jne	0x96
+;;   60:	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
 ;;      	 498b5b48             	mov	rbx, qword ptr [r11 + 0x48]
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
@@ -96,15 +99,15 @@
 ;;      	 8b1424               	mov	edx, dword ptr [rsp]
 ;;      	 ffd3                 	call	rbx
 ;;      	 4883c40c             	add	rsp, 0xc
-;;      	 e904000000           	jmp	0x93
-;;   8f:	 4883e0fe             	and	rax, 0xfffffffffffffffe
+;;      	 e904000000           	jmp	0x9a
+;;   96:	 4883e0fe             	and	rax, 0xfffffffffffffffe
 ;;      	 8b0c24               	mov	ecx, dword ptr [rsp]
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4c89f2               	mov	rdx, r14
 ;;      	 8b5a50               	mov	ebx, dword ptr [rdx + 0x50]
 ;;      	 39d9                 	cmp	ecx, ebx
-;;      	 0f8328000000         	jae	0xd0
-;;   a8:	 4189cb               	mov	r11d, ecx
+;;      	 0f8328000000         	jae	0xd7
+;;   af:	 4189cb               	mov	r11d, ecx
 ;;      	 4d6bdb08             	imul	r11, r11, 8
 ;;      	 488b5248             	mov	rdx, qword ptr [rdx + 0x48]
 ;;      	 4889d6               	mov	rsi, rdx
@@ -116,6 +119,6 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   cc:	 0f0b                 	ud2	
-;;   ce:	 0f0b                 	ud2	
-;;   d0:	 0f0b                 	ud2	
+;;   d3:	 0f0b                 	ud2	
+;;   d5:	 0f0b                 	ud2	
+;;   d7:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/table/size.wat
+++ b/winch/filetests/filetests/x64/table/size.wat
@@ -6,15 +6,16 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8711000000         	ja	0x29
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8715000000         	ja	0x30
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4d89f3               	mov	r11, r14
 ;;      	 418b4350             	mov	eax, dword ptr [r11 + 0x50]
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   29:	 0f0b                 	ud2	
+;;   30:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_block_broke.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_broke.wat
@@ -8,30 +8,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_block_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_first.wat
@@ -6,14 +6,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_block_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_last.wat
@@ -7,30 +7,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_block_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_mid.wat
@@ -8,30 +8,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_block_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_value.wat
@@ -7,30 +7,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_br_if_cond.wat
@@ -7,14 +7,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_br_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_br_value.wat
@@ -7,14 +7,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_call_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_call_first.wat
@@ -8,30 +8,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_call_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_call_last.wat
@@ -9,30 +9,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_call_mid.wat
@@ -8,30 +8,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8716000000         	ja	0x2e
-;;   18:	 897c2414             	mov	dword ptr [rsp + 0x14], edi
+;;      	 0f871a000000         	ja	0x35
+;;   1b:	 4883ec18             	sub	rsp, 0x18
+;;      	 897c2414             	mov	dword ptr [rsp + 0x14], edi
 ;;      	 89742410             	mov	dword ptr [rsp + 0x10], esi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c418             	add	rsp, 0x18
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   2e:	 0f0b                 	ud2	
+;;   35:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_func_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_first.wat
@@ -7,27 +7,29 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_func_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_last.wat
@@ -7,30 +7,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_func_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_mid.wat
@@ -8,30 +8,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_func_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_value.wat
@@ -8,30 +8,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_cond.wat
@@ -7,14 +7,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_if_else.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_else.wat
@@ -8,21 +8,22 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x41
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8409000000         	je	0x39
-;;   30:	 8b442408             	mov	eax, dword ptr [rsp + 8]
-;;      	 e902000000           	jmp	0x3b
-;;   39:	 0f0b                 	ud2	
+;;      	 0f8409000000         	je	0x40
+;;   37:	 8b442408             	mov	eax, dword ptr [rsp + 8]
+;;      	 e902000000           	jmp	0x42
+;;   40:	 0f0b                 	ud2	
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   41:	 0f0b                 	ud2	
+;;   48:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_if_then.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_then.wat
@@ -7,20 +7,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8402000000         	je	0x32
-;;   30:	 0f0b                 	ud2	
+;;      	 0f8402000000         	je	0x39
+;;   37:	 0f0b                 	ud2	
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_if_then_no_else.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_then_no_else.wat
@@ -7,20 +7,21 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x3c
-;;   18:	 897c240c             	mov	dword ptr [rsp + 0xc], edi
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 897c240c             	mov	dword ptr [rsp + 0xc], edi
 ;;      	 89742408             	mov	dword ptr [rsp + 8], esi
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f8402000000         	je	0x32
-;;   30:	 0f0b                 	ud2	
+;;      	 0f8402000000         	je	0x39
+;;   37:	 0f0b                 	ud2	
 ;;      	 8b442408             	mov	eax, dword ptr [rsp + 8]
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3c:	 0f0b                 	ud2	
+;;   43:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_loop_broke.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_broke.wat
@@ -10,30 +10,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x34
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 b801000000           	mov	eax, 1
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   34:	 0f0b                 	ud2	
+;;   3b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_loop_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_first.wat
@@ -8,14 +8,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_last.wat
@@ -9,30 +9,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_loop_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_mid.wat
@@ -9,30 +9,32 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870a000000         	ja	0x22
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f870e000000         	ja	0x29
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   22:	 0f0b                 	ud2	
+;;   29:	 0f0b                 	ud2	
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8719000000         	ja	0x31
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 4883ec08             	sub	rsp, 8
-;;      	 e800000000           	call	0x25
+;;      	 e800000000           	call	0x2c
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   31:	 0f0b                 	ud2	
+;;   38:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_return_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_return_value.wat
@@ -7,14 +7,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/type_i32.wat
+++ b/winch/filetests/filetests/x64/unreachable/type_i32.wat
@@ -5,14 +5,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/type_i64.wat
+++ b/winch/filetests/filetests/x64/unreachable/type_i64.wat
@@ -5,14 +5,15 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec08             	sub	rsp, 8
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c308000000       	add	r11, 8
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f870c000000         	ja	0x24
-;;   18:	 4c893424             	mov	qword ptr [rsp], r14
+;;      	 0f8710000000         	ja	0x2b
+;;   1b:	 4883ec08             	sub	rsp, 8
+;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   24:	 0f0b                 	ud2	
+;;   2b:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/with_spilled_local.wat
+++ b/winch/filetests/filetests/x64/unreachable/with_spilled_local.wat
@@ -11,12 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8722000000         	ja	0x3a
-;;   18:	 48c744240800000000   	
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
@@ -26,4 +27,4 @@
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   3a:	 0f0b                 	ud2	
+;;   41:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/with_spilled_local_in_if.wat
+++ b/winch/filetests/filetests/x64/unreachable/with_spilled_local_in_if.wat
@@ -16,22 +16,23 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
+;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872e000000         	ja	0x46
-;;   18:	 48c744240800000000   	
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4883ec10             	sub	rsp, 0x10
+;;      	 48c744240800000000   	
 ;; 				mov	qword ptr [rsp + 8], 0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 8b44240c             	mov	eax, dword ptr [rsp + 0xc]
 ;;      	 85c0                 	test	eax, eax
-;;      	 0f840f000000         	je	0x40
-;;   31:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
+;;      	 0f840f000000         	je	0x47
+;;   38:	 448b5c240c           	mov	r11d, dword ptr [rsp + 0xc]
 ;;      	 4883ec04             	sub	rsp, 4
 ;;      	 44891c24             	mov	dword ptr [rsp], r11d
 ;;      	 0f0b                 	ud2	
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   46:	 0f0b                 	ud2	
+;;   4d:	 0f0b                 	ud2	


### PR DESCRIPTION
Move the stack check to the function prologue in winch generated code by adding the final stack maximum to the stack min bound before comparing against the current SP.

This new approach is more accurate than the previous implementation that would only check the size of `locals`, but does require that we patch the function during `MacroAssembler::finalize`, as we don't know the stack high water mark until then. Enabling the patching required the addition of the `start_patchable`/`end_patchable` api to `MachBuffer`, which gives a way to name sections of the code buffer (with some restrictions) that can be edited later. We use this then to modify an add-with-immediate instruction to add the used stack space to the stack lower bound from `vmctx`, when finalizing the function.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
