### PR TITLE
Fix generating bindings for dead code

### DIFF
--- a/crates/component-macro/tests/codegen/dead-code.wit
+++ b/crates/component-macro/tests/codegen/dead-code.wit
@@ -1,0 +1,27 @@
+package a:b;
+
+world imports {
+  import interface-with-live-type;
+  import interface-with-dead-type;
+}
+
+interface interface-with-live-type {
+  record live-type {
+    a: u32,
+  }
+  f: func() -> live-type;
+}
+
+
+interface interface-with-dead-type {
+  use interface-with-live-type.{live-type};
+
+  record dead-type {
+    a: u32,
+  }
+
+  variant v {
+    a(live-type),
+    b(dead-type),
+  }
+}

--- a/crates/wit-bindgen/src/types.rs
+++ b/crates/wit-bindgen/src/types.rs
@@ -40,6 +40,14 @@ impl std::ops::BitOrAssign for TypeInfo {
 
 impl Types {
     pub fn analyze(&mut self, resolve: &Resolve, world: WorldId) {
+        // Build up all type information first which is inherited through types,
+        // such as properties of borrows/lists/etc.
+        for (t, _) in resolve.types.iter() {
+            self.type_id_info(resolve, t);
+        }
+
+        // ... next handle borrowed/owned flags which aren't inherited through
+        // types.
         let world = &resolve.worlds[world];
         for (import, (_, item)) in world
             .imports


### PR DESCRIPTION
This commit fixes a bindgen problem where dead types, which had no generated bindings, could be referred to from other dead types, which did have generated bindings. The fix is to not generate code for dead types at all by fixing how type information is analyzed.

Closes #8057