### PR TITLE
Update object to 0.33.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     - uses: ./.github/actions/install-rust
     - run: |
         set -e
-        curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.8.5/cargo-deny-0.8.5-x86_64-unknown-linux-musl.tar.gz | tar xzf -
+        curl -L https://github.com/EmbarkStudios/cargo-deny/releases/download/0.14.5/cargo-deny-0.14.5-x86_64-unknown-linux-musl.tar.gz | tar xzf -
         mv cargo-deny-*-x86_64-unknown-linux-musl/cargo-deny cargo-deny
         echo `pwd` >> $GITHUB_PATH
     - run: cargo deny check bans licenses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.32.0",
  "rustc-demangle",
 ]
 
@@ -757,7 +757,7 @@ dependencies = [
  "cranelift-frontend",
  "cranelift-module",
  "log",
- "object",
+ "object 0.33.0",
  "target-lexicon",
 ]
 
@@ -1465,7 +1465,7 @@ dependencies = [
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows-core 0.51.1",
+ "windows-core",
 ]
 
 [[package]]
@@ -1789,7 +1789,7 @@ version = "20.0.0"
 dependencies = [
  "anyhow",
  "libloading",
- "object",
+ "object 0.33.0",
 ]
 
 [[package]]
@@ -1852,6 +1852,15 @@ name = "object"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8dd6c0cdf9429bce006e1362bfce61fa1bfd8c898a643ed8d2b471934701d3d"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.0",
@@ -3046,7 +3055,7 @@ name = "wasi-preview1-component-adapter"
 version = "20.0.0"
 dependencies = [
  "byte-array-literals",
- "object",
+ "object 0.33.0",
  "wasi",
  "wasm-encoder",
  "wit-bindgen",
@@ -3246,7 +3255,7 @@ dependencies = [
  "ittapi",
  "libc",
  "log",
- "object",
+ "object 0.33.0",
  "once_cell",
  "paste",
  "rayon",
@@ -3457,7 +3466,7 @@ dependencies = [
  "cranelift-wasm",
  "gimli",
  "log",
- "object",
+ "object 0.33.0",
  "target-lexicon",
  "thiserror",
  "wasmparser",
@@ -3475,7 +3484,7 @@ dependencies = [
  "cranelift-control",
  "cranelift-native",
  "gimli",
- "object",
+ "object 0.33.0",
  "target-lexicon",
  "wasmtime-environ",
 ]
@@ -3493,7 +3502,7 @@ dependencies = [
  "gimli",
  "indexmap 2.0.0",
  "log",
- "object",
+ "object 0.33.0",
  "rustc-demangle",
  "serde",
  "serde_derive",
@@ -3608,7 +3617,7 @@ dependencies = [
 name = "wasmtime-jit-debug"
 version = "20.0.0"
 dependencies = [
- "object",
+ "object 0.33.0",
  "once_cell",
  "rustix",
  "wasmtime-versioned-export-macros",
@@ -3782,7 +3791,7 @@ dependencies = [
  "anyhow",
  "cranelift-codegen",
  "gimli",
- "object",
+ "object 0.33.0",
  "target-lexicon",
  "wasmparser",
  "wasmtime-cranelift-shared",
@@ -4017,17 +4026,8 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
 dependencies = [
- "windows-core 0.52.0",
+ "windows-core",
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.51.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f8cf84f35d2db49a46868f947758c7a1138116f7fac3bc844f43ade1292e64"
-dependencies = [
- "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -243,7 +243,7 @@ wit-component = "0.201.0"
 
 # Non-Bytecode Alliance maintained dependencies:
 # --------------------------
-object = { version = "0.32", default-features = false, features = ['read_core', 'elf', 'std'] }
+object = { version = "0.33", default-features = false, features = ['read_core', 'elf', 'std'] }
 gimli = { version = "0.28.0", default-features = false, features = ['read', 'std'] }
 anyhow = "1.0.22"
 windows-sys = "0.52.0"

--- a/crates/cranelift-shared/src/obj.rs
+++ b/crates/cranelift-shared/src/obj.rs
@@ -183,12 +183,12 @@ impl<'a> ModuleTextBuilder<'a> {
                             flags: SymbolFlags::None,
                         })
                     });
-                    let (encoding, kind, size) = match r.reloc {
-                        Reloc::Abs8 => (
-                            object::RelocationEncoding::Generic,
-                            object::RelocationKind::Absolute,
-                            8,
-                        ),
+                    let flags = match r.reloc {
+                        Reloc::Abs8 => object::RelocationFlags::Generic {
+                            encoding: object::RelocationEncoding::Generic,
+                            kind: object::RelocationKind::Absolute,
+                            size: 8,
+                        },
                         other => unimplemented!("unimplemented relocation kind {other:?}"),
                     };
                     self.obj
@@ -196,9 +196,7 @@ impl<'a> ModuleTextBuilder<'a> {
                             self.text_section,
                             object::write::Relocation {
                                 symbol,
-                                size,
-                                kind,
-                                encoding,
+                                flags,
                                 offset: off + u64::from(r.offset),
                                 addend: r.addend,
                             },

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -20,7 +20,7 @@ use cranelift_wasm::{
     WasmValType,
 };
 use object::write::{Object, StandardSegment, SymbolId};
-use object::{RelocationEncoding, RelocationKind, SectionKind};
+use object::{RelocationEncoding, RelocationFlags, RelocationKind, SectionKind};
 use std::any::Any;
 use std::cmp;
 use std::collections::HashMap;
@@ -613,11 +613,13 @@ impl wasmtime_environ::Compiler for Compiler {
                     section_id,
                     object::write::Relocation {
                         offset: u64::from(reloc.offset),
-                        size: reloc.size << 3,
-                        kind: RelocationKind::Absolute,
-                        encoding: RelocationEncoding::Generic,
                         symbol: target_symbol,
                         addend: i64::from(reloc.addend),
+                        flags: RelocationFlags::Generic {
+                            size: reloc.size << 3,
+                            kind: RelocationKind::Absolute,
+                            encoding: RelocationEncoding::Generic,
+                        },
                     },
                 )?;
             }

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -1826,6 +1826,15 @@ criteria = "safe-to-deploy"
 delta = "0.31.1 -> 0.32.0"
 notes = "Various new features and refactorings as one would expect from an object parsing crate, all looks good."
 
+[[audits.object]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.32.0 -> 0.33.0"
+notes = """
+No `unsafe` code in this update. Lots of changes but all
+object-file-format-related, everything looks good.
+"""
+
 [[audits.once_cell]]
 who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
object 0.33.0 has a breaking change for relocations which needs a larger than usual fix here. I already did this fix for testing purposes, but I don't need the change myself.