### PR TITLE
Bad relocation type generated (#8255)

### DIFF
--- a/crates/cranelift/src/obj.rs
+++ b/crates/cranelift/src/obj.rs
@@ -188,7 +188,7 @@ impl<'a> ModuleTextBuilder<'a> {
                         Reloc::Abs8 => object::RelocationFlags::Generic {
                             encoding: object::RelocationEncoding::Generic,
                             kind: object::RelocationKind::Absolute,
-                            size: 8,
+                            size: 64,
                         },
                         other => unimplemented!("unimplemented relocation kind {other:?}"),
                     };

--- a/crates/wasmtime/src/runtime/code_memory.rs
+++ b/crates/wasmtime/src/runtime/code_memory.rs
@@ -102,7 +102,7 @@ impl CodeMemory {
                     for (offset, reloc) in section.relocations() {
                         assert_eq!(reloc.kind(), object::RelocationKind::Absolute);
                         assert_eq!(reloc.encoding(), object::RelocationEncoding::Generic);
-                        assert_eq!(usize::from(reloc.size()), std::mem::size_of::<usize>());
+                        assert_eq!(usize::from(reloc.size()), std::mem::size_of::<usize>() * 8);
                         assert_eq!(reloc.addend(), 0);
                         let sym = match reloc.target() {
                             object::RelocationTarget::Symbol(id) => id,


### PR DESCRIPTION
When disabling sse on x86_64 architecture machines and generating float libcall, incorrect relocation type R_X86_64_8 may be obtained, with the correct type being R_X86_64_64.

Closes #8255
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
