### PR TITLE
Add CLI flags for instance limits

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -82,20 +82,25 @@ wasmtime_option_group! {
         /// copy-on-write mapping (default: yes)
         pub memory_init_cow: Option<bool>,
 
-        /// The maximum number of WebAssembly instances which can be created.
-        pub total_core_instances: Option<u32>,
+        /// The maximum number of WebAssembly instances which can be created
+        /// with the pooling allocator.
+        pub pooling_total_core_instances: Option<u32>,
 
-        /// The maximum number of WebAssembly components which can be created.
-        pub total_component_instances: Option<u32>,
+        /// The maximum number of WebAssembly components which can be created
+        /// with the pooling allocator.
+        pub pooling_total_component_instances: Option<u32>,
 
-        /// The maximum number of WebAssembly memories which can be created.
-        pub total_memories: Option<u32>,
+        /// The maximum number of WebAssembly memories which can be created with
+        /// the pooling allocator.
+        pub pooling_total_memories: Option<u32>,
 
-        /// The maximum number of WebAssembly tables which can be created.
-        pub total_tables: Option<u32>,
+        /// The maximum number of WebAssembly tables which can be created with
+        /// the pooling allocator.
+        pub pooling_total_tables: Option<u32>,
 
-        /// The maximum number of WebAssembly stacks which can be created.
-        pub total_stacks: Option<u32>,
+        /// The maximum number of WebAssembly stacks which can be created with
+        /// the pooling allocator.
+        pub pooling_total_stacks: Option<u32>,
     }
 
     enum Optimize {
@@ -543,19 +548,19 @@ impl CommonOptions {
                     if let Some(size) = self.opts.pooling_table_keep_resident {
                         cfg.table_keep_resident(size);
                     }
-                    if let Some(limit) = self.opts.total_core_instances {
+                    if let Some(limit) = self.opts.pooling_total_core_instances {
                         cfg.total_core_instances(limit);
                     }
-                    if let Some(limit) = self.opts.total_component_instances {
+                    if let Some(limit) = self.opts.pooling_total_component_instances {
                         cfg.total_component_instances(limit);
                     }
-                    if let Some(limit) = self.opts.total_memories {
+                    if let Some(limit) = self.opts.pooling_total_memories {
                         cfg.total_memories(limit);
                     }
-                    if let Some(limit) = self.opts.total_tables {
+                    if let Some(limit) = self.opts.pooling_total_tables {
                         cfg.total_tables(limit);
                     }
-                    if let Some(limit) = self.opts.total_stacks {
+                    if let Some(limit) = self.opts.pooling_total_stacks {
                         cfg.total_stacks(limit);
                     }
                     if let Some(enable) = self.opts.memory_protection_keys {

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -81,6 +81,21 @@ wasmtime_option_group! {
         /// Configure attempting to initialize linear memory via a
         /// copy-on-write mapping (default: yes)
         pub memory_init_cow: Option<bool>,
+
+        /// The maximum number of WebAssembly instances which can be created.
+        pub total_core_instances: Option<u32>,
+
+        /// The maximum number of WebAssembly components which can be created.
+        pub total_component_instances: Option<u32>,
+
+        /// The maximum number of WebAssembly memories which can be created.
+        pub total_memories: Option<u32>,
+
+        /// The maximum number of WebAssembly tables which can be created.
+        pub total_tables: Option<u32>,
+
+        /// The maximum number of WebAssembly stacks which can be created.
+        pub total_stacks: Option<u32>,
     }
 
     enum Optimize {
@@ -527,6 +542,21 @@ impl CommonOptions {
                     }
                     if let Some(size) = self.opts.pooling_table_keep_resident {
                         cfg.table_keep_resident(size);
+                    }
+                    if let Some(limit) = self.opts.total_core_instances {
+                        cfg.total_core_instances(limit);
+                    }
+                    if let Some(limit) = self.opts.total_component_instances {
+                        cfg.total_component_instances(limit);
+                    }
+                    if let Some(limit) = self.opts.total_memories {
+                        cfg.total_memories(limit);
+                    }
+                    if let Some(limit) = self.opts.total_tables {
+                        cfg.total_tables(limit);
+                    }
+                    if let Some(limit) = self.opts.total_stacks {
+                        cfg.total_stacks(limit);
                     }
                     if let Some(enable) = self.opts.memory_protection_keys {
                         if enable {


### PR DESCRIPTION
While experimenting with `wasmtime serve`, I found it helpful to be able to configure some of the maximum limits of the various objects stored in the pooling allocator. This change surfaces some new `-O total-*` flags for controlling these limits from the command line.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
