### PR TITLE
Add a "custom" platform configuration for Wasmtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -615,6 +615,7 @@ jobs:
 
   build-wasmtime-target-wasm32:
     name: Build wasmtime-target-wasm32
+    if: needs.determine.outputs.run-full
     needs: determine
     runs-on: ubuntu-latest
     steps:
@@ -831,6 +832,7 @@ jobs:
       - determine
       - miri
       - build-preview1-component-adapter
+      - build-wasmtime-target-wasm32
     if: always()
     steps:
     - name: Dump needs context

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -415,6 +415,7 @@ jobs:
     # Afterwards make sure the generated header file is up to date by ensuring
     # that the regeneration process didn't change anything in-tree.
     - run: cargo install cbindgen --vers "^0.26"
+    - run: rustup component add rust-src
     - run: ./build.sh ./embedding/x86_64-unknown-unknown.json
       working-directory: ./examples/min-platform
     - run: git diff --exit-code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,8 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
   # Check Code style quickly by running `clang-format` over all the C/C++ code
+  #
+  # Note that `wasmtime-platform.h` is excluded here as it's auto-generated.
   clangformat:
     name: Clang format
     runs-on: ubuntu-latest
@@ -63,7 +65,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - run: git ls-files '*.h' '*.c' '*.cpp' | xargs clang-format-15 --dry-run --Werror --verbose
+    - run: git ls-files '*.h' '*.c' '*.cpp' | grep -v wasmtime-platform.h | xargs clang-format-15 --dry-run --Werror --verbose
 
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}
@@ -816,6 +818,7 @@ jobs:
       - test
       - build
       - rustfmt
+      - clangformat
       - cargo_deny
       - cargo_vet
       - doc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,7 +134,7 @@ jobs:
       test-matrix: ${{ steps.calculate.outputs.test-matrix }}
       build-matrix: ${{ steps.calculate.outputs.build-matrix }}
       test-capi: ${{ steps.calculate.outputs.test-capi }}
-      build-fuzz: ${{ steps.calculate.outputs.build-fuzz }}
+      test-nightly: ${{ steps.calculate.outputs.test-nightly }}
       audit: ${{ steps.calculate.outputs.audit }}
       preview1-adapter: ${{ steps.calculate.outputs.preview1-adapter }}
     steps:
@@ -162,7 +162,10 @@ jobs:
             echo test-capi=true >> $GITHUB_OUTPUT
           fi
           if grep -q fuzz names.log; then
-            echo build-fuzz=true >> $GITHUB_OUTPUT
+            echo test-nightly=true >> $GITHUB_OUTPUT
+          fi
+          if grep -q sys.custom names.log; then
+            echo test-nightly=true >> $GITHUB_OUTPUT
           fi
           if grep -q Cargo.lock names.log; then
             echo audit=true >> $GITHUB_OUTPUT
@@ -184,7 +187,7 @@ jobs:
         if [ "$run_full" = "true" ]; then
             echo run-full=true >> $GITHUB_OUTPUT
             echo test-capi=true >> $GITHUB_OUTPUT
-            echo build-fuzz=true >> $GITHUB_OUTPUT
+            echo test-nightly=true >> $GITHUB_OUTPUT
             echo audit=true >> $GITHUB_OUTPUT
             echo preview1-adapter=true >> $GITHUB_OUTPUT
         fi
@@ -378,30 +381,41 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
-  # Verify all fuzz targets compile successfully
-  fuzz_targets:
+  # Run tests that require a nightly compiler, such as building fuzz targets.
+  test_nightly:
     needs: determine
-    if: needs.determine.outputs.build-fuzz
-    name: Fuzz Targets
+    if: needs.determine.outputs.test-nightly
+    name: Nightly tests
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    # Note that building with fuzzers requires nightly since it uses unstable
-    # flags to rustc.
+    # Note that nightly is pinned here to insulate us from breakage that might
+    # happen upstream. This is periodically updated through a PR.
     - uses: ./.github/actions/install-rust
       with:
         toolchain: nightly-2024-02-22
-    - run: cargo install cargo-fuzz --vers "^0.11"
+
+    # Ensure that fuzzers sitll build.
+    #
     # Install the OCaml packages necessary for fuzz targets that use the
     # `wasm-spec-interpreter`.
+    - run: cargo install cargo-fuzz --vers "^0.11"
     - run: sudo apt-get update && sudo apt install -y ocaml-nox ocamlbuild ocaml-findlib libzarith-ocaml-dev
     - run: cargo fetch
       working-directory: ./fuzz
     - run: cargo fuzz build --dev -s none
-    # Check that the ISLE fuzz targets build too.
     - run: cargo fuzz build --dev -s none --fuzz-dir ./cranelift/isle/fuzz
+
+    # Verify the "min platform" example still works.
+    #
+    # Afterwards make sure the generated header file is up to date by ensuring
+    # that the regeneration process didn't change anything in-tree.
+    - run: cargo install cbindgen --vers "^0.26"
+    - run: ./build.sh ./embedding/x86_64-unknown-unknown.json
+      working-directory: ./examples/min-platform
+    - run: git diff --exit-code
 
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}
@@ -807,7 +821,7 @@ jobs:
       - doc
       - checks
       - checks_winarm64
-      - fuzz_targets
+      - test_nightly
       - bench
       - meta_deterministic_check
       - verify-publish

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,6 +994,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlmalloc"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "203540e710bfadb90e5e29930baf5d10270cec1f43ab34f46f78b147b2de715a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,6 +1027,15 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "embedding"
+version = "19.0.0"
+dependencies = [
+ "anyhow",
+ "dlmalloc",
+ "wasmtime",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -1763,6 +1781,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "min-platform-host"
+version = "19.0.0"
+dependencies = [
+ "anyhow",
+ "libloading",
+ "object",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,8 @@ members = [
   "examples/wasi/wasm",
   "examples/tokio/wasm",
   "examples/component/wasm",
+  "examples/min-platform",
+  "examples/min-platform/embedding",
   "fuzz",
   "winch",
   "winch/codegen", "crates/slab",

--- a/crates/runtime/src/sys/custom/capi.rs
+++ b/crates/runtime/src/sys/custom/capi.rs
@@ -50,11 +50,12 @@ extern "C" {
     ///
     /// Memory can be lazily committed.
     ///
-    /// Returns the base pointer of the new mapping. Aborts the process on
-    /// failure.
+    /// Stores the base pointer of the new mapping in `ret` on success.
+    ///
+    /// Returns 0 on success and an error code on failure.
     ///
     /// Similar to `mmap(0, size, prot_flags, MAP_PRIVATE, 0, -1)` on Linux.
-    pub fn wasmtime_mmap_new(size: usize, prot_flags: u32) -> *mut u8;
+    pub fn wasmtime_mmap_new(size: usize, prot_flags: u32, ret: &mut *mut u8) -> i32;
 
     /// Remaps the virtual memory starting at `addr` going for `size` bytes to
     /// the protections specified with a new blank mapping.
@@ -63,28 +64,28 @@ extern "C" {
     /// anonymous memory are used to replace these mappings and the new area
     /// should have the protection specified by `prot_flags`.
     ///
-    /// Aborts the process on failure.
+    /// Returns 0 on success and an error code on failure.
     ///
     /// Similar to `mmap(addr, size, prot_flags, MAP_PRIVATE | MAP_FIXED, 0, -1)` on Linux.
-    pub fn wasmtime_mmap_remap(addr: *mut u8, size: usize, prot_flags: u32);
+    pub fn wasmtime_mmap_remap(addr: *mut u8, size: usize, prot_flags: u32) -> i32;
 
     /// Unmaps memory at the specified `ptr` for `size` bytes.
     ///
     /// The memory should be discarded and decommitted and should generate a
     /// segfault if accessed after this function call.
     ///
-    /// Aborts the process on failure.
+    /// Returns 0 on success and an error code on failure.
     ///
     /// Similar to `munmap` on Linux.
-    pub fn wasmtime_munmap(ptr: *mut u8, size: usize);
+    pub fn wasmtime_munmap(ptr: *mut u8, size: usize) -> i32;
 
     /// Configures the protections associated with a region of virtual memory
     /// starting at `ptr` and going to `size`.
     ///
-    /// Aborts the process on failure.
+    /// Returns 0 on success and an error code on failure.
     ///
     /// Similar to `mprotect` on Linux.
-    pub fn wasmtime_mprotect(ptr: *mut u8, size: usize, prot_flags: u32);
+    pub fn wasmtime_mprotect(ptr: *mut u8, size: usize, prot_flags: u32) -> i32;
 
     /// Returns the page size, in bytes, of the current system.
     pub fn wasmtime_page_size() -> usize;
@@ -131,13 +132,16 @@ extern "C" {
     /// The `handler` provided is a function pointer to invoke whenever a trap
     /// is encountered. The `handler` is invoked whenever a trap is caught by
     /// the system.
-    pub fn wasmtime_init_traps(handler: wasmtime_trap_handler_t);
+    ///
+    /// Returns 0 on success and an error code on failure.
+    pub fn wasmtime_init_traps(handler: wasmtime_trap_handler_t) -> i32;
 
     /// Attempts to create a new in-memory image of the `ptr`/`len` combo which
     /// can be mapped to virtual addresses in the future.
     ///
-    /// The returned `wasmtime_memory_image` pointer can be `NULL` to indicate
-    /// that an image cannot be created. The structure otherwise will later be
+    /// On successed the returned `wasmtime_memory_image` pointer is stored into `ret`.
+    /// This value stored can be `NULL` to indicate that an image cannot be
+    /// created but no failure occurred. The structure otherwise will later be
     /// deallocated with `wasmtime_memory_image_free` and
     /// `wasmtime_memory_image_map_at` will be used to map the image into new
     /// regions of the address space.
@@ -146,7 +150,16 @@ extern "C" {
     /// the image needs to refer to them in the future then it must make a copy.
     ///
     /// Both `ptr` and `len` are guaranteed to be page-aligned.
-    pub fn wasmtime_memory_image_new(ptr: *const u8, len: usize) -> *mut wasmtime_memory_image;
+    ///
+    /// Returns 0 on success and an error code on failure. Note that storing
+    /// `NULL` into `ret` is not considered a failure, and failure is used to
+    /// indicate that something fatal has happened and Wasmtime will propagate
+    /// the error upwards.
+    pub fn wasmtime_memory_image_new(
+        ptr: *const u8,
+        len: usize,
+        ret: &mut *mut wasmtime_memory_image,
+    ) -> i32;
 
     /// Maps the `image` provided to the virtual address at `addr` and `len`.
     ///
@@ -166,7 +179,7 @@ extern "C" {
         image: *mut wasmtime_memory_image,
         addr: *mut u8,
         len: usize,
-    );
+    ) -> i32;
 
     /// Deallocates the provided `wasmtime_memory_image`.
     ///

--- a/crates/runtime/src/sys/custom/capi.rs
+++ b/crates/runtime/src/sys/custom/capi.rs
@@ -1,0 +1,168 @@
+#![allow(non_camel_case_types)]
+
+// Flags to either `wasmtime_mmap_{new,remap}` or `wasmtime_mprotect`.
+
+/// Indicates that the memory region should be readable.
+pub const WASMTIME_PROT_READ: u32 = 1 << 0;
+/// Indicates that the memory region should be writable.
+pub const WASMTIME_PROT_WRITE: u32 = 1 << 1;
+/// Indicates that the memory region should be executable.
+pub const WASMTIME_PROT_EXEC: u32 = 1 << 2;
+
+pub use WASMTIME_PROT_EXEC as PROT_EXEC;
+pub use WASMTIME_PROT_READ as PROT_READ;
+pub use WASMTIME_PROT_WRITE as PROT_WRITE;
+
+/// Handler function for traps in Wasmtime passed to `wasmtime_init_traps`.
+///
+/// This function is invoked whenever a trap is caught by the system. For
+/// example this would be invoked during a signal handler on Linux. This
+/// function is passed a number of parameters indicating information about the
+/// trap:
+///
+/// * `ip` - the instruction pointer at the time of the trap.
+/// * `fp` - the frame pointer register's value at the time of the trap.
+/// * `has_faulting_addr` - whether this trap is associated with an access
+///   violation (e.g. a segfault) meaning memory was accessed when it shouldn't
+///   be. If this is `true` then the next parameter is filled in.
+/// * `faulting_addr` - if `has_faulting_addr` is true then this is the address
+///   that was attempted to be accessed. Otherwise this value is not used.
+///
+/// If this function returns then the trap was not handled. This probably means
+/// that a fatal exception happened and the process should be aborted.
+///
+/// This function may not return as it may invoke `wasmtime_longjmp` if a wasm
+/// trap is detected.
+pub type wasmtime_trap_handler_t =
+    extern "C" fn(ip: usize, fp: usize, has_faulting_addr: bool, faulting_addr: usize);
+
+/// Abstract pointer type used in the `wasmtime_memory_image_*` APIs which
+/// is defined by the embedder.
+pub enum wasmtime_memory_image {}
+
+extern "C" {
+    /// Creates a new virtual memory mapping of the `size` specified with
+    /// protection bits specified in `prot_flags`.
+    ///
+    /// Memory can be lazily committed.
+    ///
+    /// Returns the base pointer of the new mapping. Aborts the process on
+    /// failure.
+    ///
+    /// Similar to `mmap(0, size, prot_flags, MAP_PRIVATE, 0, -1)` on Linux.
+    pub fn wasmtime_mmap_new(size: usize, prot_flags: u32) -> *mut u8;
+
+    /// Remaps the virtual memory starting at `addr` going for `size` bytes to
+    /// the protections specified with a new blank mapping.
+    ///
+    /// This will unmap any prior mappings and decommit them. New mappings for
+    /// anonymous memory are used to replace these mappings and the new area
+    /// should have the protection specified by `prot_flags`.
+    ///
+    /// Aborts the process on failure.
+    ///
+    /// Similar to `mmap(addr, size, prot_flags, MAP_PRIVATE | MAP_FIXED, 0, -1)` on Linux.
+    pub fn wasmtime_mmap_remap(addr: *mut u8, size: usize, prot_flags: u32);
+
+    /// Unmaps memory at the specified `ptr` for `size` bytes.
+    ///
+    /// The memory should be discarded and decommitted and should generate a
+    /// segfault if accessed after this function call.
+    ///
+    /// Aborts the process on failure.
+    ///
+    /// Similar to `munmap` on Linux.
+    pub fn wasmtime_munmap(ptr: *mut u8, size: usize);
+
+    /// Configures the protections associated with a region of virtual memory
+    /// starting at `ptr` and going to `size`.
+    ///
+    /// Aborts the process on failure.
+    ///
+    /// Similar to `mprotect` on Linux.
+    pub fn wasmtime_mprotect(ptr: *mut u8, size: usize, prot_flags: u32);
+
+    /// Returns the page size, in bytes, of the current system.
+    pub fn wasmtime_page_size() -> usize;
+
+    /// Used to setup a frame on the stack to longjmp back to in the future.
+    ///
+    /// This function is used for handling traps in WebAssembly and is paried
+    /// with `wasmtime_longjmp`.
+    ///
+    /// * `jmp_buf` - this argument is filled in with a pointer which if used
+    ///   will be passed to `wasmtime_longjmp` later on by the runtime.
+    /// * `callback` - this callback should be invoked after `jmp_buf` is
+    ///   configured.
+    /// * `payload` and `callee` - the two arguments to pass to `callback`.
+    ///
+    /// Returns 0 if `wasmtime_longjmp` was used to return to this function.
+    /// Returns 1 if `wasmtime_longjmp` was not called an `callback` returned.
+    pub fn wasmtime_setjmp(
+        jmp_buf: *mut *const u8,
+        callback: extern "C" fn(*mut u8, *mut u8),
+        payload: *mut u8,
+        callee: *mut u8,
+    ) -> i32;
+
+    /// Paired with `wasmtime_setjmp` this is used to jump back to the `setjmp`
+    /// point.
+    ///
+    /// The argument here was originally passed to `wasmtime_setjmp` through its
+    /// out-param.
+    ///
+    /// This function cannot return.
+    ///
+    /// This function may be invoked from the `wasmtime_trap_handler_t`
+    /// configured by `wasmtime_init_traps`.
+    pub fn wasmtime_longjmp(jmp_buf: *const u8) -> !;
+
+    /// Initializes trap-handling logic for this platform.
+    ///
+    /// Wasmtime's implementation of WebAssembly relies on the ability to catch
+    /// signals/traps/etc. For example divide-by-zero may raise a machine
+    /// exception. Out-of-bounds memory accesses may also raise a machine
+    /// exception. This function is used to initialize trap handling.
+    ///
+    /// The `handler` provided is a function pointer to invoke whenever a trap
+    /// is encountered. The `handler` is invoked whenever a trap is caught by
+    /// the system.
+    pub fn wasmtime_init_traps(handler: wasmtime_trap_handler_t);
+
+    /// Attempts to create a new in-memory image of the `ptr`/`len` combo which
+    /// can be mapped to virtual addresses in the future. The returned
+    /// `wasmtime_memory_image` pointer can be `NULL` to indicate that an image
+    /// cannot be created. The structure otherwise will later be deallocated
+    /// with `wasmtime_memory_image_free` and `wasmtime_memory_image_map_at`
+    /// will be used to map the image into new regions of the address space.
+    pub fn wasmtime_memory_image_new(ptr: *const u8, len: usize) -> *mut wasmtime_memory_image;
+
+    /// Maps the `image` provided to the virtual address at `addr` and `len`.
+    ///
+    /// This semantically should make it such that `addr` and `len` looks the
+    /// same as the contents of what the memory image was first created with.
+    /// The mappings of `addr` should be private and changes do not reflect back
+    /// to `wasmtime_memory_image`.
+    ///
+    /// In effect this is to create a copy-on-write mapping at `addr`/`len`
+    /// pointing back to the memory used by the image originally.
+    ///
+    /// Aborts the process on failure.
+    pub fn wasmtime_memory_image_map_at(
+        image: *mut wasmtime_memory_image,
+        addr: *mut u8,
+        len: usize,
+    );
+
+    /// Replaces the VM mappings at `addr` and `len` with zeros.
+    ///
+    /// Aborts the process on failure.
+    pub fn wasmtime_memory_image_remap_zeros(
+        image: *mut wasmtime_memory_image,
+        addr: *mut u8,
+        len: usize,
+    );
+
+    /// Deallocates the provided `wasmtime_memory_image`.
+    pub fn wasmtime_memory_image_free(image: *mut wasmtime_memory_image);
+}

--- a/crates/runtime/src/sys/custom/mmap.rs
+++ b/crates/runtime/src/sys/custom/mmap.rs
@@ -1,0 +1,102 @@
+use crate::sys::capi;
+use crate::SendSyncPtr;
+use anyhow::{bail, Result};
+use std::fs::File;
+use std::ops::Range;
+use std::path::Path;
+use std::ptr::NonNull;
+
+#[derive(Debug)]
+pub struct Mmap {
+    memory: SendSyncPtr<[u8]>,
+}
+
+impl Mmap {
+    pub fn new_empty() -> Mmap {
+        Mmap {
+            memory: SendSyncPtr::from(&mut [][..]),
+        }
+    }
+
+    pub fn new(size: usize) -> Result<Self> {
+        let ptr = unsafe { capi::wasmtime_mmap_new(size, capi::PROT_READ | capi::PROT_WRITE) };
+        let memory = std::ptr::slice_from_raw_parts_mut(ptr.cast(), size);
+        let memory = SendSyncPtr::new(NonNull::new(memory).unwrap());
+        Ok(Mmap { memory })
+    }
+
+    pub fn reserve(size: usize) -> Result<Self> {
+        let ptr = unsafe { capi::wasmtime_mmap_new(size, 0) };
+        let memory = std::ptr::slice_from_raw_parts_mut(ptr.cast(), size);
+        let memory = SendSyncPtr::new(NonNull::new(memory).unwrap());
+        Ok(Mmap { memory })
+    }
+
+    pub fn from_file(_path: &Path) -> Result<(Self, File)> {
+        bail!("not supported on this platform");
+    }
+
+    pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<()> {
+        let ptr = self.memory.as_ptr().cast::<u8>();
+        unsafe {
+            capi::wasmtime_mprotect(
+                ptr.add(start).cast(),
+                len,
+                capi::PROT_READ | capi::PROT_WRITE,
+            )
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn as_ptr(&self) -> *const u8 {
+        self.memory.as_ptr() as *const u8
+    }
+
+    #[inline]
+    pub fn as_mut_ptr(&mut self) -> *mut u8 {
+        self.memory.as_ptr().cast()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        unsafe { (*self.memory.as_ptr()).len() }
+    }
+
+    pub unsafe fn make_executable(
+        &self,
+        range: Range<usize>,
+        enable_branch_protection: bool,
+    ) -> Result<()> {
+        let base = self.memory.as_ptr().cast::<u8>().add(range.start).cast();
+        let len = range.end - range.start;
+
+        // not mapped into the C API at this time.
+        let _ = enable_branch_protection;
+
+        capi::wasmtime_mprotect(base, len, capi::PROT_READ | capi::PROT_EXEC);
+        Ok(())
+    }
+
+    pub unsafe fn make_readonly(&self, range: Range<usize>) -> Result<()> {
+        let base = self.memory.as_ptr().cast::<u8>().add(range.start).cast();
+        let len = range.end - range.start;
+
+        capi::wasmtime_mprotect(base, len, capi::PROT_READ);
+        Ok(())
+    }
+}
+
+impl Drop for Mmap {
+    fn drop(&mut self) {
+        unsafe {
+            let ptr = self.memory.as_ptr().cast();
+            let len = (*self.memory.as_ptr()).len();
+            if len == 0 {
+                return;
+            }
+            capi::wasmtime_munmap(ptr, len);
+        }
+    }
+}

--- a/crates/runtime/src/sys/custom/mod.rs
+++ b/crates/runtime/src/sys/custom/mod.rs
@@ -1,0 +1,15 @@
+//! Custom platform support in Wasmtime.
+//!
+//! This module contains an implementation of defining Wasmtime's platform
+//! support in terms of a minimal C API. This API can be found in the `capi`
+//! module and all other functionality here is implemented in terms of that
+//! module.
+//!
+//! For more information about this see `./examples/min-platform` as well as
+//! `./docs/examples-minimal.md`.
+
+pub mod capi;
+pub mod mmap;
+pub mod traphandlers;
+pub mod unwind;
+pub mod vm;

--- a/crates/runtime/src/sys/custom/mod.rs
+++ b/crates/runtime/src/sys/custom/mod.rs
@@ -8,8 +8,17 @@
 //! For more information about this see `./examples/min-platform` as well as
 //! `./docs/examples-minimal.md`.
 
+use std::io;
+
 pub mod capi;
 pub mod mmap;
 pub mod traphandlers;
 pub mod unwind;
 pub mod vm;
+
+fn cvt(rc: i32) -> io::Result<()> {
+    match rc {
+        0 => Ok(()),
+        code => Err(io::Error::from_raw_os_error(code)),
+    }
+}

--- a/crates/runtime/src/sys/custom/traphandlers.rs
+++ b/crates/runtime/src/sys/custom/traphandlers.rs
@@ -1,0 +1,51 @@
+use crate::traphandlers::tls;
+use crate::VMContext;
+use std::mem;
+
+pub use crate::sys::capi::{self, wasmtime_longjmp};
+
+#[allow(missing_docs)]
+pub type SignalHandler<'a> = dyn Fn() + Send + Sync + 'a;
+
+pub unsafe fn wasmtime_setjmp(
+    jmp_buf: *mut *const u8,
+    callback: extern "C" fn(*mut u8, *mut VMContext),
+    payload: *mut u8,
+    callee: *mut VMContext,
+) -> i32 {
+    let callback = mem::transmute::<
+        extern "C" fn(*mut u8, *mut VMContext),
+        extern "C" fn(*mut u8, *mut u8),
+    >(callback);
+    capi::wasmtime_setjmp(jmp_buf, callback, payload, callee.cast())
+}
+
+pub fn platform_init(_macos_use_mach_ports: bool) {
+    unsafe {
+        capi::wasmtime_init_traps(handle_trap);
+    }
+}
+
+extern "C" fn handle_trap(ip: usize, fp: usize, has_faulting_addr: bool, faulting_addr: usize) {
+    tls::with(|info| {
+        let info = match info {
+            Some(info) => info,
+            None => return,
+        };
+        let faulting_addr = if has_faulting_addr {
+            Some(faulting_addr)
+        } else {
+            None
+        };
+        let ip = ip as *const u8;
+        let jmp_buf = info.take_jmp_buf_if_trap(ip, |_handler| {
+            panic!("custom signal handlers are not supported on this platform");
+        });
+        if !jmp_buf.is_null() {
+            info.set_jit_trap(ip, fp, faulting_addr);
+            unsafe { wasmtime_longjmp(jmp_buf) }
+        }
+    })
+}
+
+pub fn lazy_per_thread_init() {}

--- a/crates/runtime/src/sys/custom/unwind.rs
+++ b/crates/runtime/src/sys/custom/unwind.rs
@@ -1,0 +1,17 @@
+#![allow(missing_docs)]
+
+use anyhow::Result;
+
+pub struct UnwindRegistration {}
+
+impl UnwindRegistration {
+    pub const SECTION_NAME: &'static str = ".eh_frame";
+
+    pub unsafe fn new(
+        _base_address: *const u8,
+        _unwind_info: *const u8,
+        _unwind_len: usize,
+    ) -> Result<UnwindRegistration> {
+        Ok(UnwindRegistration {})
+    }
+}

--- a/crates/runtime/src/sys/custom/vm.rs
+++ b/crates/runtime/src/sys/custom/vm.rs
@@ -79,7 +79,7 @@ impl MemoryImageSource {
     }
 
     pub unsafe fn remap_as_zeros_at(&self, base: *mut u8, len: usize) -> io::Result<()> {
-        capi::wasmtime_memory_image_remap_zeros(self.data.as_ptr(), base, len);
+        capi::wasmtime_mmap_remap(base.cast(), len, capi::PROT_READ | capi::PROT_WRITE);
         Ok(())
     }
 }

--- a/crates/runtime/src/sys/custom/vm.rs
+++ b/crates/runtime/src/sys/custom/vm.rs
@@ -1,0 +1,93 @@
+use crate::sys::capi;
+use crate::SendSyncPtr;
+use std::fs::File;
+use std::io;
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+pub unsafe fn expose_existing_mapping(ptr: *mut u8, len: usize) -> io::Result<()> {
+    capi::wasmtime_mprotect(ptr.cast(), len, capi::PROT_READ | capi::PROT_WRITE);
+    Ok(())
+}
+
+pub unsafe fn hide_existing_mapping(ptr: *mut u8, len: usize) -> io::Result<()> {
+    capi::wasmtime_mprotect(ptr.cast(), len, 0);
+    Ok(())
+}
+
+pub unsafe fn erase_existing_mapping(ptr: *mut u8, len: usize) -> io::Result<()> {
+    capi::wasmtime_mmap_remap(ptr.cast(), len, 0);
+    Ok(())
+}
+
+#[cfg(feature = "pooling-allocator")]
+pub unsafe fn commit_table_pages(_addr: *mut u8, _len: usize) -> io::Result<()> {
+    // Table pages are always READ | WRITE so there's nothing that needs to be
+    // done here.
+    Ok(())
+}
+
+#[cfg(feature = "pooling-allocator")]
+pub unsafe fn decommit_table_pages(addr: *mut u8, len: usize) -> io::Result<()> {
+    if len == 0 {
+        return Ok(());
+    }
+
+    capi::wasmtime_mmap_remap(addr, len, capi::PROT_READ | capi::PROT_WRITE);
+
+    Ok(())
+}
+
+pub fn get_page_size() -> usize {
+    unsafe { capi::wasmtime_page_size() }
+}
+
+pub fn supports_madvise_dontneed() -> bool {
+    false
+}
+
+pub unsafe fn madvise_dontneed(_ptr: *mut u8, _len: usize) -> io::Result<()> {
+    unreachable!()
+}
+
+#[derive(PartialEq, Debug)]
+pub struct MemoryImageSource {
+    data: SendSyncPtr<capi::wasmtime_memory_image>,
+}
+
+impl MemoryImageSource {
+    pub fn from_file(_file: &Arc<File>) -> Option<MemoryImageSource> {
+        None
+    }
+
+    pub fn from_data(data: &[u8]) -> io::Result<Option<MemoryImageSource>> {
+        unsafe {
+            let ptr = capi::wasmtime_memory_image_new(data.as_ptr(), data.len());
+            match NonNull::new(ptr) {
+                Some(ptr) => Ok(Some(MemoryImageSource {
+                    data: SendSyncPtr::new(ptr),
+                })),
+                None => Ok(None),
+            }
+        }
+    }
+
+    pub unsafe fn map_at(&self, base: *mut u8, len: usize, offset: u64) -> io::Result<()> {
+        assert_eq!(offset, 0);
+        capi::wasmtime_memory_image_map_at(self.data.as_ptr(), base, len);
+        Ok(())
+    }
+
+    pub unsafe fn remap_as_zeros_at(&self, base: *mut u8, len: usize) -> io::Result<()> {
+        capi::wasmtime_memory_image_remap_zeros(self.data.as_ptr(), base, len);
+        Ok(())
+    }
+}
+
+impl Drop for MemoryImageSource {
+    fn drop(&mut self) {
+        unsafe {
+            capi::wasmtime_memory_image_free(self.data.as_ptr());
+        }
+    }
+}

--- a/crates/runtime/src/sys/mod.rs
+++ b/crates/runtime/src/sys/mod.rs
@@ -18,6 +18,9 @@ cfg_if::cfg_if! {
     } else if #[cfg(unix)] {
         mod unix;
         pub use unix::*;
+    } else if #[cfg(wasmtime_custom_platform)] {
+        mod custom;
+        pub use custom::*;
     } else {
         compile_error!(
             "Wasmtime is being compiled for a platform \

--- a/docs/stability-platform-support.md
+++ b/docs/stability-platform-support.md
@@ -37,11 +37,11 @@ much else will be needed.
 ## What about `#[no_std]`?
 
 The `wasmtime` project does not currently use `#[no_std]` for its crates, but
-this is not because it won't support it! At this time we're still gathering use
-cases for for what `#[no_std]` might entail, so if you're interested in this
-we'd love to hear about your use case! Feel free to [open an
+this is not because it won't support it! For information on building Wasmtime
+for a custom target see [the minimal build
+  documentation](./examples-minimal.md). Please [open an
 issue](https://github.com/bytecodealliance/wasmtime/issues/new) on the
-`wasmtime` repository to discuss this.
+`wasmtime` repository to request support for a specific platform.
 
 This is a common question we are asked, however, so to provide some more context
 on why Wasmtime is the way it is, here's some responses to frequent points

--- a/examples/min-platform/.gitignore
+++ b/examples/min-platform/.gitignore
@@ -1,0 +1,1 @@
+libwasmtime-platform.so

--- a/examples/min-platform/Cargo.toml
+++ b/examples/min-platform/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "min-platform-host"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+libloading = "0.8"
+object = { workspace = true }

--- a/examples/min-platform/README.md
+++ b/examples/min-platform/README.md
@@ -1,0 +1,76 @@
+# Example: Minimal Platform Build of Wasmtime
+
+This example is a showcase of what it looks like to build Wasmtime with a
+minimal set of platform dependencies. This might be suitable when running
+WebAssembly outside of Linux on a smaller system with a custom operating system
+for example. Support here is built on Wasmtime's support of "custom platforms"
+and more details can be found [online as
+well](https://docs.wasmtime.dev/examples-minimal.html).
+
+The example is organized into a few locations:
+
+* `examples/min-platform/embedding/{Cargo.toml,src}` - source code for the
+  embedding of Wasmtime itself. This is compiled to the target architecture
+  and will have a minimal set of dependencies.
+
+* `examples/min-platform/embedding/*.json` - custom Rust target definitions
+  which are used when compiling this example. These are the custom target files
+  that are the compilation target of the `embedding` crate. This is a feature
+  of nightly Rust to be able to use these. Note that the contents can be
+  customized and these files are only examples.
+
+* `examples/min-platform/embedding/wasmtime-platform.{h,c}` - an example
+  implementation of the platform dependencies that Wasmtime requires. This
+  is defined and documented in `crates/runtime/src/sys/custom/capi.rs`. The
+  example here implements the required functions with Linux syscalls.
+
+* `examples/min-platform/{Cargo.toml,src}` - an example "host embedding" which
+  loads and runs the `embedding` from above. This is a bit contrived and mostly
+  serves as a bit of a test case for Wasmtime itself to execute in CI. The
+  general idea though is that this is a Linux program which will load the
+  `embedding` project above and execute it to showcase that the code works.
+
+* `examples/min-platform/build.sh` - a script to build/run this example.
+
+Taken together this example is unlikely to satisfy any one individual use case
+but should set up the scaffolding to show how Wasmtime can be built for a
+nonstandard platform. Wasmtime effectively only has one requirement from the
+system which is management of virtual memory, and beyond that everything else
+can be internalized.
+
+Note that at this time this support all relies on the fact that the Rust
+standard library can be built for a custom target. Most of the Rust standard
+library will be "stubbed out" however and won't work (e.g. opening a file would
+return an error). This means that not all of the `wasmtime` crate will work, nor
+will all features of the `wasmtime` crate, but the set of features activated
+here should suffice.
+
+## Description
+
+This example will compile Wasmtime to a custom Rust target specified in
+`*.json` files. This custom target, for the example, is modeled after Linux
+except for the fact that Rust won't be able to know that (e.g. the `#[cfg]`
+directives aren't set so code won't know it actually runs on Linux). The
+embedding will run a few small examples of WebAssembly modules and then return.
+
+The host for this is a Linux program which supplies the platform dependencies
+that the embedding requires, for example the `wasmtime_*` symbols. This host
+program will load the embedding and execute it.
+
+## Points of Note
+
+* Due to the usage of custom `*.json` targets, this example requires a nightly
+  Rust compiler.
+* Compiling the embedding requires `--cfg wasmtime_custom_platform` in the
+  `RUSTFLAGS` environment variable. to indicate that Wasmtime's custom C
+  API-based definition of platform support is desired.
+* Due to the usage of a custom target most of libstd doesn't work. For example
+  panics can't print anything and the process can only abort.
+* Due to the custom target not all features of Wasmtime can be enabled because
+  some crates may require platform functionality which can't be defined due to
+  the lack of knowledge of what platform is being targeted.
+
+## Running this example
+
+This example can be built and run with the `./build.sh` script in this
+directory. Example output looks like.

--- a/examples/min-platform/build.sh
+++ b/examples/min-platform/build.sh
@@ -46,7 +46,7 @@ clang -shared -O2 -o libwasmtime-platform.so ./embedding/wasmtime-platform.c \
 # The final artifacts will be placed in Cargo's standard target directory.
 RUSTC_BOOTSTRAP_SYNTHETIC_TARGET=1 \
 RUSTFLAGS="--cfg=wasmtime_custom_platform" \
-  cargo +nightly build -Zbuild-std=std,panic_abort \
+  cargo build -Zbuild-std=std,panic_abort \
     --manifest-path embedding/Cargo.toml \
     --target $target \
     --release

--- a/examples/min-platform/build.sh
+++ b/examples/min-platform/build.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# An example script to build and run the `min-platform` example by building both
+# the embedding itself as well as the example host which will run it.
+#
+# This script takes a single argument which is a path to a Rust target json
+# file. Examples are provided in `embedding/*.json`.
+#
+# This script must be executed with the current-working-directory as
+# `examples/min-platform`.
+
+target=$1
+if [ "$target" = "" ]; then
+  echo "Usage: $0 <target-json-file>"
+  exit 1
+fi
+
+set -ex
+
+# First compile the C implementation of the platform symbols that will be
+# required by our embedding. This is the `embedding/wasmtime-platform.c` file.
+# The header file used is generated from Rust source code with the `cbindgen`
+# utility which can be installed with:
+#
+#   cargo install cbindgen
+#
+# which ensures that Rust & C agree on types and such.
+cbindgen ../../crates/runtime/src/sys/custom/capi.rs \
+    --lang C \
+    --cpp-compat > embedding/wasmtime-platform.h
+clang -shared -O2 -o libwasmtime-platform.so ./embedding/wasmtime-platform.c \
+  -D_GNU_SOURCE
+
+# Next the embedding itself is built. Points of note here:
+#
+# * `RUSTC_BOOTSTRAP_SYNTHETIC_TARGET=1` - this "fools" the Rust standard
+#   library to falling back to an "unsupported" implementation of primitives by
+#   default but without marking the standard library as requiring
+#   `feature(restricted_std)`. This is probably something that should be
+#   coordinated with upstream rust-lang/rust and get better support.
+# * `--cfg=wasmtime_custom_platform` - this flag indicates to Wasmtime that the
+#   minimal platform support is being opted into.
+# * `-Zbuild-std=std,panic_abort` - this is a nightly Cargo feature to build the
+#   Rust standard library from source.
+#
+# The final artifacts will be placed in Cargo's standard target directory.
+RUSTC_BOOTSTRAP_SYNTHETIC_TARGET=1 \
+RUSTFLAGS="--cfg=wasmtime_custom_platform" \
+  cargo +nightly build -Zbuild-std=std,panic_abort \
+    --manifest-path embedding/Cargo.toml \
+    --target $target \
+    --release
+
+# The final step here is running the host, in the current directory, which will
+# load the embedding and execute it.
+cargo run --release -- $target

--- a/examples/min-platform/embedding/Cargo.toml
+++ b/examples/min-platform/embedding/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "embedding"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+
+# Note that default-features of wasmtime are disabled and only those required
+# are enabled, in this case compilation is done in the guest from the wasm text
+# format so `cranelift` and `wat` are enabled.
+wasmtime = { workspace = true, features = ['cranelift', 'wat', 'runtime'] }
+
+# Memory allocator used in this example (not required, however)
+dlmalloc = "0.2.4"
+
+[lib]
+crate-type = ['cdylib']
+test = false
+doctest = false

--- a/examples/min-platform/embedding/aarch64-unknown-unknown.json
+++ b/examples/min-platform/embedding/aarch64-unknown-unknown.json
@@ -1,0 +1,18 @@
+{
+  "arch": "aarch64",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+  "dynamic-linking": true,
+  "has-thread-local": true,
+  "is-builtin": false,
+  "llvm-target": "aarch64-unknown-linux-gnu",
+  "max-atomic-width": 64,
+  "os": "minwasmtime",
+  "position-independent-executables": true,
+  "panic-strategy": "abort",
+  "frame-pointer": "always",
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "inline"
+  },
+  "target-pointer-width": "64"
+}

--- a/examples/min-platform/embedding/src/allocator.rs
+++ b/examples/min-platform/embedding/src/allocator.rs
@@ -1,0 +1,106 @@
+//! An allocator definition for this embedding.
+//!
+//! The Rust standard library and Wasmtime require a memory allocator to be
+//! configured. For custom embeddings of Wasmtime this might likely already be
+//! defined elsewhere in the system in which case that should be used. This file
+//! contains an example implementation using the Rust `dlmalloc` crate using
+//! memory created by `wasmtime_*` platform symbols. This provides a file that
+//! manages memory without any extra runtime dependencies, but this is just an
+//! example.
+//!
+//! Allocators in Rust are configured with the `#[global_allocator]` attribute
+//! and the `GlobalAlloc for T` trait impl. This should be used when hooking
+//! up to an allocator elsewhere in the system.
+
+use dlmalloc::Dlmalloc;
+use std::alloc::{GlobalAlloc, Layout};
+use std::sync::Mutex;
+
+#[global_allocator]
+static MALLOC: MyGlobalDmalloc = MyGlobalDmalloc {
+    dlmalloc: Mutex::new(Dlmalloc::new_with_allocator(MyAllocator)),
+};
+
+struct MyGlobalDmalloc {
+    dlmalloc: Mutex<Dlmalloc<MyAllocator>>,
+}
+
+unsafe impl Send for MyGlobalDmalloc {}
+unsafe impl Sync for MyGlobalDmalloc {}
+
+struct MyAllocator;
+
+unsafe impl GlobalAlloc for MyGlobalDmalloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        self.dlmalloc
+            .lock()
+            .unwrap()
+            .malloc(layout.size(), layout.align())
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        self.dlmalloc
+            .lock()
+            .unwrap()
+            .calloc(layout.size(), layout.align())
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        self.dlmalloc
+            .lock()
+            .unwrap()
+            .realloc(ptr, layout.size(), layout.align(), new_size)
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        self.dlmalloc
+            .lock()
+            .unwrap()
+            .free(ptr, layout.size(), layout.align())
+    }
+}
+
+// Hand-copied from `crates/runtime/src/sys/custom/capi.rs`.
+const PROT_READ: u32 = 1 << 0;
+const PROT_WRITE: u32 = 1 << 1;
+extern "C" {
+    fn wasmtime_mmap_new(size: usize, prot_flags: u32) -> *mut u8;
+    fn wasmtime_page_size() -> usize;
+    fn wasmtime_munmap(ptr: *mut u8, size: usize);
+}
+
+unsafe impl dlmalloc::Allocator for MyAllocator {
+    fn alloc(&self, size: usize) -> (*mut u8, usize, u32) {
+        unsafe {
+            let ptr = wasmtime_mmap_new(size, PROT_READ | PROT_WRITE);
+            (ptr, size, 0)
+        }
+    }
+
+    fn remap(&self, _ptr: *mut u8, _old: usize, _new: usize, _can_move: bool) -> *mut u8 {
+        std::ptr::null_mut()
+    }
+
+    fn free_part(&self, _ptr: *mut u8, _old: usize, _new: usize) -> bool {
+        false
+    }
+
+    fn free(&self, ptr: *mut u8, size: usize) -> bool {
+        unsafe {
+            wasmtime_munmap(ptr, size);
+            true
+        }
+    }
+
+    fn can_release_part(&self, _flags: u32) -> bool {
+        false
+    }
+
+    fn allocates_zeros(&self) -> bool {
+        true
+    }
+
+    fn page_size(&self) -> usize {
+        unsafe { wasmtime_page_size() }
+    }
+}

--- a/examples/min-platform/embedding/src/lib.rs
+++ b/examples/min-platform/embedding/src/lib.rs
@@ -1,0 +1,71 @@
+use anyhow::Result;
+use wasmtime::{Engine, Instance, Linker, Module, Store};
+
+mod allocator;
+
+#[no_mangle]
+pub unsafe extern "C" fn run(buf: *mut u8, size: usize) -> usize {
+    let buf = std::slice::from_raw_parts_mut(buf, size);
+    match run_result() {
+        Ok(()) => 0,
+        Err(e) => {
+            let msg = format!("{e:?}");
+            let len = buf.len().min(msg.len());
+            buf[..len].copy_from_slice(&msg.as_bytes()[..len]);
+            len
+        }
+    }
+}
+
+fn run_result() -> Result<()> {
+    smoke()?;
+    simple_add()?;
+    simple_host_fn()?;
+    Ok(())
+}
+
+fn smoke() -> Result<()> {
+    let engine = Engine::default();
+    let module = Module::new(&engine, "(module)")?;
+    Instance::new(&mut Store::new(&engine, ()), &module, &[])?;
+    Ok(())
+}
+
+fn simple_add() -> Result<()> {
+    let engine = Engine::default();
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (func (export "add") (param i32 i32) (result i32)
+                    (i32.add (local.get 0) (local.get 1)))
+            )
+        "#,
+    )?;
+    let mut store = Store::new(&engine, ());
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let func = instance.get_typed_func::<(u32, u32), u32>(&mut store, "add")?;
+    assert_eq!(func.call(&mut store, (2, 3))?, 5);
+    Ok(())
+}
+
+fn simple_host_fn() -> Result<()> {
+    let engine = Engine::default();
+    let module = Module::new(
+        &engine,
+        r#"
+            (module
+                (import "host" "multiply" (func $multiply (param i32 i32) (result i32)))
+                (func (export "add_and_mul") (param i32 i32 i32) (result i32)
+                    (i32.add (call $multiply (local.get 0) (local.get 1)) (local.get 2)))
+            )
+        "#,
+    )?;
+    let mut linker = Linker::<()>::new(&engine);
+    linker.func_wrap("host", "multiply", |a: u32, b: u32| a.saturating_mul(b))?;
+    let mut store = Store::new(&engine, ());
+    let instance = linker.instantiate(&mut store, &module)?;
+    let func = instance.get_typed_func::<(u32, u32, u32), u32>(&mut store, "add_and_mul")?;
+    assert_eq!(func.call(&mut store, (2, 3, 4))?, 10);
+    Ok(())
+}

--- a/examples/min-platform/embedding/wasmtime-platform.c
+++ b/examples/min-platform/embedding/wasmtime-platform.c
@@ -1,9 +1,9 @@
 #include <assert.h>
 #include <setjmp.h>
 #include <signal.h>
+#include <string.h>
 #include <sys/mman.h>
 #include <sys/ucontext.h>
-#include <string.h>
 #include <unistd.h>
 
 #include "wasmtime-platform.h"
@@ -20,51 +20,46 @@ static int wasmtime_to_mmap_prot_flags(uint32_t prot_flags) {
 }
 
 uint8_t *wasmtime_mmap_new(uintptr_t size, uint32_t prot_flags) {
-  void *rc = mmap(NULL, size,
-      wasmtime_to_mmap_prot_flags(prot_flags),
-      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  void *rc = mmap(NULL, size, wasmtime_to_mmap_prot_flags(prot_flags),
+                  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   assert(rc != MAP_FAILED);
   return rc;
 }
 
 void wasmtime_mmap_remap(uint8_t *addr, uintptr_t size, uint32_t prot_flags) {
-  void *rc = mmap(addr, size,
-      wasmtime_to_mmap_prot_flags(prot_flags),
-      MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  void *rc = mmap(addr, size, wasmtime_to_mmap_prot_flags(prot_flags),
+                  MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   assert(rc == addr);
-  (void) rc;
+  (void)rc;
 }
 
 void wasmtime_munmap(uint8_t *ptr, uintptr_t size) {
   int rc = munmap(ptr, size);
   assert(rc == 0);
-  (void) rc;
+  (void)rc;
 }
 
 void wasmtime_mprotect(uint8_t *ptr, uintptr_t size, uint32_t prot_flags) {
   int rc = mprotect(ptr, size, wasmtime_to_mmap_prot_flags(prot_flags));
   assert(rc == 0);
-  (void) rc;
+  (void)rc;
 }
 
-uintptr_t wasmtime_page_size(void) {
-  return sysconf(_SC_PAGESIZE);
-}
+uintptr_t wasmtime_page_size(void) { return sysconf(_SC_PAGESIZE); }
 
 int32_t wasmtime_setjmp(const uint8_t **jmp_buf_out,
-                               void (*callback)(uint8_t*, uint8_t*),
-                               uint8_t *payload,
-                               uint8_t *callee) {
+                        void (*callback)(uint8_t *, uint8_t *),
+                        uint8_t *payload, uint8_t *callee) {
   jmp_buf buf;
   if (setjmp(buf) != 0)
     return 0;
-  *jmp_buf_out = (uint8_t*) &buf;
+  *jmp_buf_out = (uint8_t *)&buf;
   callback(payload, callee);
   return 1;
 }
 
 void wasmtime_longjmp(const uint8_t *jmp_buf_ptr) {
-  longjmp(*(jmp_buf*) jmp_buf_ptr, 1);
+  longjmp(*(jmp_buf *)jmp_buf_ptr, 1);
 }
 
 static wasmtime_trap_handler_t g_handler = NULL;
@@ -87,7 +82,7 @@ static void handle_signal(int signo, siginfo_t *info, void *context) {
   bool has_faulting_addr = signo == SIGSEGV;
   uintptr_t faulting_addr = 0;
   if (has_faulting_addr)
-    faulting_addr = (uintptr_t) info->si_addr;
+    faulting_addr = (uintptr_t)info->si_addr;
   g_handler(ip, fp, has_faulting_addr, faulting_addr);
 
   // If wasmtime didn't handle this trap then reset the handler to the default
@@ -112,22 +107,21 @@ extern void wasmtime_init_traps(wasmtime_trap_handler_t handler) {
   assert(rc == 0);
   rc = sigaction(SIGFPE, &action, NULL);
   assert(rc == 0);
-  (void) rc;
+  (void)rc;
 }
 
-struct wasmtime_memory_image *wasmtime_memory_image_new(const uint8_t *ptr, uintptr_t len) {
+struct wasmtime_memory_image *wasmtime_memory_image_new(const uint8_t *ptr,
+                                                        uintptr_t len) {
   return NULL;
 }
 
 void wasmtime_memory_image_map_at(struct wasmtime_memory_image *image,
-                                  uint8_t *addr,
-                                  uintptr_t len) {
+                                  uint8_t *addr, uintptr_t len) {
   abort();
 }
 
 void wasmtime_memory_image_remap_zeros(struct wasmtime_memory_image *image,
-                                       uint8_t *addr,
-                                       uintptr_t len) {
+                                       uint8_t *addr, uintptr_t len) {
   abort();
 }
 

--- a/examples/min-platform/embedding/wasmtime-platform.c
+++ b/examples/min-platform/embedding/wasmtime-platform.c
@@ -1,0 +1,136 @@
+#include <assert.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <sys/ucontext.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "wasmtime-platform.h"
+
+static int wasmtime_to_mmap_prot_flags(uint32_t prot_flags) {
+  int flags = 0;
+  if (prot_flags & WASMTIME_PROT_READ)
+    flags |= PROT_READ;
+  if (prot_flags & WASMTIME_PROT_WRITE)
+    flags |= PROT_WRITE;
+  if (prot_flags & WASMTIME_PROT_EXEC)
+    flags |= PROT_EXEC;
+  return flags;
+}
+
+uint8_t *wasmtime_mmap_new(uintptr_t size, uint32_t prot_flags) {
+  void *rc = mmap(NULL, size,
+      wasmtime_to_mmap_prot_flags(prot_flags),
+      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  assert(rc != MAP_FAILED);
+  return rc;
+}
+
+void wasmtime_mmap_remap(uint8_t *addr, uintptr_t size, uint32_t prot_flags) {
+  void *rc = mmap(addr, size,
+      wasmtime_to_mmap_prot_flags(prot_flags),
+      MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  assert(rc == addr);
+  (void) rc;
+}
+
+void wasmtime_munmap(uint8_t *ptr, uintptr_t size) {
+  int rc = munmap(ptr, size);
+  assert(rc == 0);
+  (void) rc;
+}
+
+void wasmtime_mprotect(uint8_t *ptr, uintptr_t size, uint32_t prot_flags) {
+  int rc = mprotect(ptr, size, wasmtime_to_mmap_prot_flags(prot_flags));
+  assert(rc == 0);
+  (void) rc;
+}
+
+uintptr_t wasmtime_page_size(void) {
+  return sysconf(_SC_PAGESIZE);
+}
+
+int32_t wasmtime_setjmp(const uint8_t **jmp_buf_out,
+                               void (*callback)(uint8_t*, uint8_t*),
+                               uint8_t *payload,
+                               uint8_t *callee) {
+  jmp_buf buf;
+  if (setjmp(buf) != 0)
+    return 0;
+  *jmp_buf_out = (uint8_t*) &buf;
+  callback(payload, callee);
+  return 1;
+}
+
+void wasmtime_longjmp(const uint8_t *jmp_buf_ptr) {
+  longjmp(*(jmp_buf*) jmp_buf_ptr, 1);
+}
+
+static wasmtime_trap_handler_t g_handler = NULL;
+
+static void handle_signal(int signo, siginfo_t *info, void *context) {
+  assert(g_handler != NULL);
+  uintptr_t ip, fp;
+#if defined(__aarch64__)
+  ucontext_t *cx = context;
+  ip = cx->uc_mcontext.pc;
+  fp = cx->uc_mcontext.regs[29];
+#elif defined(__x86_64__)
+  ucontext_t *cx = context;
+  ip = cx->uc_mcontext.gregs[REG_RIP];
+  fp = cx->uc_mcontext.gregs[REG_RBP];
+#else
+#error "Unsupported platform"
+#endif
+
+  bool has_faulting_addr = signo == SIGSEGV;
+  uintptr_t faulting_addr = 0;
+  if (has_faulting_addr)
+    faulting_addr = (uintptr_t) info->si_addr;
+  g_handler(ip, fp, has_faulting_addr, faulting_addr);
+
+  // If wasmtime didn't handle this trap then reset the handler to the default
+  // behavior which will probably abort the process.
+  signal(signo, SIG_DFL);
+}
+
+extern void wasmtime_init_traps(wasmtime_trap_handler_t handler) {
+  int rc;
+  g_handler = handler;
+
+  struct sigaction action;
+  memset(&action, 0, sizeof(action));
+
+  action.sa_sigaction = handle_signal;
+  action.sa_flags = SA_SIGINFO | SA_NODEFER;
+  sigemptyset(&action.sa_mask);
+
+  rc = sigaction(SIGILL, &action, NULL);
+  assert(rc == 0);
+  rc = sigaction(SIGSEGV, &action, NULL);
+  assert(rc == 0);
+  rc = sigaction(SIGFPE, &action, NULL);
+  assert(rc == 0);
+  (void) rc;
+}
+
+struct wasmtime_memory_image *wasmtime_memory_image_new(const uint8_t *ptr, uintptr_t len) {
+  return NULL;
+}
+
+void wasmtime_memory_image_map_at(struct wasmtime_memory_image *image,
+                                  uint8_t *addr,
+                                  uintptr_t len) {
+  abort();
+}
+
+void wasmtime_memory_image_remap_zeros(struct wasmtime_memory_image *image,
+                                       uint8_t *addr,
+                                       uintptr_t len) {
+  abort();
+}
+
+void wasmtime_memory_image_free(struct wasmtime_memory_image *image) {
+  abort();
+}

--- a/examples/min-platform/embedding/wasmtime-platform.c
+++ b/examples/min-platform/embedding/wasmtime-platform.c
@@ -120,11 +120,6 @@ void wasmtime_memory_image_map_at(struct wasmtime_memory_image *image,
   abort();
 }
 
-void wasmtime_memory_image_remap_zeros(struct wasmtime_memory_image *image,
-                                       uint8_t *addr, uintptr_t len) {
-  abort();
-}
-
 void wasmtime_memory_image_free(struct wasmtime_memory_image *image) {
   abort();
 }

--- a/examples/min-platform/embedding/wasmtime-platform.h
+++ b/examples/min-platform/embedding/wasmtime-platform.h
@@ -1,0 +1,203 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Indicates that the memory region should be readable.
+ */
+#define WASMTIME_PROT_READ (1 << 0)
+
+/**
+ * Indicates that the memory region should be writable.
+ */
+#define WASMTIME_PROT_WRITE (1 << 1)
+
+/**
+ * Indicates that the memory region should be executable.
+ */
+#define WASMTIME_PROT_EXEC (1 << 2)
+
+/**
+ * Abstract pointer type used in the `wasmtime_memory_image_*` APIs which
+ * is defined by the embedder.
+ */
+typedef struct wasmtime_memory_image wasmtime_memory_image;
+
+/**
+ * Handler function for traps in Wasmtime passed to `wasmtime_init_traps`.
+ *
+ * This function is invoked whenever a trap is caught by the system. For
+ * example this would be invoked during a signal handler on Linux. This
+ * function is passed a number of parameters indicating information about the
+ * trap:
+ *
+ * * `ip` - the instruction pointer at the time of the trap.
+ * * `fp` - the frame pointer register's value at the time of the trap.
+ * * `has_faulting_addr` - whether this trap is associated with an access
+ *   violation (e.g. a segfault) meaning memory was accessed when it shouldn't
+ *   be. If this is `true` then the next parameter is filled in.
+ * * `faulting_addr` - if `has_faulting_addr` is true then this is the address
+ *   that was attempted to be accessed. Otherwise this value is not used.
+ *
+ * If this function returns then the trap was not handled. This probably means
+ * that a fatal exception happened and the process should be aborted.
+ *
+ * This function may not return as it may invoke `wasmtime_longjmp` if a wasm
+ * trap is detected.
+ */
+typedef void (*wasmtime_trap_handler_t)(uintptr_t ip,
+                                        uintptr_t fp,
+                                        bool has_faulting_addr,
+                                        uintptr_t faulting_addr);
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
+/**
+ * Creates a new virtual memory mapping of the `size` specified with
+ * protection bits specified in `prot_flags`.
+ *
+ * Memory can be lazily committed.
+ *
+ * Returns the base pointer of the new mapping. Aborts the process on
+ * failure.
+ *
+ * Similar to `mmap(0, size, prot_flags, MAP_PRIVATE, 0, -1)` on Linux.
+ */
+extern uint8_t *wasmtime_mmap_new(uintptr_t size, uint32_t prot_flags);
+
+/**
+ * Remaps the virtual memory starting at `addr` going for `size` bytes to
+ * the protections specified with a new blank mapping.
+ *
+ * This will unmap any prior mappings and decommit them. New mappings for
+ * anonymous memory are used to replace these mappings and the new area
+ * should have the protection specified by `prot_flags`.
+ *
+ * Aborts the process on failure.
+ *
+ * Similar to `mmap(addr, size, prot_flags, MAP_PRIVATE | MAP_FIXED, 0, -1)` on Linux.
+ */
+extern void wasmtime_mmap_remap(uint8_t *addr, uintptr_t size, uint32_t prot_flags);
+
+/**
+ * Unmaps memory at the specified `ptr` for `size` bytes.
+ *
+ * The memory should be discarded and decommitted and should generate a
+ * segfault if accessed after this function call.
+ *
+ * Aborts the process on failure.
+ *
+ * Similar to `munmap` on Linux.
+ */
+extern void wasmtime_munmap(uint8_t *ptr, uintptr_t size);
+
+/**
+ * Configures the protections associated with a region of virtual memory
+ * starting at `ptr` and going to `size`.
+ *
+ * Aborts the process on failure.
+ *
+ * Similar to `mprotect` on Linux.
+ */
+extern void wasmtime_mprotect(uint8_t *ptr, uintptr_t size, uint32_t prot_flags);
+
+/**
+ * Returns the page size, in bytes, of the current system.
+ */
+extern uintptr_t wasmtime_page_size(void);
+
+/**
+ * Used to setup a frame on the stack to longjmp back to in the future.
+ *
+ * This function is used for handling traps in WebAssembly and is paried
+ * with `wasmtime_longjmp`.
+ *
+ * * `jmp_buf` - this argument is filled in with a pointer which if used
+ *   will be passed to `wasmtime_longjmp` later on by the runtime.
+ * * `callback` - this callback should be invoked after `jmp_buf` is
+ *   configured.
+ * * `payload` and `callee` - the two arguments to pass to `callback`.
+ *
+ * Returns 0 if `wasmtime_longjmp` was used to return to this function.
+ * Returns 1 if `wasmtime_longjmp` was not called an `callback` returned.
+ */
+extern int32_t wasmtime_setjmp(const uint8_t **jmp_buf,
+                               void (*callback)(uint8_t*, uint8_t*),
+                               uint8_t *payload,
+                               uint8_t *callee);
+
+/**
+ * Paired with `wasmtime_setjmp` this is used to jump back to the `setjmp`
+ * point.
+ *
+ * The argument here was originally passed to `wasmtime_setjmp` through its
+ * out-param.
+ *
+ * This function cannot return.
+ *
+ * This function may be invoked from the `wasmtime_trap_handler_t`
+ * configured by `wasmtime_init_traps`.
+ */
+extern void wasmtime_longjmp(const uint8_t *jmp_buf);
+
+/**
+ * Initializes trap-handling logic for this platform.
+ *
+ * Wasmtime's implementation of WebAssembly relies on the ability to catch
+ * signals/traps/etc. For example divide-by-zero may raise a machine
+ * exception. Out-of-bounds memory accesses may also raise a machine
+ * exception. This function is used to initialize trap handling.
+ *
+ * The `handler` provided is a function pointer to invoke whenever a trap
+ * is encountered. The `handler` is invoked whenever a trap is caught by
+ * the system.
+ */
+extern void wasmtime_init_traps(wasmtime_trap_handler_t handler);
+
+/**
+ * Attempts to create a new in-memory image of the `ptr`/`len` combo which
+ * can be mapped to virtual addresses in the future. The returned
+ * `wasmtime_memory_image` pointer can be `NULL` to indicate that an image
+ * cannot be created. The structure otherwise will later be deallocated
+ * with `wasmtime_memory_image_free` and `wasmtime_memory_image_map_at`
+ * will be used to map the image into new regions of the address space.
+ */
+extern struct wasmtime_memory_image *wasmtime_memory_image_new(const uint8_t *ptr, uintptr_t len);
+
+/**
+ * Maps the `image` provided to the virtual address at `addr` and `len`.
+ *
+ * This semantically should make it such that `addr` and `len` looks the
+ * same as the contents of what the memory image was first created with.
+ * The mappings of `addr` should be private and changes do not reflect back
+ * to `wasmtime_memory_image`.
+ *
+ * In effect this is to create a copy-on-write mapping at `addr`/`len`
+ * pointing back to the memory used by the image originally.
+ *
+ * Aborts the process on failure.
+ */
+extern void wasmtime_memory_image_map_at(struct wasmtime_memory_image *image,
+                                         uint8_t *addr,
+                                         uintptr_t len);
+
+/**
+ * Replaces the VM mappings at `addr` and `len` with zeros.
+ *
+ * Aborts the process on failure.
+ */
+extern void wasmtime_memory_image_remap_zeros(struct wasmtime_memory_image *image,
+                                              uint8_t *addr,
+                                              uintptr_t len);
+
+/**
+ * Deallocates the provided `wasmtime_memory_image`.
+ */
+extern void wasmtime_memory_image_free(struct wasmtime_memory_image *image);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus

--- a/examples/min-platform/embedding/x86_64-unknown-unknown.json
+++ b/examples/min-platform/embedding/x86_64-unknown-unknown.json
@@ -1,0 +1,20 @@
+{
+  "arch": "x86_64",
+  "cpu": "x86-64",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  "features": "+sse4.2,+avx,+fma,+popcnt",
+  "dynamic-linking": true,
+  "has-thread-local": true,
+  "is-builtin": false,
+  "llvm-target": "x86_64-unknown-linux-gnu",
+  "max-atomic-width": 64,
+  "os": "minwasmtime",
+  "position-independent-executables": true,
+  "panic-strategy": "abort",
+  "frame-pointer": "always",
+  "relro-level": "full",
+  "stack-probes": {
+    "kind": "inline"
+  },
+  "target-pointer-width": "64"
+}

--- a/examples/min-platform/src/main.rs
+++ b/examples/min-platform/src/main.rs
@@ -1,0 +1,74 @@
+use anyhow::Result;
+use libloading::os::unix::{Library, Symbol, RTLD_GLOBAL, RTLD_NOW};
+use object::{Object, ObjectSymbol};
+use std::io::Write;
+use std::path::Path;
+
+fn main() -> Result<()> {
+    let target = std::env::args().nth(1).unwrap();
+    let target = Path::new(&target).file_stem().unwrap().to_str().unwrap();
+    // Path to the artifact which is the build of the embedding.
+    //
+    // In this example this is a dynamic library intended to be run on Linux.
+    // Note that this is just an example of an artifact and custom build
+    // processes can produce different kinds of artifacts.
+    let lib = format!("../../target/{target}/release/libembedding.so");
+    let binary = std::fs::read(&lib)?;
+    let object = object::File::parse(&binary[..])?;
+
+    // Showcase verification that the dynamic library in question doesn't depend
+    // on much. Wasmtime build in a "minimal platform" mode is allowed to
+    // depend on some standard C symbols such as `memcpy` but any OS-related
+    // symbol must be prefixed by `wasmtime_*` and be documented in
+    // `crates/runtime/src/sys/custom/capi.rs`.
+    //
+    // This is effectively a double-check of the above assesrtion and showing
+    // how running `libembedding.so` in this case requires only minimal
+    // dependencies.
+    for sym in object.symbols() {
+        if !sym.is_undefined() || sym.is_weak() {
+            continue;
+        }
+
+        match sym.name()? {
+            "" | "memmove" | "memset" | "memcmp" | "memcpy" | "bcmp" | "__tls_get_addr" => {}
+            s if s.starts_with("wasmtime_") => {}
+            other => {
+                panic!("unexpected dependency on symbol `{other}`")
+            }
+        }
+    }
+
+    // Next is an example of running this embedding, which also serves as test
+    // that basic functionality actually works.
+    //
+    // Here the `wasmtime_*` symbols are implemented by
+    // `./embedding/wasmtime-platform.c` which is an example implementation
+    // against glibc on Linux. This library is compiled into
+    // `libwasmtime-platform.so` and is dynamically opened here to make it
+    // available for later symbol resolution. This is just an implementation
+    // detail of this exable to enably dynamically loading `libembedding.so`
+    // next.
+    //
+    // Next the `libembedding.so` library is opened and the `run` symbol is
+    // run. The dependencies of `libembedding.so` are either satisfied by our
+    // ambient libc (e.g. `memcpy` and friends) or `libwasmtime-platform.so`
+    // (e.g. `wasmtime_*` symbols).
+    //
+    // The embedding is then run to showcase an example and then an error, if
+    // any, is written to stderr.
+    unsafe {
+        let _platform_symbols =
+            Library::open(Some("./libwasmtime-platform.so"), RTLD_NOW | RTLD_GLOBAL)?;
+
+        let lib = Library::new(&lib)?;
+        let run: Symbol<extern "C" fn(*mut u8, usize) -> usize> = lib.get(b"run")?;
+
+        let mut buf = Vec::with_capacity(1024);
+        let len = run(buf.as_mut_ptr(), buf.capacity());
+        buf.set_len(len);
+
+        std::io::stderr().write_all(&buf).unwrap();
+    }
+    Ok(())
+}

--- a/examples/min-platform/src/main.rs
+++ b/examples/min-platform/src/main.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use libloading::os::unix::{Library, Symbol, RTLD_GLOBAL, RTLD_NOW};
-use object::{Object, ObjectSymbol};
+use object::{Object, ObjectSymbol, SymbolKind};
 use std::io::Write;
 use std::path::Path;
 
@@ -26,12 +26,12 @@ fn main() -> Result<()> {
     // how running `libembedding.so` in this case requires only minimal
     // dependencies.
     for sym in object.symbols() {
-        if !sym.is_undefined() || sym.is_weak() {
+        if !sym.is_undefined() || sym.is_weak() || sym.kind() == SymbolKind::Null {
             continue;
         }
 
         match sym.name()? {
-            "" | "memmove" | "memset" | "memcmp" | "memcpy" | "bcmp" | "__tls_get_addr" => {}
+            "memmove" | "memset" | "memcmp" | "memcpy" | "bcmp" | "__tls_get_addr" => {}
             s if s.starts_with("wasmtime_") => {}
             other => {
                 panic!("unexpected dependency on symbol `{other}`")

--- a/examples/min-platform/src/main.rs
+++ b/examples/min-platform/src/main.rs
@@ -1,10 +1,16 @@
-use anyhow::Result;
-use libloading::os::unix::{Library, Symbol, RTLD_GLOBAL, RTLD_NOW};
-use object::{Object, ObjectSymbol, SymbolKind};
-use std::io::Write;
-use std::path::Path;
+#[cfg(not(target_os = "linux"))]
+fn main() {
+    eprintln!("This example only runs on Linux right now");
+}
 
+#[cfg(target_os = "linux")]
 fn main() -> Result<()> {
+    use anyhow::Result;
+    use libloading::os::unix::{Library, Symbol, RTLD_GLOBAL, RTLD_NOW};
+    use object::{Object, ObjectSymbol, SymbolKind};
+    use std::io::Write;
+    use std::path::Path;
+
     let target = std::env::args().nth(1).unwrap();
     let target = Path::new(&target).file_stem().unwrap().to_str().unwrap();
     // Path to the artifact which is the build of the embedding.

--- a/examples/min-platform/src/main.rs
+++ b/examples/min-platform/src/main.rs
@@ -1,11 +1,13 @@
+use anyhow::Result;
+
 #[cfg(not(target_os = "linux"))]
-fn main() {
+fn main() -> anyhow::Result<()> {
     eprintln!("This example only runs on Linux right now");
+    Ok(())
 }
 
 #[cfg(target_os = "linux")]
 fn main() -> Result<()> {
-    use anyhow::Result;
     use libloading::os::unix::{Library, Symbol, RTLD_GLOBAL, RTLD_NOW};
     use object::{Object, ObjectSymbol, SymbolKind};
     use std::io::Write;

--- a/examples/min-platform/src/main.rs
+++ b/examples/min-platform/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 
 #[cfg(not(target_os = "linux"))]
-fn main() -> anyhow::Result<()> {
+fn main() -> Result<()> {
     eprintln!("This example only runs on Linux right now");
     Ok(())
 }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -3270,6 +3270,12 @@ user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-07-30"
 end = "2025-02-12"
 
+[[trusted.dlmalloc]]
+criteria = "safe-to-deploy"
+user-id = 1 # Alex Crichton (alexcrichton)
+start = "2020-05-19"
+end = "2025-02-23"
+
 [[trusted.equivalent]]
 criteria = "safe-to-deploy"
 user-id = 539 # Josh Stone (cuviper)

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -466,6 +466,13 @@ user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
+[[publisher.dlmalloc]]
+version = "0.2.4"
+when = "2022-08-17"
+user-id = 1
+user-login = "alexcrichton"
+user-name = "Alex Crichton"
+
 [[publisher.equivalent]]
 version = "1.0.1"
 when = "2023-07-10"


### PR DESCRIPTION
This commit leverages adds a new "platform" to Wasmtime to be supported in the `crates/runtime/src/sys` folder. This joins preexisting platforms such as Unix and Windows. The goal of this platform is to be an opt-in way to build Wasmtime for targets that don't have a predefined way to run.

The new "custom" platform requires `--cfg wasmtime_custom_platform` to be passed to the Rust compiler, for example by using `RUSTFLAGS`. This new platform bottoms out in a C API that is intended to be small and Linux-like. The C API is effectively the interface to virtual memory that Wasmtime requires. This C API is also available as a header file at `examples/min-platform/embedding/wasmtime-platform.h` (generated by `cbindgen`).

The main purpose of this is to make it easier to experiment with porting Wasmtime to new platforms. By decoupling a platform implementation from Wasmtime itself it should be possible to run these experiments out-of-tree. An example of this I've been working on is getting Wasmtime running on bare-metal with a custom kernel. This support enables defining the platform interface of the custom kernel's syscalls outside of Wasmtime.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
