### PR TITLE
cranelift: Split return instruction emission out of gen_epilogue_frame_restore

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -418,9 +418,16 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 frame_layout.stack_args_size.try_into().unwrap(),
             ));
         }
-        insts.push(Inst::Ret {});
 
         insts
+    }
+
+    fn gen_return(
+        _call_conv: isa::CallConv,
+        _isa_flags: &RiscvFlags,
+        _frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Inst> {
+        smallvec![Inst::Ret {}]
     }
 
     fn gen_probestack(insts: &mut SmallInstVec<Self::I>, frame_size: u32) {

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -568,8 +568,15 @@ impl ABIMachineSpec for S390xMachineDeps {
                 frame_layout.stack_args_size.try_into().unwrap(),
             ));
         }
-        insts.push(Inst::Ret { link: gpr(14) });
         insts
+    }
+
+    fn gen_return(
+        _call_conv: isa::CallConv,
+        _isa_flags: &s390x_settings::Flags,
+        _frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Inst> {
+        smallvec![Inst::Ret { link: gpr(14) }]
     }
 
     fn gen_probestack(_insts: &mut SmallInstVec<Self::I>, _: u32) {

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -520,10 +520,10 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     }
 
     fn gen_epilogue_frame_restore(
-        call_conv: isa::CallConv,
+        _call_conv: isa::CallConv,
         _flags: &settings::Flags,
         _isa_flags: &x64_settings::Flags,
-        frame_layout: &FrameLayout,
+        _frame_layout: &FrameLayout,
     ) -> SmallInstVec<Self::I> {
         let mut insts = SmallVec::new();
         // `mov %rbp, %rsp`
@@ -534,14 +534,21 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         ));
         // `pop %rbp`
         insts.push(Inst::pop64(Writable::from_reg(regs::rbp())));
+        insts
+    }
+
+    fn gen_return(
+        call_conv: isa::CallConv,
+        _isa_flags: &x64_settings::Flags,
+        frame_layout: &FrameLayout,
+    ) -> SmallInstVec<Self::I> {
         // Emit return instruction.
         let stack_bytes_to_pop = if call_conv == isa::CallConv::Tail {
             frame_layout.stack_args_size
         } else {
             0
         };
-        insts.push(Inst::ret(stack_bytes_to_pop));
-        insts
+        smallvec![Inst::ret(stack_bytes_to_pop)]
     }
 
     fn gen_probestack(insts: &mut SmallInstVec<Self::I>, frame_size: u32) {


### PR DESCRIPTION
The current approach we're discussing for handling callee-save registers with the tail calling convention involves restoring the frame using the existing backend logic before emitting the jump for the tail call. To prepare for this, this PR splits the `ret` emission out of `gen_epilogue_frame_restore` so that it can be used purely to setup the frame for a return **or** jump.
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
