### PR TITLE
Don't check for null in `call_indirect` and `call_ref`

### DIFF
--- a/tests/disas/icall-simd.wat
+++ b/tests/disas/icall-simd.wat
@@ -43,11 +43,10 @@
 ;; @0033                               jump block3(v20)
 ;;
 ;;                                 block3(v15: i64):
-;; @0033                               trapz v15, icall_null
 ;; @0033                               v21 = global_value.i64 gv3
 ;; @0033                               v22 = load.i64 notrap aligned readonly v21+64
 ;; @0033                               v23 = load.i32 notrap aligned readonly v22
-;; @0033                               v24 = load.i32 notrap aligned readonly v15+24
+;; @0033                               v24 = load.i32 icall_null aligned readonly v15+24
 ;; @0033                               v25 = icmp eq v24, v23
 ;; @0033                               trapz v25, bad_sig
 ;; @0033                               v26 = load.i64 notrap aligned readonly v15+16

--- a/tests/disas/icall.wat
+++ b/tests/disas/icall.wat
@@ -43,11 +43,10 @@
 ;; @0033                               jump block3(v20)
 ;;
 ;;                                 block3(v15: i64):
-;; @0033                               trapz v15, icall_null
 ;; @0033                               v21 = global_value.i64 gv3
 ;; @0033                               v22 = load.i64 notrap aligned readonly v21+64
 ;; @0033                               v23 = load.i32 notrap aligned readonly v22
-;; @0033                               v24 = load.i32 notrap aligned readonly v15+24
+;; @0033                               v24 = load.i32 icall_null aligned readonly v15+24
 ;; @0033                               v25 = icmp eq v24, v23
 ;; @0033                               trapz v25, bad_sig
 ;; @0033                               v26 = load.i64 notrap aligned readonly v15+16

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -113,22 +113,16 @@
 ;; @0036                               jump block3(v24)
 ;;
 ;;                                 block3(v19: i64):
-;; @0038                               brif v19, block9, block8
-;;
-;;                                 block8 cold:
-;; @0038                               trap null_reference
-;;
-;;                                 block9:
-;; @0038                               v25 = load.i64 notrap aligned readonly v19+16
+;; @0038                               v25 = load.i64 null_reference aligned readonly v19+16
 ;; @0038                               v26 = load.i64 notrap aligned readonly v19+32
 ;; @0038                               v27 = call_indirect sig1, v25(v26, v0, v2, v3, v4, v5)
 ;;                                     v80 = iconst.i8 0
-;; @0049                               brif v80, block10, block11  ; v80 = 0
+;; @0049                               brif v80, block8, block9  ; v80 = 0
 ;;
-;;                                 block10 cold:
+;;                                 block8 cold:
 ;; @0049                               trap table_oob
 ;;
-;;                                 block11:
+;;                                 block9:
 ;; @0049                               v38 = load.i64 notrap aligned v0+72
 ;;                                     v81 = iconst.i8 0
 ;;                                     v78 = iconst.i64 16
@@ -148,13 +142,7 @@
 ;; @0049                               jump block5(v50)
 ;;
 ;;                                 block5(v45: i64):
-;; @004b                               brif v45, block13, block12
-;;
-;;                                 block12 cold:
-;; @004b                               trap null_reference
-;;
-;;                                 block13:
-;; @004b                               v51 = load.i64 notrap aligned readonly v45+16
+;; @004b                               v51 = load.i64 null_reference aligned readonly v45+16
 ;; @004b                               v52 = load.i64 notrap aligned readonly v45+32
 ;; @004b                               v53 = call_indirect sig1, v51(v52, v0, v2, v3, v4, v5)
 ;; @0054                               jump block1


### PR DESCRIPTION
This PR is an implementation of #5291 to slightly optimize the lowering of `call_indirect` and `call_ref` in Wasmtime. Explicitly checks for null function pointers are no longer present and instead we let a segfault happen when loading from a null function pointer. This segfault is caught and the relevant instruction is annotated with the appropriate trap code.

This support first starts by refactoring the `MemFlags` API to no longer purely be flags but instead be a mixture of flags and "flag regions". The `vmctx`/`heap`/`table` alias regions are bundled into two bits now and the various trap-related bits are now bundled into four bits. This enables putting arbitrary trap codes in a `MemFlags` so long as they aren't `TrapCode::User(_)`.

Closes #5291 