### PR TITLE
x64: Remove load sinking from `XmmCmove`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -243,7 +243,7 @@
        ;; XMM conditional move; overwrites the destination register.
        (XmmCmove (ty Type)
                  (cc CC)
-                 (consequent XmmMemAligned)
+                 (consequent Xmm)
                  (alternative Xmm)
                  (dst WritableXmm))
 
@@ -2844,7 +2844,7 @@
          (MInst.Cmove size cc consequent alternative dst)
          dst)))
 
-(decl cmove_xmm (Type CC XmmMemAligned Xmm) ConsumesFlags)
+(decl cmove_xmm (Type CC Xmm Xmm) ConsumesFlags)
 (rule (cmove_xmm ty cc consequent alternative)
       (let ((dst WritableXmm (temp_writable_xmm)))
         (ConsumesFlags.ConsumesFlagsReturnsReg
@@ -2880,14 +2880,7 @@
       (cmove ty cc consequent alternative))
 
 (rule (cmove_from_values (is_xmm_type ty) cc consequent alternative)
-      ;; force the `Value`s to `Xmm`s (in-register values) here:
-      ;; `cmove_xmm` can take an `XmmMemAligned`, but we don't want to
-      ;; allow load fusion here because `ty` may not be
-      ;; XMM-register-wide even if it is `is_xmm_type`. (E.g.,
-      ;; consider a cmove of `f64` values.)
-      (let ((cons Xmm consequent)
-            (alt Xmm alternative))
-        (cmove_xmm ty cc cons alt)))
+      (cmove_xmm ty cc consequent alternative))
 
 ;; Helper for creating `cmove` instructions with the logical OR of multiple
 ;; flags. Note that these instructions will always result in more than one
@@ -2904,7 +2897,7 @@
          cmove2
          dst)))
 
-(decl cmove_or_xmm (Type CC CC XmmMemAligned Xmm) ConsumesFlags)
+(decl cmove_or_xmm (Type CC CC Xmm Xmm) ConsumesFlags)
 (rule (cmove_or_xmm ty cc1 cc2 consequent alternative)
       (let ((dst WritableXmm (temp_writable_xmm))
             (tmp WritableXmm (temp_writable_xmm))

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1428,7 +1428,7 @@ pub(crate) fn emit(
             let alternative = allocs.next(alternative.to_reg());
             let dst = allocs.next(dst.to_reg().to_reg());
             debug_assert_eq!(alternative, dst);
-            let consequent = consequent.clone().to_reg_mem().with_allocs(allocs);
+            let consequent = allocs.next(consequent.clone().to_reg());
 
             // Lowering of the Select IR opcode when the input is an fcmp relies on the fact that
             // this doesn't clobber flags. Make sure to not do so here.
@@ -1447,7 +1447,7 @@ pub(crate) fn emit(
                     SseOpcode::Movdqa
                 }
             };
-            let inst = Inst::xmm_unary_rm_r(op, consequent, Writable::from_reg(dst));
+            let inst = Inst::xmm_unary_rm_r(op, consequent.into(), Writable::from_reg(dst));
             inst.emit(&[], sink, info, state);
 
             sink.bind_label(next, state.ctrl_plane_mut());

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1624,7 +1624,7 @@ impl PrettyPrint for Inst {
                 let size = u8::try_from(ty.bytes()).unwrap();
                 let alternative = pretty_print_reg(alternative.to_reg(), size, allocs);
                 let dst = pretty_print_reg(dst.to_reg().to_reg(), size, allocs);
-                let consequent = consequent.pretty_print(size, allocs);
+                let consequent = pretty_print_reg(consequent.to_reg(), size, allocs);
                 let suffix = match *ty {
                     types::F64 => "sd",
                     types::F32 => "ss",
@@ -2334,7 +2334,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
         } => {
             collector.reg_use(alternative.to_reg());
             collector.reg_reuse_def(dst.to_writable_reg(), 0);
-            consequent.get_operands(collector);
+            collector.reg_use(consequent.to_reg());
         }
         Inst::Push64 { src } => {
             src.get_operands(collector);

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -514,19 +514,7 @@ pub(crate) fn check(
             _ => undefined_result(ctx, vcode, dst, 64, 64),
         },
 
-        Inst::XmmCmove {
-            dst,
-            ref consequent,
-            ..
-        } => {
-            match <&RegMem>::from(consequent) {
-                RegMem::Mem { ref addr } => {
-                    check_load(ctx, None, addr, vcode, I8X16, 128)?;
-                }
-                RegMem::Reg { .. } => {}
-            }
-            ensure_no_fact(vcode, dst.to_writable_reg().to_reg())
-        }
+        Inst::XmmCmove { dst, .. } => ensure_no_fact(vcode, dst.to_writable_reg().to_reg()),
 
         Inst::Push64 { ref src } => match <&RegMemImm>::from(src) {
             RegMemImm::Mem { ref addr } => {

--- a/tests/misc_testsuite/sink-float-but-dont-trap.wast
+++ b/tests/misc_testsuite/sink-float-but-dont-trap.wast
@@ -1,0 +1,51 @@
+(module
+  (memory 1)
+
+  ;; make sure that the sunk load here doesn't try to load past the end of
+  ;; memory.
+  (func (export "select-with-sink") (param i32) (result f64)
+    local.get 0
+    f64.load
+    f64.const 1
+    local.get 0
+    select
+    return)
+
+  ;; same as above but with a slightly different codegen pattern.
+  (func (export "select-with-fcmp-and-sink") (param i32 f64 f64) (result f64)
+    local.get 0
+    f64.load
+    f64.const 1
+    local.get 1
+    local.get 2
+    f64.ne
+    select
+    return)
+
+  ;; Same as the above two but the order of operands to the `select` are
+  ;; swapped.
+  (func (export "select-with-sink-other-way") (param i32) (result f64)
+    f64.const 1
+    local.get 0
+    f64.load
+    local.get 0
+    select
+    return)
+  (func (export "select-with-fcmp-and-sink-other-way") (param i32 f64 f64) (result f64)
+    f64.const 1
+    local.get 0
+    f64.load
+    local.get 1
+    local.get 2
+    f64.ne
+    select
+    return)
+)
+
+(assert_return (invoke "select-with-sink" (i32.const 0xfff8)) (f64.const 0))
+(assert_return (invoke "select-with-fcmp-and-sink" (i32.const 0xfff8) (f64.const 0) (f64.const 0)) (f64.const 1))
+
+(assert_trap (invoke "select-with-sink" (i32.const 0xfff9)) "out of bounds")
+(assert_trap (invoke "select-with-fcmp-and-sink" (i32.const 0xfff9) (f64.const 0) (f64.const 0)) "out of bounds")
+(assert_trap (invoke "select-with-sink-other-way" (i32.const 0xfff9)) "out of bounds")
+(assert_trap (invoke "select-with-fcmp-and-sink-other-way" (i32.const 0xfff9) (f64.const 0) (f64.const 0)) "out of bounds")

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -492,7 +492,7 @@ impl Assembler {
         self.emit(Inst::XmmCmove {
             ty,
             cc: cc.into(),
-            consequent: XmmMemAligned::new(src.into()).expect("valid XmmMemAligned"),
+            consequent: Xmm::new(src.into()).expect("valid Xmm"),
             alternative: dst.into(),
             dst: dst.into(),
         })


### PR DESCRIPTION
This commit completely replaces the `XmmMemAligned` operand in `XmmCmove` with `Xmm` instead. Looking more into the fix #8113 I was looking to add some `*.wast` runtime tests to assert that the fix works at the wasm layer in addition to the instruction selection layer. I was poking around and there's a second user of `XmmCmove` which wasn't addressed in #8113.

In #8113 the only caller of `cmove_xmm` was updated to ensure that everything was always in memory. This was done to both prevent the upgrade-to-an-aligned-load from loading too much but additionally to ensure that the load always happened, regardless of the condition. There was a second constructor of `XmmCmove`, however, from `cmove_or_xmm`. This is triggered when the condition is a `f64.ne` instruction, for example, and ran into the same bug that #8112 was exposing.

To fix both of these and prevent any future issues about skipping a load by accident due to control flow this commit removes the `XmmMemAligned` argument entirely from `XmmCmove` and replaces it with `Xmm`. This prevents sinking loads entirely and sidesteps all these issues at the type level.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
