### PR TITLE
Cache a handle to the canonical ABI's `realloc`'s function type

### DIFF
--- a/crates/runtime/src/component.rs
+++ b/crates/runtime/src/component.rs
@@ -502,6 +502,11 @@ impl ComponentInstance {
         self.runtime_info.component_types()
     }
 
+    /// Get the canonical ABI's `realloc` function's runtime type.
+    pub fn realloc_func_ty(&self) -> &Arc<dyn std::any::Any + Send + Sync> {
+        self.runtime_info.realloc_func_type()
+    }
+
     /// Returns a reference to the resource type information as a `dyn Any`.
     ///
     /// Wasmtime is the one which then downcasts this to the appropriate type.
@@ -850,6 +855,10 @@ impl InstanceFlags {
 pub trait ComponentRuntimeInfo: Send + Sync + 'static {
     /// Returns the type information about the compiled component.
     fn component(&self) -> &Component;
+
     /// Returns a handle to the tables of type information for this component.
     fn component_types(&self) -> &Arc<ComponentTypes>;
+
+    /// Get the `wasmtime::FuncType` for the canonical ABI's `realloc` function.
+    fn realloc_func_type(&self) -> &Arc<dyn std::any::Any + Send + Sync>;
 }

--- a/crates/wasmtime/src/runtime/component/func/options.rs
+++ b/crates/wasmtime/src/runtime/component/func/options.rs
@@ -78,6 +78,7 @@ impl Options {
     fn realloc<'a, T>(
         &self,
         store: &'a mut StoreContextMut<'_, T>,
+        realloc_ty: &FuncType,
         old: usize,
         old_size: usize,
         old_align: u32,
@@ -86,16 +87,13 @@ impl Options {
         self.store_id.assert_belongs_to(store.0.id());
 
         let realloc = self.realloc.unwrap();
-        let realloc_ty = FuncType::from_shared_type_index(store.engine(), unsafe {
-            realloc.as_ref().type_index
-        });
 
         // Invoke the wasm malloc function using its raw and statically known
         // signature.
         let result = unsafe {
             crate::TypedFunc::<(u32, u32, u32, u32), u32>::call_raw(
                 store,
-                &realloc_ty,
+                realloc_ty,
                 realloc,
                 (
                     u32::try_from(old)?,
@@ -247,8 +245,17 @@ impl<'a, T> LowerContext<'a, T> {
         old_align: u32,
         new_size: usize,
     ) -> Result<usize> {
+        let realloc_func_ty = Arc::clone(unsafe { (*self.instance).realloc_func_ty() });
+        let realloc_func_ty = realloc_func_ty.downcast_ref::<FuncType>().unwrap();
         self.options
-            .realloc(&mut self.store, old, old_size, old_align, new_size)
+            .realloc(
+                &mut self.store,
+                &realloc_func_ty,
+                old,
+                old_size,
+                old_align,
+                new_size,
+            )
             .map(|(_, ptr)| ptr)
     }
 


### PR DESCRIPTION
This avoids locking the type registry to look up function types by `VMSharedTypeIndex` in calls to `realloc`.

This gives a ~13% speedup to `wasmtime serve`'s requests per second for me locally.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
