### PR TITLE
Run additional misc testsuite tests with Winch

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -206,10 +206,19 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
     // Ignore some tests for when testing Winch.
     if strategy == "Winch" {
         if testsuite == "misc_testsuite" {
-            // The misc/call_indirect is fully supported by Winch.
-            if testname != "call_indirect" {
-                return true;
-            }
+            let denylist = [
+                "externref_id_function",
+                "func_400_params",
+                "int_to_float_splat",
+                "issue6562",
+                "many_table_gets_lead_to_gc",
+                "mutable_externref_globals",
+                "no_mixup_stack_maps",
+                "no_panic",
+                "simple_ref_is_null",
+                "table_grow_with_funcref",
+            ];
+            return denylist.contains(&testname);
         }
         if testsuite == "spec_testsuite" {
             let denylist = [


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
We can enable more of the `misc_testsuite` to run with the Winch compilation. I've listed the currently failing tests as a deny list. Most of them require SIMD support or Reference Types support to be implemented before they'll be able to pass. `func_400_params` is the exception and requires an update to Winch to accommodate additional parameters.