### PR TITLE
PCC: add facts to all relevant iconsts to handle propagation through opts.

### DIFF
--- a/cranelift/codegen/src/context.rs
+++ b/cranelift/codegen/src/context.rs
@@ -365,6 +365,7 @@ impl Context {
             "About to optimize with egraph phase:\n{}",
             self.func.display()
         );
+        let fisa = fisa.into();
         self.compute_loop_analysis();
         let mut alias_analysis = AliasAnalysis::new(&self.func, &self.domtree);
         let mut pass = EgraphPass::new(
@@ -372,6 +373,7 @@ impl Context {
             &self.domtree,
             &self.loop_analysis,
             &mut alias_analysis,
+            &fisa.flags,
             ctrl_plane,
         );
         pass.run();

--- a/cranelift/filetests/filetests/pcc/succeed/uextend-add-iconst.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/uextend-add-iconst.clif
@@ -1,0 +1,119 @@
+test compile
+set enable_pcc=true
+set opt_level=speed
+target x86_64
+
+;; v110 is a uextend'd iconst; v111 is a memtype base; v112 is that
+;; base plus that fixed offset, and should be able to verify that its
+;; offset is in 0..4GiB. In the fuzzbug that inspired this test, we
+;; had a bare `iconst` with no range fact on it after optimization.
+
+function u0:2(i64 vmctx, i64, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> i32, i32, i32, i32, i32, i32 fast {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned readonly gv0+8
+    gv2 = load.i64 notrap aligned gv1
+    gv3 ! mem(mt0, 0x0, 0x0) = vmctx
+    gv4 ! mem(mt1, 0x0, 0x0) = load.i64 notrap aligned readonly checked gv3+96
+    mt0 = struct 104 { 96: i64 readonly ! mem(mt1, 0x0, 0x0) }
+    mt1 = memory 0x180000000
+    sig0 = (i64 vmctx, i32 uext) system_v
+    sig1 = (i64 vmctx, i32 uext, i32 uext, i32 uext) -> i32 uext system_v
+    sig2 = (i64 vmctx, i32 uext, i32 uext) -> i32 uext system_v
+    sig3 = (i64 vmctx, i32 uext) -> i32 uext system_v
+    stack_limit = gv2
+
+block0(v0 ! mem(mt0, 0x0, 0x0): i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v8: i32, v9: i32, v10: i32, v11: i32, v12: i32, v13: i32, v14: i32, v15: i32, v16: i32, v17: i32, v18: i32, v19: i32, v20: i32, v21: i32):
+    v77 -> v0
+    v81 -> v0
+    v85 -> v0
+    v87 -> v0
+    v91 -> v0
+    v95 -> v0
+    v97 -> v0
+    v130 -> v0
+    v78 = load.i32 notrap aligned table v77+176
+    v127 = iconst.i32 0
+    v79 = icmp eq v78, v127  ; v127 = 0
+    v80 = uextend.i32 v79
+    brif v80, block2, block3
+
+block2:
+    trap unreachable
+
+block3:
+    v82 = load.i32 notrap aligned table v81+176
+    v83 = iconst.i32 1
+    v84 = isub v82, v83  ; v83 = 1
+    store notrap aligned table v84, v85+176
+    jump block4
+
+block4:
+    v88 = load.i32 notrap aligned table v87+176
+    v128 = iconst.i32 0
+    v89 = icmp eq v88, v128  ; v128 = 0
+    v90 = uextend.i32 v89
+    brif v90, block6, block7
+
+block6:
+    trap unreachable
+
+block7:
+    v92 = load.i32 notrap aligned table v91+176
+    v93 = iconst.i32 1
+    v94 = isub v92, v93  ; v93 = 1
+    store notrap aligned table v94, v95+176
+    v96 = iconst.i32 0xffff_3234
+    v98 = load.i64 notrap aligned v97+104
+    v129 = iconst.i64 0x0001_0000
+    v99 = udiv v98, v129  ; v129 = 0x0001_0000
+    v100 = ireduce.i32 v99
+    v101 = iconst.i32 0x0001_0000
+    v102 = imul v100, v101  ; v101 = 0x0001_0000
+    v103 = iconst.i32 0x0005_ffee
+    v104 = iadd v103, v96  ; v103 = 0x0005_ffee, v96 = 0xffff_3234
+    v105 = icmp ule v102, v104
+    v106 = uextend.i32 v105
+    brif v106, block9, block10
+
+block10:
+    v107 = iconst.i32 0
+    v108 = icmp.i32 sle v96, v107  ; v96 = 0xffff_3234, v107 = 0
+    v109 = uextend.i32 v108
+    brif v109, block9, block11
+
+block11:
+    v110 ! range(64, 0x0, 0xffffffff) = uextend.i64 v96  ; v96 = 0xffff_3234
+    v111 ! mem(mt1, 0x0, 0x0) = load.i64 notrap aligned readonly checked v130+96
+    v112 ! mem(mt1, 0x0, 0xffffffff) = iadd v111, v110
+    v113 ! range(64, 0x5ffe6, 0x5ffe6) = iconst.i64 0x0005_ffe6
+    v114 ! mem(mt1, 0x5ffe6, 0x10005ffe5) = iadd v112, v113  ; v113 = 0x0005_ffe6
+    v115 = uload8.i64 little checked heap v114
+    jump block8(v115)
+
+block9:
+    v116 = iconst.i64 0
+    jump block8(v116)  ; v116 = 0
+
+block8(v117: i64):
+    v118 = fcvt_from_uint.f32 v117
+    v86 -> v118
+    jump block5
+
+block5:
+    v121 = iconst.i32 0
+    v22 -> v121
+    v122 = iconst.i32 0
+    v23 -> v122
+    v123 = iconst.i32 0
+    v24 -> v123
+    v124 = iconst.i32 0
+    v25 -> v124
+    v125 = iconst.i32 0
+    v26 -> v125
+    v126 = iconst.i32 0
+    v27 -> v126
+    jump block1
+
+block1:
+    return v22, v23, v24, v25, v26, v27  ; v22 = 0, v23 = 0, v24 = 0, v25 = 0, v26 = 0, v27 = 0
+}


### PR DESCRIPTION
We have various constant-propagation/folding rules in the mid-end that generate new `iconst`s in place of other expressions. We got a fuzzbug with PCC wherein it was not able to verify that an iadd-iadd-uextend combination generating a Wasm address was in-range when rules reassociated the iadds to put constants together. Rather than carefully augment all rules to propagate constant facts only where they exist on the inputs, I opted to add a hook to the optimizer to generate brand-new assertions on *all* iconsts that we insert. This adds a little more work during verification (not too much hopefully: it's pretty low-overhead to check that `mov $1, %rax` puts `1` in `rax`) but should provide broader coverage of interesting corner-cases where optimization breaks the PCC chain.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67432.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
