### PR TITLE
winch: Always free the source register when emitting Wasm stores

### DIFF
--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -658,8 +658,8 @@ where
                 .wasm_store(src.reg.into(), self.masm.address_at_reg(addr, 0), size);
 
             self.context.free_reg(addr);
-            self.context.free_reg(src);
         }
+        self.context.free_reg(src);
     }
 }
 


### PR DESCRIPTION
This commit fixes a bug where when an out-of-bounds access is detected at compile time, `emit_wasm_store` was failing to free the source register. By the time the address is computed, the register is already allocated, independently if it's used or not, it must be freed.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
