### PR TITLE
wasi-common docs: show feature related docs

### DIFF
--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -93,6 +93,9 @@ tokio = [
 ]
 exit = [ "wasmtime", "dep:libc" ]
 
+[package.metadata.docs.rs]
+all-features = true
+
 [[test]]
 name = "all"
 required-features = ["wasmtime", "sync", "tokio"]

--- a/crates/wasi-common/src/lib.rs
+++ b/crates/wasi-common/src/lib.rs
@@ -68,6 +68,7 @@
 //! interface to plug in its own implementations of each of these resources.
 
 #![warn(clippy::cast_sign_loss)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod clocks;
 mod ctx;
@@ -79,9 +80,11 @@ pub mod random;
 pub mod sched;
 pub mod snapshots;
 mod string_array;
+#[cfg_attr(docsrs, doc(cfg(feature = "sync")))]
 #[cfg(feature = "sync")]
 pub mod sync;
 pub mod table;
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 #[cfg(feature = "tokio")]
 pub mod tokio;
 
@@ -150,6 +153,7 @@ macro_rules! define_wasi {
 /// Note: this function is designed for usage where it is acceptable for
 /// Wasmtime failures to terminate the parent process, such as in the Wasmtime
 /// CLI; this would not be suitable for use in multi-tenant embeddings.
+#[cfg_attr(docsrs, doc(cfg(feature = "exit")))]
 #[cfg(feature = "exit")]
 pub fn maybe_exit_on_error(e: anyhow::Error) -> anyhow::Error {
     use std::process;


### PR DESCRIPTION
Ensure the docs of wasi-common show also code that depends on certain feature flags being enabled.

Fixes https://github.com/bytecodealliance/wasmtime/issues/8119

This is how the docs look with this patch applies, I've highlighted the information that was previously hidden:

![Screenshot 2024-03-13 at 18-38-32 wasi_common - Rust](https://github.com/bytecodealliance/wasmtime/assets/22728/6f405662-171b-4375-aacd-154af03bf922)

