### PR TITLE
Plumb coredump feature to `wasmtime-runtime`

### DIFF
--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -29,7 +29,7 @@ anyhow = { workspace = true }
 paste = "1.0.3"
 encoding_rs = { version = "0.8.31", optional = true }
 sptr = "0.3.2"
-wasm-encoder = { workspace = true }
+wasm-encoder = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 memfd = "0.6.2"
@@ -65,9 +65,10 @@ cc = "1.0"
 wasmtime-versioned-export-macros = { workspace = true }
 
 [features]
-async = ["wasmtime-fiber"]
+async = ["dep:wasmtime-fiber"]
 pooling-allocator = []
 component-model = ["wasmtime-environ/component-model", "dep:encoding_rs"]
 wmemcheck = ['dep:wasmtime-wmemcheck']
-debug-builtins = ['wasmtime-jit-debug']
+debug-builtins = ['dep:wasmtime-jit-debug']
 gc = ["wasmtime-environ/gc"]
+coredump = ["dep:wasm-encoder"]

--- a/crates/runtime/src/traphandlers.rs
+++ b/crates/runtime/src/traphandlers.rs
@@ -8,7 +8,7 @@ mod backtrace;
 mod coredump;
 #[cfg(not(feature = "coredump"))]
 #[path = "traphandlers/coredump_disabled.rs"]
-mod coredump_disabled;
+mod coredump;
 
 use crate::sys::traphandlers;
 use crate::{Instance, VMContext, VMRuntimeLimits};

--- a/crates/runtime/src/traphandlers/coredump_disabled.rs
+++ b/crates/runtime/src/traphandlers/coredump_disabled.rs
@@ -1,0 +1,16 @@
+use crate::traphandlers::CallThreadState;
+use crate::VMRuntimeLimits;
+
+/// A WebAssembly Coredump
+#[derive(Debug)]
+pub enum CoreDumpStack {}
+
+impl CallThreadState {
+    pub(super) fn capture_coredump(
+        &self,
+        _limits: *const VMRuntimeLimits,
+        _trap_pc_and_fp: Option<(usize, usize)>,
+    ) -> Option<CoreDumpStack> {
+        None
+    }
+}

--- a/crates/runtime/src/traphandlers/coredump_enabled.rs
+++ b/crates/runtime/src/traphandlers/coredump_enabled.rs
@@ -20,19 +20,21 @@ pub struct CoreDumpStack {
     pub operand_stack: Vec<Vec<CoreDumpValue>>,
 }
 
-impl CoreDumpStack {
-    /// Capture a core dump of the current wasm state
-    pub fn new(
-        cts: &CallThreadState,
+impl CallThreadState {
+    pub(super) fn capture_coredump(
+        &self,
         limits: *const VMRuntimeLimits,
         trap_pc_and_fp: Option<(usize, usize)>,
-    ) -> Self {
-        let bt = unsafe { Backtrace::new_with_trap_state(limits, cts, trap_pc_and_fp) };
+    ) -> Option<CoreDumpStack> {
+        if !self.capture_coredump {
+            return None;
+        }
+        let bt = unsafe { Backtrace::new_with_trap_state(limits, self, trap_pc_and_fp) };
 
-        Self {
+        Some(CoreDumpStack {
             bt,
             locals: vec![],
             operand_stack: vec![],
-        }
+        })
     }
 }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -167,7 +167,7 @@ wmemcheck = ["wasmtime-runtime?/wmemcheck", "wasmtime-cranelift?/wmemcheck"]
 demangle = ["wasmtime-environ/demangle"]
 
 # Enable support for generating core dumps on traps.
-coredump = ["dep:wasm-encoder", "runtime"]
+coredump = ["dep:wasm-encoder", "runtime", "wasmtime-runtime/coredump"]
 
 # Export some symbols from the final binary to assist in debugging
 # Cranelift-generated code with native debuggers like GDB and LLDB.


### PR DESCRIPTION
The `wasmtime` crate already has a `coredump` feature but whether or not it's enabled the `wasmtime-runtime` crate still captures a core dump. Use this flag in the `wasmtime` crate to plumb support to `wasmtime-runtime` to skip capture if it's not enabled.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
