### PR TITLE
Un-ignore a custom test on riscv64

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -281,16 +281,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
             testsuite == "function_references" || testsuite == "tail_call"
         }
 
-        "riscv64" => {
-            // This test case is disabled because it relies on `fvpromote_low`
-            // not flipping the sign bit of the input when it is a NaN. This
-            // is allowed by the spec. It's worth keeping the testcase as is
-            // since it is stressing a specific codegen bug in another arch.
-            //
-            // See #6961 for more details
-            testname == "issue_3327_bnot_lowering"
-        }
-
         _ => false,
     }
 }

--- a/tests/misc_testsuite/simd/issue_3327_bnot_lowering.wast
+++ b/tests/misc_testsuite/simd/issue_3327_bnot_lowering.wast
@@ -26,7 +26,10 @@
     v128.not
     i64x2.bitmask)
   (export "" (func 0)))
-(assert_return (invoke "") (i32.const 0))
+;; the f64x2.promote_low_f32x4 operation may or may not preserve the sign bit
+;; on the NaN in the first operation. This leads to one of two results depending
+;; on how platforms propagate NaN bits.
+(assert_return (invoke "") (either (i32.const 0) (i32.const 1)))
 
 ;; from #3327
 (module


### PR DESCRIPTION
Use `(either ..)` to assert one of the two possible results.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
