### PR TITLE
Lift some dependencies up to the `[workspace.dependencies]` level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ walkdir = "2.3.3"
 cfg-if = "1.0"
 tempfile = "3.1.0"
 filecheck = "0.5.0"
-libc = "0.2.60"
+libc = { version = "0.2.112", default-features = true }
 file-per-thread-logger = "0.2.0"
 tokio = { version = "1.26.0", features = [ "rt", "time" ] }
 hyper = "1.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,6 +290,7 @@ test-log = { version = "0.2", default-features = false, features = ["trace"] }
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ['fmt', 'env-filter', 'ansi', 'tracing-log'] }
 url = "2.3.1"
 humantime = "2.0.0"
+bincode = "1.2.1"
 
 # =============================================================================
 #

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -26,8 +26,8 @@ cranelift-control = { workspace = true }
 hashbrown = { workspace = true, features = ["raw"] }
 target-lexicon = { workspace = true }
 log = { workspace = true }
-serde = { version = "1.0.188", optional = true }
-serde_derive = { version = "1.0.188", optional = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 bincode = { version = "1.2.1", optional = true }
 gimli = { workspace = true, features = ["write"], optional = true }
 smallvec = { workspace = true }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -28,7 +28,7 @@ target-lexicon = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
-bincode = { version = "1.2.1", optional = true }
+bincode = { workspace = true, optional = true }
 gimli = { workspace = true, features = ["write"], optional = true }
 smallvec = { workspace = true }
 regalloc2 = { workspace = true, features = ["checker"] }

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -15,8 +15,8 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-serde = { version = "1.0.188", optional = true }
-serde_derive = { version = "1.0.188", optional = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 
 [features]
 enable-serde = ["serde", "serde_derive"]

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -20,7 +20,7 @@ cranelift-entity = { workspace = true }
 cranelift-control = { workspace = true }
 anyhow = { workspace = true }
 region = "2.2.0"
-libc = { version = "0.2.42" }
+libc = { workspace = true }
 target-lexicon = { workspace = true }
 memmap2 = { version = "0.2.1", optional = true }
 log = { workspace = true }

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -18,8 +18,8 @@ cranelift-codegen = { workspace = true }
 cranelift-control = { workspace = true }
 hashbrown = { workspace = true, optional = true }
 anyhow = { workspace = true }
-serde = { version = "1.0.188", optional = true }
-serde_derive = { version = "1.0.188", optional = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 
 [features]
 default = ["std"]

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -15,7 +15,7 @@ cranelift-codegen = { workspace = true }
 target-lexicon = { workspace = true }
 
 [target.'cfg(any(target_arch = "s390x", target_arch = "riscv64"))'.dependencies]
-libc = "0.2.95"
+libc = { workspace = true }
 
 [features]
 default = ["std"]

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -18,6 +18,6 @@ path = "src/clif-json.rs"
 
 [dependencies]
 clap = { workspace = true }
-serde_json = "1.0.26"
+serde_json = { workspace = true }
 cranelift-codegen = { workspace = true, features = ["enable-serde"] }
 cranelift-reader = { workspace = true }

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -23,8 +23,8 @@ wasmtime-types = { workspace = true }
 hashbrown = { workspace = true, optional = true }
 itertools = "0.12.0"
 log = { workspace = true }
-serde = { version = "1.0.188", optional = true }
-serde_derive = { version = "1.0.188", optional = true }
+serde = { workspace = true, optional = true }
+serde_derive = { workspace = true, optional = true }
 smallvec = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 base64 = "0.21.0"
-bincode = "1.1.4"
+bincode = { workspace = true }
 directories-next = "2.0"
 log = { workspace = true }
 serde = { workspace = true }

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -17,8 +17,8 @@ base64 = "0.21.0"
 bincode = "1.1.4"
 directories-next = "2.0"
 log = { workspace = true }
-serde = "1.0.188"
-serde_derive = "1.0.188"
+serde = { workspace = true }
+serde_derive = { workspace = true }
 sha2 = "0.10.2"
 toml = { workspace = true }
 zstd = { version = "0.13.0", default-features = false }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-bincode = "1.2.1"
+bincode = { workspace = true }
 cpp_demangle = { version = "0.4.3", optional = true }
 cranelift-entity = { workspace = true }
 wasmtime-types = { workspace = true }

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -22,8 +22,8 @@ wasmtime-types = { workspace = true }
 wasmparser = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
-serde = "1.0.188"
-serde_derive = "1.0.188"
+serde = { workspace = true }
+serde_derive = { workspace = true }
 log = { workspace = true }
 gimli = { workspace = true }
 object = { workspace = true }

--- a/crates/jit-icache-coherence/Cargo.toml
+++ b/crates/jit-icache-coherence/Cargo.toml
@@ -23,7 +23,7 @@ features = [
 ]
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os = "freebsd", target_os = "android"))'.dependencies]
-libc = "0.2.42"
+libc = { workspace = true }
 
 [features]
 # Most modern CPUs are SMP (multicore). However, when only one core is present,

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -20,7 +20,7 @@ wasmtime-environ = { workspace = true }
 wasmtime-fiber = { workspace = true, optional = true }
 wasmtime-jit-debug = { workspace = true, features = ["gdb_jit_int"], optional = true }
 wasmtime-versioned-export-macros = { workspace = true }
-libc = { version = "0.2.112", default-features = false }
+libc = { workspace = true }
 log = { workspace = true }
 memoffset = "0.9.0"
 indexmap = { workspace = true }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 
 [dependencies]
 cranelift-entity = { workspace = true, features = ['enable-serde'] }
-serde = "1.0.188"
-serde_derive = "1.0.188"
+serde = { workspace = true }
+serde_derive = { workspace = true }
 thiserror = { workspace = true }
 wasmparser = { workspace = true }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -41,8 +41,8 @@ libc = "0.2"
 cfg-if = { workspace = true }
 log = { workspace = true }
 wat = { workspace = true, optional = true }
-serde = "1.0.188"
-serde_derive = "1.0.188"
+serde = { workspace = true }
+serde_derive = { workspace = true }
 serde_json = { workspace = true }
 bincode = "1.2.1"
 indexmap = { workspace = true }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -37,7 +37,7 @@ target-lexicon = { workspace = true }
 wasmparser = { workspace = true }
 wasm-encoder = { workspace = true, optional = true }
 anyhow = { workspace = true }
-libc = "0.2"
+libc = { workspace = true }
 cfg-if = { workspace = true }
 log = { workspace = true }
 wat = { workspace = true, optional = true }

--- a/crates/wasmtime/Cargo.toml
+++ b/crates/wasmtime/Cargo.toml
@@ -44,7 +44,7 @@ wat = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 serde_json = { workspace = true }
-bincode = "1.2.1"
+bincode = { workspace = true }
 indexmap = { workspace = true }
 paste = "1.0.3"
 once_cell = { workspace = true }


### PR DESCRIPTION
Deduplicate version requirements listed for crates throughout this repository and additionally normalize the set of required features. No functional change intended here, just refactoring.