### PR TITLE
 Skip type checks on tables that don't need it 

### DIFF
--- a/cranelift/wasm/src/code_translator.rs
+++ b/cranelift/wasm/src/code_translator.rs
@@ -659,6 +659,13 @@ pub fn translate_operator<FE: FuncEnvironment + ?Sized>(
                 callee,
                 state.peekn(num_args),
             )?;
+            let call = match call {
+                Some(call) => call,
+                None => {
+                    state.reachable = false;
+                    return Ok(());
+                }
+            };
             let inst_results = builder.inst_results(call);
             debug_assert_eq!(
                 inst_results.len(),

--- a/cranelift/wasm/src/environ/dummy.rs
+++ b/cranelift/wasm/src/environ/dummy.rs
@@ -349,7 +349,7 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         sig_ref: ir::SigRef,
         callee: ir::Value,
         call_args: &[ir::Value],
-    ) -> WasmResult<ir::Inst> {
+    ) -> WasmResult<Option<ir::Inst>> {
         // Pass the current function's vmctx parameter on to the callee.
         let vmctx = builder
             .func
@@ -376,10 +376,12 @@ impl<'dummy_environment> FuncEnvironment for DummyFuncEnvironment<'dummy_environ
         args.extend(call_args.iter().cloned(), &mut builder.func.dfg.value_lists);
         args.push(vmctx, &mut builder.func.dfg.value_lists);
 
-        Ok(builder
-            .ins()
-            .CallIndirect(ir::Opcode::CallIndirect, INVALID, sig_ref, args)
-            .0)
+        Ok(Some(
+            builder
+                .ins()
+                .CallIndirect(ir::Opcode::CallIndirect, INVALID, sig_ref, args)
+                .0,
+        ))
     }
 
     fn translate_return_call_indirect(

--- a/cranelift/wasm/src/environ/spec.rs
+++ b/cranelift/wasm/src/environ/spec.rs
@@ -193,6 +193,8 @@ pub trait FuncEnvironment: TargetEnvironment {
     /// The signature `sig_ref` was previously created by `make_indirect_sig()`.
     ///
     /// Return the call instruction whose results are the WebAssembly return values.
+    /// Returns `None` if this statically traps instead of creating a call
+    /// instruction.
     fn translate_call_indirect(
         &mut self,
         builder: &mut FunctionBuilder,
@@ -201,7 +203,7 @@ pub trait FuncEnvironment: TargetEnvironment {
         sig_ref: ir::SigRef,
         callee: ir::Value,
         call_args: &[ir::Value],
-    ) -> WasmResult<ir::Inst>;
+    ) -> WasmResult<Option<ir::Inst>>;
 
     /// Translate a `return_call` WebAssembly instruction at the builder's
     /// current position.

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -1241,7 +1241,7 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
                 // If it's possible to have a null here then try to load the
                 // type information. If that fails due to the function being a
                 // null pointer, then this was a call to null. Otherwise if it
-                // succeeds then we know it wont match, so trap anyway.
+                // succeeds then we know it won't match, so trap anyway.
                 if table.table.wasm_ty.nullable {
                     let mem_flags = ir::MemFlags::trusted().with_readonly();
                     self.builder.ins().load(

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -21,7 +21,8 @@
   (func $ic1 (param i32 i32 i32 i32) (result i32)
         local.get 0)
 
-  (func $call-ics (param i32 i32 i32 i32) (result i32)
+  ;; A function which uses ICs through `table.get` plus `call_ref`
+  (func $call-ics-with-call-ref (param i32 i32 i32 i32) (result i32)
         (local $sum i32)
 
         ;; IC callsite index 1 (arbitrary).
@@ -48,7 +49,69 @@
         i32.add
         local.set $sum
 
-        local.get $sum))
+        local.get $sum)
+
+  ;; Same as the above function, but uses `call_indirect` rather than
+  ;; `call_ref`.
+  (func $call-ics-with-call-indirect (param i32 i32 i32 i32) (result i32)
+        (local $sum i32)
+
+        ;; IC callsite index 1 (arbitrary).
+        local.get 0
+        local.get 1
+        local.get 2
+        local.get 3
+        i32.const 1
+        call_indirect $ic-sites (type $ic-stub)
+        local.get $sum
+        i32.add
+        local.set $sum
+
+        ;; IC callsite index 2 (arbitrary).
+        local.get 0
+        local.get 1
+        local.get 2
+        local.get 3
+        i32.const 2
+        call_indirect $ic-sites (type $ic-stub)
+        local.get $sum
+        i32.add
+        local.set $sum
+
+        local.get $sum)
+
+  (global $ic-site0 (mut (ref $ic-stub)) (ref.func $ic1))
+  (global $ic-site1 (mut (ref $ic-stub)) (ref.func $ic1))
+
+  ;; Sort of similar to the previous two functions, but uses globals instead of
+  ;; tables to store ICs. Mostly just here for comparison in terms of codegen.
+  (func $call-ics-with-global-get (param i32 i32 i32 i32) (result i32)
+        (local $sum i32)
+
+        ;; IC callsite index 1 (arbitrary).
+        local.get 0
+        local.get 1
+        local.get 2
+        local.get 3
+        global.get $ic-site0
+        call_ref $ic-stub
+        local.get $sum
+        i32.add
+        local.set $sum
+
+        ;; IC callsite index 2 (arbitrary).
+        local.get 0
+        local.get 1
+        local.get 2
+        local.get 3
+        global.get $ic-site1
+        call_ref $ic-stub
+        local.get $sum
+        i32.add
+        local.set $sum
+
+        local.get $sum)
+)
 ;; function u0:0(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
 ;;     gv0 = vmctx
 ;;     gv1 = load.i64 notrap aligned readonly gv0+8
@@ -59,10 +122,10 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;;                                     v6 -> v2
-;; @0027                               jump block1
+;; @0039                               jump block1
 ;;
 ;;                                 block1:
-;; @0027                               return v2
+;; @0039                               return v2
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
@@ -87,68 +150,205 @@
 ;;                                     v32 -> v4
 ;;                                     v33 -> v5
 ;;                                     v62 = iconst.i8 0
-;; @0036                               brif v62, block6, block7  ; v62 = 0
+;; @0048                               brif v62, block6, block7  ; v62 = 0
 ;;
 ;;                                 block6 cold:
-;; @0036                               trap table_oob
+;; @0048                               trap table_oob
 ;;
 ;;                                 block7:
-;; @0036                               v12 = load.i64 notrap aligned v0+72
+;; @0048                               v12 = load.i64 notrap aligned v0+72
 ;;                                     v79 = iconst.i8 0
 ;;                                     v70 = iconst.i64 8
-;; @0036                               v14 = iadd v12, v70  ; v70 = 8
-;; @0036                               v16 = select_spectre_guard v79, v12, v14  ; v79 = 0
-;; @0036                               v17 = load.i64 notrap aligned table v16
+;; @0048                               v14 = iadd v12, v70  ; v70 = 8
+;; @0048                               v16 = select_spectre_guard v79, v12, v14  ; v79 = 0
+;; @0048                               v17 = load.i64 notrap aligned table v16
 ;;                                     v58 = iconst.i64 -2
-;; @0036                               v18 = band v17, v58  ; v58 = -2
-;; @0036                               brif v17, block3(v18), block2
+;; @0048                               v18 = band v17, v58  ; v58 = -2
+;; @0048                               brif v17, block3(v18), block2
 ;;
 ;;                                 block2 cold:
-;; @0049                               v48 = load.i64 notrap aligned readonly v0+56
-;; @0049                               v49 = load.i64 notrap aligned readonly v48+72
-;; @002a                               v7 = iconst.i32 0
+;; @005b                               v48 = load.i64 notrap aligned readonly v0+56
+;; @005b                               v49 = load.i64 notrap aligned readonly v48+72
+;; @003c                               v7 = iconst.i32 0
 ;;                                     v28 -> v7
-;; @0034                               v8 = iconst.i32 1
-;; @0036                               v24 = call_indirect sig0, v49(v0, v7, v8)  ; v7 = 0, v8 = 1
-;; @0036                               jump block3(v24)
+;; @0046                               v8 = iconst.i32 1
+;; @0048                               v24 = call_indirect sig0, v49(v0, v7, v8)  ; v7 = 0, v8 = 1
+;; @0048                               jump block3(v24)
 ;;
 ;;                                 block3(v19: i64):
-;; @0038                               v25 = load.i64 null_reference aligned readonly v19+16
-;; @0038                               v26 = load.i64 notrap aligned readonly v19+32
-;; @0038                               v27 = call_indirect sig1, v25(v26, v0, v2, v3, v4, v5)
+;; @004a                               v25 = load.i64 null_reference aligned readonly v19+16
+;; @004a                               v26 = load.i64 notrap aligned readonly v19+32
+;; @004a                               v27 = call_indirect sig1, v25(v26, v0, v2, v3, v4, v5)
 ;;                                     v80 = iconst.i8 0
-;; @0049                               brif v80, block8, block9  ; v80 = 0
+;; @005b                               brif v80, block8, block9  ; v80 = 0
 ;;
 ;;                                 block8 cold:
-;; @0049                               trap table_oob
+;; @005b                               trap table_oob
 ;;
 ;;                                 block9:
-;; @0049                               v38 = load.i64 notrap aligned v0+72
+;; @005b                               v38 = load.i64 notrap aligned v0+72
 ;;                                     v81 = iconst.i8 0
 ;;                                     v78 = iconst.i64 16
-;; @0049                               v40 = iadd v38, v78  ; v78 = 16
-;; @0049                               v42 = select_spectre_guard v81, v38, v40  ; v81 = 0
-;; @0049                               v43 = load.i64 notrap aligned table v42
+;; @005b                               v40 = iadd v38, v78  ; v78 = 16
+;; @005b                               v42 = select_spectre_guard v81, v38, v40  ; v81 = 0
+;; @005b                               v43 = load.i64 notrap aligned table v42
 ;;                                     v82 = iconst.i64 -2
 ;;                                     v83 = band v43, v82  ; v82 = -2
-;; @0049                               brif v43, block5(v83), block4
+;; @005b                               brif v43, block5(v83), block4
 ;;
 ;;                                 block4 cold:
 ;;                                     v84 = load.i64 notrap aligned readonly v0+56
 ;;                                     v85 = load.i64 notrap aligned readonly v84+72
 ;;                                     v86 = iconst.i32 0
-;; @0047                               v34 = iconst.i32 2
-;; @0049                               v50 = call_indirect sig0, v85(v0, v86, v34)  ; v86 = 0, v34 = 2
-;; @0049                               jump block5(v50)
+;; @0059                               v34 = iconst.i32 2
+;; @005b                               v50 = call_indirect sig0, v85(v0, v86, v34)  ; v86 = 0, v34 = 2
+;; @005b                               jump block5(v50)
 ;;
 ;;                                 block5(v45: i64):
-;; @004b                               v51 = load.i64 null_reference aligned readonly v45+16
-;; @004b                               v52 = load.i64 notrap aligned readonly v45+32
-;; @004b                               v53 = call_indirect sig1, v51(v52, v0, v2, v3, v4, v5)
-;; @0054                               jump block1
+;; @005d                               v51 = load.i64 null_reference aligned readonly v45+16
+;; @005d                               v52 = load.i64 notrap aligned readonly v45+32
+;; @005d                               v53 = call_indirect sig1, v51(v52, v0, v2, v3, v4, v5)
+;; @0066                               jump block1
 ;;
 ;;                                 block1:
-;; @004f                               v55 = iadd.i32 v53, v27
+;; @0061                               v55 = iadd.i32 v53, v27
 ;;                                     v6 -> v55
-;; @0054                               return v55
+;; @0066                               return v55
+;; }
+;;
+;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     gv4 = load.i64 notrap aligned gv3+72
+;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast
+;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
+;;     sig2 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig3 = (i64 vmctx, i32 uext) -> i32 uext system_v
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
+;;                                     v21 -> v0
+;;                                     v25 -> v0
+;;                                     v52 -> v0
+;;                                     v56 -> v0
+;;                                     v66 -> v0
+;;                                     v69 -> v0
+;;                                     v35 -> v2
+;;                                     v36 -> v3
+;;                                     v37 -> v4
+;;                                     v38 -> v5
+;;                                     v72 = iconst.i8 0
+;; @0075                               brif v72, block6, block7  ; v72 = 0
+;;
+;;                                 block6 cold:
+;; @0075                               trap table_oob
+;;
+;;                                 block7:
+;; @0075                               v12 = load.i64 notrap aligned v0+72
+;;                                     v89 = iconst.i8 0
+;;                                     v80 = iconst.i64 8
+;; @0075                               v14 = iadd v12, v80  ; v80 = 8
+;; @0075                               v16 = select_spectre_guard v89, v12, v14  ; v89 = 0
+;; @0075                               v17 = load.i64 notrap aligned table v16
+;;                                     v68 = iconst.i64 -2
+;; @0075                               v18 = band v17, v68  ; v68 = -2
+;; @0075                               brif v17, block3(v18), block2
+;;
+;;                                 block2 cold:
+;; @0087                               v53 = load.i64 notrap aligned readonly v0+56
+;; @0087                               v54 = load.i64 notrap aligned readonly v53+72
+;; @0069                               v7 = iconst.i32 0
+;;                                     v33 -> v7
+;; @0073                               v8 = iconst.i32 1
+;; @0075                               v24 = call_indirect sig1, v54(v0, v7, v8)  ; v7 = 0, v8 = 1
+;; @0075                               jump block3(v24)
+;;
+;;                                 block3(v19: i64):
+;; @0075                               v28 = load.i32 icall_null aligned readonly v19+24
+;; @0075                               v26 = load.i64 notrap aligned readonly v0+64
+;; @0075                               v27 = load.i32 notrap aligned readonly v26
+;; @0075                               v29 = icmp eq v28, v27
+;; @0075                               brif v29, block9, block8
+;;
+;;                                 block8 cold:
+;; @0075                               trap bad_sig
+;;
+;;                                 block9:
+;; @0075                               v30 = load.i64 notrap aligned readonly v19+16
+;; @0075                               v31 = load.i64 notrap aligned readonly v19+32
+;; @0075                               v32 = call_indirect sig0, v30(v31, v0, v2, v3, v4, v5)
+;;                                     v90 = iconst.i8 0
+;; @0087                               brif v90, block10, block11  ; v90 = 0
+;;
+;;                                 block10 cold:
+;; @0087                               trap table_oob
+;;
+;;                                 block11:
+;; @0087                               v43 = load.i64 notrap aligned v0+72
+;;                                     v91 = iconst.i8 0
+;;                                     v88 = iconst.i64 16
+;; @0087                               v45 = iadd v43, v88  ; v88 = 16
+;; @0087                               v47 = select_spectre_guard v91, v43, v45  ; v91 = 0
+;; @0087                               v48 = load.i64 notrap aligned table v47
+;;                                     v92 = iconst.i64 -2
+;;                                     v93 = band v48, v92  ; v92 = -2
+;; @0087                               brif v48, block5(v93), block4
+;;
+;;                                 block4 cold:
+;;                                     v94 = load.i64 notrap aligned readonly v0+56
+;;                                     v95 = load.i64 notrap aligned readonly v94+72
+;;                                     v96 = iconst.i32 0
+;; @0085                               v39 = iconst.i32 2
+;; @0087                               v55 = call_indirect sig1, v95(v0, v96, v39)  ; v96 = 0, v39 = 2
+;; @0087                               jump block5(v55)
+;;
+;;                                 block5(v50: i64):
+;; @0087                               v59 = load.i32 icall_null aligned readonly v50+24
+;; @0087                               v60 = icmp eq v59, v27
+;; @0087                               brif v60, block13, block12
+;;
+;;                                 block12 cold:
+;; @0087                               trap bad_sig
+;;
+;;                                 block13:
+;; @0087                               v61 = load.i64 notrap aligned readonly v50+16
+;; @0087                               v62 = load.i64 notrap aligned readonly v50+32
+;; @0087                               v63 = call_indirect sig0, v61(v62, v0, v2, v3, v4, v5)
+;; @0091                               jump block1
+;;
+;;                                 block1:
+;; @008c                               v65 = iadd.i32 v63, v32
+;;                                     v6 -> v65
+;; @0091                               return v65
+;; }
+;;
+;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
+;;     gv0 = vmctx
+;;     gv1 = load.i64 notrap aligned readonly gv0+8
+;;     gv2 = load.i64 notrap aligned gv1
+;;     gv3 = vmctx
+;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast
+;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+;;     sig2 = (i64 vmctx, i32 uext) -> i32 uext system_v
+;;     stack_limit = gv2
+;;
+;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
+;;                                     v8 -> v0
+;;                                     v14 -> v0
+;; @009e                               v9 = load.i64 notrap aligned table v0+96
+;; @00a0                               v10 = load.i64 null_reference aligned readonly v9+16
+;; @00a0                               v11 = load.i64 notrap aligned readonly v9+32
+;; @00a0                               v12 = call_indirect sig0, v10(v11, v0, v2, v3, v4, v5)
+;; @00af                               v15 = load.i64 notrap aligned table v0+112
+;; @00b1                               v16 = load.i64 null_reference aligned readonly v15+16
+;; @00b1                               v17 = load.i64 notrap aligned readonly v15+32
+;; @00b1                               v18 = call_indirect sig0, v16(v17, v0, v2, v3, v4, v5)
+;; @00ba                               jump block1
+;;
+;;                                 block1:
+;; @00b5                               v19 = iadd.i32 v18, v12
+;;                                     v6 -> v19
+;; @00ba                               return v19
 ;; }

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -230,98 +230,78 @@
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;;                                     v21 -> v0
-;;                                     v25 -> v0
-;;                                     v52 -> v0
+;;                                     v47 -> v0
 ;;                                     v56 -> v0
-;;                                     v66 -> v0
-;;                                     v69 -> v0
-;;                                     v35 -> v2
-;;                                     v36 -> v3
-;;                                     v37 -> v4
-;;                                     v38 -> v5
-;;                                     v72 = iconst.i8 0
-;; @0075                               brif v72, block6, block7  ; v72 = 0
+;;                                     v59 -> v0
+;;                                     v30 -> v2
+;;                                     v31 -> v3
+;;                                     v32 -> v4
+;;                                     v33 -> v5
+;;                                     v62 = iconst.i8 0
+;; @0075                               brif v62, block6, block7  ; v62 = 0
 ;;
 ;;                                 block6 cold:
 ;; @0075                               trap table_oob
 ;;
 ;;                                 block7:
 ;; @0075                               v12 = load.i64 notrap aligned v0+72
-;;                                     v89 = iconst.i8 0
-;;                                     v80 = iconst.i64 8
-;; @0075                               v14 = iadd v12, v80  ; v80 = 8
-;; @0075                               v16 = select_spectre_guard v89, v12, v14  ; v89 = 0
+;;                                     v79 = iconst.i8 0
+;;                                     v70 = iconst.i64 8
+;; @0075                               v14 = iadd v12, v70  ; v70 = 8
+;; @0075                               v16 = select_spectre_guard v79, v12, v14  ; v79 = 0
 ;; @0075                               v17 = load.i64 notrap aligned table v16
-;;                                     v68 = iconst.i64 -2
-;; @0075                               v18 = band v17, v68  ; v68 = -2
+;;                                     v58 = iconst.i64 -2
+;; @0075                               v18 = band v17, v58  ; v58 = -2
 ;; @0075                               brif v17, block3(v18), block2
 ;;
 ;;                                 block2 cold:
-;; @0087                               v53 = load.i64 notrap aligned readonly v0+56
-;; @0087                               v54 = load.i64 notrap aligned readonly v53+72
+;; @0087                               v48 = load.i64 notrap aligned readonly v0+56
+;; @0087                               v49 = load.i64 notrap aligned readonly v48+72
 ;; @0069                               v7 = iconst.i32 0
-;;                                     v33 -> v7
+;;                                     v28 -> v7
 ;; @0073                               v8 = iconst.i32 1
-;; @0075                               v24 = call_indirect sig1, v54(v0, v7, v8)  ; v7 = 0, v8 = 1
+;; @0075                               v24 = call_indirect sig1, v49(v0, v7, v8)  ; v7 = 0, v8 = 1
 ;; @0075                               jump block3(v24)
 ;;
 ;;                                 block3(v19: i64):
-;; @0075                               v28 = load.i32 icall_null aligned readonly v19+24
-;; @0075                               v26 = load.i64 notrap aligned readonly v0+64
-;; @0075                               v27 = load.i32 notrap aligned readonly v26
-;; @0075                               v29 = icmp eq v28, v27
-;; @0075                               brif v29, block9, block8
+;; @0075                               v25 = load.i64 icall_null aligned readonly v19+16
+;; @0075                               v26 = load.i64 notrap aligned readonly v19+32
+;; @0075                               v27 = call_indirect sig0, v25(v26, v0, v2, v3, v4, v5)
+;;                                     v80 = iconst.i8 0
+;; @0087                               brif v80, block8, block9  ; v80 = 0
 ;;
 ;;                                 block8 cold:
-;; @0075                               trap bad_sig
-;;
-;;                                 block9:
-;; @0075                               v30 = load.i64 notrap aligned readonly v19+16
-;; @0075                               v31 = load.i64 notrap aligned readonly v19+32
-;; @0075                               v32 = call_indirect sig0, v30(v31, v0, v2, v3, v4, v5)
-;;                                     v90 = iconst.i8 0
-;; @0087                               brif v90, block10, block11  ; v90 = 0
-;;
-;;                                 block10 cold:
 ;; @0087                               trap table_oob
 ;;
-;;                                 block11:
-;; @0087                               v43 = load.i64 notrap aligned v0+72
-;;                                     v91 = iconst.i8 0
-;;                                     v88 = iconst.i64 16
-;; @0087                               v45 = iadd v43, v88  ; v88 = 16
-;; @0087                               v47 = select_spectre_guard v91, v43, v45  ; v91 = 0
-;; @0087                               v48 = load.i64 notrap aligned table v47
-;;                                     v92 = iconst.i64 -2
-;;                                     v93 = band v48, v92  ; v92 = -2
-;; @0087                               brif v48, block5(v93), block4
+;;                                 block9:
+;; @0087                               v38 = load.i64 notrap aligned v0+72
+;;                                     v81 = iconst.i8 0
+;;                                     v78 = iconst.i64 16
+;; @0087                               v40 = iadd v38, v78  ; v78 = 16
+;; @0087                               v42 = select_spectre_guard v81, v38, v40  ; v81 = 0
+;; @0087                               v43 = load.i64 notrap aligned table v42
+;;                                     v82 = iconst.i64 -2
+;;                                     v83 = band v43, v82  ; v82 = -2
+;; @0087                               brif v43, block5(v83), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v94 = load.i64 notrap aligned readonly v0+56
-;;                                     v95 = load.i64 notrap aligned readonly v94+72
-;;                                     v96 = iconst.i32 0
-;; @0085                               v39 = iconst.i32 2
-;; @0087                               v55 = call_indirect sig1, v95(v0, v96, v39)  ; v96 = 0, v39 = 2
-;; @0087                               jump block5(v55)
+;;                                     v84 = load.i64 notrap aligned readonly v0+56
+;;                                     v85 = load.i64 notrap aligned readonly v84+72
+;;                                     v86 = iconst.i32 0
+;; @0085                               v34 = iconst.i32 2
+;; @0087                               v50 = call_indirect sig1, v85(v0, v86, v34)  ; v86 = 0, v34 = 2
+;; @0087                               jump block5(v50)
 ;;
-;;                                 block5(v50: i64):
-;; @0087                               v59 = load.i32 icall_null aligned readonly v50+24
-;; @0087                               v60 = icmp eq v59, v27
-;; @0087                               brif v60, block13, block12
-;;
-;;                                 block12 cold:
-;; @0087                               trap bad_sig
-;;
-;;                                 block13:
-;; @0087                               v61 = load.i64 notrap aligned readonly v50+16
-;; @0087                               v62 = load.i64 notrap aligned readonly v50+32
-;; @0087                               v63 = call_indirect sig0, v61(v62, v0, v2, v3, v4, v5)
+;;                                 block5(v45: i64):
+;; @0087                               v51 = load.i64 icall_null aligned readonly v45+16
+;; @0087                               v52 = load.i64 notrap aligned readonly v45+32
+;; @0087                               v53 = call_indirect sig0, v51(v52, v0, v2, v3, v4, v5)
 ;; @0091                               jump block1
 ;;
 ;;                                 block1:
-;; @008c                               v65 = iadd.i32 v63, v32
-;;                                     v6 -> v65
-;; @0091                               return v65
+;; @008c                               v55 = iadd.i32 v53, v27
+;;                                     v6 -> v55
+;; @0091                               return v55
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {

--- a/tests/misc_testsuite/function-references/call_indirect.wast
+++ b/tests/misc_testsuite/function-references/call_indirect.wast
@@ -1,0 +1,54 @@
+(module
+  (table $t1 2 funcref)
+  (elem (table $t1) (i32.const 0) func $nop)
+  (func $nop)
+
+  (func (export "t1") (param i32)
+    local.get 0
+    call_indirect $t1)
+  (func (export "t1-wrong-type") (param i32)
+    i32.const 0
+    local.get 0
+    call_indirect $t1 (param i32))
+
+  (type $empty (func))
+  (table $t2 2 (ref null $empty))
+  (elem (table $t2) (i32.const 0) (ref null $empty) (ref.func $nop))
+
+  (func (export "t2") (param i32)
+    local.get 0
+    call_indirect $t2)
+  (func (export "t2-wrong-type") (param i32)
+    i32.const 0
+    local.get 0
+    call_indirect $t2 (param i32))
+
+  (table $t3 2 (ref $empty) (ref.func $nop))
+
+  (func (export "t3") (param i32)
+    local.get 0
+    call_indirect $t3)
+  (func (export "t3-wrong-type") (param i32)
+    i32.const 0
+    local.get 0
+    call_indirect $t3 (param i32))
+)
+
+(assert_return (invoke "t1" (i32.const 0)))
+(assert_trap (invoke "t1" (i32.const 1)) "uninitialized element")
+(assert_trap (invoke "t1" (i32.const 2)) "out of bounds")
+(assert_trap (invoke "t1-wrong-type" (i32.const 0)) "call type mismatch")
+(assert_trap (invoke "t1-wrong-type" (i32.const 1)) "uninitialized element")
+(assert_trap (invoke "t1-wrong-type" (i32.const 2)) "out of bounds")
+(assert_return (invoke "t2" (i32.const 0)))
+(assert_trap (invoke "t2" (i32.const 1)) "uninitialized element")
+(assert_trap (invoke "t2" (i32.const 2)) "out of bounds")
+(assert_trap (invoke "t2-wrong-type" (i32.const 0)) "call type mismatch")
+(assert_trap (invoke "t2-wrong-type" (i32.const 1)) "uninitialized element")
+(assert_trap (invoke "t2-wrong-type" (i32.const 2)) "out of bounds")
+(assert_return (invoke "t3" (i32.const 0)))
+(assert_return (invoke "t3" (i32.const 1)))
+(assert_trap (invoke "t3" (i32.const 2)) "out of bounds")
+(assert_trap (invoke "t3-wrong-type" (i32.const 0)) "call type mismatch")
+(assert_trap (invoke "t3-wrong-type" (i32.const 1)) "call type mismatch")
+(assert_trap (invoke "t3-wrong-type" (i32.const 2)) "out of bounds")


### PR DESCRIPTION
This commit implements an optimization to skip type checks in
`call_indirect` for tables that don't require it. With the
function-references proposal it's possible to have tables of a single
type of function as opposed to today's default `funcref` which is a
heterogenous set of functions. In this situation it's possible that a
`call_indirect`'s type tag matches the type tag of a
`table`-of-typed-`funcref`-values, meaning that it's impossible for the
type check to fail.

The type check of a function pointer in `call_indirect` is refactored
here to take the table's type into account. Various things are shuffled
around to ensure that the right traps still show up in the right places
but the important part is that, when possible, the type check is omitted
entirely.