### PR TITLE
cranelift: Choose memory trap code based on memflags

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -630,9 +630,9 @@ impl Inst {
                     _ => return None,
                 };
 
-                if !flags.notrap() {
+                if let Some(trap_code) = flags.trap_code() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(TrapCode::HeapOutOfBounds);
+                    sink.add_trap(trap_code);
                 }
                 sink.put2(encode_ci_sp_load(op, rd, imm6));
             }
@@ -701,9 +701,9 @@ impl Inst {
                     encode_cl_type(op, rd, base, imm5)
                 };
 
-                if !flags.notrap() {
+                if let Some(trap_code) = flags.trap_code() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(TrapCode::HeapOutOfBounds);
+                    sink.add_trap(trap_code);
                 }
                 sink.put2(encoded);
             }
@@ -732,9 +732,9 @@ impl Inst {
                     _ => return None,
                 };
 
-                if !flags.notrap() {
+                if let Some(trap_code) = flags.trap_code() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(TrapCode::HeapOutOfBounds);
+                    sink.add_trap(trap_code);
                 }
                 sink.put2(encode_css_type(op, src, imm6));
             }
@@ -799,9 +799,9 @@ impl Inst {
                     encode_cs_type(op, src, base, imm5)
                 };
 
-                if !flags.notrap() {
+                if let Some(trap_code) = flags.trap_code() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(TrapCode::HeapOutOfBounds);
+                    sink.add_trap(trap_code);
                 }
                 sink.put2(encoded);
             }
@@ -1077,9 +1077,9 @@ impl Inst {
                     }
                 };
 
-                if !flags.notrap() {
+                if let Some(trap_code) = flags.trap_code() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(TrapCode::HeapOutOfBounds);
+                    sink.add_trap(trap_code);
                 }
 
                 sink.put4(encode_i_type(op.op_code(), rd, op.funct3(), addr, imm12));
@@ -1100,9 +1100,9 @@ impl Inst {
                     }
                 };
 
-                if !flags.notrap() {
+                if let Some(trap_code) = flags.trap_code() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(TrapCode::HeapOutOfBounds);
+                    sink.add_trap(trap_code);
                 }
 
                 sink.put4(encode_s_type(op.op_code(), op.funct3(), addr, src, imm12));
@@ -1492,7 +1492,11 @@ impl Inst {
                 src,
                 amo,
             } => {
-                sink.add_trap(TrapCode::HeapOutOfBounds);
+                // TODO: get flags from original CLIF atomic instruction
+                let flags = MemFlags::new();
+                if let Some(trap_code) = flags.trap_code() {
+                    sink.add_trap(trap_code);
+                }
                 let x = op.op_code()
                     | reg_to_gpr_num(rd.to_reg()) << 7
                     | op.funct3() << 12
@@ -2718,9 +2722,9 @@ impl Inst {
                     }
                 };
 
-                if !flags.notrap() {
+                if let Some(trap_code) = flags.trap_code() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(TrapCode::HeapOutOfBounds);
+                    sink.add_trap(trap_code);
                 }
 
                 sink.put4(encode_vmem_load(
@@ -2765,9 +2769,9 @@ impl Inst {
                     }
                 };
 
-                if !flags.notrap() {
+                if let Some(trap_code) = flags.trap_code() {
                     // Register the offset at which the actual load instruction starts.
-                    sink.add_trap(TrapCode::HeapOutOfBounds);
+                    sink.add_trap(trap_code);
                 }
 
                 sink.put4(encode_vmem_store(

--- a/cranelift/codegen/src/isa/s390x/inst/args.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/args.rs
@@ -102,10 +102,6 @@ impl MemArg {
         }
     }
 
-    pub(crate) fn can_trap(&self) -> bool {
-        !self.get_flags().notrap()
-    }
-
     /// Edit registers with allocations.
     pub fn with_allocs(&self, allocs: &mut AllocationConsumer<'_>) -> Self {
         match self {
@@ -185,10 +181,6 @@ impl MemArgPair {
             }
             _ => None,
         }
-    }
-
-    pub(crate) fn can_trap(&self) -> bool {
-        !self.flags.notrap()
     }
 
     /// Edit registers with allocations.

--- a/cranelift/codegen/src/isa/s390x/inst/emit.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/emit.rs
@@ -184,8 +184,10 @@ pub fn mem_emit(
         inst.emit(&[], sink, emit_info, state);
     }
 
-    if add_trap && mem.can_trap() {
-        sink.add_trap(TrapCode::HeapOutOfBounds);
+    if add_trap {
+        if let Some(trap_code) = mem.get_flags().trap_code() {
+            sink.add_trap(trap_code);
+        }
     }
 
     match &mem {
@@ -245,8 +247,10 @@ pub fn mem_rs_emit(
         inst.emit(&[], sink, emit_info, state);
     }
 
-    if add_trap && mem.can_trap() {
-        sink.add_trap(TrapCode::HeapOutOfBounds);
+    if add_trap {
+        if let Some(trap_code) = mem.get_flags().trap_code() {
+            sink.add_trap(trap_code);
+        }
     }
 
     match &mem {
@@ -294,8 +298,10 @@ pub fn mem_imm8_emit(
         inst.emit(&[], sink, emit_info, state);
     }
 
-    if add_trap && mem.can_trap() {
-        sink.add_trap(TrapCode::HeapOutOfBounds);
+    if add_trap {
+        if let Some(trap_code) = mem.get_flags().trap_code() {
+            sink.add_trap(trap_code);
+        }
     }
 
     match &mem {
@@ -339,8 +345,10 @@ pub fn mem_imm16_emit(
         inst.emit(&[], sink, emit_info, state);
     }
 
-    if add_trap && mem.can_trap() {
-        sink.add_trap(TrapCode::HeapOutOfBounds);
+    if add_trap {
+        if let Some(trap_code) = mem.get_flags().trap_code() {
+            sink.add_trap(trap_code);
+        }
     }
 
     match &mem {
@@ -363,8 +371,10 @@ pub fn mem_mem_emit(
     sink: &mut MachBuffer<Inst>,
     _state: &mut EmitState,
 ) {
-    if add_trap && (dst.can_trap() || src.can_trap()) {
-        sink.add_trap(TrapCode::HeapOutOfBounds);
+    if add_trap {
+        if let Some(trap_code) = dst.flags.trap_code().or(src.flags.trap_code()) {
+            sink.add_trap(trap_code);
+        }
     }
 
     put(
@@ -405,8 +415,10 @@ pub fn mem_vrx_emit(
         inst.emit(&[], sink, emit_info, state);
     }
 
-    if add_trap && mem.can_trap() {
-        sink.add_trap(TrapCode::HeapOutOfBounds);
+    if add_trap {
+        if let Some(trap_code) = mem.get_flags().trap_code() {
+            sink.add_trap(trap_code);
+        }
     }
 
     match &mem {

--- a/cranelift/codegen/src/isa/x64/encoding/evex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/evex.rs
@@ -15,7 +15,6 @@
 //! Software Development Manual, volume 2A).
 
 use super::rex::{self, LegacyPrefixes, OpcodeMap};
-use crate::ir::TrapCode;
 use crate::isa::x64::args::{Amode, Avx512TupleType};
 use crate::isa::x64::inst::Inst;
 use crate::MachBuffer;
@@ -202,8 +201,8 @@ impl EvexInstruction {
     /// - an optional immediate, if necessary (not currently implemented)
     pub fn encode(&self, sink: &mut MachBuffer<Inst>) {
         if let RegisterOrAmode::Amode(amode) = &self.rm {
-            if amode.can_trap() {
-                sink.add_trap(TrapCode::HeapOutOfBounds);
+            if let Some(trap_code) = amode.get_flags().trap_code() {
+                sink.add_trap(trap_code);
             }
         }
         sink.put4(self.bits);

--- a/cranelift/codegen/src/isa/x64/encoding/rex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/rex.rs
@@ -10,7 +10,6 @@
 
 use crate::machinst::{Reg, RegClass};
 use crate::{
-    ir::TrapCode,
     isa::x64::inst::{
         args::{Amode, OperandSize},
         regs, Inst, LabelUse,
@@ -314,9 +313,8 @@ pub(crate) fn emit_std_enc_mem(
     // 64-bit integer registers, because they are part of an address
     // expression.  But `enc_g` can be derived from a register of any class.
 
-    let can_trap = mem_e.can_trap();
-    if can_trap {
-        sink.add_trap(TrapCode::HeapOutOfBounds);
+    if let Some(trap_code) = mem_e.get_flags().trap_code() {
+        sink.add_trap(trap_code);
     }
 
     prefixes.emit(sink);

--- a/cranelift/codegen/src/isa/x64/encoding/vex.rs
+++ b/cranelift/codegen/src/isa/x64/encoding/vex.rs
@@ -4,7 +4,6 @@
 use super::evex::{Register, RegisterOrAmode};
 use super::rex::{LegacyPrefixes, OpcodeMap};
 use super::ByteSink;
-use crate::ir::TrapCode;
 use crate::isa::x64::args::Amode;
 use crate::isa::x64::encoding::rex;
 use crate::isa::x64::inst::Inst;
@@ -251,8 +250,8 @@ impl VexInstruction {
     /// Emit the VEX-encoded instruction to the provided buffer.
     pub fn encode(&self, sink: &mut MachBuffer<Inst>) {
         if let RegisterOrAmode::Amode(amode) = &self.rm {
-            if amode.can_trap() {
-                sink.add_trap(TrapCode::HeapOutOfBounds);
+            if let Some(trap_code) = amode.get_flags().trap_code() {
+                sink.add_trap(trap_code);
             }
         }
 

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -405,10 +405,6 @@ impl Amode {
         }
     }
 
-    pub(crate) fn can_trap(&self) -> bool {
-        !self.get_flags().notrap()
-    }
-
     pub(crate) fn with_allocs(&self, allocs: &mut AllocationConsumer<'_>) -> Self {
         // The order in which we consume allocs here must match the
         // order in which we produce operands in get_operands() above.

--- a/cranelift/interpreter/src/interpreter.rs
+++ b/cranelift/interpreter/src/interpreter.rs
@@ -331,7 +331,11 @@ impl<'a> State<'a> for InterpreterState<'a> {
         let src = match addr.region {
             AddressRegion::Stack => {
                 if addr_end > self.stack.len() {
-                    return Err(MemoryError::OutOfBoundsLoad { addr, load_size });
+                    return Err(MemoryError::OutOfBoundsLoad {
+                        addr,
+                        load_size,
+                        mem_flags,
+                    });
                 }
 
                 &self.stack[addr_start..addr_end]
@@ -363,7 +367,11 @@ impl<'a> State<'a> for InterpreterState<'a> {
         let dst = match addr.region {
             AddressRegion::Stack => {
                 if addr_end > self.stack.len() {
-                    return Err(MemoryError::OutOfBoundsStore { addr, store_size });
+                    return Err(MemoryError::OutOfBoundsStore {
+                        addr,
+                        store_size,
+                        mem_flags,
+                    });
                 }
 
                 &mut self.stack[addr_start..addr_end]

--- a/cranelift/interpreter/src/state.rs
+++ b/cranelift/interpreter/src/state.rs
@@ -125,9 +125,17 @@ pub enum MemoryError {
     #[error("Requested an offset of {offset} but max was {max}")]
     InvalidOffset { offset: u64, max: u64 },
     #[error("Load of {load_size} bytes is larger than available size at address {addr:?}")]
-    OutOfBoundsLoad { addr: Address, load_size: usize },
+    OutOfBoundsLoad {
+        addr: Address,
+        load_size: usize,
+        mem_flags: MemFlags,
+    },
     #[error("Store of {store_size} bytes is larger than available size at address {addr:?}")]
-    OutOfBoundsStore { addr: Address, store_size: usize },
+    OutOfBoundsStore {
+        addr: Address,
+        store_size: usize,
+        mem_flags: MemFlags,
+    },
     #[error("Load of {load_size} bytes is misaligned at address {addr:?}")]
     MisalignedLoad { addr: Address, load_size: usize },
     #[error("Store of {store_size} bytes is misaligned at address {addr:?}")]

--- a/cranelift/interpreter/src/step.rs
+++ b/cranelift/interpreter/src/step.rs
@@ -161,8 +161,12 @@ where
         MemoryError::InvalidAddressType(_) => TrapCode::HeapOutOfBounds,
         MemoryError::InvalidOffset { .. } => TrapCode::HeapOutOfBounds,
         MemoryError::InvalidEntry { .. } => TrapCode::HeapOutOfBounds,
-        MemoryError::OutOfBoundsStore { .. } => TrapCode::HeapOutOfBounds,
-        MemoryError::OutOfBoundsLoad { .. } => TrapCode::HeapOutOfBounds,
+        MemoryError::OutOfBoundsStore { mem_flags, .. } => mem_flags
+            .trap_code()
+            .expect("store with notrap flag should not trap"),
+        MemoryError::OutOfBoundsLoad { mem_flags, .. } => mem_flags
+            .trap_code()
+            .expect("load with notrap flag should not trap"),
         MemoryError::MisalignedLoad { .. } => TrapCode::HeapMisaligned,
         MemoryError::MisalignedStore { .. } => TrapCode::HeapMisaligned,
     };


### PR DESCRIPTION
Ideally we'd allow the frontend to specify what trap code a memory access instruction can produce, but we don't have room to store that information.

Instead, I'm adding additional meaning to the `table` and `heap` memflags. Besides being used in alias analysis, these flags now also indicate whether the instruction should produce a trap code of TableOutOfBounds or HeapOutOfBounds, respectively.

In the Cranelift weekly meeting we discussed that it would be nice to assert that either `table` or `heap` is set when the trap-code is requested, but I don't know if all users of the instruction encodings (such as cg-clif or Winch) set those flags, so I've chosen to default to the old behavior if none of the alias-analysis flags are set.

Currently, memory accesses with the `table` flag set always have `notrap` set as well, so the TableOutOfBounds case is never hit, but I wanted to separate this change out from the cranelift-wasm changes which will use it.