### PR TITLE
winch: Use correct heap types in explicit bounds checks

### DIFF
--- a/winch/codegen/src/codegen/bounds.rs
+++ b/winch/codegen/src/codegen/bounds.rs
@@ -125,7 +125,7 @@ pub(crate) fn ensure_index_and_offset<M: MacroAssembler>(
     masm: &mut M,
     index: Index,
     offset: u64,
-    ptr_size: OperandSize,
+    heap_ty_size: OperandSize,
 ) -> ImmOffset {
     match u32::try_from(offset) {
         // If the immediate offset fits in a u32, then we simply return.
@@ -137,7 +137,7 @@ pub(crate) fn ensure_index_and_offset<M: MacroAssembler>(
                 index.as_typed_reg().into(),
                 index.as_typed_reg().into(),
                 RegImm::i64(offset as i64),
-                ptr_size,
+                heap_ty_size,
                 TrapCode::HeapOutOfBounds,
             );
 

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -492,7 +492,8 @@ where
         let memory_index = MemoryIndex::from_u32(memarg.memory);
         let heap = self.env.resolve_heap(memory_index);
         let index = Index::from_typed_reg(self.context.pop_to_reg(self.masm, None));
-        let offset = bounds::ensure_index_and_offset(self.masm, index, memarg.offset, ptr_size);
+        let offset =
+            bounds::ensure_index_and_offset(self.masm, index, memarg.offset, heap.ty.into());
         let offset_with_access_size = add_offset_and_access_size(offset, access_size);
 
         let addr = match heap.style {
@@ -528,7 +529,7 @@ where
                     index_offset_and_access_size,
                     index_offset_and_access_size,
                     RegImm::i64(offset_with_access_size as i64),
-                    ptr_size,
+                    heap.ty.into(),
                     TrapCode::HeapOutOfBounds,
                 );
 
@@ -627,7 +628,11 @@ where
                     |masm, bounds, index| {
                         let adjusted_bounds = bounds.as_u64() - offset_with_access_size;
                         let index_reg = index.as_typed_reg().reg;
-                        masm.cmp(RegImm::i64(adjusted_bounds as i64), index_reg, ptr_size);
+                        masm.cmp(
+                            RegImm::i64(adjusted_bounds as i64),
+                            index_reg,
+                            heap.ty.into(),
+                        );
                         IntCmpKind::GtU
                     },
                 );


### PR DESCRIPTION
This commit is a follow-up to https://github.com/bytecodealliance/wasmtime/pull/8059 (in which I forgot to include the heap types for the other checks, e.g. overflow). Instead of arbitrarily using the target's pointer size, it derives the use from the heap information, in order to do bounds check calculations, this enables checking the right limits.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
