### PR TITLE
fix invalid modification of file position when write file

### DIFF
--- a/crates/wasi/src/filesystem.rs
+++ b/crates/wasi/src/filesystem.rs
@@ -354,12 +354,7 @@ impl HostOutputStream for FileOutputStream {
             }
         });
         self.state = match result {
-            SpawnBlocking::Done(Ok(nwritten)) => {
-                if let FileOutputMode::Position(ref mut p) = &mut self.mode {
-                    *p += nwritten as u64;
-                }
-                OutputState::Ready
-            }
+            SpawnBlocking::Done(Ok(_)) => OutputState::Ready,
             SpawnBlocking::Done(Err(e)) => OutputState::Error(e),
             SpawnBlocking::Spawned(task) => OutputState::Waiting(task),
         };


### PR DESCRIPTION
 
- from [issue](https://github.com/bytecodealliance/wasmtime/issues/8257)

- ```self.mode``` is not a reference of postion in [fd_write](https://github.com/bytecodealliance/wasmtime/blob/9c92881d3b936b5d2e593ded370609a6e31717d8/crates/wasi/src/preview1.rs#L1670) , which is passed by value in [write_via_stream](https://github.com/bytecodealliance/wasmtime/blob/9c92881d3b936b5d2e593ded370609a6e31717d8/crates/wasi/src/preview1.rs#L1690)
 
