### PR TITLE
Fix description of fd_write in WASI-tutorial.md

### DIFF
--- a/docs/WASI-tutorial.md
+++ b/docs/WASI-tutorial.md
@@ -269,7 +269,7 @@ First, create a new `demo.wat` file:
 (module
     ;; Import the required fd_write WASI function which will write the given io vectors to stdout
     ;; The function signature for fd_write is:
-    ;; (File Descriptor, *iovs, iovs_len, nwritten) -> Returns number of bytes written
+    ;; (File Descriptor, *iovs, iovs_len, nwritten) -> Returns 0 on success, nonzero on error
     (import "wasi_snapshot_preview1" "fd_write" (func $fd_write (param i32 i32 i32 i32) (result i32)))
 
     (memory 1)


### PR DESCRIPTION
If I am reading [the](https://github.com/WebAssembly/WASI/blob/main/legacy/tools/witx-docs.md) [docs](https://github.com/WebAssembly/WASI/blob/main/legacy/preview1/docs.md#-fd_writefd-fd-iovs-ciovec_array---resultsize-errno) correctly - and I am not at all sure that I am - the return value of `fd_write` is an `errno`, not the number of bytes written. That seems to match up with what I observe in an actual module compiled with wasi-sdk and run via Node's wasi module.

This is important because it has exactly the opposite interpretation: `0` indicates a successful write, not failure.

Possibly `nwritten` should be `*nwritten` also, since it's a pointer. (Specifically it's an out-parameter which is where the number of bytes written actually goes.)