### PR TITLE
Fix compilation cache for components

### DIFF
--- a/crates/wasmtime/src/compile/code_builder.rs
+++ b/crates/wasmtime/src/compile/code_builder.rs
@@ -179,11 +179,13 @@ impl<'a> CodeBuilder<'a> {
                         // Implementation of how to serialize artifacts
                         |(_engine, _wasm, _), (code, _info_and_types)| Some(code.mmap().to_vec()),
                         // Cache hit, deserialize the provided artifacts
-                        |(engine, _wasm, _), serialized_bytes| {
-                            let code = engine
-                                .0
-                                .load_code_bytes(&serialized_bytes, ObjectKind::Module)
-                                .ok()?;
+                        |(engine, wasm, _), serialized_bytes| {
+                            let kind = if wasmparser::Parser::is_component(&wasm) {
+                                ObjectKind::Component
+                            } else {
+                                ObjectKind::Module
+                            };
+                            let code = engine.0.load_code_bytes(&serialized_bytes, kind).ok()?;
                             Some((code, None))
                         },
                     )?;


### PR DESCRIPTION
This commit fixes a mistake in #8181 which meant that the caching for components was no longer working. The mistake is fixed in this commit as well as a new test being added too.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
