### PR TITLE
Add a script for benchmarking `wasmtime serve`'s requests per second

### DIFF
--- a/benches/wasmtime-serve-rps.sh
+++ b/benches/wasmtime-serve-rps.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Usage:
+#
+#     wasmtime-serve-rps.sh [WASMTIME-FLAGS] path/to/wasi-http-component.wasm
+#
+# For a basic WASI HTTP component, check out
+# https://github.com/sunfishcode/hello-wasi-http
+#
+# You must have the `hey` tool installed on your `$PATH`. It is available in at
+# least the `apt` and `brew` package managers, as well as a binary download via
+# its github page: https://github.com/rakyll/hey
+
+set -e
+
+repo_dir="$(dirname $0)/.."
+cargo_toml="$repo_dir/Cargo.toml"
+
+# Build Wasmtime.
+cargo build --manifest-path "$cargo_toml" --release -p wasmtime-cli
+
+# Spawn `wasmtime serve` in the background.
+cargo run --manifest-path "$cargo_toml" --release -- serve "$@" &
+pid=$!
+
+# Give it a second to print its diagnostic information and get the server up and
+# running.
+sleep 1
+
+echo 'Running `wasmtime serve` in background as pid '"$pid"
+
+# Benchmark the server!
+echo "Benchmarking for 10 seconds..."
+hey -z 10s http://0.0.0.0:8080/
+
+kill "$pid"


### PR DESCRIPTION
There are a *ton* of different options such a script could have, and things we could tweak. This is just meant to be a shared starting point so it is easy to get up and running with something.

Example output:

```
./benches/wasmtime-serve-rps.sh -O pooling-allocator hello_wasi_http.wasm
    Finished `release` profile [optimized] target(s) in 0.17s
     Running `target/release/wasmtime serve -O pooling-allocator hello_wasi_http.wasm`
Serving HTTP on http://0.0.0.0:8080/
Running `wasmtime serve` in background as pid 2476839
Benchmarking for 10 seconds...

Summary:
  Total:	10.0025 secs
  Slowest:	0.0138 secs
  Fastest:	0.0001 secs
  Average:	0.0013 secs
  Requests/sec:	39461.5419

Response time histogram:
  0.000 [1]	|
  0.001 [277602]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
  0.003 [111637]	|■■■■■■■■■■■■■■■■
  0.004 [4182]	|■
  0.006 [720]	|
  0.007 [301]	|
  0.008 [143]	|
  0.010 [76]	|
  0.011 [26]	|
  0.012 [19]	|
  0.014 [7]	|

Latency distribution:
  10% in 0.0006 secs
  25% in 0.0009 secs
  50% in 0.0012 secs
  75% in 0.0016 secs
  90% in 0.0019 secs
  95% in 0.0022 secs
  99% in 0.0031 secs

Details (average, fastest, slowest):
  DNS+dialup:	0.0000 secs, 0.0001 secs, 0.0138 secs
  DNS-lookup:	0.0000 secs, 0.0000 secs, 0.0000 secs
  req write:	0.0000 secs, 0.0000 secs, 0.0092 secs
  resp wait:	0.0012 secs, 0.0001 secs, 0.0137 secs
  resp read:	0.0000 secs, 0.0000 secs, 0.0113 secs

Status code distribution:
  [200]	394714 responses
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
