### PR TITLE
Use the wasmtime-cranelift for winch component trampolines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,7 @@ dependencies = [
  "object 0.33.0",
  "target-lexicon",
  "wasmparser",
+ "wasmtime-cranelift",
  "wasmtime-cranelift-shared",
  "wasmtime-environ",
  "winch-codegen",

--- a/crates/cranelift-shared/src/obj.rs
+++ b/crates/cranelift-shared/src/obj.rs
@@ -13,7 +13,7 @@
 //! function body, the imported wasm function do not. The trampolines symbol
 //! names have format "_trampoline_N", where N is `SignatureIndex`.
 
-use crate::{CompiledFuncEnv, CompiledFunction, RelocationTarget};
+use crate::{CompiledFunction, RelocationTarget};
 use anyhow::Result;
 use cranelift_codegen::binemit::Reloc;
 use cranelift_codegen::ir::LibCall;
@@ -107,7 +107,7 @@ impl<'a> ModuleTextBuilder<'a> {
     pub fn append_func(
         &mut self,
         name: &str,
-        compiled_func: &'a CompiledFunction<impl CompiledFuncEnv>,
+        compiled_func: &'a CompiledFunction,
         resolve_reloc_target: impl Fn(FuncIndex) -> usize,
     ) -> (SymbolId, Range<u64>) {
         let body = compiled_func.buffer.data();

--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -153,6 +153,15 @@ fn wasm_call_signature(
             CallConv::Tail
         }
 
+        // The winch calling convention is only implemented for x64 and aarch64
+        arch if tunables.tail_callable => {
+            assert!(
+                matches!(arch, Architecture::X86_64 | Architecture::Aarch64(_)),
+                "https://github.com/bytecodealliance/wasmtime/issues/6530"
+            );
+            CallConv::Winch
+        }
+
         // On s390x the "wasmtime" calling convention is used to give vectors
         // little-endian lane order at the ABI layer which should reduce the
         // need for conversion when operating on vector function arguments. By

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -56,6 +56,9 @@ pub struct Tunables {
 
     /// Whether or not Wasm functions can be tail-called or not.
     pub tail_callable: bool,
+
+    /// Whether or not Wasm functions target the winch abi.
+    pub winch_callable: bool,
 }
 
 impl Tunables {
@@ -106,6 +109,7 @@ impl Tunables {
             debug_adapter_modules: false,
             relaxed_simd_deterministic: false,
             tail_callable: false,
+            winch_callable: false,
         }
     }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1719,6 +1719,13 @@ impl Config {
             tail_callable
         }
 
+        // If we're going to compile with winch, we must use the winch calling convention.
+        tunables.winch_callable = match self.compiler_config.strategy {
+            Strategy::Auto => !cfg!(feature = "cranelift") && cfg!(feature = "winch"),
+            Strategy::Cranelift => false,
+            Strategy::Winch => true,
+        };
+
         if tunables.static_memory_offset_guard_size < tunables.dynamic_memory_offset_guard_size {
             bail!("static memory guard size cannot be smaller than dynamic memory guard size");
         }

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1720,11 +1720,14 @@ impl Config {
         }
 
         // If we're going to compile with winch, we must use the winch calling convention.
-        tunables.winch_callable = match self.compiler_config.strategy {
-            Strategy::Auto => !cfg!(feature = "cranelift") && cfg!(feature = "winch"),
-            Strategy::Cranelift => false,
-            Strategy::Winch => true,
-        };
+        #[cfg(any(feature = "cranelift", feature = "winch"))]
+        {
+            tunables.winch_callable = match self.compiler_config.strategy {
+                Strategy::Auto => !cfg!(feature = "cranelift") && cfg!(feature = "winch"),
+                Strategy::Cranelift => false,
+                Strategy::Winch => true,
+            };
+        }
 
         if tunables.static_memory_offset_guard_size < tunables.dynamic_memory_offset_guard_size {
             bail!("static memory guard size cannot be smaller than dynamic memory guard size");

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -341,6 +341,7 @@ impl Metadata<'_> {
             guard_before_linear_memory,
             relaxed_simd_deterministic,
             tail_callable,
+            winch_callable,
 
             // This doesn't affect compilation, it's just a runtime setting.
             dynamic_memory_growth_reserve: _,
@@ -402,6 +403,11 @@ impl Metadata<'_> {
             "relaxed simd deterministic semantics",
         )?;
         Self::check_bool(tail_callable, other.tail_callable, "WebAssembly tail calls")?;
+        Self::check_bool(
+            winch_callable,
+            other.winch_callable,
+            "Winch calling convention",
+        )?;
 
         Ok(())
     }

--- a/crates/winch/Cargo.toml
+++ b/crates/winch/Cargo.toml
@@ -17,10 +17,14 @@ wasmtime-environ = { workspace = true }
 anyhow = { workspace = true }
 object = { workspace = true }
 cranelift-codegen = { workspace = true }
+wasmtime-cranelift = { workspace = true }
 wasmtime-cranelift-shared = { workspace = true }
 wasmparser = { workspace = true }
 gimli = { workspace = true }
 
 [features]
-component-model = ["wasmtime-environ/component-model"]
+component-model = [
+    "wasmtime-environ/component-model",
+    "wasmtime-cranelift/component-model",
+]
 all-arch = ["winch-codegen/all-arch"]

--- a/crates/winch/src/builder.rs
+++ b/crates/winch/src/builder.rs
@@ -48,6 +48,7 @@ impl CompilerBuilder for Builder {
     }
 
     fn set_tunables(&mut self, tunables: wasmtime_environ::Tunables) -> Result<()> {
+        assert!(tunables.winch_callable);
         self.cranelift.set_tunables(tunables)?;
         Ok(())
     }

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -25,6 +25,7 @@ struct CompilationContext {
 
 pub(crate) struct Compiler {
     isa: Box<dyn TargetIsa>,
+    trampolines: Box<dyn wasmtime_environ::Compiler>,
     contexts: Mutex<Vec<CompilationContext>>,
 }
 
@@ -40,9 +41,10 @@ impl wasmtime_cranelift_shared::CompiledFuncEnv for CompiledFuncEnv {
 }
 
 impl Compiler {
-    pub fn new(isa: Box<dyn TargetIsa>) -> Self {
+    pub fn new(isa: Box<dyn TargetIsa>, trampolines: Box<dyn wasmtime_environ::Compiler>) -> Self {
         Self {
             isa,
+            trampolines,
             contexts: Mutex::new(Vec::new()),
         }
     }
@@ -68,7 +70,7 @@ impl Compiler {
     /// Emit unwind info into the [`CompiledFunction`].
     fn emit_unwind_info(
         &self,
-        compiled_function: &mut CompiledFunction<CompiledFuncEnv>,
+        compiled_function: &mut CompiledFunction,
     ) -> Result<(), CompileError> {
         let kind = match self.isa.triple().operating_system {
             target_lexicon::OperatingSystem::Windows => UnwindInfoKind::Windows,
@@ -217,9 +219,7 @@ impl wasmtime_environ::Compiler for Compiler {
 
         let mut ret = Vec::with_capacity(funcs.len());
         for (i, (sym, func)) in funcs.iter().enumerate() {
-            let func = func
-                .downcast_ref::<CompiledFunction<CompiledFuncEnv>>()
-                .unwrap();
+            let func = func.downcast_ref::<CompiledFunction>().unwrap();
 
             let (sym, range) = builder.append_func(&sym, func, |idx| resolve_reloc(i, idx));
             traps.push(range.clone(), &func.traps().collect::<Vec<_>>());
@@ -265,7 +265,7 @@ impl wasmtime_environ::Compiler for Compiler {
 
     #[cfg(feature = "component-model")]
     fn component_compiler(&self) -> &dyn wasmtime_environ::component::ComponentCompiler {
-        todo!()
+        self.trampolines.component_compiler()
     }
 
     fn append_dwarf(

--- a/crates/winch/src/compiler.rs
+++ b/crates/winch/src/compiler.rs
@@ -25,6 +25,11 @@ struct CompilationContext {
 
 pub(crate) struct Compiler {
     isa: Box<dyn TargetIsa>,
+
+    /// The trampoline compiler is only used for the component model currently, but will soon be
+    /// used for all winch trampolines. For now, mark it as unused to handle the situation where
+    /// the component-model feature is disabled.
+    #[allow(unused)]
     trampolines: Box<dyn wasmtime_environ::Compiler>,
     contexts: Mutex<Vec<CompilationContext>>,
 }


### PR DESCRIPTION
Instead of reimplementing the component trampolines directly in terms of Winch's `MacroAssembler` trait, reuse `wasmtime-cranelift`'s `Compiler` implementation to do that heavy lifting.

I had to remove the type parameter from `CompiledFunction` and make it a boxed `dyn Trait` to make this work, due to the requirements of `Compiler::append_code`, and the visibility of `ModuleTextBuilder` in the crate hierarchy. I think that this refactoring could be pushed further to avoid the need to have the `Compiler` trait interface produce `&dyn Any` results for compiled functions, but haven't looked into making changes further than what was needed to get component trampolines working here.

We can push this work further to remove all trampoline generation from the `wasmtime-winch` crate, however I didn't want to bulk out the diff in this PR with that additional change, as it's not necessary for running components with winch.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
