### PR TITLE
wasmtime-c-api: switch from wasi-common to wasmtime-wasi

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3485,10 +3485,11 @@ dependencies = [
  "futures",
  "log",
  "once_cell",
+ "tokio",
  "tracing",
- "wasi-common",
  "wasmtime",
  "wasmtime-c-api-macros",
+ "wasmtime-wasi",
  "wat",
 ]
 

--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -32,7 +32,8 @@ wat = { workspace = true, optional = true }
 
 # Optional dependencies for the `wasi` feature
 cap-std = { workspace = true, optional = true }
-wasi-common = { workspace = true, optional = true, features = ["sync"] }
+tokio = { workspace = true, optional = true, features = ["fs"] }
+wasmtime-wasi = { workspace = true, optional = true, features = ["preview1"] }
 
 # Optional dependencies for the `async` feature
 futures = { workspace = true, optional = true }
@@ -42,7 +43,7 @@ async = ['wasmtime/async', 'futures']
 profiling = ["wasmtime/profiling"]
 cache = ["wasmtime/cache"]
 parallel-compilation = ['wasmtime/parallel-compilation']
-wasi = ['cap-std', 'wasi-common']
+wasi = ['cap-std', 'wasmtime-wasi', 'tokio']
 logging = ['dep:env_logger']
 disable-logging = ["log/max_level_off", "tracing/max_level_off"]
 coredump = ["wasmtime/coredump"]

--- a/crates/c-api/src/error.rs
+++ b/crates/c-api/src/error.rs
@@ -56,7 +56,7 @@ pub extern "C" fn wasmtime_error_message(error: &wasmtime_error_t, message: &mut
 #[no_mangle]
 pub extern "C" fn wasmtime_error_exit_status(raw: &wasmtime_error_t, status: &mut i32) -> bool {
     #[cfg(feature = "wasi")]
-    if let Some(exit) = raw.error.downcast_ref::<wasi_common::I32Exit>() {
+    if let Some(exit) = raw.error.downcast_ref::<wasmtime_wasi::I32Exit>() {
         *status = exit.0;
         return true;
     }

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -112,10 +112,8 @@ pub extern "C" fn wasmtime_linker_define_wasi(
     linker: &mut wasmtime_linker_t,
 ) -> Option<Box<wasmtime_error_t>> {
     handle_result(
-        wasi_common::sync::add_to_linker(&mut linker.linker, |cx| {
-            cx.wasi.as_mut().expect(
-                "failed to define WASI on linker; did you set a WASI configuration in the store?",
-            )
+        wasmtime_wasi::preview1::add_to_linker_sync(&mut linker.linker, |ctx| {
+            ctx.wasi.as_mut().expect("wasi context must be populated")
         }),
         |_linker| (),
     )

--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -83,7 +83,7 @@ wasmtime_c_api_macros::declare_own!(wasmtime_store_t);
 pub struct WasmtimeStoreData {
     foreign: crate::ForeignData,
     #[cfg(feature = "wasi")]
-    pub(crate) wasi: Option<wasmtime_wasi::WasiP1Ctx>,
+    pub(crate) wasi: Option<wasmtime_wasi::preview1::WasiP1Ctx>,
 
     /// Temporary storage for usage during a wasm->host call to store values
     /// in a slice we pass to the C API.

--- a/crates/c-api/src/store.rs
+++ b/crates/c-api/src/store.rs
@@ -83,7 +83,7 @@ wasmtime_c_api_macros::declare_own!(wasmtime_store_t);
 pub struct WasmtimeStoreData {
     foreign: crate::ForeignData,
     #[cfg(feature = "wasi")]
-    pub(crate) wasi: Option<wasi_common::WasiCtx>,
+    pub(crate) wasi: Option<wasmtime_wasi::WasiP1Ctx>,
 
     /// Temporary storage for usage during a wasm->host call to store values
     /// in a slice we pass to the C API.

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -109,11 +109,7 @@ impl wasi_config_t {
                 builder.inherit_stdout();
             }
             WasiConfigWritePipe::File(file) => {
-                let file = tokio::fs::File::from_std(file);
-                let stdout_stream = wasmtime_wasi::AsyncStdoutStream::new(
-                    wasmtime_wasi::pipe::AsyncWriteStream::new(1024 * 1024, file),
-                );
-                builder.stdout(stdout_stream);
+                builder.stdout(wasmtime_wasi::OutputFile::new(file));
             }
         };
         match self.stderr {
@@ -122,11 +118,7 @@ impl wasi_config_t {
                 builder.inherit_stderr();
             }
             WasiConfigWritePipe::File(file) => {
-                let file = tokio::fs::File::from_std(file);
-                let stderr_stream = wasmtime_wasi::AsyncStdoutStream::new(
-                    wasmtime_wasi::pipe::AsyncWriteStream::new(1024 * 1024, file),
-                );
-                builder.stderr(stderr_stream);
+                builder.stderr(wasmtime_wasi::OutputFile::new(file));
             }
         };
         for (host_path, guest_path) in self.preopen_dirs {

--- a/crates/c-api/src/wasi.rs
+++ b/crates/c-api/src/wasi.rs
@@ -3,17 +3,12 @@
 use crate::wasm_byte_vec_t;
 use anyhow::Result;
 use cap_std::ambient_authority;
-use std::collections::HashMap;
 use std::ffi::CStr;
 use std::fs::File;
 use std::os::raw::{c_char, c_int};
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::slice;
-use wasi_common::{
-    pipe::ReadPipe,
-    sync::{Dir, TcpListener, WasiCtxBuilder},
-    WasiCtx,
-};
+use wasmtime_wasi::{WasiCtxBuilder, WasiP1Ctx};
 
 unsafe fn cstr_to_path<'a>(path: *const c_char) -> Option<&'a Path> {
     CStr::from_ptr(path).to_str().map(Path::new).ok()
@@ -39,8 +34,7 @@ pub struct wasi_config_t {
     stdin: WasiConfigReadPipe,
     stdout: WasiConfigWritePipe,
     stderr: WasiConfigWritePipe,
-    preopen_dirs: Vec<(Dir, PathBuf)>,
-    preopen_sockets: HashMap<u32, TcpListener>,
+    preopen_dirs: Vec<(cap_std::fs::Dir, String)>,
     inherit_args: bool,
     inherit_env: bool,
 }
@@ -67,20 +61,20 @@ pub enum WasiConfigWritePipe {
 wasmtime_c_api_macros::declare_own!(wasi_config_t);
 
 impl wasi_config_t {
-    pub fn into_wasi_ctx(self) -> Result<WasiCtx> {
+    pub fn into_wasi_ctx(self) -> Result<WasiP1Ctx> {
         let mut builder = WasiCtxBuilder::new();
         if self.inherit_args {
-            builder.inherit_args()?;
+            builder.inherit_args();
         } else if !self.args.is_empty() {
             let args = self
                 .args
                 .into_iter()
                 .map(|bytes| Ok(String::from_utf8(bytes)?))
                 .collect::<Result<Vec<String>>>()?;
-            builder.args(&args)?;
+            builder.args(&args);
         }
         if self.inherit_env {
-            builder.inherit_env()?;
+            builder.inherit_env();
         } else if !self.env.is_empty() {
             let env = self
                 .env
@@ -91,7 +85,7 @@ impl wasi_config_t {
                     Ok((k, v))
                 })
                 .collect::<Result<Vec<(String, String)>>>()?;
-            builder.envs(&env)?;
+            builder.envs(&env);
         }
         match self.stdin {
             WasiConfigReadPipe::None => {}
@@ -99,13 +93,15 @@ impl wasi_config_t {
                 builder.inherit_stdin();
             }
             WasiConfigReadPipe::File(file) => {
-                let file = cap_std::fs::File::from_std(file);
-                let file = wasi_common::sync::file::File::from_cap_std(file);
-                builder.stdin(Box::new(file));
+                let file = tokio::fs::File::from_std(file);
+                let stdin_stream = wasmtime_wasi::AsyncStdinStream::new(
+                    wasmtime_wasi::pipe::AsyncReadStream::new(file),
+                );
+                builder.stdin(stdin_stream);
             }
             WasiConfigReadPipe::Bytes(binary) => {
-                let binary = ReadPipe::from(binary);
-                builder.stdin(Box::new(binary));
+                let binary = wasmtime_wasi::pipe::MemoryInputPipe::new(binary);
+                builder.stdin(binary);
             }
         };
         match self.stdout {
@@ -114,9 +110,11 @@ impl wasi_config_t {
                 builder.inherit_stdout();
             }
             WasiConfigWritePipe::File(file) => {
-                let file = cap_std::fs::File::from_std(file);
-                let file = wasi_common::sync::file::File::from_cap_std(file);
-                builder.stdout(Box::new(file));
+                let file = tokio::fs::File::from_std(file);
+                let stdout_stream = wasmtime_wasi::AsyncStdoutStream::new(
+                    wasmtime_wasi::pipe::AsyncWriteStream::new(1024 * 1024, file),
+                );
+                builder.stdout(stdout_stream);
             }
         };
         match self.stderr {
@@ -125,18 +123,22 @@ impl wasi_config_t {
                 builder.inherit_stderr();
             }
             WasiConfigWritePipe::File(file) => {
-                let file = cap_std::fs::File::from_std(file);
-                let file = wasi_common::sync::file::File::from_cap_std(file);
-                builder.stderr(Box::new(file));
+                let file = tokio::fs::File::from_std(file);
+                let stderr_stream = wasmtime_wasi::AsyncStdoutStream::new(
+                    wasmtime_wasi::pipe::AsyncWriteStream::new(1024 * 1024, file),
+                );
+                builder.stderr(stderr_stream);
             }
         };
         for (dir, path) in self.preopen_dirs {
-            builder.preopened_dir(dir, path)?;
+            builder.preopened_dir(
+                dir,
+                wasmtime_wasi::DirPerms::all(),
+                wasmtime_wasi::FilePerms::all(),
+                path,
+            );
         }
-        for (fd_num, listener) in self.preopen_sockets {
-            builder.preopened_socket(fd_num, listener)?;
-        }
-        Ok(builder.build())
+        Ok(builder.build_p1())
     }
 }
 
@@ -268,59 +270,20 @@ pub unsafe extern "C" fn wasi_config_preopen_dir(
     path: *const c_char,
     guest_path: *const c_char,
 ) -> bool {
-    let guest_path = match cstr_to_path(guest_path) {
-        Some(p) => p,
+    let guest_path = match cstr_to_str(guest_path) {
+        Some(p) => p.to_owned(),
         None => return false,
     };
 
     let dir = match cstr_to_path(path) {
-        Some(p) => match Dir::open_ambient_dir(p, ambient_authority()) {
+        Some(p) => match cap_std::fs::Dir::open_ambient_dir(p, ambient_authority()) {
             Ok(d) => d,
             Err(_) => return false,
         },
         None => return false,
     };
 
-    (*config).preopen_dirs.push((dir, guest_path.to_owned()));
-
-    true
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn wasi_config_preopen_socket(
-    config: &mut wasi_config_t,
-    fd_num: u32,
-    host_port: *const c_char,
-) -> bool {
-    const VAR: &str = "WASMTIME_WASI_CONFIG_PREOPEN_SOCKET_ALLOW";
-    if std::env::var(VAR).is_err() {
-        panic!(
-            "wasmtime c-api: wasi_config_preopen_socket will be deprecated in the \
-            wasmtime 20.0.0 release. set {VAR} to enable temporarily"
-        );
-    }
-
-    let address = match cstr_to_str(host_port) {
-        Some(s) => s,
-        None => return false,
-    };
-    let listener = match std::net::TcpListener::bind(address) {
-        Ok(listener) => listener,
-        Err(_) => return false,
-    };
-
-    if let Err(_) = listener.set_nonblocking(true) {
-        return false;
-    }
-
-    // Caller cannot call in more than once with the same FD number so return an error.
-    if (*config).preopen_sockets.contains_key(&fd_num) {
-        return false;
-    }
-
-    (*config)
-        .preopen_sockets
-        .insert(fd_num, TcpListener::from_std(listener));
+    (*config).preopen_dirs.push((dir, guest_path));
 
     true
 }

--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -212,8 +212,8 @@ pub use self::network::{Network, SocketAddrUse, SocketError, SocketResult};
 pub use self::poll::{subscribe, ClosureFuture, MakeFuture, Pollable, PollableFuture, Subscribe};
 pub use self::random::{thread_rng, Deterministic};
 pub use self::stdio::{
-    stderr, stdin, stdout, AsyncStdinStream, AsyncStdoutStream, IsATTY, Stderr, Stdin, StdinStream,
-    Stdout, StdoutStream,
+    stderr, stdin, stdout, AsyncStdinStream, AsyncStdoutStream, IsATTY, OutputFile, Stderr, Stdin,
+    StdinStream, Stdout, StdoutStream,
 };
 pub use self::stream::{
     HostInputStream, HostOutputStream, InputStream, OutputStream, StreamError, StreamResult,


### PR DESCRIPTION
Based on #8053

This PR switches the wasmtime-c-api from using wasi-common to wasmtime-wasi.

The c-api still only exposes WASI P1 support to the guests - this isn't attempting to solve the problem of exposing components and WASI P2 on the c-api. It is only changing the implementation used under the hood so that we can push wasi-common into maintenance mode.

This PR removes the `wasi_config_preopen_socket` symbol from the c-api. It should be deployed as part of release-20.0.0 (not backported to 19) so that users get 1 release of deprecation warning via https://github.com/bytecodealliance/wasmtime/pull/8064 . The idea of a preopen socket is a weird corner of P1 that never got any appropriate testing in the wasmtime tree, and doesnt have a translation in the P2 world. I sought out if there were any users of that part of the P1 / wasi-common code, because the company that contributed it is now defunct, and I never found any users. The warning in #8064 may alert us to some and the symbol going away in this PR may as well.



<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
