### PR TITLE
PCC: x64: 32- and 64-bit XMM loads/stores are 32 and 64 bits, respectively.

### DIFF
--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -4,7 +4,7 @@ use crate::ir::pcc::*;
 use crate::ir::types::*;
 use crate::isa::x64::args::AvxOpcode;
 use crate::isa::x64::inst::args::{
-    AluRmiROpcode, Amode, Gpr, Imm8Reg, RegMem, RegMemImm, ShiftKind, SyntheticAmode,
+    AluRmiROpcode, Amode, Gpr, Imm8Reg, RegMem, RegMemImm, ShiftKind, SseOpcode, SyntheticAmode,
     ToWritableReg, CC,
 };
 use crate::isa::x64::inst::Inst;
@@ -545,6 +545,35 @@ pub(crate) fn check(
             ensure_no_fact(vcode, dst.to_writable_reg().to_reg())
         }
 
+        Inst::XmmUnaryRmRUnaligned {
+            dst,
+            ref src,
+            op: SseOpcode::Movss,
+            ..
+        } => {
+            match <&RegMem>::from(src) {
+                RegMem::Mem { ref addr } => {
+                    check_load(ctx, None, addr, vcode, F32, 32)?;
+                }
+                RegMem::Reg { .. } => {}
+            }
+            ensure_no_fact(vcode, dst.to_writable_reg().to_reg())
+        }
+        Inst::XmmUnaryRmRUnaligned {
+            dst,
+            ref src,
+            op: SseOpcode::Movsd,
+            ..
+        } => {
+            match <&RegMem>::from(src) {
+                RegMem::Mem { ref addr } => {
+                    check_load(ctx, None, addr, vcode, F64, 64)?;
+                }
+                RegMem::Reg { .. } => {}
+            }
+            ensure_no_fact(vcode, dst.to_writable_reg().to_reg())
+        }
+
         // NOTE: it's assumed that all of these cases perform 128-bit loads, but this hasn't been
         // verified. The effect of this will be spurious PCC failures when these instructions are
         // involved.
@@ -597,17 +626,17 @@ pub(crate) fn check(
             src: ref src2,
             ..
         } => {
-            let size = match op {
-                AvxOpcode::Vmovss => 32,
-                AvxOpcode::Vmovsd => 64,
+            let (ty, size) = match op {
+                AvxOpcode::Vmovss => (F32, 32),
+                AvxOpcode::Vmovsd => (F64, 64),
 
                 // We assume all other operations happen on 128-bit values.
-                _ => 128,
+                _ => (I8X16, 128),
             };
 
             match <&RegMem>::from(src2) {
                 RegMem::Mem { ref addr } => {
-                    check_load(ctx, None, addr, vcode, I8X16, size)?;
+                    check_load(ctx, None, addr, vcode, ty, size)?;
                 }
                 RegMem::Reg { .. } => {}
             }
@@ -651,6 +680,24 @@ pub(crate) fn check(
         }
 
         Inst::XmmToGprVex { dst, .. } => undefined_result(ctx, vcode, dst, 64, 64),
+
+        Inst::XmmMovRM {
+            ref dst,
+            op: SseOpcode::Movss,
+            ..
+        } => {
+            check_store(ctx, None, dst, vcode, F32)?;
+            Ok(())
+        }
+
+        Inst::XmmMovRM {
+            ref dst,
+            op: SseOpcode::Movsd,
+            ..
+        } => {
+            check_store(ctx, None, dst, vcode, F64)?;
+            Ok(())
+        }
 
         Inst::XmmMovRM { ref dst, .. } | Inst::XmmMovRMImm { ref dst, .. } => {
             check_store(ctx, None, dst, vcode, I8X16)?;

--- a/cranelift/filetests/filetests/pcc/succeed/fuzz-float-loads.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/fuzz-float-loads.clif
@@ -1,0 +1,86 @@
+test compile
+set enable_pcc=true
+set opt_level=speed
+target x86_64
+
+function u0:0(i64 vmctx, i64) fast {
+    gv0 = vmctx
+    gv1 = load.i64 notrap aligned readonly gv0+8
+    gv2 = load.i64 notrap aligned gv1
+    gv3 ! mem(mt0, 0x0, 0x0) = vmctx
+    gv4 ! mem(mt1, 0x0, 0x0) = load.i64 notrap aligned readonly checked gv3+80
+    mt0 = struct 88 { 80: i64 readonly ! mem(mt1, 0x0, 0x0) }
+    mt1 = memory 0x180000000
+    sig0 = (i64 vmctx) system_v
+    sig1 = (i64 vmctx, i32 uext) system_v
+    sig2 = (i64 vmctx, i32 uext, i32 uext, i32 uext) -> i32 uext system_v
+    const0 = 0x02030077ff00ff04030077ff6cff5503
+    stack_limit = gv2
+
+block0(v0: i64, v1: i64):
+    v2 = iconst.i32 0
+    v25 -> v2
+    v45 -> v2
+    v24 -> v25
+    v3 = null.r64
+    v4 = global_value.i64 gv3
+    v5 = load.i64 notrap aligned v4+8
+    v17 -> v5
+    v44 -> v5
+    v42 -> v17
+    v6 = load.i64 notrap aligned v5+8
+    v7 = iadd_imm v6, 1
+    v8 = iconst.i64 0
+    v9 = icmp sge v7, v8  ; v8 = 0
+    brif v9, block2, block3(v7)
+
+block2:
+    store.i64 notrap aligned v7, v5+8
+    v10 = global_value.i64 gv3
+    v11 = load.i64 notrap aligned readonly v10+56
+    v12 = load.i64 notrap aligned readonly v11+120
+    call_indirect sig0, v12(v10)
+    v13 = load.i64 notrap aligned v5+8
+    jump block3(v13)
+
+block3(v43: i64):
+    v15 -> v43
+    jump block4
+
+block4:
+    v14 = iconst.i64 0
+    v16 = icmp.i64 sge v15, v14  ; v14 = 0
+    brif v16, block6, block7(v15)
+
+block6:
+    store.i64 notrap aligned v15, v17+8
+    v18 = global_value.i64 gv3
+    v19 = load.i64 notrap aligned readonly v18+56
+    v20 = load.i64 notrap aligned readonly v19+120
+    call_indirect sig0, v20(v18)
+    v21 = load.i64 notrap aligned v17+8
+    jump block7(v21)
+
+block7(v40: i64):
+    v22 = vconst.i8x16 const0
+    v23 = uwiden_high v22  ; v22 = const0
+    v26 = bitcast.i8x16 little v23
+    v27 = sshr v26, v25  ; v25 = 0
+    v28 = bitcast.i64x2 little v27
+    v29 = extractlane v28, 1
+    v30 = iconst.i32 1
+    v31 = global_value.i64 gv3
+    v32 = load.i64 notrap aligned readonly v31+56
+    v33 = load.i64 notrap aligned readonly v32+24
+    call_indirect sig1, v33(v31, v30)  ; v30 = 1
+    v34 = ireduce.i32 v29
+    v35 ! range(64, 0x0, 0xffffffff) = uextend.i64 v34
+    v36 ! mem(mt1, 0x0, 0x0) = global_value.i64 gv4
+    v37 ! mem(mt1, 0x0, 0xffffffff) = iadd v36, v35
+    v38 = load.f64 little checked heap v37
+    v39 = f64const 0x0.0000000005b28p-1022
+    v41 = iadd_imm v40, 9
+    store notrap aligned v41, v17+8
+    trap unreachable
+}
+

--- a/tests/disas/pcc-loads-x64-avx.wat
+++ b/tests/disas/pcc-loads-x64-avx.wat
@@ -1,0 +1,95 @@
+;;! target = "x86_64"
+;;! test = "compile"
+;;! flags = [ "-Oopt-level=2", "-Cpcc=y", "-Ccranelift-has-avx=true" ]
+
+(module
+  (memory 1 1)
+  (func (export "load_f32") (param i32) (result f32)
+    local.get 0
+    f32.load)
+  (func (export "load_f64") (param i32) (result f64)
+    local.get 0
+    f64.load)
+  (func (export "store_f32") (param i32 f32)
+    local.get 0
+    local.get 1
+    f32.store)
+  (func (export "store_f64") (param i32 f64)
+    local.get 0
+    local.get 1
+    f64.store))
+;; function u0:0:
+;;   pushq   %rbp
+;;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
+;;   movq    %rsp, %rbp
+;;   movq    8(%rdi), %r10
+;;   movq    0(%r10), %r10
+;;   cmpq    %rsp, %r10
+;;   jnbe #trap=stk_ovf
+;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
+;; block0:
+;;   movq    80(%rdi), %r9
+;;   movl    %edx, %r10d
+;;   vmovss  0(%r9,%r10,1), %xmm0
+;;   jmp     label1
+;; block1:
+;;   movq    %rbp, %rsp
+;;   popq    %rbp
+;;   ret
+;;
+;; function u0:1:
+;;   pushq   %rbp
+;;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
+;;   movq    %rsp, %rbp
+;;   movq    8(%rdi), %r10
+;;   movq    0(%r10), %r10
+;;   cmpq    %rsp, %r10
+;;   jnbe #trap=stk_ovf
+;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
+;; block0:
+;;   movq    80(%rdi), %r9
+;;   movl    %edx, %r10d
+;;   vmovsd  0(%r9,%r10,1), %xmm0
+;;   jmp     label1
+;; block1:
+;;   movq    %rbp, %rsp
+;;   popq    %rbp
+;;   ret
+;;
+;; function u0:2:
+;;   pushq   %rbp
+;;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
+;;   movq    %rsp, %rbp
+;;   movq    8(%rdi), %r10
+;;   movq    0(%r10), %r10
+;;   cmpq    %rsp, %r10
+;;   jnbe #trap=stk_ovf
+;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
+;; block0:
+;;   movq    80(%rdi), %r9
+;;   movl    %edx, %r10d
+;;   vmovss  %xmm0, 0(%r9,%r10,1)
+;;   jmp     label1
+;; block1:
+;;   movq    %rbp, %rsp
+;;   popq    %rbp
+;;   ret
+;;
+;; function u0:3:
+;;   pushq   %rbp
+;;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
+;;   movq    %rsp, %rbp
+;;   movq    8(%rdi), %r10
+;;   movq    0(%r10), %r10
+;;   cmpq    %rsp, %r10
+;;   jnbe #trap=stk_ovf
+;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
+;; block0:
+;;   movq    80(%rdi), %r9
+;;   movl    %edx, %r10d
+;;   vmovsd  %xmm0, 0(%r9,%r10,1)
+;;   jmp     label1
+;; block1:
+;;   movq    %rbp, %rsp
+;;   popq    %rbp
+;;   ret

--- a/tests/disas/pcc-loads-x64.wat
+++ b/tests/disas/pcc-loads-x64.wat
@@ -1,0 +1,95 @@
+;;! target = "x86_64"
+;;! test = "compile"
+;;! flags = [ "-Oopt-level=2", "-Cpcc=y", "-Ccranelift-has-avx=false" ]
+
+(module
+  (memory 1 1)
+  (func (export "load_f32") (param i32) (result f32)
+    local.get 0
+    f32.load)
+  (func (export "load_f64") (param i32) (result f64)
+    local.get 0
+    f64.load)
+  (func (export "store_f32") (param i32 f32)
+    local.get 0
+    local.get 1
+    f32.store)
+  (func (export "store_f64") (param i32 f64)
+    local.get 0
+    local.get 1
+    f64.store))
+;; function u0:0:
+;;   pushq   %rbp
+;;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
+;;   movq    %rsp, %rbp
+;;   movq    8(%rdi), %r10
+;;   movq    0(%r10), %r10
+;;   cmpq    %rsp, %r10
+;;   jnbe #trap=stk_ovf
+;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
+;; block0:
+;;   movq    80(%rdi), %r9
+;;   movl    %edx, %r10d
+;;   movss   0(%r9,%r10,1), %xmm0
+;;   jmp     label1
+;; block1:
+;;   movq    %rbp, %rsp
+;;   popq    %rbp
+;;   ret
+;;
+;; function u0:1:
+;;   pushq   %rbp
+;;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
+;;   movq    %rsp, %rbp
+;;   movq    8(%rdi), %r10
+;;   movq    0(%r10), %r10
+;;   cmpq    %rsp, %r10
+;;   jnbe #trap=stk_ovf
+;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
+;; block0:
+;;   movq    80(%rdi), %r9
+;;   movl    %edx, %r10d
+;;   movsd   0(%r9,%r10,1), %xmm0
+;;   jmp     label1
+;; block1:
+;;   movq    %rbp, %rsp
+;;   popq    %rbp
+;;   ret
+;;
+;; function u0:2:
+;;   pushq   %rbp
+;;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
+;;   movq    %rsp, %rbp
+;;   movq    8(%rdi), %r10
+;;   movq    0(%r10), %r10
+;;   cmpq    %rsp, %r10
+;;   jnbe #trap=stk_ovf
+;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
+;; block0:
+;;   movq    80(%rdi), %r9
+;;   movl    %edx, %r10d
+;;   movss   %xmm0, 0(%r9,%r10,1)
+;;   jmp     label1
+;; block1:
+;;   movq    %rbp, %rsp
+;;   popq    %rbp
+;;   ret
+;;
+;; function u0:3:
+;;   pushq   %rbp
+;;   unwind PushFrameRegs { offset_upward_to_caller_sp: 16 }
+;;   movq    %rsp, %rbp
+;;   movq    8(%rdi), %r10
+;;   movq    0(%r10), %r10
+;;   cmpq    %rsp, %r10
+;;   jnbe #trap=stk_ovf
+;;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
+;; block0:
+;;   movq    80(%rdi), %r9
+;;   movl    %edx, %r10d
+;;   movsd   %xmm0, 0(%r9,%r10,1)
+;;   jmp     label1
+;; block1:
+;;   movq    %rbp, %rsp
+;;   popq    %rbp
+;;   ret


### PR DESCRIPTION
These are definitely not 128 bits wide; let's make the PCC model aware of that!

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67427.