### PR TITLE
cranelift: New InstructionData::map_values helper

### DIFF
--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -662,7 +662,7 @@ impl<'a> EgraphPass<'a> {
                         // Rewrite args of *all* instructions using the
                         // value-to-opt-value map.
                         cursor.func.dfg.resolve_aliases_in_arguments(inst);
-                        cursor.func.dfg.map_inst_values(inst, |_, arg| {
+                        cursor.func.dfg.map_inst_values(inst, |arg| {
                             let new_value = value_to_opt_value[arg];
                             trace!("rewriting arg {} of inst {} to {}", arg, inst, new_value);
                             debug_assert_ne!(new_value, Value::reserved_value());

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -341,6 +341,25 @@ impl InstructionData {
         }
     }
 
+    /// Replace the values used in this instruction according to the given
+    /// function.
+    pub fn map_values(
+        &mut self,
+        pool: &mut ValueListPool,
+        jump_tables: &mut ir::JumpTables,
+        mut f: impl FnMut(Value) -> Value,
+    ) {
+        for arg in self.arguments_mut(pool) {
+            *arg = f(*arg);
+        }
+
+        for block in self.branch_destination_mut(jump_tables) {
+            for arg in block.args_slice_mut(pool) {
+                *arg = f(*arg);
+            }
+        }
+    }
+
     /// If this is a trapping instruction, get its trap code. Otherwise, return
     /// `None`.
     pub fn trap_code(&self) -> Option<TrapCode> {


### PR DESCRIPTION
This is like the DataFlowGraph::map_inst_values method, but that method mutably borrows `self`, so it goes to a fair bit of trouble to drop its borrows around callbacks so the mutable borrow can be used in the callback too.

This new helper only actually needs to borrow two public fields from the DFG: `value_lists` and `jump_tables`. Therefore it's possible to use other fields in the callback as long as the compiler can see all the fields being used in the same scope. That's good enough for everywhere we were using this pattern, so we can simplify this way.

The case which motivated this change isn't shown here: It isn't possible to call `dfg.map_inst_values` on every instruction in `dfg.insts`, because the borrow on `dfg.insts` prevents taking a mutable borrow on `dfg`. But we can call this new helper in that case.