### PR TITLE
Fix `wasmtime settings` command.

### DIFF
--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -1,4 +1,6 @@
+use anyhow::{anyhow, bail, Result};
 use serde_derive::{Deserialize, Serialize};
+use target_lexicon::Triple;
 
 /// Tunable parameters for WebAssembly compilation.
 #[derive(Clone, Hash, Serialize, Deserialize, Debug)]
@@ -67,6 +69,19 @@ impl Tunables {
             Tunables::default_u64()
         } else {
             panic!("unsupported target_pointer_width");
+        }
+    }
+
+    /// Returns the default set of tunables for the given target triple.
+    pub fn default_for_target(target: &Triple) -> Result<Self> {
+        match target
+            .pointer_width()
+            .map_err(|_| anyhow!("failed to retrieve target pointer width"))?
+            .bits()
+        {
+            32 => Ok(Tunables::default_u32()),
+            64 => Ok(Tunables::default_u64()),
+            _ => bail!("unsupported target pointer width"),
         }
     }
 

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, bail, Result};
 use serde_derive::{Deserialize, Serialize};
-use target_lexicon::Triple;
+use target_lexicon::{PointerWidth, Triple};
 
 /// Tunable parameters for WebAssembly compilation.
 #[derive(Clone, Hash, Serialize, Deserialize, Debug)]
@@ -77,10 +77,9 @@ impl Tunables {
         match target
             .pointer_width()
             .map_err(|_| anyhow!("failed to retrieve target pointer width"))?
-            .bits()
         {
-            32 => Ok(Tunables::default_u32()),
-            64 => Ok(Tunables::default_u64()),
+            PointerWidth::U32 => Ok(Tunables::default_u32()),
+            PointerWidth::U64 => Ok(Tunables::default_u64()),
             _ => bail!("unsupported target pointer width"),
         }
     }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
-use target_lexicon::{Architecture, PointerWidth};
+use target_lexicon::Architecture;
 use wasmparser::WasmFeatures;
 #[cfg(feature = "cache")]
 use wasmtime_cache::CacheConfig;
@@ -1684,11 +1684,7 @@ impl Config {
         let mut tunables = Tunables::default_host();
         #[cfg(any(feature = "cranelift", feature = "winch"))]
         let mut tunables = match &self.compiler_config.target.as_ref() {
-            Some(target) => match target.pointer_width() {
-                Ok(PointerWidth::U32) => Tunables::default_u32(),
-                Ok(PointerWidth::U64) => Tunables::default_u64(),
-                _ => bail!("unknown pointer width"),
-            },
+            Some(target) => Tunables::default_for_target(target)?,
             None => Tunables::default_host(),
         };
 

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1588,3 +1588,10 @@ mod test_programs {
         Ok(())
     }
 }
+
+#[test]
+fn settings_command() -> Result<()> {
+    let output = run_wasmtime(&["settings"])?;
+    assert!(output.contains("Cranelift settings for target"));
+    Ok(())
+}


### PR DESCRIPTION
Currently the `settings` command panics because the tunables are not set in the compiler builder.

This commit creates a default tunables based on either the target triple passed on the command line or uses the default for the host.

Fixes #8058.