### PR TITLE
doc: update wasmtime dep to the latest one

### DIFF
--- a/docs/lang-rust.md
+++ b/docs/lang-rust.md
@@ -36,12 +36,11 @@ $ cd wasmtime_hello
 
 Next you'll want to add `hello.wat` to the root of your project.
 
-We will be using the `wasmtime` crate to run the wasm file, so next up we need a
-dependency in `Cargo.toml`:
+We will be using the `wasmtime` crate to run the wasm file. Please execute the command `cargo add wasmtime` to use the latest version of the crate. The `dependencies` block in the `Cargo.toml` file will appear as follows:
 
 ```toml
 [dependencies]
-wasmtime = "1.0.0"
+wasmtime = "19.0.0"
 ```
 
 Next up let's write the code that we need to execute this wasm file. The


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

With the following dependencies:
```toml
[dependencies]
wasmtime = "1.0.0"
```

It will have the error:
```
-> # cargo run
    Updating crates.io index
   Compiling wasmtime_hello v0.1.0 (/root/workspace/git/wasmtimelearn/wasmtime_hello)
error[E0107]: method takes 3 generic arguments but 2 generic arguments were supplied
    --> src/main.rs:33:25
     |
33   |     let answer = answer.typed::<(), i32>(&store)?;
     |                         ^^^^^   --  --- supplied 2 generic arguments
     |                         |
     |                         expected 3 generic arguments
     |
note: method defined here, with 3 generic parameters: `Params`, `Results`, `S`
    --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wasmtime-1.0.2/src/func.rs:1200:12
     |
1200 |     pub fn typed<Params, Results, S>(&self, store: S) -> Result<TypedFunc<Params, Results>>
     |            ^^^^^ ------  -------  -
help: add missing generic argument
     |
33   |     let answer = answer.typed::<(), i32, S>(&store)?;
     |                                        +++

For more information about this error, try `rustc --explain E0107`.
error: could not compile `wasmtime_hello` (bin "wasmtime_hello") due to 1 previous error
```

Let's update to the latest wasmtime crate.