### PR TITLE
s390x: Fix ABI vector-lane swap for overflow args

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst.isle
+++ b/cranelift/codegen/src/isa/s390x/inst.isle
@@ -2872,8 +2872,8 @@
       (let ((rev Reg (vec_permute_dw_imm $I64X2 reg 1 reg 0)))
         (vec_rot_imm $I16X8 (vec_rot_imm $I32X4 (vec_rot_imm $I64X2 rev 32) 16) 8)))
 
-;; When passing a vector value in register to a function whose ABI uses
-;; a different lane order than the current function, we need to swap lanes.
+;; When passing a vector value to a function whose ABI uses a different
+;; lane order than the current function, we need to swap lanes.
 ;; The first operand is the lane order used by the callee.
 (decl abi_vec_elt_rev (LaneOrder Type Reg) Reg)
 (rule 4 (abi_vec_elt_rev _ (gpr32_ty ty) reg) reg)
@@ -2948,15 +2948,17 @@
 (rule (copy_reg_to_arg_slot uses lo _ (ABIArgSlot.Reg reg ty ext) src)
       (let ((_ Unit (args_builder_push uses (abi_vec_elt_rev lo ty src) reg)))
         (output_none)))
-(rule (copy_reg_to_arg_slot _ _ base (ABIArgSlot.Stack offset ty ext) src)
-      (side_effect (arg_store (abi_ext_ty ext ty) src (memarg_stack_off base offset))))
+(rule (copy_reg_to_arg_slot _ lo base (ABIArgSlot.Stack offset ty ext) src)
+      (side_effect (arg_store (abi_ext_ty ext ty) (abi_vec_elt_rev lo ty src)
+                              (memarg_stack_off base offset))))
 
 ;; Copy one component of an argument/return value from its slot.
 (decl copy_reg_from_arg_slot (CallRetList LaneOrder i64 ABIArgSlot) Reg)
 (rule (copy_reg_from_arg_slot defs lo _ (ABIArgSlot.Reg reg ty ext))
       (abi_vec_elt_rev lo ty (defs_lookup defs reg)))
-(rule (copy_reg_from_arg_slot _ _ base (ABIArgSlot.Stack offset ty ext))
-      (arg_load (abi_ext_ty ext ty) (memarg_stack_off base offset)))
+(rule (copy_reg_from_arg_slot _ lo base (ABIArgSlot.Stack offset ty ext))
+      (abi_vec_elt_rev lo ty (arg_load (abi_ext_ty ext ty)
+                                       (memarg_stack_off base offset))))
 
 ;; Helper to compute the type of an implicitly extended argument/return value.
 (decl abi_ext_ty (ArgumentExtension Type) Type)

--- a/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
+++ b/cranelift/filetests/filetests/isa/s390x/vec-abi.clif
@@ -1,82 +1,29 @@
 test compile precise-output
 target s390x
 
-function %caller_be_to_be(i64x2, i32x4, i16x8, i8x16) -> i32x4 {
-    fn0 = %callee_be(i64x2, i32x4, i16x8, i8x16) -> i32x4
+function %caller_be_to_be(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 {
+    fn0 = %callee_be(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4
 
-block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
-    v4 = call fn0(v0, v1, v2, v3)
-    return v4
-}
-
-; VCode:
-;   stmg %r14, %r15, 112(%r15)
-;   aghi %r15, -160
-;   virtual_sp_offset_adjust 160
-; block0:
-;   bras %r1, 12 ; data %callee_be + 0 ; lg %r4, 0(%r1)
-;   basr %r14, %r4
-;   lmg %r14, %r15, 272(%r15)
-;   br %r14
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   stmg %r14, %r15, 0x70(%r15)
-;   aghi %r15, -0xa0
-; block1: ; offset 0xa
-;   bras %r1, 0x16
-;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_be 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   lg %r4, 0(%r1)
-;   basr %r14, %r4
-;   lmg %r14, %r15, 0x110(%r15)
-;   br %r14
-
-function %caller_be_to_le(i64x2, i32x4, i16x8, i8x16) -> i32x4 {
-    fn0 = %callee_le(i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v
-
-block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
-    v4 = call fn0(v0, v1, v2, v3)
-    return v4
+block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16x8, v7: i8x16, v8: i64x2, v9: i32x4, v10: i16x8, v11: i8x16):
+    v12 = call fn0(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
+    return v12
 }
 
 ; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -224
-;   virtual_sp_offset_adjust 160
-;   std %f8, 160(%r15)
-;   std %f9, 168(%r15)
-;   std %f10, 176(%r15)
-;   std %f11, 184(%r15)
-;   std %f12, 192(%r15)
-;   std %f13, 200(%r15)
-;   std %f14, 208(%r15)
-;   std %f15, 216(%r15)
+;   virtual_sp_offset_adjust 224
 ; block0:
-;   vpdi %v24, %v24, %v24, 4
-;   vpdi %v7, %v25, %v25, 4
-;   verllg %v25, %v7, 32
-;   vpdi %v19, %v26, %v26, 4
-;   verllg %v21, %v19, 32
-;   verllf %v26, %v21, 16
-;   vpdi %v27, %v27, %v27, 4
-;   verllg %v27, %v27, 32
-;   verllf %v29, %v27, 16
-;   verllh %v27, %v29, 8
-;   bras %r1, 12 ; data %callee_le + 0 ; lg %r4, 0(%r1)
+;   vl %v17, 384(%r15)
+;   vl %v19, 400(%r15)
+;   vl %v21, 416(%r15)
+;   vl %v23, 432(%r15)
+;   vst %v17, 160(%r15)
+;   vst %v19, 176(%r15)
+;   vst %v21, 192(%r15)
+;   vst %v23, 208(%r15)
+;   bras %r1, 12 ; data %callee_be + 0 ; lg %r4, 0(%r1)
 ;   basr %r14, %r4
-;   vpdi %v5, %v24, %v24, 4
-;   verllg %v24, %v5, 32
-;   ld %f8, 160(%r15)
-;   ld %f9, 168(%r15)
-;   ld %f10, 176(%r15)
-;   ld %f11, 184(%r15)
-;   ld %f12, 192(%r15)
-;   ld %f13, 200(%r15)
-;   ld %f14, 208(%r15)
-;   ld %f15, 216(%r15)
 ;   lmg %r14, %r15, 336(%r15)
 ;   br %r14
 ;
@@ -84,88 +31,338 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xe0
-;   std %f8, 0xa0(%r15)
-;   std %f9, 0xa8(%r15)
-;   std %f10, 0xb0(%r15)
-;   std %f11, 0xb8(%r15)
-;   std %f12, 0xc0(%r15)
-;   std %f13, 0xc8(%r15)
-;   std %f14, 0xd0(%r15)
-;   std %f15, 0xd8(%r15)
-; block1: ; offset 0x2a
+; block1: ; offset 0xa
+;   vl %v17, 0x180(%r15)
+;   vl %v19, 0x190(%r15)
+;   vl %v21, 0x1a0(%r15)
+;   vl %v23, 0x1b0(%r15)
+;   vst %v17, 0xa0(%r15)
+;   vst %v19, 0xb0(%r15)
+;   vst %v21, 0xc0(%r15)
+;   vst %v23, 0xd0(%r15)
+;   bras %r1, 0x46
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_be 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   lmg %r14, %r15, 0x150(%r15)
+;   br %r14
+
+function %caller_be_to_le(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 {
+    fn0 = %callee_le(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v
+
+block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16x8, v7: i8x16, v8: i64x2, v9: i32x4, v10: i16x8, v11: i8x16):
+    v12 = call fn0(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
+    return v12
+}
+
+; VCode:
+;   stmg %r14, %r15, 112(%r15)
+;   aghi %r15, -288
+;   virtual_sp_offset_adjust 224
+;   std %f8, 224(%r15)
+;   std %f9, 232(%r15)
+;   std %f10, 240(%r15)
+;   std %f11, 248(%r15)
+;   std %f12, 256(%r15)
+;   std %f13, 264(%r15)
+;   std %f14, 272(%r15)
+;   std %f15, 280(%r15)
+; block0:
+;   vl %v17, 448(%r15)
+;   vl %v19, 464(%r15)
+;   vl %v21, 480(%r15)
+;   vl %v23, 496(%r15)
 ;   vpdi %v24, %v24, %v24, 4
-;   vpdi %v7, %v25, %v25, 4
-;   verllg %v25, %v7, 0x20
-;   vpdi %v19, %v26, %v26, 4
-;   verllg %v21, %v19, 0x20
-;   verllf %v26, %v21, 0x10
-;   vpdi %v27, %v27, %v27, 4
-;   verllg %v27, %v27, 0x20
-;   verllf %v29, %v27, 0x10
-;   verllh %v27, %v29, 8
-;   bras %r1, 0x72
+;   vpdi %v0, %v25, %v25, 4
+;   verllg %v25, %v0, 32
+;   vpdi %v0, %v26, %v26, 4
+;   verllg %v1, %v0, 32
+;   verllf %v26, %v1, 16
+;   vpdi %v5, %v27, %v27, 4
+;   verllg %v7, %v5, 32
+;   verllf %v18, %v7, 16
+;   verllh %v27, %v18, 8
+;   vpdi %v28, %v28, %v28, 4
+;   vpdi %v29, %v29, %v29, 4
+;   verllg %v29, %v29, 32
+;   vpdi %v30, %v30, %v30, 4
+;   verllg %v30, %v30, 32
+;   verllf %v30, %v30, 16
+;   vpdi %v1, %v31, %v31, 4
+;   verllg %v3, %v1, 32
+;   verllf %v5, %v3, 16
+;   verllh %v31, %v5, 8
+;   vpdi %v17, %v17, %v17, 4
+;   vst %v17, 160(%r15)
+;   vpdi %v20, %v19, %v19, 4
+;   verllg %v22, %v20, 32
+;   vst %v22, 176(%r15)
+;   vpdi %v0, %v21, %v21, 4
+;   verllg %v0, %v0, 32
+;   verllf %v0, %v0, 16
+;   vst %v0, 192(%r15)
+;   vpdi %v0, %v23, %v23, 4
+;   verllg %v2, %v0, 32
+;   verllf %v4, %v2, 16
+;   verllh %v6, %v4, 8
+;   vst %v6, 208(%r15)
+;   bras %r1, 12 ; data %callee_le + 0 ; lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   vpdi %v21, %v24, %v24, 4
+;   verllg %v24, %v21, 32
+;   ld %f8, 224(%r15)
+;   ld %f9, 232(%r15)
+;   ld %f10, 240(%r15)
+;   ld %f11, 248(%r15)
+;   ld %f12, 256(%r15)
+;   ld %f13, 264(%r15)
+;   ld %f14, 272(%r15)
+;   ld %f15, 280(%r15)
+;   lmg %r14, %r15, 400(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0x120
+;   std %f8, 0xe0(%r15)
+;   std %f9, 0xe8(%r15)
+;   std %f10, 0xf0(%r15)
+;   std %f11, 0xf8(%r15)
+;   std %f12, 0x100(%r15)
+;   std %f13, 0x108(%r15)
+;   std %f14, 0x110(%r15)
+;   std %f15, 0x118(%r15)
+; block1: ; offset 0x2a
+;   vl %v17, 0x1c0(%r15)
+;   vl %v19, 0x1d0(%r15)
+;   vl %v21, 0x1e0(%r15)
+;   vl %v23, 0x1f0(%r15)
+;   vpdi %v24, %v24, %v24, 4
+;   vpdi %v0, %v25, %v25, 4
+;   verllg %v25, %v0, 0x20
+;   vpdi %v0, %v26, %v26, 4
+;   verllg %v1, %v0, 0x20
+;   verllf %v26, %v1, 0x10
+;   vpdi %v5, %v27, %v27, 4
+;   verllg %v7, %v5, 0x20
+;   verllf %v18, %v7, 0x10
+;   verllh %v27, %v18, 8
+;   vpdi %v28, %v28, %v28, 4
+;   vpdi %v29, %v29, %v29, 4
+;   verllg %v29, %v29, 0x20
+;   vpdi %v30, %v30, %v30, 4
+;   verllg %v30, %v30, 0x20
+;   verllf %v30, %v30, 0x10
+;   vpdi %v1, %v31, %v31, 4
+;   verllg %v3, %v1, 0x20
+;   verllf %v5, %v3, 0x10
+;   verllh %v31, %v5, 8
+;   vpdi %v17, %v17, %v17, 4
+;   vst %v17, 0xa0(%r15)
+;   vpdi %v20, %v19, %v19, 4
+;   verllg %v22, %v20, 0x20
+;   vst %v22, 0xb0(%r15)
+;   vpdi %v0, %v21, %v21, 4
+;   verllg %v0, %v0, 0x20
+;   verllf %v0, %v0, 0x10
+;   vst %v0, 0xc0(%r15)
+;   vpdi %v0, %v23, %v23, 4
+;   verllg %v2, %v0, 0x20
+;   verllf %v4, %v2, 0x10
+;   verllh %v6, %v4, 8
+;   vst %v6, 0xd0(%r15)
+;   bras %r1, 0x11a
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_le 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   lg %r4, 0(%r1)
 ;   basr %r14, %r4
-;   vpdi %v5, %v24, %v24, 4
-;   verllg %v24, %v5, 0x20
-;   ld %f8, 0xa0(%r15)
-;   ld %f9, 0xa8(%r15)
-;   ld %f10, 0xb0(%r15)
-;   ld %f11, 0xb8(%r15)
-;   ld %f12, 0xc0(%r15)
-;   ld %f13, 0xc8(%r15)
-;   ld %f14, 0xd0(%r15)
-;   ld %f15, 0xd8(%r15)
-;   lmg %r14, %r15, 0x150(%r15)
+;   vpdi %v21, %v24, %v24, 4
+;   verllg %v24, %v21, 0x20
+;   ld %f8, 0xe0(%r15)
+;   ld %f9, 0xe8(%r15)
+;   ld %f10, 0xf0(%r15)
+;   ld %f11, 0xf8(%r15)
+;   ld %f12, 0x100(%r15)
+;   ld %f13, 0x108(%r15)
+;   ld %f14, 0x110(%r15)
+;   ld %f15, 0x118(%r15)
+;   lmg %r14, %r15, 0x190(%r15)
 ;   br %r14
 
-function %caller_le_to_be(i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v {
-    fn0 = %callee_be(i64x2, i32x4, i16x8, i8x16) -> i32x4
+function %caller_le_to_be(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v {
+    fn0 = %callee_be(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4
 
-block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
-    v4 = call fn0(v0, v1, v2, v3)
-    return v4
+block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16x8, v7: i8x16, v8: i64x2, v9: i32x4, v10: i16x8, v11: i8x16):
+    v12 = call fn0(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
+    return v12
+}
+
+; VCode:
+;   stmg %r14, %r15, 112(%r15)
+;   aghi %r15, -288
+;   virtual_sp_offset_adjust 224
+;   std %f8, 224(%r15)
+;   std %f9, 232(%r15)
+;   std %f10, 240(%r15)
+;   std %f11, 248(%r15)
+;   std %f12, 256(%r15)
+;   std %f13, 264(%r15)
+;   std %f14, 272(%r15)
+;   std %f15, 280(%r15)
+; block0:
+;   vl %v17, 448(%r15)
+;   vl %v19, 464(%r15)
+;   vl %v21, 480(%r15)
+;   vl %v23, 496(%r15)
+;   vpdi %v24, %v24, %v24, 4
+;   vpdi %v0, %v25, %v25, 4
+;   verllg %v25, %v0, 32
+;   vpdi %v0, %v26, %v26, 4
+;   verllg %v1, %v0, 32
+;   verllf %v26, %v1, 16
+;   vpdi %v5, %v27, %v27, 4
+;   verllg %v7, %v5, 32
+;   verllf %v18, %v7, 16
+;   verllh %v27, %v18, 8
+;   vpdi %v28, %v28, %v28, 4
+;   vpdi %v29, %v29, %v29, 4
+;   verllg %v29, %v29, 32
+;   vpdi %v30, %v30, %v30, 4
+;   verllg %v30, %v30, 32
+;   verllf %v30, %v30, 16
+;   vpdi %v1, %v31, %v31, 4
+;   verllg %v3, %v1, 32
+;   verllf %v5, %v3, 16
+;   verllh %v31, %v5, 8
+;   vpdi %v17, %v17, %v17, 4
+;   vst %v17, 160(%r15)
+;   vpdi %v20, %v19, %v19, 4
+;   verllg %v22, %v20, 32
+;   vst %v22, 176(%r15)
+;   vpdi %v0, %v21, %v21, 4
+;   verllg %v0, %v0, 32
+;   verllf %v0, %v0, 16
+;   vst %v0, 192(%r15)
+;   vpdi %v0, %v23, %v23, 4
+;   verllg %v2, %v0, 32
+;   verllf %v4, %v2, 16
+;   verllh %v6, %v4, 8
+;   vst %v6, 208(%r15)
+;   bras %r1, 12 ; data %callee_be + 0 ; lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   vpdi %v21, %v24, %v24, 4
+;   verllg %v24, %v21, 32
+;   ld %f8, 224(%r15)
+;   ld %f9, 232(%r15)
+;   ld %f10, 240(%r15)
+;   ld %f11, 248(%r15)
+;   ld %f12, 256(%r15)
+;   ld %f13, 264(%r15)
+;   ld %f14, 272(%r15)
+;   ld %f15, 280(%r15)
+;   lmg %r14, %r15, 400(%r15)
+;   br %r14
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stmg %r14, %r15, 0x70(%r15)
+;   aghi %r15, -0x120
+;   std %f8, 0xe0(%r15)
+;   std %f9, 0xe8(%r15)
+;   std %f10, 0xf0(%r15)
+;   std %f11, 0xf8(%r15)
+;   std %f12, 0x100(%r15)
+;   std %f13, 0x108(%r15)
+;   std %f14, 0x110(%r15)
+;   std %f15, 0x118(%r15)
+; block1: ; offset 0x2a
+;   vl %v17, 0x1c0(%r15)
+;   vl %v19, 0x1d0(%r15)
+;   vl %v21, 0x1e0(%r15)
+;   vl %v23, 0x1f0(%r15)
+;   vpdi %v24, %v24, %v24, 4
+;   vpdi %v0, %v25, %v25, 4
+;   verllg %v25, %v0, 0x20
+;   vpdi %v0, %v26, %v26, 4
+;   verllg %v1, %v0, 0x20
+;   verllf %v26, %v1, 0x10
+;   vpdi %v5, %v27, %v27, 4
+;   verllg %v7, %v5, 0x20
+;   verllf %v18, %v7, 0x10
+;   verllh %v27, %v18, 8
+;   vpdi %v28, %v28, %v28, 4
+;   vpdi %v29, %v29, %v29, 4
+;   verllg %v29, %v29, 0x20
+;   vpdi %v30, %v30, %v30, 4
+;   verllg %v30, %v30, 0x20
+;   verllf %v30, %v30, 0x10
+;   vpdi %v1, %v31, %v31, 4
+;   verllg %v3, %v1, 0x20
+;   verllf %v5, %v3, 0x10
+;   verllh %v31, %v5, 8
+;   vpdi %v17, %v17, %v17, 4
+;   vst %v17, 0xa0(%r15)
+;   vpdi %v20, %v19, %v19, 4
+;   verllg %v22, %v20, 0x20
+;   vst %v22, 0xb0(%r15)
+;   vpdi %v0, %v21, %v21, 4
+;   verllg %v0, %v0, 0x20
+;   verllf %v0, %v0, 0x10
+;   vst %v0, 0xc0(%r15)
+;   vpdi %v0, %v23, %v23, 4
+;   verllg %v2, %v0, 0x20
+;   verllf %v4, %v2, 0x10
+;   verllh %v6, %v4, 8
+;   vst %v6, 0xd0(%r15)
+;   bras %r1, 0x11a
+;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_be 0
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   .byte 0x00, 0x00
+;   lg %r4, 0(%r1)
+;   basr %r14, %r4
+;   vpdi %v21, %v24, %v24, 4
+;   verllg %v24, %v21, 0x20
+;   ld %f8, 0xe0(%r15)
+;   ld %f9, 0xe8(%r15)
+;   ld %f10, 0xf0(%r15)
+;   ld %f11, 0xf8(%r15)
+;   ld %f12, 0x100(%r15)
+;   ld %f13, 0x108(%r15)
+;   ld %f14, 0x110(%r15)
+;   ld %f15, 0x118(%r15)
+;   lmg %r14, %r15, 0x190(%r15)
+;   br %r14
+
+function %caller_le_to_le(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v {
+    fn0 = %callee_le(i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16, i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v
+
+block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16, v4: i64x2, v5: i32x4, v6: i16x8, v7: i8x16, v8: i64x2, v9: i32x4, v10: i16x8, v11: i8x16):
+    v12 = call fn0(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11)
+    return v12
 }
 
 ; VCode:
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -224
-;   virtual_sp_offset_adjust 160
-;   std %f8, 160(%r15)
-;   std %f9, 168(%r15)
-;   std %f10, 176(%r15)
-;   std %f11, 184(%r15)
-;   std %f12, 192(%r15)
-;   std %f13, 200(%r15)
-;   std %f14, 208(%r15)
-;   std %f15, 216(%r15)
+;   virtual_sp_offset_adjust 224
 ; block0:
-;   vpdi %v24, %v24, %v24, 4
-;   vpdi %v7, %v25, %v25, 4
-;   verllg %v25, %v7, 32
-;   vpdi %v19, %v26, %v26, 4
-;   verllg %v21, %v19, 32
-;   verllf %v26, %v21, 16
-;   vpdi %v27, %v27, %v27, 4
-;   verllg %v27, %v27, 32
-;   verllf %v29, %v27, 16
-;   verllh %v27, %v29, 8
-;   bras %r1, 12 ; data %callee_be + 0 ; lg %r4, 0(%r1)
+;   vl %v17, 384(%r15)
+;   vl %v19, 400(%r15)
+;   vl %v21, 416(%r15)
+;   vl %v23, 432(%r15)
+;   vst %v17, 160(%r15)
+;   vst %v19, 176(%r15)
+;   vst %v21, 192(%r15)
+;   vst %v23, 208(%r15)
+;   bras %r1, 12 ; data %callee_le + 0 ; lg %r4, 0(%r1)
 ;   basr %r14, %r4
-;   vpdi %v5, %v24, %v24, 4
-;   verllg %v24, %v5, 32
-;   ld %f8, 160(%r15)
-;   ld %f9, 168(%r15)
-;   ld %f10, 176(%r15)
-;   ld %f11, 184(%r15)
-;   ld %f12, 192(%r15)
-;   ld %f13, 200(%r15)
-;   ld %f14, 208(%r15)
-;   ld %f15, 216(%r15)
 ;   lmg %r14, %r15, 336(%r15)
 ;   br %r14
 ;
@@ -173,75 +370,22 @@ block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
 ; block0: ; offset 0x0
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xe0
-;   std %f8, 0xa0(%r15)
-;   std %f9, 0xa8(%r15)
-;   std %f10, 0xb0(%r15)
-;   std %f11, 0xb8(%r15)
-;   std %f12, 0xc0(%r15)
-;   std %f13, 0xc8(%r15)
-;   std %f14, 0xd0(%r15)
-;   std %f15, 0xd8(%r15)
-; block1: ; offset 0x2a
-;   vpdi %v24, %v24, %v24, 4
-;   vpdi %v7, %v25, %v25, 4
-;   verllg %v25, %v7, 0x20
-;   vpdi %v19, %v26, %v26, 4
-;   verllg %v21, %v19, 0x20
-;   verllf %v26, %v21, 0x10
-;   vpdi %v27, %v27, %v27, 4
-;   verllg %v27, %v27, 0x20
-;   verllf %v29, %v27, 0x10
-;   verllh %v27, %v29, 8
-;   bras %r1, 0x72
-;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_be 0
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   .byte 0x00, 0x00
-;   lg %r4, 0(%r1)
-;   basr %r14, %r4
-;   vpdi %v5, %v24, %v24, 4
-;   verllg %v24, %v5, 0x20
-;   ld %f8, 0xa0(%r15)
-;   ld %f9, 0xa8(%r15)
-;   ld %f10, 0xb0(%r15)
-;   ld %f11, 0xb8(%r15)
-;   ld %f12, 0xc0(%r15)
-;   ld %f13, 0xc8(%r15)
-;   ld %f14, 0xd0(%r15)
-;   ld %f15, 0xd8(%r15)
-;   lmg %r14, %r15, 0x150(%r15)
-;   br %r14
-
-function %caller_le_to_le(i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v {
-    fn0 = %callee_le(i64x2, i32x4, i16x8, i8x16) -> i32x4 wasmtime_system_v
-
-block0(v0: i64x2, v1: i32x4, v2: i16x8, v3: i8x16):
-    v4 = call fn0(v0, v1, v2, v3)
-    return v4
-}
-
-; VCode:
-;   stmg %r14, %r15, 112(%r15)
-;   aghi %r15, -160
-;   virtual_sp_offset_adjust 160
-; block0:
-;   bras %r1, 12 ; data %callee_le + 0 ; lg %r4, 0(%r1)
-;   basr %r14, %r4
-;   lmg %r14, %r15, 272(%r15)
-;   br %r14
-;
-; Disassembled:
-; block0: ; offset 0x0
-;   stmg %r14, %r15, 0x70(%r15)
-;   aghi %r15, -0xa0
 ; block1: ; offset 0xa
-;   bras %r1, 0x16
+;   vl %v17, 0x180(%r15)
+;   vl %v19, 0x190(%r15)
+;   vl %v21, 0x1a0(%r15)
+;   vl %v23, 0x1b0(%r15)
+;   vst %v17, 0xa0(%r15)
+;   vst %v19, 0xb0(%r15)
+;   vst %v21, 0xc0(%r15)
+;   vst %v23, 0xd0(%r15)
+;   bras %r1, 0x46
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %callee_le 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
 ;   lg %r4, 0(%r1)
 ;   basr %r14, %r4
-;   lmg %r14, %r15, 0x110(%r15)
+;   lmg %r14, %r15, 0x150(%r15)
 ;   br %r14
 


### PR DESCRIPTION
On s390x we support ABIs with little-endian or big-endian vector lane ordering.  When calling to function with a different lane order, vector arguments need to be lane-swapped.  This currently happens for arguments passed in registers, but not for those passed on the stack - that is a bug.

Fixed by swapping stack arguments as well.

Fixes https://github.com/bytecodealliance/wasmtime/issues/8132

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
