### PR TITLE
Adjust an error message expectation for v8

### DIFF
--- a/crates/fuzzing/src/oracles/diff_v8.rs
+++ b/crates/fuzzing/src/oracles/diff_v8.rs
@@ -92,10 +92,7 @@ impl DiffEngine for V8Engine {
         };
         match wasmtime {
             Trap::MemoryOutOfBounds => {
-                return verify_v8(&[
-                    "memory access out of bounds",
-                    "data segment is out of bounds",
-                ])
+                return verify_v8(&["memory access out of bounds", "is out of bounds"])
             }
             Trap::UnreachableCodeReached => {
                 return verify_v8(&[


### PR DESCRIPTION
Looks like the new error message has a data segment index in it so match a more general error here.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
