### PR TITLE
Miscellaneous tweaks to speed up call/RPS benchmarks

### DIFF
--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -233,6 +233,7 @@ impl Instance {
     /// and that it's valid to acquire `&mut Instance` at this time. For example
     /// this can't be called twice on the same `VMContext` to get two active
     /// pointers to the same `Instance`.
+    #[inline]
     pub unsafe fn from_vmctx<R>(vmctx: *mut VMContext, f: impl FnOnce(&mut Instance) -> R) -> R {
         let ptr = vmctx
             .cast::<u8>()

--- a/crates/runtime/src/send_sync_ptr.rs
+++ b/crates/runtime/src/send_sync_ptr.rs
@@ -12,28 +12,33 @@ unsafe impl<T: Sync + ?Sized> Sync for SendSyncPtr<T> {}
 
 impl<T: ?Sized> SendSyncPtr<T> {
     /// Creates a new pointer wrapping the non-nullable pointer provided.
+    #[inline]
     pub fn new(ptr: NonNull<T>) -> SendSyncPtr<T> {
         SendSyncPtr(ptr)
     }
 
     /// Returns the underlying raw pointer.
+    #[inline]
     pub fn as_ptr(&self) -> *mut T {
         self.0.as_ptr()
     }
 
     /// Unsafely assert that this is a pointer to valid contents and it's also
     /// valid to get a shared reference to it at this time.
+    #[inline]
     pub unsafe fn as_ref<'a>(&self) -> &'a T {
         self.0.as_ref()
     }
 
     /// Unsafely assert that this is a pointer to valid contents and it's also
     /// valid to get a mutable reference to it at this time.
+    #[inline]
     pub unsafe fn as_mut<'a>(&mut self) -> &'a mut T {
         self.0.as_mut()
     }
 
     /// Returns the underlying `NonNull<T>` wrapper.
+    #[inline]
     pub fn as_non_null(&self) -> NonNull<T> {
         self.0
     }
@@ -41,6 +46,7 @@ impl<T: ?Sized> SendSyncPtr<T> {
 
 impl<T> SendSyncPtr<[T]> {
     /// Returns the slice's length component of the pointer.
+    #[inline]
     pub fn len(&self) -> usize {
         self.0.len()
     }
@@ -50,6 +56,7 @@ impl<T: ?Sized, U> From<U> for SendSyncPtr<T>
 where
     U: Into<NonNull<T>>,
 {
+    #[inline]
     fn from(ptr: U) -> SendSyncPtr<T> {
         SendSyncPtr::new(ptr.into())
     }
@@ -68,6 +75,7 @@ impl<T: ?Sized> fmt::Pointer for SendSyncPtr<T> {
 }
 
 impl<T: ?Sized> Clone for SendSyncPtr<T> {
+    #[inline]
     fn clone(&self) -> Self {
         *self
     }
@@ -76,6 +84,7 @@ impl<T: ?Sized> Clone for SendSyncPtr<T> {
 impl<T: ?Sized> Copy for SendSyncPtr<T> {}
 
 impl<T: ?Sized> PartialEq for SendSyncPtr<T> {
+    #[inline]
     fn eq(&self, other: &SendSyncPtr<T>) -> bool {
         self.0 == other.0
     }

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -326,11 +326,13 @@ mod call_thread_state {
             self.prev.get()
         }
 
+        #[inline]
         pub(crate) unsafe fn push(&self) {
             assert!(self.prev.get().is_null());
             self.prev.set(tls::raw::replace(self));
         }
 
+        #[inline]
         pub(crate) unsafe fn pop(&self) {
             let prev = self.prev.replace(ptr::null());
             let head = tls::raw::replace(prev);
@@ -346,6 +348,7 @@ enum UnwindReason {
 }
 
 impl CallThreadState {
+    #[inline]
     fn with(
         mut self,
         closure: impl FnOnce(&CallThreadState) -> i32,


### PR DESCRIPTION
This commit makes the following changes:

* A handful of `#[inline]` annotations.

* A couple cases of splitting out uncommon/slow paths from `#[inline]`-annotated functions into their own non-`#[inline]`-annotated functions.

* Remove a call to `mpk::is_supported()` in async context construction. It is sufficient to just check `self.pkey.is_some()` since if mpk isn't supported we won't have a pkey, if we do have a pkey mpk must have been supported for us to get it, and even if mpk is supported, if we don't have a pkey we don't need to do anything here.

Criterion benchmark results:

```
sync/no-hook/core - host-to-wasm - typed - nop-params-and-results
                        time:   [25.214 ns 25.322 ns 25.443 ns]
                        change: [-21.901% -20.227% -18.749%] (p = 0.00 < 0.05)
                        Performance has improved.
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
