### PR TITLE
PCC: fuzz static (no dynamic checks) case in Wasmtime fuzzers.

### DIFF
--- a/cranelift/codegen/src/result.rs
+++ b/cranelift/codegen/src/result.rs
@@ -77,6 +77,9 @@ impl std::fmt::Display for CodegenError {
             #[cfg(feature = "unwind")]
             CodegenError::RegisterMappingError(_0) => write!(f, "Register mapping error"),
             CodegenError::Regalloc(errors) => write!(f, "Regalloc validation errors: {:?}", errors),
+
+            // NOTE: if this is changed, please update the `is_pcc_error` function defined in
+            // `wasmtime/crates/fuzzing/src/oracles.rs`
             CodegenError::Pcc(e) => write!(f, "Proof-carrying-code validation error: {:?}", e),
         }
     }

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -170,7 +170,8 @@ impl Config {
                 self.wasmtime.memory_guaranteed_dense_image_size,
             ))
             .allocation_strategy(self.wasmtime.strategy.to_wasmtime())
-            .generate_address_map(self.wasmtime.generate_address_map);
+            .generate_address_map(self.wasmtime.generate_address_map)
+            .cranelift_pcc(self.wasmtime.pcc);
 
         if !self.module_config.config.simd_enabled {
             cfg.wasm_relaxed_simd(false);
@@ -427,6 +428,9 @@ pub struct WasmtimeConfig {
     native_unwind_info: bool,
     /// Configuration for the compiler to use.
     pub compiler_strategy: CompilerStrategy,
+
+    /// Whether or not fuzzing should enable PCC.
+    pcc: bool,
 }
 
 impl WasmtimeConfig {

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -1,7 +1,8 @@
 //! Generate a configuration for both Wasmtime and the Wasm module to execute.
 
 use super::{
-    CodegenSettings, InstanceAllocationStrategy, MemoryConfig, ModuleConfig, UnalignedMemoryCreator,
+    CodegenSettings, InstanceAllocationStrategy, MemoryConfig, ModuleConfig, NormalMemoryConfig,
+    UnalignedMemoryCreator,
 };
 use crate::oracles::{StoreLimits, Timeout};
 use anyhow::Result;
@@ -228,7 +229,20 @@ impl Config {
         //   `CustomUnaligned` variant isn't actually safe to use with a shared
         //   memory.
         if !self.module_config.config.threads_enabled {
-            match &self.wasmtime.memory_config {
+            // If PCC is enabled, force other options to be compatible: PCC is currently only
+            // supported when bounds checks are elided.
+            let memory_config = if self.wasmtime.pcc {
+                MemoryConfig::Normal(NormalMemoryConfig {
+                    static_memory_maximum_size: Some(4 << 30), // 4 GiB
+                    static_memory_guard_size: Some(2 << 30),   // 2 GiB
+                    dynamic_memory_guard_size: Some(0),
+                    guard_before_linear_memory: false,
+                })
+            } else {
+                self.wasmtime.memory_config.clone()
+            };
+
+            match &memory_config {
                 MemoryConfig::Normal(memory_config) => {
                     cfg.static_memory_maximum_size(
                         memory_config.static_memory_maximum_size.unwrap_or(0),
@@ -245,14 +259,6 @@ impl Config {
                         .guard_before_linear_memory(false);
                 }
             }
-        }
-
-        // If PCC is enabled, force other options to be compatible: PCC is currently only
-        // supported when bounds checks are elided.
-        if self.wasmtime.pcc {
-            cfg.static_memory_maximum_size(4 << 30); // 4 GiB
-            cfg.static_memory_guard_size(2 << 30); // 2 GiB
-            cfg.dynamic_memory_guard_size(0);
         }
 
         return cfg;

--- a/tests/pcc_memory.rs
+++ b/tests/pcc_memory.rs
@@ -75,8 +75,8 @@ mod pcc_memory_tests {
         }
 
         for test in &bodies {
-            for static_memory_maximum_size in [0, 64 * KIB, 1 * MIB, 4 * GIB, 6 * GIB] {
-                for guard_size in [0, 64 * KIB, 2 * GIB] {
+            for static_memory_maximum_size in [4 * GIB] {
+                for guard_size in [2 * GIB] {
                     for enable_spectre in [true /* not yet supported by PCC: false */] {
                         for _memory_bits in [32 /* not yet supported by PCC: 64 */] {
                             log::trace!("test:\n{}\n", test);

--- a/tests/pcc_memory.rs
+++ b/tests/pcc_memory.rs
@@ -8,132 +8,44 @@ mod pcc_memory_tests {
 
     const TESTS: &'static [&'static str] = &[
         r#"
-(module
- (memory 1 1)
- (func (param i32)
   local.get 0
   i32.load8_u
-  drop))
+  drop
     "#,
         r#"
-(module
- (memory 1 1)
- (func (param i32)
   local.get 0
   i32.load8_u offset=0x10000
-  drop))
+  drop
     "#,
         r#"
-(module
- (memory 1 1)
- (func (param i32)
   local.get 0
   i32.load16_u
-  drop))
+  drop
     "#,
         r#"
-(module
- (memory 1 1)
- (func (param i32)
   local.get 0
   i32.load16_u offset=0x10000
-  drop))
+  drop
     "#,
         r#"
-(module
- (memory 1 1)
- (func (param i32)
   local.get 0
   i32.load
-  drop))
+  drop
     "#,
         r#"
-(module
- (memory 1 1)
- (func (param i32)
   local.get 0
   i32.load offset=0x10000
-  drop))
+  drop
     "#,
         r#"
-(module
- (memory 1 1)
- (func (param i32)
   local.get 0
   i64.load
-  drop))
+  drop
     "#,
         r#"
-(module
- (memory 1 1)
- (func (param i32)
   local.get 0
   i64.load offset=0x10000
-  drop))
-    "#,
-        r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load8_u
-  drop))
-    "#,
-        r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load8_u offset=0x10000
-  drop))
-    "#,
-        r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load16_u
-  drop))
-    "#,
-        r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load16_u offset=0x10000
-  drop))
-    "#,
-        r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load
-  drop))
-    "#,
-        r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i32.load offset=0x10000
-  drop))
-    "#,
-        r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i64.load
-  drop))
-    "#,
-        r#"
-(module
- (memory 10 20)
- (func (param i32)
-  local.get 0
-  i64.load offset=0x10000
-  drop))
+  drop
     "#,
     ];
 
@@ -145,7 +57,24 @@ mod pcc_memory_tests {
         const MIB: u64 = 1024 * KIB;
         const GIB: u64 = 1024 * MIB;
 
-        for &test in TESTS {
+        let mut bodies = vec![];
+        for (mem_min, mem_max) in [(1, 1), (10, 20)] {
+            for &snippet in TESTS {
+                bodies.push(format!(
+                    "(module (memory {mem_min} {mem_max}) (func (param i32) {snippet}))"
+                ));
+            }
+            let all_snippets = TESTS
+                .iter()
+                .map(|s| s.to_owned())
+                .collect::<Vec<_>>()
+                .join("\n");
+            bodies.push(format!(
+                "(module (memory {mem_min} {mem_max}) (func (param i32) {all_snippets}))"
+            ));
+        }
+
+        for test in &bodies {
             for static_memory_maximum_size in [0, 64 * KIB, 1 * MIB, 4 * GIB, 6 * GIB] {
                 for guard_size in [0, 64 * KIB, 2 * GIB] {
                     for enable_spectre in [true /* not yet supported by PCC: false */] {


### PR DESCRIPTION
This PR updates the fuzzing configuration generation logic to turn on proof-carrying code (PCC) when randomly selected. When PCC is on, it forces the memory configuration to one that PCC can handle: a statically-sized 4GiB memory with 2GiB guard region, so no dynamic checks occur. I have fuzzed this for ~100 CPU-hours so far (on x86-64) and haven't found anything, with a local change that forces the PCC arbitrary-bool to true to concentrate fuzzing effort in just the new bit. (I've confirmed that manually introducing failures into the PCC code does properly bubble up.)

The commits start with one that updates the `pcc_memory` integration test to put all the various loads together in one body such that the optimizer will merge some of their address-computation logic. This was the root of failures I was seeing when last working on PCC in the fall, and that still exist for dynamic-check cases. A subsequent commit reduces the coverage of that test to only the 4GiB/2GiB static case for now so it passes; in this PR I am arguing that we should support this and push it forward first, and fix the dynamic case later (more below).

This PR includes rebases of two commits from @elliottt's #7511, and then a last change to force the memory configuration to the supported static one only when PCC is selected by fuzzing.

Why only the static case? I've made approximately three attempts to get the general dynamic case to work, be fully general, handle all edge-cases, and be scalable (not blow up quadratically): combined static+dynamic ranges in all facts, a more flexible set-of-lower/upper-bound-expressions engine (#7965), and just recently an implementation of the "order graph" I described in the last comment on that PR. All of these suffer from some combination of maddening complexity and a quadratic worst-case when N accesses merge together and we have to symbolically reason about all of them together -- to the point that I know when to cut my losses and would rather ship the static case without digging further. I do think there's maybe something more possible, but it needs more thought and time when not under pressure (and under demand by a few other projects too).

Assuming this sticks and fuzzbugs if any are manageable, I plan to eventually propose an "on but permissive by default" approach (with warnings but no failures), then eventually an "on and enforcing by default", but all of those things will come after more experience and discussions with folks. For now I just want the fuzzers to do their thing!