### PR TITLE
Stop threading Cranelift tables through cranelift-wasm callbacks

### DIFF
--- a/cranelift/filetests/src/test_wasm/env.rs
+++ b/cranelift/filetests/src/test_wasm/env.rs
@@ -361,14 +361,6 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
         self.inner.make_global(func, index)
     }
 
-    fn make_table(
-        &mut self,
-        func: &mut ir::Function,
-        index: cranelift_wasm::TableIndex,
-    ) -> cranelift_wasm::WasmResult<ir::Table> {
-        self.inner.make_table(func, index)
-    }
-
     fn make_indirect_sig(
         &mut self,
         func: &mut ir::Function,
@@ -389,7 +381,6 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
         &mut self,
         builder: &mut cranelift_frontend::FunctionBuilder,
         table_index: cranelift_wasm::TableIndex,
-        table: ir::Table,
         sig_index: cranelift_wasm::TypeIndex,
         sig_ref: ir::SigRef,
         callee: ir::Value,
@@ -398,7 +389,6 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
         self.inner.translate_call_indirect(
             builder,
             table_index,
-            table,
             sig_index,
             sig_ref,
             callee,
@@ -410,7 +400,6 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
         &mut self,
         builder: &mut cranelift_frontend::FunctionBuilder,
         table_index: cranelift_wasm::TableIndex,
-        table: ir::Table,
         sig_index: TypeIndex,
         sig_ref: ir::SigRef,
         callee: ir::Value,
@@ -419,7 +408,6 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
         self.inner.translate_return_call_indirect(
             builder,
             table_index,
-            table,
             sig_index,
             sig_ref,
             callee,
@@ -511,67 +499,52 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
         &mut self,
         pos: cranelift_codegen::cursor::FuncCursor,
         index: cranelift_wasm::TableIndex,
-        table: ir::Table,
     ) -> cranelift_wasm::WasmResult<ir::Value> {
-        self.inner.translate_table_size(pos, index, table)
+        self.inner.translate_table_size(pos, index)
     }
 
     fn translate_table_grow(
         &mut self,
         pos: cranelift_codegen::cursor::FuncCursor,
         table_index: cranelift_wasm::TableIndex,
-        table: ir::Table,
         delta: ir::Value,
         init_value: ir::Value,
     ) -> cranelift_wasm::WasmResult<ir::Value> {
         self.inner
-            .translate_table_grow(pos, table_index, table, delta, init_value)
+            .translate_table_grow(pos, table_index, delta, init_value)
     }
 
     fn translate_table_get(
         &mut self,
         builder: &mut cranelift_frontend::FunctionBuilder,
         table_index: cranelift_wasm::TableIndex,
-        table: ir::Table,
         index: ir::Value,
     ) -> cranelift_wasm::WasmResult<ir::Value> {
-        self.inner
-            .translate_table_get(builder, table_index, table, index)
+        self.inner.translate_table_get(builder, table_index, index)
     }
 
     fn translate_table_set(
         &mut self,
         builder: &mut cranelift_frontend::FunctionBuilder,
         table_index: cranelift_wasm::TableIndex,
-        table: ir::Table,
         value: ir::Value,
         index: ir::Value,
     ) -> cranelift_wasm::WasmResult<()> {
         self.inner
-            .translate_table_set(builder, table_index, table, value, index)
+            .translate_table_set(builder, table_index, value, index)
     }
 
     fn translate_table_copy(
         &mut self,
         pos: cranelift_codegen::cursor::FuncCursor,
         dst_table_index: cranelift_wasm::TableIndex,
-        dst_table: ir::Table,
         src_table_index: cranelift_wasm::TableIndex,
-        src_table: ir::Table,
         dst: ir::Value,
         src: ir::Value,
         len: ir::Value,
     ) -> cranelift_wasm::WasmResult<()> {
-        self.inner.translate_table_copy(
-            pos,
-            dst_table_index,
-            dst_table,
-            src_table_index,
-            src_table,
-            dst,
-            src,
-            len,
-        )
+        self.inner
+            .translate_table_copy(pos, dst_table_index, src_table_index, dst, src, len)
     }
 
     fn translate_table_fill(
@@ -591,13 +564,12 @@ impl<'a> FuncEnvironment for FuncEnv<'a> {
         pos: cranelift_codegen::cursor::FuncCursor,
         seg_index: u32,
         table_index: cranelift_wasm::TableIndex,
-        table: ir::Table,
         dst: ir::Value,
         src: ir::Value,
         len: ir::Value,
     ) -> cranelift_wasm::WasmResult<()> {
         self.inner
-            .translate_table_init(pos, seg_index, table_index, table, dst, src, len)
+            .translate_table_init(pos, seg_index, table_index, dst, src, len)
     }
 
     fn translate_elem_drop(

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -135,12 +135,6 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// The index space covers both imported and locally declared memories.
     fn make_heap(&mut self, func: &mut ir::Function, index: MemoryIndex) -> WasmResult<Heap>;
 
-    /// Set up the necessary preamble definitions in `func` to access the table identified
-    /// by `index`.
-    ///
-    /// The index space covers both imported and locally declared tables.
-    fn make_table(&mut self, func: &mut ir::Function, index: TableIndex) -> WasmResult<ir::Table>;
-
     /// Set up a signature definition in the preamble of `func` that can be used for an indirect
     /// call with signature `index`.
     ///
@@ -203,7 +197,6 @@ pub trait FuncEnvironment: TargetEnvironment {
         &mut self,
         builder: &mut FunctionBuilder,
         table_index: TableIndex,
-        table: ir::Table,
         sig_index: TypeIndex,
         sig_ref: ir::SigRef,
         callee: ir::Value,
@@ -243,7 +236,6 @@ pub trait FuncEnvironment: TargetEnvironment {
         &mut self,
         builder: &mut FunctionBuilder,
         table_index: TableIndex,
-        table: ir::Table,
         sig_index: TypeIndex,
         sig_ref: ir::SigRef,
         callee: ir::Value,
@@ -365,19 +357,14 @@ pub trait FuncEnvironment: TargetEnvironment {
     fn translate_data_drop(&mut self, pos: FuncCursor, seg_index: u32) -> WasmResult<()>;
 
     /// Translate a `table.size` WebAssembly instruction.
-    fn translate_table_size(
-        &mut self,
-        pos: FuncCursor,
-        index: TableIndex,
-        table: ir::Table,
-    ) -> WasmResult<ir::Value>;
+    fn translate_table_size(&mut self, pos: FuncCursor, index: TableIndex)
+        -> WasmResult<ir::Value>;
 
     /// Translate a `table.grow` WebAssembly instruction.
     fn translate_table_grow(
         &mut self,
         pos: FuncCursor,
         table_index: TableIndex,
-        table: ir::Table,
         delta: ir::Value,
         init_value: ir::Value,
     ) -> WasmResult<ir::Value>;
@@ -387,7 +374,6 @@ pub trait FuncEnvironment: TargetEnvironment {
         &mut self,
         builder: &mut FunctionBuilder,
         table_index: TableIndex,
-        table: ir::Table,
         index: ir::Value,
     ) -> WasmResult<ir::Value>;
 
@@ -396,7 +382,6 @@ pub trait FuncEnvironment: TargetEnvironment {
         &mut self,
         builder: &mut FunctionBuilder,
         table_index: TableIndex,
-        table: ir::Table,
         value: ir::Value,
         index: ir::Value,
     ) -> WasmResult<()>;
@@ -406,9 +391,7 @@ pub trait FuncEnvironment: TargetEnvironment {
         &mut self,
         pos: FuncCursor,
         dst_table_index: TableIndex,
-        dst_table: ir::Table,
         src_table_index: TableIndex,
-        src_table: ir::Table,
         dst: ir::Value,
         src: ir::Value,
         len: ir::Value,
@@ -430,7 +413,6 @@ pub trait FuncEnvironment: TargetEnvironment {
         pos: FuncCursor,
         seg_index: u32,
         table_index: TableIndex,
-        table: ir::Table,
         dst: ir::Value,
         src: ir::Value,
         len: ir::Value,

--- a/cranelift/wasm/src/state.rs
+++ b/cranelift/wasm/src/state.rs
@@ -4,7 +4,7 @@
 //! value and control stacks during the translation of a single function.
 
 use crate::environ::{FuncEnvironment, GlobalVariable};
-use crate::{FuncIndex, GlobalIndex, Heap, MemoryIndex, TableIndex, TypeIndex, WasmResult};
+use crate::{FuncIndex, GlobalIndex, Heap, MemoryIndex, TypeIndex, WasmResult};
 use crate::{HashMap, Occupied, Vacant};
 use cranelift_codegen::ir::{self, Block, Inst, Value};
 use std::vec::Vec;
@@ -229,9 +229,6 @@ pub struct FuncTranslationState {
     // Map of heaps that have been created by `FuncEnvironment::make_heap`.
     memory_to_heap: HashMap<MemoryIndex, Heap>,
 
-    // Map of tables that have been created by `FuncEnvironment::make_table`.
-    pub(crate) tables: HashMap<TableIndex, ir::Table>,
-
     // Map of indirect call signatures that have been created by
     // `FuncEnvironment::make_indirect_sig()`.
     // Stores both the signature reference and the number of WebAssembly arguments
@@ -261,7 +258,6 @@ impl FuncTranslationState {
             reachable: true,
             globals: HashMap::new(),
             memory_to_heap: HashMap::new(),
-            tables: HashMap::new(),
             signatures: HashMap::new(),
             functions: HashMap::new(),
         }
@@ -273,7 +269,6 @@ impl FuncTranslationState {
         self.reachable = true;
         self.globals.clear();
         self.memory_to_heap.clear();
-        self.tables.clear();
         self.signatures.clear();
         self.functions.clear();
     }
@@ -469,21 +464,6 @@ impl FuncTranslationState {
         match self.memory_to_heap.entry(index) {
             Occupied(entry) => Ok(*entry.get()),
             Vacant(entry) => Ok(*entry.insert(environ.make_heap(func, index)?)),
-        }
-    }
-
-    /// Get the `Table` reference that should be used to access table `index`.
-    /// Create the reference if necessary.
-    pub(crate) fn get_or_create_table<FE: FuncEnvironment + ?Sized>(
-        &mut self,
-        func: &mut ir::Function,
-        index: u32,
-        environ: &mut FE,
-    ) -> WasmResult<ir::Table> {
-        let index = TableIndex::from_u32(index);
-        match self.tables.entry(index) {
-            Occupied(entry) => Ok(*entry.get()),
-            Vacant(entry) => Ok(*entry.insert(environ.make_table(func, index)?)),
         }
     }
 


### PR DESCRIPTION
Previously, every table-related method in the FuncEnvironment trait took two IDs to identify a table: the TableIndex from the WebAssembly module, and the Cranelift Table we generated associated with it.

This is redundant and most implementations only used one or the other. The TableIndex is a perfectly good identifier and we can use it in a SecondaryMap if we need to associate additional data with the table, such as a Cranelift Table ID.

This is a step toward #5532, where we don't want to use Cranelift's table support at all, so the associated data that an implementation needs will be different.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
