### PR TITLE
riscv64: Emit the correct `min` op in `rv_min` helper when the `Zbb` extension is enabled.

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -1644,7 +1644,7 @@
 ;; Helper for emitting the `min` instruction.
 (decl rv_min (XReg XReg) XReg)
 (rule (rv_min rs1 rs2)
-  (alu_rrr (AluOPRRR.Max) rs1 rs2))
+  (alu_rrr (AluOPRRR.Min) rs1 rs2))
 
 ;; Helper for emitting the `minu` instruction.
 (decl rv_minu (XReg XReg) XReg)

--- a/cranelift/filetests/filetests/isa/riscv64/smin-zbb.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/smin-zbb.clif
@@ -12,14 +12,14 @@ block0(v0: i8, v1: i8):
 ; block0:
 ;   sext.b a3,a0
 ;   sext.b a5,a1
-;   max a0,a3,a5
+;   min a0,a3,a5
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x93, 0x16, 0x45, 0x60
 ;   .byte 0x93, 0x97, 0x45, 0x60
-;   .byte 0x33, 0xe5, 0xf6, 0x0a
+;   .byte 0x33, 0xc5, 0xf6, 0x0a
 ;   ret
 
 function %smin_i16(i16, i16) -> i16{
@@ -32,14 +32,14 @@ block0(v0: i16, v1: i16):
 ; block0:
 ;   sext.h a3,a0
 ;   sext.h a5,a1
-;   max a0,a3,a5
+;   min a0,a3,a5
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   .byte 0x93, 0x16, 0x55, 0x60
 ;   .byte 0x93, 0x97, 0x55, 0x60
-;   .byte 0x33, 0xe5, 0xf6, 0x0a
+;   .byte 0x33, 0xc5, 0xf6, 0x0a
 ;   ret
 
 function %smin_i32(i32, i32) -> i32{
@@ -52,14 +52,14 @@ block0(v0: i32, v1: i32):
 ; block0:
 ;   sext.w a3,a0
 ;   sext.w a5,a1
-;   max a0,a3,a5
+;   min a0,a3,a5
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   sext.w a3, a0
 ;   sext.w a5, a1
-;   .byte 0x33, 0xe5, 0xf6, 0x0a
+;   .byte 0x33, 0xc5, 0xf6, 0x0a
 ;   ret
 
 function %smin_i64(i64, i64) -> i64{
@@ -70,12 +70,12 @@ block0(v0: i64, v1: i64):
 
 ; VCode:
 ; block0:
-;   max a0,a0,a1
+;   min a0,a0,a1
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   .byte 0x33, 0x65, 0xb5, 0x0a
+;   .byte 0x33, 0x45, 0xb5, 0x0a
 ;   ret
 
 function %smin_i128(i128, i128) -> i128{

--- a/cranelift/filetests/filetests/runtests/integer-minmax.clif
+++ b/cranelift/filetests/filetests/runtests/integer-minmax.clif
@@ -4,6 +4,7 @@ target aarch64
 target s390x
 target x86_64
 target riscv64
+target riscv64 has_zbb
 target riscv64 has_c has_zcb
 
 


### PR DESCRIPTION
👋 Hey,

This PR fixes #8114

We were accidentally using the `max` opcode in the `min` helper when using the `Zbb` extension. This wasn't caught by testing since we never enabled the `smin` tests with the `Zbb` extension enabled.

Furthermore this should have been caught by fuzzing, but we also don't regularly fuzz RISC-V. (And I haven't ran it manually in quite a while).

Thanks for reporting it @candymate, let me know if you find anything else!
