### PR TITLE
Don't fail with `--env` and nonexistent env vars

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -743,8 +743,15 @@ impl RunCommand {
         for (key, value) in self.vars.iter() {
             let value = match value {
                 Some(value) => value.clone(),
-                None => std::env::var(key)
-                    .map_err(|_| anyhow!("environment variable `{key}` not found"))?,
+                None => match std::env::var_os(key) {
+                    Some(val) => val
+                        .into_string()
+                        .map_err(|_| anyhow!("environment variable `{key}` not valid utf-8"))?,
+                    None => {
+                        // leave the env var un-set in the guest
+                        continue;
+                    }
+                },
             };
             builder.env(key, &value)?;
         }
@@ -775,8 +782,15 @@ impl RunCommand {
         for (key, value) in self.vars.iter() {
             let value = match value {
                 Some(value) => value.clone(),
-                None => std::env::var(key)
-                    .map_err(|_| anyhow!("environment variable `{key}` not found"))?,
+                None => match std::env::var_os(key) {
+                    Some(val) => val
+                        .into_string()
+                        .map_err(|_| anyhow!("environment variable `{key}` not valid utf-8"))?,
+                    None => {
+                        // leave the env var un-set in the guest
+                        continue;
+                    }
+                },
             };
             builder.env(key, &value);
         }

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -519,7 +519,7 @@ fn specify_env() -> Result<()> {
             "tests/all/cli_tests/print_env.wat",
         ])
         .output()?;
-    assert!(!output.status.success());
+    assert!(output.status.success());
 
     Ok(())
 }


### PR DESCRIPTION
Instead just leave it unset in the guest.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
