### PR TITLE
Rename `-S common` to `-S cli`.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,9 +8,9 @@ Unreleased.
 
 ### Changed
 
-The `-S common` flag is renamed to `-S cli`, to better reflect that it provides
-the wasi-cli APIs. `-S common` is still accepted for now, and will be deprecated
-in the future.
+* The `-S common` flag is renamed to `-S cli`, to better reflect that it provides
+  the wasi-cli APIs. `-S common` is still accepted for now, and will be deprecated
+  in the future.
 
 --------------------------------------------------------------------------------
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,10 @@ Unreleased.
 
 ### Changed
 
+The `-S common` flag is renamed to `-S cli`, to better reflect that it provides
+the wasi-cli APIs. `-S common` is still accepted for now, and will be deprecated
+in the future.
+
 --------------------------------------------------------------------------------
 
 ## 19.0.0

--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -252,7 +252,9 @@ wasmtime_option_group! {
 wasmtime_option_group! {
     #[derive(PartialEq, Clone)]
     pub struct WasiOptions {
-        /// Enable support for WASI common APIs
+        /// Enable support for WASI CLI APIs, including filesystems, sockets, clocks, and random.
+        pub cli: Option<bool>,
+        /// Deprecated alias for `cli`
         pub common: Option<bool>,
         /// Enable suport for WASI neural network API (experimental)
         pub nn: Option<bool>,
@@ -265,7 +267,7 @@ wasmtime_option_group! {
         pub listenfd: Option<bool>,
         /// Grant access to the given TCP listen socket
         pub tcplisten: Vec<String>,
-        /// Implement WASI with preview2 primitives (experimental).
+        /// Implement WASI CLI APIs with preview2 primitives (experimental).
         ///
         /// Indicates that the implementation of WASI preview1 should be backed by
         /// the preview2 implementation for components.

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -607,7 +607,21 @@ impl RunCommand {
         store: &mut Store<Host>,
         module: &RunTarget,
     ) -> Result<()> {
-        if self.run.common.wasi.common != Some(false) {
+        let mut cli = self.run.common.wasi.cli;
+
+        // Accept -Scommon as a deprecated alias for -Scli.
+        if let Some(common) = self.run.common.wasi.common {
+            if cli.is_some() {
+                bail!(
+                    "The -Scommon option should not be use with -Scli as it is a deprecated alias"
+                );
+            } else {
+                eprintln!("warning: The -Scommon flag has been renamed to -Scli");
+                cli = Some(common);
+            }
+        }
+
+        if cli != Some(false) {
             match linker {
                 CliLinker::Core(linker) => {
                     match (self.run.common.wasi.preview2, self.run.common.wasi.threads) {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -616,7 +616,8 @@ impl RunCommand {
                     "The -Scommon option should not be use with -Scli as it is a deprecated alias"
                 );
             } else {
-                eprintln!("warning: The -Scommon flag has been renamed to -Scli");
+                // In the future, we may add a warning here to tell users to use
+                // `-S cli` instead of `-S common`.
                 cli = Some(common);
             }
         }

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -200,7 +200,8 @@ impl ServeCommand {
                     "The -Scommon option should not be use with -Scli as it is a deprecated alias"
                 );
             } else {
-                eprintln!("warning: The -Scommon flag has been renamed to -Scli");
+                // In the future, we may add a warning here to tell users to use
+                // `-S cli` instead of `-S common`.
                 cli = Some(common);
             }
         }

--- a/src/old_cli.rs
+++ b/src/old_cli.rs
@@ -981,7 +981,7 @@ impl CommonOptions {
             ret.wasi.http = wasi_http;
             ret.wasi.nn = wasi_nn;
             ret.wasi.threads = wasi_threads;
-            ret.wasi.common = wasi_common;
+            ret.wasi.cli = wasi_common;
         }
         ret
     }

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1499,7 +1499,7 @@ mod test_programs {
             &[
                 "-Ccache=no",
                 "-Wcomponent-model",
-                "-Scommon,http,preview2",
+                "-Scli,http,preview2",
                 HTTP_OUTBOUND_REQUEST_RESPONSE_BUILD_COMPONENT,
             ],
             None,


### PR DESCRIPTION
The "common" in `-S common` came from "wasi-common" which came from the idea of having code in common between Wasmtime, Lucet, and others. It doesn't have a clear meaning for end users, and has a risk of being interpreted as "common" functionality that's generally available everywhere.

This PR renames `-S common` to `-S cli`, and documents it as including the WASI CLI APIs, to clarify its purpose `-S common` is still accepted, with a warning.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
