### PR TITLE
Fix a memory leak found in fuzzing

### DIFF
--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -321,9 +321,7 @@ impl Table {
 
         for (item, slot) in items.zip(elements) {
             debug_assert!(ty.matches(&item));
-            unsafe {
-                *slot = item.into_table_value();
-            }
+            Self::set_raw(ty, slot, item);
         }
         Ok(())
     }


### PR DESCRIPTION
This fixes a mistake introduced in #7996 where a `global.get` used to initialize a table did not properly drop previous items in the table causing them to leak as the reference count was not decremented.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
