### PR TITLE
x64: Fix load sinking in `rounds{s,d}` loading too much

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1570,7 +1570,7 @@
 (extern constructor xmm_to_xmm_mem xmm_to_xmm_mem)
 
 ;; Construct a new `XmmMem` from an `RegMem`.
-(decl xmm_mem_to_reg_mem (XmmMem) RegMem)
+(decl pure xmm_mem_to_reg_mem (XmmMem) RegMem)
 (extern constructor xmm_mem_to_reg_mem xmm_mem_to_reg_mem)
 
 ;; Convert a `GprMem` to a `RegMem`.
@@ -3768,20 +3768,51 @@
       (xmm_vex_pinsr (AvxOpcode.Vpinsrq) src1 src2 lane))
 
 ;; Helper for creating `roundss` instructions.
+;;
+;; NB: the non-AVX variant of this instruction does not require that the operand
+;; is aligned, but the instruction variant used here requires it to be aligned.
+;; This means that if the operand here points to memory then we'll eagerly load
+;; it, but the eager load will load too much (the full register width of 16
+;; bytes). To fix this a `put_xmm_mem_in_xmm` helper is used to force the
+;; operand to be a register where the load is done with the appropriate type if
+;; it's in memory.
+;;
+;; Some more discussion of this can be found on #8112. Ideally this would use
+;; a variant that allows an unaligned `XmmMem` in the instruction variant.
+;; Either that or the auto-conversion to aligned memory is removed and/or starts
+;; to require a type.
+;;
+;; Also note that the argument here isn't changed to `Xmm` instead of `XmmMem`
+;; because the AVX variant, when available, doesn't need alignment and can
+;; pass through the `src1` argument as-is.
 (decl x64_roundss (XmmMem RoundImm) Xmm)
 (rule (x64_roundss src1 round)
-      (xmm_unary_rm_r_imm (SseOpcode.Roundss) src1 (encode_round_imm round)))
+      (xmm_unary_rm_r_imm (SseOpcode.Roundss) (put_xmm_mem_in_xmm $F32 src1) (encode_round_imm round)))
 (rule 1 (x64_roundss src1 round)
         (if-let $true (use_avx))
         (xmm_unary_rm_r_imm_vex (AvxOpcode.Vroundss) src1 (encode_round_imm round)))
 
 ;; Helper for creating `roundsd` instructions.
+;;
+;; NB: see `x64_roundss` above for `put_xmm_mem_in_xmm` in call.
 (decl x64_roundsd (XmmMem RoundImm) Xmm)
 (rule (x64_roundsd src1 round)
-      (xmm_unary_rm_r_imm (SseOpcode.Roundsd) src1 (encode_round_imm round)))
+      (xmm_unary_rm_r_imm (SseOpcode.Roundsd) (put_xmm_mem_in_xmm $F64 src1) (encode_round_imm round)))
 (rule 1 (x64_roundsd src1 round)
         (if-let $true (use_avx))
         (xmm_unary_rm_r_imm_vex (AvxOpcode.Vroundsd) src1 (encode_round_imm round)))
+
+;; Helper for forcing an `XmmMem` to be placed into an `Xmm` register.
+;;
+;; If it's already in a register it stays there, otherwise it turns into a
+;; load instruction with the destination register as output.
+(decl put_xmm_mem_in_xmm (Type XmmMem) Xmm)
+(rule (put_xmm_mem_in_xmm ty xmm_mem)
+      (if-let (RegMem.Reg r) (xmm_mem_to_reg_mem xmm_mem))
+      (xmm_new r))
+(rule (put_xmm_mem_in_xmm ty xmm_mem)
+      (if-let (RegMem.Mem amode) (xmm_mem_to_reg_mem xmm_mem))
+      (x64_load ty amode (ExtKind.None)))
 
 ;; Helper for creating `roundps` instructions.
 (decl x64_roundps (XmmMem RoundImm) Xmm)

--- a/tests/misc_testsuite/float-round-doesnt-load-too-much.wast
+++ b/tests/misc_testsuite/float-round-doesnt-load-too-much.wast
@@ -1,0 +1,28 @@
+(module
+  (memory 1)
+  (func (export "ceil") (param i32) (result f64)
+    local.get 0
+    f64.load
+    f64.ceil
+    return)
+  (func (export "trunc") (param i32) (result f64)
+    local.get 0
+    f64.load
+    f64.trunc
+    return)
+  (func (export "floor") (param i32) (result f64)
+    local.get 0
+    f64.load
+    f64.floor
+    return)
+  (func (export "nearest") (param i32) (result f64)
+    local.get 0
+    f64.load
+    f64.nearest
+    return)
+)
+
+(assert_return (invoke "ceil" (i32.const 0xfff8)) (f64.const 0))
+(assert_return (invoke "trunc" (i32.const 0xfff8)) (f64.const 0))
+(assert_return (invoke "floor" (i32.const 0xfff8)) (f64.const 0))
+(assert_return (invoke "nearest" (i32.const 0xfff8)) (f64.const 0))


### PR DESCRIPTION
This commit aims to address #8116 by fixing these two instructions to load the proper amount of bytes when a load is sunk into them. Currently the instruction variant used here requires an aligned `XmmMem` which is today auto-translated with a 16-byte load unconditionally. For loads near the end of memory this loads too much and can erroneously cause a trap. The fix in this commit is to force the load to happen manually with the appropriate type rather than a 16-byte type.

I'll note that `XmmMem` is left as an argument in this case because the AVX variants of these instructions can continue to leverage unaligned accesses. This also means that the test added here won't fail on a machine with AVX support, it needs to be explicitly disabled.

Closes #8116

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
