### PR TITLE
winch: Use the `vmctx!` macro where possible

### DIFF
--- a/winch/codegen/src/codegen/bounds.rs
+++ b/winch/codegen/src/codegen/bounds.rs
@@ -3,7 +3,7 @@
 //! recommended when working on this area of Winch.
 use super::env::{HeapData, HeapStyle};
 use crate::{
-    abi::ABI,
+    abi::{vmctx, ABI},
     codegen::CodeGenContext,
     isa::reg::Reg,
     masm::{IntCmpKind, MacroAssembler, OperandSize, RegImm, TrapCode},
@@ -102,7 +102,7 @@ where
                 masm.load_ptr(addr, scratch);
                 scratch
             } else {
-                <M::ABI as ABI>::vmctx_reg()
+                vmctx!(M)
             };
             let addr = masm.address_at_reg(base, heap.current_length_offset);
             masm.load_ptr(addr, dst);
@@ -205,7 +205,7 @@ pub(crate) fn load_heap_addr_unchecked<M>(
     } else {
         // Else if the WebAssembly memory is defined in the current module,
         // simply use the `VMContext` as the base for subsequent operations.
-        <M::ABI as ABI>::vmctx_reg()
+        vmctx!(M)
     };
 
     // Load the base of the memory into the `addr` register.


### PR DESCRIPTION
No functional changes. 

This commit is a follow-up to https://github.com/bytecodealliance/wasmtime/pull/7974. This commit makes use of the `vmctx!` macro across the compiler codebase

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
