### PR TITLE
s390x: Fix TLS GD relocation order

### DIFF
--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1549,9 +1549,10 @@ impl<I: VCodeInst> MachBuffer<I> {
         }
     }
 
-    /// Add an external relocation at the current offset.
-    pub fn add_reloc<T: Into<RelocTarget> + Clone>(
+    /// Add an external relocation at the given offset from current offset.
+    pub fn add_reloc_at_offset<T: Into<RelocTarget> + Clone>(
         &mut self,
+        offset: CodeOffset,
         kind: Reloc,
         target: &T,
         addend: Addend,
@@ -1591,11 +1592,21 @@ impl<I: VCodeInst> MachBuffer<I> {
         // when a relocation can't otherwise be resolved later, so it shouldn't
         // actually result in any memory unsafety or anything like that.
         self.relocs.push(MachReloc {
-            offset: self.data.len() as CodeOffset,
+            offset: self.data.len() as CodeOffset + offset,
             kind,
             target,
             addend,
         });
+    }
+
+    /// Add an external relocation at the current offset.
+    pub fn add_reloc<T: Into<RelocTarget> + Clone>(
+        &mut self,
+        kind: Reloc,
+        target: &T,
+        addend: Addend,
+    ) {
+        self.add_reloc_at_offset(0, kind, target, addend);
     }
 
     /// Add a trap record at the current offset.

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -430,7 +430,7 @@ impl<T: CompilePhase> CompiledCodeBase<T> {
                 let end = i.address() + i.bytes().len() as u64;
                 let contains = |off| i.address() <= off && off < end;
 
-                if let Some(reloc) = relocs.iter().find(|reloc| contains(reloc.offset as u64)) {
+                for reloc in relocs.iter().filter(|reloc| contains(reloc.offset as u64)) {
                     write!(
                         buf,
                         " ; reloc_external {} {} {}",

--- a/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
+++ b/cranelift/filetests/filetests/isa/s390x/tls_elf.clif
@@ -37,7 +37,7 @@ block0(v0: i32):
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   lg %r2, 0(%r1)
-;   brasl %r14, 0x22 ; reloc_external TlsGdCall u1:0 0
+;   brasl %r14, 0x22 ; reloc_external PLTRel32Dbl %ElfTlsGetOffset 2 ; reloc_external TlsGdCall u1:0 0
 ;   ear %r3, %a0
 ;   sllg %r5, %r3, 0x20
 ;   ear %r5, %a1


### PR DESCRIPTION
When emitting a call to __tls_get_offset, the instruction needs to carry two relocations, a R_390_PLT32DBL targeting __tls_get_offset and a R_390_TLS_GDCALL targeting the TLS symbol.  Specifically, the system linker expects to see these two relocation in that order.

However, the cranelift backend currently emits the relocations in reverse order - this unfortunately causes the linker to corrupt the instruction sequence when performing a TLS relaxation.

To fix this in the backend, I need support in machinst common code to emit a relocation at some offset to the instruction about to be emitted (e.g. the relocation should target two bytes into the 6-byte instruction that will be emitted next).  I've added a new routine add_reloc_at_offset to that effect.  This also allowed to simplify some existing code in the backend.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
