### PR TITLE
Wasm ICs / typed-funcrefs test: switch to nullable table.

### DIFF
--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -14,9 +14,9 @@
   (type $ic-stub (func (param i32 i32 i32 i32) (result i32)))
 
   ;; This syntax declares a table that is exactly 100 elements, whose
-  ;; elements are non-nullable function references, and whose default
-  ;; value (needed because non-nullable) is a pointer to `$ic1`.
-  (table $ic-sites 100 100 (ref $ic-stub) (ref.func $ic1))
+  ;; elements are nullable function references, and whose default
+  ;; value is `null`.
+  (table $ic-sites 100 100 (ref null $ic-stub))
 
   (func $ic1 (param i32 i32 i32 i32) (result i32)
         local.get 0)
@@ -59,10 +59,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;;                                     v6 -> v2
-;; @002c                               jump block1
+;; @0027                               jump block1
 ;;
 ;;                                 block1:
-;; @002c                               return v2
+;; @0027                               return v2
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
@@ -87,80 +87,80 @@
 ;;                                     v32 -> v4
 ;;                                     v33 -> v5
 ;;                                     v62 = iconst.i8 0
-;; @003b                               brif v62, block6, block7  ; v62 = 0
+;; @0036                               brif v62, block6, block7  ; v62 = 0
 ;;
 ;;                                 block6 cold:
-;; @003b                               trap table_oob
+;; @0036                               trap table_oob
 ;;
 ;;                                 block7:
-;; @003b                               v12 = load.i64 notrap aligned v0+72
+;; @0036                               v12 = load.i64 notrap aligned v0+72
 ;;                                     v79 = iconst.i8 0
 ;;                                     v70 = iconst.i64 8
-;; @003b                               v14 = iadd v12, v70  ; v70 = 8
-;; @003b                               v16 = select_spectre_guard v79, v12, v14  ; v79 = 0
-;; @003b                               v17 = load.i64 notrap aligned table v16
+;; @0036                               v14 = iadd v12, v70  ; v70 = 8
+;; @0036                               v16 = select_spectre_guard v79, v12, v14  ; v79 = 0
+;; @0036                               v17 = load.i64 notrap aligned table v16
 ;;                                     v58 = iconst.i64 -2
-;; @003b                               v18 = band v17, v58  ; v58 = -2
-;; @003b                               brif v17, block3(v18), block2
+;; @0036                               v18 = band v17, v58  ; v58 = -2
+;; @0036                               brif v17, block3(v18), block2
 ;;
 ;;                                 block2 cold:
-;; @004e                               v48 = load.i64 notrap aligned readonly v0+56
-;; @004e                               v49 = load.i64 notrap aligned readonly v48+72
-;; @002f                               v7 = iconst.i32 0
+;; @0049                               v48 = load.i64 notrap aligned readonly v0+56
+;; @0049                               v49 = load.i64 notrap aligned readonly v48+72
+;; @002a                               v7 = iconst.i32 0
 ;;                                     v28 -> v7
-;; @0039                               v8 = iconst.i32 1
-;; @003b                               v24 = call_indirect sig0, v49(v0, v7, v8)  ; v7 = 0, v8 = 1
-;; @003b                               jump block3(v24)
+;; @0034                               v8 = iconst.i32 1
+;; @0036                               v24 = call_indirect sig0, v49(v0, v7, v8)  ; v7 = 0, v8 = 1
+;; @0036                               jump block3(v24)
 ;;
 ;;                                 block3(v19: i64):
-;; @003d                               brif v19, block9, block8
+;; @0038                               brif v19, block9, block8
 ;;
 ;;                                 block8 cold:
-;; @003d                               trap null_reference
+;; @0038                               trap null_reference
 ;;
 ;;                                 block9:
-;; @003d                               v25 = load.i64 notrap aligned readonly v19+16
-;; @003d                               v26 = load.i64 notrap aligned readonly v19+32
-;; @003d                               v27 = call_indirect sig1, v25(v26, v0, v2, v3, v4, v5)
+;; @0038                               v25 = load.i64 notrap aligned readonly v19+16
+;; @0038                               v26 = load.i64 notrap aligned readonly v19+32
+;; @0038                               v27 = call_indirect sig1, v25(v26, v0, v2, v3, v4, v5)
 ;;                                     v80 = iconst.i8 0
-;; @004e                               brif v80, block10, block11  ; v80 = 0
+;; @0049                               brif v80, block10, block11  ; v80 = 0
 ;;
 ;;                                 block10 cold:
-;; @004e                               trap table_oob
+;; @0049                               trap table_oob
 ;;
 ;;                                 block11:
-;; @004e                               v38 = load.i64 notrap aligned v0+72
+;; @0049                               v38 = load.i64 notrap aligned v0+72
 ;;                                     v81 = iconst.i8 0
 ;;                                     v78 = iconst.i64 16
-;; @004e                               v40 = iadd v38, v78  ; v78 = 16
-;; @004e                               v42 = select_spectre_guard v81, v38, v40  ; v81 = 0
-;; @004e                               v43 = load.i64 notrap aligned table v42
+;; @0049                               v40 = iadd v38, v78  ; v78 = 16
+;; @0049                               v42 = select_spectre_guard v81, v38, v40  ; v81 = 0
+;; @0049                               v43 = load.i64 notrap aligned table v42
 ;;                                     v82 = iconst.i64 -2
 ;;                                     v83 = band v43, v82  ; v82 = -2
-;; @004e                               brif v43, block5(v83), block4
+;; @0049                               brif v43, block5(v83), block4
 ;;
 ;;                                 block4 cold:
 ;;                                     v84 = load.i64 notrap aligned readonly v0+56
 ;;                                     v85 = load.i64 notrap aligned readonly v84+72
 ;;                                     v86 = iconst.i32 0
-;; @004c                               v34 = iconst.i32 2
-;; @004e                               v50 = call_indirect sig0, v85(v0, v86, v34)  ; v86 = 0, v34 = 2
-;; @004e                               jump block5(v50)
+;; @0047                               v34 = iconst.i32 2
+;; @0049                               v50 = call_indirect sig0, v85(v0, v86, v34)  ; v86 = 0, v34 = 2
+;; @0049                               jump block5(v50)
 ;;
 ;;                                 block5(v45: i64):
-;; @0050                               brif v45, block13, block12
+;; @004b                               brif v45, block13, block12
 ;;
 ;;                                 block12 cold:
-;; @0050                               trap null_reference
+;; @004b                               trap null_reference
 ;;
 ;;                                 block13:
-;; @0050                               v51 = load.i64 notrap aligned readonly v45+16
-;; @0050                               v52 = load.i64 notrap aligned readonly v45+32
-;; @0050                               v53 = call_indirect sig1, v51(v52, v0, v2, v3, v4, v5)
-;; @0059                               jump block1
+;; @004b                               v51 = load.i64 notrap aligned readonly v45+16
+;; @004b                               v52 = load.i64 notrap aligned readonly v45+32
+;; @004b                               v53 = call_indirect sig1, v51(v52, v0, v2, v3, v4, v5)
+;; @0054                               jump block1
 ;;
 ;;                                 block1:
-;; @0054                               v55 = iadd.i32 v53, v27
+;; @004f                               v55 = iadd.i32 v53, v27
 ;;                                     v6 -> v55
-;; @0059                               return v55
+;; @0054                               return v55
 ;; }


### PR DESCRIPTION
This is based on discussion in #8158: as noted in #8160, if we use a nullable typed funcref table instead (and given that we know we'll initialize a particular slot before use on the application side, so we won't actually call a null ref), and if we have a null-ref default value, we should be able to avoid the lazy table-init mechanism entirely.

(Ignore the part where this module doesn't actually have any update logic that would set non-null refs anywhere; it's a compile-test, not a runtest!)

Once #8159 is merged and #8160 is implemented (and table-at-constant-index is fully optimized), we should see zero branches in this test.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
