### PR TITLE
Enhance test around stack overflow

### DIFF
--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -9,35 +9,98 @@ fn host_always_has_some_stack() -> Result<()> {
     // assume hosts always have at least 128k of stack
     const HOST_STACK: usize = 128 * 1024;
 
-    let mut store = Store::<()>::default();
+    let mut store = if cfg!(target_arch = "x86_64") {
+        let mut config = Config::new();
+        // Force cranelift-based libcalls to show up by ensuring that platform
+        // support is turned off.
+        unsafe {
+            config.cranelift_flag_set("has_avx", "false");
+            config.cranelift_flag_set("has_sse42", "false");
+            config.cranelift_flag_set("has_sse41", "false");
+            config.cranelift_flag_set("has_ssse3", "false");
+            config.cranelift_flag_set("has_sse3", "false");
+        }
+        Store::new(&Engine::new(&config)?, ())
+    } else {
+        Store::<()>::default()
+    };
 
     // Create a module that's infinitely recursive, but calls the host on each
     // level of wasm stack to always test how much host stack we have left.
+    //
+    // Each of the function exports of this module calls out to the host in a
+    // different way, and each one is tested below to make sure that the way of
+    // exiting out to the host is tested thoroughly.
     let module = Module::new(
         store.engine(),
         r#"
             (module
-                (import "" "" (func $host))
-                (func $recursive (export "foo")
-                    call $host
-                    call $recursive)
+                (import "" "" (func $host1))
+                (import "" "" (func $host2))
+
+                ;; exit via wasm-to-native trampoline
+                (func $recursive1 (export "f1")
+                    call $host1
+                    call $recursive1)
+
+                ;; exit via wasm-to-array trampoline
+                (func $recursive2 (export "f2")
+                    call $host2
+                    call $recursive2)
+
+                ;; exit via a wasmtime-based libcall
+                (memory 1)
+                (func $recursive3 (export "f3")
+                    (drop (memory.grow (i32.const 00)))
+                    call $recursive3)
+
+                ;; exit via a cranelift-based libcall
+                (func $recursive4 (export "f4")
+                    (drop (call $f32_ceil (f32.const 0)))
+                    call $host2
+                    call $recursive4)
+                (func $f32_ceil (param f32) (result f32)
+                    (f32.ceil (local.get 0)))
             )
         "#,
     )?;
-    let func = Func::wrap(&mut store, test_host_stack);
-    let instance = Instance::new(&mut store, &module, &[func.into()])?;
-    let foo = instance.get_typed_func::<(), ()>(&mut store, "foo")?;
+    let host1 = Func::wrap(&mut store, test_host_stack);
+    let ty = FuncType::new(store.engine(), [], []);
+    let host2 = Func::new(&mut store, ty, |_, _, _| {
+        test_host_stack();
+        Ok(())
+    });
+    let instance = Instance::new(&mut store, &module, &[host1.into(), host2.into()])?;
+    let f1 = instance.get_typed_func::<(), ()>(&mut store, "f1")?;
+    let f2 = instance.get_typed_func::<(), ()>(&mut store, "f2")?;
+    let f3 = instance.get_typed_func::<(), ()>(&mut store, "f3")?;
+    let f4 = instance.get_typed_func::<(), ()>(&mut store, "f4")?;
 
     // Make sure that our function traps and the trap says that the call stack
     // has been exhausted.
-    let trap = foo.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
+    let hits1 = HITS.load(SeqCst);
+    let trap = f1.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
     assert_eq!(trap, Trap::StackOverflow);
+    let hits2 = HITS.load(SeqCst);
+    let trap = f2.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
+    assert_eq!(trap, Trap::StackOverflow);
+    let hits3 = HITS.load(SeqCst);
+    let trap = f3.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
+    assert_eq!(trap, Trap::StackOverflow);
+    let hits4 = HITS.load(SeqCst);
+    let trap = f4.call(&mut store, ()).unwrap_err().downcast::<Trap>()?;
+    assert_eq!(trap, Trap::StackOverflow);
+    let hits5 = HITS.load(SeqCst);
 
     // Additionally, however, and this is the crucial test, make sure that the
     // host function actually completed. If HITS is 1 then we entered but didn't
     // exit meaning we segfaulted while executing the host, yet still tried to
     // recover from it with longjmp.
-    assert_eq!(HITS.load(SeqCst), 0);
+    assert_eq!(hits1, 0);
+    assert_eq!(hits2, 0);
+    assert_eq!(hits3, 0);
+    assert_eq!(hits4, 0);
+    assert_eq!(hits5, 0);
 
     return Ok(());
 

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -51,7 +51,7 @@ fn host_always_has_some_stack() -> Result<()> {
                 ;; exit via a wasmtime-based libcall
                 (memory 1)
                 (func $recursive3 (export "f3")
-                    (drop (memory.grow (i32.const 00)))
+                    (drop (memory.grow (i32.const 0)))
                     call $recursive3)
 
                 ;; exit via a cranelift-based libcall

--- a/tests/all/stack_overflow.rs
+++ b/tests/all/stack_overflow.rs
@@ -57,7 +57,6 @@ fn host_always_has_some_stack() -> Result<()> {
                 ;; exit via a cranelift-based libcall
                 (func $recursive4 (export "f4")
                     (drop (call $f32_ceil (f32.const 0)))
-                    call $host2
                     call $recursive4)
                 (func $f32_ceil (param f32) (result f32)
                     (f32.ceil (local.get 0)))


### PR DESCRIPTION
This commit enhances the `host_always_has_some_stack` a bit in light of some thinking around #8135. Notably this test ensures that the host itself never segfaults even if the wasm exhausts all of its stack. There are a number of ways that we can exit out to the host, though, and only one was tested previously. This commit updates to ensure more cases are covered.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
