### PR TITLE
Remove type information from `wasmtime::component::Val`

### DIFF
--- a/crates/component-macro/src/component.rs
+++ b/crates/component-macro/src/component.rs
@@ -447,7 +447,7 @@ impl Expander for LiftExpander {
             if let Some(ty) = ty {
                 let payload_ty = match style {
                     VariantStyle::Variant => {
-                        quote!(ty.cases[#index].ty.unwrap_or_else(#internal::bad_type_info))
+                        quote!(ty.cases[#index].unwrap_or_else(#internal::bad_type_info))
                     }
                     VariantStyle::Enum => unreachable!(),
                 };
@@ -626,7 +626,7 @@ impl Expander for LowerExpander {
             if ty.is_some() {
                 let ty = match style {
                     VariantStyle::Variant => {
-                        quote!(ty.cases[#index].ty.unwrap_or_else(#internal::bad_type_info))
+                        quote!(ty.cases[#index].unwrap_or_else(#internal::bad_type_info))
                     }
                     VariantStyle::Enum => unreachable!(),
                 };

--- a/crates/environ/src/component/types.rs
+++ b/crates/environ/src/component/types.rs
@@ -8,7 +8,7 @@ use cranelift_entity::EntityRef;
 use indexmap::{IndexMap, IndexSet};
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::hash::Hash;
+use std::hash::{Hash, Hasher};
 use std::ops::Index;
 use wasmparser::names::KebabString;
 use wasmparser::types;
@@ -757,19 +757,20 @@ impl ComponentTypesBuilder {
                 if case.refines.is_some() {
                     bail!("refines is not supported at this time");
                 }
-                Ok(VariantCase {
-                    name: name.to_string(),
-                    ty: match &case.ty.as_ref() {
+                Ok((
+                    name.to_string(),
+                    match &case.ty.as_ref() {
                         Some(ty) => Some(self.valtype(types, ty)?),
                         None => None,
                     },
-                })
+                ))
             })
-            .collect::<Result<Box<[_]>>>()?;
-        let (info, abi) = VariantInfo::new(cases.iter().map(|c| {
-            c.ty.as_ref()
-                .map(|ty| self.component_types.canonical_abi(ty))
-        }));
+            .collect::<Result<IndexMap<_, _>>>()?;
+        let (info, abi) = VariantInfo::new(
+            cases
+                .iter()
+                .map(|(_, c)| c.as_ref().map(|ty| self.component_types.canonical_abi(ty))),
+        );
         Ok(self.add_variant_type(TypeVariant { cases, abi, info }))
     }
 
@@ -804,7 +805,10 @@ impl ComponentTypesBuilder {
     }
 
     fn enum_type(&mut self, variants: &IndexSet<KebabString>) -> TypeEnumIndex {
-        let names = variants.iter().map(|s| s.to_string()).collect::<Box<[_]>>();
+        let names = variants
+            .iter()
+            .map(|s| s.to_string())
+            .collect::<IndexSet<_>>();
         let (info, abi) = VariantInfo::new(names.iter().map(|_| None));
         self.add_enum_type(TypeEnum { names, abi, info })
     }
@@ -1485,24 +1489,23 @@ pub struct RecordField {
 /// Variants are close to Rust `enum` declarations where a value is one of many
 /// cases and each case has a unique name and an optional payload associated
 /// with it.
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct TypeVariant {
     /// The list of cases that this variant can take.
-    pub cases: Box<[VariantCase]>,
+    pub cases: IndexMap<String, Option<InterfaceType>>,
     /// Byte information about this type in the canonical ABI.
     pub abi: CanonicalAbiInfo,
     /// Byte information about this variant type.
     pub info: VariantInfo,
 }
 
-/// One case of a `variant` type which contains the name of the variant as well
-/// as the payload.
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
-pub struct VariantCase {
-    /// Name of the variant, unique amongst all cases in a variant.
-    pub name: String,
-    /// Optional type associated with this payload.
-    pub ty: Option<InterfaceType>,
+impl Hash for TypeVariant {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        let TypeVariant { cases, abi, info } = self;
+        cases.as_slice().hash(h);
+        abi.hash(h);
+        info.hash(h);
+    }
 }
 
 /// Shape of a "tuple" type in interface types.
@@ -1521,12 +1524,20 @@ pub struct TypeTuple {
 ///
 /// This can be thought of as a record-of-bools, although the representation is
 /// more efficient as bitflags.
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct TypeFlags {
     /// The names of all flags, all of which are unique.
-    pub names: Box<[String]>,
+    pub names: IndexSet<String>,
     /// Byte information about this type in the canonical ABI.
     pub abi: CanonicalAbiInfo,
+}
+
+impl Hash for TypeFlags {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        let TypeFlags { names, abi } = self;
+        names.as_slice().hash(h);
+        abi.hash(h);
+    }
 }
 
 /// Shape of an "enum" type in interface types, not to be confused with a Rust
@@ -1534,14 +1545,23 @@ pub struct TypeFlags {
 ///
 /// In interface types enums are simply a bag of names, and can be seen as a
 /// variant where all payloads are `Unit`.
-#[derive(Serialize, Deserialize, Clone, Hash, Eq, PartialEq, Debug)]
+#[derive(Serialize, Deserialize, Clone, Eq, PartialEq, Debug)]
 pub struct TypeEnum {
     /// The names of this enum, all of which are unique.
-    pub names: Box<[String]>,
+    pub names: IndexSet<String>,
     /// Byte information about this type in the canonical ABI.
     pub abi: CanonicalAbiInfo,
     /// Byte information about this variant type.
     pub info: VariantInfo,
+}
+
+impl Hash for TypeEnum {
+    fn hash<H: Hasher>(&self, h: &mut H) {
+        let TypeEnum { names, abi, info } = self;
+        names.as_slice().hash(h);
+        abi.hash(h);
+        info.hash(h);
+    }
 }
 
 /// Shape of an "option" interface type.
@@ -1909,7 +1929,7 @@ impl TypeInformation {
         self.build_variant(
             ty.cases
                 .iter()
-                .map(|c| c.ty.as_ref().map(|ty| types.type_information(ty))),
+                .map(|(_, c)| c.as_ref().map(|ty| types.type_information(ty))),
         )
     }
 

--- a/crates/environ/src/fact/trampoline.rs
+++ b/crates/environ/src/fact/trampoline.rs
@@ -2179,25 +2179,29 @@ impl Compiler<'_, '_> {
             _ => panic!("expected a variant"),
         };
 
-        let src_info = variant_info(self.types, src_ty.cases.iter().map(|c| c.ty.as_ref()));
-        let dst_info = variant_info(self.types, dst_ty.cases.iter().map(|c| c.ty.as_ref()));
+        let src_info = variant_info(self.types, src_ty.cases.iter().map(|(_, c)| c.as_ref()));
+        let dst_info = variant_info(self.types, dst_ty.cases.iter().map(|(_, c)| c.as_ref()));
 
-        let iter = src_ty.cases.iter().enumerate().map(|(src_i, src_case)| {
-            let dst_i = dst_ty
-                .cases
-                .iter()
-                .position(|c| c.name == src_case.name)
-                .unwrap();
-            let dst_case = &dst_ty.cases[dst_i];
-            let src_i = u32::try_from(src_i).unwrap();
-            let dst_i = u32::try_from(dst_i).unwrap();
-            VariantCase {
-                src_i,
-                src_ty: src_case.ty.as_ref(),
-                dst_i,
-                dst_ty: dst_case.ty.as_ref(),
-            }
-        });
+        let iter = src_ty
+            .cases
+            .iter()
+            .enumerate()
+            .map(|(src_i, (src_case, src_case_ty))| {
+                let dst_i = dst_ty
+                    .cases
+                    .iter()
+                    .position(|(c, _)| c == src_case)
+                    .unwrap();
+                let dst_case_ty = &dst_ty.cases[dst_i];
+                let src_i = u32::try_from(src_i).unwrap();
+                let dst_i = u32::try_from(dst_i).unwrap();
+                VariantCase {
+                    src_i,
+                    src_ty: src_case_ty.as_ref(),
+                    dst_i,
+                    dst_ty: dst_case_ty.as_ref(),
+                }
+            });
         self.convert_variant(src, &src_info, dst, &dst_info, iter);
     }
 

--- a/crates/wasmtime/src/runtime/component/func.rs
+++ b/crates/wasmtime/src/runtime/component/func.rs
@@ -395,11 +395,6 @@ impl Func {
             );
         }
 
-        for (param, ty) in params.iter().zip(param_tys.iter()) {
-            ty.is_supertype_of(param)
-                .context("type mismatch with parameters")?;
-        }
-
         self.call_raw(
             store,
             params,

--- a/crates/wasmtime/src/runtime/component/func/host.rs
+++ b/crates/wasmtime/src/runtime/component/func/host.rs
@@ -1,7 +1,7 @@
 use crate::component::func::{LiftContext, LowerContext, Options};
 use crate::component::matching::InstanceType;
 use crate::component::storage::slice_to_storage_mut;
-use crate::component::{ComponentNamedList, ComponentType, Lift, Lower, Type, Val};
+use crate::component::{ComponentNamedList, ComponentType, Lift, Lower, Val};
 use crate::{AsContextMut, StoreContextMut, ValRaw};
 use anyhow::{anyhow, bail, Context, Result};
 use std::any::Any;
@@ -383,10 +383,6 @@ where
     flags.set_may_leave(false);
 
     let mut cx = LowerContext::new(store, &options, types, instance);
-    let instance = cx.instance_type();
-    for (val, ty) in result_vals.iter().zip(result_tys.types.iter()) {
-        Type::from(ty, &instance).is_supertype_of(val)?;
-    }
     if let Some(cnt) = result_tys.abi.flat_count(MAX_FLAT_RESULTS) {
         let mut dst = storage[..cnt].iter_mut();
         for (val, ty) in result_vals.iter().zip(result_tys.types.iter()) {

--- a/crates/wasmtime/src/runtime/component/func/typed.rs
+++ b/crates/wasmtime/src/runtime/component/func/typed.rs
@@ -1787,12 +1787,12 @@ pub fn typecheck_variant(
                 );
             }
 
-            for (case, &(name, check)) in cases.iter().zip(expected) {
-                if case.name != name {
-                    bail!("expected variant case named {name}, found {}", case.name);
+            for ((case_name, case_ty), &(name, check)) in cases.iter().zip(expected) {
+                if *case_name != name {
+                    bail!("expected variant case named {name}, found {case_name}");
                 }
 
-                match (check, &case.ty) {
+                match (check, case_ty) {
                     (Some(check), Some(ty)) => check(ty, types)
                         .with_context(|| format!("type mismatch for case {name}"))?,
                     (None, None) => {}

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -61,7 +61,7 @@ pub use self::linker::{Linker, LinkerInstance, ResourceImportIndex};
 pub use self::resource_table::{ResourceTable, ResourceTableError};
 pub use self::resources::{Resource, ResourceAny};
 pub use self::types::{ResourceType, Type};
-pub use self::values::{Enum, Flags, List, OptionVal, Record, ResultVal, Tuple, Val, Variant};
+pub use self::values::Val;
 
 pub(crate) use self::resources::HostResourceData;
 

--- a/crates/wast/src/wast.rs
+++ b/crates/wast/src/wast.rs
@@ -186,16 +186,11 @@ where
             }
             #[cfg(feature = "component-model")]
             Export::Component(func) => {
-                let params = func.params(&self.store);
-                if exec.args.len() != params.len() {
-                    bail!("mismatched number of parameters")
-                }
                 let values = exec
                     .args
                     .iter()
-                    .zip(params.iter())
-                    .map(|(v, t)| match v {
-                        WastArg::Component(v) => component::val(v, t),
+                    .map(|v| match v {
+                        WastArg::Component(v) => component::val(v),
                         WastArg::Core(_) => bail!("expected core function, found component"),
                     })
                     .collect::<Result<Vec<_>>>()?;

--- a/tests/all/component_model/import.rs
+++ b/tests/all/component_model/import.rs
@@ -706,7 +706,7 @@ fn stack_and_heap_args_and_rets() -> Result<()> {
         .root()
         .func_new(&component, "f2", |_, args, results| {
             if let Val::Tuple(tuple) = &args[0] {
-                if let Val::String(s) = &tuple.values()[0] {
+                if let Val::String(s) = &tuple[0] {
                     assert_eq!(s.deref(), "abc");
                     results[0] = Val::U32(3);
                     Ok(())
@@ -732,7 +732,7 @@ fn stack_and_heap_args_and_rets() -> Result<()> {
         .root()
         .func_new(&component, "f4", |_, args, results| {
             if let Val::Tuple(tuple) = &args[0] {
-                if let Val::String(s) = &tuple.values()[0] {
+                if let Val::String(s) = &tuple[0] {
                     assert_eq!(s.deref(), "abc");
                     results[0] = Val::String("xyz".into());
                     Ok(())


### PR DESCRIPTION
This commit is a large refactor of the `Val` type as used with components to remove inherent type information present currently. The `Val` type is now only an AST of what a component model value looks like and cannot fully describe the type that it is without further context. For example enums only store the case that's being used, not the full set of cases.

The motivation for this commit is to make it simpler to use and construct `Val`, especially in the face of resources. Some problems solved here are:

* With resources in play managing type information is not trivial and can often be surprising. For example if you learn the type of a function from a component and the instantiate the component twice the type information is not suitable to use with either function due to exported resources acquiring unique types on all instantiations.

* Functionally it's much easier to construct values when type information is not required as it no longer requires probing various pieces for type information here and there.

* API-wise there's far less for us to maintain as there's no need for a type-per-variant of component model types. Pieces now fit much more naturally into a `Val` shape without extra types.

* Functionally when working with `Val` there's now only one typecheck instead of two. Previously a typecheck was performed first when a `Val` was created and then again later when it was passed to wasm. Now the typecheck only happens when passed to wasm.

It's worth pointing out that `Val` as-is is a pretty inefficient representation of component model values, for example flags are stored as a list of strings. While semantically correct this is quite inefficient for most purposes other than "get something working". To that extent my goal is to, in the future, add traits that enable building a custom user-defined `Val` (of sorts), but still dynamically. This should enable embedders to opt-in to a more efficient representation that relies on contextual knowledge.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
