### PR TITLE
Fix a bug that prevented enabling the winch calling convention

### DIFF
--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -154,7 +154,7 @@ fn wasm_call_signature(
         }
 
         // The winch calling convention is only implemented for x64 and aarch64
-        arch if tunables.tail_callable => {
+        arch if tunables.winch_callable => {
             assert!(
                 matches!(arch, Architecture::X86_64 | Architecture::Aarch64(_)),
                 "https://github.com/bytecodealliance/wasmtime/issues/6530"


### PR DESCRIPTION
Fix a bug introduced in #8082, where we were testing the `tail_callable` tunable instead of the newly introduced `winch_callable` tunable.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
