### PR TITLE
Use a multi-threaded Tokio runtime as a fallback

### DIFF
--- a/crates/test-programs/src/bin/cli_sleep.rs
+++ b/crates/test-programs/src/bin/cli_sleep.rs
@@ -1,0 +1,5 @@
+use std::time::Duration;
+
+fn main() {
+    std::thread::sleep(Duration::from_nanos(100));
+}

--- a/crates/wasi/src/runtime.rs
+++ b/crates/wasi/src/runtime.rs
@@ -25,7 +25,7 @@ use std::task::{Context, Poll};
 
 pub(crate) static RUNTIME: once_cell::sync::Lazy<tokio::runtime::Runtime> =
     once_cell::sync::Lazy::new(|| {
-        tokio::runtime::Builder::new_current_thread()
+        tokio::runtime::Builder::new_multi_thread()
             .enable_time()
             .enable_io()
             .build()

--- a/tests/all/cli_tests.rs
+++ b/tests/all/cli_tests.rs
@@ -1596,6 +1596,13 @@ mod test_programs {
         assert!(output.status.success());
         Ok(())
     }
+
+    #[test]
+    fn cli_sleep() -> Result<()> {
+        run_wasmtime(&["run", CLI_SLEEP])?;
+        run_wasmtime(&["run", CLI_SLEEP_COMPONENT])?;
+        Ok(())
+    }
 }
 
 #[test]


### PR DESCRIPTION
This commit fixes a bug that was introduced in #8190 and brought up on [Zulip]. In #8190 there was a subtle change in how Tokio and the CLI are managed, namely that a Tokio runtime is installed at the start of the CLI to avoid entering/exiting the runtime on each blocking call. This had a small performance improvement relative to entering/exiting on each blocking call. This meant, though, that calls previously blocked with `Runtime::block_on` and now block with `Handle::block_on`. The [documentation of `Handle::block_on`][doc] has a clause that says that for single-threaded runtimes I/O and timers won't work.

To fix this issue I've switch the fallback runtime to a multi-threaded runtime to ensure that I/O and timers continue to work.

[Zulip]: https://bytecodealliance.zulipchat.com/#narrow/stream/219900-wasi/topic/Wasi-http.20requests.20hang/near/429187256
[doc]: https://docs.rs/tokio/latest/tokio/runtime/struct.Handle.html#method.block_on

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
