### PR TITLE
Update Wasmtime's policy on `cargo vet`

### DIFF
--- a/docs/contributing-coding-guidelines.md
+++ b/docs/contributing-coding-guidelines.md
@@ -117,8 +117,13 @@ though to add vet entries this is done through one of a few methods:
 
 Note for the last case it's important to ensure that after you push to the PR
 any future updates pushed by the contributor either contain or don't overwrite
-your vet entries. It's recommended to add vet entries just before approval to
-minimize interference with the contributor.
+your vet entries. Also verify that if the PR branch is rebased or force-pushed,
+the details of your previously pushed vetting remain the same: e.g., versions
+were not bumped and descriptive reasons remain the same. If pushing a vetting
+commit to a contributor's PR and also asking for more changes, request that the
+contributor make the requested fixes in an additional commit rather than
+force-pushing a rewritten history, so your existing vetting commit remains
+untouched. These guidelines make it easier to verify no tampering has occurred
 
 ### Policy for adding `cargo vet` entries
 


### PR DESCRIPTION
This was discussed at today's Wasmtime meeting out of some concerns around our current policies. Namely I felt the current state of affairs is not striking the right balance between cost and benefit with our usage of `cargo vet`. After discussion we've reached consensus around two changes to our `cargo vet` policy documented here in this PR:

* An exemption can be added for "popular crates" at any time with no review required. This should handle most big crates that are needed for various dependencies. The thinking behind this is that a supply-chain attack against these crates is highly likely to be detected in a short time due to their popularity. Coupled with the fact that changes to Wasmtime take a minimum of two weeks to get released means that it's an unlikely exploitation vector.

* Maintainers are recommended to push directly to contributor's PRs for `cargo vet` entries instead of making separate PRs. This avoids the need for contributor rebasing and additionally solves the problem where the `vet` entries land in a separate PR but then the contributor's PR takes much longer to land. In the interim some `vet` entries have been cleaned up by accident which requires re-landing the PR to add the entries.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
