### PR TITLE
Bump MSRV to 1.75.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
 # current stable release of Rust minus 2.
-rust-version = "1.74.0"
+rust-version = "1.75.0"
 
 [workspace.lints.rust]
 # Turn on some lints which are otherwise allow-by-default in rustc.

--- a/crates/wasi-nn/src/backend/onnxruntime.rs
+++ b/crates/wasi-nn/src/backend/onnxruntime.rs
@@ -48,7 +48,7 @@ impl BackendFromDir for OnnxBackend {
     }
 }
 
-struct ONNXGraph(Arc<Mutex<Session>>, ExecutionTarget);
+struct ONNXGraph(Arc<Mutex<Session>>, #[allow(dead_code)] ExecutionTarget);
 
 unsafe impl Send for ONNXGraph {}
 unsafe impl Sync for ONNXGraph {}


### PR DESCRIPTION
Coupled with today's release of 1.77.0. Today's release actually has some nice functions and such I think we'll want to use in Wasmtime but we'll need to wait 3 months to be able to use them.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
