### PR TITLE
winch: Refactor the prologue and epilogue interface

### DIFF
--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -86,22 +86,22 @@ where
     }
 
     fn emit_start(&mut self) -> Result<()> {
-        self.masm.prologue();
+        let vmctx = self
+            .sig
+            .params()
+            .first()
+            .expect("VMContext argument")
+            .unwrap_reg()
+            .into();
+
+        // We need to use the vmctx paramter before pinning it for stack checking, and we don't
+        // have any callee save registers in the winch calling convention.
+        self.masm
+            .prologue(vmctx, &[], self.context.frame.locals_size);
 
         // Pin the `VMContext` pointer.
-        self.pin_vmctx();
-
-        // Stack overflow checks must occur during the function prologue to ensure that unwinding
-        // will not assume they're user-handlable exceptions. As the `save_clobbers` call below
-        // marks the end of the prologue for unwinding annotations, we make the stack check here.
-        self.masm.check_stack(vmctx!(M));
-
-        // We don't have any callee save registers in the winch calling convention, but
-        // `save_clobbers` does some useful work for setting up unwinding state, and marks the end
-        // of the function prologue as far as the windows unwind annotation is concerend.
-        self.masm.save_clobbers(&[]);
-
-        self.masm.reserve_stack(self.context.frame.locals_size);
+        self.masm
+            .mov(vmctx.into(), vmctx!(M), self.env.ptr_type().into());
 
         // Once we have emitted the epilogue and reserved stack space for the locals, we push the
         // base control flow block.
@@ -160,18 +160,6 @@ where
             // in this state through an infinite loop.
             frame.ensure_stack_state(self.masm, &mut self.context);
         }
-    }
-
-    /// Assigns the [VMContext] pointer to the designated, pinned [VMContext]
-    /// register.
-    fn pin_vmctx(&mut self) {
-        let pinned = vmctx!(M);
-        let vmctx = self.sig.params().first().expect("VMContext argument");
-        self.masm.mov(
-            vmctx.unwrap_reg().into(),
-            pinned,
-            self.env.ptr_type().into(),
-        );
     }
 
     fn emit_body(
@@ -327,8 +315,7 @@ where
             self.masm.reset_stack_pointer(base);
         }
         debug_assert_eq!(self.context.stack.len(), 0);
-        self.masm.restore_clobbers(&[]);
-        self.masm.epilogue(self.context.frame.locals_size);
+        self.masm.epilogue(&[], self.context.frame.locals_size);
         Ok(())
     }
 

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -96,12 +96,13 @@ where
 
         // We need to use the vmctx paramter before pinning it for stack checking, and we don't
         // have any callee save registers in the winch calling convention.
-        self.masm
-            .prologue(vmctx, &[], self.context.frame.locals_size);
+        self.masm.prologue(vmctx, &[]);
 
         // Pin the `VMContext` pointer.
         self.masm
             .mov(vmctx.into(), vmctx!(M), self.env.ptr_type().into());
+
+        self.masm.reserve_stack(self.context.frame.locals_size);
 
         // Once we have emitted the epilogue and reserved stack space for the locals, we push the
         // base control flow block.
@@ -315,7 +316,8 @@ where
             self.masm.reset_stack_pointer(base);
         }
         debug_assert_eq!(self.context.stack.len(), 0);
-        self.masm.epilogue(&[], self.context.frame.locals_size);
+        self.masm.free_stack(self.context.frame.locals_size);
+        self.masm.epilogue(&[]);
         Ok(())
     }
 

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -61,7 +61,7 @@ impl Masm for MacroAssembler {
     type Ptr = u8;
     type ABI = X64ABI;
 
-    fn prologue(&mut self) {
+    fn frame_setup(&mut self) {
         let frame_pointer = rbp();
         let stack_pointer = rsp();
 
@@ -801,12 +801,8 @@ impl Masm for MacroAssembler {
         context.stack.push(Val::reg(rdx, divisor.ty));
     }
 
-    fn epilogue(&mut self, locals_size: u32) {
-        assert_eq!(self.sp_offset, locals_size);
-
-        if locals_size > 0 {
-            self.free_stack(locals_size);
-        }
+    fn frame_restore(&mut self) {
+        assert_eq!(self.sp_offset, 0);
         self.asm.pop_r(rbp());
         self.asm.ret();
     }

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -468,11 +468,10 @@ pub(crate) trait MacroAssembler {
     type ABI: abi::ABI;
 
     /// Emit the function prologue.
-    fn prologue(&mut self, vmctx: Reg, clobbers: &[(Reg, OperandSize)], locals_size: u32) {
+    fn prologue(&mut self, vmctx: Reg, clobbers: &[(Reg, OperandSize)]) {
         self.frame_setup();
         self.check_stack(vmctx);
         self.save_clobbers(clobbers);
-        self.reserve_stack(locals_size);
     }
 
     /// Generate the frame setup sequence.
@@ -502,8 +501,7 @@ pub(crate) trait MacroAssembler {
     fn check_stack(&mut self, vmctx: Reg);
 
     /// Emit the function epilogue.
-    fn epilogue(&mut self, clobbers: &[(Reg, OperandSize)], locals_size: u32) {
-        self.free_stack(locals_size);
+    fn epilogue(&mut self, clobbers: &[(Reg, OperandSize)]) {
         self.restore_clobbers(clobbers);
         self.frame_restore();
     }

--- a/winch/codegen/src/trampoline.rs
+++ b/winch/codegen/src/trampoline.rs
@@ -102,7 +102,7 @@ where
         let (vmctx, caller_vmctx) = Self::callee_and_caller_vmctx(&array_sig.params)?;
         let (dst_callee_vmctx, dst_caller_vmctx) = Self::callee_and_caller_vmctx(&wasm_sig.params)?;
 
-        self.masm.prologue(caller_vmctx, &self.callee_saved_regs, 0);
+        self.masm.prologue(caller_vmctx, &self.callee_saved_regs);
 
         self.masm
             .mov(vmctx.into(), dst_callee_vmctx, self.pointer_type.into());
@@ -157,7 +157,7 @@ where
         }
 
         self.masm.free_stack(spill_size);
-        self.masm.epilogue(&self.callee_saved_regs, 0);
+        self.masm.epilogue(&self.callee_saved_regs);
         Ok(())
     }
 
@@ -198,7 +198,7 @@ where
         let wasm_sig = wasm_sig::<M::ABI>(&ty);
         let (vmctx, caller_vmctx) = Self::callee_and_caller_vmctx(&native_sig.params)?;
 
-        self.masm.prologue(caller_vmctx, &self.callee_saved_regs, 0);
+        self.masm.prologue(caller_vmctx, &self.callee_saved_regs);
 
         let vmctx_runtime_limits_addr = self.vmctx_runtime_limits_addr(vmctx);
         let ret_area = self.make_ret_area(&wasm_sig);
@@ -233,7 +233,7 @@ where
         }
 
         self.masm.free_stack(spill_size);
-        self.masm.epilogue(&self.callee_saved_regs, 0);
+        self.masm.epilogue(&self.callee_saved_regs);
 
         Ok(())
     }
@@ -367,7 +367,7 @@ where
         let (vmctx, caller_vmctx) = Self::callee_and_caller_vmctx(&wasm_sig.params).unwrap();
         let vmctx_runtime_limits_addr = self.vmctx_runtime_limits_addr(caller_vmctx);
 
-        self.masm.prologue(caller_vmctx, &[], 0);
+        self.masm.prologue(caller_vmctx, &[]);
 
         // Save the FP and return address when exiting Wasm.
         // TODO: Once Winch supports comparison operators,
@@ -418,7 +418,7 @@ where
         }
 
         self.masm.free_stack(spill_size);
-        self.masm.epilogue(&[], 0);
+        self.masm.epilogue(&[]);
 
         Ok(())
     }

--- a/winch/codegen/src/trampoline.rs
+++ b/winch/codegen/src/trampoline.rs
@@ -102,7 +102,7 @@ where
         let (vmctx, caller_vmctx) = Self::callee_and_caller_vmctx(&array_sig.params)?;
         let (dst_callee_vmctx, dst_caller_vmctx) = Self::callee_and_caller_vmctx(&wasm_sig.params)?;
 
-        self.prologue_with_callee_saved(caller_vmctx);
+        self.masm.prologue(caller_vmctx, &self.callee_saved_regs, 0);
 
         self.masm
             .mov(vmctx.into(), dst_callee_vmctx, self.pointer_type.into());
@@ -156,7 +156,8 @@ where
             self.masm.free_stack(wasm_sig.results.size());
         }
 
-        self.epilogue_with_callee_saved_restore(spill_size);
+        self.masm.free_stack(spill_size);
+        self.masm.epilogue(&self.callee_saved_regs, 0);
         Ok(())
     }
 
@@ -197,7 +198,7 @@ where
         let wasm_sig = wasm_sig::<M::ABI>(&ty);
         let (vmctx, caller_vmctx) = Self::callee_and_caller_vmctx(&native_sig.params)?;
 
-        self.prologue_with_callee_saved(caller_vmctx);
+        self.masm.prologue(caller_vmctx, &self.callee_saved_regs, 0);
 
         let vmctx_runtime_limits_addr = self.vmctx_runtime_limits_addr(vmctx);
         let ret_area = self.make_ret_area(&wasm_sig);
@@ -230,7 +231,9 @@ where
         if wasm_sig.has_stack_results() {
             self.masm.free_stack(wasm_sig.results.size());
         }
-        self.epilogue_with_callee_saved_restore(spill_size);
+
+        self.masm.free_stack(spill_size);
+        self.masm.epilogue(&self.callee_saved_regs, 0);
 
         Ok(())
     }
@@ -364,7 +367,7 @@ where
         let (vmctx, caller_vmctx) = Self::callee_and_caller_vmctx(&wasm_sig.params).unwrap();
         let vmctx_runtime_limits_addr = self.vmctx_runtime_limits_addr(caller_vmctx);
 
-        self.prologue(caller_vmctx);
+        self.masm.prologue(caller_vmctx, &[], 0);
 
         // Save the FP and return address when exiting Wasm.
         // TODO: Once Winch supports comparison operators,
@@ -414,7 +417,8 @@ where
             self.masm.free_stack(native_sig.results.size());
         }
 
-        self.epilogue(spill_size);
+        self.masm.free_stack(spill_size);
+        self.masm.epilogue(&[], 0);
 
         Ok(())
     }
@@ -618,39 +622,5 @@ where
         let ret_addr = masm.address_at_reg(fp, ret_addr_offset.into());
         masm.load_ptr(ret_addr, scratch);
         masm.store(scratch.into(), last_wasm_exit_pc_addr, OperandSize::S64);
-    }
-
-    /// The trampoline's prologue.
-    fn prologue(&mut self, vmctx: Reg) {
-        self.masm.prologue();
-        self.masm.check_stack(vmctx);
-        self.masm.save_clobbers(&[]);
-    }
-
-    /// Similar to [Trampoline::prologue], but saves
-    /// callee-saved registers.
-    fn prologue_with_callee_saved(&mut self, vmctx: Reg) {
-        self.masm.prologue();
-        self.masm.check_stack(vmctx);
-        // Save any callee-saved registers.
-        self.masm.save_clobbers(&self.callee_saved_regs);
-    }
-
-    /// Similar to [Trampoline::epilogue], but restores
-    /// callee-saved registers.
-    fn epilogue_with_callee_saved_restore(&mut self, arg_size: u32) {
-        // Free the stack space allocated by pushing the trampoline arguments.
-        self.masm.free_stack(arg_size);
-        // Restore the callee-saved registers.
-        self.masm.restore_clobbers(&self.callee_saved_regs);
-        self.masm.epilogue(0);
-    }
-
-    /// The trampoline's epilogue.
-    fn epilogue(&mut self, arg_size: u32) {
-        // Free the stack space allocated by pushing the trampoline arguments.
-        self.masm.free_stack(arg_size);
-        self.masm.restore_clobbers(&[]);
-        self.masm.epilogue(0);
     }
 }

--- a/winch/filetests/filetests/x64/block/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/block/as_if_cond.wat
@@ -9,13 +9,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -25,13 +25,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/block/as_if_else.wat
+++ b/winch/filetests/filetests/x64/block/as_if_else.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/block/as_if_then.wat
+++ b/winch/filetests/filetests/x64/block/as_if_then.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/block/deep.wat
+++ b/winch/filetests/filetests/x64/block/deep.wat
@@ -46,13 +46,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -62,13 +62,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/block/empty.wat
+++ b/winch/filetests/filetests/x64/block/empty.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -26,13 +26,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10

--- a/winch/filetests/filetests/x64/block/get_and_set.wat
+++ b/winch/filetests/filetests/x64/block/get_and_set.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c31c000000       	add	r11, 0x1c
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/block/get_and_tee.wat
+++ b/winch/filetests/filetests/x64/block/get_and_tee.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c31c000000       	add	r11, 0x1c
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/block/nested.wat
+++ b/winch/filetests/filetests/x64/block/nested.wat
@@ -11,13 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -27,13 +27,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x56
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/block/singular.wat
+++ b/winch/filetests/filetests/x64/block/singular.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b807000000           	mov	eax, 7

--- a/winch/filetests/filetests/x64/block/with_local_float.wat
+++ b/winch/filetests/filetests/x64/block/with_local_float.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c31c000000       	add	r11, 0x1c
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/br/as_block_first.wat
+++ b/winch/filetests/filetests/x64/br/as_block_first.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10

--- a/winch/filetests/filetests/x64/br/as_block_last.wat
+++ b/winch/filetests/filetests/x64/br/as_block_last.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/br/as_block_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_block_mid.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/br/as_block_value.wat
+++ b/winch/filetests/filetests/x64/br/as_block_value.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/br/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/br/as_br_if_cond.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10

--- a/winch/filetests/filetests/x64/br/as_br_value.wat
+++ b/winch/filetests/filetests/x64/br/as_br_value.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b809000000           	mov	eax, 9

--- a/winch/filetests/filetests/x64/br/as_call_all.wat
+++ b/winch/filetests/filetests/x64/br/as_call_all.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -27,13 +27,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b80f000000           	mov	eax, 0xf

--- a/winch/filetests/filetests/x64/br/as_call_first.wat
+++ b/winch/filetests/filetests/x64/br/as_call_first.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -30,13 +30,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b80c000000           	mov	eax, 0xc

--- a/winch/filetests/filetests/x64/br/as_call_last.wat
+++ b/winch/filetests/filetests/x64/br/as_call_last.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -29,13 +29,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b80e000000           	mov	eax, 0xe

--- a/winch/filetests/filetests/x64/br/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_call_mid.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -30,13 +30,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b80d000000           	mov	eax, 0xd

--- a/winch/filetests/filetests/x64/br/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/br/as_if_cond.wat
@@ -11,13 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/br/as_if_else.wat
+++ b/winch/filetests/filetests/x64/br/as_if_else.wat
@@ -11,13 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/br/as_if_then.wat
+++ b/winch/filetests/filetests/x64/br/as_if_then.wat
@@ -11,13 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/br/as_loop_first.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_first.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b803000000           	mov	eax, 3

--- a/winch/filetests/filetests/x64/br/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_last.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -25,13 +25,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/br/as_loop_mid.wat
+++ b/winch/filetests/filetests/x64/br/as_loop_mid.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -26,13 +26,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/br/br_jump.wat
+++ b/winch/filetests/filetests/x64/br/br_jump.wat
@@ -14,13 +14,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873f000000         	ja	0x5d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8742000000         	ja	0x5d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/br_if/as_block_last.wat
+++ b/winch/filetests/filetests/x64/br_if/as_block_last.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -23,13 +23,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8754000000         	ja	0x72
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8757000000         	ja	0x72
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/br_if/as_block_last_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_block_last_value.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -25,13 +25,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8759000000         	ja	0x77
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f875c000000         	ja	0x77
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/br_if/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/br_if/as_br_if_cond.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872d000000         	ja	0x4b
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/br_if/as_br_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_br_value.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b902000000           	mov	ecx, 2

--- a/winch/filetests/filetests/x64/br_if/as_call_first.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_first.wat
@@ -11,13 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -31,13 +31,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8757000000         	ja	0x75
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f875a000000         	ja	0x75
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b901000000           	mov	ecx, 1

--- a/winch/filetests/filetests/x64/br_if/as_call_last.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_last.wat
@@ -11,13 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -31,13 +31,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8757000000         	ja	0x75
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f875a000000         	ja	0x75
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b901000000           	mov	ecx, 1

--- a/winch/filetests/filetests/x64/br_if/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/br_if/as_call_mid.wat
@@ -11,13 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -31,13 +31,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8757000000         	ja	0x75
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f875a000000         	ja	0x75
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b901000000           	mov	ecx, 1

--- a/winch/filetests/filetests/x64/br_if/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/br_if/as_if_cond.wat
@@ -12,13 +12,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x5e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/br_if/as_if_else.wat
+++ b/winch/filetests/filetests/x64/br_if/as_if_else.wat
@@ -10,13 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -26,13 +26,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874f000000         	ja	0x6d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8752000000         	ja	0x6d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/br_if/as_if_then.wat
+++ b/winch/filetests/filetests/x64/br_if/as_if_then.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -25,13 +25,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874f000000         	ja	0x6d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8752000000         	ja	0x6d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
+++ b/winch/filetests/filetests/x64/br_if/as_local_set_value.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x5a
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873f000000         	ja	0x5a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/br_if/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/br_if/as_loop_last.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -23,13 +23,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x5a
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873f000000         	ja	0x5a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/br_if/with_machine_stack_entry.wat
+++ b/winch/filetests/filetests/x64/br_if/with_machine_stack_entry.wat
@@ -13,13 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8757000000         	ja	0x75
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f875a000000         	ja	0x75
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14
@@ -46,13 +46,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/br_table/ensure_sp_state.wat
+++ b/winch/filetests/filetests/x64/br_table/ensure_sp_state.wat
@@ -12,13 +12,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874c000000         	ja	0x6a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f874f000000         	ja	0x6a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b800000000           	mov	eax, 0

--- a/winch/filetests/filetests/x64/br_table/large.wat
+++ b/winch/filetests/filetests/x64/br_table/large.wat
@@ -739,13 +739,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87e6800100         	ja	0x18104
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f87e9800100         	ja	0x18104
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/br_table/nested_br_table_loop_block.wat
+++ b/winch/filetests/filetests/x64/br_table/nested_br_table_loop_block.wat
@@ -19,13 +19,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8781000000         	ja	0x9f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8784000000         	ja	0x9f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/br_table/stack_handling.wat
+++ b/winch/filetests/filetests/x64/br_table/stack_handling.wat
@@ -12,13 +12,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c31c000000       	add	r11, 0x1c
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8763000000         	ja	0x81
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8766000000         	ja	0x81
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/call/params.wat
+++ b/winch/filetests/filetests/x64/call/params.wat
@@ -37,13 +37,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c350000000       	add	r11, 0x50
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734010000         	ja	0x152
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8737010000         	ja	0x152
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx
@@ -119,13 +119,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8755000000         	ja	0x73
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8758000000         	ja	0x73
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx

--- a/winch/filetests/filetests/x64/call/recursive.wat
+++ b/winch/filetests/filetests/x64/call/recursive.wat
@@ -24,13 +24,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f879e000000         	ja	0xbc
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f87a1000000         	ja	0xbc
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/call/reg_on_stack.wat
+++ b/winch/filetests/filetests/x64/call/reg_on_stack.wat
@@ -12,13 +12,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c324000000       	add	r11, 0x24
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8786000000         	ja	0xa4
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8789000000         	ja	0xa4
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/call/simple.wat
+++ b/winch/filetests/filetests/x64/call/simple.wat
@@ -15,13 +15,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876d000000         	ja	0x8b
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8770000000         	ja	0x8b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0
@@ -53,13 +53,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/call_indirect/call_indirect.wat
+++ b/winch/filetests/filetests/x64/call_indirect/call_indirect.wat
@@ -31,13 +31,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c330000000       	add	r11, 0x30
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87b4010000         	ja	0x1d2
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f87b7010000         	ja	0x1d2
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/call_indirect/local_arg.wat
+++ b/winch/filetests/filetests/x64/call_indirect/local_arg.wat
@@ -18,13 +18,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx
@@ -35,13 +35,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87cd000000         	ja	0xeb
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f87d0000000         	ja	0xeb
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_abs/f32_abs_const.wat
+++ b/winch/filetests/filetests/x64/f32_abs/f32_abs_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f32_abs/f32_abs_param.wat
+++ b/winch/filetests/filetests/x64/f32_abs/f32_abs_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_add/const.wat
+++ b/winch/filetests/filetests/x64/f32_add/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f32_add/locals.wat
+++ b/winch/filetests/filetests/x64/f32_add/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8749000000         	ja	0x67
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f874c000000         	ja	0x67
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_add/params.wat
+++ b/winch/filetests/filetests/x64/f32_add/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_ceil/f32_ceil_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_ceil/f32_ceil_const_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f100515000000     	movss	xmm0, dword ptr [rip + 0x15]

--- a/winch/filetests/filetests/x64/f32_ceil/f32_ceil_param.wat
+++ b/winch/filetests/filetests/x64/f32_ceil/f32_ceil_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874f000000         	ja	0x6d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8752000000         	ja	0x6d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_ceil/f32_ceil_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_ceil/f32_ceil_param_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_const/call_id.wat
+++ b/winch/filetests/filetests/x64/f32_const/call_id.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872b000000         	ja	0x49
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/f32_const/id.wat
+++ b/winch/filetests/filetests/x64/f32_const/id.wat
@@ -5,13 +5,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_convert_i32_s/const.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x3a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/f32_convert_i32_s/locals.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_convert_i32_s/params.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/f32_convert_i32_s/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_s/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872e000000         	ja	0x4c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8731000000         	ja	0x4c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/f32_convert_i32_u/const.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_u/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8748000000         	ja	0x66
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b901000000           	mov	ecx, 1

--- a/winch/filetests/filetests/x64/f32_convert_i32_u/locals.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_u/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8750000000         	ja	0x6e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8753000000         	ja	0x6e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_convert_i32_u/params.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_u/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874c000000         	ja	0x6a
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f874f000000         	ja	0x6a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/f32_convert_i32_u/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i32_u/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875a000000         	ja	0x78
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f875d000000         	ja	0x78
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b901000000           	mov	ecx, 1

--- a/winch/filetests/filetests/x64/f32_convert_i64_s/const.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/f32_convert_i64_s/locals.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_convert_i64_s/params.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/f32_convert_i64_s/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_s/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/f32_convert_i64_u/const.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_u/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8748000000         	ja	0x66
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c101000000       	mov	rcx, 1

--- a/winch/filetests/filetests/x64/f32_convert_i64_u/locals.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_u/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_convert_i64_u/params.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_u/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874a000000         	ja	0x68
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f874d000000         	ja	0x68
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/f32_convert_i64_u/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_convert_i64_u/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875a000000         	ja	0x78
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f875d000000         	ja	0x78
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c101000000       	mov	rcx, 1

--- a/winch/filetests/filetests/x64/f32_copysign/const.wat
+++ b/winch/filetests/filetests/x64/f32_copysign/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x5e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]

--- a/winch/filetests/filetests/x64/f32_copysign/locals.wat
+++ b/winch/filetests/filetests/x64/f32_copysign/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875f000000         	ja	0x7d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8762000000         	ja	0x7d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_copysign/params.wat
+++ b/winch/filetests/filetests/x64/f32_copysign/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x65
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f874a000000         	ja	0x65
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_demote_f64/const.wat
+++ b/winch/filetests/filetests/x64/f32_demote_f64/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10050d000000     	movsd	xmm0, qword ptr [rip + 0xd]

--- a/winch/filetests/filetests/x64/f32_demote_f64/locals.wat
+++ b/winch/filetests/filetests/x64/f32_demote_f64/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_demote_f64/params.wat
+++ b/winch/filetests/filetests/x64/f32_demote_f64/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8722000000         	ja	0x40
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f32_demote_f64/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_demote_f64/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f100525000000     	movsd	xmm0, qword ptr [rip + 0x25]

--- a/winch/filetests/filetests/x64/f32_div/const.wat
+++ b/winch/filetests/filetests/x64/f32_div/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f32_div/locals.wat
+++ b/winch/filetests/filetests/x64/f32_div/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8749000000         	ja	0x67
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f874c000000         	ja	0x67
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_div/params.wat
+++ b/winch/filetests/filetests/x64/f32_div/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_eq/const.wat
+++ b/winch/filetests/filetests/x64/f32_eq/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x5a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f873f000000         	ja	0x5a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]

--- a/winch/filetests/filetests/x64/f32_eq/locals.wat
+++ b/winch/filetests/filetests/x64/f32_eq/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875b000000         	ja	0x79
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f875e000000         	ja	0x79
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_eq/params.wat
+++ b/winch/filetests/filetests/x64/f32_eq/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8743000000         	ja	0x61
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_floor/f32_floor_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_floor/f32_floor_const_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f100515000000     	movss	xmm0, dword ptr [rip + 0x15]

--- a/winch/filetests/filetests/x64/f32_floor/f32_floor_param.wat
+++ b/winch/filetests/filetests/x64/f32_floor/f32_floor_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874f000000         	ja	0x6d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8752000000         	ja	0x6d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_floor/f32_floor_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_floor/f32_floor_param_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_ge/const.wat
+++ b/winch/filetests/filetests/x64/f32_ge/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x5a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f873f000000         	ja	0x5a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]

--- a/winch/filetests/filetests/x64/f32_ge/locals.wat
+++ b/winch/filetests/filetests/x64/f32_ge/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875b000000         	ja	0x79
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f875e000000         	ja	0x79
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_ge/params.wat
+++ b/winch/filetests/filetests/x64/f32_ge/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8743000000         	ja	0x61
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_gt/const.wat
+++ b/winch/filetests/filetests/x64/f32_gt/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x5a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f873f000000         	ja	0x5a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]

--- a/winch/filetests/filetests/x64/f32_gt/locals.wat
+++ b/winch/filetests/filetests/x64/f32_gt/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875b000000         	ja	0x79
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f875e000000         	ja	0x79
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_gt/params.wat
+++ b/winch/filetests/filetests/x64/f32_gt/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8743000000         	ja	0x61
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_le/const.wat
+++ b/winch/filetests/filetests/x64/f32_le/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f32_le/locals.wat
+++ b/winch/filetests/filetests/x64/f32_le/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_le/params.wat
+++ b/winch/filetests/filetests/x64/f32_le/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8736000000         	ja	0x54
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8739000000         	ja	0x54
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_lt/const.wat
+++ b/winch/filetests/filetests/x64/f32_lt/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f32_lt/locals.wat
+++ b/winch/filetests/filetests/x64/f32_lt/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_lt/params.wat
+++ b/winch/filetests/filetests/x64/f32_lt/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8736000000         	ja	0x54
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8739000000         	ja	0x54
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_max/const.wat
+++ b/winch/filetests/filetests/x64/f32_max/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874b000000         	ja	0x69
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f874e000000         	ja	0x69
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10053d000000     	movss	xmm0, dword ptr [rip + 0x3d]

--- a/winch/filetests/filetests/x64/f32_max/locals.wat
+++ b/winch/filetests/filetests/x64/f32_max/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876a000000         	ja	0x88
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f876d000000         	ja	0x88
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_max/params.wat
+++ b/winch/filetests/filetests/x64/f32_max/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8752000000         	ja	0x70
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8755000000         	ja	0x70
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_min/const.wat
+++ b/winch/filetests/filetests/x64/f32_min/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874b000000         	ja	0x69
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f874e000000         	ja	0x69
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10053d000000     	movss	xmm0, dword ptr [rip + 0x3d]

--- a/winch/filetests/filetests/x64/f32_min/locals.wat
+++ b/winch/filetests/filetests/x64/f32_min/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876a000000         	ja	0x88
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f876d000000         	ja	0x88
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_min/params.wat
+++ b/winch/filetests/filetests/x64/f32_min/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8752000000         	ja	0x70
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8755000000         	ja	0x70
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_mul/const.wat
+++ b/winch/filetests/filetests/x64/f32_mul/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f32_mul/locals.wat
+++ b/winch/filetests/filetests/x64/f32_mul/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8749000000         	ja	0x67
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f874c000000         	ja	0x67
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_mul/params.wat
+++ b/winch/filetests/filetests/x64/f32_mul/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_ne/const.wat
+++ b/winch/filetests/filetests/x64/f32_ne/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x5a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f873f000000         	ja	0x5a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10052d000000     	movss	xmm0, dword ptr [rip + 0x2d]

--- a/winch/filetests/filetests/x64/f32_ne/locals.wat
+++ b/winch/filetests/filetests/x64/f32_ne/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875b000000         	ja	0x79
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f875e000000         	ja	0x79
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_ne/params.wat
+++ b/winch/filetests/filetests/x64/f32_ne/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8743000000         	ja	0x61
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_nearest/f32_floor_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_nearest/f32_floor_const_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f100515000000     	movss	xmm0, dword ptr [rip + 0x15]

--- a/winch/filetests/filetests/x64/f32_nearest/f32_floor_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_nearest/f32_floor_param_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_nearest/f32_nearest_param.wat
+++ b/winch/filetests/filetests/x64/f32_nearest/f32_nearest_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874f000000         	ja	0x6d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8752000000         	ja	0x6d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_neg/f32_neg_const.wat
+++ b/winch/filetests/filetests/x64/f32_neg/f32_neg_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f32_neg/f32_neg_param.wat
+++ b/winch/filetests/filetests/x64/f32_neg/f32_neg_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_reinterpret_i32/const.wat
+++ b/winch/filetests/filetests/x64/f32_reinterpret_i32/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x3a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/f32_reinterpret_i32/locals.wat
+++ b/winch/filetests/filetests/x64/f32_reinterpret_i32/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_reinterpret_i32/params.wat
+++ b/winch/filetests/filetests/x64/f32_reinterpret_i32/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/f32_reinterpret_i32/ret_int.wat
+++ b/winch/filetests/filetests/x64/f32_reinterpret_i32/ret_int.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/f32_reinterpret_i32/spilled.wat
+++ b/winch/filetests/filetests/x64/f32_reinterpret_i32/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872e000000         	ja	0x4c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8731000000         	ja	0x4c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/f32_sqrt/f32_sqrt_const.wat
+++ b/winch/filetests/filetests/x64/f32_sqrt/f32_sqrt_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10050d000000     	movss	xmm0, dword ptr [rip + 0xd]

--- a/winch/filetests/filetests/x64/f32_sqrt/f32_sqrt_param.wat
+++ b/winch/filetests/filetests/x64/f32_sqrt/f32_sqrt_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_sub/const.wat
+++ b/winch/filetests/filetests/x64/f32_sub/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f32_sub/locals.wat
+++ b/winch/filetests/filetests/x64/f32_sub/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8749000000         	ja	0x67
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f874c000000         	ja	0x67
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f32_sub/params.wat
+++ b/winch/filetests/filetests/x64/f32_sub/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_trunc/f32_trunc_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_trunc/f32_trunc_const_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f100515000000     	movss	xmm0, dword ptr [rip + 0x15]

--- a/winch/filetests/filetests/x64/f32_trunc/f32_trunc_param.wat
+++ b/winch/filetests/filetests/x64/f32_trunc/f32_trunc_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874f000000         	ja	0x6d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8752000000         	ja	0x6d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f32_trunc/f32_trunc_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f32_trunc/f32_trunc_param_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f64_abs/f64_abs_const.wat
+++ b/winch/filetests/filetests/x64/f64_abs/f64_abs_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f64_abs/f64_abs_param.wat
+++ b/winch/filetests/filetests/x64/f64_abs/f64_abs_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8732000000         	ja	0x50
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f64_add/const.wat
+++ b/winch/filetests/filetests/x64/f64_add/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872b000000         	ja	0x49
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f64_add/locals.wat
+++ b/winch/filetests/filetests/x64/f64_add/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_add/params.wat
+++ b/winch/filetests/filetests/x64/f64_add/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8732000000         	ja	0x50
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_ceil/f64_ceil_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_ceil/f64_ceil_const_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f100515000000     	movsd	xmm0, qword ptr [rip + 0x15]

--- a/winch/filetests/filetests/x64/f64_ceil/f64_ceil_param.wat
+++ b/winch/filetests/filetests/x64/f64_ceil/f64_ceil_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8744000000         	ja	0x62
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8747000000         	ja	0x62
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f64_ceil/f64_ceil_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_ceil/f64_ceil_param_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f64_const/call_id.wat
+++ b/winch/filetests/filetests/x64/f64_const/call_id.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872b000000         	ja	0x49
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/f64_const/id.wat
+++ b/winch/filetests/filetests/x64/f64_const/id.wat
@@ -5,13 +5,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f64_convert_i32_s/const.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x3a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/f64_convert_i32_s/locals.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f64_convert_i32_s/params.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/f64_convert_i32_s/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_s/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872e000000         	ja	0x4c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8731000000         	ja	0x4c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/f64_convert_i32_u/const.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_u/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8748000000         	ja	0x66
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b901000000           	mov	ecx, 1

--- a/winch/filetests/filetests/x64/f64_convert_i32_u/locals.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_u/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8750000000         	ja	0x6e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8753000000         	ja	0x6e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f64_convert_i32_u/params.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_u/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874c000000         	ja	0x6a
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f874f000000         	ja	0x6a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/f64_convert_i32_u/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i32_u/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875a000000         	ja	0x78
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f875d000000         	ja	0x78
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b901000000           	mov	ecx, 1

--- a/winch/filetests/filetests/x64/f64_convert_i64_s/const.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/f64_convert_i64_s/locals.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f64_convert_i64_s/params.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/f64_convert_i64_s/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_s/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/f64_convert_i64_u/const.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_u/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8748000000         	ja	0x66
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f874b000000         	ja	0x66
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c101000000       	mov	rcx, 1

--- a/winch/filetests/filetests/x64/f64_convert_i64_u/locals.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_u/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f64_convert_i64_u/params.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_u/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874a000000         	ja	0x68
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f874d000000         	ja	0x68
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/f64_convert_i64_u/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_convert_i64_u/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875a000000         	ja	0x78
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f875d000000         	ja	0x78
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c101000000       	mov	rcx, 1

--- a/winch/filetests/filetests/x64/f64_copysign/const.wat
+++ b/winch/filetests/filetests/x64/f64_copysign/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8749000000         	ja	0x67
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f874c000000         	ja	0x67
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10053d000000     	movsd	xmm0, qword ptr [rip + 0x3d]

--- a/winch/filetests/filetests/x64/f64_copysign/locals.wat
+++ b/winch/filetests/filetests/x64/f64_copysign/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876c000000         	ja	0x8a
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f876f000000         	ja	0x8a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_copysign/params.wat
+++ b/winch/filetests/filetests/x64/f64_copysign/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8750000000         	ja	0x6e
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8753000000         	ja	0x6e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_div/const.wat
+++ b/winch/filetests/filetests/x64/f64_div/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872b000000         	ja	0x49
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f64_div/locals.wat
+++ b/winch/filetests/filetests/x64/f64_div/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_div/params.wat
+++ b/winch/filetests/filetests/x64/f64_div/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8732000000         	ja	0x50
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_eq/const.wat
+++ b/winch/filetests/filetests/x64/f64_eq/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873d000000         	ja	0x5b
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10052d000000     	movsd	xmm0, qword ptr [rip + 0x2d]

--- a/winch/filetests/filetests/x64/f64_eq/locals.wat
+++ b/winch/filetests/filetests/x64/f64_eq/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8760000000         	ja	0x7e
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8763000000         	ja	0x7e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_eq/params.wat
+++ b/winch/filetests/filetests/x64/f64_eq/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8744000000         	ja	0x62
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8747000000         	ja	0x62
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_floor/f64_floor_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_floor/f64_floor_const_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f100515000000     	movsd	xmm0, qword ptr [rip + 0x15]

--- a/winch/filetests/filetests/x64/f64_floor/f64_floor_param.wat
+++ b/winch/filetests/filetests/x64/f64_floor/f64_floor_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8744000000         	ja	0x62
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8747000000         	ja	0x62
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f64_floor/f64_floor_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_floor/f64_floor_param_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f64_ge/const.wat
+++ b/winch/filetests/filetests/x64/f64_ge/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873d000000         	ja	0x5b
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10052d000000     	movsd	xmm0, qword ptr [rip + 0x2d]

--- a/winch/filetests/filetests/x64/f64_ge/locals.wat
+++ b/winch/filetests/filetests/x64/f64_ge/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8760000000         	ja	0x7e
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8763000000         	ja	0x7e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_ge/params.wat
+++ b/winch/filetests/filetests/x64/f64_ge/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8744000000         	ja	0x62
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8747000000         	ja	0x62
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_gt/const.wat
+++ b/winch/filetests/filetests/x64/f64_gt/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873d000000         	ja	0x5b
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10052d000000     	movsd	xmm0, qword ptr [rip + 0x2d]

--- a/winch/filetests/filetests/x64/f64_gt/locals.wat
+++ b/winch/filetests/filetests/x64/f64_gt/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8760000000         	ja	0x7e
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8763000000         	ja	0x7e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_gt/params.wat
+++ b/winch/filetests/filetests/x64/f64_gt/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8744000000         	ja	0x62
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8747000000         	ja	0x62
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_le/const.wat
+++ b/winch/filetests/filetests/x64/f64_le/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f64_le/locals.wat
+++ b/winch/filetests/filetests/x64/f64_le/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8753000000         	ja	0x71
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8756000000         	ja	0x71
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_le/params.wat
+++ b/winch/filetests/filetests/x64/f64_le/params.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8753000000         	ja	0x71
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8756000000         	ja	0x71
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_lt/const.wat
+++ b/winch/filetests/filetests/x64/f64_lt/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f64_lt/locals.wat
+++ b/winch/filetests/filetests/x64/f64_lt/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8753000000         	ja	0x71
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8756000000         	ja	0x71
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_lt/params.wat
+++ b/winch/filetests/filetests/x64/f64_lt/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8737000000         	ja	0x55
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f873a000000         	ja	0x55
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_max/const.wat
+++ b/winch/filetests/filetests/x64/f64_max/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10053d000000     	movsd	xmm0, qword ptr [rip + 0x3d]

--- a/winch/filetests/filetests/x64/f64_max/locals.wat
+++ b/winch/filetests/filetests/x64/f64_max/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8771000000         	ja	0x8f
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8774000000         	ja	0x8f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_max/params.wat
+++ b/winch/filetests/filetests/x64/f64_max/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8755000000         	ja	0x73
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8758000000         	ja	0x73
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_min/const.wat
+++ b/winch/filetests/filetests/x64/f64_min/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10053d000000     	movsd	xmm0, qword ptr [rip + 0x3d]

--- a/winch/filetests/filetests/x64/f64_min/locals.wat
+++ b/winch/filetests/filetests/x64/f64_min/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8771000000         	ja	0x8f
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8774000000         	ja	0x8f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_min/params.wat
+++ b/winch/filetests/filetests/x64/f64_min/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8755000000         	ja	0x73
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8758000000         	ja	0x73
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_mul/const.wat
+++ b/winch/filetests/filetests/x64/f64_mul/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872b000000         	ja	0x49
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f64_mul/locals.wat
+++ b/winch/filetests/filetests/x64/f64_mul/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_mul/params.wat
+++ b/winch/filetests/filetests/x64/f64_mul/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8732000000         	ja	0x50
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_ne/const.wat
+++ b/winch/filetests/filetests/x64/f64_ne/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873d000000         	ja	0x5b
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10052d000000     	movsd	xmm0, qword ptr [rip + 0x2d]

--- a/winch/filetests/filetests/x64/f64_ne/locals.wat
+++ b/winch/filetests/filetests/x64/f64_ne/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8760000000         	ja	0x7e
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8763000000         	ja	0x7e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_ne/params.wat
+++ b/winch/filetests/filetests/x64/f64_ne/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8744000000         	ja	0x62
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8747000000         	ja	0x62
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_nearest/f64_nearest_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_nearest/f64_nearest_const_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f100515000000     	movsd	xmm0, qword ptr [rip + 0x15]

--- a/winch/filetests/filetests/x64/f64_nearest/f64_nearest_param.wat
+++ b/winch/filetests/filetests/x64/f64_nearest/f64_nearest_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8744000000         	ja	0x62
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8747000000         	ja	0x62
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f64_nearest/f64_nearest_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_nearest/f64_nearest_param_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f64_neg/f64_neg_const.wat
+++ b/winch/filetests/filetests/x64/f64_neg/f64_neg_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f64_neg/f64_neg_param.wat
+++ b/winch/filetests/filetests/x64/f64_neg/f64_neg_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8732000000         	ja	0x50
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f64_promote_f32/const.wat
+++ b/winch/filetests/filetests/x64/f64_promote_f32/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10050d000000     	movss	xmm0, dword ptr [rip + 0xd]

--- a/winch/filetests/filetests/x64/f64_promote_f32/locals.wat
+++ b/winch/filetests/filetests/x64/f64_promote_f32/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f64_promote_f32/params.wat
+++ b/winch/filetests/filetests/x64/f64_promote_f32/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/f64_promote_f32/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_promote_f32/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f100525000000     	movss	xmm0, dword ptr [rip + 0x25]

--- a/winch/filetests/filetests/x64/f64_reinterpret_i64/const.wat
+++ b/winch/filetests/filetests/x64/f64_reinterpret_i64/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/f64_reinterpret_i64/locals.wat
+++ b/winch/filetests/filetests/x64/f64_reinterpret_i64/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/f64_reinterpret_i64/params.wat
+++ b/winch/filetests/filetests/x64/f64_reinterpret_i64/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/f64_reinterpret_i64/ret_int.wat
+++ b/winch/filetests/filetests/x64/f64_reinterpret_i64/ret_int.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/f64_reinterpret_i64/spilled.wat
+++ b/winch/filetests/filetests/x64/f64_reinterpret_i64/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/f64_sqrt/f64_sqrt_const.wat
+++ b/winch/filetests/filetests/x64/f64_sqrt/f64_sqrt_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10050d000000     	movsd	xmm0, qword ptr [rip + 0xd]

--- a/winch/filetests/filetests/x64/f64_sqrt/f64_sqrt_param.wat
+++ b/winch/filetests/filetests/x64/f64_sqrt/f64_sqrt_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8722000000         	ja	0x40
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f64_sub/const.wat
+++ b/winch/filetests/filetests/x64/f64_sub/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872b000000         	ja	0x49
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/f64_sub/locals.wat
+++ b/winch/filetests/filetests/x64/f64_sub/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/f64_sub/params.wat
+++ b/winch/filetests/filetests/x64/f64_sub/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8732000000         	ja	0x50
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f20f11442408         	movsd	qword ptr [rsp + 8], xmm0

--- a/winch/filetests/filetests/x64/f64_trunc/f64_trunc_const_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_trunc/f64_trunc_const_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f100515000000     	movsd	xmm0, qword ptr [rip + 0x15]

--- a/winch/filetests/filetests/x64/f64_trunc/f64_trunc_param.wat
+++ b/winch/filetests/filetests/x64/f64_trunc/f64_trunc_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8744000000         	ja	0x62
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8747000000         	ja	0x62
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/f64_trunc/f64_trunc_param_sse41.wat
+++ b/winch/filetests/filetests/x64/f64_trunc/f64_trunc_param_sse41.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/i32_add/const.wat
+++ b/winch/filetests/filetests/x64/i32_add/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b80a000000           	mov	eax, 0xa

--- a/winch/filetests/filetests/x64/i32_add/locals.wat
+++ b/winch/filetests/filetests/x64/i32_add/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x56
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_add/max.wat
+++ b/winch/filetests/filetests/x64/i32_add/max.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b8ffffff7f           	mov	eax, 0x7fffffff

--- a/winch/filetests/filetests/x64/i32_add/max_one.wat
+++ b/winch/filetests/filetests/x64/i32_add/max_one.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b800000080           	mov	eax, 0x80000000

--- a/winch/filetests/filetests/x64/i32_add/mixed.wat
+++ b/winch/filetests/filetests/x64/i32_add/mixed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff

--- a/winch/filetests/filetests/x64/i32_add/params.wat
+++ b/winch/filetests/filetests/x64/i32_add/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_add/signed.wat
+++ b/winch/filetests/filetests/x64/i32_add/signed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff

--- a/winch/filetests/filetests/x64/i32_add/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i32_add/unsigned_with_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_and/const.wat
+++ b/winch/filetests/filetests/x64/i32_and/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_and/locals.wat
+++ b/winch/filetests/filetests/x64/i32_and/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x56
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_and/params.wat
+++ b/winch/filetests/filetests/x64/i32_and/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_clz/lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i32_clz/lzcnt_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x3a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_clz/lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i32_clz/lzcnt_local.wat
@@ -14,13 +14,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872d000000         	ja	0x4b
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_clz/lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i32_clz/lzcnt_param.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_clz/no_lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i32_clz/no_lzcnt_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872d000000         	ja	0x4b
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_clz/no_lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i32_clz/no_lzcnt_local.wat
@@ -13,13 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873e000000         	ja	0x5c
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8741000000         	ja	0x5c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_clz/no_lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i32_clz/no_lzcnt_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_ctz/bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/bmi1_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x3a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_ctz/bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/bmi1_local.wat
@@ -15,13 +15,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872d000000         	ja	0x4b
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_ctz/bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/bmi1_param.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_ctz/no_bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/no_bmi1_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x4a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872f000000         	ja	0x4a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_ctz/no_bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/no_bmi1_local.wat
@@ -13,13 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873d000000         	ja	0x5b
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_ctz/no_bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i32_ctz/no_bmi1_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_divs/const.wat
+++ b/winch/filetests/filetests/x64/i32_divs/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x47
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b90a000000           	mov	ecx, 0xa

--- a/winch/filetests/filetests/x64/i32_divs/one_zero.wat
+++ b/winch/filetests/filetests/x64/i32_divs/one_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x47
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b900000000           	mov	ecx, 0

--- a/winch/filetests/filetests/x64/i32_divs/overflow.wat
+++ b/winch/filetests/filetests/x64/i32_divs/overflow.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x47
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b9ffffffff           	mov	ecx, 0xffffffff

--- a/winch/filetests/filetests/x64/i32_divs/params.wat
+++ b/winch/filetests/filetests/x64/i32_divs/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872e000000         	ja	0x4c
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8731000000         	ja	0x4c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_divs/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i32_divs/zero_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x47
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b900000000           	mov	ecx, 0

--- a/winch/filetests/filetests/x64/i32_divu/const.wat
+++ b/winch/filetests/filetests/x64/i32_divu/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b90a000000           	mov	ecx, 0xa

--- a/winch/filetests/filetests/x64/i32_divu/one_zero.wat
+++ b/winch/filetests/filetests/x64/i32_divu/one_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b900000000           	mov	ecx, 0

--- a/winch/filetests/filetests/x64/i32_divu/params.wat
+++ b/winch/filetests/filetests/x64/i32_divu/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_divu/signed.wat
+++ b/winch/filetests/filetests/x64/i32_divu/signed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b9ffffffff           	mov	ecx, 0xffffffff

--- a/winch/filetests/filetests/x64/i32_divu/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i32_divu/zero_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b900000000           	mov	ecx, 0

--- a/winch/filetests/filetests/x64/i32_eq/const.wat
+++ b/winch/filetests/filetests/x64/i32_eq/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/i32_eq/locals.wat
+++ b/winch/filetests/filetests/x64/i32_eq/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_eq/params.wat
+++ b/winch/filetests/filetests/x64/i32_eq/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_eqz/const.wat
+++ b/winch/filetests/filetests/x64/i32_eqz/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_eqz/local.wat
+++ b/winch/filetests/filetests/x64/i32_eqz/local.wat
@@ -13,13 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8735000000         	ja	0x53
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_eqz/param.wat
+++ b/winch/filetests/filetests/x64/i32_eqz/param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_extend_16_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_extend_16_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_extend_16_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_extend_16_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_extend_16_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_extend_16_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_extend_8_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_extend_8_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_extend_8_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_extend_8_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_extend_8_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_extend_8_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_ge_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_ge_s/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/i32_ge_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ge_s/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_ge_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_ge_s/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_ge_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_ge_u/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/i32_ge_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ge_u/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_ge_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_ge_u/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_gt_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_gt_s/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/i32_gt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_gt_s/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_gt_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_gt_s/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_gt_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_gt_u/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/i32_gt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_gt_u/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_gt_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_gt_u/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_le_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_le_s/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/i32_le_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_le_s/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_le_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_le_s/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_le_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_le_u/const.wat
@@ -10,13 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/i32_le_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_le_u/locals.wat
@@ -18,13 +18,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_le_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_le_u/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_lt_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_lt_s/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/i32_lt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_lt_s/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_lt_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_lt_s/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_lt_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_lt_u/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/i32_lt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_lt_u/locals.wat
@@ -18,13 +18,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_lt_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_lt_u/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_mul/const.wat
+++ b/winch/filetests/filetests/x64/i32_mul/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b80a000000           	mov	eax, 0xa

--- a/winch/filetests/filetests/x64/i32_mul/locals.wat
+++ b/winch/filetests/filetests/x64/i32_mul/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8739000000         	ja	0x57
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873c000000         	ja	0x57
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_mul/max.wat
+++ b/winch/filetests/filetests/x64/i32_mul/max.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b8ffffff7f           	mov	eax, 0x7fffffff

--- a/winch/filetests/filetests/x64/i32_mul/max_one.wat
+++ b/winch/filetests/filetests/x64/i32_mul/max_one.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b800000080           	mov	eax, 0x80000000

--- a/winch/filetests/filetests/x64/i32_mul/mixed.wat
+++ b/winch/filetests/filetests/x64/i32_mul/mixed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff

--- a/winch/filetests/filetests/x64/i32_mul/params.wat
+++ b/winch/filetests/filetests/x64/i32_mul/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_mul/signed.wat
+++ b/winch/filetests/filetests/x64/i32_mul/signed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff

--- a/winch/filetests/filetests/x64/i32_mul/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i32_mul/unsigned_with_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_ne/const.wat
+++ b/winch/filetests/filetests/x64/i32_ne/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/i32_ne/locals.wat
+++ b/winch/filetests/filetests/x64/i32_ne/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_ne/params.wat
+++ b/winch/filetests/filetests/x64/i32_ne/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_or/const.wat
+++ b/winch/filetests/filetests/x64/i32_or/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_or/locals.wat
+++ b/winch/filetests/filetests/x64/i32_or/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x56
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_or/params.wat
+++ b/winch/filetests/filetests/x64/i32_or/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_popcnt/const.wat
+++ b/winch/filetests/filetests/x64/i32_popcnt/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x3a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b803000000           	mov	eax, 3

--- a/winch/filetests/filetests/x64/i32_popcnt/fallback.wat
+++ b/winch/filetests/filetests/x64/i32_popcnt/fallback.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b80f000000           	mov	eax, 0xf

--- a/winch/filetests/filetests/x64/i32_popcnt/no_sse42.wat
+++ b/winch/filetests/filetests/x64/i32_popcnt/no_sse42.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b803000000           	mov	eax, 3

--- a/winch/filetests/filetests/x64/i32_popcnt/reg.wat
+++ b/winch/filetests/filetests/x64/i32_popcnt/reg.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_reinterpret_f32/const.wat
+++ b/winch/filetests/filetests/x64/i32_reinterpret_f32/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10050d000000     	movss	xmm0, dword ptr [rip + 0xd]

--- a/winch/filetests/filetests/x64/i32_reinterpret_f32/locals.wat
+++ b/winch/filetests/filetests/x64/i32_reinterpret_f32/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_reinterpret_f32/params.wat
+++ b/winch/filetests/filetests/x64/i32_reinterpret_f32/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/i32_reinterpret_f32/ret_float.wat
+++ b/winch/filetests/filetests/x64/i32_reinterpret_f32/ret_float.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f100515000000     	movss	xmm0, dword ptr [rip + 0x15]

--- a/winch/filetests/filetests/x64/i32_rems/const.wat
+++ b/winch/filetests/filetests/x64/i32_rems/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8735000000         	ja	0x53
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b905000000           	mov	ecx, 5

--- a/winch/filetests/filetests/x64/i32_rems/one_zero.wat
+++ b/winch/filetests/filetests/x64/i32_rems/one_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8735000000         	ja	0x53
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b900000000           	mov	ecx, 0

--- a/winch/filetests/filetests/x64/i32_rems/overflow.wat
+++ b/winch/filetests/filetests/x64/i32_rems/overflow.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8735000000         	ja	0x53
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b9ffffffff           	mov	ecx, 0xffffffff

--- a/winch/filetests/filetests/x64/i32_rems/params.wat
+++ b/winch/filetests/filetests/x64/i32_rems/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x58
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873d000000         	ja	0x58
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_rems/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i32_rems/zero_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8735000000         	ja	0x53
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b900000000           	mov	ecx, 0

--- a/winch/filetests/filetests/x64/i32_remu/const.wat
+++ b/winch/filetests/filetests/x64/i32_remu/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b905000000           	mov	ecx, 5

--- a/winch/filetests/filetests/x64/i32_remu/one_zero.wat
+++ b/winch/filetests/filetests/x64/i32_remu/one_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b900000000           	mov	ecx, 0

--- a/winch/filetests/filetests/x64/i32_remu/params.wat
+++ b/winch/filetests/filetests/x64/i32_remu/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_remu/signed.wat
+++ b/winch/filetests/filetests/x64/i32_remu/signed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b9ffffffff           	mov	ecx, 0xffffffff

--- a/winch/filetests/filetests/x64/i32_remu/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i32_remu/zero_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b900000000           	mov	ecx, 0

--- a/winch/filetests/filetests/x64/i32_rotl/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/16_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_rotl/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/8_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_rotl/locals.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8736000000         	ja	0x54
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8739000000         	ja	0x54
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_rotl/params.wat
+++ b/winch/filetests/filetests/x64/i32_rotl/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_rotr/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/16_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_rotr/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/8_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_rotr/locals.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8736000000         	ja	0x54
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8739000000         	ja	0x54
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_rotr/params.wat
+++ b/winch/filetests/filetests/x64/i32_rotr/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_shl/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_shl/16_const.wat
@@ -10,13 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_shl/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_shl/8_const.wat
@@ -10,13 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_shl/locals.wat
+++ b/winch/filetests/filetests/x64/i32_shl/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8736000000         	ja	0x54
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8739000000         	ja	0x54
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_shl/params.wat
+++ b/winch/filetests/filetests/x64/i32_shl/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_shr_s/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/16_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_shr_s/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/8_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_shr_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8736000000         	ja	0x54
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8739000000         	ja	0x54
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_shr_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_shr_s/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_shr_u/16_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/16_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_shr_u/8_const.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/8_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_shr_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8736000000         	ja	0x54
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8739000000         	ja	0x54
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_shr_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_shr_u/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_sub/const.wat
+++ b/winch/filetests/filetests/x64/i32_sub/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b80a000000           	mov	eax, 0xa

--- a/winch/filetests/filetests/x64/i32_sub/locals.wat
+++ b/winch/filetests/filetests/x64/i32_sub/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x56
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_sub/max.wat
+++ b/winch/filetests/filetests/x64/i32_sub/max.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b8ffffff7f           	mov	eax, 0x7fffffff

--- a/winch/filetests/filetests/x64/i32_sub/max_one.wat
+++ b/winch/filetests/filetests/x64/i32_sub/max_one.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b800000080           	mov	eax, 0x80000000

--- a/winch/filetests/filetests/x64/i32_sub/mixed.wat
+++ b/winch/filetests/filetests/x64/i32_sub/mixed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff

--- a/winch/filetests/filetests/x64/i32_sub/params.wat
+++ b/winch/filetests/filetests/x64/i32_sub/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i32_sub/signed.wat
+++ b/winch/filetests/filetests/x64/i32_sub/signed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b8ffffffff           	mov	eax, 0xffffffff

--- a/winch/filetests/filetests/x64/i32_sub/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i32_sub/unsigned_with_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_trunc_f32_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8755000000         	ja	0x73
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8758000000         	ja	0x73
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10054d000000     	movss	xmm0, dword ptr [rip + 0x4d]

--- a/winch/filetests/filetests/x64/i32_trunc_f32_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875c000000         	ja	0x7a
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f875f000000         	ja	0x7a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_trunc_f32_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875a000000         	ja	0x78
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f875d000000         	ja	0x78
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/i32_trunc_f32_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_u/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8760000000         	ja	0x7e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8763000000         	ja	0x7e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f100d55000000     	movss	xmm1, dword ptr [rip + 0x55]

--- a/winch/filetests/filetests/x64/i32_trunc_f32_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_u/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8767000000         	ja	0x85
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f876a000000         	ja	0x85
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_trunc_f32_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f32_u/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8765000000         	ja	0x83
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8768000000         	ja	0x83
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/i32_trunc_f64_s/const.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875c000000         	ja	0x7a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f875f000000         	ja	0x7a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f100555000000     	movsd	xmm0, qword ptr [rip + 0x55]

--- a/winch/filetests/filetests/x64/i32_trunc_f64_s/locals.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8762000000         	ja	0x80
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8765000000         	ja	0x80
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_trunc_f64_s/params.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875f000000         	ja	0x7d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8762000000         	ja	0x7d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/i32_trunc_f64_u/const.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_u/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8765000000         	ja	0x83
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8768000000         	ja	0x83
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f100d5d000000     	movsd	xmm1, qword ptr [rip + 0x5d]

--- a/winch/filetests/filetests/x64/i32_trunc_f64_u/locals.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_u/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876b000000         	ja	0x89
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f876e000000         	ja	0x89
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_trunc_f64_u/params.wat
+++ b/winch/filetests/filetests/x64/i32_trunc_f64_u/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8768000000         	ja	0x86
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f876b000000         	ja	0x86
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/i32_wrap_i64/const.wat
+++ b/winch/filetests/filetests/x64/i32_wrap_i64/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x3a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i32_wrap_i64/locals.wat
+++ b/winch/filetests/filetests/x64/i32_wrap_i64/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8722000000         	ja	0x40
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_wrap_i64/params.wat
+++ b/winch/filetests/filetests/x64/i32_wrap_i64/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/i32_wrap_i64/spilled.wat
+++ b/winch/filetests/filetests/x64/i32_wrap_i64/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i32_xor/const.wat
+++ b/winch/filetests/filetests/x64/i32_xor/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i32_xor/locals.wat
+++ b/winch/filetests/filetests/x64/i32_xor/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x56
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i32_xor/params.wat
+++ b/winch/filetests/filetests/x64/i32_xor/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i64_add/const.wat
+++ b/winch/filetests/filetests/x64/i64_add/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c00a000000       	mov	rax, 0xa

--- a/winch/filetests/filetests/x64/i64_add/locals.wat
+++ b/winch/filetests/filetests/x64/i64_add/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8746000000         	ja	0x64
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8749000000         	ja	0x64
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_add/max.wat
+++ b/winch/filetests/filetests/x64/i64_add/max.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_add/max_one.wat
+++ b/winch/filetests/filetests/x64/i64_add/max_one.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b80000000000000080 	

--- a/winch/filetests/filetests/x64/i64_add/mixed.wat
+++ b/winch/filetests/filetests/x64/i64_add/mixed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff

--- a/winch/filetests/filetests/x64/i64_add/params.wat
+++ b/winch/filetests/filetests/x64/i64_add/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x4a
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f872f000000         	ja	0x4a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_add/signed.wat
+++ b/winch/filetests/filetests/x64/i64_add/signed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff

--- a/winch/filetests/filetests/x64/i64_add/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i64_add/unsigned_with_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_and/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_and/32_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_and/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_and/64_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_and/locals.wat
+++ b/winch/filetests/filetests/x64/i64_and/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8746000000         	ja	0x64
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8749000000         	ja	0x64
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_and/params.wat
+++ b/winch/filetests/filetests/x64/i64_and/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x4a
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f872f000000         	ja	0x4a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_clz/lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i64_clz/lzcnt_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_clz/lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i64_clz/lzcnt_local.wat
@@ -14,13 +14,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_clz/lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i64_clz/lzcnt_param.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/i64_clz/no_lzcnt_const.wat
+++ b/winch/filetests/filetests/x64/i64_clz/no_lzcnt_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8732000000         	ja	0x50
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8735000000         	ja	0x50
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_clz/no_lzcnt_local.wat
+++ b/winch/filetests/filetests/x64/i64_clz/no_lzcnt_local.wat
@@ -13,13 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8743000000         	ja	0x61
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_clz/no_lzcnt_param.wat
+++ b/winch/filetests/filetests/x64/i64_clz/no_lzcnt_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/i64_ctz/bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/bmi1_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_ctz/bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/bmi1_local.wat
@@ -14,13 +14,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_ctz/bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/bmi1_param.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/i64_ctz/no_bmi1_const.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/no_bmi1_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_ctz/no_bmi1_local.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/no_bmi1_local.wat
@@ -13,13 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x5e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_ctz/no_bmi1_param.wat
+++ b/winch/filetests/filetests/x64/i64_ctz/no_bmi1_param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/i64_divs/const.wat
+++ b/winch/filetests/filetests/x64/i64_divs/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c10a000000       	mov	rcx, 0xa

--- a/winch/filetests/filetests/x64/i64_divs/one_zero.wat
+++ b/winch/filetests/filetests/x64/i64_divs/one_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c100000000       	mov	rcx, 0

--- a/winch/filetests/filetests/x64/i64_divs/overflow.wat
+++ b/winch/filetests/filetests/x64/i64_divs/overflow.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c1ffffffff       	mov	rcx, 0xffffffffffffffff

--- a/winch/filetests/filetests/x64/i64_divs/params.wat
+++ b/winch/filetests/filetests/x64/i64_divs/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8735000000         	ja	0x53
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_divs/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i64_divs/zero_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c100000000       	mov	rcx, 0

--- a/winch/filetests/filetests/x64/i64_divu/const.wat
+++ b/winch/filetests/filetests/x64/i64_divu/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c10a000000       	mov	rcx, 0xa

--- a/winch/filetests/filetests/x64/i64_divu/one_zero.wat
+++ b/winch/filetests/filetests/x64/i64_divu/one_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c100000000       	mov	rcx, 0

--- a/winch/filetests/filetests/x64/i64_divu/params.wat
+++ b/winch/filetests/filetests/x64/i64_divu/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x4a
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f872f000000         	ja	0x4a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_divu/signed.wat
+++ b/winch/filetests/filetests/x64/i64_divu/signed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c1ffffffff       	mov	rcx, 0xffffffffffffffff

--- a/winch/filetests/filetests/x64/i64_divu/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i64_divu/zero_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c100000000       	mov	rcx, 0

--- a/winch/filetests/filetests/x64/i64_eq/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_eq/32_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_eq/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_eq/64_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_eq/locals.wat
+++ b/winch/filetests/filetests/x64/i64_eq/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_eq/params.wat
+++ b/winch/filetests/filetests/x64/i64_eq/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_eqz/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_eqz/32_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_eqz/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_eqz/64_const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8ffffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_eqz/local.wat
+++ b/winch/filetests/filetests/x64/i64_eqz/local.wat
@@ -13,13 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x56
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_eqz/param.wat
+++ b/winch/filetests/filetests/x64/i64_eqz/param.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x47
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/i64_eqz/spilled.wat
+++ b/winch/filetests/filetests/x64/i64_eqz/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c314000000       	add	r11, 0x14
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8735000000         	ja	0x53
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_extend_16_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_extend_16_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_extend_16_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_extend_16_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_extend_16_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_extend_16_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/i64_extend_32_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_extend_32_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871d000000         	ja	0x3b
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_extend_32_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_extend_32_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_extend_32_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_extend_32_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/i64_extend_8_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_extend_8_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_extend_8_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_extend_8_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8724000000         	ja	0x42
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8727000000         	ja	0x42
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_extend_8_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_extend_8_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/i64_extend_i32_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871b000000         	ja	0x39
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871e000000         	ja	0x39
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i64_extend_i32_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_extend_i32_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i64_extend_i32_s/spilled.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_s/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871d000000         	ja	0x3b
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8720000000         	ja	0x3b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i64_extend_i32_u/const.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_u/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x38
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i64_extend_i32_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_u/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8722000000         	ja	0x40
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8725000000         	ja	0x40
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_extend_i32_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_u/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/i64_extend_i32_u/spilled.wat
+++ b/winch/filetests/filetests/x64/i64_extend_i32_u/spilled.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x3a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/i64_ge_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/32_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_ge_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/64_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_ge_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_ge_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_ge_s/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_ge_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/32_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_ge_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/64_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_ge_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_ge_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_ge_u/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_gt_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/32_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_gt_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/64_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_gt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_gt_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_gt_s/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_gt_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/32_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_gt_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/64_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_gt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_gt_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_gt_u/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_le_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/32_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_le_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/64_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_le_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_le_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_le_s/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_le_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/32_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_le_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/64_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_le_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_le_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_le_u/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_lt_s/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/32_const.wat
@@ -10,13 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_lt_s/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/64_const.wat
@@ -10,13 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_lt_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/locals.wat
@@ -18,13 +18,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_lt_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_lt_s/params.wat
@@ -10,13 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_lt_u/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/32_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_lt_u/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/64_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_lt_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_lt_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_lt_u/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_mul/const.wat
+++ b/winch/filetests/filetests/x64/i64_mul/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c00a000000       	mov	rax, 0xa

--- a/winch/filetests/filetests/x64/i64_mul/locals.wat
+++ b/winch/filetests/filetests/x64/i64_mul/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8747000000         	ja	0x65
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f874a000000         	ja	0x65
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_mul/max.wat
+++ b/winch/filetests/filetests/x64/i64_mul/max.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8ffffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_mul/max_one.wat
+++ b/winch/filetests/filetests/x64/i64_mul/max_one.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b80000000000000080 	

--- a/winch/filetests/filetests/x64/i64_mul/mixed.wat
+++ b/winch/filetests/filetests/x64/i64_mul/mixed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff

--- a/winch/filetests/filetests/x64/i64_mul/params.wat
+++ b/winch/filetests/filetests/x64/i64_mul/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872d000000         	ja	0x4b
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8730000000         	ja	0x4b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_mul/signed.wat
+++ b/winch/filetests/filetests/x64/i64_mul/signed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff

--- a/winch/filetests/filetests/x64/i64_mul/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i64_mul/unsigned_with_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_ne/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_ne/32_const.wat
@@ -10,13 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8727000000         	ja	0x45
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872a000000         	ja	0x45
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_ne/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_ne/64_const.wat
@@ -10,13 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_ne/locals.wat
+++ b/winch/filetests/filetests/x64/i64_ne/locals.wat
@@ -18,13 +18,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874e000000         	ja	0x6c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8751000000         	ja	0x6c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_ne/params.wat
+++ b/winch/filetests/filetests/x64/i64_ne/params.wat
@@ -10,13 +10,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_or/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_or/32_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_or/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_or/64_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_or/locals.wat
+++ b/winch/filetests/filetests/x64/i64_or/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8746000000         	ja	0x64
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8749000000         	ja	0x64
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_or/params.wat
+++ b/winch/filetests/filetests/x64/i64_or/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x4a
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f872f000000         	ja	0x4a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_popcnt/const.wat
+++ b/winch/filetests/filetests/x64/i64_popcnt/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871f000000         	ja	0x3d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8722000000         	ja	0x3d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c003000000       	mov	rax, 3

--- a/winch/filetests/filetests/x64/i64_popcnt/fallback.wat
+++ b/winch/filetests/filetests/x64/i64_popcnt/fallback.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8774000000         	ja	0x92
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8777000000         	ja	0x92
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c00f000000       	mov	rax, 0xf

--- a/winch/filetests/filetests/x64/i64_popcnt/no_sse42.wat
+++ b/winch/filetests/filetests/x64/i64_popcnt/no_sse42.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8774000000         	ja	0x92
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8777000000         	ja	0x92
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c003000000       	mov	rax, 3

--- a/winch/filetests/filetests/x64/i64_popcnt/reg.wat
+++ b/winch/filetests/filetests/x64/i64_popcnt/reg.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/i64_reinterpret_f64/const.wat
+++ b/winch/filetests/filetests/x64/i64_reinterpret_f64/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10050d000000     	movsd	xmm0, qword ptr [rip + 0xd]

--- a/winch/filetests/filetests/x64/i64_reinterpret_f64/locals.wat
+++ b/winch/filetests/filetests/x64/i64_reinterpret_f64/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_reinterpret_f64/params.wat
+++ b/winch/filetests/filetests/x64/i64_reinterpret_f64/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/i64_reinterpret_f64/ret_float.wat
+++ b/winch/filetests/filetests/x64/i64_reinterpret_f64/ret_float.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f100515000000     	movsd	xmm0, qword ptr [rip + 0x15]

--- a/winch/filetests/filetests/x64/i64_rems/const.wat
+++ b/winch/filetests/filetests/x64/i64_rems/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873d000000         	ja	0x5b
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c105000000       	mov	rcx, 5

--- a/winch/filetests/filetests/x64/i64_rems/one_zero.wat
+++ b/winch/filetests/filetests/x64/i64_rems/one_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873d000000         	ja	0x5b
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c100000000       	mov	rcx, 0

--- a/winch/filetests/filetests/x64/i64_rems/overflow.wat
+++ b/winch/filetests/filetests/x64/i64_rems/overflow.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8740000000         	ja	0x5e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8743000000         	ja	0x5e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c1ffffffff       	mov	rcx, 0xffffffffffffffff

--- a/winch/filetests/filetests/x64/i64_rems/params.wat
+++ b/winch/filetests/filetests/x64/i64_rems/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x60
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8745000000         	ja	0x60
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_rems/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i64_rems/zero_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873d000000         	ja	0x5b
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8740000000         	ja	0x5b
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c100000000       	mov	rcx, 0

--- a/winch/filetests/filetests/x64/i64_remu/const.wat
+++ b/winch/filetests/filetests/x64/i64_remu/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c105000000       	mov	rcx, 5

--- a/winch/filetests/filetests/x64/i64_remu/one_zero.wat
+++ b/winch/filetests/filetests/x64/i64_remu/one_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c100000000       	mov	rcx, 0

--- a/winch/filetests/filetests/x64/i64_remu/params.wat
+++ b/winch/filetests/filetests/x64/i64_remu/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_remu/signed.wat
+++ b/winch/filetests/filetests/x64/i64_remu/signed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c1ffffffff       	mov	rcx, 0xffffffffffffffff

--- a/winch/filetests/filetests/x64/i64_remu/zero_zero.wat
+++ b/winch/filetests/filetests/x64/i64_remu/zero_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c100000000       	mov	rcx, 0

--- a/winch/filetests/filetests/x64/i64_rotl/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/16_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_rotl/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/8_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_rotl/locals.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8743000000         	ja	0x61
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_rotl/params.wat
+++ b/winch/filetests/filetests/x64/i64_rotl/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x47
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_rotr/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/16_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_rotr/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/8_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_rotr/locals.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8743000000         	ja	0x61
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_rotr/params.wat
+++ b/winch/filetests/filetests/x64/i64_rotr/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x47
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_shl/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_shl/16_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_shl/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_shl/8_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_shl/locals.wat
+++ b/winch/filetests/filetests/x64/i64_shl/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8743000000         	ja	0x61
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_shl/params.wat
+++ b/winch/filetests/filetests/x64/i64_shl/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x47
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_shr_s/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/16_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_shr_s/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/8_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_shr_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8743000000         	ja	0x61
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_shr_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_shr_s/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x47
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_shr_u/16_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/16_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_shr_u/8_const.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/8_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_shr_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8743000000         	ja	0x61
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8746000000         	ja	0x61
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_shr_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_shr_u/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x47
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_sub/const.wat
+++ b/winch/filetests/filetests/x64/i64_sub/const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c00a000000       	mov	rax, 0xa

--- a/winch/filetests/filetests/x64/i64_sub/locals.wat
+++ b/winch/filetests/filetests/x64/i64_sub/locals.wat
@@ -18,13 +18,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8746000000         	ja	0x64
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8749000000         	ja	0x64
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_sub/max.wat
+++ b/winch/filetests/filetests/x64/i64_sub/max.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8ffffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_sub/max_one.wat
+++ b/winch/filetests/filetests/x64/i64_sub/max_one.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b80000000000000080 	

--- a/winch/filetests/filetests/x64/i64_sub/mixed.wat
+++ b/winch/filetests/filetests/x64/i64_sub/mixed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff

--- a/winch/filetests/filetests/x64/i64_sub/params.wat
+++ b/winch/filetests/filetests/x64/i64_sub/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x4a
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f872f000000         	ja	0x4a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/i64_sub/signed.wat
+++ b/winch/filetests/filetests/x64/i64_sub/signed.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c0ffffffff       	mov	rax, 0xffffffffffffffff

--- a/winch/filetests/filetests/x64/i64_sub/unsigned_with_zero.wat
+++ b/winch/filetests/filetests/x64/i64_sub/unsigned_with_zero.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c001000000       	mov	rax, 1

--- a/winch/filetests/filetests/x64/i64_trunc_f32_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8757000000         	ja	0x75
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f875a000000         	ja	0x75
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10054d000000     	movss	xmm0, dword ptr [rip + 0x4d]

--- a/winch/filetests/filetests/x64/i64_trunc_f32_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875e000000         	ja	0x7c
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8761000000         	ja	0x7c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_trunc_f32_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875c000000         	ja	0x7a
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f875f000000         	ja	0x7a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/i64_trunc_f32_u/const.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_u/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876b000000         	ja	0x89
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f876e000000         	ja	0x89
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f100d5d000000     	movss	xmm1, dword ptr [rip + 0x5d]

--- a/winch/filetests/filetests/x64/i64_trunc_f32_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_u/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8772000000         	ja	0x90
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8775000000         	ja	0x90
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_trunc_f32_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f32_u/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8770000000         	ja	0x8e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8773000000         	ja	0x8e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f30f11442404         	movss	dword ptr [rsp + 4], xmm0

--- a/winch/filetests/filetests/x64/i64_trunc_f64_s/const.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_s/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f875e000000         	ja	0x7c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8761000000         	ja	0x7c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f100555000000     	movsd	xmm0, qword ptr [rip + 0x55]

--- a/winch/filetests/filetests/x64/i64_trunc_f64_s/locals.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_s/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8764000000         	ja	0x82
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8767000000         	ja	0x82
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_trunc_f64_s/params.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_s/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8761000000         	ja	0x7f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8764000000         	ja	0x7f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/i64_trunc_f64_u/const.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_u/const.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8770000000         	ja	0x8e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8773000000         	ja	0x8e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f100d65000000     	movsd	xmm1, qword ptr [rip + 0x65]

--- a/winch/filetests/filetests/x64/i64_trunc_f64_u/locals.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_u/locals.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8776000000         	ja	0x94
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8779000000         	ja	0x94
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/i64_trunc_f64_u/params.wat
+++ b/winch/filetests/filetests/x64/i64_trunc_f64_u/params.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8773000000         	ja	0x91
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8776000000         	ja	0x91
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 f20f110424           	movsd	qword ptr [rsp], xmm0

--- a/winch/filetests/filetests/x64/i64_xor/32_const.wat
+++ b/winch/filetests/filetests/x64/i64_xor/32_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871e000000         	ja	0x3c
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8721000000         	ja	0x3c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/i64_xor/64_const.wat
+++ b/winch/filetests/filetests/x64/i64_xor/64_const.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872a000000         	ja	0x48
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872d000000         	ja	0x48
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48b8feffffffffffff7f 	

--- a/winch/filetests/filetests/x64/i64_xor/locals.wat
+++ b/winch/filetests/filetests/x64/i64_xor/locals.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8746000000         	ja	0x64
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8749000000         	ja	0x64
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4531db               	xor	r11d, r11d

--- a/winch/filetests/filetests/x64/i64_xor/params.wat
+++ b/winch/filetests/filetests/x64/i64_xor/params.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x4a
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f872f000000         	ja	0x4a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/if/as_binop.wat
+++ b/winch/filetests/filetests/x64/if/as_binop.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -33,13 +33,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87c3000000         	ja	0xe1
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f87c6000000         	ja	0xe1
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/if/as_br_if_last.wat
+++ b/winch/filetests/filetests/x64/if/as_br_if_last.wat
@@ -16,13 +16,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -32,13 +32,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f878e000000         	ja	0xac
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8791000000         	ja	0xac
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/if/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/if/as_if_cond.wat
@@ -14,13 +14,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -30,13 +30,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f877a000000         	ja	0x98
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f877d000000         	ja	0x98
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/if/as_testop.wat
+++ b/winch/filetests/filetests/x64/if/as_testop.wat
@@ -12,13 +12,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -28,13 +28,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876f000000         	ja	0x8d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8772000000         	ja	0x8d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/if/break_value.wat
+++ b/winch/filetests/filetests/x64/if/break_value.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8733000000         	ja	0x51
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8736000000         	ja	0x51
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/if/nested.wat
+++ b/winch/filetests/filetests/x64/if/nested.wat
@@ -24,13 +24,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -40,13 +40,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8756010000         	ja	0x174
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8759010000         	ja	0x174
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/if/reachability.wat
+++ b/winch/filetests/filetests/x64/if/reachability.wat
@@ -15,13 +15,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c31c000000       	add	r11, 0x1c
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874f000000         	ja	0x6d
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8752000000         	ja	0x6d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/if/singular.wat
+++ b/winch/filetests/filetests/x64/if/singular.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -26,13 +26,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f874b000000         	ja	0x69
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f874e000000         	ja	0x69
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/load/f32.wat
+++ b/winch/filetests/filetests/x64/load/f32.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b800000000           	mov	eax, 0

--- a/winch/filetests/filetests/x64/load/f64.wat
+++ b/winch/filetests/filetests/x64/load/f64.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b800000000           	mov	eax, 0

--- a/winch/filetests/filetests/x64/load/i32.wat
+++ b/winch/filetests/filetests/x64/load/i32.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b800000000           	mov	eax, 0

--- a/winch/filetests/filetests/x64/load/i64.wat
+++ b/winch/filetests/filetests/x64/load/i64.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873a000000         	ja	0x58
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873d000000         	ja	0x58
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/local/latent.wat
+++ b/winch/filetests/filetests/x64/local/latent.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c31c000000       	add	r11, 0x1c
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8735000000         	ja	0x53
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/local/materialized.wat
+++ b/winch/filetests/filetests/x64/local/materialized.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8720000000         	ja	0x3e
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8723000000         	ja	0x3e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/loop/as_binary_operand.wat
+++ b/winch/filetests/filetests/x64/loop/as_binary_operand.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -26,13 +26,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873b000000         	ja	0x59
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/loop/as_br_if_first.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_if_first.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b902000000           	mov	ecx, 2

--- a/winch/filetests/filetests/x64/loop/as_br_if_last.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_if_last.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b901000000           	mov	ecx, 1

--- a/winch/filetests/filetests/x64/loop/as_br_value.wat
+++ b/winch/filetests/filetests/x64/loop/as_br_value.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/loop/as_call_value.wat
+++ b/winch/filetests/filetests/x64/loop/as_call_value.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871c000000         	ja	0x3a
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f871f000000         	ja	0x3a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx
@@ -25,13 +25,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/loop/as_if_condition.wat
+++ b/winch/filetests/filetests/x64/loop/as_if_condition.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -23,13 +23,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8730000000         	ja	0x4e
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8733000000         	ja	0x4e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/loop/as_if_else.wat
+++ b/winch/filetests/filetests/x64/loop/as_if_else.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/loop/as_if_then.wat
+++ b/winch/filetests/filetests/x64/loop/as_if_then.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872f000000         	ja	0x4d
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8732000000         	ja	0x4d
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/loop/as_local_set_value.wat
+++ b/winch/filetests/filetests/x64/loop/as_local_set_value.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8729000000         	ja	0x47
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f872c000000         	ja	0x47
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/loop/as_test_operand.wat
+++ b/winch/filetests/filetests/x64/loop/as_test_operand.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -23,13 +23,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/loop/as_unary_operand.wat
+++ b/winch/filetests/filetests/x64/loop/as_unary_operand.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -23,13 +23,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873c000000         	ja	0x5a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f873f000000         	ja	0x5a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/loop/break_inner.wat
+++ b/winch/filetests/filetests/x64/loop/break_inner.wat
@@ -13,13 +13,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c31c000000       	add	r11, 0x1c
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87c4000000         	ja	0xe2
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f87c7000000         	ja	0xe2
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/loop/cont_inner.wat
+++ b/winch/filetests/filetests/x64/loop/cont_inner.wat
@@ -11,13 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c31c000000       	add	r11, 0x1c
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8737000000         	ja	0x55
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873a000000         	ja	0x55
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/loop/deep.wat
+++ b/winch/filetests/filetests/x64/loop/deep.wat
@@ -48,13 +48,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -64,13 +64,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/loop/effects.wat
+++ b/winch/filetests/filetests/x64/loop/effects.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8756000000         	ja	0x74
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8759000000         	ja	0x74
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/loop/empty.wat
+++ b/winch/filetests/filetests/x64/loop/empty.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10

--- a/winch/filetests/filetests/x64/loop/for.wat
+++ b/winch/filetests/filetests/x64/loop/for.wat
@@ -17,13 +17,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c328000000       	add	r11, 0x28
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8781000000         	ja	0x9f
-;;   1e:	 4883ec28             	sub	rsp, 0x28
+;;      	 0f8784000000         	ja	0x9f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec28             	sub	rsp, 0x28
 ;;      	 48897c2420           	mov	qword ptr [rsp + 0x20], rdi
 ;;      	 4889742418           	mov	qword ptr [rsp + 0x18], rsi
 ;;      	 4889542410           	mov	qword ptr [rsp + 0x10], rdx

--- a/winch/filetests/filetests/x64/loop/multi.wat
+++ b/winch/filetests/filetests/x64/loop/multi.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -25,13 +25,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8788000000         	ja	0xa6
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f878b000000         	ja	0xa6
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/loop/nested.wat
+++ b/winch/filetests/filetests/x64/loop/nested.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -26,13 +26,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8738000000         	ja	0x56
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f873b000000         	ja	0x56
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/loop/singular.wat
+++ b/winch/filetests/filetests/x64/loop/singular.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b807000000           	mov	eax, 7

--- a/winch/filetests/filetests/x64/loop/while.wat
+++ b/winch/filetests/filetests/x64/loop/while.wat
@@ -16,13 +16,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f876e000000         	ja	0x8c
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8771000000         	ja	0x8c
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 4889542408           	mov	qword ptr [rsp + 8], rdx

--- a/winch/filetests/filetests/x64/nop/nop.wat
+++ b/winch/filetests/filetests/x64/nop/nop.wat
@@ -8,13 +8,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10

--- a/winch/filetests/filetests/x64/return/as_block_first.wat
+++ b/winch/filetests/filetests/x64/return/as_block_first.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10

--- a/winch/filetests/filetests/x64/return/as_block_last.wat
+++ b/winch/filetests/filetests/x64/return/as_block_last.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/return/as_block_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_block_mid.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8723000000         	ja	0x41
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8726000000         	ja	0x41
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/return/as_block_value.wat
+++ b/winch/filetests/filetests/x64/return/as_block_value.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/return/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/return/as_br_if_cond.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10

--- a/winch/filetests/filetests/x64/return/as_br_value.wat
+++ b/winch/filetests/filetests/x64/return/as_br_value.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b809000000           	mov	eax, 9

--- a/winch/filetests/filetests/x64/return/as_call_fist.wat
+++ b/winch/filetests/filetests/x64/return/as_call_fist.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -28,13 +28,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b80c000000           	mov	eax, 0xc

--- a/winch/filetests/filetests/x64/return/as_call_last.wat
+++ b/winch/filetests/filetests/x64/return/as_call_last.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -28,13 +28,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b80e000000           	mov	eax, 0xe

--- a/winch/filetests/filetests/x64/return/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_call_mid.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -28,13 +28,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b80d000000           	mov	eax, 0xd

--- a/winch/filetests/filetests/x64/return/as_func_first.wat
+++ b/winch/filetests/filetests/x64/return/as_func_first.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/return/as_func_last.wat
+++ b/winch/filetests/filetests/x64/return/as_func_last.wat
@@ -5,13 +5,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10

--- a/winch/filetests/filetests/x64/return/as_func_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_func_mid.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/return/as_func_value.wat
+++ b/winch/filetests/filetests/x64/return/as_func_value.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/return/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/return/as_if_cond.wat
@@ -10,13 +10,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -26,13 +26,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b802000000           	mov	eax, 2

--- a/winch/filetests/filetests/x64/return/as_if_else.wat
+++ b/winch/filetests/filetests/x64/return/as_if_else.wat
@@ -11,13 +11,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -27,13 +27,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/return/as_if_then.wat
+++ b/winch/filetests/filetests/x64/return/as_if_then.wat
@@ -11,13 +11,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -27,13 +27,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8734000000         	ja	0x52
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8737000000         	ja	0x52
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/return/as_loop_first.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_first.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b803000000           	mov	eax, 3

--- a/winch/filetests/filetests/x64/return/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_last.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/return/as_loop_mid.wat
+++ b/winch/filetests/filetests/x64/return/as_loop_mid.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/return/as_return_value.wat
+++ b/winch/filetests/filetests/x64/return/as_return_value.wat
@@ -8,13 +8,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x38
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c007000000       	mov	rax, 7

--- a/winch/filetests/filetests/x64/return/nullary.wat
+++ b/winch/filetests/filetests/x64/return/nullary.wat
@@ -6,13 +6,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -22,13 +22,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10

--- a/winch/filetests/filetests/x64/return/type_i32.wat
+++ b/winch/filetests/filetests/x64/return/type_i32.wat
@@ -9,13 +9,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -25,13 +25,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/return/type_i64_value.wat
+++ b/winch/filetests/filetests/x64/return/type_i64_value.wat
@@ -9,13 +9,13 @@
   
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -25,13 +25,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x38
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 48c7c002000000       	mov	rax, 2

--- a/winch/filetests/filetests/x64/select/f32.wat
+++ b/winch/filetests/filetests/x64/select/f32.wat
@@ -8,13 +8,13 @@
  
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 f30f1144240c         	movss	dword ptr [rsp + 0xc], xmm0

--- a/winch/filetests/filetests/x64/select/f64.wat
+++ b/winch/filetests/filetests/x64/select/f64.wat
@@ -8,13 +8,13 @@
  
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c328000000       	add	r11, 0x28
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8741000000         	ja	0x5f
-;;   1e:	 4883ec28             	sub	rsp, 0x28
+;;      	 0f8744000000         	ja	0x5f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec28             	sub	rsp, 0x28
 ;;      	 48897c2420           	mov	qword ptr [rsp + 0x20], rdi
 ;;      	 4889742418           	mov	qword ptr [rsp + 0x18], rsi
 ;;      	 f20f11442410         	movsd	qword ptr [rsp + 0x10], xmm0

--- a/winch/filetests/filetests/x64/select/i32.wat
+++ b/winch/filetests/filetests/x64/select/i32.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8735000000         	ja	0x53
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8738000000         	ja	0x53
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx

--- a/winch/filetests/filetests/x64/select/i64.wat
+++ b/winch/filetests/filetests/x64/select/i64.wat
@@ -8,13 +8,13 @@
  
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c328000000       	add	r11, 0x28
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f873b000000         	ja	0x59
-;;   1e:	 4883ec28             	sub	rsp, 0x28
+;;      	 0f873e000000         	ja	0x59
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec28             	sub	rsp, 0x28
 ;;      	 48897c2420           	mov	qword ptr [rsp + 0x20], rdi
 ;;      	 4889742418           	mov	qword ptr [rsp + 0x18], rsi
 ;;      	 4889542410           	mov	qword ptr [rsp + 0x10], rdx

--- a/winch/filetests/filetests/x64/store/f32.wat
+++ b/winch/filetests/filetests/x64/store/f32.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872b000000         	ja	0x49
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f30f10051d000000     	movss	xmm0, dword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/store/f64.wat
+++ b/winch/filetests/filetests/x64/store/f64.wat
@@ -7,13 +7,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872b000000         	ja	0x49
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 f20f10051d000000     	movsd	xmm0, qword ptr [rip + 0x1d]

--- a/winch/filetests/filetests/x64/store/i32.wat
+++ b/winch/filetests/filetests/x64/store/i32.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8726000000         	ja	0x44
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8729000000         	ja	0x44
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b801000000           	mov	eax, 1

--- a/winch/filetests/filetests/x64/store/i64.wat
+++ b/winch/filetests/filetests/x64/store/i64.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b820000000           	mov	eax, 0x20

--- a/winch/filetests/filetests/x64/table/fill.wat
+++ b/winch/filetests/filetests/x64/table/fill.wat
@@ -21,13 +21,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -37,13 +37,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -53,13 +53,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -69,13 +69,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c340000000       	add	r11, 0x40
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8704010000         	ja	0x122
-;;   1e:	 4883ec28             	sub	rsp, 0x28
+;;      	 0f8707010000         	ja	0x122
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec28             	sub	rsp, 0x28
 ;;      	 48897c2420           	mov	qword ptr [rsp + 0x20], rdi
 ;;      	 4889742418           	mov	qword ptr [rsp + 0x18], rsi
 ;;      	 89542414             	mov	dword ptr [rsp + 0x14], edx

--- a/winch/filetests/filetests/x64/table/get.wat
+++ b/winch/filetests/filetests/x64/table/get.wat
@@ -11,13 +11,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -27,13 +27,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8794000000         	ja	0xb2
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8797000000         	ja	0xb2
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/table/grow.wat
+++ b/winch/filetests/filetests/x64/table/grow.wat
@@ -11,13 +11,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8742000000         	ja	0x60
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8745000000         	ja	0x60
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48891424             	mov	qword ptr [rsp], rdx

--- a/winch/filetests/filetests/x64/table/init_copy_drop.wat
+++ b/winch/filetests/filetests/x64/table/init_copy_drop.wat
@@ -35,13 +35,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b805000000           	mov	eax, 5
@@ -52,13 +52,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b806000000           	mov	eax, 6
@@ -69,13 +69,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b807000000           	mov	eax, 7
@@ -86,13 +86,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b808000000           	mov	eax, 8
@@ -103,13 +103,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8718000000         	ja	0x36
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871b000000         	ja	0x36
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 b809000000           	mov	eax, 9
@@ -120,13 +120,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f877c010000         	ja	0x19a
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f877f010000         	ja	0x19a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4d8b5e38             	mov	r11, qword ptr [r14 + 0x38]
@@ -218,13 +218,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87d4000000         	ja	0xf2
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f87d7000000         	ja	0xf2
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/table/set.wat
+++ b/winch/filetests/filetests/x64/table/set.wat
@@ -16,13 +16,13 @@
 
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -32,13 +32,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8750000000         	ja	0x6e
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8753000000         	ja	0x6e
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -66,13 +66,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f87ce000000         	ja	0xec
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f87d1000000         	ja	0xec
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/table/size.wat
+++ b/winch/filetests/filetests/x64/table/size.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f871a000000         	ja	0x38
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f871d000000         	ja	0x38
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4d89f3               	mov	r11, r14

--- a/winch/filetests/filetests/x64/unreachable/as_block_broke.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_broke.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/unreachable/as_block_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_first.wat
@@ -6,13 +6,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_block_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_last.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -23,13 +23,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/unreachable/as_block_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_mid.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/unreachable/as_block_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_block_value.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -23,13 +23,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/unreachable/as_br_if_cond.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_br_if_cond.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_br_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_br_value.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_call_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_call_first.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -27,13 +27,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_call_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_call_last.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -28,13 +28,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_call_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_call_mid.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c320000000       	add	r11, 0x20
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8721000000         	ja	0x3f
-;;   1e:	 4883ec20             	sub	rsp, 0x20
+;;      	 0f8724000000         	ja	0x3f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec20             	sub	rsp, 0x20
 ;;      	 48897c2418           	mov	qword ptr [rsp + 0x18], rdi
 ;;      	 4889742410           	mov	qword ptr [rsp + 0x10], rsi
 ;;      	 8954240c             	mov	dword ptr [rsp + 0xc], edx
@@ -27,13 +27,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_func_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_first.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -23,13 +23,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_func_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_last.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -23,13 +23,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/unreachable/as_func_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_mid.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/unreachable/as_func_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_func_value.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -24,13 +24,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/unreachable/as_if_cond.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_cond.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_if_else.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_else.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8731000000         	ja	0x4f
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f8734000000         	ja	0x4f
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/unreachable/as_if_then.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_then.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x4a
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f872f000000         	ja	0x4a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/unreachable/as_if_then_no_else.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_if_then_no_else.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c318000000       	add	r11, 0x18
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872c000000         	ja	0x4a
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f872f000000         	ja	0x4a
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 89542404             	mov	dword ptr [rsp + 4], edx

--- a/winch/filetests/filetests/x64/unreachable/as_loop_broke.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_broke.wat
@@ -10,13 +10,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -26,13 +26,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8728000000         	ja	0x46
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f872b000000         	ja	0x46
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/unreachable/as_loop_first.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_first.wat
@@ -8,13 +8,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/as_loop_last.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_last.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -25,13 +25,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/unreachable/as_loop_mid.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_loop_mid.wat
@@ -9,13 +9,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8713000000         	ja	0x31
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8716000000         	ja	0x31
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4883c410             	add	rsp, 0x10
@@ -25,13 +25,13 @@
 ;;
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8725000000         	ja	0x43
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8728000000         	ja	0x43
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 4c89f7               	mov	rdi, r14

--- a/winch/filetests/filetests/x64/unreachable/as_return_value.wat
+++ b/winch/filetests/filetests/x64/unreachable/as_return_value.wat
@@ -7,13 +7,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/type_i32.wat
+++ b/winch/filetests/filetests/x64/unreachable/type_i32.wat
@@ -5,13 +5,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/type_i64.wat
+++ b/winch/filetests/filetests/x64/unreachable/type_i64.wat
@@ -5,13 +5,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c310000000       	add	r11, 0x10
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8715000000         	ja	0x33
-;;   1e:	 4883ec10             	sub	rsp, 0x10
+;;      	 0f8718000000         	ja	0x33
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec10             	sub	rsp, 0x10
 ;;      	 48897c2408           	mov	qword ptr [rsp + 8], rdi
 ;;      	 48893424             	mov	qword ptr [rsp], rsi
 ;;      	 0f0b                 	ud2	

--- a/winch/filetests/filetests/x64/unreachable/with_spilled_local.wat
+++ b/winch/filetests/filetests/x64/unreachable/with_spilled_local.wat
@@ -11,13 +11,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c31c000000       	add	r11, 0x1c
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f872b000000         	ja	0x49
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f872e000000         	ja	0x49
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0

--- a/winch/filetests/filetests/x64/unreachable/with_spilled_local_in_if.wat
+++ b/winch/filetests/filetests/x64/unreachable/with_spilled_local_in_if.wat
@@ -16,13 +16,13 @@
 )
 ;;      	 55                   	push	rbp
 ;;      	 4889e5               	mov	rbp, rsp
-;;      	 4989fe               	mov	r14, rdi
-;;      	 4d8b5e08             	mov	r11, qword ptr [r14 + 8]
+;;      	 4c8b5f08             	mov	r11, qword ptr [rdi + 8]
 ;;      	 4d8b1b               	mov	r11, qword ptr [r11]
 ;;      	 4981c31c000000       	add	r11, 0x1c
 ;;      	 4939e3               	cmp	r11, rsp
-;;      	 0f8737000000         	ja	0x55
-;;   1e:	 4883ec18             	sub	rsp, 0x18
+;;      	 0f873a000000         	ja	0x55
+;;   1b:	 4989fe               	mov	r14, rdi
+;;      	 4883ec18             	sub	rsp, 0x18
 ;;      	 48897c2410           	mov	qword ptr [rsp + 0x10], rdi
 ;;      	 4889742408           	mov	qword ptr [rsp + 8], rsi
 ;;      	 48c7042400000000     	mov	qword ptr [rsp], 0


### PR DESCRIPTION
Rework the winch prologue and epilogue definitions as default implementations in the `MacroAssembler` trait, naming the common sequence of frame setup, check stack, handle clobbers, and reserve space for locals. This change also allows us to remove the special prologue and epilogue functions from the trampoline module, and rely instead on the same function used by the normal function compilation path.

As I moved the pinning of the vmctx register to after the prologue, this change had a pretty noisy effect on the filetests.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
