### PR TITLE
cranelift: Enable "chaos mode" in egraph pass

### DIFF
--- a/cranelift/filetests/src/test_optimize.rs
+++ b/cranelift/filetests/src/test_optimize.rs
@@ -10,6 +10,7 @@
 use crate::subtest::{check_precise_output, run_filecheck, Context, SubTest};
 use anyhow::Result;
 use cranelift_codegen::ir;
+use cranelift_control::ControlPlane;
 use cranelift_reader::{TestCommand, TestOption};
 use std::borrow::Cow;
 
@@ -53,7 +54,7 @@ impl SubTest for TestOptimize {
         let mut comp_ctx = cranelift_codegen::Context::for_function(func.into_owned());
 
         comp_ctx
-            .optimize(isa)
+            .optimize(isa, &mut ControlPlane::default())
             .map_err(|e| crate::pretty_anyhow_error(&comp_ctx.func, e))?;
 
         let clif = format!("{:?}", comp_ctx.func);

--- a/cranelift/filetests/src/test_wasm.rs
+++ b/cranelift/filetests/src/test_wasm.rs
@@ -5,6 +5,7 @@ mod env;
 
 use anyhow::{bail, ensure, Context, Result};
 use config::TestConfig;
+use cranelift_control::ControlPlane;
 use env::ModuleEnv;
 use similar::TextDiff;
 use std::{fmt::Write, path::Path};
@@ -64,7 +65,7 @@ pub fn run(path: &Path, wat: &str) -> Result<()> {
             writeln!(&mut actual, "{}", code.vcode.as_ref().unwrap()).unwrap();
         } else if config.optimize {
             let mut ctx = cranelift_codegen::Context::for_function(func.clone());
-            ctx.optimize(isa)
+            ctx.optimize(isa, &mut ControlPlane::default())
                 .map_err(|e| crate::pretty_anyhow_error(&ctx.func, e))?;
             writeln!(&mut actual, "{}", ctx.func.display()).unwrap();
         } else {

--- a/cranelift/src/souper_harvest.rs
+++ b/cranelift/src/souper_harvest.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context as _, Result};
 use clap::Parser;
+use cranelift_codegen::control::ControlPlane;
 use cranelift_codegen::Context;
 use cranelift_reader::parse_sets_and_triple;
 use cranelift_wasm::DummyEnvironment;
@@ -133,7 +134,7 @@ pub fn run(options: &Options) -> Result<()> {
             let mut ctx = Context::new();
             ctx.func = func;
 
-            ctx.optimize(fisa.isa.unwrap())
+            ctx.optimize(fisa.isa.unwrap(), &mut ControlPlane::default())
                 .context("failed to run optimizations")?;
 
             ctx.souper_harvest(send)

--- a/fuzz/fuzz_targets/cranelift-fuzzgen.rs
+++ b/fuzz/fuzz_targets/cranelift-fuzzgen.rs
@@ -236,12 +236,14 @@ impl TestCase {
     }
 
     fn to_optimized(&self) -> Self {
+        let mut ctrl_planes = self.ctrl_planes.clone();
         let optimized_functions: Vec<Function> = self
             .functions
             .iter()
-            .map(|func| {
+            .zip(ctrl_planes.iter_mut())
+            .map(|(func, ctrl_plane)| {
                 let mut ctx = Context::for_function(func.clone());
-                ctx.optimize(self.isa.as_ref()).unwrap();
+                ctx.optimize(self.isa.as_ref(), ctrl_plane).unwrap();
                 ctx.func
             })
             .collect();
@@ -249,7 +251,7 @@ impl TestCase {
         TestCase {
             isa: self.isa.clone(),
             functions: optimized_functions,
-            ctrl_planes: self.ctrl_planes.clone(),
+            ctrl_planes,
             inputs: self.inputs.clone(),
             compare_against_host: false,
         }


### PR DESCRIPTION
First of all, thread a "chaos mode" control-plane into Context::optimize and from there into EgraphPass, OptimizeCtx, and Elaborator.

In this commit we use the control-plane to change the following behaviors in ways which shouldn't cause incorrect results:

- Dominator-tree block traversal order for both the rule application and elaboration passes
- Order of evaluating optimization alternatives from `simplify`
- Choose worst values instead of best in each eclass

@lpereira and I wrote this together.