### PR TITLE
PCC: turn off fuzzing for now.

### DIFF
--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -49,3 +49,6 @@ wasm-spec-interpreter = { path = "./wasm-spec-interpreter", optional = true, fea
 
 [features]
 fuzz-spec-interpreter = ['wasm-spec-interpreter']
+
+# Fuzz proof-carrying code. Off by default.
+fuzz-pcc = []

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -188,7 +188,9 @@ impl Config {
         // Determine whether we will actually enable PCC -- this is
         // disabled if the module erquires memory64, which is not yet
         // compatible (due to the need for dynamic checks).
-        let pcc = self.wasmtime.pcc && !self.module_config.config.memory64_enabled;
+        let pcc = cfg!(feature = "fuzz-pcc")
+            && self.wasmtime.pcc
+            && !self.module_config.config.memory64_enabled;
 
         // Only set cranelift specific flags when the Cranelift strategy is
         // chosen.


### PR DESCRIPTION
There have been more fuzzbugs than expected and the onslaught of issues is something I definitely don't have time to deal with right now; let's try again later in the year (unless someone else wants to drive this!).

This puts the fuzzing logic under an off-by-default feature so it can still be tested and developed in-tree as desired.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
