### PR TITLE
Release Wasmtime 18.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "18.0.1"
+version = "18.0.2"
 
 [[package]]
 name = "byteorder"
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -566,14 +566,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -601,25 +601,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.105.1"
+version = "0.105.2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "serde",
  "serde_derive",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.0",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.105.1"
+version = "0.105.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2877,7 +2877,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "wasmparser 0.121.0",
@@ -2927,7 +2927,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "byte-array-literals",
  "object",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3216,14 +3216,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3239,14 +3239,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3381,11 +3381,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "18.0.1"
+version = "18.0.2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "object",
  "once_cell",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "cc",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -3715,7 +3715,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "18.0.1"
+version = "18.0.2"
 
 [[package]]
 name = "wast"
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "18.0.1"
+version = "18.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3887,7 +3887,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "18.0.1"
+version = "18.0.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -156,57 +156,57 @@ all = 'allow'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=18.0.1" }
-wasmtime = { path = "crates/wasmtime", version = "18.0.1", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=18.0.1" }
-wasmtime-cache = { path = "crates/cache", version = "=18.0.1" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=18.0.1" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=18.0.1" }
-wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=18.0.1" }
-wasmtime-winch = { path = "crates/winch", version = "=18.0.1" }
-wasmtime-environ = { path = "crates/environ", version = "=18.0.1" }
-wasmtime-explorer = { path = "crates/explorer", version = "=18.0.1" }
-wasmtime-fiber = { path = "crates/fiber", version = "=18.0.1" }
-wasmtime-types = { path = "crates/types", version = "18.0.1" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=18.0.1" }
-wasmtime-runtime = { path = "crates/runtime", version = "=18.0.1" }
-wasmtime-wast = { path = "crates/wast", version = "=18.0.1" }
-wasmtime-wasi = { path = "crates/wasi", version = "18.0.1", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=18.0.1", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "18.0.1" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "18.0.1" }
-wasmtime-component-util = { path = "crates/component-util", version = "=18.0.1" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=18.0.1" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=18.0.1" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=18.0.1" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=18.0.2" }
+wasmtime = { path = "crates/wasmtime", version = "18.0.2", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=18.0.2" }
+wasmtime-cache = { path = "crates/cache", version = "=18.0.2" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=18.0.2" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=18.0.2" }
+wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=18.0.2" }
+wasmtime-winch = { path = "crates/winch", version = "=18.0.2" }
+wasmtime-environ = { path = "crates/environ", version = "=18.0.2" }
+wasmtime-explorer = { path = "crates/explorer", version = "=18.0.2" }
+wasmtime-fiber = { path = "crates/fiber", version = "=18.0.2" }
+wasmtime-types = { path = "crates/types", version = "18.0.2" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=18.0.2" }
+wasmtime-runtime = { path = "crates/runtime", version = "=18.0.2" }
+wasmtime-wast = { path = "crates/wast", version = "=18.0.2" }
+wasmtime-wasi = { path = "crates/wasi", version = "18.0.2", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=18.0.2", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "18.0.2" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "18.0.2" }
+wasmtime-component-util = { path = "crates/component-util", version = "=18.0.2" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=18.0.2" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=18.0.2" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=18.0.2" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=18.0.1", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=18.0.1" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=18.0.1" }
-wasi-common = { path = "crates/wasi-common", version = "=18.0.1", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=18.0.2", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=18.0.2" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=18.0.2" }
+wasi-common = { path = "crates/wasi-common", version = "=18.0.2", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=18.0.1" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=18.0.1" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=18.0.2" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=18.0.2" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.105.1" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.105.1", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.105.1" }
-cranelift-entity = { path = "cranelift/entity", version = "0.105.1" }
-cranelift-native = { path = "cranelift/native", version = "0.105.1" }
-cranelift-module = { path = "cranelift/module", version = "0.105.1" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.105.1" }
-cranelift-reader = { path = "cranelift/reader", version = "0.105.1" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.105.2" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.105.2", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.105.2" }
+cranelift-entity = { path = "cranelift/entity", version = "0.105.2" }
+cranelift-native = { path = "cranelift/native", version = "0.105.2" }
+cranelift-module = { path = "cranelift/module", version = "0.105.2" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.105.2" }
+cranelift-reader = { path = "cranelift/reader", version = "0.105.2" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.105.1" }
-cranelift-jit = { path = "cranelift/jit", version = "0.105.1" }
+cranelift-object = { path = "cranelift/object", version = "0.105.2" }
+cranelift-jit = { path = "cranelift/jit", version = "0.105.2" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.105.1" }
-cranelift-control = { path = "cranelift/control", version = "0.105.1" }
-cranelift = { path = "cranelift/umbrella", version = "0.105.1" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.105.2" }
+cranelift-control = { path = "cranelift/control", version = "0.105.2" }
+cranelift = { path = "cranelift/umbrella", version = "0.105.2" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.16.1" }
+winch-codegen = { path = "winch/codegen", version = "=0.16.2" }
 winch-filetests = { path = "winch/filetests" }
 winch-test-macros = { path = "winch/test-macros" }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,8 @@
 
 ## 18.0.2
 
+Released 2024-02-28.
+
 ### Fixed
 
 * Fix an egraph rule bug that was permitting an incorrect `ireduce` rewrite to

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.105.1"
+version = "0.105.2"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.105.1"
+version = "0.105.2"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.105.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.105.2" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -44,8 +44,8 @@ criterion = { version = "0.5.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.105.1" }
-cranelift-isle = { path = "../isle/isle", version = "=0.105.1" }
+cranelift-codegen-meta = { path = "meta", version = "0.105.2" }
+cranelift-isle = { path = "../isle/isle", version = "=0.105.2" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.105.1"
+version = "0.105.2"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.105.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.105.2" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.105.1"
+version = "0.105.2"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.105.1"
+version = "0.105.2"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.105.1"
+version = "0.105.2"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.105.1"
+version = "0.105.2"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.105.1"
+version = "0.105.2"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.105.1"
+version = "0.105.2"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.105.1"
+version = "0.105.2"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.105.1"
+version = "0.105.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.105.1"
+version = "0.105.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.105.1"
+version = "0.105.2"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.105.1"
+version = "0.105.2"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.105.1"
+version = "0.105.2"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.105.1"
+version = "0.105.2"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.105.1"
+version = "0.105.2"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -205,7 +205,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "18.0.1"
+#define WASMTIME_VERSION "18.0.2"
 /**
  * \brief Wasmtime major version number.
  */
@@ -217,7 +217,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 1
+#define WASMTIME_VERSION_PATCH 2
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.104.0"
 version = "0.105.1"
 audited_as = "0.105.0"
 
+[[unpublished.cranelift]]
+version = "0.105.2"
+audited_as = "0.105.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -16,6 +20,10 @@ audited_as = "0.104.0"
 [[unpublished.cranelift-bforest]]
 version = "0.105.1"
 audited_as = "0.105.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.105.2"
+audited_as = "0.105.1"
 
 [[unpublished.cranelift-codegen]]
 version = "0.105.0"
@@ -25,6 +33,10 @@ audited_as = "0.104.0"
 version = "0.105.1"
 audited_as = "0.105.0"
 
+[[unpublished.cranelift-codegen]]
+version = "0.105.2"
+audited_as = "0.105.1"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -32,6 +44,10 @@ audited_as = "0.104.0"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.105.1"
 audited_as = "0.105.0"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.105.2"
+audited_as = "0.105.1"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.105.0"
@@ -41,6 +57,10 @@ audited_as = "0.104.0"
 version = "0.105.1"
 audited_as = "0.105.0"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.105.2"
+audited_as = "0.105.1"
+
 [[unpublished.cranelift-control]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -48,6 +68,10 @@ audited_as = "0.104.0"
 [[unpublished.cranelift-control]]
 version = "0.105.1"
 audited_as = "0.105.0"
+
+[[unpublished.cranelift-control]]
+version = "0.105.2"
+audited_as = "0.105.1"
 
 [[unpublished.cranelift-entity]]
 version = "0.105.0"
@@ -57,6 +81,10 @@ audited_as = "0.104.0"
 version = "0.105.1"
 audited_as = "0.105.0"
 
+[[unpublished.cranelift-entity]]
+version = "0.105.2"
+audited_as = "0.105.1"
+
 [[unpublished.cranelift-frontend]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -64,6 +92,10 @@ audited_as = "0.104.0"
 [[unpublished.cranelift-frontend]]
 version = "0.105.1"
 audited_as = "0.105.0"
+
+[[unpublished.cranelift-frontend]]
+version = "0.105.2"
+audited_as = "0.105.1"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.105.0"
@@ -73,6 +105,10 @@ audited_as = "0.104.0"
 version = "0.105.1"
 audited_as = "0.105.0"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.105.2"
+audited_as = "0.105.1"
+
 [[unpublished.cranelift-isle]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -80,6 +116,10 @@ audited_as = "0.104.0"
 [[unpublished.cranelift-isle]]
 version = "0.105.1"
 audited_as = "0.105.0"
+
+[[unpublished.cranelift-isle]]
+version = "0.105.2"
+audited_as = "0.105.1"
 
 [[unpublished.cranelift-jit]]
 version = "0.105.0"
@@ -89,6 +129,10 @@ audited_as = "0.104.0"
 version = "0.105.1"
 audited_as = "0.105.0"
 
+[[unpublished.cranelift-jit]]
+version = "0.105.2"
+audited_as = "0.105.1"
+
 [[unpublished.cranelift-module]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -96,6 +140,10 @@ audited_as = "0.104.0"
 [[unpublished.cranelift-module]]
 version = "0.105.1"
 audited_as = "0.105.0"
+
+[[unpublished.cranelift-module]]
+version = "0.105.2"
+audited_as = "0.105.1"
 
 [[unpublished.cranelift-native]]
 version = "0.105.0"
@@ -105,6 +153,10 @@ audited_as = "0.104.0"
 version = "0.105.1"
 audited_as = "0.105.0"
 
+[[unpublished.cranelift-native]]
+version = "0.105.2"
+audited_as = "0.105.1"
+
 [[unpublished.cranelift-object]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -112,6 +164,10 @@ audited_as = "0.104.0"
 [[unpublished.cranelift-object]]
 version = "0.105.1"
 audited_as = "0.105.0"
+
+[[unpublished.cranelift-object]]
+version = "0.105.2"
+audited_as = "0.105.1"
 
 [[unpublished.cranelift-reader]]
 version = "0.105.0"
@@ -121,6 +177,10 @@ audited_as = "0.104.0"
 version = "0.105.1"
 audited_as = "0.105.0"
 
+[[unpublished.cranelift-reader]]
+version = "0.105.2"
+audited_as = "0.105.1"
+
 [[unpublished.cranelift-serde]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -129,6 +189,10 @@ audited_as = "0.104.0"
 version = "0.105.1"
 audited_as = "0.105.0"
 
+[[unpublished.cranelift-serde]]
+version = "0.105.2"
+audited_as = "0.105.1"
+
 [[unpublished.cranelift-wasm]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -136,6 +200,10 @@ audited_as = "0.104.0"
 [[unpublished.cranelift-wasm]]
 version = "0.105.1"
 audited_as = "0.105.0"
+
+[[unpublished.cranelift-wasm]]
+version = "0.105.2"
+audited_as = "0.105.1"
 
 [[unpublished.wasi-cap-std-sync]]
 version = "18.0.0"
@@ -149,6 +217,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasi-common]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasi-tokio]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -161,6 +233,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -169,8 +245,20 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-asm-macros]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
+[[unpublished.wasmtime-c-api-impl]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-c-api-impl]]
 version = "19.0.0"
+audited_as = "18.0.1"
+
+[[unpublished.wasmtime-c-api-macros]]
+version = "18.0.2"
 audited_as = "18.0.1"
 
 [[unpublished.wasmtime-c-api-macros]]
@@ -185,6 +273,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-cache]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -192,6 +284,10 @@ audited_as = "17.0.0"
 [[unpublished.wasmtime-cli]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "18.0.0"
@@ -201,6 +297,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-component-macro]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -208,6 +308,10 @@ audited_as = "17.0.0"
 [[unpublished.wasmtime-component-macro]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wasmtime-component-macro]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wasmtime-component-util]]
 version = "18.0.0"
@@ -217,6 +321,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-component-util]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-cranelift]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -224,6 +332,10 @@ audited_as = "17.0.0"
 [[unpublished.wasmtime-cranelift]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wasmtime-cranelift]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "18.0.0"
@@ -233,6 +345,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-cranelift-shared]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-environ]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -240,6 +356,10 @@ audited_as = "17.0.0"
 [[unpublished.wasmtime-environ]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wasmtime-environ]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wasmtime-explorer]]
 version = "18.0.0"
@@ -249,6 +369,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-explorer]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-fiber]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -256,6 +380,10 @@ audited_as = "17.0.0"
 [[unpublished.wasmtime-fiber]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wasmtime-fiber]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "18.0.0"
@@ -265,6 +393,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -272,6 +404,10 @@ audited_as = "17.0.0"
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wasmtime-runtime]]
 version = "18.0.0"
@@ -281,6 +417,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-runtime]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-types]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -288,6 +428,10 @@ audited_as = "17.0.0"
 [[unpublished.wasmtime-types]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wasmtime-types]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "18.0.0"
@@ -297,6 +441,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -304,6 +452,10 @@ audited_as = "17.0.0"
 [[unpublished.wasmtime-wasi-http]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "18.0.0"
@@ -313,6 +465,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -320,6 +476,10 @@ audited_as = "17.0.0"
 [[unpublished.wasmtime-wasi-threads]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "18.0.0"
@@ -329,6 +489,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-wast]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-winch]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -336,6 +500,10 @@ audited_as = "17.0.0"
 [[unpublished.wasmtime-winch]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wasmtime-winch]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "18.0.0"
@@ -345,6 +513,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -352,6 +524,10 @@ audited_as = "17.0.0"
 [[unpublished.wasmtime-wmemcheck]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wiggle]]
 version = "18.0.0"
@@ -361,6 +537,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wiggle]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -369,6 +549,10 @@ audited_as = "17.0.0"
 version = "18.0.1"
 audited_as = "18.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "18.0.2"
+audited_as = "18.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -376,6 +560,10 @@ audited_as = "17.0.0"
 [[unpublished.wiggle-macro]]
 version = "18.0.1"
 audited_as = "18.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "18.0.2"
+audited_as = "18.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -388,6 +576,10 @@ audited_as = "0.15.0"
 [[unpublished.winch-codegen]]
 version = "0.16.1"
 audited_as = "0.16.0"
+
+[[unpublished.winch-codegen]]
+version = "0.16.2"
+audited_as = "0.16.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -569,6 +761,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.105.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -577,6 +775,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.cranelift-bforest]]
 version = "0.105.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.105.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -593,6 +797,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.105.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -601,6 +811,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.cranelift-codegen-meta]]
 version = "0.105.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.105.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -617,6 +833,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.105.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -625,6 +847,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.cranelift-control]]
 version = "0.105.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.105.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -641,6 +869,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.105.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -649,6 +883,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.cranelift-frontend]]
 version = "0.105.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.105.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -665,6 +905,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.105.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -673,6 +919,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.cranelift-isle]]
 version = "0.105.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.105.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -689,6 +941,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.105.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -697,6 +955,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.cranelift-module]]
 version = "0.105.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.105.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -713,6 +977,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.105.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -721,6 +991,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.cranelift-object]]
 version = "0.105.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.105.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -737,6 +1013,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.105.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -749,6 +1031,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.105.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -757,6 +1045,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.cranelift-wasm]]
 version = "0.105.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.105.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1087,6 +1381,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -1190,6 +1490,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1198,6 +1504,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-asm-macros]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1226,6 +1538,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1234,6 +1552,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cli]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1250,6 +1574,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1258,6 +1588,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-component-macro]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1274,6 +1610,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1282,6 +1624,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-cranelift]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1298,6 +1646,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cranelift-shared]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-environ]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1306,6 +1660,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-environ]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-environ]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1322,6 +1682,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-explorer]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-fiber]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1330,6 +1696,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-fiber]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-fiber]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1346,6 +1718,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-debug]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1354,6 +1732,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1370,6 +1754,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-runtime]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-types]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1378,6 +1768,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-types]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-types]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1394,6 +1790,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1402,6 +1804,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-http]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1418,6 +1826,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-nn]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1426,6 +1840,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wasi-threads]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1442,6 +1862,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1450,6 +1876,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-winch]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-winch]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1466,6 +1898,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1474,6 +1912,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-wmemcheck]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1504,6 +1948,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1516,6 +1966,12 @@ when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1524,6 +1980,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.wiggle-macro]]
 version = "18.0.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "18.0.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"
@@ -1550,6 +2012,12 @@ user-login = "wasmtime-publish"
 
 [[publisher.winch-codegen]]
 version = "0.16.0"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.16.1"
 when = "2024-02-20"
 user-id = 73222
 user-login = "wasmtime-publish"

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.16.1"
+version = "0.16.2"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 18.0.2, requested by @elliottt.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
