### PR TITLE
Add a script to vendor WIT files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -354,6 +354,12 @@ jobs:
     - run: rustup component add clippy
     - run: cargo clippy --workspace
 
+    # Re-vendor all WIT files and ensure that they're all up-to-date by ensuring
+    # that there's no git changes.
+    - name: Re-vendor WIT
+      run: ./ci/vendor-wit.sh
+    - run: git diff --exit-code
+
     # common logic to cancel the entire run if this job fails
     - run: gh run cancel ${{ github.run_id }}
       if: failure() && github.event_name != 'pull_request'
@@ -525,12 +531,6 @@ jobs:
       env:
         RUST_BACKTRACE: 1
       if: matrix.target == '' && matrix.os != 'windows-latest' && needs.determine.outputs.test-capi
-
-    # Ensure wit definitions are in sync: both wasmtime-wasi and wasmtime-wasi-http need their own
-    # copy of the wit definitions so publishing works, but we need to ensure they are identical copies.
-    - name: Check that the wasi and wasi-http wit directories agree
-      run: |
-        diff -ru crates/wasi/wit crates/wasi-http/wit
 
     # Record some CPU details; this is helpful information if tests fail due
     # to CPU-specific features.

--- a/ci/vendor-wit.sh
+++ b/ci/vendor-wit.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Script to re-vendor the WIT files that Wasmtime uses as defined by a
+# particular tag in upstream repositories.
+#
+# This script is executed on CI to ensure that everything is up-to-date.
+
+set -ex
+
+dst=crates/wasi/wit/deps
+
+rm -rf $dst
+mkdir -p $dst
+
+repos="cli clocks filesystem http io random sockets"
+tag=0.2.0
+
+for repo in $repos; do
+  mkdir $dst/$repo
+  curl -L https://github.com/WebAssembly/wasi-$repo/archive/refs/tags/v$tag.tar.gz | \
+    tar xzf - --strip-components=2 -C $dst/$repo wasi-$repo-$tag/wit
+  rm -rf $dst/$repo/deps*
+done
+
+rm -rf crates/wasi-http/wit/deps
+cp -r $dst crates/wasi-http/wit

--- a/ci/vendor-wit.sh
+++ b/ci/vendor-wit.sh
@@ -5,15 +5,22 @@
 #
 # This script is executed on CI to ensure that everything is up-to-date.
 
+# Space-separated list of wasi proposals that are vendored here along with the
+# tag that they're all vendored at.
+#
+# This assumes that the repositories all have the pattern:
+# https://github.com/WebAssembly/wasi-$repo
+# and every repository has a tag `v$tag` here. That is currently done as part
+# of the WASI release process.
+repos="cli clocks filesystem http io random sockets"
+tag=0.2.0
+
 set -ex
 
 dst=crates/wasi/wit/deps
 
 rm -rf $dst
 mkdir -p $dst
-
-repos="cli clocks filesystem http io random sockets"
-tag=0.2.0
 
 for repo in $repos; do
   mkdir $dst/$repo

--- a/crates/wasi-http/wit/deps/io/poll.wit
+++ b/crates/wasi-http/wit/deps/io/poll.wit
@@ -27,9 +27,8 @@ interface poll {
     /// The result `list<u32>` contains one or more indices of handles in the
     /// argument list that is ready for I/O.
     ///
-    /// This function traps if either:
-    /// - the list is empty, or:
-    /// - the list contains more elements than can be indexed with a `u32` value.
+    /// If the list contains more elements than can be indexed with a `u32`
+    /// value, this function traps.
     ///
     /// A timeout can be implemented by adding a pollable from the
     /// wasi-clocks API to the list.

--- a/crates/wasi/wit/deps/io/poll.wit
+++ b/crates/wasi/wit/deps/io/poll.wit
@@ -27,9 +27,8 @@ interface poll {
     /// The result `list<u32>` contains one or more indices of handles in the
     /// argument list that is ready for I/O.
     ///
-    /// This function traps if either:
-    /// - the list is empty, or:
-    /// - the list contains more elements than can be indexed with a `u32` value.
+    /// If the list contains more elements than can be indexed with a `u32`
+    /// value, this function traps.
     ///
     /// A timeout can be implemented by adding a pollable from the
     /// wasi-clocks API to the list.


### PR DESCRIPTION
This is a follow-up to #7929 where it was concluded that we want to retain textual WIT files in this repository. Currently today we have no automated checks for vendoring and re-vendoring requires hand-editing. To help incrementally improve this situation this commit adds a script to do all the vendoring for us. This way CI can verify that everything is generated with respect to the output of this script.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
