### PR TITLE
winch: Fix bounds checks for dynamic heaps

### DIFF
--- a/tests/all/winch.rs
+++ b/tests/all/winch.rs
@@ -239,3 +239,75 @@ fn wasm_to_native_trap() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn dynamic_heap() -> Result<()> {
+    let mut c = Config::new();
+
+    c.strategy(Strategy::Winch);
+    c.static_memory_maximum_size(0);
+    c.static_memory_guard_size(0);
+    c.guard_before_linear_memory(false);
+    c.dynamic_memory_guard_size(0);
+
+    let engine = Engine::new(&c)?;
+    let wat = r#"
+        (module
+          (type (;0;) (func (result i32)))
+          (func (;0;) (type 0) (result i32)
+            (local i32 i64)
+            global.get 0
+            i32.eqz
+            if ;; label = @1
+              unreachable
+            end
+            global.get 0
+            i32.const 1
+            i32.sub
+            global.set 0
+            memory.size
+            local.set 0
+            block ;; label = @1
+              block ;; label = @2
+                memory.size
+                i32.const 65536
+                i32.mul
+                i32.const 65511
+                local.get 0
+                i32.add
+                i32.le_u
+                br_if 0 (;@2;)
+                local.get 0
+                i32.const 0
+                i32.le_s
+                br_if 0 (;@2;)
+                local.get 0
+                i64.load8_s offset=65503
+                local.set 1
+                br 1 (;@1;)
+              end
+              i64.const 0
+              local.set 1
+            end
+            local.get 1
+            drop
+            i32.const 0
+          )
+          (memory (;0;) 1 3)
+          (global (;0;) (mut i32) i32.const 1000)
+          (export " " (func 0))
+          (export "" (memory 0))
+        )
+    "#;
+    let mut store = Store::new(&engine, ());
+    let module = Module::new(&engine, wat)?;
+    let func = Func::wrap::<(), (), Result<()>>(&mut store, || bail!("error"));
+    let instance = Instance::new(&mut store, &module, &[])?;
+    let f = instance.get_typed_func::<(), i32>(&mut store, " ")?;
+    let result = f.call(&mut store, ())?;
+
+    assert!(result == 0);
+
+    Ok(())
+}

--- a/tests/all/winch.rs
+++ b/tests/all/winch.rs
@@ -302,7 +302,6 @@ fn dynamic_heap() -> Result<()> {
     "#;
     let mut store = Store::new(&engine, ());
     let module = Module::new(&engine, wat)?;
-    let func = Func::wrap::<(), (), Result<()>>(&mut store, || bail!("error"));
     let instance = Instance::new(&mut store, &module, &[])?;
     let f = instance.get_typed_func::<(), i32>(&mut store, " ")?;
     let result = f.call(&mut store, ())?;


### PR DESCRIPTION
This commit fixes a fuzz bug in which the current implementation was incorrectly clobbering the index register of a memory access (for addition overflow check) and then using that same clobbered register to perform the memory access. The clobbered register contained the value: `index + offset + access_size`, which resulting in an incorrect access and consequently in an incorrect `HeapOutOfBounds` trap.

This bug is only reproducible when modifying Wasmtime's memory settings, forcing the heap to be treated as `Dynamic`.

Currently in Winch there's no easy way to have specific Wasmtime configurations, so having a filetests for this case is not straightforward. I've opted to add an integration test, in which it's easier to configure Wasmtime.

Note that the `tests/all/winch.rs`  file is temporary, and the plan is to execute all the other integration tests with Winch at some point. In the case of `memory.rs`, that will be once Winch supports `memory64` hoping to reduce the amount of code needed in order to integrate Winch.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
