### PR TITLE
Winch: Use Option<u8> for register indexes

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -208,7 +208,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
         if testsuite == "misc_testsuite" {
             let denylist = [
                 "externref_id_function",
-                "func_400_params",
                 "int_to_float_splat",
                 "issue6562",
                 "many_table_gets_lead_to_gc",

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -16,9 +16,9 @@ use wasmtime_environ::{WasmHeapType, WasmValType};
 struct RegIndexEnv {
     /// General purpose register index or the field used for absolute
     /// counts.
-    gpr_or_absolute_count: u16,
+    gpr_or_absolute_count: u8,
     /// Floating point register index.
-    fpr: u16,
+    fpr: u8,
     /// Whether the count should be absolute rather than per register class.
     /// When this field is true, only the `gpr_or_absolute_count` field is
     /// incremented.
@@ -36,11 +36,11 @@ impl RegIndexEnv {
 }
 
 impl RegIndexEnv {
-    fn next_gpr(&mut self) -> u16 {
+    fn next_gpr(&mut self) -> Option<u8> {
         Self::increment(&mut self.gpr_or_absolute_count)
     }
 
-    fn next_fpr(&mut self) -> u16 {
+    fn next_fpr(&mut self) -> Option<u8> {
         if self.absolute_count {
             Self::increment(&mut self.gpr_or_absolute_count)
         } else {
@@ -48,10 +48,15 @@ impl RegIndexEnv {
         }
     }
 
-    fn increment(index: &mut u16) -> u16 {
+    fn increment(index: &mut u8) -> Option<u8> {
         let current = *index;
-        *index += 1;
-        current
+        match index.checked_add(1) {
+            Some(next) => {
+                *index = next;
+                Some(current)
+            }
+            None => None,
+        }
     }
 }
 
@@ -249,11 +254,16 @@ impl X64ABI {
     }
 
     fn int_reg_for(
-        index: u16,
+        index: Option<u8>,
         call_conv: &CallingConvention,
         params_or_returns: ParamsOrReturns,
     ) -> Option<Reg> {
         use ParamsOrReturns::*;
+
+        let index = match index {
+            None => return None,
+            Some(index) => index,
+        };
 
         if call_conv.is_fastcall() {
             return match (index, params_or_returns) {
@@ -283,11 +293,17 @@ impl X64ABI {
     }
 
     fn float_reg_for(
-        index: u16,
+        index: Option<u8>,
         call_conv: &CallingConvention,
         params_or_returns: ParamsOrReturns,
     ) -> Option<Reg> {
         use ParamsOrReturns::*;
+
+        let index = match index {
+            None => return None,
+            Some(index) => index,
+        };
+
         if call_conv.is_fastcall() {
             return match (index, params_or_returns) {
                 (0, Params) => Some(regs::xmm0()),
@@ -335,21 +351,21 @@ mod tests {
     #[test]
     fn test_get_next_reg_index() {
         let mut index_env = RegIndexEnv::default();
-        assert_eq!(index_env.next_fpr(), 0);
-        assert_eq!(index_env.next_gpr(), 0);
-        assert_eq!(index_env.next_fpr(), 1);
-        assert_eq!(index_env.next_gpr(), 1);
-        assert_eq!(index_env.next_fpr(), 2);
-        assert_eq!(index_env.next_gpr(), 2);
+        assert_eq!(index_env.next_fpr(), Some(0));
+        assert_eq!(index_env.next_gpr(), Some(0));
+        assert_eq!(index_env.next_fpr(), Some(1));
+        assert_eq!(index_env.next_gpr(), Some(1));
+        assert_eq!(index_env.next_fpr(), Some(2));
+        assert_eq!(index_env.next_gpr(), Some(2));
     }
 
     #[test]
     fn test_reg_index_env_absolute_count() {
         let mut e = RegIndexEnv::with_absolute_count();
-        assert!(e.next_gpr() == 0);
-        assert!(e.next_fpr() == 1);
-        assert!(e.next_gpr() == 2);
-        assert!(e.next_fpr() == 3);
+        assert!(e.next_gpr() == Some(0));
+        assert!(e.next_fpr() == Some(1));
+        assert!(e.next_gpr() == Some(2));
+        assert!(e.next_fpr() == Some(3));
     }
 
     #[test]

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -16,9 +16,9 @@ use wasmtime_environ::{WasmHeapType, WasmValType};
 struct RegIndexEnv {
     /// General purpose register index or the field used for absolute
     /// counts.
-    gpr_or_absolute_count: u8,
+    gpr_or_absolute_count: u16,
     /// Floating point register index.
-    fpr: u8,
+    fpr: u16,
     /// Whether the count should be absolute rather than per register class.
     /// When this field is true, only the `gpr_or_absolute_count` field is
     /// incremented.
@@ -36,11 +36,11 @@ impl RegIndexEnv {
 }
 
 impl RegIndexEnv {
-    fn next_gpr(&mut self) -> u8 {
+    fn next_gpr(&mut self) -> u16 {
         Self::increment(&mut self.gpr_or_absolute_count)
     }
 
-    fn next_fpr(&mut self) -> u8 {
+    fn next_fpr(&mut self) -> u16 {
         if self.absolute_count {
             Self::increment(&mut self.gpr_or_absolute_count)
         } else {
@@ -48,7 +48,7 @@ impl RegIndexEnv {
         }
     }
 
-    fn increment(index: &mut u8) -> u8 {
+    fn increment(index: &mut u16) -> u16 {
         let current = *index;
         *index += 1;
         current
@@ -249,7 +249,7 @@ impl X64ABI {
     }
 
     fn int_reg_for(
-        index: u8,
+        index: u16,
         call_conv: &CallingConvention,
         params_or_returns: ParamsOrReturns,
     ) -> Option<Reg> {
@@ -283,7 +283,7 @@ impl X64ABI {
     }
 
     fn float_reg_for(
-        index: u8,
+        index: u16,
         call_conv: &CallingConvention,
         params_or_returns: ParamsOrReturns,
     ) -> Option<Reg> {

--- a/winch/filetests/filetests/aarch64/params/400_params.wat
+++ b/winch/filetests/filetests/aarch64/params/400_params.wat
@@ -1,0 +1,69 @@
+;;! target = "aarch64"
+
+(module
+  (type (;0;) (func (param
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+    i32 i32 i32 i32 i32 i32 i32 i32 i32 i32
+  )
+
+    (result i32)
+  ))
+  (func (export "x") (type 0) local.get 0)
+)
+;;      	 fd7bbfa9             	stp	x29, x30, [sp, #-0x10]!
+;;      	 fd030091             	mov	x29, sp
+;;      	 fc030091             	mov	x28, sp
+;;      	 e90300aa             	mov	x9, x0
+;;      	 ffa300d1             	sub	sp, sp, #0x28
+;;      	 fc030091             	mov	x28, sp
+;;      	 800302f8             	stur	x0, [x28, #0x20]
+;;      	 818301f8             	stur	x1, [x28, #0x18]
+;;      	 824301b8             	stur	w2, [x28, #0x14]
+;;      	 830301b8             	stur	w3, [x28, #0x10]
+;;      	 84c300b8             	stur	w4, [x28, #0xc]
+;;      	 858300b8             	stur	w5, [x28, #8]
+;;      	 864300b8             	stur	w6, [x28, #4]
+;;      	 870300b8             	stur	w7, [x28]
+;;      	 804341b8             	ldur	w0, [x28, #0x14]
+;;      	 ffa30091             	add	sp, sp, #0x28
+;;      	 fc030091             	mov	x28, sp
+;;      	 fd7bc1a8             	ldp	x29, x30, [sp], #0x10
+;;      	 c0035fd6             	ret	


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
Returning an `Option<u8>` to track the register index allows us to support parameter lists that are longer than 255 since we can return `None` instead of overflowing when we hit the the maximum value for `u8`. It looks like v8 supports 1000 params.