### PR TITLE
winch: Ensure correct handling of libcalls

### DIFF
--- a/cranelift/codegen/src/lib.rs
+++ b/cranelift/codegen/src/lib.rs
@@ -59,8 +59,8 @@ pub use crate::machinst::buffer::{
 };
 pub use crate::machinst::{
     CompiledCode, Final, MachBuffer, MachBufferFinalized, MachInst, MachInstEmit,
-    MachInstEmitState, MachLabel, RealReg, Reg, TextSectionBuilder, VCodeConstantData,
-    VCodeConstants, Writable,
+    MachInstEmitState, MachLabel, RealReg, Reg, RelocDistance, TextSectionBuilder,
+    VCodeConstantData, VCodeConstants, Writable,
 };
 
 mod alias_analysis;

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -422,7 +422,7 @@ impl Masm for MacroAssembler {
         match callee {
             CalleeKind::Indirect(reg) => self.asm.call_with_reg(reg),
             CalleeKind::Direct(idx) => self.asm.call_with_index(idx),
-            CalleeKind::Known(lib) => self.asm.call_with_lib(lib),
+            CalleeKind::Known(lib) => self.asm.call_with_lib(lib, regs::scratch()),
         };
         total_stack
     }

--- a/winch/filetests/filetests/x64/f32_ceil/f32_ceil_param.wat
+++ b/winch/filetests/filetests/x64/f32_ceil/f32_ceil_param.wat
@@ -12,7 +12,7 @@
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x50
+;;      	 0f8740000000         	ja	0x58
 ;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f3440f107c240c       	movss	xmm15, dword ptr [rsp + 0xc]
@@ -20,10 +20,12 @@
 ;;      	 f3440f113c24         	movss	dword ptr [rsp], xmm15
 ;;      	 4883ec0c             	sub	rsp, 0xc
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
-;;      	 e800000000           	call	0x42
+;;      	 49bb0000000000000000 	
+;; 				movabs	r11, 0
+;;      	 41ffd3               	call	r11
 ;;      	 4883c40c             	add	rsp, 0xc
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   50:	 0f0b                 	ud2	
+;;   58:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_floor/f32_floor_param.wat
+++ b/winch/filetests/filetests/x64/f32_floor/f32_floor_param.wat
@@ -12,7 +12,7 @@
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x50
+;;      	 0f8740000000         	ja	0x58
 ;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f3440f107c240c       	movss	xmm15, dword ptr [rsp + 0xc]
@@ -20,10 +20,12 @@
 ;;      	 f3440f113c24         	movss	dword ptr [rsp], xmm15
 ;;      	 4883ec0c             	sub	rsp, 0xc
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
-;;      	 e800000000           	call	0x42
+;;      	 49bb0000000000000000 	
+;; 				movabs	r11, 0
+;;      	 41ffd3               	call	r11
 ;;      	 4883c40c             	add	rsp, 0xc
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   50:	 0f0b                 	ud2	
+;;   58:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_nearest/f32_nearest_param.wat
+++ b/winch/filetests/filetests/x64/f32_nearest/f32_nearest_param.wat
@@ -12,7 +12,7 @@
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x50
+;;      	 0f8740000000         	ja	0x58
 ;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f3440f107c240c       	movss	xmm15, dword ptr [rsp + 0xc]
@@ -20,10 +20,12 @@
 ;;      	 f3440f113c24         	movss	dword ptr [rsp], xmm15
 ;;      	 4883ec0c             	sub	rsp, 0xc
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
-;;      	 e800000000           	call	0x42
+;;      	 49bb0000000000000000 	
+;; 				movabs	r11, 0
+;;      	 41ffd3               	call	r11
 ;;      	 4883c40c             	add	rsp, 0xc
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   50:	 0f0b                 	ud2	
+;;   58:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f32_trunc/f32_trunc_param.wat
+++ b/winch/filetests/filetests/x64/f32_trunc/f32_trunc_param.wat
@@ -12,7 +12,7 @@
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x50
+;;      	 0f8740000000         	ja	0x58
 ;;   18:	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f3440f107c240c       	movss	xmm15, dword ptr [rsp + 0xc]
@@ -20,10 +20,12 @@
 ;;      	 f3440f113c24         	movss	dword ptr [rsp], xmm15
 ;;      	 4883ec0c             	sub	rsp, 0xc
 ;;      	 f30f1044240c         	movss	xmm0, dword ptr [rsp + 0xc]
-;;      	 e800000000           	call	0x42
+;;      	 49bb0000000000000000 	
+;; 				movabs	r11, 0
+;;      	 41ffd3               	call	r11
 ;;      	 4883c40c             	add	rsp, 0xc
 ;;      	 4883c404             	add	rsp, 4
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   50:	 0f0b                 	ud2	
+;;   58:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_ceil/f64_ceil_param.wat
+++ b/winch/filetests/filetests/x64/f64_ceil/f64_ceil_param.wat
@@ -12,7 +12,7 @@
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x50
+;;      	 0f8740000000         	ja	0x58
 ;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f2440f107c2408       	movsd	xmm15, qword ptr [rsp + 8]
@@ -20,10 +20,12 @@
 ;;      	 f2440f113c24         	movsd	qword ptr [rsp], xmm15
 ;;      	 4883ec08             	sub	rsp, 8
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
-;;      	 e800000000           	call	0x42
+;;      	 49bb0000000000000000 	
+;; 				movabs	r11, 0
+;;      	 41ffd3               	call	r11
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   50:	 0f0b                 	ud2	
+;;   58:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_floor/f64_floor_param.wat
+++ b/winch/filetests/filetests/x64/f64_floor/f64_floor_param.wat
@@ -12,7 +12,7 @@
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x50
+;;      	 0f8740000000         	ja	0x58
 ;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f2440f107c2408       	movsd	xmm15, qword ptr [rsp + 8]
@@ -20,10 +20,12 @@
 ;;      	 f2440f113c24         	movsd	qword ptr [rsp], xmm15
 ;;      	 4883ec08             	sub	rsp, 8
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
-;;      	 e800000000           	call	0x42
+;;      	 49bb0000000000000000 	
+;; 				movabs	r11, 0
+;;      	 41ffd3               	call	r11
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   50:	 0f0b                 	ud2	
+;;   58:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_nearest/f64_nearest_param.wat
+++ b/winch/filetests/filetests/x64/f64_nearest/f64_nearest_param.wat
@@ -12,7 +12,7 @@
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x50
+;;      	 0f8740000000         	ja	0x58
 ;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f2440f107c2408       	movsd	xmm15, qword ptr [rsp + 8]
@@ -20,10 +20,12 @@
 ;;      	 f2440f113c24         	movsd	qword ptr [rsp], xmm15
 ;;      	 4883ec08             	sub	rsp, 8
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
-;;      	 e800000000           	call	0x42
+;;      	 49bb0000000000000000 	
+;; 				movabs	r11, 0
+;;      	 41ffd3               	call	r11
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   50:	 0f0b                 	ud2	
+;;   58:	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/f64_trunc/f64_trunc_param.wat
+++ b/winch/filetests/filetests/x64/f64_trunc/f64_trunc_param.wat
@@ -12,7 +12,7 @@
 ;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x50
+;;      	 0f8740000000         	ja	0x58
 ;;   18:	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0
 ;;      	 4c893424             	mov	qword ptr [rsp], r14
 ;;      	 f2440f107c2408       	movsd	xmm15, qword ptr [rsp + 8]
@@ -20,10 +20,12 @@
 ;;      	 f2440f113c24         	movsd	qword ptr [rsp], xmm15
 ;;      	 4883ec08             	sub	rsp, 8
 ;;      	 f20f10442408         	movsd	xmm0, qword ptr [rsp + 8]
-;;      	 e800000000           	call	0x42
+;;      	 49bb0000000000000000 	
+;; 				movabs	r11, 0
+;;      	 41ffd3               	call	r11
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c408             	add	rsp, 8
 ;;      	 4883c410             	add	rsp, 0x10
 ;;      	 5d                   	pop	rbp
 ;;      	 c3                   	ret	
-;;   50:	 0f0b                 	ud2	
+;;   58:	 0f0b                 	ud2	


### PR DESCRIPTION
This commit fixes a fuzz bug where modules involving known libcalls would fail to compile given that they were unconditionally treated as colocated libcalls.

This bug is only reproducible in non sse41 environments, given that some operations like `floor` default to libcalls in this case. The `use_colocated_libcalls` setting is not configurable within Wasmtime and as such, they should be loaded into a register prior to emitting the call. This will also ensure that the right 8-byte absolute relocation is used.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
