### PR TITLE
Fix `connect_timeout` for `wasi-http`

### DIFF
--- a/crates/test-programs/src/bin/http_outbound_request_get.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_get.rs
@@ -10,6 +10,9 @@ fn main() {
         "/get?some=arg&goes=here",
         None,
         None,
+        None,
+        None,
+        None,
     )
     .context("/get")
     .unwrap();

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_dnsname.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_dnsname.rs
@@ -8,6 +8,9 @@ fn main() {
         "/",
         None,
         None,
+        None,
+        None,
+        None,
     );
 
     let e = res.unwrap_err();

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_port.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_port.rs
@@ -8,6 +8,9 @@ fn main() {
         "/",
         None,
         None,
+        None,
+        None,
+        None,
     );
 
     assert!(res.is_err());

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_version.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_version.rs
@@ -3,7 +3,17 @@ use test_programs::wasi::http::types::{ErrorCode, Method, Scheme};
 fn main() {
     let addr = std::env::var("HTTP_SERVER").unwrap();
     let res =
-        test_programs::http::request(Method::Connect, Scheme::Http, &addr, "/", None, Some(&[]));
+        test_programs::http::request(
+            Method::Connect,
+            Scheme::Http,
+            &addr,
+            "/",
+            None,
+            Some(&[]),
+            None,
+            None,
+            None,
+        );
 
     assert!(matches!(
         res.unwrap_err()

--- a/crates/test-programs/src/bin/http_outbound_request_invalid_version.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_invalid_version.rs
@@ -2,18 +2,17 @@ use test_programs::wasi::http::types::{ErrorCode, Method, Scheme};
 
 fn main() {
     let addr = std::env::var("HTTP_SERVER").unwrap();
-    let res =
-        test_programs::http::request(
-            Method::Connect,
-            Scheme::Http,
-            &addr,
-            "/",
-            None,
-            Some(&[]),
-            None,
-            None,
-            None,
-        );
+    let res = test_programs::http::request(
+        Method::Connect,
+        Scheme::Http,
+        &addr,
+        "/",
+        None,
+        Some(&[]),
+        None,
+        None,
+        None,
+    );
 
     assert!(matches!(
         res.unwrap_err()

--- a/crates/test-programs/src/bin/http_outbound_request_large_post.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_large_post.rs
@@ -15,6 +15,9 @@ fn main() {
         "/post",
         Some(&buffer),
         None,
+        None,
+        None,
+        None,
     )
     .context("/post large")
     .unwrap();

--- a/crates/test-programs/src/bin/http_outbound_request_post.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_post.rs
@@ -10,6 +10,9 @@ fn main() {
         "/post",
         Some(b"{\"foo\": \"bar\"}"),
         None,
+        None,
+        None,
+        None,
     )
     .context("/post")
     .unwrap();

--- a/crates/test-programs/src/bin/http_outbound_request_put.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_put.rs
@@ -4,9 +4,19 @@ use test_programs::wasi::http::types::{Method, Scheme};
 fn main() {
     let addr = std::env::var("HTTP_SERVER").unwrap();
     let res =
-        test_programs::http::request(Method::Put, Scheme::Http, &addr, "/put", Some(&[]), None)
-            .context("/put")
-            .unwrap();
+        test_programs::http::request(
+            Method::Put,
+            Scheme::Http,
+            &addr,
+            "/put",
+            Some(&[]),
+            None,
+            None,
+            None,
+            None,
+        )
+        .context("/put")
+        .unwrap();
 
     println!("/put: {res:?}");
     assert_eq!(res.status, 200);

--- a/crates/test-programs/src/bin/http_outbound_request_put.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_put.rs
@@ -3,20 +3,19 @@ use test_programs::wasi::http::types::{Method, Scheme};
 
 fn main() {
     let addr = std::env::var("HTTP_SERVER").unwrap();
-    let res =
-        test_programs::http::request(
-            Method::Put,
-            Scheme::Http,
-            &addr,
-            "/put",
-            Some(&[]),
-            None,
-            None,
-            None,
-            None,
-        )
-        .context("/put")
-        .unwrap();
+    let res = test_programs::http::request(
+        Method::Put,
+        Scheme::Http,
+        &addr,
+        "/put",
+        Some(&[]),
+        None,
+        None,
+        None,
+        None,
+    )
+    .context("/put")
+    .unwrap();
 
     println!("/put: {res:?}");
     assert_eq!(res.status, 200);

--- a/crates/test-programs/src/bin/http_outbound_request_timeout.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_timeout.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use std::net::SocketAddr;
 use std::time::{Duration, Instant};
-use test_programs::wasi::http::types::{Method, Scheme};
+use test_programs::wasi::http::types::{ErrorCode, Method, Scheme};
 
 fn main() {
     // This address inside the TEST-NET-3 address block is expected to time out.
@@ -23,6 +23,13 @@ fn main() {
     .context("/get");
 
     assert!(res.is_err());
+    assert!(
+        matches!(
+            res.unwrap_err().downcast_ref::<ErrorCode>(),
+            Some(ErrorCode::ConnectionTimeout)
+        ),
+        "expected connection timeout"
+    );
 
     let actual = start.elapsed();
     let tolerance = Duration::from_millis(100);

--- a/crates/test-programs/src/bin/http_outbound_request_timeout.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_timeout.rs
@@ -1,0 +1,31 @@
+use anyhow::Context;
+use std::net::SocketAddr;
+use std::time::{Duration, Instant};
+use test_programs::wasi::http::types::{Method, Scheme};
+
+fn main() {
+    // This address inside the TEST-NET-3 address block is expected to time out.
+    let addr = SocketAddr::from(([203, 0, 113, 12], 80)).to_string();
+    let timeout = Duration::from_millis(200);
+    let start = Instant::now();
+    let connect_timeout : Option<u64> = Some(timeout.as_nanos() as u64);
+    let res = test_programs::http::request(
+        Method::Get,
+        Scheme::Http,
+        &addr,
+        "/get?some=arg&goes=here",
+        None,
+        None,
+        connect_timeout,
+        None,
+        None,
+    )
+    .context("/get");
+
+    assert!(res.is_err());
+
+    let actual = start.elapsed();
+    let tolerance = Duration::from_millis(100);
+    let expected: Duration = timeout + tolerance;
+    assert!(actual < expected);
+}

--- a/crates/test-programs/src/bin/http_outbound_request_timeout.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_timeout.rs
@@ -1,13 +1,12 @@
 use anyhow::Context;
 use std::net::SocketAddr;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 use test_programs::wasi::http::types::{ErrorCode, Method, Scheme};
 
 fn main() {
     // This address inside the TEST-NET-3 address block is expected to time out.
     let addr = SocketAddr::from(([203, 0, 113, 12], 80)).to_string();
     let timeout = Duration::from_millis(200);
-    let start = Instant::now();
     let connect_timeout: Option<u64> = Some(timeout.as_nanos() as u64);
     let res = test_programs::http::request(
         Method::Get,
@@ -30,9 +29,4 @@ fn main() {
         ),
         "expected connection timeout"
     );
-
-    let actual = start.elapsed();
-    let tolerance = Duration::from_millis(100);
-    let upper_bound = timeout + tolerance;
-    assert!(actual < upper_bound);
 }

--- a/crates/test-programs/src/bin/http_outbound_request_timeout.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_timeout.rs
@@ -8,7 +8,7 @@ fn main() {
     let addr = SocketAddr::from(([203, 0, 113, 12], 80)).to_string();
     let timeout = Duration::from_millis(200);
     let start = Instant::now();
-    let connect_timeout : Option<u64> = Some(timeout.as_nanos() as u64);
+    let connect_timeout: Option<u64> = Some(timeout.as_nanos() as u64);
     let res = test_programs::http::request(
         Method::Get,
         Scheme::Http,

--- a/crates/test-programs/src/bin/http_outbound_request_timeout.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_timeout.rs
@@ -33,6 +33,6 @@ fn main() {
 
     let actual = start.elapsed();
     let tolerance = Duration::from_millis(100);
-    let expected: Duration = timeout + tolerance;
-    assert!(actual < expected);
+    let upper_bound = timeout + tolerance;
+    assert!(actual < upper_bound);
 }

--- a/crates/test-programs/src/bin/http_outbound_request_unknown_method.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_unknown_method.rs
@@ -8,6 +8,9 @@ fn main() {
         "/",
         None,
         None,
+        None,
+        None,
+        None,
     );
 
     // This error arises from input validation in the `set_method` function on `OutgoingRequest`.

--- a/crates/test-programs/src/bin/http_outbound_request_unsupported_scheme.rs
+++ b/crates/test-programs/src/bin/http_outbound_request_unsupported_scheme.rs
@@ -8,6 +8,9 @@ fn main() {
         "/",
         None,
         None,
+        None,
+        None,
+        None,
     );
 
     assert!(matches!(

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -22,15 +22,15 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
 
         let connect_timeout = opts
             .and_then(|opts| opts.connect_timeout)
-            .unwrap_or(std::time::Duration::from_millis(600 * 1000));
+            .unwrap_or(std::time::Duration::from_secs(600));
 
         let first_byte_timeout = opts
             .and_then(|opts| opts.first_byte_timeout)
-            .unwrap_or(std::time::Duration::from_millis(600 * 1000));
+            .unwrap_or(std::time::Duration::from_secs(600));
 
         let between_bytes_timeout = opts
             .and_then(|opts| opts.between_bytes_timeout)
-            .unwrap_or(std::time::Duration::from_millis(600 * 1000));
+            .unwrap_or(std::time::Duration::from_secs(600));
 
         let req = self.table().delete(request_id)?;
         let mut builder = hyper::Request::builder();

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -148,23 +148,27 @@ async fn handler(
     mut request: http::Request<HyperOutgoingBody>,
     between_bytes_timeout: Duration,
 ) -> Result<IncomingResponseInternal, types::ErrorCode> {
-    let tcp_stream = TcpStream::connect(authority.clone())
-        .await
-        .map_err(|e| match e.kind() {
-            std::io::ErrorKind::AddrNotAvailable => {
-                dns_error("address not available".to_string(), 0)
-            }
+    let tcp_stream = timeout(
+        connect_timeout,
+        TcpStream::connect(authority.clone())
+    )
+    .await
+    .map_err(|_| types::ErrorCode::ConnectionTimeout)?
+    .map_err(|e| match e.kind() {
+        std::io::ErrorKind::AddrNotAvailable => {
+            dns_error("address not available".to_string(), 0)
+        }
 
-            _ => {
-                if e.to_string()
-                    .starts_with("failed to lookup address information")
-                {
-                    dns_error("address not available".to_string(), 0)
-                } else {
-                    types::ErrorCode::ConnectionRefused
-                }
+        _ => {
+            if e.to_string()
+                .starts_with("failed to lookup address information")
+            {
+                dns_error("address not available".to_string(), 0)
+            } else {
+                types::ErrorCode::ConnectionRefused
             }
-        })?;
+        }
+    })?;
 
     let (mut sender, worker) = if use_tls {
         #[cfg(any(target_arch = "riscv64", target_arch = "s390x"))]

--- a/crates/wasi-http/tests/all/async_.rs
+++ b/crates/wasi-http/tests/all/async_.rs
@@ -27,6 +27,12 @@ async fn http_outbound_request_get() -> Result<()> {
 }
 
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn http_outbound_request_timeout() -> Result<()> {
+    let server = Server::http1()?;
+    run(HTTP_OUTBOUND_REQUEST_TIMEOUT_COMPONENT, &server).await
+}
+
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn http_outbound_request_post() -> Result<()> {
     let server = Server::http1()?;
     run(HTTP_OUTBOUND_REQUEST_POST_COMPONENT, &server).await

--- a/crates/wasi-http/tests/all/sync.rs
+++ b/crates/wasi-http/tests/all/sync.rs
@@ -25,6 +25,12 @@ fn http_outbound_request_get() -> Result<()> {
 }
 
 #[test_log::test]
+fn http_outbound_request_timeout() -> Result<()> {
+    let server = Server::http1()?;
+    run(HTTP_OUTBOUND_REQUEST_TIMEOUT_COMPONENT, &server)
+}
+
+#[test_log::test]
 fn http_outbound_request_post() -> Result<()> {
     let server = Server::http1()?;
     run(HTTP_OUTBOUND_REQUEST_POST_COMPONENT, &server)


### PR DESCRIPTION
@elliottt in https://github.com/bytecodealliance/wasmtime/issues/7356 mentions that `connect_timeout`, `first_byte_timeout`, and `between_bytes_timeout` should be tested.

This PR adds a test for `connect_timeout` and ensures that `TcpStream::connect` adheres to the timeout. Without this fix, setting `connect_timeout` has no effect on hosts where `TcpStream::connect` tries to connect.

Note that the variable `connect_timeout` is also used a bit later for the handshake:

https://github.com/bytecodealliance/wasmtime/blob/8dd2ae9e2c57b3fd32f91fb8f0ec1543854f4c7c/crates/wasi-http/src/types.rs#L207-L213

I'm not sure whether using this variable twice is correct.
