### PR TITLE
winch: Enable stack overflow checking in trampolines

### DIFF
--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -94,7 +94,7 @@ where
         // Stack overflow checks must occur during the function prologue to ensure that unwinding
         // will not assume they're user-handlable exceptions. As the `save_clobbers` call below
         // marks the end of the prologue for unwinding annotations, we make the stack check here.
-        self.masm.check_stack();
+        self.masm.check_stack(vmctx!(M));
 
         // We don't have any callee save registers in the winch calling convention, but
         // `save_clobbers` does some useful work for setting up unwinding state, and marks the end

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -49,7 +49,7 @@ impl Masm for MacroAssembler {
         self.move_sp_to_shadow_sp();
     }
 
-    fn check_stack(&mut self) {
+    fn check_stack(&mut self, _vmctx: Reg) {
         // TODO: Implement when we have more complete assembler support.
     }
 

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -77,12 +77,12 @@ impl Masm for MacroAssembler {
             .mov_rr(stack_pointer, frame_pointer, OperandSize::S64);
     }
 
-    fn check_stack(&mut self) {
+    fn check_stack(&mut self, vmctx: Reg) {
         let ptr_size: u8 = self.ptr_size.bytes().try_into().unwrap();
         let scratch = regs::scratch();
 
         self.load_ptr(
-            self.address_at_vmctx(ptr_size.vmcontext_runtime_limits().into()),
+            self.address_at_reg(vmctx, ptr_size.vmcontext_runtime_limits().into()),
             scratch,
         );
 

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -110,7 +110,7 @@ impl Masm for MacroAssembler {
                     RegClass::Float => align_to(total, float_bytes) + float_bytes,
                     RegClass::Vector => unimplemented!(),
                 }),
-            16,
+            float_bytes,
         );
 
         // Emit unwind info.
@@ -148,6 +148,9 @@ impl Masm for MacroAssembler {
     }
 
     fn restore_clobbers(&mut self, clobbers: &[(Reg, OperandSize)]) {
+        let int_bytes: u32 = Self::ABI::word_bytes().try_into().unwrap();
+        let float_bytes = int_bytes * 2;
+
         let mut off = 0;
         for &(reg, size) in clobbers {
             // Align the current offset
@@ -161,7 +164,7 @@ impl Masm for MacroAssembler {
             off += size.bytes();
         }
 
-        self.free_stack(align_to(off, 16));
+        self.free_stack(align_to(off, float_bytes));
     }
 
     fn push(&mut self, reg: Reg, size: OperandSize) -> StackSlot {

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -488,7 +488,7 @@ pub(crate) trait MacroAssembler {
     }
 
     /// Emit a stack check.
-    fn check_stack(&mut self);
+    fn check_stack(&mut self, vmctx: Reg);
 
     /// Emit the function epilogue.
     fn epilogue(&mut self, locals_size: u32);


### PR DESCRIPTION
Stack overflow checking in trampolines is slightly different than when translating arbitrary wasm functions, as the vmctx isn't necessarily in the pinned register yet. To avoid bloating the function prologue, I opted to parameterize the `MacroAssembler::check_stack` function on the register that currently contains the `vmctx`. This change allows the trampolines to pass the current location of `vmctx` instead of forcing it to live in the pinned register.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
