### PR TITLE
cranelift: Only enable winch calling convention for x64

### DIFF
--- a/cranelift/fuzzgen/src/cranelift_arbitrary.rs
+++ b/cranelift/fuzzgen/src/cranelift_arbitrary.rs
@@ -64,7 +64,7 @@ impl<'a> CraneliftArbitrary for &mut Unstructured<'a> {
             allowed_callconvs.push(CallConv::Tail);
         }
 
-        // The winch calling convention is supposed to work on x64 and aarch64
+        // The winch calling convention is supposed to work on x64.
         if matches!(architecture, Architecture::X86_64) {
             allowed_callconvs.push(CallConv::Winch);
         }

--- a/cranelift/fuzzgen/src/cranelift_arbitrary.rs
+++ b/cranelift/fuzzgen/src/cranelift_arbitrary.rs
@@ -65,10 +65,7 @@ impl<'a> CraneliftArbitrary for &mut Unstructured<'a> {
         }
 
         // The winch calling convention is supposed to work on x64 and aarch64
-        if matches!(
-            architecture,
-            Architecture::X86_64 | Architecture::Aarch64(_)
-        ) {
+        if matches!(architecture, Architecture::X86_64) {
             allowed_callconvs.push(CallConv::Winch);
         }
 


### PR DESCRIPTION
This commit is a follow up to https://github.com/bytecodealliance/wasmtime/pull/8198; it ensures ensures that the Winch calling convention is only allowed  when the architecture is x64.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
