### PR TITLE
Update to wit-bindgen 0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,7 +653,7 @@ dependencies = [
  "target-lexicon",
  "thiserror",
  "toml",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wat",
 ]
 
@@ -832,7 +832,7 @@ dependencies = [
  "serde_derive",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wasmtime-types",
  "wat",
 ]
@@ -2647,7 +2647,7 @@ version = "0.0.0"
 dependencies = [
  "cargo_metadata",
  "heck",
- "wit-component 0.201.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -2957,7 +2957,7 @@ name = "verify-component-adapter"
 version = "19.0.0"
 dependencies = [
  "anyhow",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wat",
 ]
 
@@ -3048,7 +3048,7 @@ dependencies = [
  "byte-array-literals",
  "object",
  "wasi",
- "wasm-encoder 0.201.0",
+ "wasm-encoder",
  "wit-bindgen",
 ]
 
@@ -3108,36 +3108,11 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.200.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e3fb0c8fbddd78aa6095b850dfeedbc7506cf5f81e633f69cf8f2333ab84b9"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9c7d2731df60006819b013f64ccc2019691deccf6e11a1804bc850cd6748f1a"
 dependencies = [
  "leb128",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.200.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b8cc0c21f46d55b0aaa419cacce1eadcf28eaebd0e1488d6a6313ee71a586"
-dependencies = [
- "anyhow",
- "indexmap 2.0.0",
- "serde",
- "serde_derive",
- "serde_json",
- "spdx",
- "wasm-encoder 0.200.0",
- "wasmparser 0.200.0",
 ]
 
 [[package]]
@@ -3152,8 +3127,8 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "spdx",
- "wasm-encoder 0.201.0",
- "wasmparser 0.201.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3166,8 +3141,8 @@ dependencies = [
  "log",
  "rand",
  "thiserror",
- "wasm-encoder 0.201.0",
- "wasmparser 0.201.0",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3181,7 +3156,7 @@ dependencies = [
  "flagset",
  "indexmap 2.0.0",
  "leb128",
- "wasm-encoder 0.201.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -3226,17 +3201,6 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.200.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a03f65ac876612140c57ff6c3b8fe4990067cce97c2cfdb07368a3cc3354b062"
-dependencies = [
- "bitflags 2.4.1",
- "indexmap 2.0.0",
- "semver",
-]
-
-[[package]]
-name = "wasmparser"
 version = "0.201.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84e5df6dba6c0d7fafc63a450f1738451ed7a0b52295d83e868218fa286bf708"
@@ -3262,7 +3226,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a67e66da702706ba08729a78e3c0079085f6bfcb1a62e4799e97bbf728c2c265"
 dependencies = [
  "anyhow",
- "wasmparser 0.201.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3294,8 +3258,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasi-common",
- "wasm-encoder 0.201.0",
- "wasmparser 0.201.0",
+ "wasm-encoder",
+ "wasmparser",
  "wasmtime-cache",
  "wasmtime-component-macro",
  "wasmtime-component-util",
@@ -3426,7 +3390,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "wasi-common",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wasmtime",
  "wasmtime-cache",
  "wasmtime-cli-flags",
@@ -3443,7 +3407,7 @@ dependencies = [
  "wast 201.0.0",
  "wat",
  "windows-sys 0.52.0",
- "wit-component 0.201.0",
+ "wit-component",
 ]
 
 [[package]]
@@ -3472,7 +3436,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
- "wit-parser 0.201.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -3496,7 +3460,7 @@ dependencies = [
  "object",
  "target-lexicon",
  "thiserror",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "wasmtime-versioned-export-macros",
@@ -3535,8 +3499,8 @@ dependencies = [
  "serde_derive",
  "target-lexicon",
  "thiserror",
- "wasm-encoder 0.201.0",
- "wasmparser 0.201.0",
+ "wasm-encoder",
+ "wasmparser",
  "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
@@ -3551,7 +3515,7 @@ dependencies = [
  "component-fuzz-util",
  "env_logger",
  "libfuzzer-sys",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wasmprinter",
  "wasmtime-environ",
  "wat",
@@ -3608,7 +3572,7 @@ dependencies = [
  "rand",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wasmtime",
  "wasmtime-fuzzing",
 ]
@@ -3628,12 +3592,12 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "v8",
- "wasm-encoder 0.201.0",
+ "wasm-encoder",
  "wasm-mutate",
  "wasm-smith",
  "wasm-spec-interpreter",
  "wasmi",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wasmprinter",
  "wasmtime",
  "wasmtime-wast",
@@ -3680,7 +3644,7 @@ dependencies = [
  "rand",
  "rustix",
  "sptr",
- "wasm-encoder 0.201.0",
+ "wasm-encoder",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",
@@ -3702,7 +3666,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "thiserror",
- "wasmparser 0.201.0",
+ "wasmparser",
 ]
 
 [[package]]
@@ -3819,7 +3783,7 @@ dependencies = [
  "gimli",
  "object",
  "target-lexicon",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "winch-codegen",
@@ -3832,7 +3796,7 @@ dependencies = [
  "anyhow",
  "heck",
  "indexmap 2.0.0",
- "wit-parser 0.201.0",
+ "wit-parser",
 ]
 
 [[package]]
@@ -3858,7 +3822,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.201.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -3992,7 +3956,7 @@ dependencies = [
  "regalloc2",
  "smallvec",
  "target-lexicon",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wasmtime-environ",
 ]
 
@@ -4008,7 +3972,7 @@ dependencies = [
  "similar",
  "target-lexicon",
  "toml",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wasmtime-environ",
  "wat",
  "winch-codegen",
@@ -4038,7 +4002,7 @@ dependencies = [
  "similar",
  "target-lexicon",
  "toml",
- "wasmparser 0.201.0",
+ "wasmparser",
  "wasmtime-environ",
  "wat",
  "winch-codegen",
@@ -4208,9 +4172,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37d270da94012e0ac490ac633ad5bdd76a10a3fb15069edb033c1b771ce931f"
+checksum = "39e6058f3ef320faece2d48ab105a278e94bac47df03b04af69c205173e0afcc"
 dependencies = [
  "bitflags 2.4.1",
  "wit-bindgen-rust-macro",
@@ -4218,32 +4182,33 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9121070bebf9dda946f7ecffc9ec23a890b46c79be84ff6359f0c588223b20e7"
+checksum = "11a8abb3fed5dee9be41aef6609fe2bc4a9d10f82af24fe9b843e885d51ef638"
 dependencies = [
  "anyhow",
- "wit-parser 0.200.0",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1753606a880b4c7701da8870d3935e550e667261a9b570f709cfefc22136ea5"
+checksum = "e7c63da73f9dc6b68c6aea864b3e277ddb056ec49bd3e41b2b76bc2165d769a9"
 dependencies = [
  "anyhow",
  "heck",
- "wasm-metadata 0.200.0",
+ "indexmap 2.0.0",
+ "wasm-metadata",
  "wit-bindgen-core",
- "wit-component 0.200.0",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171482ae1eb3c417b61e7e1b487e4dded906a136e1ac5da35eab38bdff5554c5"
+checksum = "2adddfe43ab23342715b15225a32b29010f8af91ad9cab7a51a46c5006aea08e"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4251,25 +4216,6 @@ dependencies = [
  "syn 2.0.32",
  "wit-bindgen-core",
  "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.200.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39979723340baea490b87b11b2abae05f149d86f2b55c18d41d78a2a2b284c16"
-dependencies = [
- "anyhow",
- "bitflags 2.4.1",
- "indexmap 2.0.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.200.0",
- "wasm-metadata 0.200.0",
- "wasmparser 0.200.0",
- "wit-parser 0.200.0",
 ]
 
 [[package]]
@@ -4285,28 +4231,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.201.0",
- "wasm-metadata 0.201.0",
- "wasmparser 0.201.0",
- "wit-parser 0.201.0",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.200.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f717576b37f01c15696bda7f6f13868367b9c5913485f9f0ec8e59fd28c8e13"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.0.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.200.0",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
 ]
 
 [[package]]
@@ -4324,7 +4252,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.201.0",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -228,7 +228,7 @@ io-lifetimes = { version = "2.0.3", default-features = false }
 io-extras = "0.18.1"
 rustix = "0.38.31"
 # wit-bindgen:
-wit-bindgen = { version = "0.19.2", default-features = false }
+wit-bindgen = { version = "0.20.0", default-features = false }
 
 # wasm-tools family:
 wasmparser = "0.201.0"

--- a/crates/test-programs/src/bin/api_proxy.rs
+++ b/crates/test-programs/src/bin/api_proxy.rs
@@ -1,18 +1,16 @@
 pub mod bindings {
-    use super::T;
-
     wit_bindgen::generate!({
         path: "../wasi-http/wit",
         world: "wasi:http/proxy",
-        exports: {
-            "wasi:http/incoming-handler": T,
-        },
+        default_bindings_module: "bindings",
     });
 }
 
 use bindings::wasi::http::types::{IncomingRequest, ResponseOutparam};
 
 struct T;
+
+bindings::export!(T);
 
 impl bindings::exports::wasi::http::incoming_handler::Guest for T {
     fn handle(request: IncomingRequest, outparam: ResponseOutparam) {

--- a/crates/test-programs/src/bin/api_proxy_streaming.rs
+++ b/crates/test-programs/src/bin/api_proxy_streaming.rs
@@ -7,20 +7,18 @@ use futures::{future, stream, Future, SinkExt, StreamExt, TryStreamExt};
 use url::Url;
 
 mod bindings {
-    use super::Handler;
-
     wit_bindgen::generate!({
         path: "../wasi-http/wit",
         world: "wasi:http/proxy",
-        exports: {
-            "wasi:http/incoming-handler": Handler,
-        },
+        default_bindings_module: "bindings",
     });
 }
 
 const MAX_CONCURRENCY: usize = 16;
 
 struct Handler;
+
+bindings::export!(Handler);
 
 impl bindings::exports::wasi::http::incoming_handler::Guest for Handler {
     fn handle(request: IncomingRequest, response_out: ResponseOutparam) {

--- a/crates/test-programs/src/bin/api_reactor.rs
+++ b/crates/test-programs/src/bin/api_reactor.rs
@@ -1,12 +1,11 @@
 wit_bindgen::generate!({
     world: "test-reactor",
     path: "../wasi/wit",
-    exports: {
-        world: T,
-    }
 });
 
 struct T;
+
+export!(T);
 
 static mut STATE: Vec<String> = Vec::new();
 

--- a/examples/component/wasm/guest.rs
+++ b/examples/component/wasm/guest.rs
@@ -3,12 +3,11 @@
 wit_bindgen::generate!({
     path: "..",
     world: "convert",
-    exports: {
-        world: GuestComponent,
-    },
 });
 
 struct GuestComponent;
+
+export!(GuestComponent);
 
 impl Guest for GuestComponent {
     fn convert_celsius_to_fahrenheit(x: f32) -> f32 {

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -86,10 +86,10 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.wasmtime-c-api-impl]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.wasmtime-c-api-macros]
-audit-as-crates-io = true
+audit-as-crates-io = false
 
 [policy.wasmtime-cache]
 audit-as-crates-io = true

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -976,18 +976,6 @@ when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
-[[publisher.wasmtime-c-api-impl]]
-version = "18.0.1"
-when = "2024-02-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
-[[publisher.wasmtime-c-api-macros]]
-version = "18.0.1"
-when = "2024-02-20"
-user-id = 73222
-user-login = "wasmtime-publish"
-
 [[publisher.wasmtime-cache]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1362,6 +1350,12 @@ when = "2024-02-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-bindgen]]
+version = "0.20.0"
+when = "2024-02-29"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-bindgen-core]]
 version = "0.17.0"
 when = "2024-02-05"
@@ -1378,6 +1372,12 @@ user-login = "wasmtime-publish"
 [[publisher.wit-bindgen-core]]
 version = "0.19.2"
 when = "2024-02-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-bindgen-core]]
+version = "0.20.0"
+when = "2024-02-29"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1400,6 +1400,12 @@ when = "2024-02-26"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wit-bindgen-rust]]
+version = "0.20.0"
+when = "2024-02-29"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wit-bindgen-rust-macro]]
 version = "0.17.0"
 when = "2024-02-05"
@@ -1416,6 +1422,12 @@ user-login = "wasmtime-publish"
 [[publisher.wit-bindgen-rust-macro]]
 version = "0.19.2"
 when = "2024-02-26"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wit-bindgen-rust-macro]]
+version = "0.20.0"
+when = "2024-02-29"
 user-id = 73222
 user-login = "wasmtime-publish"
 


### PR DESCRIPTION
Keepin' up to date.

I don't know what's going on with `cargo vet` and the entries here. I can't run `cargo vet` on main and I'm not sure why. I ran `cargo vet regenerate audit-as-crates-io` and it flipped some flags to `false` and all of a sudden I could run it, so I stopped asking questions.