### PR TITLE
winch: Fix the bounds check for dynamic heaps

### DIFF
--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -494,7 +494,6 @@ where
         let index = Index::from_typed_reg(self.context.pop_to_reg(self.masm, None));
         let offset = bounds::ensure_index_and_offset(self.masm, index, memarg.offset, ptr_size);
         let offset_with_access_size = add_offset_and_access_size(offset, access_size);
-        let scratch = <M::ABI as ABI>::scratch_reg();
 
         let addr = match heap.style {
             // == Dynamic Heaps ==
@@ -509,17 +508,25 @@ where
                     bounds::load_dynamic_heap_bounds(&mut self.context, self.masm, &heap, ptr_size);
 
                 let index_reg = index.as_typed_reg().reg;
+                // Allocate a temporary register to hold
+                //      index + offset + access_size
+                //  which will serve as the check condition.
+                let index_offset_and_access_size = self.context.any_gpr(self.masm);
 
-                // Move the value of the index to the scratch register
-                // to perform the overflow check to avoid clobbering the
-                // initial index value.
-                self.masm.mov(index_reg.into(), scratch, heap.ty.into());
+                // Move the value of the index to the
+                // index_offset_and_access_size register to perform the overflow
+                // check to avoid clobbering the initial index value.
+                self.masm.mov(
+                    index_reg.into(),
+                    index_offset_and_access_size,
+                    heap.ty.into(),
+                );
                 // Perform
                 // index = index + offset + access_size, trapping if the
                 // addition overflows.
                 self.masm.checked_uadd(
-                    scratch,
-                    scratch,
+                    index_offset_and_access_size,
+                    index_offset_and_access_size,
                     RegImm::i64(offset_with_access_size as i64),
                     ptr_size,
                     TrapCode::HeapOutOfBounds,
@@ -534,14 +541,18 @@ where
                     bounds,
                     index,
                     offset,
-                    |masm, bounds, index| {
-                        let index_reg = index.as_typed_reg().reg;
+                    |masm, bounds, _| {
                         let bounds_reg = bounds.as_typed_reg().reg;
-                        masm.cmp(bounds_reg.into(), index_reg.into(), heap.ty.into());
+                        masm.cmp(
+                            bounds_reg.into(),
+                            index_offset_and_access_size.into(),
+                            heap.ty.into(),
+                        );
                         IntCmpKind::GtU
                     },
                 );
                 self.context.free_reg(bounds.as_typed_reg().reg);
+                self.context.free_reg(index_offset_and_access_size);
                 Some(addr)
             }
 


### PR DESCRIPTION
This commit fixes the bounds check comparison for dynamic heaps. The previous implementation wasn't using the right value: for the general case of dynamic heaps, we want to compare if 

      index + offset + access_size > bounds

But it was only comparing
      
     index > bounds

This commit addresses the issue by adding a new temporary register into the equation which will be used for the bounds check comparison and for overflow checks. This approach is preferred over using the scratch register because it's harder to know when the scratch register might get clobbered (in the case of spectre checks, it could for example)

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
