### PR TITLE
Fix the SystemV abi of i128 arguments

### DIFF
--- a/cranelift/filetests/filetests/isa/x64/llvm-abi-no-split-stack-u128.clif
+++ b/cranelift/filetests/filetests/isa/x64/llvm-abi-no-split-stack-u128.clif
@@ -1,0 +1,30 @@
+test compile precise-output
+set enable_llvm_abi_extensions=1
+target x86_64
+
+function u0:0(i64, i128, i128, i128) -> i128 system_v {
+block0(v0: i64, v1: i128, v2: i128, v3: i128):
+    return v3
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movq    16(%rbp), %rax
+;   movq    24(%rbp), %rdx
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movq 0x10(%rbp), %rax
+;   movq 0x18(%rbp), %rdx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+


### PR DESCRIPTION
i128 arguments must always be passed either fully in registers or fully on the stack according to GCC. LLVM until recently allowed splitting it into a half passed in a register and a half passed on the stack. This was recently fixed. For cg_clif to remain ABI compatible with cg_llvm, it is necessary to apply the same fix to Cranelift.

See also https://blog.rust-lang.org/2024/03/30/i128-layout-update.html