### PR TITLE
Canonicalize fpromote/fdemote operations

### DIFF
--- a/cranelift/codegen/src/nan_canonicalization.rs
+++ b/cranelift/codegen/src/nan_canonicalization.rs
@@ -38,6 +38,8 @@ fn is_fp_arith(pos: &mut FuncCursor, inst: Inst) -> bool {
                 || opcode == Opcode::Nearest
                 || opcode == Opcode::Sqrt
                 || opcode == Opcode::Trunc
+                || opcode == Opcode::Fdemote
+                || opcode == Opcode::Fpromote
         }
         InstructionData::Binary { opcode, .. } => {
             opcode == Opcode::Fadd
@@ -48,24 +50,6 @@ fn is_fp_arith(pos: &mut FuncCursor, inst: Inst) -> bool {
                 || opcode == Opcode::Fsub
         }
         InstructionData::Ternary { opcode, .. } => opcode == Opcode::Fma,
-
-        // bitcasts coming from arbitrary integers need canonicalization as the
-        // integer isn't known to necessarily be a canonical NaN
-        InstructionData::LoadNoOffset {
-            opcode: Opcode::Bitcast,
-            arg,
-            flags: _,
-        } => {
-            let ret = pos.func.dfg.first_result(inst);
-            let ret_type = pos.func.dfg.value_type(ret);
-            let arg_type = pos.func.dfg.value_type(arg);
-            match (arg_type, ret_type) {
-                (types::I32, types::F32) => true,
-                (types::I64, types::F64) => true,
-                _ => false,
-            }
-        }
-
         _ => false,
     }
 }

--- a/tests/misc_testsuite/simd/canonicalize-nan.wast
+++ b/tests/misc_testsuite/simd/canonicalize-nan.wast
@@ -39,6 +39,24 @@
     f64.reinterpret_i64
     f32.demote_f64
     i32.reinterpret_f32)
+
+  (func (export "reinterpret-and-promote") (param i32) (result i64)
+    local.get 0
+    f32.reinterpret_i32
+    f64.promote_f32
+    i64.reinterpret_f64)
+
+  (func (export "copysign-and-demote") (param f64) (result f32)
+    local.get 0
+    f64.const -0x1
+    f64.copysign
+    f32.demote_f64)
+
+  (func (export "copysign-and-promote") (param f32) (result f64)
+    local.get 0
+    f32.const -0x1
+    f32.copysign
+    f64.promote_f32)
 )
 
 (assert_return (invoke "f32x4.floor" (v128.const f32x4 1 -2.2 3.4 nan))
@@ -65,3 +83,9 @@
 
 (assert_return (invoke "reinterpret-and-demote" (i64.const 0xfffefdfccccdcecf))
                (i32.const 0x7fc00000))
+(assert_return (invoke "reinterpret-and-promote" (i32.const 0xfffefdfc))
+               (i64.const 0x7ff8000000000000))
+(assert_return (invoke "copysign-and-demote" (f64.const nan))
+               (f32.const nan:0x7fc00000))
+(assert_return (invoke "copysign-and-promote" (f32.const nan))
+               (f64.const nan:0x7ff8000000000000))


### PR DESCRIPTION
This commit changes the strategy implemented in #8146 to canonicalize promotes/demotes of floats to additionally handle #8179.

Closes #8179

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
