### PR TITLE
Always run the `Check` job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -268,7 +268,6 @@ jobs:
   # double-check that Rust code compiles and is likely to work everywhere else.
   checks:
     needs: determine
-    if: needs.determine.outputs.run-full
     name: Check
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
The `Check` job is pretty cheap, and is a nice sanity check for pull requests. This PR changes it to always run.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
