### PR TITLE
Don't infer host flags for cross-compiled targets

### DIFF
--- a/crates/cranelift-shared/src/isa_builder.rs
+++ b/crates/cranelift-shared/src/isa_builder.rs
@@ -28,9 +28,12 @@ impl<T> IsaBuilder<T> {
             .set("enable_probestack", "false")
             .expect("should be valid flag");
 
+        let triple_specified = triple.is_some();
         let triple = triple.unwrap_or_else(Triple::host);
         let mut isa_flags = lookup(triple)?;
-        cranelift_native::infer_native_flags(&mut isa_flags).unwrap();
+        if !triple_specified {
+            cranelift_native::infer_native_flags(&mut isa_flags).unwrap();
+        }
 
         Ok(Self {
             shared_flags: flags,


### PR DESCRIPTION
This commit fixes an accidental regression from #7766 where `infer_native_flags` is called even if a target is explicitly specified to a `Config`. Now inference only happens if a target isn't specified meaning that the host is selected.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
