### PR TITLE
winch: Defer the usage of `format!`

### DIFF
--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -225,10 +225,12 @@ impl Masm for MacroAssembler {
         let (reg, offset) = local
             .addressed_from_sp()
             .then(|| {
-                let offset = self.sp_offset.checked_sub(local.offset).expect(&format!(
-                    "Invalid local offset = {}; sp offset = {}",
-                    local.offset, self.sp_offset
-                ));
+                let offset = self.sp_offset.checked_sub(local.offset).unwrap_or_else(|| {
+                    panic!(
+                        "Invalid local offset = {}; sp offset = {}",
+                        local.offset, self.sp_offset
+                    )
+                });
                 (rsp(), offset)
             })
             .unwrap_or((rbp(), local.offset));


### PR DESCRIPTION
This commit defers the usage of `format!` until it's actually needed when retrieving addresses for locals. This helps improve performance in modules that incur in a considerable number of local lookups.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
