### PR TITLE
Enable compiling the Wasmtime CLI to Wasm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -293,6 +293,11 @@ jobs:
 
     # Feature combinations of the `wasmtime-cli`
     - run: cargo check -p wasmtime-cli --no-default-features
+    - run: cargo check -p wasmtime-cli --no-default-features --features run
+    - run: cargo check -p wasmtime-cli --no-default-features --features run,component-model
+    - run: cargo check -p wasmtime-cli --no-default-features --features compile
+    - run: cargo check -p wasmtime-cli --no-default-features --features compile,cranelift
+    - run: cargo check -p wasmtime-cli --no-default-features --features compile,cranelift,component-model
 
     # Check that benchmarks of the cranelift project build
     - run: cargo check --benches -p cranelift-codegen
@@ -563,7 +568,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - run: rustup update stable && rustup default stable
+    - uses: ./.github/actions/install-rust
     - run: rustup target add wasm32-wasi wasm32-unknown-unknown
 
     - name: Install wasm-tools
@@ -596,9 +601,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - run: rustup update stable && rustup default stable
+    - uses: ./.github/actions/install-rust
     - run: rustup target add wasm32-wasi wasm32-unknown-unknown
-    - run: cargo build -p wasmtime --target wasm32-wasi --no-default-features --features cranelift,all-arch
+    - run: cargo build --target wasm32-wasi --no-default-features --features compile,cranelift,all-arch
       env:
         VERSION: ${{ github.sha }}
 
@@ -656,7 +661,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - run: rustup update stable && rustup default stable
+    - uses: ./.github/actions/install-rust
     - run: |
         cd ${{ runner.tool_cache }}
         curl -L https://github.com/mozilla/sccache/releases/download/0.2.13/sccache-0.2.13-x86_64-unknown-linux-musl.tar.gz | tar xzf -

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,19 +32,17 @@ wasmtime-cranelift = { workspace = true, optional = true }
 wasmtime-environ = { workspace = true }
 wasmtime-explorer = { workspace = true, optional = true }
 wasmtime-wast = { workspace = true, optional = true }
-wasi-common = { workspace = true, default-features = true, features = [
-  "exit",
-] }
-wasmtime-wasi = { workspace = true, default-features = true }
+wasi-common = { workspace = true, default-features = true, features = ["exit" ], optional = true }
+wasmtime-wasi = { workspace = true, default-features = true, optional = true }
 wasmtime-wasi-nn = { workspace = true, optional = true }
 wasmtime-wasi-threads = { workspace = true, optional = true }
 wasmtime-wasi-http = { workspace = true, optional = true }
-wasmtime-runtime = { workspace = true }
+wasmtime-runtime = { workspace = true, optional = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
 target-lexicon = { workspace = true }
 once_cell = { workspace = true }
-listenfd = "1.0.0"
+listenfd = { version = "1.0.0", optional = true }
 wat = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
@@ -303,6 +301,7 @@ humantime = "2.0.0"
 [features]
 default = [
   # All subcommands are included by default.
+  "run",
   "compile",
   "explore",
   "serve",
@@ -385,6 +384,7 @@ explore = ["dep:wasmtime-explorer"]
 wast = ["dep:wasmtime-wast"]
 config = ["cache"]
 compile = ["cranelift"]
+run = ["dep:wasmtime-wasi", "wasmtime/runtime", "wasmtime-runtime", "dep:listenfd", "dep:wasi-common"]
 
 [[test]]
 name = "host_segfault"

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -463,6 +463,11 @@ impl Engine {
             };
         }
 
+        #[cfg(target_family = "wasm")]
+        {
+            let _ = &mut enabled;
+        }
+
         match enabled {
             Some(true) => return Ok(()),
             Some(false) => {

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -34,9 +34,15 @@ use clap::Parser;
     args_conflicts_with_subcommands = true
 )]
 struct Wasmtime {
+    #[cfg(not(feature = "run"))]
+    #[command(subcommand)]
+    subcommand: Subcommand,
+
+    #[cfg(feature = "run")]
     #[command(subcommand)]
     subcommand: Option<Subcommand>,
     #[command(flatten)]
+    #[cfg(feature = "run")]
     run: wasmtime_cli::commands::RunCommand,
 }
 
@@ -48,6 +54,7 @@ fn version() -> &'static str {
 #[derive(Parser, PartialEq)]
 enum Subcommand {
     /// Runs a WebAssembly module
+    #[cfg(feature = "run")]
     Run(wasmtime_cli::commands::RunCommand),
 
     /// Controls Wasmtime configuration settings
@@ -78,8 +85,13 @@ enum Subcommand {
 impl Wasmtime {
     /// Executes the command.
     pub fn execute(self) -> Result<()> {
+        #[cfg(feature = "run")]
         let subcommand = self.subcommand.unwrap_or(Subcommand::Run(self.run));
+        #[cfg(not(feature = "run"))]
+        let subcommand = self.subcommand;
+
         match subcommand {
+            #[cfg(feature = "run")]
             Subcommand::Run(c) => c.execute(),
 
             #[cfg(feature = "cache")]

--- a/src/bin/wasmtime.rs
+++ b/src/bin/wasmtime.rs
@@ -62,7 +62,7 @@ enum Subcommand {
     Config(wasmtime_cli::commands::ConfigCommand),
 
     /// Compiles a WebAssembly module.
-    #[cfg(feature = "cranelift")]
+    #[cfg(feature = "compile")]
     Compile(wasmtime_cli::commands::CompileCommand),
 
     /// Explore the compilation of a WebAssembly module to native code.
@@ -97,7 +97,7 @@ impl Wasmtime {
             #[cfg(feature = "cache")]
             Subcommand::Config(c) => c.execute(),
 
-            #[cfg(feature = "cranelift")]
+            #[cfg(feature = "compile")]
             Subcommand::Compile(c) => c.execute(),
 
             #[cfg(feature = "explore")]

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -1,6 +1,8 @@
 //! The module for the Wasmtime CLI commands.
 
+#[cfg(feature = "run")]
 mod run;
+#[cfg(feature = "run")]
 pub use self::run::*;
 
 #[cfg(feature = "serve")]

--- a/src/commands/compile.rs
+++ b/src/commands/compile.rs
@@ -100,7 +100,14 @@ impl CompileCommand {
         });
 
         let output_bytes = if wasmparser::Parser::is_component(&input) {
-            engine.precompile_component(&input)?
+            #[cfg(feature = "component-model")]
+            {
+                engine.precompile_component(&input)?
+            }
+            #[cfg(not(feature = "component-model"))]
+            {
+                bail!("component model support was disabled at compile time")
+            }
         } else {
             engine.precompile_module(&input)?
         };

--- a/src/common.rs
+++ b/src/common.rs
@@ -186,6 +186,7 @@ impl RunCommon {
             Some(Precompiled::Component) => {
                 bail!("support for components was not enabled at compile time");
             }
+            #[cfg(any(feature = "cranelift", feature = "winch"))]
             None => {
                 // Parse the text format here specifically to add the `path` to
                 // the error message if there's a syntax error.
@@ -206,11 +207,13 @@ impl RunCommon {
                         bail!("support for components was not enabled at compile time");
                     }
                 } else {
-                    #[cfg(feature = "cranelift")]
-                    return Ok(RunTarget::Core(Module::new(engine, &bytes)?));
-                    #[cfg(not(feature = "cranelift"))]
-                    bail!("support for compiling modules was disabled at compile time");
+                    RunTarget::Core(Module::new(engine, &bytes)?)
                 }
+            }
+            #[cfg(not(any(feature = "cranelift", feature = "winch")))]
+            None => {
+                let _ = path;
+                bail!("support for compiling modules was disabled at compile time");
             }
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod commands;
 
+#[cfg(feature = "run")]
 pub(crate) mod common;
 
 #[cfg(feature = "old-cli")]


### PR DESCRIPTION
While not the most useful thing to do in the world it's kind of neat to play around with. This builds on the previous work to exclude the runtime from the `wasmtime` crate so it's now possible to compile the Wasmtime CLI's `compile` command, and only the `compile` command, to wasm itself. This means you can run Wasmtime in Wasmtime!

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
