### PR TITLE
Slightly improve error message of feeding components to `Module` APIs

### DIFF
--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -238,3 +238,15 @@ fn large_add_chain_no_stack_overflow() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn compile_a_component() -> Result<()> {
+    let engine = Engine::default();
+    let err = Module::new(&engine, "(component)").unwrap_err();
+    let err = format!("{err:?}");
+    assert!(
+        err.contains("expected a WebAssembly module but was given a WebAssembly component"),
+        "bad error: {err}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
This commit slightly improves the error message of feeding a component into a module-taking API. This at least tries to convey that a component was recognized but a module was expected.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
