### PR TITLE
Add a component type accessor for `Component`

### DIFF
--- a/crates/wasmtime/src/runtime/component/matching.rs
+++ b/crates/wasmtime/src/runtime/component/matching.rs
@@ -193,7 +193,10 @@ impl<'a> InstanceType<'a> {
 
     pub fn resource_type(&self, index: TypeResourceTableIndex) -> ResourceType {
         let index = self.types[index].ty;
-        self.resources[index]
+        self.resources
+            .get(index)
+            .copied()
+            .unwrap_or_else(|| ResourceType::uninstantiated(&self.types, index))
     }
 }
 

--- a/tests/all/component_model/aot.rs
+++ b/tests/all/component_model/aot.rs
@@ -136,7 +136,6 @@ fn detect_precompiled() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(miri, ignore)]
 fn reflect_resource_import() -> Result<()> {
     let engine = super::engine();
     let c = Component::new(

--- a/tests/all/component_model/aot.rs
+++ b/tests/all/component_model/aot.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
-use wasmtime::component::{Component, Linker};
+use wasmtime::component::types::ComponentItem;
+use wasmtime::component::{Component, Linker, Type};
 use wasmtime::{Module, Precompiled, Store};
 
 #[test]
@@ -131,5 +132,36 @@ fn detect_precompiled() -> Result<()> {
         engine.detect_precompiled(&buffer),
         Some(Precompiled::Component)
     );
+    Ok(())
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn reflect_resource_import() -> Result<()> {
+    let engine = super::engine();
+    let c = Component::new(
+        &engine,
+        r#"
+        (component
+            (import "x" (type $x (sub resource)))
+            (import "y" (func (result (own $x))))
+        )
+        "#,
+    )?;
+    let ty = c.component_type();
+    let mut imports = ty.imports(&engine);
+    let (_, x) = imports.next().unwrap();
+    let (_, y) = imports.next().unwrap();
+    let x = match x {
+        ComponentItem::Resource(t) => t,
+        _ => unreachable!(),
+    };
+    let y = match y {
+        ComponentItem::ComponentFunc(t) => t,
+        _ => unreachable!(),
+    };
+    let result = y.results().next().unwrap();
+    assert_eq!(result, Type::Own(x));
+
     Ok(())
 }


### PR DESCRIPTION
All the bits are already in place so all that's needed is to touch up some docs and fixup a minor case uncovered through testing. Otherwise this enables runtime reflection over the imports and exports of an uninstantiated component.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
