### PR TITLE
Avoid `std::panic` in `wasmtime-runtime` with `-Cpanic=abort`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,6 +322,12 @@ jobs:
     - run: cargo check -p wasmtime-c-api --no-default-features --features wat
     - run: cargo check -p wasmtime-c-api --no-default-features --features wasi
 
+    # Check that wasmtime-runtime compiles with panic=abort since there's some
+    # #[cfg] for specifically panic=abort there.
+    - run: cargo check -p wasmtime-runtime
+      env:
+        RUSTFLAGS: -Cpanic=abort
+
     # Check a few builds of the cranelift backend
     # - only x86 backend support,
     # - only arm64 backend support,

--- a/crates/runtime/src/component/libcalls.rs
+++ b/crates/runtime/src/component/libcalls.rs
@@ -129,18 +129,17 @@ mod trampolines {
                     //
                     // Additionally assume that every function below returns a
                     // `Result` where errors turn into traps.
-                    let result = std::panic::catch_unwind(|| {
+                    let result = crate::traphandlers::catch_unwind_and_longjmp(|| {
                         shims!(@invoke $name() $($pname)*)
                     });
                     match result {
-                        Ok(Ok(ret)) => shims!(@convert_ret ret $($pname: $param)*),
-                        Ok(Err(err)) => crate::traphandlers::raise_trap(
+                        Ok(ret) => shims!(@convert_ret ret $($pname: $param)*),
+                        Err(err) => crate::traphandlers::raise_trap(
                             crate::traphandlers::TrapReason::User {
                                 error: err,
                                 needs_backtrace: true,
                             },
                         ),
-                        Err(panic) => crate::traphandlers::resume_panic(panic),
                     }
                 }
             )*

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -110,17 +110,14 @@ pub mod raw {
                 ) $( -> libcall!(@ty $result))? {
                     $(#[cfg($attr)])?
                     {
-                        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                        let ret = crate::traphandlers::catch_unwind_and_longjmp(|| {
                             Instance::from_vmctx(vmctx, |instance| {
                                 {
                                     super::$name(instance, $($pname),*)
                                 }
                             })
-                        }));
-                        match result {
-                            Ok(ret) => LibcallResult::convert(ret),
-                            Err(panic) => crate::traphandlers::resume_panic(panic),
-                        }
+                        });
+                        LibcallResult::convert(ret)
                     }
                     $(
                         #[cfg(not($attr))]


### PR DESCRIPTION
This commit refactors the `wasmtime-runtime` crate to avoid the `std::panic` module entirely if it's compiled with `panic=abort`. From an optimization perspective this is not really required since it'll optimize the same either way with `-Cpanic=abort`, but avoiding `std::panic` can help make the code a bit more portable. This refactoring bundles in the `catch_unwind` with the longjmp of the panic to keep the `#[cfg]` in one location. Callers are then updated as appropriate.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
