### PR TITLE
Canonicalize floats produced through bitcasts

### DIFF
--- a/cranelift/codegen/src/nan_canonicalization.rs
+++ b/cranelift/codegen/src/nan_canonicalization.rs
@@ -48,6 +48,24 @@ fn is_fp_arith(pos: &mut FuncCursor, inst: Inst) -> bool {
                 || opcode == Opcode::Fsub
         }
         InstructionData::Ternary { opcode, .. } => opcode == Opcode::Fma,
+
+        // bitcasts coming from arbitrary integers need canonicalization as the
+        // integer isn't known to necessarily be a canonical NaN
+        InstructionData::LoadNoOffset {
+            opcode: Opcode::Bitcast,
+            arg,
+            flags: _,
+        } => {
+            let ret = pos.func.dfg.first_result(inst);
+            let ret_type = pos.func.dfg.value_type(ret);
+            let arg_type = pos.func.dfg.value_type(arg);
+            match (arg_type, ret_type) {
+                (types::I32, types::F32) => true,
+                (types::I64, types::F64) => true,
+                _ => false,
+            }
+        }
+
         _ => false,
     }
 }

--- a/tests/misc_testsuite/simd/canonicalize-nan.wast
+++ b/tests/misc_testsuite/simd/canonicalize-nan.wast
@@ -33,6 +33,12 @@
   (func (export "f64x2.ceil") (param v128) (result v128)
     local.get 0
     f64x2.ceil)
+
+  (func (export "reinterpret-and-demote") (param i64) (result i32)
+    local.get 0
+    f64.reinterpret_i64
+    f32.demote_f64
+    i32.reinterpret_f32)
 )
 
 (assert_return (invoke "f32x4.floor" (v128.const f32x4 1 -2.2 3.4 nan))
@@ -56,3 +62,6 @@
                (v128.const f64x2 3 nan))
 (assert_return (invoke "f64x2.ceil" (v128.const f64x2 3.4 nan))
                (v128.const f64x2 4 nan))
+
+(assert_return (invoke "reinterpret-and-demote" (i64.const 0xfffefdfccccdcecf))
+               (i32.const 0x7fc00000))


### PR DESCRIPTION
This commit updates the nan-canonicalization pass that Cranelift does to canonicalize bitcasts from arbitrary integers in addition to floating point arithmetic operations.

Closes #8145

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
