### PR TITLE
Show true error reason in `wasmtime serve`

### DIFF
--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -386,7 +386,7 @@ async fn handle_request(
     let (sender, receiver) = tokio::sync::oneshot::channel();
 
     // TODO: need to track the join handle, but don't want to block the response on it
-    tokio::task::spawn(async move {
+    let task = tokio::task::spawn(async move {
         let req_id = inner.next_req_id();
         let (mut parts, body) = req.into_parts();
 
@@ -450,7 +450,17 @@ async fn handle_request(
     match receiver.await {
         Ok(Ok(resp)) => Ok(resp),
         Ok(Err(e)) => Err(e.into()),
-        Err(_) => bail!("guest never invoked `response-outparam::set` method"),
+        Err(_) => {
+            // If the receiver has an error (`RecvError`), it will not describe
+            // the real failure in any meaningful way. Instead we retrieve and
+            // propagate the error from inside the task which should more
+            // clearly tell the user what went wrong.
+            let e = match task.await {
+                Ok(r) => r.expect_err("if the receiver has an error, the task must have failed"),
+                Err(e) => e.into(),
+            };
+            bail!("guest never invoked `response-outparam::set` method: {e:?}")
+        }
     }
 }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -454,7 +454,9 @@ async fn handle_request(
             // task exited before a response was sent (i.e., the sender was
             // dropped); it does not describe the underlying cause of failure.
             // Instead we retrieve and propagate the error from inside the task
-            // which should more clearly tell the user what went wrong.
+            // which should more clearly tell the user what went wrong. Note
+            // that we assume the task has already exited at this point so the
+            // `await` should resolve immediately.
             let e = match task.await {
                 Ok(r) => r.expect_err("if the receiver has an error, the task must have failed"),
                 Err(e) => e.into(),

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -450,10 +450,11 @@ async fn handle_request(
         Ok(Ok(resp)) => Ok(resp),
         Ok(Err(e)) => Err(e.into()),
         Err(_) => {
-            // If the receiver has an error (`RecvError`), it will not describe
-            // the real failure in any meaningful way. Instead we retrieve and
-            // propagate the error from inside the task which should more
-            // clearly tell the user what went wrong.
+            // An error in the receiver (`RecvError`) only indicates that the
+            // task exited before a response was sent (i.e., the sender was
+            // dropped); it does not describe the underlying cause of failure.
+            // Instead we retrieve and propagate the error from inside the task
+            // which should more clearly tell the user what went wrong.
             let e = match task.await {
                 Ok(r) => r.expect_err("if the receiver has an error, the task must have failed"),
                 Err(e) => e.into(),

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -385,7 +385,6 @@ async fn handle_request(
 
     let (sender, receiver) = tokio::sync::oneshot::channel();
 
-    // TODO: need to track the join handle, but don't want to block the response on it
     let task = tokio::task::spawn(async move {
         let req_id = inner.next_req_id();
         let (mut parts, body) = req.into_parts();


### PR DESCRIPTION
The `wasmtime serve` command prints failed HTTP handling to `stderr` but, when the reason was due to failure inside the HTTP handler itself, the printed error message is not descriptive enough. After looking at long dumps of `guest never invoked `response-outparam::set` method`, I realized that errors inside the Tokio `task` are never propagated outwards. This change captures those errors and appends them to the printed error message.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
