### PR TITLE
winch: Fix sp_offset usage when callee save registers are present

### DIFF
--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -197,6 +197,17 @@ impl Masm for MacroAssembler {
         todo!()
     }
 
+    fn clear_sp_offset(&mut self) -> SPOffset {
+        let offset = self.sp_offset();
+        self.sp_offset = 0;
+        offset
+    }
+
+    fn restore_sp_offset(&mut self, offset: SPOffset) {
+        assert_eq!(self.sp_offset, 0);
+        self.sp_offset = offset.as_u32();
+    }
+
     fn sp_offset(&self) -> SPOffset {
         SPOffset::from_u32(self.sp_offset)
     }

--- a/winch/codegen/src/isa/x64/masm.rs
+++ b/winch/codegen/src/isa/x64/masm.rs
@@ -464,6 +464,17 @@ impl Masm for MacroAssembler {
         }
     }
 
+    fn clear_sp_offset(&mut self) -> SPOffset {
+        let offset = self.sp_offset();
+        self.sp_offset = 0;
+        offset
+    }
+
+    fn restore_sp_offset(&mut self, offset: SPOffset) {
+        assert_eq!(self.sp_offset, 0);
+        self.sp_offset = offset.as_u32();
+    }
+
     fn sp_offset(&self) -> SPOffset {
         SPOffset::from_u32(self.sp_offset)
     }

--- a/winch/codegen/src/trampoline.rs
+++ b/winch/codegen/src/trampoline.rs
@@ -102,7 +102,7 @@ where
         let (vmctx, caller_vmctx) = Self::callee_and_caller_vmctx(&array_sig.params)?;
         let (dst_callee_vmctx, dst_caller_vmctx) = Self::callee_and_caller_vmctx(&wasm_sig.params)?;
 
-        self.masm.prologue(caller_vmctx, &self.callee_saved_regs);
+        let prologue_sp_offset = self.masm.prologue(caller_vmctx, &self.callee_saved_regs);
 
         self.masm
             .mov(vmctx.into(), dst_callee_vmctx, self.pointer_type.into());
@@ -157,7 +157,8 @@ where
         }
 
         self.masm.free_stack(spill_size);
-        self.masm.epilogue(&self.callee_saved_regs);
+        self.masm
+            .epilogue(prologue_sp_offset, &self.callee_saved_regs);
         Ok(())
     }
 
@@ -198,7 +199,7 @@ where
         let wasm_sig = wasm_sig::<M::ABI>(&ty);
         let (vmctx, caller_vmctx) = Self::callee_and_caller_vmctx(&native_sig.params)?;
 
-        self.masm.prologue(caller_vmctx, &self.callee_saved_regs);
+        let prologue_sp_offset = self.masm.prologue(caller_vmctx, &self.callee_saved_regs);
 
         let vmctx_runtime_limits_addr = self.vmctx_runtime_limits_addr(vmctx);
         let ret_area = self.make_ret_area(&wasm_sig);
@@ -233,7 +234,8 @@ where
         }
 
         self.masm.free_stack(spill_size);
-        self.masm.epilogue(&self.callee_saved_regs);
+        self.masm
+            .epilogue(prologue_sp_offset, &self.callee_saved_regs);
 
         Ok(())
     }
@@ -367,7 +369,7 @@ where
         let (vmctx, caller_vmctx) = Self::callee_and_caller_vmctx(&wasm_sig.params).unwrap();
         let vmctx_runtime_limits_addr = self.vmctx_runtime_limits_addr(caller_vmctx);
 
-        self.masm.prologue(caller_vmctx, &[]);
+        let prologue_sp_offset = self.masm.prologue(caller_vmctx, &[]);
 
         // Save the FP and return address when exiting Wasm.
         // TODO: Once Winch supports comparison operators,
@@ -418,7 +420,7 @@ where
         }
 
         self.masm.free_stack(spill_size);
-        self.masm.epilogue(&[]);
+        self.masm.epilogue(prologue_sp_offset, &[]);
 
         Ok(())
     }


### PR DESCRIPTION
If non-empty callee-save registers are passed to the winch `MacroAssembler::prologue` function, the stack offset used when computing the value in `address_from_sp` is incorrect. To fix this, we now reset the internal stack offset to `0` after the prologue, to ensure that we're skipping the callee save space. The prologue stack offset is restored for the epilogue, ensuring that the prologue and epilogue have a consistent view of the state of the stack when they run.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
