### PR TITLE
winch: Remove unused functions after trampoline refactoring

### DIFF
--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -47,7 +47,7 @@
 //! |                               |
 use crate::codegen::ptr_type_from_ptr_size;
 use crate::isa::{reg::Reg, CallingConvention};
-use crate::masm::{OperandSize, SPOffset};
+use crate::masm::SPOffset;
 use smallvec::SmallVec;
 use std::collections::HashSet;
 use std::ops::{Add, BitAnd, Not, Sub};
@@ -161,11 +161,6 @@ pub(crate) trait ABI {
     /// Returns the pinned register used to hold
     /// the `VMContext`.
     fn vmctx_reg() -> Reg;
-
-    /// Returns the callee-saved registers for the given
-    /// calling convention.
-    #[allow(unused)]
-    fn callee_saved_regs(call_conv: &CallingConvention) -> SmallVec<[(Reg, OperandSize); 18]>;
 
     /// The size, in bytes, of each stack slot used for stack parameter passing.
     fn stack_slot_size() -> u8;

--- a/winch/codegen/src/abi/mod.rs
+++ b/winch/codegen/src/abi/mod.rs
@@ -101,10 +101,6 @@ pub(crate) trait ABI {
     /// The offset to the argument base, relative to the frame pointer.
     fn arg_base_offset() -> u8;
 
-    /// The offset to the return address, relative to the frame pointer.
-    #[allow(unused)]
-    fn ret_addr_offset() -> u8;
-
     /// Construct the ABI-specific signature from a WebAssembly
     /// function type.
     #[cfg(test)]
@@ -149,14 +145,6 @@ pub(crate) trait ABI {
             _ => unimplemented!(),
         }
     }
-
-    /// Returns the frame pointer register.
-    #[allow(unused)]
-    fn fp_reg() -> Reg;
-
-    /// Returns the stack pointer register.
-    #[allow(unused)]
-    fn sp_reg() -> Reg;
 
     /// Returns the pinned register used to hold
     /// the `VMContext`.

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -94,9 +94,8 @@ where
             .unwrap_reg()
             .into();
 
-        // We need to use the vmctx paramter before pinning it for stack checking, and we don't
-        // have any callee save registers in the winch calling convention.
-        self.masm.prologue(vmctx, &[]);
+        // We need to use the vmctx paramter before pinning it for stack checking.
+        self.masm.prologue(vmctx);
 
         // Pin the `VMContext` pointer.
         self.masm
@@ -317,7 +316,7 @@ where
         }
         debug_assert_eq!(self.context.stack.len(), 0);
         self.masm.free_stack(self.context.frame.locals_size);
-        self.masm.epilogue(&[]);
+        self.masm.epilogue();
         Ok(())
     }
 

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -1,8 +1,6 @@
 use super::regs;
 use crate::abi::{align_to, ABIOperand, ABIParams, ABIResults, ABISig, ParamsOrReturns, ABI};
 use crate::isa::{reg::Reg, CallingConvention};
-use crate::masm::OperandSize;
-use smallvec::SmallVec;
 use wasmtime_environ::{WasmHeapType, WasmValType};
 
 #[derive(Default)]
@@ -137,10 +135,6 @@ impl ABI for Aarch64ABI {
 
     fn vmctx_reg() -> Reg {
         regs::xreg(9)
-    }
-
-    fn callee_saved_regs(_call_conv: &CallingConvention) -> SmallVec<[(Reg, OperandSize); 18]> {
-        regs::callee_saved()
     }
 
     fn stack_slot_size() -> u8 {

--- a/winch/codegen/src/isa/aarch64/abi.rs
+++ b/winch/codegen/src/isa/aarch64/abi.rs
@@ -73,10 +73,6 @@ impl ABI for Aarch64ABI {
         16
     }
 
-    fn ret_addr_offset() -> u8 {
-        8
-    }
-
     fn word_bits() -> u8 {
         64
     }
@@ -123,14 +119,6 @@ impl ABI for Aarch64ABI {
 
     fn float_scratch_reg() -> Reg {
         todo!()
-    }
-
-    fn sp_reg() -> Reg {
-        todo!()
-    }
-
-    fn fp_reg() -> Reg {
-        regs::fp()
     }
 
     fn vmctx_reg() -> Reg {

--- a/winch/codegen/src/isa/aarch64/regs.rs
+++ b/winch/codegen/src/isa/aarch64/regs.rs
@@ -1,8 +1,7 @@
 //! AArch64 register definition.
 
-use crate::{isa::reg::Reg, masm::OperandSize};
+use crate::isa::reg::Reg;
 use regalloc2::{PReg, RegClass};
-use smallvec::{smallvec, SmallVec};
 
 /// FPR index bound.
 pub(crate) const MAX_FPR: u32 = 32;
@@ -148,37 +147,3 @@ pub(crate) const NON_ALLOCATABLE_GPR: u32 = (1 << ip0().hw_enc())
 
 /// Bitmask to represent the available general purpose registers.
 pub(crate) const ALL_GPR: u32 = u32::MAX & !NON_ALLOCATABLE_GPR;
-
-/// Returns the callee-saved registers.
-///
-/// This function will return the set of registers that need to be saved
-/// according to the system ABI and that are known not to be saved during the
-/// prologue emission.
-#[allow(unused)]
-pub(crate) fn callee_saved() -> SmallVec<[(Reg, OperandSize); 18]> {
-    use OperandSize::*;
-    let regs: SmallVec<[_; 18]> = smallvec![
-        xreg(19),
-        xreg(20),
-        xreg(21),
-        xreg(22),
-        xreg(23),
-        xreg(24),
-        xreg(25),
-        xreg(26),
-        xreg(27),
-        xreg(28),
-        vreg(8),
-        vreg(9),
-        vreg(10),
-        vreg(11),
-        vreg(12),
-        vreg(13),
-        vreg(14),
-        vreg(15),
-    ];
-    // Aarch64's calling convention states that for VReg's only
-    // the lower 64 bits are callee-saved (D8-D15).  See
-    // https://developer.arm.com/documentation/102374/0101/Procedure-Call-Standard
-    regs.into_iter().map(|reg| (reg, S64)).collect()
-}

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -2,9 +2,7 @@ use super::regs;
 use crate::{
     abi::{align_to, ABIOperand, ABIParams, ABIResults, ABISig, ParamsOrReturns, ABI},
     isa::{reg::Reg, CallingConvention},
-    masm::OperandSize,
 };
-use smallvec::SmallVec;
 use wasmtime_environ::{WasmHeapType, WasmValType};
 
 /// Helper environment to track argument-register
@@ -173,10 +171,6 @@ impl ABI for X64ABI {
 
     fn vmctx_reg() -> Reg {
         regs::vmctx()
-    }
-
-    fn callee_saved_regs(call_conv: &CallingConvention) -> SmallVec<[(Reg, OperandSize); 18]> {
-        regs::callee_saved(call_conv)
     }
 
     fn stack_slot_size() -> u8 {

--- a/winch/codegen/src/isa/x64/abi.rs
+++ b/winch/codegen/src/isa/x64/abi.rs
@@ -84,18 +84,6 @@ impl ABI for X64ABI {
         16
     }
 
-    fn ret_addr_offset() -> u8 {
-        // 1 8-byte slot.
-        // ┌──────────┬
-        // │   Ret    │
-        // │   Addr   │
-        // ├──────────┼ * offset
-        // │          │
-        // │   FP     │
-        // └──────────┴
-        8
-    }
-
     fn word_bits() -> u8 {
         64
     }
@@ -159,14 +147,6 @@ impl ABI for X64ABI {
 
     fn float_scratch_reg() -> Reg {
         regs::scratch_xmm()
-    }
-
-    fn fp_reg() -> Reg {
-        regs::rbp()
-    }
-
-    fn sp_reg() -> Reg {
-        regs::rsp()
     }
 
     fn vmctx_reg() -> Reg {

--- a/winch/codegen/src/masm.rs
+++ b/winch/codegen/src/masm.rs
@@ -468,10 +468,9 @@ pub(crate) trait MacroAssembler {
     type ABI: abi::ABI;
 
     /// Emit the function prologue.
-    fn prologue(&mut self, vmctx: Reg, clobbers: &[(Reg, OperandSize)]) {
+    fn prologue(&mut self, vmctx: Reg) {
         self.frame_setup();
         self.check_stack(vmctx);
-        self.save_clobbers(clobbers);
     }
 
     /// Generate the frame setup sequence.
@@ -480,29 +479,11 @@ pub(crate) trait MacroAssembler {
     /// Generate the frame restore sequence.
     fn frame_restore(&mut self);
 
-    /// Save all the given clobbered registers to the stack. By default this is the same as pushing
-    /// the registers, however it's present in the [`MacroAssembler`] trait to ensure that it's
-    /// possible to add unwind info for register saves in backends.
-    fn save_clobbers(&mut self, clobbers: &[(Reg, OperandSize)]) {
-        for &(reg, size) in clobbers {
-            self.push(reg, size);
-        }
-    }
-
-    /// Restore all clobbered registers, assumed to be passed in the same order as to
-    /// [`save_clobbers`].
-    fn restore_clobbers(&mut self, clobbers: &[(Reg, OperandSize)]) {
-        for &(reg, size) in clobbers.iter().rev() {
-            self.pop(reg, size);
-        }
-    }
-
     /// Emit a stack check.
     fn check_stack(&mut self, vmctx: Reg);
 
     /// Emit the function epilogue.
-    fn epilogue(&mut self, clobbers: &[(Reg, OperandSize)]) {
-        self.restore_clobbers(clobbers);
+    fn epilogue(&mut self) {
         self.frame_restore();
     }
 


### PR DESCRIPTION
After switching to using `wasmtime-cranelift` for all trampolines in Winch, there were some functions that became unused in `winch-codegen`. Additionally, as Winch no longer needs to generate functions with callee-saves, I've removed that functionality.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
