### PR TITLE
fix(wasi): export `FileInputStream`

### DIFF
--- a/crates/wasi/src/lib.rs
+++ b/crates/wasi/src/lib.rs
@@ -34,7 +34,7 @@ mod write_stream;
 pub use self::clocks::{HostMonotonicClock, HostWallClock};
 pub use self::ctx::{WasiCtx, WasiCtxBuilder, WasiView};
 pub use self::error::{I32Exit, TrappableError};
-pub use self::filesystem::{DirPerms, FilePerms, FsError, FsResult};
+pub use self::filesystem::{DirPerms, FileInputStream, FilePerms, FsError, FsResult};
 pub use self::network::{Network, SocketAddrUse, SocketError, SocketResult};
 #[cfg(feature = "preview1")]
 pub use self::p1ctx::WasiP1Ctx;


### PR DESCRIPTION
Currently, `HostInputStream` is a public enum, meaning that embedders can e.g. `delete` them from the table, match the cases and call methods on `FileInputStream` stored in `HostInputStream::File`, however embedders cannot *name* the `FileInputStream` type, since it's contained in a private `filesystem` module and not re-exported. Re-export to remove the need for embedders to always match on the `HostInputStream` rather than just using the `FileInputStream` directly