### PR TITLE
cranelift: Constant propagate `bswap`

### DIFF
--- a/cranelift/codegen/src/opts.rs
+++ b/cranelift/codegen/src/opts.rs
@@ -281,4 +281,16 @@ impl<'a, 'b, 'c> generated_code::Context for IsleContext<'a, 'b, 'c> {
     fn f64_from_sint(&mut self, n: i64) -> Ieee64 {
         Ieee64::with_float(n as f64)
     }
+
+    fn u64_bswap16(&mut self, n: u64) -> u64 {
+        (n as u16).swap_bytes() as u64
+    }
+
+    fn u64_bswap32(&mut self, n: u64) -> u64 {
+        (n as u32).swap_bytes() as u64
+    }
+
+    fn u64_bswap64(&mut self, n: u64) -> u64 {
+        n.swap_bytes()
+    }
 }

--- a/cranelift/codegen/src/opts/cprop.isle
+++ b/cranelift/codegen/src/opts/cprop.isle
@@ -264,3 +264,18 @@
 (extern constructor f32_from_sint f32_from_sint)
 (decl f64_from_sint (i64) Ieee64)
 (extern constructor f64_from_sint f64_from_sint)
+
+;; Constant fold bswap of a constant.
+(rule (simplify (bswap $I16 (iconst ty (u64_from_imm64 n))))
+      (subsume (iconst $I16 (imm64 (u64_bswap16 n)))))
+(rule (simplify (bswap $I32 (iconst ty (u64_from_imm64 n))))
+      (subsume (iconst $I32 (imm64 (u64_bswap32 n)))))
+(rule (simplify (bswap $I64 (iconst ty (u64_from_imm64 n))))
+      (subsume (iconst $I64 (imm64 (u64_bswap64 n)))))
+
+(decl pure u64_bswap16 (u64) u64)
+(extern constructor u64_bswap16 u64_bswap16)
+(decl pure u64_bswap32 (u64) u64)
+(extern constructor u64_bswap32 u64_bswap32)
+(decl pure u64_bswap64 (u64) u64)
+(extern constructor u64_bswap64 u64_bswap64)

--- a/cranelift/filetests/filetests/egraph/cprop.clif
+++ b/cranelift/filetests/filetests/egraph/cprop.clif
@@ -282,3 +282,33 @@ block0(v0: i32):
 ; check: v3 = iconst.i32 1
 ; nextln: v4 = iadd v0, v3  ; v3 = 1
 ; nextln: return v4
+
+function %bswap_i16() -> i16 {
+block0:
+    v0 = iconst.i16 0x1234
+    v1 = bswap v0
+    return v1
+}
+
+; check: v2 = iconst.i16 0x3412
+; nextln: return v2
+
+function %bswap_i32() -> i32 {
+block0:
+    v0 = iconst.i32 0x1234_5678
+    v1 = bswap v0
+    return v1
+}
+
+; check: v2 = iconst.i32 0x7856_3412
+; nextln: return v2
+
+function %bswap_i64() -> i64 {
+block0:
+    v0 = iconst.i64 0x1234_5678_9abc_def0
+    v1 = bswap v0
+    return v1
+}
+
+; check: v2 = iconst.i64 0xf0de_bc9a_7856_3412
+; nextln: return v2


### PR DESCRIPTION
This adds constant propagation for 16-, 32- and 64-bit `bswap`s. I did not add `u128`, since it seems like ISLE doesn't have any existing rules for dealing with `uimm128`. (Though they could be added, I assume)

Please let me know if there's a better approach for the added rules!