### PR TITLE
Back port 7991 to v18 release branch

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,14 @@
 --------------------------------------------------------------------------------
 
+## 18.0.3
+
+### Fixed
+
+* Fix inferring native flags when a compilation target is specified.
+  https://github.com/bytecodealliance/wasmtime/pull/7991
+
+--------------------------------------------------------------------------------
+
 ## 18.0.2
 
 Released 2024-02-28.

--- a/crates/cranelift-shared/src/isa_builder.rs
+++ b/crates/cranelift-shared/src/isa_builder.rs
@@ -28,9 +28,12 @@ impl<T> IsaBuilder<T> {
             .set("enable_probestack", "false")
             .expect("should be valid flag");
 
+        let triple_specified = triple.is_some();
         let triple = triple.unwrap_or_else(Triple::host);
         let mut isa_flags = lookup(triple)?;
-        cranelift_native::infer_native_flags(&mut isa_flags).unwrap();
+        if !triple_specified {
+            cranelift_native::infer_native_flags(&mut isa_flags).unwrap();
+        }
 
         Ok(Self {
             shared_flags: flags,


### PR DESCRIPTION
Back ports https://github.com/bytecodealliance/wasmtime/pull/7991 to the v18.0.0 release branch.

This allows cross-compilation to work on v18.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
