### PR TITLE
Support `global.get` in more constant expressions

### DIFF
--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -459,7 +459,7 @@ impl ModuleTranslation<'_> {
             // Get the end of this segment. If out-of-bounds, or too
             // large for our dense table representation, then skip the
             // segment.
-            let top = match segment.offset.checked_add(segment.elements.len() as u32) {
+            let top = match segment.offset.checked_add(segment.elements.len()) {
                 Some(top) => top,
                 None => break,
             };
@@ -482,6 +482,13 @@ impl ModuleTranslation<'_> {
                 WasmHeapType::Extern => break,
             }
 
+            // Function indices can be optimized here, but fully general
+            // expressions are deferred to get evaluated at runtime.
+            let function_elements = match &segment.elements {
+                TableSegmentElements::Functions(indices) => indices,
+                TableSegmentElements::Expressions(_) => break,
+            };
+
             let precomputed =
                 match &mut self.module.table_initialization.initial_values[defined_index] {
                     TableInitialValue::Null { precomputed } => precomputed,
@@ -492,7 +499,7 @@ impl ModuleTranslation<'_> {
                     // Technically this won't trap so it's possible to process
                     // further initializers, but that's left as a future
                     // optimization.
-                    TableInitialValue::FuncRef(_) => break,
+                    TableInitialValue::FuncRef(_) | TableInitialValue::GlobalGet(_) => break,
                 };
 
             // At this point we're committing to pre-initializing the table
@@ -504,7 +511,7 @@ impl ModuleTranslation<'_> {
                 precomputed.resize(top as usize, FuncIndex::reserved_value());
             }
             let dst = &mut precomputed[(segment.offset as usize)..(top as usize)];
-            dst.copy_from_slice(&segment.elements[..]);
+            dst.copy_from_slice(&function_elements);
 
             // advance the iterator to see the next segment
             let _ = segments.next();
@@ -757,6 +764,10 @@ pub enum TableInitialValue {
     /// Initialize each table element to the function reference given
     /// by the `FuncIndex`.
     FuncRef(FuncIndex),
+
+    /// At instantiation time this global is loaded and the funcref value is
+    /// used to initialize the table.
+    GlobalGet(GlobalIndex),
 }
 
 /// A WebAssembly table initializer segment.
@@ -769,7 +780,39 @@ pub struct TableSegment {
     /// The offset to add to the base.
     pub offset: u32,
     /// The values to write into the table elements.
-    pub elements: Box<[FuncIndex]>,
+    pub elements: TableSegmentElements,
+}
+
+/// Elements of a table segment, either a list of functions or list of arbitrary
+/// expressions.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum TableSegmentElements {
+    /// A sequential list of functions where `FuncIndex::reserved_value()`
+    /// indicates a null function.
+    Functions(Box<[FuncIndex]>),
+    /// Arbitrary expressions, aka either functions, null or a load of a global.
+    Expressions(Box<[TableElementExpression]>),
+}
+
+impl TableSegmentElements {
+    /// Returns the number of elements in this segment.
+    pub fn len(&self) -> u32 {
+        match self {
+            Self::Functions(s) => s.len() as u32,
+            Self::Expressions(s) => s.len() as u32,
+        }
+    }
+}
+
+/// Different kinds of expression that can initialize table elements.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum TableElementExpression {
+    /// `ref.func $f`
+    Function(FuncIndex),
+    /// `global.get $g`
+    GlobalGet(GlobalIndex),
+    /// `ref.null $ty`
+    Null,
 }
 
 /// Different types that can appear in a module.
@@ -815,7 +858,7 @@ pub struct Module {
     pub memory_initialization: MemoryInitialization,
 
     /// WebAssembly passive elements.
-    pub passive_elements: Vec<Box<[FuncIndex]>>,
+    pub passive_elements: Vec<TableSegmentElements>,
 
     /// The map from passive element index (element segment index space) to index in `passive_elements`.
     pub passive_elements_map: BTreeMap<ElemIndex, usize>,

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -34,6 +34,16 @@ pub enum TableElementType {
     Extern,
 }
 
+impl TableElementType {
+    fn matches(&self, val: &TableElement) -> bool {
+        match (val, self) {
+            (TableElement::FuncRef(_), TableElementType::Func) => true,
+            (TableElement::ExternRef(_), TableElementType::Extern) => true,
+            _ => false,
+        }
+    }
+}
+
 // The usage of `*mut VMFuncRef` is safe w.r.t. thread safety, this
 // just relies on thread-safety of `VMExternRef` itself.
 unsafe impl Send for TableElement where VMExternRef: Send {}
@@ -288,12 +298,12 @@ impl Table {
     /// Fill `table[dst..]` with values from `items`
     ///
     /// Returns a trap error on out-of-bounds accesses.
-    pub fn init_funcs(
+    pub fn init(
         &mut self,
         dst: u32,
-        items: impl ExactSizeIterator<Item = *mut VMFuncRef>,
+        items: impl ExactSizeIterator<Item = TableElement>,
     ) -> Result<(), Trap> {
-        assert!(self.element_type() == TableElementType::Func);
+        let ty = self.element_type();
 
         let elements = match self
             .elements_mut()
@@ -305,8 +315,9 @@ impl Table {
         };
 
         for (item, slot) in items.zip(elements) {
+            debug_assert!(ty.matches(&item));
             unsafe {
-                *slot = TableElement::FuncRef(item).into_table_value();
+                *slot = item.into_table_value();
             }
         }
         Ok(())
@@ -488,11 +499,7 @@ impl Table {
     }
 
     fn type_matches(&self, val: &TableElement) -> bool {
-        match (&val, self.element_type()) {
-            (TableElement::FuncRef(_), TableElementType::Func) => true,
-            (TableElement::ExternRef(_), TableElementType::Extern) => true,
-            _ => false,
-        }
+        self.element_type().matches(val)
     }
 
     fn elements(&self) -> &[TableValue] {

--- a/crates/wast/src/spectest.rs
+++ b/crates/wast/src/spectest.rs
@@ -30,11 +30,11 @@ pub fn link_spectest<T>(
     linker.define(&mut *store, "spectest", "global_i64", g)?;
 
     let ty = GlobalType::new(ValType::F32, Mutability::Const);
-    let g = Global::new(&mut *store, ty, Val::F32(0x4426_8000))?;
+    let g = Global::new(&mut *store, ty, Val::F32(0x4426_a666))?;
     linker.define(&mut *store, "spectest", "global_f32", g)?;
 
     let ty = GlobalType::new(ValType::F64, Mutability::Const);
-    let g = Global::new(&mut *store, ty, Val::F64(0x4084_d000_0000_0000))?;
+    let g = Global::new(&mut *store, ty, Val::F64(0x4084_d4cc_cccc_cccd))?;
     linker.define(&mut *store, "spectest", "global_f64", g)?;
 
     let ty = TableType::new(RefType::FUNCREF, 10, Some(20));

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -133,7 +133,7 @@ fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()>
             .max_memory_protection_keys(2)
             .memory_pages(805)
             .max_memories_per_module(if multi_memory { 9 } else { 1 })
-            .max_tables_per_module(4);
+            .max_tables_per_module(5);
 
         // When testing, we may choose to start with MPK force-enabled to ensure
         // we use that functionality.


### PR DESCRIPTION
This commit updates Wasmtime to support `global.get` in constant expressions when located in table initializers and element segments. Pre-reference-types this never came up because there was no valid `global.get` that would typecheck. After the reference-types proposal landed however this became possible but Wasmtime did not support it. This was surfaced in #6705 when the spec test suite was updated and has a new test that exercises this functionality.

This commit both updates the spec test suite and additionally adds support for this new form of element segment and table initialization expression.

The fact that Wasmtime hasn't supported this until now also means that we have a gap in our fuzz-testing infrastructure. The `wasm-smith` generator is being updated in bytecodealliance/wasm-tools#1426 to generate modules with this particular feature and I've tested that with that PR fuzzing here eventually generates an error before this PR.

Closes #6705

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
