### PR TITLE
cranelift: Add a winch calling convention

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1107,8 +1107,8 @@ impl ABIMachineSpec for AArch64MachineDeps {
 
     fn get_regs_clobbered_by_call(call_conv_of_callee: isa::CallConv) -> PRegSet {
         match call_conv_of_callee {
-            isa::CallConv::Tail => TAIL_CLOBBERS,
-            isa::CallConv::Winch => WINCH_CLOBBERS,
+            isa::CallConv::Tail => ALL_CLOBBERS,
+            isa::CallConv::Winch => ALL_CLOBBERS,
             _ => DEFAULT_AAPCS_CLOBBERS,
         }
     }
@@ -1299,7 +1299,7 @@ fn compute_arg_locs_tail<'a, I>(
 where
     I: IntoIterator<Item = &'a ir::AbiParam>,
 {
-    let mut xregs = TAIL_CLOBBERS
+    let mut xregs = ALL_CLOBBERS
         .into_iter()
         .filter(|r| r.class() == RegClass::Int)
         // We reserve `x0` for the return area pointer. For simplicity, we
@@ -1313,7 +1313,7 @@ where
         // indirect calls. So skip `x1` also, reserving it for that role.
         .skip(2);
 
-    let mut vregs = TAIL_CLOBBERS
+    let mut vregs = ALL_CLOBBERS
         .into_iter()
         .filter(|r| r.class() == RegClass::Float);
 
@@ -1542,8 +1542,8 @@ const fn default_aapcs_clobbers() -> PRegSet {
 
 const DEFAULT_AAPCS_CLOBBERS: PRegSet = default_aapcs_clobbers();
 
-// NB: The `tail` calling convention clobbers all allocatable registers.
-const TAIL_CLOBBERS: PRegSet = PRegSet::empty()
+// For calling conventions that clobber all registers.
+const ALL_CLOBBERS: PRegSet = PRegSet::empty()
     .with(xreg_preg(0))
     .with(xreg_preg(1))
     .with(xreg_preg(2))
@@ -1608,71 +1608,6 @@ const TAIL_CLOBBERS: PRegSet = PRegSet::empty()
     .with(vreg_preg(30))
     .with(vreg_preg(31));
 
-// NB: The `winch` calling convention clobbers all allocatable registers.
-const WINCH_CLOBBERS: PRegSet = PRegSet::empty()
-    .with(xreg_preg(0))
-    .with(xreg_preg(1))
-    .with(xreg_preg(2))
-    .with(xreg_preg(3))
-    .with(xreg_preg(4))
-    .with(xreg_preg(5))
-    .with(xreg_preg(6))
-    .with(xreg_preg(7))
-    .with(xreg_preg(8))
-    .with(xreg_preg(9))
-    .with(xreg_preg(10))
-    .with(xreg_preg(11))
-    .with(xreg_preg(12))
-    .with(xreg_preg(13))
-    .with(xreg_preg(14))
-    .with(xreg_preg(15))
-    // Cranelift reserves x16 and x17 as unallocatable scratch registers.
-    //
-    // x18 can be used by the platform and therefore is not allocatable.
-    .with(xreg_preg(19))
-    .with(xreg_preg(20))
-    .with(xreg_preg(21))
-    .with(xreg_preg(22))
-    .with(xreg_preg(23))
-    .with(xreg_preg(24))
-    .with(xreg_preg(25))
-    .with(xreg_preg(26))
-    .with(xreg_preg(27))
-    .with(xreg_preg(28))
-    // NB: x29 is the FP, x30 is the link register, and x31 is the SP. None of
-    // these are allocatable.
-    .with(vreg_preg(0))
-    .with(vreg_preg(1))
-    .with(vreg_preg(2))
-    .with(vreg_preg(3))
-    .with(vreg_preg(4))
-    .with(vreg_preg(5))
-    .with(vreg_preg(6))
-    .with(vreg_preg(7))
-    .with(vreg_preg(8))
-    .with(vreg_preg(9))
-    .with(vreg_preg(10))
-    .with(vreg_preg(11))
-    .with(vreg_preg(12))
-    .with(vreg_preg(13))
-    .with(vreg_preg(14))
-    .with(vreg_preg(15))
-    .with(vreg_preg(16))
-    .with(vreg_preg(17))
-    .with(vreg_preg(18))
-    .with(vreg_preg(19))
-    .with(vreg_preg(20))
-    .with(vreg_preg(21))
-    .with(vreg_preg(22))
-    .with(vreg_preg(23))
-    .with(vreg_preg(24))
-    .with(vreg_preg(25))
-    .with(vreg_preg(26))
-    .with(vreg_preg(27))
-    .with(vreg_preg(28))
-    .with(vreg_preg(29))
-    .with(vreg_preg(30))
-    .with(vreg_preg(31));
 fn create_reg_env(enable_pinned_reg: bool) -> MachineEnv {
     fn preg(r: Reg) -> PReg {
         r.to_real_reg().unwrap().into()

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1106,10 +1106,10 @@ impl ABIMachineSpec for AArch64MachineDeps {
     }
 
     fn get_regs_clobbered_by_call(call_conv_of_callee: isa::CallConv) -> PRegSet {
-        if call_conv_of_callee == isa::CallConv::Tail {
-            TAIL_CLOBBERS
-        } else {
-            DEFAULT_AAPCS_CLOBBERS
+        match call_conv_of_callee {
+            isa::CallConv::Tail => TAIL_CLOBBERS,
+            isa::CallConv::Winch => WINCH_CLOBBERS,
+            _ => DEFAULT_AAPCS_CLOBBERS,
         }
     }
 
@@ -1429,7 +1429,7 @@ fn is_reg_saved_in_prologue(
     sig: &Signature,
     r: RealReg,
 ) -> bool {
-    if call_conv == isa::CallConv::Tail {
+    if call_conv == isa::CallConv::Tail || call_conv == isa::CallConv::Winch {
         return false;
     }
 
@@ -1608,6 +1608,71 @@ const TAIL_CLOBBERS: PRegSet = PRegSet::empty()
     .with(vreg_preg(30))
     .with(vreg_preg(31));
 
+// NB: The `winch` calling convention clobbers all allocatable registers.
+const WINCH_CLOBBERS: PRegSet = PRegSet::empty()
+    .with(xreg_preg(0))
+    .with(xreg_preg(1))
+    .with(xreg_preg(2))
+    .with(xreg_preg(3))
+    .with(xreg_preg(4))
+    .with(xreg_preg(5))
+    .with(xreg_preg(6))
+    .with(xreg_preg(7))
+    .with(xreg_preg(8))
+    .with(xreg_preg(9))
+    .with(xreg_preg(10))
+    .with(xreg_preg(11))
+    .with(xreg_preg(12))
+    .with(xreg_preg(13))
+    .with(xreg_preg(14))
+    .with(xreg_preg(15))
+    // Cranelift reserves x16 and x17 as unallocatable scratch registers.
+    //
+    // x18 can be used by the platform and therefore is not allocatable.
+    .with(xreg_preg(19))
+    .with(xreg_preg(20))
+    .with(xreg_preg(21))
+    .with(xreg_preg(22))
+    .with(xreg_preg(23))
+    .with(xreg_preg(24))
+    .with(xreg_preg(25))
+    .with(xreg_preg(26))
+    .with(xreg_preg(27))
+    .with(xreg_preg(28))
+    // NB: x29 is the FP, x30 is the link register, and x31 is the SP. None of
+    // these are allocatable.
+    .with(vreg_preg(0))
+    .with(vreg_preg(1))
+    .with(vreg_preg(2))
+    .with(vreg_preg(3))
+    .with(vreg_preg(4))
+    .with(vreg_preg(5))
+    .with(vreg_preg(6))
+    .with(vreg_preg(7))
+    .with(vreg_preg(8))
+    .with(vreg_preg(9))
+    .with(vreg_preg(10))
+    .with(vreg_preg(11))
+    .with(vreg_preg(12))
+    .with(vreg_preg(13))
+    .with(vreg_preg(14))
+    .with(vreg_preg(15))
+    .with(vreg_preg(16))
+    .with(vreg_preg(17))
+    .with(vreg_preg(18))
+    .with(vreg_preg(19))
+    .with(vreg_preg(20))
+    .with(vreg_preg(21))
+    .with(vreg_preg(22))
+    .with(vreg_preg(23))
+    .with(vreg_preg(24))
+    .with(vreg_preg(25))
+    .with(vreg_preg(26))
+    .with(vreg_preg(27))
+    .with(vreg_preg(28))
+    .with(vreg_preg(29))
+    .with(vreg_preg(30))
+    .with(vreg_preg(31));
 fn create_reg_env(enable_pinned_reg: bool) -> MachineEnv {
     fn preg(r: Reg) -> PReg {
         r.to_real_reg().unwrap().into()

--- a/cranelift/codegen/src/isa/call_conv.rs
+++ b/cranelift/codegen/src/isa/call_conv.rs
@@ -35,7 +35,7 @@ pub enum CallConv {
     WasmtimeSystemV,
     /// The winch calling convention, not ABI-stable.
     ///
-    /// The main difference to [`WasmtimeSystemV`] is that the winch calling
+    /// The main difference to WasmtimeSystemV is that the winch calling
     /// convention defines no callee-save registers, and restricts the number
     /// of return registers to one integer, and one floating point.
     Winch,

--- a/cranelift/codegen/src/isa/call_conv.rs
+++ b/cranelift/codegen/src/isa/call_conv.rs
@@ -33,6 +33,12 @@ pub enum CallConv {
     /// FIXME: remove this when Wasmtime uses the "tail" calling convention for
     /// all wasm functions.
     WasmtimeSystemV,
+    /// The winch calling convention, not ABI-stable.
+    ///
+    /// The main difference to [`WasmtimeSystemV`] is that the winch calling
+    /// convention defines no callee-save registers, and restricts the number
+    /// of return registers to one integer, and one floating point.
+    Winch,
 }
 
 impl CallConv {
@@ -97,6 +103,7 @@ impl fmt::Display for CallConv {
             Self::AppleAarch64 => "apple_aarch64",
             Self::Probestack => "probestack",
             Self::WasmtimeSystemV => "wasmtime_system_v",
+            Self::Winch => "winch",
         })
     }
 }
@@ -113,6 +120,7 @@ impl str::FromStr for CallConv {
             "apple_aarch64" => Ok(Self::AppleAarch64),
             "probestack" => Ok(Self::Probestack),
             "wasmtime_system_v" => Ok(Self::WasmtimeSystemV),
+            "winch" => Ok(Self::Winch),
             _ => Err(()),
         }
     }

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -98,6 +98,12 @@ impl ABIMachineSpec for Riscv64MachineDeps {
     where
         I: IntoIterator<Item = &'a ir::AbiParam>,
     {
+        assert_ne!(
+            call_conv,
+            isa::CallConv::Winch,
+            "riscv64 does not support the 'winch' calling convention yet"
+        );
+
         // All registers that can be used as parameters or rets.
         // both start and end are included.
         let (x_start, x_end, f_start, f_end) = match (call_conv, args_or_rets) {

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -236,6 +236,11 @@ impl ABIMachineSpec for S390xMachineDeps {
             isa::CallConv::Tail,
             "s390x does not support the 'tail' calling convention yet"
         );
+        assert_ne!(
+            call_conv,
+            isa::CallConv::Winch,
+            "s390x does not support the 'winch' calling convention yet"
+        );
 
         let mut next_gpr = 0;
         let mut next_fpr = 0;

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -804,8 +804,8 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
     fn get_regs_clobbered_by_call(call_conv_of_callee: isa::CallConv) -> PRegSet {
         match call_conv_of_callee {
-            isa::CallConv::Tail => TAIL_CLOBBERS,
-            isa::CallConv::Winch => WINCH_CLOBBERS,
+            isa::CallConv::Tail => ALL_CLOBBERS,
+            isa::CallConv::Winch => ALL_CLOBBERS,
             _ if call_conv_of_callee.extends_windows_fastcall() => WINDOWS_CLOBBERS,
             _ => SYSV_CLOBBERS,
         }
@@ -1158,8 +1158,7 @@ fn compute_clobber_size(clobbers: &[Writable<RealReg>]) -> u32 {
 
 const WINDOWS_CLOBBERS: PRegSet = windows_clobbers();
 const SYSV_CLOBBERS: PRegSet = sysv_clobbers();
-const TAIL_CLOBBERS: PRegSet = tail_clobbers();
-const WINCH_CLOBBERS: PRegSet = winch_clobbers();
+const ALL_CLOBBERS: PRegSet = all_clobbers();
 
 const fn windows_clobbers() -> PRegSet {
     PRegSet::empty()
@@ -1207,41 +1206,8 @@ const fn sysv_clobbers() -> PRegSet {
         .with(regs::fpr_preg(15))
 }
 
-const fn tail_clobbers() -> PRegSet {
-    PRegSet::empty()
-        .with(regs::gpr_preg(regs::ENC_RAX))
-        .with(regs::gpr_preg(regs::ENC_RCX))
-        .with(regs::gpr_preg(regs::ENC_RDX))
-        .with(regs::gpr_preg(regs::ENC_RBX))
-        .with(regs::gpr_preg(regs::ENC_RSI))
-        .with(regs::gpr_preg(regs::ENC_RDI))
-        .with(regs::gpr_preg(regs::ENC_R8))
-        .with(regs::gpr_preg(regs::ENC_R9))
-        .with(regs::gpr_preg(regs::ENC_R10))
-        .with(regs::gpr_preg(regs::ENC_R11))
-        .with(regs::gpr_preg(regs::ENC_R12))
-        .with(regs::gpr_preg(regs::ENC_R13))
-        .with(regs::gpr_preg(regs::ENC_R14))
-        .with(regs::gpr_preg(regs::ENC_R15))
-        .with(regs::fpr_preg(0))
-        .with(regs::fpr_preg(1))
-        .with(regs::fpr_preg(2))
-        .with(regs::fpr_preg(3))
-        .with(regs::fpr_preg(4))
-        .with(regs::fpr_preg(5))
-        .with(regs::fpr_preg(6))
-        .with(regs::fpr_preg(7))
-        .with(regs::fpr_preg(8))
-        .with(regs::fpr_preg(9))
-        .with(regs::fpr_preg(10))
-        .with(regs::fpr_preg(11))
-        .with(regs::fpr_preg(12))
-        .with(regs::fpr_preg(13))
-        .with(regs::fpr_preg(14))
-        .with(regs::fpr_preg(15))
-}
-
-const fn winch_clobbers() -> PRegSet {
+/// For calling conventions that clobber all registers.
+const fn all_clobbers() -> PRegSet {
     PRegSet::empty()
         .with(regs::gpr_preg(regs::ENC_RAX))
         .with(regs::gpr_preg(regs::ENC_RCX))

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -1112,7 +1112,8 @@ impl<M: ABIMachineSpec> Callee<M> {
                 || call_conv == isa::CallConv::Cold
                 || call_conv.extends_windows_fastcall()
                 || call_conv == isa::CallConv::WasmtimeSystemV
-                || call_conv == isa::CallConv::AppleAarch64,
+                || call_conv == isa::CallConv::AppleAarch64
+                || call_conv == isa::CallConv::Winch,
             "Unsupported calling convention: {:?}",
             call_conv
         );

--- a/cranelift/filetests/filetests/isa/aarch64/winch.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/winch.clif
@@ -1,0 +1,240 @@
+test compile precise-output
+target aarch64
+
+function %f1() winch {
+block0:
+    return
+}
+
+; VCode:
+; block0:
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   ret
+
+function %f2(i64, i64, i64, i64, i64, i64) -> i64 winch {
+  sig0 = () winch
+  fn0 = %g sig0
+
+block0(v0:i64, v1:i64, v2:i64, v3:i64, v4:i64, v5:i64):
+  call fn0()
+  return v0
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   sub sp, sp, #16
+; block0:
+;   str x0, [sp]
+;   load_ext_name x7, TestCase(%g)+0
+;   blr x7
+;   ldr x0, [sp]
+;   add sp, sp, #16
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block1: ; offset 0xc
+;   stur x0, [sp]
+;   ldr x7, #0x18
+;   b #0x20
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x7
+;   ldur x0, [sp]
+;   add sp, sp, #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+
+function %f3(i64, i64, i64, i64, i64, i64) -> i64 {
+  sig0 = () winch
+  fn0 = %g sig0
+
+block0(v0:i64, v1:i64, v2:i64, v3:i64, v4:i64, v5:i64):
+  call fn0()
+  return v0
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   stp x27, x28, [sp, #-16]!
+;   stp x25, x26, [sp, #-16]!
+;   stp x23, x24, [sp, #-16]!
+;   stp x21, x22, [sp, #-16]!
+;   stp x19, x20, [sp, #-16]!
+;   stp d14, d15, [sp, #-16]!
+;   stp d12, d13, [sp, #-16]!
+;   stp d10, d11, [sp, #-16]!
+;   stp d8, d9, [sp, #-16]!
+;   sub sp, sp, #16
+; block0:
+;   str x0, [sp]
+;   load_ext_name x7, TestCase(%g)+0
+;   blr x7
+;   ldr x0, [sp]
+;   add sp, sp, #16
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp x19, x20, [sp], #16
+;   ldp x21, x22, [sp], #16
+;   ldp x23, x24, [sp], #16
+;   ldp x25, x26, [sp], #16
+;   ldp x27, x28, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   stp x27, x28, [sp, #-0x10]!
+;   stp x25, x26, [sp, #-0x10]!
+;   stp x23, x24, [sp, #-0x10]!
+;   stp x21, x22, [sp, #-0x10]!
+;   stp x19, x20, [sp, #-0x10]!
+;   stp d14, d15, [sp, #-0x10]!
+;   stp d12, d13, [sp, #-0x10]!
+;   stp d10, d11, [sp, #-0x10]!
+;   stp d8, d9, [sp, #-0x10]!
+;   sub sp, sp, #0x10
+; block1: ; offset 0x30
+;   stur x0, [sp]
+;   ldr x7, #0x3c
+;   b #0x44
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x7
+;   ldur x0, [sp]
+;   add sp, sp, #0x10
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp x19, x20, [sp], #0x10
+;   ldp x21, x22, [sp], #0x10
+;   ldp x23, x24, [sp], #0x10
+;   ldp x25, x26, [sp], #0x10
+;   ldp x27, x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+
+function %f4(i64, i64, i64, i64, i64, i64) -> i64 winch {
+  sig0 = (i64, i64, i64, i64, i64, i64) -> i64 winch
+  fn0 = %g sig0
+
+block0(v0:i64, v1:i64, v2:i64, v3:i64, v4:i64, v5:i64):
+  v6 = call fn0(v5, v1, v2, v3, v4, v0)
+  return v6
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   mov x6, x0
+;   mov x0, x5
+;   mov x5, x6
+;   load_ext_name x8, TestCase(%g)+0
+;   blr x8
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block1: ; offset 0x8
+;   mov x6, x0
+;   mov x0, x5
+;   mov x5, x6
+;   ldr x8, #0x1c
+;   b #0x24
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x8
+;   ldp x29, x30, [sp], #0x10
+;   ret
+
+function %f5(i64, i64, i64, i64, i64, i64) -> i64 {
+  sig0 = (i64, i64, i64, i64, i64, i64) -> i64 winch
+  fn0 = %g sig0
+
+block0(v0:i64, v1:i64, v2:i64, v3:i64, v4:i64, v5:i64):
+  v6 = call fn0(v5, v1, v2, v3, v4, v0)
+  return v6
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   stp x27, x28, [sp, #-16]!
+;   stp x25, x26, [sp, #-16]!
+;   stp x23, x24, [sp, #-16]!
+;   stp x21, x22, [sp, #-16]!
+;   stp x19, x20, [sp, #-16]!
+;   stp d14, d15, [sp, #-16]!
+;   stp d12, d13, [sp, #-16]!
+;   stp d10, d11, [sp, #-16]!
+;   stp d8, d9, [sp, #-16]!
+; block0:
+;   mov x6, x0
+;   mov x0, x5
+;   mov x5, x6
+;   load_ext_name x8, TestCase(%g)+0
+;   blr x8
+;   ldp d8, d9, [sp], #16
+;   ldp d10, d11, [sp], #16
+;   ldp d12, d13, [sp], #16
+;   ldp d14, d15, [sp], #16
+;   ldp x19, x20, [sp], #16
+;   ldp x21, x22, [sp], #16
+;   ldp x23, x24, [sp], #16
+;   ldp x25, x26, [sp], #16
+;   ldp x27, x28, [sp], #16
+;   ldp fp, lr, [sp], #16
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   stp x27, x28, [sp, #-0x10]!
+;   stp x25, x26, [sp, #-0x10]!
+;   stp x23, x24, [sp, #-0x10]!
+;   stp x21, x22, [sp, #-0x10]!
+;   stp x19, x20, [sp, #-0x10]!
+;   stp d14, d15, [sp, #-0x10]!
+;   stp d12, d13, [sp, #-0x10]!
+;   stp d10, d11, [sp, #-0x10]!
+;   stp d8, d9, [sp, #-0x10]!
+; block1: ; offset 0x2c
+;   mov x6, x0
+;   mov x0, x5
+;   mov x5, x6
+;   ldr x8, #0x40
+;   b #0x48
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   blr x8
+;   ldp d8, d9, [sp], #0x10
+;   ldp d10, d11, [sp], #0x10
+;   ldp d12, d13, [sp], #0x10
+;   ldp d14, d15, [sp], #0x10
+;   ldp x19, x20, [sp], #0x10
+;   ldp x21, x22, [sp], #0x10
+;   ldp x23, x24, [sp], #0x10
+;   ldp x25, x26, [sp], #0x10
+;   ldp x27, x28, [sp], #0x10
+;   ldp x29, x30, [sp], #0x10
+;   ret
+

--- a/cranelift/filetests/filetests/isa/x64/winch.clif
+++ b/cranelift/filetests/filetests/isa/x64/winch.clif
@@ -1,0 +1,217 @@
+test compile precise-output
+target x86_64
+
+function %f1() winch {
+block0:
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %f2(i64, i64, i64, i64, i64, i64) -> i64 winch {
+  sig0 = () winch
+  fn0 = %g sig0
+
+block0(v0:i64, v1:i64, v2:i64, v3:i64, v4:i64, v5:i64):
+  call fn0()
+  return v0
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+; block0:
+;   movq    %rdi, rsp(0 + virtual offset)
+;   load_ext_name %g+0, %r10
+;   call    *%r10
+;   movq    rsp(0 + virtual offset), %rax
+;   addq    %rsp, $16, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x10, %rsp
+; block1: ; offset 0x8
+;   movq %rdi, (%rsp)
+;   movabsq $0, %r10 ; reloc_external Abs8 %g 0
+;   callq *%r10
+;   movq (%rsp), %rax
+;   addq $0x10, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %f3(i64, i64, i64, i64, i64, i64) -> i64 {
+  sig0 = () winch
+  fn0 = %g sig0
+
+block0(v0:i64, v1:i64, v2:i64, v3:i64, v4:i64, v5:i64):
+  call fn0()
+  return v0
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $64, %rsp
+;   movq    %rbx, 16(%rsp)
+;   movq    %r12, 24(%rsp)
+;   movq    %r13, 32(%rsp)
+;   movq    %r14, 40(%rsp)
+;   movq    %r15, 48(%rsp)
+; block0:
+;   movq    %rdi, rsp(0 + virtual offset)
+;   load_ext_name %g+0, %r10
+;   call    *%r10
+;   movq    rsp(0 + virtual offset), %rax
+;   movq    16(%rsp), %rbx
+;   movq    24(%rsp), %r12
+;   movq    32(%rsp), %r13
+;   movq    40(%rsp), %r14
+;   movq    48(%rsp), %r15
+;   addq    %rsp, $64, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x40, %rsp
+;   movq %rbx, 0x10(%rsp)
+;   movq %r12, 0x18(%rsp)
+;   movq %r13, 0x20(%rsp)
+;   movq %r14, 0x28(%rsp)
+;   movq %r15, 0x30(%rsp)
+; block1: ; offset 0x21
+;   movq %rdi, (%rsp)
+;   movabsq $0, %r10 ; reloc_external Abs8 %g 0
+;   callq *%r10
+;   movq (%rsp), %rax
+;   movq 0x10(%rsp), %rbx
+;   movq 0x18(%rsp), %r12
+;   movq 0x20(%rsp), %r13
+;   movq 0x28(%rsp), %r14
+;   movq 0x30(%rsp), %r15
+;   addq $0x40, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %f4(i64, i64, i64, i64, i64, i64) -> i64 winch {
+  sig0 = (i64, i64, i64, i64, i64, i64) -> i64 winch
+  fn0 = %g sig0
+
+block0(v0:i64, v1:i64, v2:i64, v3:i64, v4:i64, v5:i64):
+  v6 = call fn0(v5, v1, v2, v3, v4, v0)
+  return v6
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdi, %rax
+;   movq    %r9, %rdi
+;   movq    %rax, %r9
+;   load_ext_name %g+0, %r11
+;   call    *%r11
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdi, %rax
+;   movq %r9, %rdi
+;   movq %rax, %r9
+;   movabsq $0, %r11 ; reloc_external Abs8 %g 0
+;   callq *%r11
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %f5(i64, i64, i64, i64, i64, i64) -> i64 {
+  sig0 = (i64, i64, i64, i64, i64, i64) -> i64 winch
+  fn0 = %g sig0
+
+block0(v0:i64, v1:i64, v2:i64, v3:i64, v4:i64, v5:i64):
+  v6 = call fn0(v5, v1, v2, v3, v4, v0)
+  return v6
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $48, %rsp
+;   movq    %rbx, 0(%rsp)
+;   movq    %r12, 8(%rsp)
+;   movq    %r13, 16(%rsp)
+;   movq    %r14, 24(%rsp)
+;   movq    %r15, 32(%rsp)
+; block0:
+;   movq    %rdi, %rax
+;   movq    %r9, %rdi
+;   movq    %rax, %r9
+;   load_ext_name %g+0, %r11
+;   call    *%r11
+;   movq    0(%rsp), %rbx
+;   movq    8(%rsp), %r12
+;   movq    16(%rsp), %r13
+;   movq    24(%rsp), %r14
+;   movq    32(%rsp), %r15
+;   addq    %rsp, $48, %rsp
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0x30, %rsp
+;   movq %rbx, (%rsp)
+;   movq %r12, 8(%rsp)
+;   movq %r13, 0x10(%rsp)
+;   movq %r14, 0x18(%rsp)
+;   movq %r15, 0x20(%rsp)
+; block1: ; offset 0x20
+;   movq %rdi, %rax
+;   movq %r9, %rdi
+;   movq %rax, %r9
+;   movabsq $0, %r11 ; reloc_external Abs8 %g 0
+;   callq *%r11
+;   movq (%rsp), %rbx
+;   movq 8(%rsp), %r12
+;   movq 0x10(%rsp), %r13
+;   movq 0x18(%rsp), %r14
+;   movq 0x20(%rsp), %r15
+;   addq $0x30, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/fuzzgen/src/cranelift_arbitrary.rs
+++ b/cranelift/fuzzgen/src/cranelift_arbitrary.rs
@@ -64,6 +64,14 @@ impl<'a> CraneliftArbitrary for &mut Unstructured<'a> {
             allowed_callconvs.push(CallConv::Tail);
         }
 
+        // The winch calling convention is supposed to work on x64 and aarch64
+        if matches!(
+            architecture,
+            Architecture::X86_64 | Architecture::Aarch64(_)
+        ) {
+            allowed_callconvs.push(CallConv::Winch);
+        }
+
         Ok(*self.choose(&allowed_callconvs[..])?)
     }
 


### PR DESCRIPTION
Add a `Winch` calling convention to cranelift that has no callee saves, and clobbers everything. This will enable us to use the `wasmtime-cranelift` generated trampolines in the `wasmtime-winch` crate.

I've enabled fuzzing for this calling convention, as well as added clif tests for the `x64` and `aarch64` backends. I've explicitly disabled support in `riscv64` and `s390x`, as it's not currently possible to target either of those architectures with winch.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
