### PR TITLE
cranelift: Support callee-saved registers with tail calls on x64

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -100,6 +100,9 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
             self.lower_ctx.sigs(),
             callee_sig,
             &callee,
+            // TODO: this should be Opcode::ReturnCall, once aarch64 has been ported to the new
+            // tail call strategy.
+            Opcode::Call,
             distance,
             caller_conv,
             self.backend.flags().clone(),

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -18,7 +18,7 @@ use crate::machinst::{VCodeConstant, VCodeConstantData};
 use crate::{
     ir::{
         immediates::*, types::*, AtomicRmwOp, BlockCall, ExternalName, Inst, InstructionData,
-        MemFlags, StackSlot, TrapCode, Value, ValueList,
+        MemFlags, Opcode, StackSlot, TrapCode, Value, ValueList,
     },
     isa::riscv64::inst::*,
     machinst::{ArgPair, InstOutput},
@@ -82,6 +82,9 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
             self.lower_ctx.sigs(),
             callee_sig,
             &callee,
+            // TODO: this should be Opcode::ReturnCall, once riscv64 has been ported to the new
+            // tail call strategy.
+            Opcode::Call,
             distance,
             caller_conv,
             self.backend.flags().clone(),

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -912,14 +912,14 @@ impl X64CallSite {
             core::cmp::Ordering::Equal => {}
             core::cmp::Ordering::Less => {
                 let tmp = ctx.temp_writable_gpr();
-                ctx.emit(Inst::ShrinkFrame {
+                ctx.emit(Inst::ShrinkArgumentArea {
                     amount: old_stack_arg_size - new_stack_arg_size,
                     tmp,
                 });
             }
             core::cmp::Ordering::Greater => {
                 let tmp = ctx.temp_writable_gpr();
-                ctx.emit(Inst::GrowFrame {
+                ctx.emit(Inst::GrowArgumentArea {
                     amount: new_stack_arg_size - old_stack_arg_size,
                     tmp,
                 });

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -931,8 +931,7 @@ impl X64CallSite {
         self.emit_args(ctx, args);
         self.emit_stack_ret_arg_for_tail_call(ctx);
 
-        // Finally, emit the macro instruction to copy the new stack frame over
-        // our current one and do the actual tail call!
+        // Finally, do the actual tail call!
         let dest = self.dest().clone();
         let info = Box::new(ReturnCallInfo {
             uses: self.take_uses(),

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -541,6 +541,16 @@
        (ReturnCallUnknown (callee RegMem)
                           (info BoxReturnCallInfo))
 
+       ;; Move the frame down in memory to accommodate additional stack
+       ;; arguments, when setting up for a tail call.
+       (GrowFrame (amount u32)
+                  (tmp WritableGpr))
+
+       ;; Move the frame up in memory to accommodate fewer stack arguments, when
+       ;; setting up for a tail call.
+       (ShrinkFrame (amount u32)
+                    (tmp WritableGpr))
+
        ;; A pseudo-instruction that captures register arguments in vregs.
        (Args
         (args VecArgPair))

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -541,15 +541,22 @@
        (ReturnCallUnknown (callee RegMem)
                           (info BoxReturnCallInfo))
 
-       ;; Move the frame down in memory to accommodate additional stack
-       ;; arguments, when setting up for a tail call.
-       (GrowFrame (amount u32)
-                  (tmp WritableGpr))
+       ;; GrowArgumentArea does a memmove of everything in the frame except for
+       ;; the argument area, to make room for more arguments. That includes all
+       ;; the stack slots, the callee-saved registers, and the saved FP and
+       ;; return address. To keep the stack pointers in sync with that change,
+       ;; it also subtracts the given amount from both the FP and SP registers.
+       (GrowArgumentArea (amount u32)
+                         (tmp WritableGpr))
 
-       ;; Move the frame up in memory to accommodate fewer stack arguments, when
-       ;; setting up for a tail call.
-       (ShrinkFrame (amount u32)
-                    (tmp WritableGpr))
+       ;; ShrinkArgumentArea does a memmove of everything in the frame except
+       ;; for the argument area, to trim space for fewer arguments. That
+       ;; includes all the stack slots, the callee-saved registers, and the
+       ;; saved FP and return address. To keep the stack pointers in sync with
+       ;; that change, it also adds the given amount to both the FP and SP
+       ;; registers.
+       (ShrinkArgumentArea (amount u32)
+                           (tmp WritableGpr))
 
        ;; A pseudo-instruction that captures register arguments in vregs.
        (Args

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1,6 +1,6 @@
 use crate::ir;
 use crate::ir::immediates::{Ieee32, Ieee64};
-use crate::ir::{KnownSymbol, MemFlags};
+use crate::ir::KnownSymbol;
 use crate::isa::x64::encoding::evex::{EvexInstruction, EvexVectorLength, RegisterOrAmode};
 use crate::isa::x64::encoding::rex::{
     emit_simm, emit_std_enc_enc, emit_std_enc_mem, emit_std_reg_mem, emit_std_reg_reg, int_reg_enc,
@@ -1628,18 +1628,7 @@ pub(crate) fn emit(
             callee,
             info: call_info,
         } => {
-            emit_return_call_common_sequence(
-                allocs,
-                sink,
-                info,
-                state,
-                call_info.new_stack_arg_size,
-                call_info.old_stack_arg_size,
-                call_info.ret_addr,
-                call_info.fp,
-                call_info.tmp,
-                &call_info.uses,
-            );
+            emit_return_call_common_sequence(allocs, sink, info, state, &call_info.uses);
 
             // Finally, jump to the callee!
             //
@@ -1660,18 +1649,7 @@ pub(crate) fn emit(
         } => {
             let callee = callee.with_allocs(allocs);
 
-            emit_return_call_common_sequence(
-                allocs,
-                sink,
-                info,
-                state,
-                call_info.new_stack_arg_size,
-                call_info.old_stack_arg_size,
-                call_info.ret_addr,
-                call_info.fp,
-                call_info.tmp,
-                &call_info.uses,
-            );
+            emit_return_call_common_sequence(allocs, sink, info, state, &call_info.uses);
 
             Inst::JmpUnknown { target: callee }.emit(&[], sink, info, state);
             sink.add_call_site(ir::Opcode::ReturnCallIndirect);
@@ -1737,12 +1715,19 @@ pub(crate) fn emit(
             // TODO: this needs to be accounted for by the stack check, before `GrowFrame` is
             // emitted, so that the increment here is expected.
             //
-            // Decrement SP by `amount`
+            // Decrement SP and FP by `amount`
             Inst::alu_rmi_r(
                 OperandSize::Size64,
                 AluRmiROpcode::Sub,
                 RegMemImm::imm(*amount),
                 Writable::from_reg(regs::rsp()),
+            )
+            .emit(&[], sink, info, state);
+            Inst::alu_rmi_r(
+                OperandSize::Size64,
+                AluRmiROpcode::Sub,
+                RegMemImm::imm(*amount),
+                Writable::from_reg(regs::rbp()),
             )
             .emit(&[], sink, info, state);
 
@@ -1815,6 +1800,15 @@ pub(crate) fn emit(
                 AluRmiROpcode::Add,
                 RegMemImm::imm(*amount),
                 Writable::from_reg(regs::rsp()),
+            )
+            .emit(&[], sink, info, state);
+
+            // Increment FP by `amount`
+            Inst::alu_rmi_r(
+                OperandSize::Size64,
+                AluRmiROpcode::Add,
+                RegMemImm::imm(*amount),
+                Writable::from_reg(regs::rbp()),
             )
             .emit(&[], sink, info, state);
         }
@@ -4349,11 +4343,6 @@ fn emit_return_call_common_sequence(
     sink: &mut MachBuffer<Inst>,
     info: &EmitInfo,
     state: &mut EmitState,
-    new_stack_arg_size: u32,
-    old_stack_arg_size: u32,
-    ret_addr: Option<Gpr>,
-    fp: Gpr,
-    tmp: WritableGpr,
     uses: &CallArgList,
 ) {
     assert!(
@@ -4366,125 +4355,18 @@ fn emit_return_call_common_sequence(
         let _ = allocs.next(u.vreg);
     }
 
-    let ret_addr = ret_addr.map(|r| Gpr::new(allocs.next(*r)).unwrap());
-
-    let fp = allocs.next(*fp);
-
-    let tmp = allocs.next(tmp.to_reg().to_reg());
-    let tmp = Gpr::new(tmp).unwrap();
-    let tmp_w = WritableGpr::from_reg(tmp);
-
-    // Copy the new frame (which is `frame_size` bytes above the SP)
-    // onto our current frame, using only volatile, non-argument
-    // registers.
-    //
-    //
-    // The current stack layout is the following:
-    //
-    //            | ...                 |
-    //            +---------------------+
-    //            | ...                 |
-    //            | stack arguments     |
-    //            | ...                 |
-    //    current | return address      |
-    //    frame   | old FP              | <-- FP
-    //            | callee saves        |
-    //            | ...                 |
-    //            | old stack slots     |
-    //            | ...                 |
-    //            +---------------------+
-    //            | ...                 |
-    //    new     | new stack arguments |
-    //    frame   | ...                 | <-- SP
-    //            +---------------------+
-    //
-    // We need to restore the old FP, copy the new stack arguments over the old
-    // stack arguments, write the return address into the correct slot just
-    // after the new stack arguments, adjust SP to point to the new return
-    // address, and then jump to the callee (which will push the old FP again).
-
-    // Restore the old FP into `rbp`.
-    Inst::Mov64MR {
-        src: SyntheticAmode::Real(Amode::ImmReg {
-            simm32: 0,
-            base: fp,
-            flags: MemFlags::trusted(),
-        }),
-        dst: Writable::from_reg(Gpr::new(regs::rbp()).unwrap()),
-    }
-    .emit(&[], sink, info, state);
-
-    // The new lowest address (top of stack) -- relative to FP -- for
-    // our tail callee. We compute this now so that we can move our
-    // stack arguments into place.
-    let callee_sp_relative_to_fp = i64::from(old_stack_arg_size) - i64::from(new_stack_arg_size);
-
-    // Copy over each word, using `tmp` as a temporary register.
-    //
-    // Note that we have to do this from stack slots with the highest
-    // address to lowest address because in the case of when the tail
-    // callee has more stack arguments than we do, we might otherwise
-    // overwrite some of our stack arguments before they've been copied
-    // into place.
-    assert_eq!(
-        new_stack_arg_size % 8,
-        0,
-        "stack argument space sizes should always be 8-byte aligned"
-    );
-    for i in (0..new_stack_arg_size / 8).rev() {
-        Inst::Mov64MR {
-            src: SyntheticAmode::Real(Amode::ImmReg {
-                simm32: (i * 8).try_into().unwrap(),
-                base: regs::rsp(),
-                flags: MemFlags::trusted(),
-            }),
-            dst: tmp_w,
-        }
-        .emit(&[], sink, info, state);
-        Inst::MovRM {
-            size: OperandSize::Size64,
-            src: tmp,
-            dst: SyntheticAmode::Real(Amode::ImmReg {
-                // Add 2 because we need to skip over the old FP and the
-                // return address.
-                simm32: (callee_sp_relative_to_fp + i64::from((i + 2) * 8))
-                    .try_into()
-                    .unwrap(),
-                base: fp,
-                flags: MemFlags::trusted(),
-            }),
-        }
-        .emit(&[], sink, info, state);
+    for inst in
+        X64ABIMachineSpec::gen_clobber_restore(CallConv::Tail, &info.flags, state.frame_layout())
+    {
+        inst.emit(&[], sink, info, state);
     }
 
-    // Initialize SP for the tail callee, deallocating the temporary
-    // stack arguments space at the same time.
-    Inst::LoadEffectiveAddress {
-        size: OperandSize::Size64,
-        addr: SyntheticAmode::Real(Amode::ImmReg {
-            // NB: We add a word to `callee_sp_relative_to_fp` here because the
-            // callee will push FP, not us.
-            simm32: callee_sp_relative_to_fp.wrapping_add(8).try_into().unwrap(),
-            base: fp,
-            flags: MemFlags::trusted(),
-        }),
-        dst: Writable::from_reg(Gpr::new(regs::rsp()).unwrap()),
-    }
-    .emit(&[], sink, info, state);
-
-    state.adjust_virtual_sp_offset(-i64::from(new_stack_arg_size));
-
-    // Write the return address into the correct stack slot.
-    if let Some(ret_addr) = ret_addr {
-        Inst::MovRM {
-            size: OperandSize::Size64,
-            src: ret_addr,
-            dst: SyntheticAmode::Real(Amode::ImmReg {
-                simm32: 0,
-                base: regs::rsp(),
-                flags: MemFlags::trusted(),
-            }),
-        }
-        .emit(&[], sink, info, state);
+    for inst in X64ABIMachineSpec::gen_epilogue_frame_restore(
+        CallConv::Tail,
+        &info.flags,
+        &info.isa_flags,
+        state.frame_layout(),
+    ) {
+        inst.emit(&[], sink, info, state);
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1700,13 +1700,13 @@ pub(crate) fn emit(
             }
         }
 
-        Inst::GrowFrame { amount, tmp } => {
+        Inst::GrowArgumentArea { amount, tmp } => {
             debug_assert!(*amount > 0);
             debug_assert_eq!(*amount % 8, 0);
 
             assert!(
                 info.flags.preserve_frame_pointers(),
-                "frame pointers must be enabled for GrowFrame"
+                "frame pointers must be enabled for GrowArgumentArea"
             );
 
             let tmp = allocs.next(tmp.to_reg().to_reg());
@@ -1761,13 +1761,13 @@ pub(crate) fn emit(
             }
         }
 
-        Inst::ShrinkFrame { amount, tmp } => {
+        Inst::ShrinkArgumentArea { amount, tmp } => {
             debug_assert!(*amount > 0);
             debug_assert_eq!(*amount % 8, 0);
 
             assert!(
                 info.flags.preserve_frame_pointers(),
-                "frame pointers must be enabled for ShrinkFrame"
+                "frame pointers must be enabled for ShrinkArgumentArea"
             );
 
             let tmp = allocs.next(tmp.to_reg().to_reg());

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1733,7 +1733,8 @@ pub(crate) fn emit(
 
             // The total size that we're going to copy, including the return address and frame
             // pointer that are pushed on the stack already.
-            let size = i32::try_from(state.nominal_sp_to_fp()).unwrap() + 16;
+            let size = i32::try_from(state.nominal_sp_to_fp()).unwrap()
+                + i32::try_from(state.frame_layout().setup_area_size).unwrap();
 
             debug_assert_eq!(size % 8, 0);
 
@@ -1771,7 +1772,8 @@ pub(crate) fn emit(
 
             // The total size that we're going to copy, including the return address and frame
             // pointer that are pushed on the stack alreadcy.
-            let size = i32::try_from(state.nominal_sp_to_fp()).unwrap() + 16;
+            let size = i32::try_from(state.nominal_sp_to_fp()).unwrap()
+                + i32::try_from(state.frame_layout().setup_area_size).unwrap();
 
             debug_assert_eq!(size % 8, 0);
 

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1704,17 +1704,19 @@ pub(crate) fn emit(
             debug_assert!(*amount > 0);
             debug_assert_eq!(*amount % 8, 0);
 
+            assert!(
+                info.flags.preserve_frame_pointers(),
+                "frame pointers must be enabled for GrowFrame"
+            );
+
             let tmp = allocs.next(tmp.to_reg().to_reg());
-            let src = Gpr::new(tmp).unwrap();
-            let dst = WritableGpr::from_reg(src);
+            let tmp = Gpr::new(tmp).unwrap();
+            let tmp_w = WritableGpr::from_reg(tmp);
 
             // As we're increasing the number of stack arguments, we need to move the frame down in
             // memory, by decrementing SP by `amount` and looping from lower addresses to higher
             // ones, copying down.
 
-            // TODO: this needs to be accounted for by the stack check, before `GrowFrame` is
-            // emitted, so that the increment here is expected.
-            //
             // Decrement SP and FP by `amount`
             Inst::alu_rmi_r(
                 OperandSize::Size64,
@@ -1738,20 +1740,21 @@ pub(crate) fn emit(
 
             debug_assert_eq!(size % 8, 0);
 
-            // Iterate word offsets from `SP + amount`, copying them to SP.
+            // Copy the `i`th word in the stack from `SP + amount + i * 8` to `SP + i * 8`. Do this
+            // from lower to higher addresses to avoid clobbering words we haven't copied yet.
             for sp_word_offset in 0..(size / 8) {
                 let sp_byte_offset = sp_word_offset * 8;
                 Inst::Mov64MR {
                     src: SyntheticAmode::nominal_sp_offset(
                         sp_byte_offset + i32::try_from(*amount).unwrap(),
                     ),
-                    dst,
+                    dst: tmp_w,
                 }
                 .emit(&[], sink, info, state);
 
                 Inst::MovRM {
                     size: OperandSize::Size64,
-                    src,
+                    src: tmp,
                     dst: SyntheticAmode::nominal_sp_offset(sp_byte_offset),
                 }
                 .emit(&[], sink, info, state);
@@ -1762,9 +1765,14 @@ pub(crate) fn emit(
             debug_assert!(*amount > 0);
             debug_assert_eq!(*amount % 8, 0);
 
+            assert!(
+                info.flags.preserve_frame_pointers(),
+                "frame pointers must be enabled for ShrinkFrame"
+            );
+
             let tmp = allocs.next(tmp.to_reg().to_reg());
-            let src = Gpr::new(tmp).unwrap();
-            let dst = WritableGpr::from_reg(src);
+            let tmp = Gpr::new(tmp).unwrap();
+            let tmp_w = WritableGpr::from_reg(tmp);
 
             // As we're decreasing the number of stack arguments, we need to move the frame up in
             // memory, looping from higher addresses to lower ones copying up, and finally
@@ -1777,18 +1785,19 @@ pub(crate) fn emit(
 
             debug_assert_eq!(size % 8, 0);
 
-            // Iterate word offsets from `SP`, copying them to `SP + amount`.
+            // Copy the `i`th word in the stack from `SP + i * 8` to `SP + amount + i * 8`. Do this
+            // from higher to lower addresses to avoid clobbering words we haven't copied yet.
             for sp_word_offset in (0..(size / 8)).rev() {
                 let sp_byte_offset = sp_word_offset * 8;
                 Inst::Mov64MR {
                     src: SyntheticAmode::nominal_sp_offset(sp_byte_offset),
-                    dst,
+                    dst: tmp_w,
                 }
                 .emit(&[], sink, info, state);
 
                 Inst::MovRM {
                     size: OperandSize::Size64,
-                    src,
+                    src: tmp,
                     dst: SyntheticAmode::nominal_sp_offset(
                         sp_byte_offset + i32::try_from(*amount).unwrap(),
                     ),

--- a/cranelift/codegen/src/isa/x64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit.rs
@@ -1732,7 +1732,7 @@ pub(crate) fn emit(
             .emit(&[], sink, info, state);
 
             // The total size that we're going to copy, including the return address and frame
-            // pointer that are pushed on the stack alreadcy.
+            // pointer that are pushed on the stack already.
             let size = i32::try_from(state.nominal_sp_to_fp()).unwrap() + 16;
 
             debug_assert_eq!(size % 8, 0);

--- a/cranelift/codegen/src/isa/x64/inst/emit_state.rs
+++ b/cranelift/codegen/src/isa/x64/inst/emit_state.rs
@@ -14,6 +14,10 @@ pub struct EmitState {
     /// Only used during fuzz-testing. Otherwise, it is a zero-sized struct and
     /// optimized away at compiletime. See [cranelift_control].
     ctrl_plane: ControlPlane,
+
+    /// A copy of the frame layout, used during the emission of `Inst::ReturnCallKnown` and
+    /// `Inst::ReturnCallUnknown` instructions.
+    frame_layout: FrameLayout,
 }
 
 impl MachInstEmitState<Inst> for EmitState {
@@ -23,6 +27,7 @@ impl MachInstEmitState<Inst> for EmitState {
             nominal_sp_to_fp: abi.frame_size() as i64,
             stack_map: None,
             ctrl_plane,
+            frame_layout: abi.frame_layout().clone(),
         }
     }
 
@@ -61,5 +66,9 @@ impl EmitState {
 
     pub(crate) fn nominal_sp_to_fp(&self) -> i64 {
         self.nominal_sp_to_fp
+    }
+
+    pub(crate) fn frame_layout(&self) -> &FrameLayout {
+        &self.frame_layout
     }
 }

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -2329,11 +2329,6 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
         Inst::CallUnknown { info, dest, .. } => {
             let info = info.as_ref().expect("CallInfo is expected in this path");
             match dest {
-                RegMem::Reg { reg } if info.callee_conv == CallConv::Tail => {
-                    // TODO(https://github.com/bytecodealliance/regalloc2/issues/145):
-                    // This shouldn't be a fixed register constraint.
-                    collector.reg_fixed_use(*reg, regs::r15())
-                }
                 RegMem::Reg { reg } if info.callee_conv == CallConv::Winch => {
                     // TODO(https://github.com/bytecodealliance/regalloc2/issues/145):
                     // This shouldn't be a fixed register constraint.

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -124,8 +124,8 @@ impl Inst {
             | Inst::Pop64 { .. }
             | Inst::Push64 { .. }
             | Inst::StackProbeLoop { .. }
-            | Inst::GrowFrame { .. }
-            | Inst::ShrinkFrame { .. }
+            | Inst::GrowArgumentArea { .. }
+            | Inst::ShrinkArgumentArea { .. }
             | Inst::Args { .. }
             | Inst::Rets { .. }
             | Inst::Ret { .. }
@@ -1685,13 +1685,13 @@ impl PrettyPrint for Inst {
                 s
             }
 
-            Inst::GrowFrame { amount, tmp } => {
+            Inst::GrowArgumentArea { amount, tmp } => {
                 let amount = *amount;
                 let tmp = regs::show_reg(tmp.to_reg().to_reg());
                 format!("grow_frame {amount} {tmp}")
             }
 
-            Inst::ShrinkFrame { amount, tmp } => {
+            Inst::ShrinkArgumentArea { amount, tmp } => {
                 let amount = *amount;
                 let tmp = regs::show_reg(tmp.to_reg().to_reg());
                 format!("shrink_frame {amount} {tmp}")
@@ -2362,7 +2362,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             }
         }
 
-        Inst::GrowFrame { tmp, .. } | Inst::ShrinkFrame { tmp, .. } => {
+        Inst::GrowArgumentArea { tmp, .. } | Inst::ShrinkArgumentArea { tmp, .. } => {
             collector.reg_def(tmp.to_writable_reg());
         }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -1687,14 +1687,14 @@ impl PrettyPrint for Inst {
 
             Inst::GrowArgumentArea { amount, tmp } => {
                 let amount = *amount;
-                let tmp = regs::show_reg(tmp.to_reg().to_reg());
-                format!("grow_frame {amount} {tmp}")
+                let tmp = pretty_print_reg(tmp.to_reg().to_reg(), 8, allocs);
+                format!("grow_argument_area {amount} {tmp}")
             }
 
             Inst::ShrinkArgumentArea { amount, tmp } => {
                 let amount = *amount;
-                let tmp = regs::show_reg(tmp.to_reg().to_reg());
-                format!("shrink_frame {amount} {tmp}")
+                let tmp = pretty_print_reg(tmp.to_reg().to_reg(), 8, allocs);
+                format!("shrink_argument_area {amount} {tmp}")
             }
 
             Inst::Args { args } => {

--- a/cranelift/codegen/src/isa/x64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/x64/lower/isle.rs
@@ -118,6 +118,7 @@ impl Context for IsleContext<'_, '_, MInst, X64Backend> {
             self.lower_ctx.sigs(),
             callee_sig,
             &callee,
+            Opcode::ReturnCall,
             distance,
             caller_conv,
             self.backend.flags().clone(),

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -808,8 +808,8 @@ pub(crate) fn check(
         | Inst::ReturnCallKnown { .. }
         | Inst::JmpKnown { .. }
         | Inst::Ret { .. }
-        | Inst::GrowFrame { .. }
-        | Inst::ShrinkFrame { .. }
+        | Inst::GrowArgumentArea { .. }
+        | Inst::ShrinkArgumentArea { .. }
         | Inst::JmpIf { .. }
         | Inst::JmpCond { .. }
         | Inst::TrapIf { .. }

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -808,6 +808,8 @@ pub(crate) fn check(
         | Inst::ReturnCallKnown { .. }
         | Inst::JmpKnown { .. }
         | Inst::Ret { .. }
+        | Inst::GrowFrame { .. }
+        | Inst::ShrinkFrame { .. }
         | Inst::JmpIf { .. }
         | Inst::JmpCond { .. }
         | Inst::TrapIf { .. }

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -2346,6 +2346,11 @@ impl<M: ABIMachineSpec> CallSite<M> {
                 }),
                 ArgLoc::Stack { offset, ty } => {
                     let amode = if self.is_tail_call() {
+                        assert!(
+                            self.flags.preserve_frame_pointers(),
+                            "tail calls require frame pointers to be enabled"
+                        );
+
                         StackAMode::FPOffset(
                             offset + M::fp_to_arg_offset(self.caller_conv, &self.flags),
                             ty,

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -987,6 +987,7 @@ impl std::ops::Index<Sig> for SigSet {
 }
 
 /// Structure describing the layout of a function's stack frame.
+#[derive(Clone, Debug, Default)]
 pub struct FrameLayout {
     /// N.B. The areas whose sizes are given in this structure fully
     /// cover the current function's stack frame, from high to low
@@ -1886,7 +1887,7 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// This should include any stack frame or other setup necessary to use the
     /// other methods (`load_arg`, `store_retval`, and spillslot accesses.)
     pub fn gen_prologue(&self) -> SmallInstVec<M::I> {
-        let frame_layout = self.frame_layout.as_ref().unwrap();
+        let frame_layout = self.frame_layout();
         let mut insts = smallvec![];
 
         // Set up frame.
@@ -1953,7 +1954,7 @@ impl<M: ABIMachineSpec> Callee<M> {
     /// emitting this in the lowering logic), because the epilogue code comes
     /// before the return and the two are likely closely related.
     pub fn gen_epilogue(&self) -> SmallInstVec<M::I> {
-        let frame_layout = self.frame_layout.as_ref().unwrap();
+        let frame_layout = self.frame_layout();
         let mut insts = smallvec![];
 
         // Restore clobbered registers.
@@ -1988,25 +1989,27 @@ impl<M: ABIMachineSpec> Callee<M> {
         insts
     }
 
+    /// Return a reference to the computed frame layout information. This
+    /// function will panic if it's called before [`Self::compute_frame_layout`].
+    pub fn frame_layout(&self) -> &FrameLayout {
+        self.frame_layout
+            .as_ref()
+            .expect("frame layout not computed before prologue generation")
+    }
+
     /// Returns the full frame size for the given function, after prologue
     /// emission has run. This comprises the spill slots and stack-storage
     /// slots as well as storage for clobbered callee-save registers, but
     /// not arguments arguments pushed at callsites within this function,
     /// or other ephemeral pushes.
     pub fn frame_size(&self) -> u32 {
-        let frame_layout = self
-            .frame_layout
-            .as_ref()
-            .expect("frame size not computed before prologue generation");
+        let frame_layout = self.frame_layout();
         frame_layout.clobber_size + frame_layout.fixed_frame_storage_size
     }
 
     /// Returns offset from the nominal SP to caller's SP.
     pub fn nominal_sp_to_caller_sp_offset(&self) -> u32 {
-        let frame_layout = self
-            .frame_layout
-            .as_ref()
-            .expect("frame size not computed before prologue generation");
+        let frame_layout = self.frame_layout();
         frame_layout.clobber_size
             + frame_layout.fixed_frame_storage_size
             + frame_layout.setup_area_size
@@ -2069,7 +2072,7 @@ impl<M: ABIMachineSpec> Callee<M> {
 #[derive(Clone, Debug)]
 pub enum ArgLoc {
     Reg(PReg),
-    Stack(StackAMode),
+    Stack { offset: i64, ty: ir::Type },
 }
 
 /// An input argument to a call instruction: the vreg that is used,
@@ -2133,6 +2136,7 @@ impl<M: ABIMachineSpec> CallSite<M> {
         sigs: &SigSet,
         sig_ref: ir::SigRef,
         extname: &ir::ExternalName,
+        opcode: ir::Opcode,
         dist: RelocDistance,
         caller_conv: isa::CallConv,
         flags: settings::Flags,
@@ -2145,7 +2149,7 @@ impl<M: ABIMachineSpec> CallSite<M> {
             defs: smallvec![],
             clobbers,
             dest: CallDest::ExtName(extname.clone(), dist),
-            opcode: ir::Opcode::Call,
+            opcode,
             caller_conv,
             flags,
             _mach: PhantomData,
@@ -2212,6 +2216,17 @@ impl<M: ABIMachineSpec> CallSite<M> {
 
     pub(crate) fn take_uses(self) -> CallArgList {
         self.uses
+    }
+
+    pub(crate) fn sig<'a>(&self, sigs: &'a SigSet) -> &'a SigData {
+        &sigs[self.sig]
+    }
+
+    pub(crate) fn is_tail_call(&self) -> bool {
+        matches!(
+            self.opcode,
+            ir::Opcode::ReturnCall | ir::Opcode::ReturnCallIndirect
+        )
     }
 }
 
@@ -2329,7 +2344,17 @@ impl<M: ABIMachineSpec> CallSite<M> {
                     vreg,
                     preg: preg.into(),
                 }),
-                ArgLoc::Stack(amode) => ctx.emit(M::gen_store_stack(amode, vreg, amode.get_type())),
+                ArgLoc::Stack { offset, ty } => {
+                    let amode = if self.is_tail_call() {
+                        StackAMode::FPOffset(
+                            offset + M::fp_to_arg_offset(self.caller_conv, &self.flags),
+                            ty,
+                        )
+                    } else {
+                        StackAMode::SPOffset(offset, ty)
+                    };
+                    ctx.emit(M::gen_store_stack(amode, vreg, ty))
+                }
             }
         }
     }
@@ -2416,10 +2441,7 @@ impl<M: ABIMachineSpec> CallSite<M> {
                                 } else {
                                     (*from_reg, ty)
                                 };
-                            locs.push((
-                                data.into(),
-                                ArgLoc::Stack(StackAMode::SPOffset(offset, ty)),
-                            ));
+                            locs.push((data.into(), ArgLoc::Stack { offset, ty }));
                         }
                     }
                 }
@@ -2444,7 +2466,7 @@ impl<M: ABIMachineSpec> CallSite<M> {
                     ABIArgSlot::Reg { reg, .. } => ArgLoc::Reg(reg.into()),
                     ABIArgSlot::Stack { offset, .. } => {
                         let ty = M::word_type();
-                        ArgLoc::Stack(StackAMode::SPOffset(offset, ty))
+                        ArgLoc::Stack { offset, ty }
                     }
                 };
                 locs.push((tmp.into(), loc));

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -2071,7 +2071,13 @@ impl<M: ABIMachineSpec> Callee<M> {
 /// The register or stack slot location of an argument.
 #[derive(Clone, Debug)]
 pub enum ArgLoc {
+    /// The physical register that the value will be passed through.
     Reg(PReg),
+
+    /// The offset into the argument area where this value will be passed. It's up to the consumer
+    /// of the `ArgLoc::Stack` variant to decide how to find the argument area that the `offset`
+    /// value is relative to. Depending on the abi, this may end up being relative to SP or FP, for
+    /// example with a tail call where the frame is reused.
     Stack { offset: i64, ty: ir::Type },
 }
 

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -758,6 +758,7 @@ macro_rules! isle_prelude_caller_methods {
                 self.lower_ctx.sigs(),
                 sig_ref,
                 &extname,
+                Opcode::Call,
                 dist,
                 caller_conv,
                 self.backend.flags().clone(),

--- a/cranelift/filetests/filetests/isa/x64/fuzzbug-60035.clif
+++ b/cranelift/filetests/filetests/isa/x64/fuzzbug-60035.clif
@@ -15,25 +15,14 @@ block0:
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   subq    %rsp, $64, %rsp
-;   movq    %rbx, 16(%rsp)
-;   movq    %r12, 24(%rsp)
-;   movq    %r13, 32(%rsp)
-;   movq    %r14, 40(%rsp)
-;   movq    %r15, 48(%rsp)
+;   subq    %rsp, $16, %rsp
+;   movq    %r15, 0(%rsp)
 ; block0:
 ;   load_ext_name userextname0+0, %r15
-;   movq    %r15, rsp(0 + virtual offset)
-;   movq    rsp(0 + virtual offset), %r15
 ;   call    *%r15
-;   movq    rsp(0 + virtual offset), %r15
 ;   call    *%r15
-;   movq    16(%rsp), %rbx
-;   movq    24(%rsp), %r12
-;   movq    32(%rsp), %r13
-;   movq    40(%rsp), %r14
-;   movq    48(%rsp), %r15
-;   addq    %rsp, $64, %rsp
+;   movq    0(%rsp), %r15
+;   addq    %rsp, $16, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -42,25 +31,14 @@ block0:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   subq $0x40, %rsp
-;   movq %rbx, 0x10(%rsp)
-;   movq %r12, 0x18(%rsp)
-;   movq %r13, 0x20(%rsp)
-;   movq %r14, 0x28(%rsp)
-;   movq %r15, 0x30(%rsp)
-; block1: ; offset 0x21
-;   movabsq $0, %r15 ; reloc_external Abs8 u1:7 0
+;   subq $0x10, %rsp
 ;   movq %r15, (%rsp)
-;   movq (%rsp), %r15
+; block1: ; offset 0xc
+;   movabsq $0, %r15 ; reloc_external Abs8 u1:7 0
+;   callq *%r15
 ;   callq *%r15
 ;   movq (%rsp), %r15
-;   callq *%r15
-;   movq 0x10(%rsp), %rbx
-;   movq 0x18(%rsp), %r12
-;   movq 0x20(%rsp), %r13
-;   movq 0x28(%rsp), %r14
-;   movq 0x30(%rsp), %r15
-;   addq $0x40, %rsp
+;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/fuzzbug-60035.clif
+++ b/cranelift/filetests/filetests/isa/x64/fuzzbug-60035.clif
@@ -16,12 +16,12 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $16, %rsp
-;   movq    %r15, 0(%rsp)
+;   movq    %rbx, 0(%rsp)
 ; block0:
-;   load_ext_name userextname0+0, %r15
-;   call    *%r15
-;   call    *%r15
-;   movq    0(%rsp), %r15
+;   load_ext_name userextname0+0, %rbx
+;   call    *%rbx
+;   call    *%rbx
+;   movq    0(%rsp), %rbx
 ;   addq    %rsp, $16, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -32,12 +32,12 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0x10, %rsp
-;   movq %r15, (%rsp)
+;   movq %rbx, (%rsp)
 ; block1: ; offset 0xc
-;   movabsq $0, %r15 ; reloc_external Abs8 u1:7 0
-;   callq *%r15
-;   callq *%r15
-;   movq (%rsp), %r15
+;   movabsq $0, %rbx ; reloc_external Abs8 u1:7 0
+;   callq *%rbx
+;   callq *%rbx
+;   movq (%rsp), %rbx
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp

--- a/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
@@ -14,7 +14,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lea     10(%rax), %rax
+;   lea     10(%rdi), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -24,7 +24,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   addq $0xa, %rax
+;   leaq 0xa(%rdi), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -42,18 +42,18 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_ext_name %callee_i64+0, %rcx
-;   return_call_unknown %rcx %rax=%rax
+;   load_ext_name %callee_i64+0, %rax
+;   return_call_unknown %rax %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movabsq $0, %rcx ; reloc_external Abs8 %callee_i64 0
+;   movabsq $0, %rax ; reloc_external Abs8 %callee_i64 0
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   jmpq *%rcx
+;   jmpq *%rax
 
 ;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -70,18 +70,18 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_ext_name %callee_i64+0, %rcx
-;   return_call_unknown %rcx %rax=%rax
+;   load_ext_name %callee_i64+0, %rax
+;   return_call_unknown %rax %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   leaq (%rip), %rcx ; reloc_external CallPCRel4 %callee_i64 -4
+;   leaq (%rip), %rax ; reloc_external CallPCRel4 %callee_i64 -4
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   jmpq *%rcx
+;   jmpq *%rax
 
 ;;;; Test passing `f64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -165,7 +165,7 @@ block0(v0: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   testb   %al, %al
+;   testb   %dil, %dil
 ;   setz    %al
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -176,7 +176,7 @@ block0(v0: i8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   testb %al, %al
+;   testb %dil, %dil
 ;   sete %al
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -195,16 +195,16 @@ block0(v0: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_ext_name %callee_i8+0, %rcx
-;   return_call_unknown %rcx %rax=%rax
+;   load_ext_name %callee_i8+0, %rax
+;   return_call_unknown %rax %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movabsq $0, %rcx ; reloc_external Abs8 %callee_i8 0
+;   movabsq $0, %rax ; reloc_external Abs8 %callee_i8 0
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   jmpq *%rcx
+;   jmpq *%rax
 

--- a/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
@@ -42,20 +42,18 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_ext_name %callee_i64+0, %rdx
-;   movq    %rbp, %rcx
-;   return_call_unknown %rdx new_stack_arg_size:0 old_stack_arg_size:0 ret_addr:None fp:%v194 tmp:%v195 %rax=%rax
+;   load_ext_name %callee_i64+0, %rcx
+;   return_call_unknown %rcx %rax=%rax
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movabsq $0, %rdx ; reloc_external Abs8 %callee_i64 0
-;   movq %rbp, %rcx
-;   movq (%rcx), %rbp
-;   leaq 8(%rcx), %rsp
-;   jmpq *%rdx
+;   movabsq $0, %rcx ; reloc_external Abs8 %callee_i64 0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmpq *%rcx
 
 ;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -72,20 +70,18 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_ext_name %callee_i64+0, %rdx
-;   movq    %rbp, %rcx
-;   return_call_unknown %rdx new_stack_arg_size:0 old_stack_arg_size:0 ret_addr:None fp:%v194 tmp:%v195 %rax=%rax
+;   load_ext_name %callee_i64+0, %rcx
+;   return_call_unknown %rcx %rax=%rax
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   leaq (%rip), %rdx ; reloc_external CallPCRel4 %callee_i64 -4
-;   movq %rbp, %rcx
-;   movq (%rcx), %rbp
-;   leaq 8(%rcx), %rsp
-;   jmpq *%rdx
+;   leaq (%rip), %rcx ; reloc_external CallPCRel4 %callee_i64 -4
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmpq *%rcx
 
 ;;;; Test passing `f64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -143,20 +139,18 @@ block0(v0: f64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_ext_name %callee_f64+0, %rdx
-;   movq    %rbp, %rcx
-;   return_call_unknown %rdx new_stack_arg_size:0 old_stack_arg_size:0 ret_addr:None fp:%v194 tmp:%v195 %xmm0=%xmm0
+;   load_ext_name %callee_f64+0, %rax
+;   return_call_unknown %rax %xmm0=%xmm0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movabsq $0, %rdx ; reloc_external Abs8 %callee_f64 0
-;   movq %rbp, %rcx
-;   movq (%rcx), %rbp
-;   leaq 8(%rcx), %rsp
-;   jmpq *%rdx
+;   movabsq $0, %rax ; reloc_external Abs8 %callee_f64 0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmpq *%rax
 
 ;;;; Test passing `i8`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -201,18 +195,16 @@ block0(v0: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_ext_name %callee_i8+0, %rdx
-;   movq    %rbp, %rcx
-;   return_call_unknown %rdx new_stack_arg_size:0 old_stack_arg_size:0 ret_addr:None fp:%v194 tmp:%v195 %rax=%rax
+;   load_ext_name %callee_i8+0, %rcx
+;   return_call_unknown %rcx %rax=%rax
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movabsq $0, %rdx ; reloc_external Abs8 %callee_i8 0
-;   movq %rbp, %rcx
-;   movq (%rcx), %rbp
-;   leaq 8(%rcx), %rsp
-;   jmpq *%rdx
+;   movabsq $0, %rcx ; reloc_external Abs8 %callee_i8 0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmpq *%rcx
 

--- a/cranelift/filetests/filetests/isa/x64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call.clif
@@ -40,20 +40,18 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rbp, %rcx
-;   load_ext_name %callee_i64+0, %r8
-;   return_call_unknown %r8 new_stack_arg_size:0 old_stack_arg_size:0 ret_addr:None fp:%v193 tmp:%v194 %rax=%rax
+;   load_ext_name %callee_i64+0, %rcx
+;   return_call_unknown %rcx %rax=%rax
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rbp, %rcx
-;   movabsq $0, %r8 ; reloc_external Abs8 %callee_i64 0
-;   movq (%rcx), %rbp
-;   leaq 8(%rcx), %rsp
-;   jmpq *%r8
+;   movabsq $0, %rcx ; reloc_external Abs8 %callee_i64 0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmpq *%rcx
 
 ;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -68,18 +66,16 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rbp, %rcx
-;   return_call_known TestCase(%callee_i64) new_stack_arg_size:0 old_stack_arg_size:0 ret_addr:None fp:%v193 tmp:%v194 %rax=%rax
+;   return_call_known TestCase(%callee_i64) %rax=%rax
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rbp, %rcx
-;   movq (%rcx), %rbp
-;   leaq 8(%rcx), %rsp
-;   jmp 0x13 ; reloc_external CallPCRel4 %callee_i64 -4
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmp 0xd ; reloc_external CallPCRel4 %callee_i64 -4
 
 ;;;; Test passing `f64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -135,20 +131,18 @@ block0(v0: f64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rbp, %rax
-;   load_ext_name %callee_f64+0, %r8
-;   return_call_unknown %r8 new_stack_arg_size:0 old_stack_arg_size:0 ret_addr:None fp:%v193 tmp:%v194 %xmm0=%xmm0
+;   load_ext_name %callee_f64+0, %rax
+;   return_call_unknown %rax %xmm0=%xmm0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rbp, %rax
-;   movabsq $0, %r8 ; reloc_external Abs8 %callee_f64 0
-;   movq (%rax), %rbp
-;   leaq 8(%rax), %rsp
-;   jmpq *%r8
+;   movabsq $0, %rax ; reloc_external Abs8 %callee_f64 0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmpq *%rax
 
 ;;;; Test passing `i8`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -191,20 +185,18 @@ block0(v0: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %rbp, %rcx
-;   load_ext_name %callee_i8+0, %r8
-;   return_call_unknown %r8 new_stack_arg_size:0 old_stack_arg_size:0 ret_addr:None fp:%v193 tmp:%v194 %rax=%rax
+;   load_ext_name %callee_i8+0, %rcx
+;   return_call_unknown %rcx %rax=%rax
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %rbp, %rcx
-;   movabsq $0, %r8 ; reloc_external Abs8 %callee_i8 0
-;   movq (%rcx), %rbp
-;   leaq 8(%rcx), %rsp
-;   jmpq *%r8
+;   movabsq $0, %rcx ; reloc_external Abs8 %callee_i8 0
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmpq *%rcx
 
 ;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -320,49 +312,46 @@ block0:
 ;   movq    %r10, rsp(32 + virtual offset)
 ;   movl    $55, %r11d
 ;   movq    %r11, rsp(24 + virtual offset)
-;   movl    $60, %r15d
-;   movl    $65, %r12d
-;   movl    $70, %r13d
-;   movl    $75, %r14d
-;   movl    $80, %ecx
-;   movq    %rcx, rsp(16 + virtual offset)
+;   movl    $60, %r13d
+;   movl    $65, %r14d
+;   movl    $70, %r15d
+;   movl    $75, %r12d
+;   movl    $80, %eax
 ;   movl    $85, %ecx
 ;   movl    $90, %edx
 ;   movl    $95, %ebx
-;   movl    $100, %esi
+;   movl    $100, %edi
+;   movq    %rdi, rsp(16 + virtual offset)
 ;   movl    $105, %edi
 ;   movl    $110, %r8d
 ;   movl    $115, %r9d
 ;   movl    $120, %r10d
 ;   movl    $125, %r11d
-;   movl    $130, %eax
-;   movq    %rax, rsp(8 + virtual offset)
-;   movl    $135, %eax
-;   movq    %rax, rsp(0 + virtual offset)
-;   subq    %rsp, $128, %rsp
-;   virtual_sp_offset_adjust 128
-;   movq    %r15, 0(%rsp)
-;   movq    %r12, 8(%rsp)
-;   movq    %r13, 16(%rsp)
-;   movq    %r14, 24(%rsp)
-;   movq    rsp(16 + virtual offset), %rax
-;   movq    %rax, 32(%rsp)
-;   movq    %rcx, 40(%rsp)
-;   movq    %rdx, 48(%rsp)
-;   movq    %rbx, 56(%rsp)
-;   movq    %rsi, 64(%rsp)
-;   movq    %rdi, 72(%rsp)
-;   movq    %r8, 80(%rsp)
-;   movq    %r9, 88(%rsp)
-;   movq    %r10, 96(%rsp)
-;   movq    %r11, 104(%rsp)
-;   movq    rsp(8 + virtual offset), %rax
-;   movq    %rax, 112(%rsp)
-;   movq    rsp(0 + virtual offset), %rax
-;   movq    %rax, 120(%rsp)
-;   movq    %rbp, %r15
-;   movq    8(%r15), %r13
-;   load_ext_name %tail_callee_stack_args+0, %r12
+;   movl    $130, %esi
+;   movq    %rsi, rsp(8 + virtual offset)
+;   movl    $135, %esi
+;   movq    %rsi, rsp(0 + virtual offset)
+;   grow_frame 128 %v218
+;   movq    %r13, 16(%rbp)
+;   movq    %r14, 24(%rbp)
+;   movq    %r15, 32(%rbp)
+;   movq    %r12, 40(%rbp)
+;   movq    %rax, 48(%rbp)
+;   movq    %rcx, 56(%rbp)
+;   movq    %rdx, 64(%rbp)
+;   movq    %rbx, 72(%rbp)
+;   movq    rsp(16 + virtual offset), %rsi
+;   movq    %rsi, 80(%rbp)
+;   movq    %rdi, 88(%rbp)
+;   movq    %r8, 96(%rbp)
+;   movq    %r9, 104(%rbp)
+;   movq    %r10, 112(%rbp)
+;   movq    %r11, 120(%rbp)
+;   movq    rsp(8 + virtual offset), %rsi
+;   movq    %rsi, 128(%rbp)
+;   movq    rsp(0 + virtual offset), %rsi
+;   movq    %rsi, 136(%rbp)
+;   load_ext_name %tail_callee_stack_args+0, %r15
 ;   movq    rsp(96 + virtual offset), %rax
 ;   movq    rsp(88 + virtual offset), %rcx
 ;   movq    rsp(80 + virtual offset), %rdx
@@ -373,7 +362,7 @@ block0:
 ;   movq    rsp(40 + virtual offset), %r9
 ;   movq    rsp(32 + virtual offset), %r10
 ;   movq    rsp(24 + virtual offset), %r11
-;   return_call_unknown %r12 new_stack_arg_size:128 old_stack_arg_size:0 ret_addr:Some("%v219") fp:%v218 tmp:%v220 %rax=%rax %rcx=%rcx %rdx=%rdx %rbx=%rbx %rsi=%rsi %rdi=%rdi %r8=%r8 %r9=%r9 %r10=%r10 %r11=%r11
+;   return_call_unknown %r15 %rax=%rax %rcx=%rcx %rdx=%rdx %rbx=%rbx %rsi=%rsi %rdi=%rdi %r8=%r8 %r9=%r9 %r10=%r10 %r11=%r11
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -401,92 +390,91 @@ block0:
 ;   movq %r10, 0x20(%rsp)
 ;   movl $0x37, %r11d
 ;   movq %r11, 0x18(%rsp)
-;   movl $0x3c, %r15d
-;   movl $0x41, %r12d
-;   movl $0x46, %r13d
-;   movl $0x4b, %r14d
-;   movl $0x50, %ecx
-;   movq %rcx, 0x10(%rsp)
+;   movl $0x3c, %r13d
+;   movl $0x41, %r14d
+;   movl $0x46, %r15d
+;   movl $0x4b, %r12d
+;   movl $0x50, %eax
 ;   movl $0x55, %ecx
 ;   movl $0x5a, %edx
 ;   movl $0x5f, %ebx
-;   movl $0x64, %esi
+;   movl $0x64, %edi
+;   movq %rdi, 0x10(%rsp)
 ;   movl $0x69, %edi
 ;   movl $0x6e, %r8d
 ;   movl $0x73, %r9d
 ;   movl $0x78, %r10d
 ;   movl $0x7d, %r11d
-;   movl $0x82, %eax
-;   movq %rax, 8(%rsp)
-;   movl $0x87, %eax
-;   movq %rax, (%rsp)
+;   movl $0x82, %esi
+;   movq %rsi, 8(%rsp)
+;   movl $0x87, %esi
+;   movq %rsi, (%rsp)
 ;   subq $0x80, %rsp
-;   movq %r15, (%rsp)
-;   movq %r12, 8(%rsp)
-;   movq %r13, 0x10(%rsp)
-;   movq %r14, 0x18(%rsp)
-;   movq 0x90(%rsp), %rax
-;   movq %rax, 0x20(%rsp)
-;   movq %rcx, 0x28(%rsp)
-;   movq %rdx, 0x30(%rsp)
-;   movq %rbx, 0x38(%rsp)
-;   movq %rsi, 0x40(%rsp)
-;   movq %rdi, 0x48(%rsp)
-;   movq %r8, 0x50(%rsp)
-;   movq %r9, 0x58(%rsp)
-;   movq %r10, 0x60(%rsp)
-;   movq %r11, 0x68(%rsp)
-;   movq 0x88(%rsp), %rax
-;   movq %rax, 0x70(%rsp)
-;   movq 0x80(%rsp), %rax
-;   movq %rax, 0x78(%rsp)
-;   movq %rbp, %r15
-;   movq 8(%r15), %r13
-;   movabsq $0, %r12 ; reloc_external Abs8 %tail_callee_stack_args 0
-;   movq 0xe0(%rsp), %rax
-;   movq 0xd8(%rsp), %rcx
-;   movq 0xd0(%rsp), %rdx
-;   movq 0xc8(%rsp), %rbx
+;   subq $0x80, %rbp
+;   movq 0x80(%rsp), %rsi
+;   movq %rsi, (%rsp)
+;   movq 0x88(%rsp), %rsi
+;   movq %rsi, 8(%rsp)
+;   movq 0x90(%rsp), %rsi
+;   movq %rsi, 0x10(%rsp)
+;   movq 0x98(%rsp), %rsi
+;   movq %rsi, 0x18(%rsp)
+;   movq 0xa0(%rsp), %rsi
+;   movq %rsi, 0x20(%rsp)
+;   movq 0xa8(%rsp), %rsi
+;   movq %rsi, 0x28(%rsp)
+;   movq 0xb0(%rsp), %rsi
+;   movq %rsi, 0x30(%rsp)
+;   movq 0xb8(%rsp), %rsi
+;   movq %rsi, 0x38(%rsp)
 ;   movq 0xc0(%rsp), %rsi
-;   movq 0xb8(%rsp), %rdi
-;   movq 0xb0(%rsp), %r8
-;   movq 0xa8(%rsp), %r9
-;   movq 0xa0(%rsp), %r10
-;   movq 0x98(%rsp), %r11
-;   movq (%r15), %rbp
-;   movq 0x78(%rsp), %r14
-;   movq %r14, 8(%r15)
-;   movq 0x70(%rsp), %r14
-;   movq %r14, (%r15)
-;   movq 0x68(%rsp), %r14
-;   movq %r14, -8(%r15)
-;   movq 0x60(%rsp), %r14
-;   movq %r14, -0x10(%r15)
-;   movq 0x58(%rsp), %r14
-;   movq %r14, -0x18(%r15)
-;   movq 0x50(%rsp), %r14
-;   movq %r14, -0x20(%r15)
-;   movq 0x48(%rsp), %r14
-;   movq %r14, -0x28(%r15)
-;   movq 0x40(%rsp), %r14
-;   movq %r14, -0x30(%r15)
-;   movq 0x38(%rsp), %r14
-;   movq %r14, -0x38(%r15)
-;   movq 0x30(%rsp), %r14
-;   movq %r14, -0x40(%r15)
-;   movq 0x28(%rsp), %r14
-;   movq %r14, -0x48(%r15)
-;   movq 0x20(%rsp), %r14
-;   movq %r14, -0x50(%r15)
-;   movq 0x18(%rsp), %r14
-;   movq %r14, -0x58(%r15)
-;   movq 0x10(%rsp), %r14
-;   movq %r14, -0x60(%r15)
-;   movq 8(%rsp), %r14
-;   movq %r14, -0x68(%r15)
-;   movq (%rsp), %r14
-;   movq %r14, -0x70(%r15)
-;   leaq -0x78(%r15), %rsp
-;   movq %r13, (%rsp)
-;   jmpq *%r12
+;   movq %rsi, 0x40(%rsp)
+;   movq 0xc8(%rsp), %rsi
+;   movq %rsi, 0x48(%rsp)
+;   movq 0xd0(%rsp), %rsi
+;   movq %rsi, 0x50(%rsp)
+;   movq 0xd8(%rsp), %rsi
+;   movq %rsi, 0x58(%rsp)
+;   movq 0xe0(%rsp), %rsi
+;   movq %rsi, 0x60(%rsp)
+;   movq 0xe8(%rsp), %rsi
+;   movq %rsi, 0x68(%rsp)
+;   movq 0xf0(%rsp), %rsi
+;   movq %rsi, 0x70(%rsp)
+;   movq 0xf8(%rsp), %rsi
+;   movq %rsi, 0x78(%rsp)
+;   movq %r13, 0x10(%rbp)
+;   movq %r14, 0x18(%rbp)
+;   movq %r15, 0x20(%rbp)
+;   movq %r12, 0x28(%rbp)
+;   movq %rax, 0x30(%rbp)
+;   movq %rcx, 0x38(%rbp)
+;   movq %rdx, 0x40(%rbp)
+;   movq %rbx, 0x48(%rbp)
+;   movq 0x10(%rsp), %rsi
+;   movq %rsi, 0x50(%rbp)
+;   movq %rdi, 0x58(%rbp)
+;   movq %r8, 0x60(%rbp)
+;   movq %r9, 0x68(%rbp)
+;   movq %r10, 0x70(%rbp)
+;   movq %r11, 0x78(%rbp)
+;   movq 8(%rsp), %rsi
+;   movq %rsi, 0x80(%rbp)
+;   movq (%rsp), %rsi
+;   movq %rsi, 0x88(%rbp)
+;   movabsq $0, %r15 ; reloc_external Abs8 %tail_callee_stack_args 0
+;   movq 0x60(%rsp), %rax
+;   movq 0x58(%rsp), %rcx
+;   movq 0x50(%rsp), %rdx
+;   movq 0x48(%rsp), %rbx
+;   movq 0x40(%rsp), %rsi
+;   movq 0x38(%rsp), %rdi
+;   movq 0x30(%rsp), %r8
+;   movq 0x28(%rsp), %r9
+;   movq 0x20(%rsp), %r10
+;   movq 0x18(%rsp), %r11
+;   addq $0x70, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmpq *%r15
 

--- a/cranelift/filetests/filetests/isa/x64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call.clif
@@ -14,7 +14,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lea     10(%rax), %rax
+;   lea     10(%rdi), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -24,7 +24,7 @@ block0(v0: i64):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   addq $0xa, %rax
+;   leaq 0xa(%rdi), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -40,18 +40,18 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_ext_name %callee_i64+0, %rcx
-;   return_call_unknown %rcx %rax=%rax
+;   load_ext_name %callee_i64+0, %rax
+;   return_call_unknown %rax %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movabsq $0, %rcx ; reloc_external Abs8 %callee_i64 0
+;   movabsq $0, %rax ; reloc_external Abs8 %callee_i64 0
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   jmpq *%rcx
+;   jmpq *%rax
 
 ;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -66,7 +66,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   return_call_known TestCase(%callee_i64) %rax=%rax
+;   return_call_known TestCase(%callee_i64) %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -157,7 +157,7 @@ block0(v0: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   testb   %al, %al
+;   testb   %dil, %dil
 ;   setz    %al
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -168,7 +168,7 @@ block0(v0: i8):
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   testb %al, %al
+;   testb %dil, %dil
 ;   sete %al
 ;   movq %rbp, %rsp
 ;   popq %rbp
@@ -185,18 +185,18 @@ block0(v0: i8):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   load_ext_name %callee_i8+0, %rcx
-;   return_call_unknown %rcx %rax=%rax
+;   load_ext_name %callee_i8+0, %rax
+;   return_call_unknown %rax %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movabsq $0, %rcx ; reloc_external Abs8 %callee_i8 0
+;   movabsq $0, %rax ; reloc_external Abs8 %callee_i8 0
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   jmpq *%rcx
+;   jmpq *%rax
 
 ;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -209,50 +209,58 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    16(%rbp), %rax
-;   movq    24(%rbp), %rdx
-;   movq    32(%rbp), %r9
-;   movq    40(%rbp), %r11
-;   movq    48(%rbp), %rdi
-;   movq    56(%rbp), %rcx
-;   movq    64(%rbp), %r8
-;   movq    72(%rbp), %r10
-;   movq    80(%rbp), %rsi
-;   movq    88(%rbp), %rax
-;   movq    96(%rbp), %rdx
-;   movq    104(%rbp), %r9
-;   movq    112(%rbp), %r11
-;   movq    120(%rbp), %rdi
-;   movq    128(%rbp), %rcx
-;   movq    136(%rbp), %rax
+;   movq    16(%rbp), %r10
+;   movq    24(%rbp), %rsi
+;   movq    32(%rbp), %rax
+;   movq    40(%rbp), %rdx
+;   movq    48(%rbp), %r9
+;   movq    56(%rbp), %r11
+;   movq    64(%rbp), %rdi
+;   movq    72(%rbp), %rcx
+;   movq    80(%rbp), %r8
+;   movq    88(%rbp), %r10
+;   movq    96(%rbp), %rsi
+;   movq    104(%rbp), %rax
+;   movq    112(%rbp), %rdx
+;   movq    120(%rbp), %r9
+;   movq    128(%rbp), %r11
+;   movq    136(%rbp), %rdi
+;   movq    144(%rbp), %rcx
+;   movq    152(%rbp), %r8
+;   movq    160(%rbp), %r10
+;   movq    168(%rbp), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
-;   ret 128
+;   ret 160
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq 0x10(%rbp), %rax
-;   movq 0x18(%rbp), %rdx
-;   movq 0x20(%rbp), %r9
-;   movq 0x28(%rbp), %r11
-;   movq 0x30(%rbp), %rdi
-;   movq 0x38(%rbp), %rcx
-;   movq 0x40(%rbp), %r8
-;   movq 0x48(%rbp), %r10
-;   movq 0x50(%rbp), %rsi
-;   movq 0x58(%rbp), %rax
-;   movq 0x60(%rbp), %rdx
-;   movq 0x68(%rbp), %r9
-;   movq 0x70(%rbp), %r11
-;   movq 0x78(%rbp), %rdi
-;   movq 0x80(%rbp), %rcx
-;   movq 0x88(%rbp), %rax
+;   movq 0x10(%rbp), %r10
+;   movq 0x18(%rbp), %rsi
+;   movq 0x20(%rbp), %rax
+;   movq 0x28(%rbp), %rdx
+;   movq 0x30(%rbp), %r9
+;   movq 0x38(%rbp), %r11
+;   movq 0x40(%rbp), %rdi
+;   movq 0x48(%rbp), %rcx
+;   movq 0x50(%rbp), %r8
+;   movq 0x58(%rbp), %r10
+;   movq 0x60(%rbp), %rsi
+;   movq 0x68(%rbp), %rax
+;   movq 0x70(%rbp), %rdx
+;   movq 0x78(%rbp), %r9
+;   movq 0x80(%rbp), %r11
+;   movq 0x88(%rbp), %rdi
+;   movq 0x90(%rbp), %rcx
+;   movq 0x98(%rbp), %r8
+;   movq 0xa0(%rbp), %r10
+;   movq 0xa8(%rbp), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   retq $0x80
+;   retq $0xa0
 
 function %tail_caller_stack_args() -> i64 tail {
     fn0 = %tail_callee_stack_args(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64 tail
@@ -290,191 +298,226 @@ block0:
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   subq    %rsp, $112, %rsp
+;   subq    %rsp, $160, %rsp
+;   movq    %rbx, 112(%rsp)
+;   movq    %r12, 120(%rsp)
+;   movq    %r13, 128(%rsp)
+;   movq    %r14, 136(%rsp)
+;   movq    %r15, 144(%rsp)
 ; block0:
-;   movl    $10, %eax
-;   movq    %rax, rsp(96 + virtual offset)
-;   movl    $15, %ecx
-;   movq    %rcx, rsp(88 + virtual offset)
+;   movl    $10, %edi
+;   movq    %rdi, rsp(96 + virtual offset)
+;   movl    $15, %esi
+;   movq    %rsi, rsp(88 + virtual offset)
 ;   movl    $20, %edx
 ;   movq    %rdx, rsp(80 + virtual offset)
-;   movl    $25, %ebx
-;   movq    %rbx, rsp(72 + virtual offset)
-;   movl    $30, %esi
-;   movq    %rsi, rsp(64 + virtual offset)
-;   movl    $35, %edi
-;   movq    %rdi, rsp(56 + virtual offset)
-;   movl    $40, %r8d
-;   movq    %r8, rsp(48 + virtual offset)
-;   movl    $45, %r9d
-;   movq    %r9, rsp(40 + virtual offset)
-;   movl    $50, %r10d
-;   movq    %r10, rsp(32 + virtual offset)
-;   movl    $55, %r11d
-;   movq    %r11, rsp(24 + virtual offset)
-;   movl    $60, %r13d
-;   movl    $65, %r14d
-;   movl    $70, %r15d
+;   movl    $25, %ecx
+;   movq    %rcx, rsp(72 + virtual offset)
+;   movl    $30, %r8d
+;   movq    %r8, rsp(64 + virtual offset)
+;   movl    $35, %r9d
+;   movq    %r9, rsp(56 + virtual offset)
+;   movl    $40, %eax
+;   movl    $45, %r10d
+;   movl    $50, %r11d
+;   movl    $55, %r13d
+;   movl    $60, %r14d
+;   movl    $65, %r15d
+;   movl    $70, %ebx
 ;   movl    $75, %r12d
-;   movl    $80, %eax
-;   movl    $85, %ecx
+;   movl    $80, %edi
+;   movl    $85, %esi
+;   movq    %rsi, rsp(48 + virtual offset)
 ;   movl    $90, %edx
-;   movl    $95, %ebx
-;   movl    $100, %edi
-;   movq    %rdi, rsp(16 + virtual offset)
-;   movl    $105, %edi
-;   movl    $110, %r8d
-;   movl    $115, %r9d
-;   movl    $120, %r10d
-;   movl    $125, %r11d
+;   movl    $95, %ecx
+;   movl    $100, %r8d
+;   movl    $105, %r9d
+;   movl    $110, %esi
+;   movq    %rsi, rsp(40 + virtual offset)
+;   movl    $115, %esi
+;   movq    %rsi, rsp(32 + virtual offset)
+;   movl    $120, %esi
+;   movq    %rsi, rsp(24 + virtual offset)
+;   movl    $125, %esi
+;   movq    %rsi, rsp(16 + virtual offset)
 ;   movl    $130, %esi
 ;   movq    %rsi, rsp(8 + virtual offset)
 ;   movl    $135, %esi
 ;   movq    %rsi, rsp(0 + virtual offset)
-;   grow_frame 128 %v218
-;   movq    %r13, 16(%rbp)
-;   movq    %r14, 24(%rbp)
-;   movq    %r15, 32(%rbp)
-;   movq    %r12, 40(%rbp)
-;   movq    %rax, 48(%rbp)
-;   movq    %rcx, 56(%rbp)
-;   movq    %rdx, 64(%rbp)
-;   movq    %rbx, 72(%rbp)
-;   movq    rsp(16 + virtual offset), %rsi
-;   movq    %rsi, 80(%rbp)
+;   grow_frame 160 %v218
+;   movq    %rax, 16(%rbp)
+;   movq    %r10, 24(%rbp)
+;   movq    %r11, 32(%rbp)
+;   movq    %r13, 40(%rbp)
+;   movq    %r14, 48(%rbp)
+;   movq    %r15, 56(%rbp)
+;   movq    %rbx, 64(%rbp)
+;   movq    %r12, 72(%rbp)
+;   movq    %rdi, 80(%rbp)
+;   movq    rsp(48 + virtual offset), %rdi
 ;   movq    %rdi, 88(%rbp)
-;   movq    %r8, 96(%rbp)
-;   movq    %r9, 104(%rbp)
-;   movq    %r10, 112(%rbp)
-;   movq    %r11, 120(%rbp)
-;   movq    rsp(8 + virtual offset), %rsi
+;   movq    %rdx, 96(%rbp)
+;   movq    %rcx, 104(%rbp)
+;   movq    %r8, 112(%rbp)
+;   movq    %r9, 120(%rbp)
+;   movq    rsp(40 + virtual offset), %rsi
 ;   movq    %rsi, 128(%rbp)
-;   movq    rsp(0 + virtual offset), %rsi
+;   movq    rsp(32 + virtual offset), %rsi
 ;   movq    %rsi, 136(%rbp)
-;   load_ext_name %tail_callee_stack_args+0, %r15
-;   movq    rsp(96 + virtual offset), %rax
-;   movq    rsp(88 + virtual offset), %rcx
+;   movq    rsp(24 + virtual offset), %rsi
+;   movq    %rsi, 144(%rbp)
+;   movq    rsp(16 + virtual offset), %rsi
+;   movq    %rsi, 152(%rbp)
+;   movq    rsp(8 + virtual offset), %rsi
+;   movq    %rsi, 160(%rbp)
+;   movq    rsp(0 + virtual offset), %rsi
+;   movq    %rsi, 168(%rbp)
+;   load_ext_name %tail_callee_stack_args+0, %r10
+;   movq    rsp(72 + virtual offset), %rcx
 ;   movq    rsp(80 + virtual offset), %rdx
-;   movq    rsp(72 + virtual offset), %rbx
-;   movq    rsp(64 + virtual offset), %rsi
-;   movq    rsp(56 + virtual offset), %rdi
-;   movq    rsp(48 + virtual offset), %r8
-;   movq    rsp(40 + virtual offset), %r9
-;   movq    rsp(32 + virtual offset), %r10
-;   movq    rsp(24 + virtual offset), %r11
-;   return_call_unknown %r15 %rax=%rax %rcx=%rcx %rdx=%rdx %rbx=%rbx %rsi=%rsi %rdi=%rdi %r8=%r8 %r9=%r9 %r10=%r10 %r11=%r11
+;   movq    rsp(88 + virtual offset), %rsi
+;   movq    rsp(96 + virtual offset), %rdi
+;   movq    rsp(64 + virtual offset), %r8
+;   movq    rsp(56 + virtual offset), %r9
+;   return_call_unknown %r10 %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   subq $0x70, %rsp
-; block1: ; offset 0x8
-;   movl $0xa, %eax
-;   movq %rax, 0x60(%rsp)
-;   movl $0xf, %ecx
-;   movq %rcx, 0x58(%rsp)
+;   subq $0xa0, %rsp
+;   movq %rbx, 0x70(%rsp)
+;   movq %r12, 0x78(%rsp)
+;   movq %r13, 0x80(%rsp)
+;   movq %r14, 0x88(%rsp)
+;   movq %r15, 0x90(%rsp)
+; block1: ; offset 0x2d
+;   movl $0xa, %edi
+;   movq %rdi, 0x60(%rsp)
+;   movl $0xf, %esi
+;   movq %rsi, 0x58(%rsp)
 ;   movl $0x14, %edx
 ;   movq %rdx, 0x50(%rsp)
-;   movl $0x19, %ebx
-;   movq %rbx, 0x48(%rsp)
-;   movl $0x1e, %esi
-;   movq %rsi, 0x40(%rsp)
-;   movl $0x23, %edi
-;   movq %rdi, 0x38(%rsp)
-;   movl $0x28, %r8d
-;   movq %r8, 0x30(%rsp)
-;   movl $0x2d, %r9d
-;   movq %r9, 0x28(%rsp)
-;   movl $0x32, %r10d
-;   movq %r10, 0x20(%rsp)
-;   movl $0x37, %r11d
-;   movq %r11, 0x18(%rsp)
-;   movl $0x3c, %r13d
-;   movl $0x41, %r14d
-;   movl $0x46, %r15d
+;   movl $0x19, %ecx
+;   movq %rcx, 0x48(%rsp)
+;   movl $0x1e, %r8d
+;   movq %r8, 0x40(%rsp)
+;   movl $0x23, %r9d
+;   movq %r9, 0x38(%rsp)
+;   movl $0x28, %eax
+;   movl $0x2d, %r10d
+;   movl $0x32, %r11d
+;   movl $0x37, %r13d
+;   movl $0x3c, %r14d
+;   movl $0x41, %r15d
+;   movl $0x46, %ebx
 ;   movl $0x4b, %r12d
-;   movl $0x50, %eax
-;   movl $0x55, %ecx
+;   movl $0x50, %edi
+;   movl $0x55, %esi
+;   movq %rsi, 0x30(%rsp)
 ;   movl $0x5a, %edx
-;   movl $0x5f, %ebx
-;   movl $0x64, %edi
-;   movq %rdi, 0x10(%rsp)
-;   movl $0x69, %edi
-;   movl $0x6e, %r8d
-;   movl $0x73, %r9d
-;   movl $0x78, %r10d
-;   movl $0x7d, %r11d
+;   movl $0x5f, %ecx
+;   movl $0x64, %r8d
+;   movl $0x69, %r9d
+;   movl $0x6e, %esi
+;   movq %rsi, 0x28(%rsp)
+;   movl $0x73, %esi
+;   movq %rsi, 0x20(%rsp)
+;   movl $0x78, %esi
+;   movq %rsi, 0x18(%rsp)
+;   movl $0x7d, %esi
+;   movq %rsi, 0x10(%rsp)
 ;   movl $0x82, %esi
 ;   movq %rsi, 8(%rsp)
 ;   movl $0x87, %esi
 ;   movq %rsi, (%rsp)
-;   subq $0x80, %rsp
-;   subq $0x80, %rbp
-;   movq 0x80(%rsp), %rsi
-;   movq %rsi, (%rsp)
-;   movq 0x88(%rsp), %rsi
-;   movq %rsi, 8(%rsp)
-;   movq 0x90(%rsp), %rsi
-;   movq %rsi, 0x10(%rsp)
-;   movq 0x98(%rsp), %rsi
-;   movq %rsi, 0x18(%rsp)
+;   subq $0xa0, %rsp
+;   subq $0xa0, %rbp
 ;   movq 0xa0(%rsp), %rsi
-;   movq %rsi, 0x20(%rsp)
+;   movq %rsi, (%rsp)
 ;   movq 0xa8(%rsp), %rsi
-;   movq %rsi, 0x28(%rsp)
+;   movq %rsi, 8(%rsp)
 ;   movq 0xb0(%rsp), %rsi
-;   movq %rsi, 0x30(%rsp)
+;   movq %rsi, 0x10(%rsp)
 ;   movq 0xb8(%rsp), %rsi
-;   movq %rsi, 0x38(%rsp)
+;   movq %rsi, 0x18(%rsp)
 ;   movq 0xc0(%rsp), %rsi
-;   movq %rsi, 0x40(%rsp)
+;   movq %rsi, 0x20(%rsp)
 ;   movq 0xc8(%rsp), %rsi
-;   movq %rsi, 0x48(%rsp)
+;   movq %rsi, 0x28(%rsp)
 ;   movq 0xd0(%rsp), %rsi
-;   movq %rsi, 0x50(%rsp)
+;   movq %rsi, 0x30(%rsp)
 ;   movq 0xd8(%rsp), %rsi
-;   movq %rsi, 0x58(%rsp)
+;   movq %rsi, 0x38(%rsp)
 ;   movq 0xe0(%rsp), %rsi
-;   movq %rsi, 0x60(%rsp)
+;   movq %rsi, 0x40(%rsp)
 ;   movq 0xe8(%rsp), %rsi
-;   movq %rsi, 0x68(%rsp)
+;   movq %rsi, 0x48(%rsp)
 ;   movq 0xf0(%rsp), %rsi
-;   movq %rsi, 0x70(%rsp)
+;   movq %rsi, 0x50(%rsp)
 ;   movq 0xf8(%rsp), %rsi
+;   movq %rsi, 0x58(%rsp)
+;   movq 0x100(%rsp), %rsi
+;   movq %rsi, 0x60(%rsp)
+;   movq 0x108(%rsp), %rsi
+;   movq %rsi, 0x68(%rsp)
+;   movq 0x110(%rsp), %rsi
+;   movq %rsi, 0x70(%rsp)
+;   movq 0x118(%rsp), %rsi
 ;   movq %rsi, 0x78(%rsp)
-;   movq %r13, 0x10(%rbp)
-;   movq %r14, 0x18(%rbp)
-;   movq %r15, 0x20(%rbp)
-;   movq %r12, 0x28(%rbp)
-;   movq %rax, 0x30(%rbp)
-;   movq %rcx, 0x38(%rbp)
-;   movq %rdx, 0x40(%rbp)
-;   movq %rbx, 0x48(%rbp)
-;   movq 0x10(%rsp), %rsi
-;   movq %rsi, 0x50(%rbp)
+;   movq 0x120(%rsp), %rsi
+;   movq %rsi, 0x80(%rsp)
+;   movq 0x128(%rsp), %rsi
+;   movq %rsi, 0x88(%rsp)
+;   movq 0x130(%rsp), %rsi
+;   movq %rsi, 0x90(%rsp)
+;   movq 0x138(%rsp), %rsi
+;   movq %rsi, 0x98(%rsp)
+;   movq 0x140(%rsp), %rsi
+;   movq %rsi, 0xa0(%rsp)
+;   movq 0x148(%rsp), %rsi
+;   movq %rsi, 0xa8(%rsp)
+;   movq %rax, 0x10(%rbp)
+;   movq %r10, 0x18(%rbp)
+;   movq %r11, 0x20(%rbp)
+;   movq %r13, 0x28(%rbp)
+;   movq %r14, 0x30(%rbp)
+;   movq %r15, 0x38(%rbp)
+;   movq %rbx, 0x40(%rbp)
+;   movq %r12, 0x48(%rbp)
+;   movq %rdi, 0x50(%rbp)
+;   movq 0x30(%rsp), %rdi
 ;   movq %rdi, 0x58(%rbp)
-;   movq %r8, 0x60(%rbp)
-;   movq %r9, 0x68(%rbp)
-;   movq %r10, 0x70(%rbp)
-;   movq %r11, 0x78(%rbp)
-;   movq 8(%rsp), %rsi
+;   movq %rdx, 0x60(%rbp)
+;   movq %rcx, 0x68(%rbp)
+;   movq %r8, 0x70(%rbp)
+;   movq %r9, 0x78(%rbp)
+;   movq 0x28(%rsp), %rsi
 ;   movq %rsi, 0x80(%rbp)
-;   movq (%rsp), %rsi
+;   movq 0x20(%rsp), %rsi
 ;   movq %rsi, 0x88(%rbp)
-;   movabsq $0, %r15 ; reloc_external Abs8 %tail_callee_stack_args 0
-;   movq 0x60(%rsp), %rax
-;   movq 0x58(%rsp), %rcx
+;   movq 0x18(%rsp), %rsi
+;   movq %rsi, 0x90(%rbp)
+;   movq 0x10(%rsp), %rsi
+;   movq %rsi, 0x98(%rbp)
+;   movq 8(%rsp), %rsi
+;   movq %rsi, 0xa0(%rbp)
+;   movq (%rsp), %rsi
+;   movq %rsi, 0xa8(%rbp)
+;   movabsq $0, %r10 ; reloc_external Abs8 %tail_callee_stack_args 0
+;   movq 0x48(%rsp), %rcx
 ;   movq 0x50(%rsp), %rdx
-;   movq 0x48(%rsp), %rbx
-;   movq 0x40(%rsp), %rsi
-;   movq 0x38(%rsp), %rdi
-;   movq 0x30(%rsp), %r8
-;   movq 0x28(%rsp), %r9
-;   movq 0x20(%rsp), %r10
-;   movq 0x18(%rsp), %r11
-;   addq $0x70, %rsp
+;   movq 0x58(%rsp), %rsi
+;   movq 0x60(%rsp), %rdi
+;   movq 0x40(%rsp), %r8
+;   movq 0x38(%rsp), %r9
+;   movq 0x70(%rsp), %rbx
+;   movq 0x78(%rsp), %r12
+;   movq 0x80(%rsp), %r13
+;   movq 0x88(%rsp), %r14
+;   movq 0x90(%rsp), %r15
+;   addq $0xa0, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   jmpq *%r15
+;   jmpq *%r10
 

--- a/cranelift/filetests/filetests/isa/x64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call.clif
@@ -198,6 +198,165 @@ block0(v0: i8):
 ;   popq %rbp
 ;   jmpq *%rax
 
+;;;; Test passing fewer arguments on the stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %one_stack_arg(i32, i32, i32, i32, i32, i32, i32) tail {
+block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
+    return
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    16(%rbp), %r10
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret 16
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq 0x10(%rbp), %r10
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq $0x10
+
+function %call_one_stack_arg(i32, i32, i32, i32, i32, i32, i32, i32, i32) tail {
+    fn0 = colocated %one_stack_arg(i32, i32, i32, i32, i32, i32, i32) tail
+
+block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v8: i32):
+    return_call fn0(v2, v3, v4, v5, v6, v7, v8)
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %r8, %r10
+;   movq    %rdx, %rdi
+;   movq    %rcx, %rsi
+;   movq    %r9, %rcx
+;   movq    16(%rbp), %r8
+;   movq    24(%rbp), %r9
+;   movq    32(%rbp), %rax
+;   shrink_argument_area 16 %rdx
+;   movl    %eax, 16(%rbp)
+;   movq    %r10, %rdx
+;   return_call_known TestCase(%one_stack_arg) %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %r8, %r10
+;   movq %rdx, %rdi
+;   movq %rcx, %rsi
+;   movq %r9, %rcx
+;   movq 0x10(%rbp), %r8
+;   movq 0x18(%rbp), %r9
+;   movq 0x20(%rbp), %rax
+;   movq 8(%rsp), %rdx
+;   movq %rdx, 0x18(%rsp)
+;   movq (%rsp), %rdx
+;   movq %rdx, 0x10(%rsp)
+;   addq $0x10, %rsp
+;   addq $0x10, %rbp
+;   movl %eax, 0x10(%rbp)
+;   movq %r10, %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmp 0x46 ; reloc_external CallPCRel4 %one_stack_arg -4
+
+function %call_zero_stack_args(i32, i32, i32, i32, i32, i32, i32, i32, i8) -> i8 tail {
+    fn0 = colocated %callee_i8(i8) -> i8 tail
+
+block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v8: i8):
+    return_call fn0(v8)
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    16(%rbp), %r10
+;   movq    24(%rbp), %rsi
+;   movq    32(%rbp), %rdi
+;   shrink_argument_area 32 %rdx
+;   return_call_known TestCase(%callee_i8) %rdi=%rdi
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq 0x10(%rbp), %r10
+;   movq 0x18(%rbp), %rsi
+;   movq 0x20(%rbp), %rdi
+;   movq 8(%rsp), %rdx
+;   movq %rdx, 0x28(%rsp)
+;   movq (%rsp), %rdx
+;   movq %rdx, 0x20(%rsp)
+;   addq $0x20, %rsp
+;   addq $0x20, %rbp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmp 0x34 ; reloc_external CallPCRel4 %callee_i8 -4
+
+;;;; Test growing the argument area when it's non-empty ;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %call_from_one_stack_arg(i32, i32, i32, i32, i32, i32, i32) tail {
+    fn0 = colocated %call_one_stack_arg(i32, i32, i32, i32, i32, i32, i32, i32, i32) tail
+
+block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
+    return_call fn0(v1, v2, v3, v4, v5, v6, v0, v0, v1)
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    %rdx, %r10
+;   movq    %rcx, %rdx
+;   movq    %r8, %rcx
+;   movq    %r9, %r8
+;   movq    16(%rbp), %r9
+;   grow_argument_area 16 %rax
+;   movl    %edi, 16(%rbp)
+;   movl    %edi, 24(%rbp)
+;   movl    %esi, 32(%rbp)
+;   movq    %rsi, %rdi
+;   movq    %r10, %rsi
+;   return_call_known TestCase(%call_one_stack_arg) %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq %rdx, %r10
+;   movq %rcx, %rdx
+;   movq %r8, %rcx
+;   movq %r9, %r8
+;   movq 0x10(%rbp), %r9
+;   subq $0x10, %rsp
+;   subq $0x10, %rbp
+;   movq 0x10(%rsp), %rax
+;   movq %rax, (%rsp)
+;   movq 0x18(%rsp), %rax
+;   movq %rax, 8(%rsp)
+;   movl %edi, 0x10(%rbp)
+;   movl %edi, 0x18(%rbp)
+;   movl %esi, 0x20(%rbp)
+;   movq %rsi, %rdi
+;   movq %r10, %rsi
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmp 0x47 ; reloc_external CallPCRel4 %call_one_stack_arg -4
+
 ;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 function %tail_callee_stack_args(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64 tail {
@@ -344,7 +503,7 @@ block0:
 ;   movq    %rsi, rsp(8 + virtual offset)
 ;   movl    $135, %esi
 ;   movq    %rsi, rsp(0 + virtual offset)
-;   grow_frame 160 %v218
+;   grow_argument_area 160 %rsi
 ;   movq    %rax, 16(%rbp)
 ;   movq    %r10, 24(%rbp)
 ;   movq    %r11, 32(%rbp)

--- a/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
@@ -12,28 +12,36 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    16(%rbp), %rax
-;   movq    24(%rbp), %rdx
-;   movq    32(%rbp), %r9
-;   movq    40(%rbp), %r11
-;   movq    48(%rbp), %rax
+;   movq    16(%rbp), %r10
+;   movq    24(%rbp), %rsi
+;   movq    32(%rbp), %rax
+;   movq    40(%rbp), %rdx
+;   movq    48(%rbp), %r9
+;   movq    56(%rbp), %r11
+;   movq    64(%rbp), %rdi
+;   movq    72(%rbp), %rcx
+;   movq    80(%rbp), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
-;   ret 48
+;   ret 80
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq 0x10(%rbp), %rax
-;   movq 0x18(%rbp), %rdx
-;   movq 0x20(%rbp), %r9
-;   movq 0x28(%rbp), %r11
-;   movq 0x30(%rbp), %rax
+;   movq 0x10(%rbp), %r10
+;   movq 0x18(%rbp), %rsi
+;   movq 0x20(%rbp), %rax
+;   movq 0x28(%rbp), %rdx
+;   movq 0x30(%rbp), %r9
+;   movq 0x38(%rbp), %r11
+;   movq 0x40(%rbp), %rdi
+;   movq 0x48(%rbp), %rcx
+;   movq 0x50(%rbp), %rax
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   retq $0x30
+;   retq $0x50
 
 function %tail_caller_stack_args() -> i64 {
     fn0 = %tail_callee_stack_args(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64 tail
@@ -68,31 +76,35 @@ block0:
 ;   movq    %r14, 40(%rsp)
 ;   movq    %r15, 48(%rsp)
 ; block0:
-;   movl    $10, %eax
-;   movq    %rax, rsp(0 + virtual offset)
-;   movl    $15, %ecx
+;   movl    $10, %edi
+;   movq    %rdi, rsp(0 + virtual offset)
+;   movl    $15, %esi
 ;   movl    $20, %edx
-;   movl    $25, %ebx
-;   movl    $30, %esi
-;   movl    $35, %edi
-;   movl    $40, %r8d
-;   movl    $45, %r9d
-;   movl    $50, %r10d
-;   movl    $55, %r11d
-;   movl    $60, %r12d
-;   movl    $65, %r13d
-;   movl    $70, %r14d
-;   movl    $75, %r15d
-;   movl    $80, %eax
-;   subq    %rsp, $48, %rsp
-;   virtual_sp_offset_adjust 48
-;   movq    %r12, 0(%rsp)
-;   movq    %r13, 8(%rsp)
-;   movq    %r14, 16(%rsp)
-;   movq    %r15, 24(%rsp)
-;   movq    %rax, 32(%rsp)
+;   movl    $25, %ecx
+;   movl    $30, %r8d
+;   movl    $35, %r9d
+;   movl    $40, %r10d
+;   movl    $45, %r11d
+;   movl    $50, %eax
+;   movl    $55, %r12d
+;   movl    $60, %r13d
+;   movl    $65, %r14d
+;   movl    $70, %r15d
+;   movl    $75, %ebx
+;   movl    $80, %edi
+;   subq    %rsp, $80, %rsp
+;   virtual_sp_offset_adjust 80
+;   movq    %r10, 0(%rsp)
+;   movq    %r11, 8(%rsp)
+;   movq    %rax, 16(%rsp)
+;   movq    %r12, 24(%rsp)
+;   movq    %r13, 32(%rsp)
+;   movq    %r14, 40(%rsp)
+;   movq    %r15, 48(%rsp)
+;   movq    %rbx, 56(%rsp)
+;   movq    %rdi, 64(%rsp)
 ;   load_ext_name %tail_callee_stack_args+0, %r15
-;   movq    rsp(0 + virtual offset), %rax
+;   movq    rsp(0 + virtual offset), %rdi
 ;   call    *%r15
 ;   movq    16(%rsp), %rbx
 ;   movq    24(%rsp), %r12
@@ -115,30 +127,34 @@ block0:
 ;   movq %r14, 0x28(%rsp)
 ;   movq %r15, 0x30(%rsp)
 ; block1: ; offset 0x21
-;   movl $0xa, %eax
-;   movq %rax, (%rsp)
-;   movl $0xf, %ecx
+;   movl $0xa, %edi
+;   movq %rdi, (%rsp)
+;   movl $0xf, %esi
 ;   movl $0x14, %edx
-;   movl $0x19, %ebx
-;   movl $0x1e, %esi
-;   movl $0x23, %edi
-;   movl $0x28, %r8d
-;   movl $0x2d, %r9d
-;   movl $0x32, %r10d
-;   movl $0x37, %r11d
-;   movl $0x3c, %r12d
-;   movl $0x41, %r13d
-;   movl $0x46, %r14d
-;   movl $0x4b, %r15d
-;   movl $0x50, %eax
-;   subq $0x30, %rsp
-;   movq %r12, (%rsp)
-;   movq %r13, 8(%rsp)
-;   movq %r14, 0x10(%rsp)
-;   movq %r15, 0x18(%rsp)
-;   movq %rax, 0x20(%rsp)
+;   movl $0x19, %ecx
+;   movl $0x1e, %r8d
+;   movl $0x23, %r9d
+;   movl $0x28, %r10d
+;   movl $0x2d, %r11d
+;   movl $0x32, %eax
+;   movl $0x37, %r12d
+;   movl $0x3c, %r13d
+;   movl $0x41, %r14d
+;   movl $0x46, %r15d
+;   movl $0x4b, %ebx
+;   movl $0x50, %edi
+;   subq $0x50, %rsp
+;   movq %r10, (%rsp)
+;   movq %r11, 8(%rsp)
+;   movq %rax, 0x10(%rsp)
+;   movq %r12, 0x18(%rsp)
+;   movq %r13, 0x20(%rsp)
+;   movq %r14, 0x28(%rsp)
+;   movq %r15, 0x30(%rsp)
+;   movq %rbx, 0x38(%rsp)
+;   movq %rdi, 0x40(%rsp)
 ;   movabsq $0, %r15 ; reloc_external Abs8 %tail_callee_stack_args 0
-;   movq 0x30(%rsp), %rax
+;   movq 0x50(%rsp), %rdi
 ;   callq *%r15
 ;   movq 0x10(%rsp), %rbx
 ;   movq 0x18(%rsp), %r12
@@ -186,74 +202,90 @@ block0:
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   subq    %rsp, $112, %rsp
+;   subq    %rsp, $160, %rsp
+;   movq    %rbx, 112(%rsp)
+;   movq    %r12, 120(%rsp)
+;   movq    %r13, 128(%rsp)
+;   movq    %r14, 136(%rsp)
+;   movq    %r15, 144(%rsp)
 ; block0:
-;   movl    $10, %esi
-;   movq    %rsi, rsp(96 + virtual offset)
+;   movl    $10, %eax
+;   movq    %rax, rsp(104 + virtual offset)
 ;   movl    $15, %ecx
-;   movq    %rcx, rsp(88 + virtual offset)
+;   movq    %rcx, rsp(96 + virtual offset)
 ;   movl    $20, %edx
-;   movq    %rdx, rsp(80 + virtual offset)
-;   movl    $25, %ebx
-;   movq    %rbx, rsp(72 + virtual offset)
+;   movq    %rdx, rsp(88 + virtual offset)
+;   movl    $25, %esi
+;   movq    %rsi, rsp(80 + virtual offset)
 ;   movl    $30, %esi
-;   movq    %rsi, rsp(64 + virtual offset)
-;   movl    $35, %edi
-;   movq    %rdi, rsp(56 + virtual offset)
-;   movl    $40, %r8d
-;   movq    %r8, rsp(48 + virtual offset)
-;   movl    $45, %r9d
-;   movq    %r9, rsp(40 + virtual offset)
-;   movl    $50, %r10d
-;   movq    %r10, rsp(32 + virtual offset)
-;   movl    $55, %r11d
-;   movq    %r11, rsp(24 + virtual offset)
-;   movl    $60, %r12d
-;   movq    %r12, rsp(16 + virtual offset)
-;   movl    $65, %r13d
-;   movq    %r13, rsp(8 + virtual offset)
-;   movl    $70, %r14d
-;   movq    %r14, rsp(0 + virtual offset)
-;   movl    $75, %r15d
-;   movl    $80, %ecx
-;   movl    $85, %edx
-;   movl    $90, %ebx
+;   movq    %rsi, rsp(72 + virtual offset)
+;   movl    $35, %r8d
+;   movq    %r8, rsp(64 + virtual offset)
+;   movl    $40, %r9d
+;   movq    %r9, rsp(56 + virtual offset)
+;   movl    $45, %r10d
+;   movq    %r10, rsp(48 + virtual offset)
+;   movl    $50, %r11d
+;   movq    %r11, rsp(40 + virtual offset)
+;   movl    $55, %r13d
+;   movl    $60, %r14d
+;   movl    $65, %r15d
+;   movl    $70, %ebx
+;   movl    $75, %r12d
+;   movl    $80, %eax
+;   movl    $85, %ecx
+;   movl    $90, %edx
 ;   movl    $95, %esi
-;   movl    $100, %edi
-;   movl    $105, %r8d
-;   movl    $110, %r9d
-;   movl    $115, %r10d
-;   movl    $120, %r11d
-;   movl    $125, %r12d
-;   movl    $130, %r13d
-;   movl    $135, %r14d
-;   movq    %r15, 0(%rax)
-;   movq    %rcx, 8(%rax)
-;   movq    %rdx, 16(%rax)
-;   movq    %rbx, 24(%rax)
-;   movq    %rsi, 32(%rax)
-;   movq    %rdi, 40(%rax)
-;   movq    %r8, 48(%rax)
-;   movq    %r9, 56(%rax)
-;   movq    %r10, 64(%rax)
-;   movq    %r11, 72(%rax)
-;   movq    %r12, 80(%rax)
-;   movq    %r13, 88(%rax)
-;   movq    %r14, 96(%rax)
-;   movq    rsp(96 + virtual offset), %rax
-;   movq    rsp(88 + virtual offset), %rcx
-;   movq    rsp(80 + virtual offset), %rdx
-;   movq    rsp(72 + virtual offset), %rbx
-;   movq    rsp(64 + virtual offset), %rsi
-;   movq    rsp(56 + virtual offset), %rdi
-;   movq    rsp(48 + virtual offset), %r8
-;   movq    rsp(40 + virtual offset), %r9
-;   movq    rsp(32 + virtual offset), %r10
-;   movq    rsp(24 + virtual offset), %r11
-;   movq    rsp(16 + virtual offset), %r12
-;   movq    rsp(8 + virtual offset), %r13
-;   movq    rsp(0 + virtual offset), %r14
-;   addq    %rsp, $112, %rsp
+;   movq    %rsi, rsp(32 + virtual offset)
+;   movl    $100, %r8d
+;   movl    $105, %r9d
+;   movl    $110, %r10d
+;   movl    $115, %r11d
+;   movl    $120, %esi
+;   movq    %rsi, rsp(24 + virtual offset)
+;   movl    $125, %esi
+;   movq    %rsi, rsp(16 + virtual offset)
+;   movl    $130, %esi
+;   movq    %rsi, rsp(8 + virtual offset)
+;   movl    $135, %esi
+;   movq    %rsi, rsp(0 + virtual offset)
+;   movq    %r13, 0(%rdi)
+;   movq    %r14, 8(%rdi)
+;   movq    %r15, 16(%rdi)
+;   movq    %rbx, 24(%rdi)
+;   movq    %r12, 32(%rdi)
+;   movq    %rax, 40(%rdi)
+;   movq    %rcx, 48(%rdi)
+;   movq    %rdx, 56(%rdi)
+;   movq    rsp(32 + virtual offset), %rax
+;   movq    %rax, 64(%rdi)
+;   movq    %r8, 72(%rdi)
+;   movq    %r9, 80(%rdi)
+;   movq    %r10, 88(%rdi)
+;   movq    %r11, 96(%rdi)
+;   movq    rsp(24 + virtual offset), %rsi
+;   movq    %rsi, 104(%rdi)
+;   movq    rsp(16 + virtual offset), %rsi
+;   movq    %rsi, 112(%rdi)
+;   movq    rsp(8 + virtual offset), %rsi
+;   movq    %rsi, 120(%rdi)
+;   movq    rsp(0 + virtual offset), %rsi
+;   movq    %rsi, 128(%rdi)
+;   movq    rsp(104 + virtual offset), %rax
+;   movq    rsp(96 + virtual offset), %rcx
+;   movq    rsp(88 + virtual offset), %rdx
+;   movq    rsp(80 + virtual offset), %rsi
+;   movq    rsp(72 + virtual offset), %rdi
+;   movq    rsp(64 + virtual offset), %r8
+;   movq    rsp(56 + virtual offset), %r9
+;   movq    rsp(48 + virtual offset), %r10
+;   movq    rsp(40 + virtual offset), %r11
+;   movq    112(%rsp), %rbx
+;   movq    120(%rsp), %r12
+;   movq    128(%rsp), %r13
+;   movq    136(%rsp), %r14
+;   movq    144(%rsp), %r15
+;   addq    %rsp, $160, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -262,74 +294,90 @@ block0:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   subq $0x70, %rsp
-; block1: ; offset 0x8
-;   movl $0xa, %esi
-;   movq %rsi, 0x60(%rsp)
+;   subq $0xa0, %rsp
+;   movq %rbx, 0x70(%rsp)
+;   movq %r12, 0x78(%rsp)
+;   movq %r13, 0x80(%rsp)
+;   movq %r14, 0x88(%rsp)
+;   movq %r15, 0x90(%rsp)
+; block1: ; offset 0x2d
+;   movl $0xa, %eax
+;   movq %rax, 0x68(%rsp)
 ;   movl $0xf, %ecx
-;   movq %rcx, 0x58(%rsp)
+;   movq %rcx, 0x60(%rsp)
 ;   movl $0x14, %edx
-;   movq %rdx, 0x50(%rsp)
-;   movl $0x19, %ebx
-;   movq %rbx, 0x48(%rsp)
+;   movq %rdx, 0x58(%rsp)
+;   movl $0x19, %esi
+;   movq %rsi, 0x50(%rsp)
 ;   movl $0x1e, %esi
-;   movq %rsi, 0x40(%rsp)
-;   movl $0x23, %edi
-;   movq %rdi, 0x38(%rsp)
-;   movl $0x28, %r8d
-;   movq %r8, 0x30(%rsp)
-;   movl $0x2d, %r9d
-;   movq %r9, 0x28(%rsp)
-;   movl $0x32, %r10d
-;   movq %r10, 0x20(%rsp)
-;   movl $0x37, %r11d
-;   movq %r11, 0x18(%rsp)
-;   movl $0x3c, %r12d
-;   movq %r12, 0x10(%rsp)
-;   movl $0x41, %r13d
-;   movq %r13, 8(%rsp)
-;   movl $0x46, %r14d
-;   movq %r14, (%rsp)
-;   movl $0x4b, %r15d
-;   movl $0x50, %ecx
-;   movl $0x55, %edx
-;   movl $0x5a, %ebx
+;   movq %rsi, 0x48(%rsp)
+;   movl $0x23, %r8d
+;   movq %r8, 0x40(%rsp)
+;   movl $0x28, %r9d
+;   movq %r9, 0x38(%rsp)
+;   movl $0x2d, %r10d
+;   movq %r10, 0x30(%rsp)
+;   movl $0x32, %r11d
+;   movq %r11, 0x28(%rsp)
+;   movl $0x37, %r13d
+;   movl $0x3c, %r14d
+;   movl $0x41, %r15d
+;   movl $0x46, %ebx
+;   movl $0x4b, %r12d
+;   movl $0x50, %eax
+;   movl $0x55, %ecx
+;   movl $0x5a, %edx
 ;   movl $0x5f, %esi
-;   movl $0x64, %edi
-;   movl $0x69, %r8d
-;   movl $0x6e, %r9d
-;   movl $0x73, %r10d
-;   movl $0x78, %r11d
-;   movl $0x7d, %r12d
-;   movl $0x82, %r13d
-;   movl $0x87, %r14d
-;   movq %r15, (%rax)
-;   movq %rcx, 8(%rax)
-;   movq %rdx, 0x10(%rax)
-;   movq %rbx, 0x18(%rax)
-;   movq %rsi, 0x20(%rax)
-;   movq %rdi, 0x28(%rax)
-;   movq %r8, 0x30(%rax)
-;   movq %r9, 0x38(%rax)
-;   movq %r10, 0x40(%rax)
-;   movq %r11, 0x48(%rax)
-;   movq %r12, 0x50(%rax)
-;   movq %r13, 0x58(%rax)
-;   movq %r14, 0x60(%rax)
-;   movq 0x60(%rsp), %rax
-;   movq 0x58(%rsp), %rcx
-;   movq 0x50(%rsp), %rdx
-;   movq 0x48(%rsp), %rbx
-;   movq 0x40(%rsp), %rsi
-;   movq 0x38(%rsp), %rdi
-;   movq 0x30(%rsp), %r8
-;   movq 0x28(%rsp), %r9
-;   movq 0x20(%rsp), %r10
-;   movq 0x18(%rsp), %r11
-;   movq 0x10(%rsp), %r12
-;   movq 8(%rsp), %r13
-;   movq (%rsp), %r14
-;   addq $0x70, %rsp
+;   movq %rsi, 0x20(%rsp)
+;   movl $0x64, %r8d
+;   movl $0x69, %r9d
+;   movl $0x6e, %r10d
+;   movl $0x73, %r11d
+;   movl $0x78, %esi
+;   movq %rsi, 0x18(%rsp)
+;   movl $0x7d, %esi
+;   movq %rsi, 0x10(%rsp)
+;   movl $0x82, %esi
+;   movq %rsi, 8(%rsp)
+;   movl $0x87, %esi
+;   movq %rsi, (%rsp)
+;   movq %r13, (%rdi)
+;   movq %r14, 8(%rdi)
+;   movq %r15, 0x10(%rdi)
+;   movq %rbx, 0x18(%rdi)
+;   movq %r12, 0x20(%rdi)
+;   movq %rax, 0x28(%rdi)
+;   movq %rcx, 0x30(%rdi)
+;   movq %rdx, 0x38(%rdi)
+;   movq 0x20(%rsp), %rax
+;   movq %rax, 0x40(%rdi)
+;   movq %r8, 0x48(%rdi)
+;   movq %r9, 0x50(%rdi)
+;   movq %r10, 0x58(%rdi)
+;   movq %r11, 0x60(%rdi)
+;   movq 0x18(%rsp), %rsi
+;   movq %rsi, 0x68(%rdi)
+;   movq 0x10(%rsp), %rsi
+;   movq %rsi, 0x70(%rdi)
+;   movq 8(%rsp), %rsi
+;   movq %rsi, 0x78(%rdi)
+;   movq (%rsp), %rsi
+;   movq %rsi, 0x80(%rdi)
+;   movq 0x68(%rsp), %rax
+;   movq 0x60(%rsp), %rcx
+;   movq 0x58(%rsp), %rdx
+;   movq 0x50(%rsp), %rsi
+;   movq 0x48(%rsp), %rdi
+;   movq 0x40(%rsp), %r8
+;   movq 0x38(%rsp), %r9
+;   movq 0x30(%rsp), %r10
+;   movq 0x28(%rsp), %r11
+;   movq 0x70(%rsp), %rbx
+;   movq 0x78(%rsp), %r12
+;   movq 0x80(%rsp), %r13
+;   movq 0x88(%rsp), %r14
+;   movq 0x90(%rsp), %r15
+;   addq $0xa0, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -346,25 +394,29 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   subq    %rsp, $112, %rsp
-;   virtual_sp_offset_adjust 112
-;   lea     0(%rsp), %rax
+;   subq    %rsp, $144, %rsp
+;   virtual_sp_offset_adjust 144
+;   lea     0(%rsp), %rdi
 ;   call    TestCase(%tail_callee_stack_rets)
-;   movq    0(%rsp), %r11
-;   movq    8(%rsp), %rdi
-;   movq    16(%rsp), %rcx
-;   movq    24(%rsp), %r8
-;   movq    32(%rsp), %r10
-;   movq    40(%rsp), %rsi
-;   movq    48(%rsp), %rax
-;   movq    56(%rsp), %rdx
-;   movq    64(%rsp), %r9
-;   movq    72(%rsp), %r11
-;   movq    80(%rsp), %rdi
-;   movq    88(%rsp), %rcx
-;   movq    96(%rsp), %rax
-;   addq    %rsp, $112, %rsp
-;   virtual_sp_offset_adjust -112
+;   movq    0(%rsp), %rdx
+;   movq    8(%rsp), %r9
+;   movq    16(%rsp), %r11
+;   movq    24(%rsp), %rdi
+;   movq    32(%rsp), %rcx
+;   movq    40(%rsp), %r8
+;   movq    48(%rsp), %r10
+;   movq    56(%rsp), %rsi
+;   movq    64(%rsp), %rax
+;   movq    72(%rsp), %rdx
+;   movq    80(%rsp), %r9
+;   movq    88(%rsp), %r11
+;   movq    96(%rsp), %rdi
+;   movq    104(%rsp), %rcx
+;   movq    112(%rsp), %r8
+;   movq    120(%rsp), %r10
+;   movq    128(%rsp), %rax
+;   addq    %rsp, $144, %rsp
+;   virtual_sp_offset_adjust -144
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -374,23 +426,27 @@ block0:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   subq $0x70, %rsp
-;   leaq (%rsp), %rax
-;   callq 0x11 ; reloc_external CallPCRel4 %tail_callee_stack_rets -4
-;   movq (%rsp), %r11
-;   movq 8(%rsp), %rdi
-;   movq 0x10(%rsp), %rcx
-;   movq 0x18(%rsp), %r8
-;   movq 0x20(%rsp), %r10
-;   movq 0x28(%rsp), %rsi
-;   movq 0x30(%rsp), %rax
-;   movq 0x38(%rsp), %rdx
-;   movq 0x40(%rsp), %r9
-;   movq 0x48(%rsp), %r11
-;   movq 0x50(%rsp), %rdi
-;   movq 0x58(%rsp), %rcx
-;   movq 0x60(%rsp), %rax
-;   addq $0x70, %rsp
+;   subq $0x90, %rsp
+;   leaq (%rsp), %rdi
+;   callq 0x14 ; reloc_external CallPCRel4 %tail_callee_stack_rets -4
+;   movq (%rsp), %rdx
+;   movq 8(%rsp), %r9
+;   movq 0x10(%rsp), %r11
+;   movq 0x18(%rsp), %rdi
+;   movq 0x20(%rsp), %rcx
+;   movq 0x28(%rsp), %r8
+;   movq 0x30(%rsp), %r10
+;   movq 0x38(%rsp), %rsi
+;   movq 0x40(%rsp), %rax
+;   movq 0x48(%rsp), %rdx
+;   movq 0x50(%rsp), %r9
+;   movq 0x58(%rsp), %r11
+;   movq 0x60(%rsp), %rdi
+;   movq 0x68(%rsp), %rcx
+;   movq 0x70(%rsp), %r8
+;   movq 0x78(%rsp), %r10
+;   movq 0x80(%rsp), %rax
+;   addq $0x90, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
@@ -406,135 +462,171 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   subq    %rsp, $112, %rsp
+;   subq    %rsp, $160, %rsp
+;   movq    %rbx, 112(%rsp)
+;   movq    %r12, 120(%rsp)
+;   movq    %r13, 128(%rsp)
+;   movq    %r14, 136(%rsp)
+;   movq    %r15, 144(%rsp)
 ; block0:
-;   movq    %rax, rsp(0 + virtual offset)
-;   movq    %rcx, rsp(8 + virtual offset)
+;   movq    %rdi, rsp(0 + virtual offset)
+;   movq    %rsi, rsp(8 + virtual offset)
 ;   movq    %rdx, rsp(16 + virtual offset)
-;   movq    %rbx, rsp(24 + virtual offset)
-;   movq    %rsi, rsp(32 + virtual offset)
-;   movq    %rdi, rsp(40 + virtual offset)
-;   movq    %r8, rsp(48 + virtual offset)
-;   movq    %r9, rsp(56 + virtual offset)
-;   movq    %r10, rsp(64 + virtual offset)
-;   movq    %r11, rsp(72 + virtual offset)
-;   movq    16(%rbp), %r12
-;   movq    %r12, rsp(80 + virtual offset)
-;   movq    24(%rbp), %r13
-;   movq    %r13, rsp(88 + virtual offset)
-;   movq    32(%rbp), %r14
-;   movq    %r14, rsp(96 + virtual offset)
-;   movq    40(%rbp), %r13
-;   movq    48(%rbp), %r12
-;   movq    56(%rbp), %rbx
-;   movq    64(%rbp), %r8
+;   movq    %rcx, rsp(24 + virtual offset)
+;   movq    %r8, rsp(32 + virtual offset)
+;   movq    %r9, rsp(40 + virtual offset)
+;   movq    16(%rbp), %r9
+;   movq    %r9, rsp(48 + virtual offset)
+;   movq    24(%rbp), %r10
+;   movq    %r10, rsp(56 + virtual offset)
+;   movq    32(%rbp), %r11
+;   movq    %r11, rsp(64 + virtual offset)
+;   movq    40(%rbp), %rdx
+;   movq    48(%rbp), %r9
+;   movq    %r9, rsp(72 + virtual offset)
+;   movq    56(%rbp), %r11
+;   movq    %r11, rsp(80 + virtual offset)
+;   movq    64(%rbp), %r11
 ;   movq    72(%rbp), %r10
-;   movq    80(%rbp), %rsi
-;   movq    88(%rbp), %rax
-;   movq    96(%rbp), %rdx
-;   movq    104(%rbp), %r9
-;   movq    112(%rbp), %r11
-;   movq    120(%rbp), %rdi
-;   movq    128(%rbp), %rcx
-;   movq    136(%rbp), %r15
-;   movq    144(%rbp), %r14
-;   movq    %r13, 0(%r14)
-;   movq    %r12, 8(%r14)
-;   movq    %rbx, 16(%r14)
-;   movq    %r8, 24(%r14)
-;   movq    %r10, 32(%r14)
-;   movq    %rsi, 40(%r14)
-;   movq    %rax, 48(%r14)
-;   movq    %rdx, 56(%r14)
-;   movq    %r9, 64(%r14)
-;   movq    %r11, 72(%r14)
-;   movq    %rdi, 80(%r14)
-;   movq    %rcx, 88(%r14)
-;   movq    %r15, 96(%r14)
+;   movq    80(%rbp), %r9
+;   movq    88(%rbp), %rsi
+;   movq    %rsi, rsp(88 + virtual offset)
+;   movq    96(%rbp), %r13
+;   movq    104(%rbp), %r15
+;   movq    112(%rbp), %r12
+;   movq    120(%rbp), %r14
+;   movq    128(%rbp), %rbx
+;   movq    136(%rbp), %rdi
+;   movq    %rdi, rsp(96 + virtual offset)
+;   movq    144(%rbp), %rcx
+;   movq    152(%rbp), %r8
+;   movq    160(%rbp), %rdi
+;   movq    168(%rbp), %rsi
+;   movq    176(%rbp), %rax
+;   movq    %rdx, 0(%rax)
+;   movq    rsp(72 + virtual offset), %rdx
+;   movq    %rdx, 8(%rax)
+;   movq    rsp(80 + virtual offset), %rdx
+;   movq    %rdx, 16(%rax)
+;   movq    %r11, 24(%rax)
+;   movq    %r10, 32(%rax)
+;   movq    %r9, 40(%rax)
+;   movq    rsp(88 + virtual offset), %r10
+;   movq    %r10, 48(%rax)
+;   movq    %r13, 56(%rax)
+;   movq    %r15, 64(%rax)
+;   movq    %r12, 72(%rax)
+;   movq    %r14, 80(%rax)
+;   movq    %rbx, 88(%rax)
+;   movq    rsp(96 + virtual offset), %rdx
+;   movq    %rdx, 96(%rax)
+;   movq    %rcx, 104(%rax)
+;   movq    %r8, 112(%rax)
+;   movq    %rdi, 120(%rax)
+;   movq    %rsi, 128(%rax)
 ;   movq    rsp(0 + virtual offset), %rax
 ;   movq    rsp(8 + virtual offset), %rcx
 ;   movq    rsp(16 + virtual offset), %rdx
-;   movq    rsp(24 + virtual offset), %rbx
-;   movq    rsp(32 + virtual offset), %rsi
-;   movq    rsp(40 + virtual offset), %rdi
-;   movq    rsp(48 + virtual offset), %r8
-;   movq    rsp(56 + virtual offset), %r9
-;   movq    rsp(64 + virtual offset), %r10
-;   movq    rsp(72 + virtual offset), %r11
-;   movq    rsp(80 + virtual offset), %r12
-;   movq    rsp(88 + virtual offset), %r13
-;   movq    rsp(96 + virtual offset), %r14
-;   addq    %rsp, $112, %rsp
+;   movq    rsp(24 + virtual offset), %rsi
+;   movq    rsp(32 + virtual offset), %rdi
+;   movq    rsp(40 + virtual offset), %r8
+;   movq    rsp(48 + virtual offset), %r9
+;   movq    rsp(56 + virtual offset), %r10
+;   movq    rsp(64 + virtual offset), %r11
+;   movq    112(%rsp), %rbx
+;   movq    120(%rsp), %r12
+;   movq    128(%rsp), %r13
+;   movq    136(%rsp), %r14
+;   movq    144(%rsp), %r15
+;   addq    %rsp, $160, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
-;   ret 144
+;   ret 176
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   subq $0x70, %rsp
-; block1: ; offset 0x8
-;   movq %rax, (%rsp)
-;   movq %rcx, 8(%rsp)
+;   subq $0xa0, %rsp
+;   movq %rbx, 0x70(%rsp)
+;   movq %r12, 0x78(%rsp)
+;   movq %r13, 0x80(%rsp)
+;   movq %r14, 0x88(%rsp)
+;   movq %r15, 0x90(%rsp)
+; block1: ; offset 0x2d
+;   movq %rdi, (%rsp)
+;   movq %rsi, 8(%rsp)
 ;   movq %rdx, 0x10(%rsp)
-;   movq %rbx, 0x18(%rsp)
-;   movq %rsi, 0x20(%rsp)
-;   movq %rdi, 0x28(%rsp)
-;   movq %r8, 0x30(%rsp)
-;   movq %r9, 0x38(%rsp)
-;   movq %r10, 0x40(%rsp)
-;   movq %r11, 0x48(%rsp)
-;   movq 0x10(%rbp), %r12
-;   movq %r12, 0x50(%rsp)
-;   movq 0x18(%rbp), %r13
-;   movq %r13, 0x58(%rsp)
-;   movq 0x20(%rbp), %r14
-;   movq %r14, 0x60(%rsp)
-;   movq 0x28(%rbp), %r13
-;   movq 0x30(%rbp), %r12
-;   movq 0x38(%rbp), %rbx
-;   movq 0x40(%rbp), %r8
+;   movq %rcx, 0x18(%rsp)
+;   movq %r8, 0x20(%rsp)
+;   movq %r9, 0x28(%rsp)
+;   movq 0x10(%rbp), %r9
+;   movq %r9, 0x30(%rsp)
+;   movq 0x18(%rbp), %r10
+;   movq %r10, 0x38(%rsp)
+;   movq 0x20(%rbp), %r11
+;   movq %r11, 0x40(%rsp)
+;   movq 0x28(%rbp), %rdx
+;   movq 0x30(%rbp), %r9
+;   movq %r9, 0x48(%rsp)
+;   movq 0x38(%rbp), %r11
+;   movq %r11, 0x50(%rsp)
+;   movq 0x40(%rbp), %r11
 ;   movq 0x48(%rbp), %r10
-;   movq 0x50(%rbp), %rsi
-;   movq 0x58(%rbp), %rax
-;   movq 0x60(%rbp), %rdx
-;   movq 0x68(%rbp), %r9
-;   movq 0x70(%rbp), %r11
-;   movq 0x78(%rbp), %rdi
-;   movq 0x80(%rbp), %rcx
-;   movq 0x88(%rbp), %r15
-;   movq 0x90(%rbp), %r14
-;   movq %r13, (%r14)
-;   movq %r12, 8(%r14)
-;   movq %rbx, 0x10(%r14)
-;   movq %r8, 0x18(%r14)
-;   movq %r10, 0x20(%r14)
-;   movq %rsi, 0x28(%r14)
-;   movq %rax, 0x30(%r14)
-;   movq %rdx, 0x38(%r14)
-;   movq %r9, 0x40(%r14)
-;   movq %r11, 0x48(%r14)
-;   movq %rdi, 0x50(%r14)
-;   movq %rcx, 0x58(%r14)
-;   movq %r15, 0x60(%r14)
+;   movq 0x50(%rbp), %r9
+;   movq 0x58(%rbp), %rsi
+;   movq %rsi, 0x58(%rsp)
+;   movq 0x60(%rbp), %r13
+;   movq 0x68(%rbp), %r15
+;   movq 0x70(%rbp), %r12
+;   movq 0x78(%rbp), %r14
+;   movq 0x80(%rbp), %rbx
+;   movq 0x88(%rbp), %rdi
+;   movq %rdi, 0x60(%rsp)
+;   movq 0x90(%rbp), %rcx
+;   movq 0x98(%rbp), %r8
+;   movq 0xa0(%rbp), %rdi
+;   movq 0xa8(%rbp), %rsi
+;   movq 0xb0(%rbp), %rax
+;   movq %rdx, (%rax)
+;   movq 0x48(%rsp), %rdx
+;   movq %rdx, 8(%rax)
+;   movq 0x50(%rsp), %rdx
+;   movq %rdx, 0x10(%rax)
+;   movq %r11, 0x18(%rax)
+;   movq %r10, 0x20(%rax)
+;   movq %r9, 0x28(%rax)
+;   movq 0x58(%rsp), %r10
+;   movq %r10, 0x30(%rax)
+;   movq %r13, 0x38(%rax)
+;   movq %r15, 0x40(%rax)
+;   movq %r12, 0x48(%rax)
+;   movq %r14, 0x50(%rax)
+;   movq %rbx, 0x58(%rax)
+;   movq 0x60(%rsp), %rdx
+;   movq %rdx, 0x60(%rax)
+;   movq %rcx, 0x68(%rax)
+;   movq %r8, 0x70(%rax)
+;   movq %rdi, 0x78(%rax)
+;   movq %rsi, 0x80(%rax)
 ;   movq (%rsp), %rax
 ;   movq 8(%rsp), %rcx
 ;   movq 0x10(%rsp), %rdx
-;   movq 0x18(%rsp), %rbx
-;   movq 0x20(%rsp), %rsi
-;   movq 0x28(%rsp), %rdi
-;   movq 0x30(%rsp), %r8
-;   movq 0x38(%rsp), %r9
-;   movq 0x40(%rsp), %r10
-;   movq 0x48(%rsp), %r11
-;   movq 0x50(%rsp), %r12
-;   movq 0x58(%rsp), %r13
-;   movq 0x60(%rsp), %r14
-;   addq $0x70, %rsp
+;   movq 0x18(%rsp), %rsi
+;   movq 0x20(%rsp), %rdi
+;   movq 0x28(%rsp), %r8
+;   movq 0x30(%rsp), %r9
+;   movq 0x38(%rsp), %r10
+;   movq 0x40(%rsp), %r11
+;   movq 0x70(%rsp), %rbx
+;   movq 0x78(%rsp), %r12
+;   movq 0x80(%rsp), %r13
+;   movq 0x88(%rsp), %r14
+;   movq 0x90(%rsp), %r15
+;   addq $0xa0, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   retq $0x90
+;   retq $0xb0
 
 function %tail_caller_stack_args_and_rets() -> i64 tail {
     fn0 = %tail_callee_stack_args_and_rets(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64 tail
@@ -573,81 +665,90 @@ block0:
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   subq    %rsp, $112, %rsp
+;   subq    %rsp, $160, %rsp
+;   movq    %rbx, 112(%rsp)
+;   movq    %r12, 120(%rsp)
+;   movq    %r13, 128(%rsp)
+;   movq    %r14, 136(%rsp)
+;   movq    %r15, 144(%rsp)
 ; block0:
-;   movl    $10, %eax
-;   movq    %rax, rsp(96 + virtual offset)
-;   movl    $15, %ecx
-;   movq    %rcx, rsp(88 + virtual offset)
+;   movl    $10, %edi
+;   movq    %rdi, rsp(96 + virtual offset)
+;   movl    $15, %esi
+;   movq    %rsi, rsp(88 + virtual offset)
 ;   movl    $20, %edx
 ;   movq    %rdx, rsp(80 + virtual offset)
-;   movl    $25, %ebx
-;   movq    %rbx, rsp(72 + virtual offset)
-;   movl    $30, %esi
-;   movq    %rsi, rsp(64 + virtual offset)
-;   movl    $35, %edi
-;   movq    %rdi, rsp(56 + virtual offset)
-;   movl    $40, %r8d
-;   movq    %r8, rsp(48 + virtual offset)
-;   movl    $45, %r9d
-;   movq    %r9, rsp(40 + virtual offset)
+;   movl    $25, %ecx
+;   movq    %rcx, rsp(72 + virtual offset)
+;   movl    $30, %r8d
+;   movq    %r8, rsp(64 + virtual offset)
+;   movl    $35, %r9d
+;   movq    %r9, rsp(56 + virtual offset)
+;   movl    $40, %esi
+;   movq    %rsi, rsp(48 + virtual offset)
+;   movl    $45, %eax
 ;   movl    $50, %r10d
-;   movq    %r10, rsp(32 + virtual offset)
-;   movl    $55, %r11d
-;   movq    %r11, rsp(24 + virtual offset)
-;   movl    $60, %r14d
-;   movl    $65, %r15d
+;   movl    $55, %r14d
+;   movl    $60, %r15d
+;   movl    $65, %ebx
 ;   movl    $70, %r12d
 ;   movl    $75, %r13d
-;   movl    $80, %eax
-;   movl    $85, %ecx
+;   movl    $80, %edi
+;   movl    $85, %esi
 ;   movl    $90, %edx
-;   movl    $95, %ebx
-;   movl    $100, %esi
-;   movl    $105, %edi
-;   movl    $110, %r8d
-;   movl    $115, %r9d
-;   movl    $120, %r10d
+;   movl    $95, %ecx
+;   movl    $100, %r8d
+;   movl    $105, %r9d
+;   movl    $110, %r11d
+;   movq    %r11, rsp(40 + virtual offset)
+;   movl    $115, %r11d
+;   movq    %r11, rsp(32 + virtual offset)
+;   movl    $120, %r11d
+;   movq    %r11, rsp(24 + virtual offset)
 ;   movl    $125, %r11d
 ;   movq    %r11, rsp(16 + virtual offset)
 ;   movl    $130, %r11d
 ;   movq    %r11, rsp(8 + virtual offset)
 ;   movl    $135, %r11d
 ;   movq    %r11, rsp(0 + virtual offset)
-;   subq    %rsp, $256, %rsp
-;   virtual_sp_offset_adjust 256
-;   movq    %r14, 0(%rsp)
-;   movq    %r15, 8(%rsp)
-;   movq    %r12, 16(%rsp)
-;   movq    %r13, 24(%rsp)
-;   movq    %rax, 32(%rsp)
-;   movq    %rcx, 40(%rsp)
-;   movq    %rdx, 48(%rsp)
-;   movq    %rbx, 56(%rsp)
-;   movq    %rsi, 64(%rsp)
-;   movq    %rdi, 72(%rsp)
-;   movq    %r8, 80(%rsp)
-;   movq    %r9, 88(%rsp)
-;   movq    %r10, 96(%rsp)
-;   movq    rsp(16 + virtual offset), %rsi
-;   movq    %rsi, 104(%rsp)
-;   movq    rsp(8 + virtual offset), %r11
+;   subq    %rsp, $320, %rsp
+;   virtual_sp_offset_adjust 320
+;   movq    rsp(48 + virtual offset), %r11
+;   movq    %r11, 0(%rsp)
+;   movq    %rax, 8(%rsp)
+;   movq    %r10, 16(%rsp)
+;   movq    %r14, 24(%rsp)
+;   movq    %r15, 32(%rsp)
+;   movq    %rbx, 40(%rsp)
+;   movq    %r12, 48(%rsp)
+;   movq    %r13, 56(%rsp)
+;   movq    %rdi, 64(%rsp)
+;   movq    %rsi, 72(%rsp)
+;   movq    %rdx, 80(%rsp)
+;   movq    %rcx, 88(%rsp)
+;   movq    %r8, 96(%rsp)
+;   movq    %r9, 104(%rsp)
+;   movq    rsp(40 + virtual offset), %r11
 ;   movq    %r11, 112(%rsp)
-;   movq    rsp(0 + virtual offset), %r11
+;   movq    rsp(32 + virtual offset), %r11
 ;   movq    %r11, 120(%rsp)
-;   lea     144(%rsp), %r10
-;   movq    %r10, 128(%rsp)
-;   load_ext_name %tail_callee_stack_args_and_rets+0, %r15
-;   movq    rsp(96 + virtual offset), %rax
-;   movq    rsp(88 + virtual offset), %rcx
-;   movq    rsp(80 + virtual offset), %rdx
-;   movq    rsp(72 + virtual offset), %rbx
-;   movq    rsp(64 + virtual offset), %rsi
-;   movq    rsp(56 + virtual offset), %rdi
-;   movq    rsp(48 + virtual offset), %r8
-;   movq    rsp(40 + virtual offset), %r9
-;   movq    rsp(32 + virtual offset), %r10
 ;   movq    rsp(24 + virtual offset), %r11
+;   movq    %r11, 128(%rsp)
+;   movq    rsp(16 + virtual offset), %r11
+;   movq    %r11, 136(%rsp)
+;   movq    rsp(8 + virtual offset), %r11
+;   movq    %r11, 144(%rsp)
+;   movq    rsp(0 + virtual offset), %r11
+;   movq    %r11, 152(%rsp)
+;   lea     176(%rsp), %rax
+;   movq    %rax, 160(%rsp)
+;   load_ext_name %tail_callee_stack_args_and_rets+0, %r15
+;   movq    rsp(72 + virtual offset), %rcx
+;   movq    rsp(80 + virtual offset), %rdx
+;   movq    rsp(88 + virtual offset), %rsi
+;   movq    rsp(96 + virtual offset), %rdi
+;   movq    rsp(64 + virtual offset), %r8
+;   movq    rsp(56 + virtual offset), %r9
 ;   call    *%r15
 ;   movq    0(%rsp), %r10
 ;   movq    8(%rsp), %rsi
@@ -661,10 +762,19 @@ block0:
 ;   movq    72(%rsp), %r10
 ;   movq    80(%rsp), %rsi
 ;   movq    88(%rsp), %rax
-;   movq    96(%rsp), %rax
-;   addq    %rsp, $112, %rsp
-;   virtual_sp_offset_adjust -112
-;   addq    %rsp, $112, %rsp
+;   movq    96(%rsp), %rdx
+;   movq    104(%rsp), %r9
+;   movq    112(%rsp), %r11
+;   movq    120(%rsp), %rdi
+;   movq    128(%rsp), %rax
+;   addq    %rsp, $144, %rsp
+;   virtual_sp_offset_adjust -144
+;   movq    112(%rsp), %rbx
+;   movq    120(%rsp), %r12
+;   movq    128(%rsp), %r13
+;   movq    136(%rsp), %r14
+;   movq    144(%rsp), %r15
+;   addq    %rsp, $160, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -673,80 +783,89 @@ block0:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   subq $0x70, %rsp
-; block1: ; offset 0x8
-;   movl $0xa, %eax
-;   movq %rax, 0x60(%rsp)
-;   movl $0xf, %ecx
-;   movq %rcx, 0x58(%rsp)
+;   subq $0xa0, %rsp
+;   movq %rbx, 0x70(%rsp)
+;   movq %r12, 0x78(%rsp)
+;   movq %r13, 0x80(%rsp)
+;   movq %r14, 0x88(%rsp)
+;   movq %r15, 0x90(%rsp)
+; block1: ; offset 0x2d
+;   movl $0xa, %edi
+;   movq %rdi, 0x60(%rsp)
+;   movl $0xf, %esi
+;   movq %rsi, 0x58(%rsp)
 ;   movl $0x14, %edx
 ;   movq %rdx, 0x50(%rsp)
-;   movl $0x19, %ebx
-;   movq %rbx, 0x48(%rsp)
-;   movl $0x1e, %esi
-;   movq %rsi, 0x40(%rsp)
-;   movl $0x23, %edi
-;   movq %rdi, 0x38(%rsp)
-;   movl $0x28, %r8d
-;   movq %r8, 0x30(%rsp)
-;   movl $0x2d, %r9d
-;   movq %r9, 0x28(%rsp)
+;   movl $0x19, %ecx
+;   movq %rcx, 0x48(%rsp)
+;   movl $0x1e, %r8d
+;   movq %r8, 0x40(%rsp)
+;   movl $0x23, %r9d
+;   movq %r9, 0x38(%rsp)
+;   movl $0x28, %esi
+;   movq %rsi, 0x30(%rsp)
+;   movl $0x2d, %eax
 ;   movl $0x32, %r10d
-;   movq %r10, 0x20(%rsp)
-;   movl $0x37, %r11d
-;   movq %r11, 0x18(%rsp)
-;   movl $0x3c, %r14d
-;   movl $0x41, %r15d
+;   movl $0x37, %r14d
+;   movl $0x3c, %r15d
+;   movl $0x41, %ebx
 ;   movl $0x46, %r12d
 ;   movl $0x4b, %r13d
-;   movl $0x50, %eax
-;   movl $0x55, %ecx
+;   movl $0x50, %edi
+;   movl $0x55, %esi
 ;   movl $0x5a, %edx
-;   movl $0x5f, %ebx
-;   movl $0x64, %esi
-;   movl $0x69, %edi
-;   movl $0x6e, %r8d
-;   movl $0x73, %r9d
-;   movl $0x78, %r10d
+;   movl $0x5f, %ecx
+;   movl $0x64, %r8d
+;   movl $0x69, %r9d
+;   movl $0x6e, %r11d
+;   movq %r11, 0x28(%rsp)
+;   movl $0x73, %r11d
+;   movq %r11, 0x20(%rsp)
+;   movl $0x78, %r11d
+;   movq %r11, 0x18(%rsp)
 ;   movl $0x7d, %r11d
 ;   movq %r11, 0x10(%rsp)
 ;   movl $0x82, %r11d
 ;   movq %r11, 8(%rsp)
 ;   movl $0x87, %r11d
 ;   movq %r11, (%rsp)
-;   subq $0x100, %rsp
-;   movq %r14, (%rsp)
-;   movq %r15, 8(%rsp)
-;   movq %r12, 0x10(%rsp)
-;   movq %r13, 0x18(%rsp)
-;   movq %rax, 0x20(%rsp)
-;   movq %rcx, 0x28(%rsp)
-;   movq %rdx, 0x30(%rsp)
-;   movq %rbx, 0x38(%rsp)
-;   movq %rsi, 0x40(%rsp)
-;   movq %rdi, 0x48(%rsp)
-;   movq %r8, 0x50(%rsp)
-;   movq %r9, 0x58(%rsp)
-;   movq %r10, 0x60(%rsp)
-;   movq 0x110(%rsp), %rsi
-;   movq %rsi, 0x68(%rsp)
-;   movq 0x108(%rsp), %r11
+;   subq $0x140, %rsp
+;   movq 0x170(%rsp), %r11
+;   movq %r11, (%rsp)
+;   movq %rax, 8(%rsp)
+;   movq %r10, 0x10(%rsp)
+;   movq %r14, 0x18(%rsp)
+;   movq %r15, 0x20(%rsp)
+;   movq %rbx, 0x28(%rsp)
+;   movq %r12, 0x30(%rsp)
+;   movq %r13, 0x38(%rsp)
+;   movq %rdi, 0x40(%rsp)
+;   movq %rsi, 0x48(%rsp)
+;   movq %rdx, 0x50(%rsp)
+;   movq %rcx, 0x58(%rsp)
+;   movq %r8, 0x60(%rsp)
+;   movq %r9, 0x68(%rsp)
+;   movq 0x168(%rsp), %r11
 ;   movq %r11, 0x70(%rsp)
-;   movq 0x100(%rsp), %r11
+;   movq 0x160(%rsp), %r11
 ;   movq %r11, 0x78(%rsp)
-;   leaq 0x90(%rsp), %r10
-;   movq %r10, 0x80(%rsp)
+;   movq 0x158(%rsp), %r11
+;   movq %r11, 0x80(%rsp)
+;   movq 0x150(%rsp), %r11
+;   movq %r11, 0x88(%rsp)
+;   movq 0x148(%rsp), %r11
+;   movq %r11, 0x90(%rsp)
+;   movq 0x140(%rsp), %r11
+;   movq %r11, 0x98(%rsp)
+;   leaq 0xb0(%rsp), %rax
+;   movq %rax, 0xa0(%rsp)
 ;   movabsq $0, %r15 ; reloc_external Abs8 %tail_callee_stack_args_and_rets 0
-;   movq 0x160(%rsp), %rax
-;   movq 0x158(%rsp), %rcx
-;   movq 0x150(%rsp), %rdx
-;   movq 0x148(%rsp), %rbx
-;   movq 0x140(%rsp), %rsi
-;   movq 0x138(%rsp), %rdi
-;   movq 0x130(%rsp), %r8
-;   movq 0x128(%rsp), %r9
-;   movq 0x120(%rsp), %r10
-;   movq 0x118(%rsp), %r11
+;   movq 0x188(%rsp), %rcx
+;   movq 0x190(%rsp), %rdx
+;   movq 0x198(%rsp), %rsi
+;   movq 0x1a0(%rsp), %rdi
+;   movq 0x180(%rsp), %r8
+;   movq 0x178(%rsp), %r9
 ;   callq *%r15
 ;   movq (%rsp), %r10
 ;   movq 8(%rsp), %rsi
@@ -760,9 +879,18 @@ block0:
 ;   movq 0x48(%rsp), %r10
 ;   movq 0x50(%rsp), %rsi
 ;   movq 0x58(%rsp), %rax
-;   movq 0x60(%rsp), %rax
-;   addq $0x70, %rsp
-;   addq $0x70, %rsp
+;   movq 0x60(%rsp), %rdx
+;   movq 0x68(%rsp), %r9
+;   movq 0x70(%rsp), %r11
+;   movq 0x78(%rsp), %rdi
+;   movq 0x80(%rsp), %rax
+;   addq $0x90, %rsp
+;   movq 0x70(%rsp), %rbx
+;   movq 0x78(%rsp), %r12
+;   movq 0x80(%rsp), %r13
+;   movq 0x88(%rsp), %r14
+;   movq 0x90(%rsp), %r15
+;   addq $0xa0, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq

--- a/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
@@ -103,9 +103,9 @@ block0:
 ;   movq    %r15, 48(%rsp)
 ;   movq    %rbx, 56(%rsp)
 ;   movq    %rdi, 64(%rsp)
-;   load_ext_name %tail_callee_stack_args+0, %r15
+;   load_ext_name %tail_callee_stack_args+0, %rax
 ;   movq    rsp(0 + virtual offset), %rdi
-;   call    *%r15
+;   call    *%rax
 ;   movq    16(%rsp), %rbx
 ;   movq    24(%rsp), %r12
 ;   movq    32(%rsp), %r13
@@ -153,9 +153,9 @@ block0:
 ;   movq %r15, 0x30(%rsp)
 ;   movq %rbx, 0x38(%rsp)
 ;   movq %rdi, 0x40(%rsp)
-;   movabsq $0, %r15 ; reloc_external Abs8 %tail_callee_stack_args 0
+;   movabsq $0, %rax ; reloc_external Abs8 %tail_callee_stack_args 0
 ;   movq 0x50(%rsp), %rdi
-;   callq *%r15
+;   callq *%rax
 ;   movq 0x10(%rsp), %rbx
 ;   movq 0x18(%rsp), %r12
 ;   movq 0x20(%rsp), %r13
@@ -742,14 +742,14 @@ block0:
 ;   movq    %r11, 152(%rsp)
 ;   lea     176(%rsp), %rax
 ;   movq    %rax, 160(%rsp)
-;   load_ext_name %tail_callee_stack_args_and_rets+0, %r15
+;   load_ext_name %tail_callee_stack_args_and_rets+0, %r10
 ;   movq    rsp(72 + virtual offset), %rcx
 ;   movq    rsp(80 + virtual offset), %rdx
 ;   movq    rsp(88 + virtual offset), %rsi
 ;   movq    rsp(96 + virtual offset), %rdi
 ;   movq    rsp(64 + virtual offset), %r8
 ;   movq    rsp(56 + virtual offset), %r9
-;   call    *%r15
+;   call    *%r10
 ;   movq    0(%rsp), %r10
 ;   movq    8(%rsp), %rsi
 ;   movq    16(%rsp), %rax
@@ -859,14 +859,14 @@ block0:
 ;   movq %r11, 0x98(%rsp)
 ;   leaq 0xb0(%rsp), %rax
 ;   movq %rax, 0xa0(%rsp)
-;   movabsq $0, %r15 ; reloc_external Abs8 %tail_callee_stack_args_and_rets 0
+;   movabsq $0, %r10 ; reloc_external Abs8 %tail_callee_stack_args_and_rets 0
 ;   movq 0x188(%rsp), %rcx
 ;   movq 0x190(%rsp), %rdx
 ;   movq 0x198(%rsp), %rsi
 ;   movq 0x1a0(%rsp), %rdi
 ;   movq 0x180(%rsp), %r8
 ;   movq 0x178(%rsp), %r9
-;   callq *%r15
+;   callq *%r10
 ;   movq (%rsp), %r10
 ;   movq 8(%rsp), %rsi
 ;   movq 0x10(%rsp), %rax

--- a/cranelift/filetests/filetests/isa/x64/tail-stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/x64/tail-stack-limit.clif
@@ -19,9 +19,9 @@ block0(v0: i64, v1: i8, v2: i8, v3: i8, v4: i8, v5: i8, v6: i8, v7: i8, v8: i128
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   movq    %rdi, %r14
-;   addq    %r14, $16, %r14
-;   cmpq    %rsp, %r14
+;   movq    %rdi, %r10
+;   addq    %r10, $16, %r10
+;   cmpq    %rsp, %r10
 ;   jnbe #trap=stk_ovf
 ;   subq    %rsp, $16, %rsp
 ; block0:
@@ -38,9 +38,9 @@ block0(v0: i64, v1: i8, v2: i8, v3: i8, v4: i8, v5: i8, v6: i8, v7: i8, v8: i128
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   movq %rdi, %r14
-;   addq $0x10, %r14
-;   cmpq %rsp, %r14
+;   movq %rdi, %r10
+;   addq $0x10, %r10
+;   cmpq %rsp, %r10
 ;   ja 0x33
 ;   subq $0x10, %rsp
 ; block1: ; offset 0x18

--- a/cranelift/filetests/filetests/isa/x64/tail-stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/x64/tail-stack-limit.clif
@@ -19,33 +19,38 @@ block0(v0: i64, v1: i8, v2: i8, v3: i8, v4: i8, v5: i8, v6: i8, v7: i8, v8: i128
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
-;   movq    %rax, %r14
+;   movq    %rdi, %r14
 ;   addq    %r14, $16, %r14
 ;   cmpq    %rsp, %r14
 ;   jnbe #trap=stk_ovf
 ;   subq    %rsp, $16, %rsp
 ; block0:
-;   movq    %r10, %rax
-;   movq    %r11, %rcx
+;   movq    16(%rbp), %r10
+;   movq    24(%rbp), %rsi
+;   movq    32(%rbp), %rax
+;   movq    40(%rbp), %rcx
 ;   addq    %rsp, $16, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
-;   ret
+;   ret 32
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-;   movq %rax, %r14
+;   movq %rdi, %r14
 ;   addq $0x10, %r14
 ;   cmpq %rsp, %r14
-;   ja 0x27
+;   ja 0x33
 ;   subq $0x10, %rsp
 ; block1: ; offset 0x18
-;   movq %r10, %rax
-;   movq %r11, %rcx
+;   movq 0x10(%rbp), %r10
+;   movq 0x18(%rbp), %rsi
+;   movq 0x20(%rbp), %rax
+;   movq 0x28(%rbp), %rcx
 ;   addq $0x10, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   retq
+;   retq $0x20
 ;   ud2 ; trap: stk_ovf
+


### PR DESCRIPTION
Rework the tail calling convention on x64 to support tail calls by changing the compilation strategy in the following ways:

1. Instead of making a shadow frame that we copy over the old one, instead determine if we need to grow or shrink the stack argument area and emit a special-purpose instruction to handle that case.
2. As we're now growing and shrinking the frame in a separate instruction sequence, emit arguments as moving to FP offsets instead of SP offsets, placing them where they'll need to go for the tail call being setup.
3. Finally, when emitting a `Inst::ReturnCall` in the x64 backend, reuse the `gen_clobber_save` and `gen_epilogue_frame_restore` functions to setup the frame and any callee-saved registers to the state expected by the callee we're jumping to.

With these three changes in place, we modified the x64 abi for tail calls to include a list of callee-saved registers, and observed that we now save them in the prologue, and restore them right before jumping to the tail-callee.

## TODO

- [x] Account for the extra space used by `GrowFrame` in the stack check
- [x] Revisit the use of `r14` for the stack limit in the `Tail` calling convention

Co-authored-by: Jamey Sharp <jsharp@fastly.com>

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
