### PR TITLE
Release Wasmtime 18.0.0

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 ## 18.0.0
 
-Unreleased.
+Released 2024-02-20.
 
 ### Added
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,48 @@ Released 2024-02-20.
 
 ### Added
 
+* The `wasmtime-c-api-impl` crate is now published on crates.io.
+  [#7837](https://github.com/bytecodealliance/wasmtime/pull/7837)
+
+* A new `EngineWeak` type enables holding a weak pointer to an engine with the
+  ability to dynamically and fallibly upgrade it to an `Engine`.
+  [#7797](https://github.com/bytecodealliance/wasmtime/pull/7797)
+
+* The WebAssembly tail calls proposal can now be enabled through the C API.
+  [#7811](https://github.com/bytecodealliance/wasmtime/pull/7811)
+
+* The import and export types of a `Component` can now be inspected at runtime.
+  [#7804](https://github.com/bytecodealliance/wasmtime/pull/7804)
+
+* New APIs/types have been added to support a faster version of looking up
+  module exports without using string lookups with `Module::get_export_index`.
+  [#7828](https://github.com/bytecodealliance/wasmtime/pull/7828)
+
 ### Changed
+
+* Owned resources represented with `ResourceAny` can now be passed as arguments
+  to functions that require a `borrow<T>` parameter.
+  [#7783](https://github.com/bytecodealliance/wasmtime/pull/7783)
+
+* Generated structures from `wasmtime::component::bindgen!` for exported
+  interfaces are now all renamed to `Guest` to avoid conflicting with WIT names.
+  [#7794](https://github.com/bytecodealliance/wasmtime/pull/7794)
+
+* Guest profiler output will now automatically demangle symbols.
+  [#7809](https://github.com/bytecodealliance/wasmtime/pull/7809)
+
+* The `wasmtime` crate now has a `runtime` Cargo feature which, if disabled,
+  enables building Wasmtime with only the ability to compile WebAssembly
+  modules. This enables compiling Wasmtime's compilation infrastructure, for
+  example, to WebAssembly itself.
+  [#7766](https://github.com/bytecodealliance/wasmtime/pull/7766)
+
+* Support for the old `wasi-common` crate and the original implementation of
+  "WASIp1" aka "preview1" is being deprecated in the `wasmtime-wasi` crate.
+  Users should migrate to the  `wasmtime_wasi::preview2` implementation, which
+  supports both WASIp1 and WASIp2, as in the next release the
+  `wasi-common`-based reexports of `wasmtime-wasi` will be deleted.
+  [#7881](https://github.com/bytecodealliance/wasmtime/pull/7881)
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
This is an [automated pull request][process] from CI which is
intended to notify maintainers that it's time to release Wasmtime
18.0.0. The [release branch][branch] was created roughly two weeks ago
and it's now time for it to be published and released.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
[branch]: https://github.com/bytecodealliance/wasmtime/tree/release-18.0.0
