### PR TITLE
winch: Introduce `TypeConverter` in the function environment

### DIFF
--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -205,9 +205,10 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
     {
         let types = self.translation.get_types();
         let ty = types[types.core_function_at(idx.as_u32())].unwrap_func();
-        let ty = self.convert_func_type(ty);
         let import = self.translation.module.is_imported_function(idx);
         let val = || {
+            let converter = TypeConverter::new(self.translation, self.types);
+            let ty = converter.convert_func_type(&ty);
             let sig = wasm_sig::<A>(&ty);
             CalleeInfo { sig, index: idx }
         };
@@ -225,7 +226,7 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
         match ty {
             Empty => BlockSig::new(control::BlockType::void()),
             Type(ty) => {
-                let ty = self.convert_valtype(ty);
+                let ty = TypeConverter::new(self.translation, self.types).convert_valtype(ty);
                 BlockSig::new(control::BlockType::single(ty))
             }
             FuncType(idx) => {
@@ -351,13 +352,26 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
     }
 }
 
-impl<P: PtrSize> TypeConvert for FuncEnv<'_, '_, '_, P> {
+/// A wrapper struct over a reference to a [ModuleTranslation] and
+/// [ModuleTypesBuilder].
+pub(crate) struct TypeConverter<'a, 'data: 'a> {
+    translation: &'a ModuleTranslation<'data>,
+    types: &'a ModuleTypesBuilder,
+}
+
+impl TypeConvert for TypeConverter<'_, '_> {
     fn lookup_heap_type(&self, idx: wasmparser::UnpackedIndex) -> WasmHeapType {
         wasmtime_environ::WasmparserTypeConverter {
             module: &self.translation.module,
             types: self.types,
         }
         .lookup_heap_type(idx)
+    }
+}
+
+impl<'a, 'data> TypeConverter<'a, 'data> {
+    pub fn new(translation: &'a ModuleTranslation<'data>, types: &'a ModuleTypesBuilder) -> Self {
+        Self { translation, types }
     }
 }
 

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -1,7 +1,7 @@
 use self::regs::{ALL_GPR, MAX_FPR, MAX_GPR, NON_ALLOCATABLE_GPR};
 use crate::{
     abi::{wasm_sig, ABI},
-    codegen::{CodeGen, CodeGenContext, FuncEnv},
+    codegen::{CodeGen, CodeGenContext, FuncEnv, TypeConverter},
     frame::{DefinedLocals, Frame},
     isa::{Builder, TargetIsa},
     masm::MacroAssembler,
@@ -106,7 +106,9 @@ impl TargetIsa for Aarch64 {
             self,
             abi::Aarch64ABI::ptr_type(),
         );
-        let defined_locals = DefinedLocals::new::<abi::Aarch64ABI>(&env, &mut body, validator)?;
+        let type_converter = TypeConverter::new(env.translation, env.types);
+        let defined_locals =
+            DefinedLocals::new::<abi::Aarch64ABI>(&type_converter, &mut body, validator)?;
         let frame = Frame::new::<abi::Aarch64ABI>(&abi_sig, &defined_locals)?;
         let gpr = RegBitSet::int(
             ALL_GPR.into(),

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     abi::{wasm_sig, ABI},
-    codegen::{BuiltinFunctions, CodeGen, CodeGenContext, FuncEnv},
+    codegen::{BuiltinFunctions, CodeGen, CodeGenContext, FuncEnv, TypeConverter},
 };
 
 use crate::frame::{DefinedLocals, Frame};
@@ -116,7 +116,9 @@ impl TargetIsa for X64 {
             self,
             abi::X64ABI::ptr_type(),
         );
-        let defined_locals = DefinedLocals::new::<abi::X64ABI>(&env, &mut body, validator)?;
+        let type_converter = TypeConverter::new(env.translation, env.types);
+        let defined_locals =
+            DefinedLocals::new::<abi::X64ABI>(&type_converter, &mut body, validator)?;
         let frame = Frame::new::<abi::X64ABI>(&abi_sig, &defined_locals)?;
         let gpr = RegBitSet::int(
             ALL_GPR.into(),


### PR DESCRIPTION
This commit introduces the `TypeConverter` struct, used to enable partial borrowing of a `ModuleTranslation` and a `ModuleTypesBuilder` from the function environment. This makes it easier to defer type conversions until they are actually needed, for example when resolving callee signatures.  

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
