### PR TITLE
Cranelift: resolve value aliases when printing CLIF functions

### DIFF
--- a/cranelift/codegen/src/write.rs
+++ b/cranelift/codegen/src/write.rs
@@ -352,13 +352,14 @@ fn write_instruction(
     // Write out the result values, if any.
     let mut has_results = false;
     for r in func.dfg.inst_results(inst) {
+        let r = func.dfg.resolve_aliases(*r);
         if !has_results {
             has_results = true;
             write!(w, "{}", r)?;
         } else {
             write!(w, ", {}", r)?;
         }
-        if let Some(f) = &func.dfg.facts[*r] {
+        if let Some(f) = &func.dfg.facts[r] {
             write!(w, " ! {}", f)?;
         }
     }
@@ -388,13 +389,23 @@ fn write_instruction(
 pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt::Result {
     let pool = &dfg.value_lists;
     let jump_tables = &dfg.jump_tables;
+
+    // Resolve a value to its alias, if any.
+    let v = |v: Value| dfg.resolve_aliases(v);
+
+    // Resolve a list of values to their aliases and format them.
+    let vs = |vs: &[_]| {
+        let vs: Vec<_> = vs.iter().copied().map(v).collect();
+        DisplayValues(&vs).to_string()
+    };
+
     use crate::ir::instructions::InstructionData::*;
     match dfg.insts[inst] {
-        AtomicRmw { op, args, .. } => write!(w, " {} {}, {}", op, args[0], args[1]),
-        AtomicCas { args, .. } => write!(w, " {}, {}, {}", args[0], args[1], args[2]),
-        LoadNoOffset { flags, arg, .. } => write!(w, "{} {}", flags, arg),
-        StoreNoOffset { flags, args, .. } => write!(w, "{} {}, {}", flags, args[0], args[1]),
-        Unary { arg, .. } => write!(w, " {}", arg),
+        AtomicRmw { op, args, .. } => write!(w, " {} {}, {}", op, v(args[0]), v(args[1])),
+        AtomicCas { args, .. } => write!(w, " {}, {}, {}", v(args[0]), v(args[1]), v(args[2])),
+        LoadNoOffset { flags, arg, .. } => write!(w, "{} {}", flags, v(arg)),
+        StoreNoOffset { flags, args, .. } => write!(w, "{} {}, {}", flags, v(args[0]), v(args[1])),
+        Unary { arg, .. } => write!(w, " {}", v(arg)),
         UnaryImm { imm, .. } => write!(w, " {}", imm),
         UnaryIeee32 { imm, .. } => write!(w, " {}", imm),
         UnaryIeee64 { imm, .. } => write!(w, " {}", imm),
@@ -402,29 +413,29 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
         UnaryConst {
             constant_handle, ..
         } => write!(w, " {}", constant_handle),
-        Binary { args, .. } => write!(w, " {}, {}", args[0], args[1]),
-        BinaryImm8 { arg, imm, .. } => write!(w, " {}, {}", arg, imm),
-        BinaryImm64 { arg, imm, .. } => write!(w, " {}, {}", arg, imm),
-        Ternary { args, .. } => write!(w, " {}, {}, {}", args[0], args[1], args[2]),
+        Binary { args, .. } => write!(w, " {}, {}", v(args[0]), v(args[1])),
+        BinaryImm8 { arg, imm, .. } => write!(w, " {}, {}", v(arg), imm),
+        BinaryImm64 { arg, imm, .. } => write!(w, " {}, {}", v(arg), imm),
+        Ternary { args, .. } => write!(w, " {}, {}, {}", v(args[0]), v(args[1]), v(args[2])),
         MultiAry { ref args, .. } => {
             if args.is_empty() {
                 write!(w, "")
             } else {
-                write!(w, " {}", DisplayValues(args.as_slice(pool)))
+                write!(w, " {}", vs(args.as_slice(pool)))
             }
         }
         NullAry { .. } => write!(w, " "),
-        TernaryImm8 { imm, args, .. } => write!(w, " {}, {}, {}", args[0], args[1], imm),
+        TernaryImm8 { imm, args, .. } => write!(w, " {}, {}, {}", v(args[0]), v(args[1]), imm),
         Shuffle { imm, args, .. } => {
             let data = dfg.immediates.get(imm).expect(
                 "Expected the shuffle mask to already be inserted into the immediates table",
             );
-            write!(w, " {}, {}, {}", args[0], args[1], data)
+            write!(w, " {}, {}, {}", v(args[0]), v(args[1]), data)
         }
-        IntCompare { cond, args, .. } => write!(w, " {} {}, {}", cond, args[0], args[1]),
+        IntCompare { cond, args, .. } => write!(w, " {} {}, {}", cond, v(args[0]), v(args[1])),
         IntCompareImm { cond, arg, imm, .. } => write!(w, " {} {}, {}", cond, arg, imm),
-        IntAddTrap { args, code, .. } => write!(w, " {}, {}, {}", args[0], args[1], code),
-        FloatCompare { cond, args, .. } => write!(w, " {} {}, {}", cond, args[0], args[1]),
+        IntAddTrap { args, code, .. } => write!(w, " {}, {}, {}", v(args[0]), v(args[1]), code),
+        FloatCompare { cond, args, .. } => write!(w, " {} {}, {}", cond, v(args[0]), v(args[1])),
         Jump { destination, .. } => {
             write!(w, " {}", destination.display(pool))
         }
@@ -433,26 +444,20 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
             blocks: [block_then, block_else],
             ..
         } => {
-            write!(w, " {}, {}", arg, block_then.display(pool))?;
+            write!(w, " {}, {}", v(arg), block_then.display(pool))?;
             write!(w, ", {}", block_else.display(pool))
         }
         BranchTable { arg, table, .. } => {
-            write!(w, " {}, {}", arg, jump_tables[table].display(pool))
+            write!(w, " {}, {}", v(arg), jump_tables[table].display(pool))
         }
         Call {
             func_ref, ref args, ..
-        } => write!(w, " {}({})", func_ref, DisplayValues(args.as_slice(pool))),
+        } => write!(w, " {}({})", func_ref, vs(args.as_slice(pool))),
         CallIndirect {
             sig_ref, ref args, ..
         } => {
             let args = args.as_slice(pool);
-            write!(
-                w,
-                " {}, {}({})",
-                sig_ref,
-                args[0],
-                DisplayValues(&args[1..])
-            )
+            write!(w, " {}, {}({})", sig_ref, args[0], vs(&args[1..]))
         }
         FuncAddr { func_ref, .. } => write!(w, " {}", func_ref),
         StackLoad {
@@ -463,7 +468,7 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
             stack_slot,
             offset,
             ..
-        } => write!(w, " {}, {}{}", arg, stack_slot, offset),
+        } => write!(w, " {}, {}{}", v(arg), stack_slot, offset),
         DynamicStackLoad {
             dynamic_stack_slot, ..
         } => write!(w, " {}", dynamic_stack_slot),
@@ -474,15 +479,15 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
         } => write!(w, " {}, {}", arg, dynamic_stack_slot),
         Load {
             flags, arg, offset, ..
-        } => write!(w, "{} {}{}", flags, arg, offset),
+        } => write!(w, "{} {}{}", flags, v(arg), offset),
         Store {
             flags,
             args,
             offset,
             ..
-        } => write!(w, "{} {}, {}{}", flags, args[0], args[1], offset),
+        } => write!(w, "{} {}, {}{}", flags, v(args[0]), v(args[1]), offset),
         Trap { code, .. } => write!(w, " {}", code),
-        CondTrap { arg, code, .. } => write!(w, " {}, {}", arg, code),
+        CondTrap { arg, code, .. } => write!(w, " {}, {}", v(arg), code),
     }?;
 
     let mut sep = "  ; ";
@@ -497,7 +502,7 @@ pub fn write_operands(w: &mut dyn Write, dfg: &DataFlowGraph, inst: Inst) -> fmt
                 } => constant_handle.to_string(),
                 _ => continue,
             };
-            write!(w, "{}{} = {}", sep, arg, imm)?;
+            write!(w, "{}{} = {}", sep, v(arg), imm)?;
             sep = ", ";
         }
     }
@@ -603,7 +608,7 @@ mod tests {
         }
         assert_eq!(
             func.to_string(),
-            "function u0:0() fast {\nblock0(v3: i32):\n    v0 -> v3\n    v2 -> v0\n    v4 = iconst.i32 42\n    v5 = iadd v0, v0\n    v1 -> v5\n    v6 = iconst.i32 23\n    v7 = iadd v1, v1\n}\n"
+            "function u0:0() fast {\nblock0(v3: i32):\n    v0 -> v3\n    v2 -> v0\n    v4 = iconst.i32 42\n    v5 = iadd v3, v3\n    v1 -> v5\n    v6 = iconst.i32 23\n    v7 = iadd v5, v5\n}\n"
         );
     }
 

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -1294,8 +1294,8 @@ block0:
     v1 -> v4
     v3 = iconst.i64 0
     v0 -> v3
-    v2 = call fn0(v1, v0, v1)  ; v1 = 0, v0 = 0, v1 = 0
-    return v1  ; v1 = 0
+    v2 = call fn0(v4, v3, v4)  ; v4 = 0, v3 = 0, v4 = 0
+    return v4  ; v4 = 0
 }
 ",
         );
@@ -1347,9 +1347,9 @@ block0:
     v1 -> v4
     v3 = iconst.i64 0
     v0 -> v3
-    v2 = load.i64 aligned v0  ; v0 = 0
-    store aligned v2, v1  ; v1 = 0
-    return v1  ; v1 = 0
+    v2 = load.i64 aligned v3  ; v3 = 0
+    store aligned v2, v4  ; v4 = 0
+    return v4  ; v4 = 0
 }
 ",
         );
@@ -1405,8 +1405,8 @@ block0:
     v4 = iconst.i64 0
     v0 -> v4
     v2 = iconst.i64 8192
-    v3 = call fn0(v1, v0, v2)  ; v1 = 0, v0 = 0, v2 = 8192
-    return v1  ; v1 = 0
+    v3 = call fn0(v5, v4, v2)  ; v5 = 0, v4 = 0, v2 = 8192
+    return v5  ; v5 = 0
 }
 ",
         );
@@ -1445,8 +1445,8 @@ block0:
     v2 = iconst.i64 0
     v0 -> v2
     v1 = iconst.i64 0x0101_0101_0101_0101
-    store aligned v1, v0  ; v1 = 0x0101_0101_0101_0101, v0 = 0
-    return v0  ; v0 = 0
+    store aligned v1, v2  ; v1 = 0x0101_0101_0101_0101, v2 = 0
+    return v2  ; v2 = 0
 }
 ",
         );
@@ -1490,8 +1490,8 @@ block0:
     v1 = iconst.i8 1
     v2 = iconst.i64 8192
     v3 = uextend.i32 v1  ; v1 = 1
-    v4 = call fn0(v0, v3, v2)  ; v0 = 0, v2 = 8192
-    return v0  ; v0 = 0
+    v4 = call fn0(v5, v3, v2)  ; v5 = 0, v2 = 8192
+    return v5  ; v5 = 0
 }
 ",
         );
@@ -1555,7 +1555,7 @@ block0:
     v1 -> v5
     v4 = iconst.i64 0
     v0 -> v4
-    v3 = call fn0(v0, v1, v2)  ; v0 = 0, v1 = 0, v2 = 0
+    v3 = call fn0(v4, v5, v6)  ; v4 = 0, v5 = 0, v6 = 0
     return v3
 }
 ",
@@ -1599,8 +1599,8 @@ block0:
     v1 -> v6
     v5 = iconst.i64 0
     v0 -> v5
-    v2 = load.i8 aligned v0  ; v0 = 0
-    v3 = load.i8 aligned v1  ; v1 = 0
+    v2 = load.i8 aligned v5  ; v5 = 0
+    v3 = load.i8 aligned v6  ; v6 = 0
     v4 = icmp ugt v2, v3
     return v4",
             |builder, target, x, y| {
@@ -1628,8 +1628,8 @@ block0:
     v1 -> v6
     v5 = iconst.i64 0
     v0 -> v5
-    v2 = load.i32 aligned v0  ; v0 = 0
-    v3 = load.i32 aligned v1  ; v1 = 0
+    v2 = load.i32 aligned v5  ; v5 = 0
+    v3 = load.i32 aligned v6  ; v6 = 0
     v4 = icmp eq v2, v3
     return v4",
             |builder, target, x, y| {
@@ -1657,8 +1657,8 @@ block0:
     v1 -> v6
     v5 = iconst.i64 0
     v0 -> v5
-    v2 = load.i128 v0  ; v0 = 0
-    v3 = load.i128 v1  ; v1 = 0
+    v2 = load.i128 v5  ; v5 = 0
+    v3 = load.i128 v6  ; v6 = 0
     v4 = icmp ne v2, v3
     return v4",
             |builder, target, x, y| {
@@ -1690,7 +1690,7 @@ block0:
     v5 = iconst.i64 0
     v0 -> v5
     v2 = iconst.i64 3
-    v3 = call fn0(v0, v1, v2)  ; v0 = 0, v1 = 0, v2 = 3
+    v3 = call fn0(v5, v6, v2)  ; v5 = 0, v6 = 0, v2 = 3
     v4 = icmp_imm sge v3, 0
     return v4",
             |builder, target, x, y| {
@@ -1801,7 +1801,7 @@ block0:
     v1 -> v4
     v3 = vconst.i8x16 const0
     v0 -> v3
-    return v0, v1, v2  ; v0 = const0, v1 = const0
+    return v3, v4, v6  ; v3 = const0, v4 = const0
 }
 ",
         );

--- a/tests/disas/dead-code.wat
+++ b/tests/disas/dead-code.wat
@@ -32,7 +32,7 @@
 ;; @0023                               jump block2
 ;;
 ;;                                 block2:
-;; @0029                               brif.i32 v3, block4, block5
+;; @0029                               brif.i32 v2, block4, block5
 ;;
 ;;                                 block5:
 ;; @002b                               jump block2

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -56,7 +56,7 @@
 ;; @0045                               jump block2(v3)  ; v3 = 35
 ;;
 ;;                                 block2(v4: i32):
-;; @0049                               brif.i32 v5, block4, block6(v4)
+;; @0049                               brif.i32 v2, block4, block6(v4)
 ;;
 ;;                                 block4:
 ;; @004b                               v7 = uextend.i64 v4

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -32,7 +32,7 @@
 ;; @0054                               v4 = iconst.i32 7
 ;; @0054                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0054                               v6 = uextend.i64 v3  ; v3 = 0
-;; @0054                               v7 = load.i64 notrap aligned v25+72
+;; @0054                               v7 = load.i64 notrap aligned v0+72
 ;;                                     v26 = iconst.i64 3
 ;; @0054                               v8 = ishl v6, v26  ; v26 = 3
 ;; @0054                               v9 = iadd v7, v8
@@ -44,7 +44,7 @@
 ;; @0054                               brif v13, block2, block3
 ;;
 ;;                                 block3:
-;; @0054                               v15 = load.i64 notrap aligned v14+32
+;; @0054                               v15 = load.i64 notrap aligned v0+32
 ;; @0054                               v16 = load.i64 notrap aligned v15
 ;; @0054                               v17 = load.i64 notrap aligned v15+8
 ;; @0054                               v18 = icmp eq v16, v17
@@ -62,16 +62,16 @@
 ;; @0054                               jump block2
 ;;
 ;;                                 block4:
-;; @0054                               v20 = load.i64 notrap aligned readonly v19+56
+;; @0054                               v20 = load.i64 notrap aligned readonly v0+56
 ;; @0054                               v21 = load.i64 notrap aligned readonly v20+208
-;; @0054                               call_indirect sig0, v21(v19, v12)
+;; @0054                               call_indirect sig0, v21(v0, v12)
 ;; @0054                               jump block2
 ;;
 ;;                                 block2:
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
-;; @0056                               return v2
+;; @0056                               return v12
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> r64 fast {
@@ -90,7 +90,7 @@
 ;; @005b                               v4 = iconst.i32 7
 ;; @005b                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005b                               v6 = uextend.i64 v2
-;; @005b                               v7 = load.i64 notrap aligned v25+72
+;; @005b                               v7 = load.i64 notrap aligned v0+72
 ;;                                     v26 = iconst.i64 3
 ;; @005b                               v8 = ishl v6, v26  ; v26 = 3
 ;; @005b                               v9 = iadd v7, v8
@@ -102,7 +102,7 @@
 ;; @005b                               brif v13, block2, block3
 ;;
 ;;                                 block3:
-;; @005b                               v15 = load.i64 notrap aligned v14+32
+;; @005b                               v15 = load.i64 notrap aligned v0+32
 ;; @005b                               v16 = load.i64 notrap aligned v15
 ;; @005b                               v17 = load.i64 notrap aligned v15+8
 ;; @005b                               v18 = icmp eq v16, v17
@@ -120,14 +120,14 @@
 ;; @005b                               jump block2
 ;;
 ;;                                 block4:
-;; @005b                               v20 = load.i64 notrap aligned readonly v19+56
+;; @005b                               v20 = load.i64 notrap aligned readonly v0+56
 ;; @005b                               v21 = load.i64 notrap aligned readonly v20+208
-;; @005b                               call_indirect sig0, v21(v19, v12)
+;; @005b                               call_indirect sig0, v21(v0, v12)
 ;; @005b                               jump block2
 ;;
 ;;                                 block2:
 ;; @005d                               jump block1
 ;;
 ;;                                 block1:
-;; @005d                               return v3
+;; @005d                               return v12
 ;; }

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -30,10 +30,10 @@
 ;;                                     v25 -> v0
 ;;                                     v26 -> v0
 ;; @0051                               v3 = iconst.i32 0
-;; @0053                               v4 = load.i32 notrap aligned v25+80
+;; @0053                               v4 = load.i32 notrap aligned v0+80
 ;; @0053                               v5 = icmp uge v3, v4  ; v3 = 0
 ;; @0053                               v6 = uextend.i64 v3  ; v3 = 0
-;; @0053                               v7 = load.i64 notrap aligned v26+72
+;; @0053                               v7 = load.i64 notrap aligned v0+72
 ;;                                     v27 = iconst.i64 3
 ;; @0053                               v8 = ishl v6, v27  ; v27 = 3
 ;; @0053                               v9 = iadd v7, v8
@@ -45,7 +45,7 @@
 ;; @0053                               brif v13, block2, block3
 ;;
 ;;                                 block3:
-;; @0053                               v15 = load.i64 notrap aligned v14+32
+;; @0053                               v15 = load.i64 notrap aligned v0+32
 ;; @0053                               v16 = load.i64 notrap aligned v15
 ;; @0053                               v17 = load.i64 notrap aligned v15+8
 ;; @0053                               v18 = icmp eq v16, v17
@@ -63,16 +63,16 @@
 ;; @0053                               jump block2
 ;;
 ;;                                 block4:
-;; @0053                               v20 = load.i64 notrap aligned readonly v19+56
+;; @0053                               v20 = load.i64 notrap aligned readonly v0+56
 ;; @0053                               v21 = load.i64 notrap aligned readonly v20+208
-;; @0053                               call_indirect sig0, v21(v19, v12)
+;; @0053                               call_indirect sig0, v21(v0, v12)
 ;; @0053                               jump block2
 ;;
 ;;                                 block2:
 ;; @0055                               jump block1
 ;;
 ;;                                 block1:
-;; @0055                               return v2
+;; @0055                               return v12
 ;; }
 ;;
 ;; function u0:1(i64 vmctx, i64, i32) -> r64 fast {
@@ -90,10 +90,10 @@
 ;;                                     v19 -> v0
 ;;                                     v25 -> v0
 ;;                                     v26 -> v0
-;; @005a                               v4 = load.i32 notrap aligned v25+80
+;; @005a                               v4 = load.i32 notrap aligned v0+80
 ;; @005a                               v5 = icmp uge v2, v4
 ;; @005a                               v6 = uextend.i64 v2
-;; @005a                               v7 = load.i64 notrap aligned v26+72
+;; @005a                               v7 = load.i64 notrap aligned v0+72
 ;;                                     v27 = iconst.i64 3
 ;; @005a                               v8 = ishl v6, v27  ; v27 = 3
 ;; @005a                               v9 = iadd v7, v8
@@ -105,7 +105,7 @@
 ;; @005a                               brif v13, block2, block3
 ;;
 ;;                                 block3:
-;; @005a                               v15 = load.i64 notrap aligned v14+32
+;; @005a                               v15 = load.i64 notrap aligned v0+32
 ;; @005a                               v16 = load.i64 notrap aligned v15
 ;; @005a                               v17 = load.i64 notrap aligned v15+8
 ;; @005a                               v18 = icmp eq v16, v17
@@ -123,14 +123,14 @@
 ;; @005a                               jump block2
 ;;
 ;;                                 block4:
-;; @005a                               v20 = load.i64 notrap aligned readonly v19+56
+;; @005a                               v20 = load.i64 notrap aligned readonly v0+56
 ;; @005a                               v21 = load.i64 notrap aligned readonly v20+208
-;; @005a                               call_indirect sig0, v21(v19, v12)
+;; @005a                               call_indirect sig0, v21(v0, v12)
 ;; @005a                               jump block2
 ;;
 ;;                                 block2:
 ;; @005c                               jump block1
 ;;
 ;;                                 block1:
-;; @005c                               return v3
+;; @005c                               return v12
 ;; }

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -33,7 +33,7 @@
 ;; @0056                               v4 = iconst.i32 7
 ;; @0056                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
 ;; @0056                               v6 = uextend.i64 v3  ; v3 = 0
-;; @0056                               v7 = load.i64 notrap aligned v23+72
+;; @0056                               v7 = load.i64 notrap aligned v0+72
 ;;                                     v24 = iconst.i64 3
 ;; @0056                               v8 = ishl v6, v24  ; v24 = 3
 ;; @0056                               v9 = iadd v7, v8
@@ -66,9 +66,9 @@
 ;; @0056                               brif v19, block5, block6
 ;;
 ;;                                 block5:
-;; @0056                               v21 = load.i64 notrap aligned readonly v20+56
+;; @0056                               v21 = load.i64 notrap aligned readonly v0+56
 ;; @0056                               v22 = load.i64 notrap aligned readonly v21+200
-;; @0056                               call_indirect sig0, v22(v20, v12)
+;; @0056                               call_indirect sig0, v22(v0, v12)
 ;; @0056                               jump block6
 ;;
 ;;                                 block6:
@@ -93,7 +93,7 @@
 ;; @005f                               v4 = iconst.i32 7
 ;; @005f                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005f                               v6 = uextend.i64 v2
-;; @005f                               v7 = load.i64 notrap aligned v23+72
+;; @005f                               v7 = load.i64 notrap aligned v0+72
 ;;                                     v24 = iconst.i64 3
 ;; @005f                               v8 = ishl v6, v24  ; v24 = 3
 ;; @005f                               v9 = iadd v7, v8
@@ -126,9 +126,9 @@
 ;; @005f                               brif v19, block5, block6
 ;;
 ;;                                 block5:
-;; @005f                               v21 = load.i64 notrap aligned readonly v20+56
+;; @005f                               v21 = load.i64 notrap aligned readonly v0+56
 ;; @005f                               v22 = load.i64 notrap aligned readonly v21+200
-;; @005f                               call_indirect sig0, v22(v20, v12)
+;; @005f                               call_indirect sig0, v22(v0, v12)
 ;; @005f                               jump block6
 ;;
 ;;                                 block6:

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -31,10 +31,10 @@
 ;;                                     v23 -> v0
 ;;                                     v24 -> v0
 ;; @0051                               v3 = iconst.i32 0
-;; @0055                               v4 = load.i32 notrap aligned v23+80
+;; @0055                               v4 = load.i32 notrap aligned v0+80
 ;; @0055                               v5 = icmp uge v3, v4  ; v3 = 0
 ;; @0055                               v6 = uextend.i64 v3  ; v3 = 0
-;; @0055                               v7 = load.i64 notrap aligned v24+72
+;; @0055                               v7 = load.i64 notrap aligned v0+72
 ;;                                     v25 = iconst.i64 3
 ;; @0055                               v8 = ishl v6, v25  ; v25 = 3
 ;; @0055                               v9 = iadd v7, v8
@@ -67,9 +67,9 @@
 ;; @0055                               brif v19, block5, block6
 ;;
 ;;                                 block5:
-;; @0055                               v21 = load.i64 notrap aligned readonly v20+56
+;; @0055                               v21 = load.i64 notrap aligned readonly v0+56
 ;; @0055                               v22 = load.i64 notrap aligned readonly v21+200
-;; @0055                               call_indirect sig0, v22(v20, v12)
+;; @0055                               call_indirect sig0, v22(v0, v12)
 ;; @0055                               jump block6
 ;;
 ;;                                 block6:
@@ -93,10 +93,10 @@
 ;;                                     v20 -> v0
 ;;                                     v23 -> v0
 ;;                                     v24 -> v0
-;; @005e                               v4 = load.i32 notrap aligned v23+80
+;; @005e                               v4 = load.i32 notrap aligned v0+80
 ;; @005e                               v5 = icmp uge v2, v4
 ;; @005e                               v6 = uextend.i64 v2
-;; @005e                               v7 = load.i64 notrap aligned v24+72
+;; @005e                               v7 = load.i64 notrap aligned v0+72
 ;;                                     v25 = iconst.i64 3
 ;; @005e                               v8 = ishl v6, v25  ; v25 = 3
 ;; @005e                               v9 = iadd v7, v8
@@ -129,9 +129,9 @@
 ;; @005e                               brif v19, block5, block6
 ;;
 ;;                                 block5:
-;; @005e                               v21 = load.i64 notrap aligned readonly v20+56
+;; @005e                               v21 = load.i64 notrap aligned readonly v0+56
 ;; @005e                               v22 = load.i64 notrap aligned readonly v21+200
-;; @005e                               call_indirect sig0, v22(v20, v12)
+;; @005e                               call_indirect sig0, v22(v0, v12)
 ;; @005e                               jump block6
 ;;
 ;;                                 block6:


### PR DESCRIPTION
This makes the CLIF much easier to follow.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
