### PR TITLE
Fix Cargo metadata on the `wasmtime-c-api-macros` crate

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,18 @@ Unreleased.
 
 --------------------------------------------------------------------------------
 
+## 18.0.1
+
+Released 2024-02-20.
+
+### Fixed
+
+* Fixed a mistake in the CI release process that caused the crates.io
+  publication of the 18.0.0 release to not succeed.
+  [#7966](https://github.com/bytecodealliance/wasmtime/pull/7966)
+
+--------------------------------------------------------------------------------
+
 ## 18.0.0
 
 Released 2024-02-20

--- a/crates/c-api-macros/Cargo.toml
+++ b/crates/c-api-macros/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 authors = ["The Wasmtime Project Developers"]
 license = "Apache-2.0 WITH LLVM-exception"
 edition.workspace = true
+description = "Support macros for `wasmtime-c-api`"
+repository = "https://github.com/bytecodealliance/wasmtime"
 
 [lints]
 workspace = true


### PR DESCRIPTION
This is a forward-port of https://github.com/bytecodealliance/wasmtime/pull/7966 to the `main` branch