### PR TITLE
Fix a panic reflecting the types of a component

### DIFF
--- a/crates/wasmtime/src/runtime/component/types.rs
+++ b/crates/wasmtime/src/runtime/component/types.rs
@@ -944,7 +944,18 @@ impl ComponentItem {
                 engine,
                 ty.types[*idx].clone(),
             )),
-            TypeDef::Resource(idx) => Self::Resource(ty.resources[ty.types[*idx].ty]),
+            TypeDef::Resource(idx) => {
+                let resource_index = ty.types[*idx].ty;
+                let ty = match ty.resources.get(resource_index) {
+                    // This resource type was substituted by a linker for
+                    // example so it's replaced here.
+                    Some(ty) => *ty,
+
+                    // This resource type was not substituted.
+                    None => ResourceType::uninstantiated(&ty.types, resource_index),
+                };
+                Self::Resource(ty)
+            }
         }
     }
 }


### PR DESCRIPTION
This commit fixes an issue when inspecting the types of a component where if a resource type wasn't substituted through an import it would end up panicking. The fix here is to add a third kind of resource type which represents an uninstantiated component as opposed to an instantiated component or host type.

Closes #8003

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
