### PR TITLE
Assume non-Windows x86_64 uses system-v ABI

### DIFF
--- a/crates/runtime/src/arch/x86_64.rs
+++ b/crates/runtime/src/arch/x86_64.rs
@@ -48,12 +48,10 @@ cfg_if::cfg_if! {
         macro_rules! callee_vmctx { () => ("rcx") }
         macro_rules! scratch0 { () => ("r10") }
         macro_rules! scratch1 { () => ("r11") }
-    } else if #[cfg(unix)] {
+    } else {
         macro_rules! callee_vmctx { () => ("rdi") }
         macro_rules! scratch0 { () => ("r10") }
         macro_rules! scratch1 { () => ("r11") }
-    } else {
-        compile_error!("default calling convention for this platform is not known");
     }
 }
 pub(crate) use {callee_vmctx, scratch0, scratch1};


### PR DESCRIPTION
This is true for anything I've ever encountered historically so I'm not sure if it's worth having an explicit `compile_error!` here for all non-enumerated platforms.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
