### PR TITLE
Use some new standard library methods from Rust 1.74, 1.75

### DIFF
--- a/crates/fiber/src/unix.rs
+++ b/crates/fiber/src/unix.rs
@@ -71,13 +71,13 @@ impl FiberStack {
             )?;
 
             rustix::mm::mprotect(
-                mmap.cast::<u8>().add(page_size).cast(),
+                mmap.byte_add(page_size).cast(),
                 size,
                 rustix::mm::MprotectFlags::READ | rustix::mm::MprotectFlags::WRITE,
             )?;
 
             Ok(Self::Default {
-                top: mmap.cast::<u8>().add(mmap_len),
+                top: mmap.byte_add(mmap_len).cast(),
                 len: mmap_len,
                 mmap: true,
             })

--- a/crates/runtime/src/component.rs
+++ b/crates/runtime/src/component.rs
@@ -156,8 +156,7 @@ impl ComponentInstance {
         f: impl FnOnce(&mut ComponentInstance) -> R,
     ) -> R {
         let ptr = vmctx
-            .cast::<u8>()
-            .sub(mem::size_of::<ComponentInstance>())
+            .byte_sub(mem::size_of::<ComponentInstance>())
             .cast::<ComponentInstance>();
         f(&mut *ptr)
     }
@@ -205,8 +204,7 @@ impl ComponentInstance {
                 vmctx_self_reference: SendSyncPtr::new(
                     NonNull::new(
                         ptr.as_ptr()
-                            .cast::<u8>()
-                            .add(mem::size_of::<ComponentInstance>())
+                            .byte_add(mem::size_of::<ComponentInstance>())
                             .cast(),
                     )
                     .unwrap(),
@@ -230,15 +228,13 @@ impl ComponentInstance {
 
     unsafe fn vmctx_plus_offset<T>(&self, offset: u32) -> *const T {
         self.vmctx()
-            .cast::<u8>()
-            .add(usize::try_from(offset).unwrap())
+            .byte_add(usize::try_from(offset).unwrap())
             .cast()
     }
 
     unsafe fn vmctx_plus_offset_mut<T>(&mut self, offset: u32) -> *mut T {
         self.vmctx()
-            .cast::<u8>()
-            .add(usize::try_from(offset).unwrap())
+            .byte_add(usize::try_from(offset).unwrap())
             .cast()
     }
 

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -189,9 +189,7 @@ impl Instance {
                 dropped_elements,
                 dropped_data,
                 host_state: req.host_state,
-                vmctx_self_reference: SendSyncPtr::new(
-                    NonNull::new(ptr.cast::<u8>().add(mem::size_of::<Instance>()).cast()).unwrap(),
-                ),
+                vmctx_self_reference: SendSyncPtr::new(NonNull::new(ptr.add(1).cast()).unwrap()),
                 vmctx: VMContext {
                     _marker: std::marker::PhantomPinned,
                 },
@@ -236,8 +234,7 @@ impl Instance {
     #[inline]
     pub unsafe fn from_vmctx<R>(vmctx: *mut VMContext, f: impl FnOnce(&mut Instance) -> R) -> R {
         let ptr = vmctx
-            .cast::<u8>()
-            .sub(mem::size_of::<Instance>())
+            .byte_sub(mem::size_of::<Instance>())
             .cast::<Instance>();
         f(&mut *ptr)
     }
@@ -251,16 +248,14 @@ impl Instance {
     /// `VMContext` object trailing this instance.
     unsafe fn vmctx_plus_offset<T>(&self, offset: u32) -> *const T {
         self.vmctx()
-            .cast::<u8>()
-            .add(usize::try_from(offset).unwrap())
+            .byte_add(usize::try_from(offset).unwrap())
             .cast()
     }
 
     /// Dual of `vmctx_plus_offset`, but for mutability.
     unsafe fn vmctx_plus_offset_mut<T>(&mut self, offset: u32) -> *mut T {
         self.vmctx()
-            .cast::<u8>()
-            .add(usize::try_from(offset).unwrap())
+            .byte_add(usize::try_from(offset).unwrap())
             .cast()
     }
 

--- a/crates/runtime/src/memory.rs
+++ b/crates/runtime/src/memory.rs
@@ -585,7 +585,7 @@ impl SharedMemory {
         // SAFETY: `addr_index` was validated by `validate_atomic_addr` above.
         assert!(std::mem::size_of::<AtomicU32>() == 4);
         assert!(std::mem::align_of::<AtomicU32>() <= 4);
-        let atomic = unsafe { &*(addr as *const AtomicU32) };
+        let atomic = unsafe { AtomicU32::from_ptr(addr.cast()) };
 
         WAITER.with(|waiter| {
             let mut waiter = waiter.borrow_mut();
@@ -608,7 +608,7 @@ impl SharedMemory {
         // SAFETY: `addr_index` was validated by `validate_atomic_addr` above.
         assert!(std::mem::size_of::<AtomicU64>() == 8);
         assert!(std::mem::align_of::<AtomicU64>() <= 8);
-        let atomic = unsafe { &*(addr as *const AtomicU64) };
+        let atomic = unsafe { AtomicU64::from_ptr(addr.cast()) };
 
         WAITER.with(|waiter| {
             let mut waiter = waiter.borrow_mut();

--- a/crates/runtime/src/sys/custom/mmap.rs
+++ b/crates/runtime/src/sys/custom/mmap.rs
@@ -42,10 +42,10 @@ impl Mmap {
     }
 
     pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<()> {
-        let ptr = self.memory.as_ptr().cast::<u8>();
+        let ptr = self.memory.as_ptr();
         unsafe {
             cvt(capi::wasmtime_mprotect(
-                ptr.add(start).cast(),
+                ptr.byte_add(start).cast(),
                 len,
                 capi::PROT_READ | capi::PROT_WRITE,
             ))?;
@@ -74,7 +74,7 @@ impl Mmap {
         range: Range<usize>,
         enable_branch_protection: bool,
     ) -> Result<()> {
-        let base = self.memory.as_ptr().cast::<u8>().add(range.start).cast();
+        let base = self.memory.as_ptr().byte_add(range.start).cast();
         let len = range.end - range.start;
 
         // not mapped into the C API at this time.
@@ -89,7 +89,7 @@ impl Mmap {
     }
 
     pub unsafe fn make_readonly(&self, range: Range<usize>) -> Result<()> {
-        let base = self.memory.as_ptr().cast::<u8>().add(range.start).cast();
+        let base = self.memory.as_ptr().byte_add(range.start).cast();
         let len = range.end - range.start;
 
         cvt(capi::wasmtime_mprotect(base, len, capi::PROT_READ))?;

--- a/crates/runtime/src/sys/miri/mmap.rs
+++ b/crates/runtime/src/sys/miri/mmap.rs
@@ -51,7 +51,7 @@ impl Mmap {
         // The memory is technically always accessible but this marks it as
         // initialized for miri-level checking.
         unsafe {
-            std::ptr::write_bytes(self.memory.as_ptr().cast::<u8>().add(start), 0u8, len);
+            std::ptr::write_bytes(self.as_mut_ptr().add(start), 0u8, len);
         }
         Ok(())
     }

--- a/crates/runtime/src/sys/unix/mmap.rs
+++ b/crates/runtime/src/sys/unix/mmap.rs
@@ -72,10 +72,10 @@ impl Mmap {
     }
 
     pub fn make_accessible(&mut self, start: usize, len: usize) -> Result<()> {
-        let ptr = self.memory.as_ptr().cast::<u8>();
+        let ptr = self.memory.as_ptr();
         unsafe {
             mprotect(
-                ptr.add(start).cast(),
+                ptr.byte_add(start).cast(),
                 len,
                 MprotectFlags::READ | MprotectFlags::WRITE,
             )?;
@@ -104,7 +104,7 @@ impl Mmap {
         range: Range<usize>,
         enable_branch_protection: bool,
     ) -> Result<()> {
-        let base = self.memory.as_ptr().cast::<u8>().add(range.start).cast();
+        let base = self.memory.as_ptr().byte_add(range.start).cast();
         let len = range.end - range.start;
 
         let flags = MprotectFlags::READ | MprotectFlags::EXEC;
@@ -128,7 +128,7 @@ impl Mmap {
     }
 
     pub unsafe fn make_readonly(&self, range: Range<usize>) -> Result<()> {
-        let base = self.memory.as_ptr().cast::<u8>().add(range.start).cast();
+        let base = self.memory.as_ptr().byte_add(range.start).cast();
         let len = range.end - range.start;
 
         mprotect(base, len, MprotectFlags::READ)?;

--- a/tests/all/memory.rs
+++ b/tests/all/memory.rs
@@ -609,8 +609,8 @@ fn shared_memory_wait_notify() -> Result<()> {
 
     let engine = Engine::default();
     let memory = SharedMemory::new(&engine, MemoryType::shared(1, 1))?;
-    let data = unsafe { &*(memory.data().as_ptr() as *const AtomicU32) };
-    let locked = unsafe { &*(memory.data().as_ptr().add(4) as *const AtomicU32) };
+    let data = unsafe { AtomicU32::from_ptr(memory.data().as_ptr().cast_mut().cast()) };
+    let locked = unsafe { AtomicU32::from_ptr(memory.data().as_ptr().add(4).cast_mut().cast()) };
 
     // Note that `SeqCst` is used here to not think much about the orderings
     // here, and it also somewhat more closely mirrors what's happening in wasm.


### PR DESCRIPTION
Helps clean up some code with some newer nice methods in the Rust standard library.