### PR TITLE
Don't take a custom FuncWriter in pretty_verifier_error

### DIFF
--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -1750,7 +1750,7 @@ impl<'a> Verifier<'a> {
         if !errors.is_empty() {
             log::warn!(
                 "Found verifier errors in function:\n{}",
-                pretty_verifier_error(self.func, None, errors.clone())
+                pretty_verifier_error(self.func, errors.clone())
             );
         }
 

--- a/cranelift/filetests/src/runone.rs
+++ b/cranelift/filetests/src/runone.rs
@@ -104,7 +104,7 @@ pub fn run(
 fn verify_testfile(testfile: &TestFile, fisa: FlagsOrIsa) -> anyhow::Result<()> {
     for (func, _) in &testfile.functions {
         verify_function(func, fisa)
-            .map_err(|errors| anyhow::anyhow!("{}", pretty_verifier_error(&func, None, errors)))?;
+            .map_err(|errors| anyhow::anyhow!("{}", pretty_verifier_error(&func, errors)))?;
     }
 
     Ok(())

--- a/cranelift/jit/tests/basic.rs
+++ b/cranelift/jit/tests/basic.rs
@@ -147,8 +147,7 @@ fn switch_error() {
     match cranelift_codegen::verify_function(&func, &flags) {
         Ok(_) => {}
         Err(err) => {
-            let pretty_error =
-                cranelift_codegen::print_errors::pretty_verifier_error(&func, None, err);
+            let pretty_error = cranelift_codegen::print_errors::pretty_verifier_error(&func, err);
             panic!("pretty_error:\n{}", pretty_error);
         }
     }

--- a/cranelift/object/tests/basic.rs
+++ b/cranelift/object/tests/basic.rs
@@ -137,8 +137,7 @@ fn switch_error() {
     match cranelift_codegen::verify_function(&func, &flags) {
         Ok(_) => {}
         Err(err) => {
-            let pretty_error =
-                cranelift_codegen::print_errors::pretty_verifier_error(&func, None, err);
+            let pretty_error = cranelift_codegen::print_errors::pretty_verifier_error(&func, err);
             panic!("pretty_error:\n{}", pretty_error);
         }
     }

--- a/cranelift/src/wasm.rs
+++ b/cranelift/src/wasm.rs
@@ -242,7 +242,7 @@ fn handle_module(options: &Options, path: &Path, name: &str, fisa: FlagsOrIsa) -
         let mut mem = vec![];
         let (relocs, traps, stack_maps) = if options.check_translation {
             if let Err(errors) = context.verify(fisa) {
-                anyhow::bail!("{}", pretty_verifier_error(&context.func, None, errors));
+                anyhow::bail!("{}", pretty_verifier_error(&context.func, errors));
             }
             (vec![], vec![], vec![])
         } else {


### PR DESCRIPTION
This flexibility is not used anywhere, so let's specialize it.

As far as I can tell, it's never been used since being introduced in https://github.com/bytecodealliance/cranelift/pull/379 in 2018.

@bjorn3, is this used in cg-clif?