### PR TITLE
cranelift: Stop printing value aliases in CLIF functions

### DIFF
--- a/cranelift/codegen/src/cfg_printer.rs
+++ b/cranelift/codegen/src/cfg_printer.rs
@@ -1,9 +1,7 @@
 //! The `CFGPrinter` utility.
 
-use alloc::vec::Vec;
 use core::fmt::{Display, Formatter, Result, Write};
 
-use crate::entity::SecondaryMap;
 use crate::flowgraph::{BlockPredecessor, ControlFlowGraph};
 use crate::ir::Function;
 use crate::write::{FuncWriter, PlainWriter};
@@ -41,21 +39,13 @@ impl<'a> CFGPrinter<'a> {
     }
 
     fn block_nodes(&self, w: &mut dyn Write) -> Result {
-        let mut aliases = SecondaryMap::<_, Vec<_>>::new();
-        for v in self.func.dfg.values() {
-            // VADFS returns the immediate target of an alias
-            if let Some(k) = self.func.dfg.value_alias_dest_for_serialization(v) {
-                aliases[k].push(v);
-            }
-        }
-
         for block in &self.func.layout {
             write!(w, "    {} [shape=record, label=\"{{", block)?;
             crate::write::write_block_header(w, self.func, block, 4)?;
             // Add all outgoing branch instructions to the label.
             if let Some(inst) = self.func.layout.last_inst(block) {
                 write!(w, " | <{}>", inst)?;
-                PlainWriter.write_instruction(w, self.func, &aliases, inst, 0)?;
+                PlainWriter.write_instruction(w, self.func, inst, 0)?;
             }
             writeln!(w, "}}\"]")?
         }

--- a/cranelift/codegen/src/print_errors.rs
+++ b/cranelift/codegen/src/print_errors.rs
@@ -1,8 +1,7 @@
 //! Utility routines for pretty-printing error messages.
 
-use crate::entity::SecondaryMap;
 use crate::ir;
-use crate::ir::entities::{AnyEntity, Block, Inst, Value};
+use crate::ir::entities::{AnyEntity, Block, Inst};
 use crate::ir::function::Function;
 use crate::ir::pcc::Fact;
 use crate::result::CodegenError;
@@ -59,11 +58,10 @@ impl<'a> FuncWriter for PrettyVerifierError<'a> {
         &mut self,
         w: &mut dyn Write,
         func: &Function,
-        aliases: &SecondaryMap<Value, Vec<Value>>,
         inst: Inst,
         indent: usize,
     ) -> fmt::Result {
-        pretty_instruction_error(w, func, aliases, inst, indent, &mut *self.0, self.1)
+        pretty_instruction_error(w, func, inst, indent, &mut *self.0, self.1)
     }
 
     fn write_entity_definition(
@@ -119,14 +117,13 @@ fn pretty_block_header_error(
 fn pretty_instruction_error(
     w: &mut dyn Write,
     func: &Function,
-    aliases: &SecondaryMap<Value, Vec<Value>>,
     cur_inst: Inst,
     indent: usize,
     func_w: &mut dyn FuncWriter,
     errors: &mut Vec<VerifierError>,
 ) -> fmt::Result {
     let mut s = String::new();
-    func_w.write_instruction(&mut s, func, aliases, cur_inst, indent)?;
+    func_w.write_instruction(&mut s, func, cur_inst, indent)?;
     write!(w, "{}", s)?;
 
     // TODO: Use drain_filter here when it gets stabilized

--- a/cranelift/filetests/filetests/alias/categories.clif
+++ b/cranelift/filetests/filetests/alias/categories.clif
@@ -15,8 +15,7 @@ block0(v0: i64, v1: i64):
 
     v4 = load.i32 heap v0+8
     v5 = load.i32 table v1+8
-    ; check: v4 -> v2
-    ; check: v5 -> v3
 
     return v4, v5
+    ; check: return v2, v3
 }

--- a/cranelift/filetests/filetests/alias/multiple-blocks.clif
+++ b/cranelift/filetests/filetests/alias/multiple-blocks.clif
@@ -15,8 +15,8 @@ block0(v0: i64, v1: i32):
 
 block1:
     v4 = load.i32 v2+8
-    ; check: v4 -> v3
     jump block3(v4)
+    ; check: jump block3(v3)
 
 block2:
     jump block3(v3)

--- a/cranelift/filetests/filetests/alias/simple-alias.clif
+++ b/cranelift/filetests/filetests/alias/simple-alias.clif
@@ -16,7 +16,6 @@ block0(v0: i64, v1: i32):
     v3 = load.i32 v2+8
     ;; This should reuse the load above.
     v5 = load.i32 v2+8
-    ; check: v5 -> v3
 
     call fn0(v0)
 
@@ -24,9 +23,9 @@ block0(v0: i64, v1: i32):
     ;; is a barrier that prevents reusing v3 or v5.
     v6 = load.i32 v2+8
     v7 = load.i32 v2+8
-    ; check: v7 -> v6
 
     return v3, v5, v6, v7
+    ; check: return v3, v3, v6, v6
 }
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -44,7 +43,7 @@ block0(v0: i64, v1: i32):
 
     ;; This load should pick up the store above.
     v4 = load.i32 v2+8
-    ; check: v4 -> v1
 
     return v4
+    ; check: return v1
 }

--- a/cranelift/filetests/filetests/egraph/licm.clif
+++ b/cranelift/filetests/filetests/egraph/licm.clif
@@ -58,7 +58,6 @@ block2(v8: i64x2):
 ; check:      v9 = iconst.i32 1
 ; check:      v10 = isub v3, v9
 ; check:      v5 = iadd v2, v4
-; check:      v8 -> v5
 ; check:      brif v10, block1(v5, v10), block2
 ; check:  block2:
 ; check:      return v5

--- a/cranelift/frontend/src/frontend.rs
+++ b/cranelift/frontend/src/frontend.rs
@@ -1291,9 +1291,7 @@ mod tests {
 
 block0:
     v4 = iconst.i64 0
-    v1 -> v4
     v3 = iconst.i64 0
-    v0 -> v3
     v2 = call fn0(v4, v3, v4)  ; v4 = 0, v3 = 0, v4 = 0
     return v4  ; v4 = 0
 }
@@ -1344,9 +1342,7 @@ block0:
             "function %sample() -> i32 system_v {
 block0:
     v4 = iconst.i64 0
-    v1 -> v4
     v3 = iconst.i64 0
-    v0 -> v3
     v2 = load.i64 aligned v3  ; v3 = 0
     store aligned v2, v4  ; v4 = 0
     return v4  ; v4 = 0
@@ -1401,9 +1397,7 @@ block0:
 
 block0:
     v5 = iconst.i64 0
-    v1 -> v5
     v4 = iconst.i64 0
-    v0 -> v4
     v2 = iconst.i64 8192
     v3 = call fn0(v5, v4, v2)  ; v5 = 0, v4 = 0, v2 = 8192
     return v5  ; v5 = 0
@@ -1443,7 +1437,6 @@ block0:
             "function %sample() -> i32 system_v {
 block0:
     v2 = iconst.i64 0
-    v0 -> v2
     v1 = iconst.i64 0x0101_0101_0101_0101
     store aligned v1, v2  ; v1 = 0x0101_0101_0101_0101, v2 = 0
     return v2  ; v2 = 0
@@ -1486,7 +1479,6 @@ block0:
 
 block0:
     v5 = iconst.i64 0
-    v0 -> v5
     v1 = iconst.i8 1
     v2 = iconst.i64 8192
     v3 = uextend.i32 v1  ; v1 = 1
@@ -1550,11 +1542,8 @@ block0:
 
 block0:
     v6 = iconst.i64 0
-    v2 -> v6
     v5 = iconst.i64 0
-    v1 -> v5
     v4 = iconst.i64 0
-    v0 -> v4
     v3 = call fn0(v4, v5, v6)  ; v4 = 0, v5 = 0, v6 = 0
     return v3
 }
@@ -1569,9 +1558,7 @@ block0:
             "
 block0:
     v4 = iconst.i64 0
-    v1 -> v4
     v3 = iconst.i64 0
-    v0 -> v3
     v2 = iconst.i8 1
     return v2  ; v2 = 1",
             |builder, target, x, y| {
@@ -1596,9 +1583,7 @@ block0:
             "
 block0:
     v6 = iconst.i64 0
-    v1 -> v6
     v5 = iconst.i64 0
-    v0 -> v5
     v2 = load.i8 aligned v5  ; v5 = 0
     v3 = load.i8 aligned v6  ; v6 = 0
     v4 = icmp ugt v2, v3
@@ -1625,9 +1610,7 @@ block0:
             "
 block0:
     v6 = iconst.i64 0
-    v1 -> v6
     v5 = iconst.i64 0
-    v0 -> v5
     v2 = load.i32 aligned v5  ; v5 = 0
     v3 = load.i32 aligned v6  ; v6 = 0
     v4 = icmp eq v2, v3
@@ -1654,9 +1637,7 @@ block0:
             "
 block0:
     v6 = iconst.i64 0
-    v1 -> v6
     v5 = iconst.i64 0
-    v0 -> v5
     v2 = load.i128 v5  ; v5 = 0
     v3 = load.i128 v6  ; v6 = 0
     v4 = icmp ne v2, v3
@@ -1686,9 +1667,7 @@ block0:
 
 block0:
     v6 = iconst.i64 0
-    v1 -> v6
     v5 = iconst.i64 0
-    v0 -> v5
     v2 = iconst.i64 3
     v3 = call fn0(v5, v6, v2)  ; v5 = 0, v6 = 0, v2 = 3
     v4 = icmp_imm sge v3, 0
@@ -1796,11 +1775,8 @@ block0:
 block0:
     v5 = f32const 0.0
     v6 = splat.f32x4 v5  ; v5 = 0.0
-    v2 -> v6
     v4 = vconst.i8x16 const0
-    v1 -> v4
     v3 = vconst.i8x16 const0
-    v0 -> v3
     return v3, v4, v6  ; v3 = const0, v4 = const0
 }
 ",

--- a/tests/disas/dead-code.wat
+++ b/tests/disas/dead-code.wat
@@ -28,7 +28,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v3 -> v2
 ;; @0023                               jump block2
 ;;
 ;;                                 block2:

--- a/tests/disas/duplicate-loads-dynamic-memory.wat
+++ b/tests/disas/duplicate-loads-dynamic-memory.wat
@@ -32,10 +32,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v21 -> v0
-;;                                     v22 -> v0
-;;                                     v23 -> v0
-;;                                     v24 -> v0
 ;; @0057                               v6 = load.i64 notrap aligned v0+88
 ;; @0057                               v8 = load.i64 notrap aligned checked v0+80
 ;; @0057                               v5 = uextend.i64 v2
@@ -44,7 +40,6 @@
 ;; @0057                               v9 = iadd v8, v5
 ;; @0057                               v11 = select_spectre_guard v7, v10, v9  ; v10 = 0
 ;; @0057                               v12 = load.i32 little heap v11
-;;                                     v3 -> v12
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
@@ -61,10 +56,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v25 -> v0
-;;                                     v26 -> v0
-;;                                     v27 -> v0
-;;                                     v28 -> v0
 ;; @0064                               v6 = load.i64 notrap aligned v0+88
 ;; @0064                               v8 = load.i64 notrap aligned checked v0+80
 ;; @0064                               v5 = uextend.i64 v2
@@ -75,7 +66,6 @@
 ;; @0064                               v11 = iadd v9, v10  ; v10 = 1234
 ;; @0064                               v13 = select_spectre_guard v7, v12, v11  ; v12 = 0
 ;; @0064                               v14 = load.i32 little heap v13
-;;                                     v3 -> v14
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/duplicate-loads-static-memory.wat
+++ b/tests/disas/duplicate-loads-static-memory.wat
@@ -26,13 +26,10 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v13 -> v0
-;;                                     v14 -> v0
 ;; @0057                               v6 = load.i64 notrap aligned readonly checked v0+80
 ;; @0057                               v5 = uextend.i64 v2
 ;; @0057                               v7 = iadd v6, v5
 ;; @0057                               v8 = load.i32 little heap v7
-;;                                     v3 -> v8
 ;; @005f                               jump block1
 ;;
 ;;                                 block1:
@@ -48,15 +45,12 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v17 -> v0
-;;                                     v18 -> v0
 ;; @0064                               v6 = load.i64 notrap aligned readonly checked v0+80
 ;; @0064                               v5 = uextend.i64 v2
 ;; @0064                               v7 = iadd v6, v5
 ;; @0064                               v8 = iconst.i64 1234
 ;; @0064                               v9 = iadd v7, v8  ; v8 = 1234
 ;; @0064                               v10 = load.i32 little heap v9
-;;                                     v3 -> v10
 ;; @006e                               jump block1
 ;;
 ;;                                 block1:

--- a/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-no-spectre-access-same-index-different-offsets.wat
@@ -45,12 +45,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v30 -> v0
-;;                                     v31 -> v0
-;;                                     v32 -> v0
-;;                                     v33 -> v0
-;;                                     v34 -> v0
-;;                                     v35 -> v0
 ;; @0047                               v7 = load.i64 notrap aligned v0+88
 ;; @0047                               v6 = uextend.i64 v2
 ;; @0047                               v8 = icmp ugt v6, v7
@@ -63,7 +57,6 @@
 ;; @0047                               v9 = load.i64 notrap aligned checked v0+80
 ;; @0047                               v10 = iadd v9, v6
 ;; @0047                               v11 = load.i32 little heap v10
-;;                                     v3 -> v11
 ;; @004c                               brif.i8 v8, block4, block5
 ;;
 ;;                                 block4 cold:
@@ -73,7 +66,6 @@
 ;; @004c                               v17 = iconst.i64 4
 ;; @004c                               v18 = iadd.i64 v10, v17  ; v17 = 4
 ;; @004c                               v19 = load.i32 little heap v18
-;;                                     v4 -> v19
 ;; @0051                               v21 = iconst.i64 0x0010_0003
 ;; @0051                               v22 = uadd_overflow_trap.i64 v6, v21, heap_oob  ; v21 = 0x0010_0003
 ;; @0051                               v24 = icmp ugt v22, v7
@@ -88,7 +80,6 @@
 ;; @0051                               v27 = iconst.i64 0x000f_ffff
 ;; @0051                               v28 = iadd v26, v27  ; v27 = 0x000f_ffff
 ;; @0051                               v29 = load.i32 little heap v28
-;;                                     v5 -> v29
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
@@ -105,12 +96,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;;                                     v27 -> v0
-;;                                     v28 -> v0
-;;                                     v29 -> v0
-;;                                     v30 -> v0
-;;                                     v31 -> v0
-;;                                     v32 -> v0
 ;; @005d                               v7 = load.i64 notrap aligned v0+88
 ;; @005d                               v6 = uextend.i64 v2
 ;; @005d                               v8 = icmp ugt v6, v7

--- a/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
+++ b/tests/disas/dynamic-memory-yes-spectre-access-same-index-different-offsets.wat
@@ -41,12 +41,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v36 -> v0
-;;                                     v37 -> v0
-;;                                     v38 -> v0
-;;                                     v39 -> v0
-;;                                     v40 -> v0
-;;                                     v41 -> v0
 ;; @0047                               v7 = load.i64 notrap aligned v0+88
 ;; @0047                               v9 = load.i64 notrap aligned checked v0+80
 ;; @0047                               v6 = uextend.i64 v2
@@ -55,12 +49,10 @@
 ;; @0047                               v10 = iadd v9, v6
 ;; @0047                               v12 = select_spectre_guard v8, v11, v10  ; v11 = 0
 ;; @0047                               v13 = load.i32 little heap v12
-;;                                     v3 -> v13
 ;; @004c                               v19 = iconst.i64 4
 ;; @004c                               v20 = iadd v10, v19  ; v19 = 4
 ;; @004c                               v22 = select_spectre_guard v8, v11, v20  ; v11 = 0
 ;; @004c                               v23 = load.i32 little heap v22
-;;                                     v4 -> v23
 ;; @0051                               v25 = iconst.i64 0x0010_0003
 ;; @0051                               v26 = uadd_overflow_trap v6, v25, heap_oob  ; v25 = 0x0010_0003
 ;; @0051                               v28 = icmp ugt v26, v7
@@ -68,7 +60,6 @@
 ;; @0051                               v32 = iadd v10, v31  ; v31 = 0x000f_ffff
 ;; @0051                               v34 = select_spectre_guard v28, v11, v32  ; v11 = 0
 ;; @0051                               v35 = load.i32 little heap v34
-;;                                     v5 -> v35
 ;; @0056                               jump block1
 ;;
 ;;                                 block1:
@@ -85,12 +76,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;;                                     v33 -> v0
-;;                                     v34 -> v0
-;;                                     v35 -> v0
-;;                                     v36 -> v0
-;;                                     v37 -> v0
-;;                                     v38 -> v0
 ;; @005d                               v7 = load.i64 notrap aligned v0+88
 ;; @005d                               v9 = load.i64 notrap aligned checked v0+80
 ;; @005d                               v6 = uextend.i64 v2

--- a/tests/disas/icall-loop.wat
+++ b/tests/disas/icall-loop.wat
@@ -33,18 +33,13 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v16 -> v0
-;;                                     v20 -> v0
-;;                                     v29 -> v0
-;;                                     v3 -> v2
-;;                                     v28 -> v3
 ;; @002b                               v4 = iconst.i32 2
 ;; @002b                               v5 = icmp uge v2, v4  ; v4 = 2
 ;; @002b                               v10 = iconst.i64 0
 ;; @002b                               v6 = uextend.i64 v2
-;;                                     v30 = iconst.i64 3
-;; @002b                               v8 = ishl v6, v30  ; v30 = 3
-;;                                     v31 = iconst.i64 -2
+;;                                     v29 = iconst.i64 3
+;; @002b                               v8 = ishl v6, v29  ; v29 = 3
+;;                                     v30 = iconst.i64 -2
 ;; @002b                               v17 = load.i64 notrap aligned readonly v0+56
 ;; @002b                               v18 = load.i64 notrap aligned readonly v17+72
 ;; @002b                               v15 = iconst.i32 0
@@ -55,16 +50,16 @@
 ;;                                 block2:
 ;; @002b                               v7 = load.i64 notrap aligned v0+72
 ;; @002b                               v9 = iadd v7, v8
-;;                                     v32 = iconst.i64 0
-;;                                     v33 = select_spectre_guard v5, v32, v9  ; v32 = 0
-;; @002b                               v12 = load.i64 table_oob aligned table v33
-;;                                     v34 = iconst.i64 -2
-;;                                     v35 = band v12, v34  ; v34 = -2
-;; @002b                               brif v12, block5(v35), block4
+;;                                     v31 = iconst.i64 0
+;;                                     v32 = select_spectre_guard v5, v31, v9  ; v31 = 0
+;; @002b                               v12 = load.i64 table_oob aligned table v32
+;;                                     v33 = iconst.i64 -2
+;;                                     v34 = band v12, v33  ; v33 = -2
+;; @002b                               brif v12, block5(v34), block4
 ;;
 ;;                                 block4 cold:
-;;                                     v36 = iconst.i32 0
-;; @002b                               v19 = call_indirect.i64 sig1, v18(v0, v36, v2)  ; v36 = 0
+;;                                     v35 = iconst.i32 0
+;; @002b                               v19 = call_indirect.i64 sig1, v18(v0, v35, v2)  ; v35 = 0
 ;; @002b                               jump block5(v19)
 ;;
 ;;                                 block5(v14: i64):
@@ -93,9 +88,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v15 -> v0
-;;                                     v19 -> v0
-;;                                     v27 -> v0
 ;;                                     v38 = iconst.i64 8
 ;;                                     v29 = iconst.i64 -2
 ;; @0038                               v16 = load.i64 notrap aligned readonly v0+56

--- a/tests/disas/if-unreachable-else-params.wat
+++ b/tests/disas/if-unreachable-else-params.wat
@@ -51,7 +51,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v5 -> v2
 ;; @0043                               v3 = iconst.i32 35
 ;; @0045                               jump block2(v3)  ; v3 = 35
 ;;

--- a/tests/disas/readonly-funcrefs.wat
+++ b/tests/disas/readonly-funcrefs.wat
@@ -42,9 +42,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v15 -> v0
-;;                                     v19 -> v0
-;;                                     v26 -> v0
 ;; @0031                               v6 = load.i64 notrap aligned v0+72
 ;; @0031                               v3 = iconst.i32 2
 ;; @0031                               v4 = icmp uge v2, v3  ; v3 = 2

--- a/tests/disas/table-get-fixed-size.wat
+++ b/tests/disas/table-get-fixed-size.wat
@@ -25,9 +25,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v14 -> v0
-;;                                     v19 -> v0
-;;                                     v25 -> v0
 ;; @0052                               v3 = iconst.i32 0
 ;; @0054                               v4 = iconst.i32 7
 ;; @0054                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
@@ -39,7 +36,6 @@
 ;; @0054                               v10 = iconst.i64 0
 ;; @0054                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0054                               v12 = load.r64 table_oob aligned table v11
-;;                                     v2 -> v12
 ;; @0054                               v13 = is_null v12
 ;; @0054                               brif v13, block2, block3
 ;;
@@ -84,9 +80,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v14 -> v0
-;;                                     v19 -> v0
-;;                                     v25 -> v0
 ;; @005b                               v4 = iconst.i32 7
 ;; @005b                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005b                               v6 = uextend.i64 v2
@@ -97,7 +90,6 @@
 ;; @005b                               v10 = iconst.i64 0
 ;; @005b                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005b                               v12 = load.r64 table_oob aligned table v11
-;;                                     v3 -> v12
 ;; @005b                               v13 = is_null v12
 ;; @005b                               brif v13, block2, block3
 ;;

--- a/tests/disas/table-get.wat
+++ b/tests/disas/table-get.wat
@@ -25,10 +25,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64):
-;;                                     v14 -> v0
-;;                                     v19 -> v0
-;;                                     v25 -> v0
-;;                                     v26 -> v0
 ;; @0051                               v3 = iconst.i32 0
 ;; @0053                               v4 = load.i32 notrap aligned v0+80
 ;; @0053                               v5 = icmp uge v3, v4  ; v3 = 0
@@ -40,7 +36,6 @@
 ;; @0053                               v10 = iconst.i64 0
 ;; @0053                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @0053                               v12 = load.r64 table_oob aligned table v11
-;;                                     v2 -> v12
 ;; @0053                               v13 = is_null v12
 ;; @0053                               brif v13, block2, block3
 ;;
@@ -86,10 +81,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32):
-;;                                     v14 -> v0
-;;                                     v19 -> v0
-;;                                     v25 -> v0
-;;                                     v26 -> v0
 ;; @005a                               v4 = load.i32 notrap aligned v0+80
 ;; @005a                               v5 = icmp uge v2, v4
 ;; @005a                               v6 = uextend.i64 v2
@@ -100,7 +91,6 @@
 ;; @005a                               v10 = iconst.i64 0
 ;; @005a                               v11 = select_spectre_guard v5, v10, v9  ; v10 = 0
 ;; @005a                               v12 = load.r64 table_oob aligned table v11
-;;                                     v3 -> v12
 ;; @005a                               v13 = is_null v12
 ;; @005a                               brif v13, block2, block3
 ;;

--- a/tests/disas/table-set-fixed-size.wat
+++ b/tests/disas/table-set-fixed-size.wat
@@ -27,8 +27,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: r64):
-;;                                     v20 -> v0
-;;                                     v23 -> v0
 ;; @0052                               v3 = iconst.i32 0
 ;; @0056                               v4 = iconst.i32 7
 ;; @0056                               v5 = icmp uge v3, v4  ; v3 = 0, v4 = 7
@@ -88,8 +86,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: r64):
-;;                                     v20 -> v0
-;;                                     v23 -> v0
 ;; @005f                               v4 = iconst.i32 7
 ;; @005f                               v5 = icmp uge v2, v4  ; v4 = 7
 ;; @005f                               v6 = uextend.i64 v2

--- a/tests/disas/table-set.wat
+++ b/tests/disas/table-set.wat
@@ -27,9 +27,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: r64):
-;;                                     v20 -> v0
-;;                                     v23 -> v0
-;;                                     v24 -> v0
 ;; @0051                               v3 = iconst.i32 0
 ;; @0055                               v4 = load.i32 notrap aligned v0+80
 ;; @0055                               v5 = icmp uge v3, v4  ; v3 = 0
@@ -90,9 +87,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: r64):
-;;                                     v20 -> v0
-;;                                     v23 -> v0
-;;                                     v24 -> v0
 ;; @005e                               v4 = load.i32 notrap aligned v0+80
 ;; @005e                               v5 = icmp uge v2, v4
 ;; @005e                               v6 = uextend.i64 v2

--- a/tests/disas/typed-funcrefs.wat
+++ b/tests/disas/typed-funcrefs.wat
@@ -120,7 +120,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;;                                     v6 -> v2
 ;; @0039                               jump block1
 ;;
 ;;                                 block1:
@@ -138,14 +137,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;;                                     v21 -> v0
-;;                                     v47 -> v0
-;;                                     v56 -> v0
-;;                                     v59 -> v0
-;;                                     v30 -> v2
-;;                                     v31 -> v3
-;;                                     v32 -> v4
-;;                                     v33 -> v5
 ;; @0048                               v12 = load.i64 notrap aligned v0+72
 ;;                                     v70 = iconst.i64 8
 ;; @0048                               v14 = iadd v12, v70  ; v70 = 8
@@ -158,7 +149,6 @@
 ;; @005b                               v48 = load.i64 notrap aligned readonly v0+56
 ;; @005b                               v49 = load.i64 notrap aligned readonly v48+72
 ;; @003c                               v7 = iconst.i32 0
-;;                                     v28 -> v7
 ;; @0046                               v8 = iconst.i32 1
 ;; @0048                               v24 = call_indirect sig0, v49(v0, v7, v8)  ; v7 = 0, v8 = 1
 ;; @0048                               jump block3(v24)
@@ -191,7 +181,6 @@
 ;;
 ;;                                 block1:
 ;; @0061                               v55 = iadd.i32 v53, v27
-;;                                     v6 -> v55
 ;; @0066                               return v55
 ;; }
 ;;
@@ -206,14 +195,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;;                                     v21 -> v0
-;;                                     v47 -> v0
-;;                                     v56 -> v0
-;;                                     v59 -> v0
-;;                                     v30 -> v2
-;;                                     v31 -> v3
-;;                                     v32 -> v4
-;;                                     v33 -> v5
 ;; @0075                               v12 = load.i64 notrap aligned v0+72
 ;;                                     v70 = iconst.i64 8
 ;; @0075                               v14 = iadd v12, v70  ; v70 = 8
@@ -226,7 +207,6 @@
 ;; @0087                               v48 = load.i64 notrap aligned readonly v0+56
 ;; @0087                               v49 = load.i64 notrap aligned readonly v48+72
 ;; @0069                               v7 = iconst.i32 0
-;;                                     v28 -> v7
 ;; @0073                               v8 = iconst.i32 1
 ;; @0075                               v24 = call_indirect sig1, v49(v0, v7, v8)  ; v7 = 0, v8 = 1
 ;; @0075                               jump block3(v24)
@@ -259,7 +239,6 @@
 ;;
 ;;                                 block1:
 ;; @008c                               v55 = iadd.i32 v53, v27
-;;                                     v6 -> v55
 ;; @0091                               return v55
 ;; }
 ;;
@@ -272,8 +251,6 @@
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
-;;                                     v8 -> v0
-;;                                     v14 -> v0
 ;; @009e                               v9 = load.i64 notrap aligned table v0+96
 ;; @00a0                               v10 = load.i64 null_reference aligned readonly v9+16
 ;; @00a0                               v11 = load.i64 notrap aligned readonly v9+32
@@ -286,6 +263,5 @@
 ;;
 ;;                                 block1:
 ;; @00b5                               v19 = iadd.i32 v18, v12
-;;                                     v6 -> v19
 ;; @00ba                               return v19
 ;; }


### PR DESCRIPTION
This is a follow-up to #8214. That PR made the CLIF printer resolve aliases before printing any value, which means now the aliases are never referenced.

I expected plenty of tests to change due to removing the aliases from the printed representation of CLIF functions, but there was one surprise: in tests/disas/icall-loop.wat, this didn't just remove the aliases, but also changed the value numbering.

As it turns out, in that one function, the last value in the function that Wasmtime generated was an alias (v28 -> v3). The disas test harness has Wasmtime print the CLIF it generated, then the harness re-parses that CLIF, and passes the re-parsed CLIF to Cranelift's optimization passes. Since after this change the aliases are not printed, re-parsing the printed form doesn't round-trip perfectly, and specifically the last allocated value number changes. As a result, when legalization and optimization introduce new instructions, they get different result value numbers.

My conclusion is that this is fine. The disas tests don't need to produce exactly the same value numbers that the full Wasmtime to Cranelift pipeline would produce. This process does produce the same instructions in the same order, and I think that's all that matters.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
