### PR TITLE
Run `cargo vet regenerate audit-as-crates-io`

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -313,6 +313,22 @@ start = "2022-08-22"
 end = "2024-06-26"
 notes = "The Bytecode Alliance is the author of this crate."
 
+[[wildcard-audits.wasmtime-c-api-impl]]
+who = "Trevor Elliott <telliott@fastly.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-02-20"
+end = "2025-02-28"
+notes = "The Bytecode Alliance is the author of this crate."
+
+[[wildcard-audits.wasmtime-c-api-macros]]
+who = "Trevor Elliott <telliott@fastly.com>"
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-02-20"
+end = "2025-02-28"
+notes = "The Bytecode Alliance is the author of this crate."
+
 [[wildcard-audits.wasmtime-cache]]
 who = "Bobby Holley <bobbyholley@gmail.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -85,6 +85,12 @@ audit-as-crates-io = true
 [policy.wasmtime-asm-macros]
 audit-as-crates-io = true
 
+[policy.wasmtime-c-api-impl]
+audit-as-crates-io = true
+
+[policy.wasmtime-c-api-macros]
+audit-as-crates-io = true
+
 [policy.wasmtime-cache]
 audit-as-crates-io = true
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -81,6 +81,14 @@ audited_as = "17.0.1"
 version = "19.0.0"
 audited_as = "17.0.1"
 
+[[unpublished.wasmtime-c-api-impl]]
+version = "19.0.0"
+audited_as = "18.0.1"
+
+[[unpublished.wasmtime-c-api-macros]]
+version = "19.0.0"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-cache]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -922,6 +930,18 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "17.0.1"
 when = "2024-02-07"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-c-api-impl]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-c-api-macros]]
+version = "18.0.1"
+when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
To unblock the release process, run `cargo vet regenerate audit-as-crates-io` to include entries for both `wasmtime-c-api` and `wasmtime-c-api-macros`.

Additionally, I certified `wasmtime-c-api-macros` and `wasmtime-c-api-impl` with wildcard audits, and the usual message about them being BA projects.

Commands run:
```
$ cargo vet regenerate audit-as-crates-io
$ cargo vet certify wasmtime-c-api-macros --wildcard wasmtime-publish --who "Trevor Elliott <telliott@fastly.com>"
$ cargo vet certify wasmtime-c-api-impl --wildcard wasmtime-publish --who "Trevor Elliott <telliott@fastly.com>"
```

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
