### PR TITLE
cranelift: Fix indirect tail calls on aarch64/riscv64

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -131,7 +131,9 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
             self.lower_ctx.sigs(),
             callee_sig,
             callee,
-            Opcode::ReturnCallIndirect,
+            // TODO: this should be Opcode::ReturnCallIndirect, once aarch64 has
+            // been ported to the new tail call strategy.
+            Opcode::CallIndirect,
             caller_conv,
             self.backend.flags().clone(),
         );

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -113,7 +113,9 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
             self.lower_ctx.sigs(),
             callee_sig,
             callee,
-            Opcode::ReturnCallIndirect,
+            // TODO: this should be Opcode::ReturnCallIndirect, once riscv64 has
+            // been ported to the new tail call strategy.
+            Opcode::CallIndirect,
             caller_conv,
             self.backend.flags().clone(),
         );

--- a/cranelift/filetests/filetests/isa/aarch64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/return-call-indirect.clif
@@ -1,0 +1,316 @@
+test compile precise-output
+
+target aarch64
+
+;;;; Test passing `i64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %callee_i64(i64) -> i64 tail {
+block0(v0: i64):
+    v1 = iadd_imm.i64 v0, 10
+    return v1
+}
+
+; VCode:
+; block0:
+;   add x2, x2, #10
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   add x2, x2, #0xa
+;   ret
+
+function %call_i64(i64) -> i64 tail {
+    sig0 = (i64) -> i64 tail
+    fn0 = %callee_i64(i64) -> i64 tail
+
+block0(v0: i64):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   load_ext_name x3, TestCase(%callee_i64)+0
+;   return_call_ind x3 old_stack_arg_size:0 new_stack_arg_size:0 x2=x2
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block1: ; offset 0x8
+;   ldr x3, #0x10
+;   b #0x18
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i64 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldp x16, x30, [x29]
+;   add sp, x29, #0x10
+;   mov x29, x16
+;   br x3
+
+;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %colocated_i64(i64) -> i64 tail {
+    sig0 = (i64) -> i64 tail
+    fn0 = colocated %callee_i64(i64) -> i64 tail
+
+block0(v0: i64):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   load_ext_name x3, TestCase(%callee_i64)+0
+;   return_call_ind x3 old_stack_arg_size:0 new_stack_arg_size:0 x2=x2
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block1: ; offset 0x8
+;   ldr x3, #0x10
+;   b #0x18
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i64 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldp x16, x30, [x29]
+;   add sp, x29, #0x10
+;   mov x29, x16
+;   br x3
+
+;;;; Test passing `f64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %callee_f64(f64) -> f64 tail {
+block0(v0: f64):
+    v1 = f64const 0x10.0
+    v2 = fadd.f64 v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   fmov d3, #16
+;   fadd d0, d0, d3
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   fmov d3, #16.00000000
+;   fadd d0, d0, d3
+;   ret
+
+function %call_f64(f64) -> f64 tail {
+    sig0 = (f64) -> f64 tail
+    fn0 = %callee_f64(f64) -> f64 tail
+
+block0(v0: f64):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   load_ext_name x2, TestCase(%callee_f64)+0
+;   return_call_ind x2 old_stack_arg_size:0 new_stack_arg_size:0 v0=v0
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block1: ; offset 0x8
+;   ldr x2, #0x10
+;   b #0x18
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_f64 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldp x16, x30, [x29]
+;   add sp, x29, #0x10
+;   mov x29, x16
+;   br x2
+
+;;;; Test passing `i8`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %callee_i8(i8) -> i8 tail {
+block0(v0: i8):
+    v1 = iconst.i8 0
+    v2 = icmp eq v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   uxtb w2, w2
+;   subs wzr, w2, #0
+;   cset x2, eq
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   uxtb w2, w2
+;   cmp w2, #0
+;   cset x2, eq
+;   ret
+
+function %call_i8(i8) -> i8 tail {
+    sig0 = (i8) -> i8 tail
+    fn0 = %callee_i8(i8) -> i8 tail
+
+block0(v0: i8):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+; block0:
+;   load_ext_name x3, TestCase(%callee_i8)+0
+;   return_call_ind x3 old_stack_arg_size:0 new_stack_arg_size:0 x2=x2
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+; block1: ; offset 0x8
+;   ldr x3, #0x10
+;   b #0x18
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i8 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ldp x16, x30, [x29]
+;   add sp, x29, #0x10
+;   mov x29, x16
+;   br x3
+
+;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %tail_caller_stack_args() -> i64 tail {
+    fn0 = %tail_callee_stack_args(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64 tail
+
+block0:
+    v0 = iconst.i64 10
+    v1 = iconst.i64 15
+    v2 = iconst.i64 20
+    v3 = iconst.i64 25
+    v4 = iconst.i64 30
+    v5 = iconst.i64 35
+    v6 = iconst.i64 40
+    v7 = iconst.i64 45
+    v8 = iconst.i64 50
+    v9 = iconst.i64 55
+    v10 = iconst.i64 60
+    v11 = iconst.i64 65
+    v12 = iconst.i64 70
+    v13 = iconst.i64 75
+    v14 = iconst.i64 80
+    v15 = iconst.i64 85
+    v16 = iconst.i64 90
+    v17 = iconst.i64 95
+    v18 = iconst.i64 100
+    v19 = iconst.i64 105
+    v20 = iconst.i64 110
+    v21 = iconst.i64 115
+    v22 = iconst.i64 120
+    v23 = iconst.i64 125
+    v24 = iconst.i64 130
+    v25 = iconst.i64 135
+    v26 = func_addr.i64 fn0
+    return_call_indirect sig0, v26(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25)
+}
+
+; VCode:
+;   stp fp, lr, [sp, #-16]!
+;   mov fp, sp
+;   sub sp, sp, #16
+; block0:
+;   movz x2, #10
+;   movz x3, #15
+;   movz x4, #20
+;   movz x5, #25
+;   movz x6, #30
+;   movz x7, #35
+;   movz x8, #40
+;   movz x9, #45
+;   movz x10, #50
+;   str x10, [sp]
+;   movz x11, #55
+;   movz x12, #60
+;   movz x13, #65
+;   movz x14, #70
+;   movz x15, #75
+;   movz x19, #80
+;   movz x20, #85
+;   movz x21, #90
+;   movz x22, #95
+;   movz x23, #100
+;   movz x24, #105
+;   movz x25, #110
+;   movz x26, #115
+;   movz x27, #120
+;   movz x28, #125
+;   movz x0, #130
+;   movz x1, #135
+;   load_ext_name x10, TestCase(%tail_callee_stack_args)+0
+;   sub sp, sp, #16
+;   virtual_sp_offset_adjust 16
+;   str x0, [sp]
+;   str x1, [sp, #8]
+;   mov x0, x10
+;   ldr x10, [sp, #16]
+;   return_call_ind x0 old_stack_arg_size:0 new_stack_arg_size:16 x2=x2 x3=x3 x4=x4 x5=x5 x6=x6 x7=x7 x8=x8 x9=x9 x10=x10 x11=x11 x12=x12 x13=x13 x14=x14 x15=x15 x19=x19 x20=x20 x21=x21 x22=x22 x23=x23 x24=x24 x25=x25 x26=x26 x27=x27 x28=x28
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   stp x29, x30, [sp, #-0x10]!
+;   mov x29, sp
+;   sub sp, sp, #0x10
+; block1: ; offset 0xc
+;   mov x2, #0xa
+;   mov x3, #0xf
+;   mov x4, #0x14
+;   mov x5, #0x19
+;   mov x6, #0x1e
+;   mov x7, #0x23
+;   mov x8, #0x28
+;   mov x9, #0x2d
+;   mov x10, #0x32
+;   stur x10, [sp]
+;   mov x11, #0x37
+;   mov x12, #0x3c
+;   mov x13, #0x41
+;   mov x14, #0x46
+;   mov x15, #0x4b
+;   mov x19, #0x50
+;   mov x20, #0x55
+;   mov x21, #0x5a
+;   mov x22, #0x5f
+;   mov x23, #0x64
+;   mov x24, #0x69
+;   mov x25, #0x6e
+;   mov x26, #0x73
+;   mov x27, #0x78
+;   mov x28, #0x7d
+;   mov x0, #0x82
+;   mov x1, #0x87
+;   ldr x10, #0x80
+;   b #0x88
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   sub sp, sp, #0x10
+;   stur x0, [sp]
+;   stur x1, [sp, #8]
+;   mov x0, x10
+;   ldur x10, [sp, #0x10]
+;   ldp x16, x30, [x29]
+;   ldur x17, [sp, #8]
+;   stur x17, [x29, #8]
+;   ldur x17, [sp]
+;   stur x17, [x29]
+;   mov sp, x29
+;   mov x29, x16
+;   br x0
+

--- a/cranelift/filetests/filetests/isa/riscv64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/return-call-indirect.clif
@@ -1,0 +1,370 @@
+test compile precise-output
+
+target riscv64
+
+;;;; Test passing `i64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %callee_i64(i64) -> i64 tail {
+block0(v0: i64):
+    v1 = iadd_imm.i64 v0, 10
+    return v1
+}
+
+; VCode:
+; block0:
+;   addi s1,s1,10
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi s1, s1, 0xa
+;   ret
+
+function %call_i64(i64) -> i64 tail {
+    sig0 = (i64) -> i64 tail
+    fn0 = %callee_i64(i64) -> i64 tail
+
+block0(v0: i64):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   load_sym a2,%callee_i64+0
+;   return_call_ind a2 old_stack_arg_size:0 new_stack_arg_size:0 s1=s1
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+; block1: ; offset 0x10
+;   auipc a2, 0
+;   ld a2, 0xc(a2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i64 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ld ra, 8(s0)
+;   ld t6, 0(s0)
+;   addi sp, s0, 0x10
+;   mv s0, t6
+;   jr a2
+
+;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %colocated_i64(i64) -> i64 tail {
+    sig0 = (i64) -> i64 tail
+    fn0 = colocated %callee_i64(i64) -> i64 tail
+
+block0(v0: i64):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   load_sym a2,%callee_i64+0
+;   return_call_ind a2 old_stack_arg_size:0 new_stack_arg_size:0 s1=s1
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+; block1: ; offset 0x10
+;   auipc a2, 0
+;   ld a2, 0xc(a2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i64 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ld ra, 8(s0)
+;   ld t6, 0(s0)
+;   addi sp, s0, 0x10
+;   mv s0, t6
+;   jr a2
+
+;;;; Test passing `f64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %callee_f64(f64) -> f64 tail {
+block0(v0: f64):
+    v1 = f64const 0x10.0
+    v2 = fadd.f64 v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   lui a3,1027
+;   slli a5,a3,40
+;   fmv.d.x fa1,a5
+;   fadd.d ft0,ft0,fa1,rne
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   lui a3, 0x403
+;   slli a5, a3, 0x28
+;   fmv.d.x fa1, a5
+;   fadd.d ft0, ft0, fa1, rne
+;   ret
+
+function %call_f64(f64) -> f64 tail {
+    sig0 = (f64) -> f64 tail
+    fn0 = %callee_f64(f64) -> f64 tail
+
+block0(v0: f64):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   load_sym a2,%callee_f64+0
+;   return_call_ind a2 old_stack_arg_size:0 new_stack_arg_size:0 ft0=ft0
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+; block1: ; offset 0x10
+;   auipc a2, 0
+;   ld a2, 0xc(a2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_f64 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ld ra, 8(s0)
+;   ld t6, 0(s0)
+;   addi sp, s0, 0x10
+;   mv s0, t6
+;   jr a2
+
+;;;; Test passing `i8`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %callee_i8(i8) -> i8 tail {
+block0(v0: i8):
+    v1 = iconst.i8 0
+    v2 = icmp eq v0, v1
+    return v2
+}
+
+; VCode:
+; block0:
+;   andi a2,s1,255
+;   seqz s1,a2
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   andi a2, s1, 0xff
+;   seqz s1, a2
+;   ret
+
+function %call_i8(i8) -> i8 tail {
+    sig0 = (i8) -> i8 tail
+    fn0 = %callee_i8(i8) -> i8 tail
+
+block0(v0: i8):
+    v1 = func_addr.i64 fn0
+    return_call_indirect sig0, v1(v0)
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+; block0:
+;   load_sym a2,%callee_i8+0
+;   return_call_ind a2 old_stack_arg_size:0 new_stack_arg_size:0 s1=s1
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+; block1: ; offset 0x10
+;   auipc a2, 0
+;   ld a2, 0xc(a2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i8 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   ld ra, 8(s0)
+;   ld t6, 0(s0)
+;   addi sp, s0, 0x10
+;   mv s0, t6
+;   jr a2
+
+;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %tail_caller_stack_args() -> i64 tail {
+    fn0 = %tail_callee_stack_args(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64 tail
+
+block0:
+    v0 = iconst.i64 10
+    v1 = iconst.i64 15
+    v2 = iconst.i64 20
+    v3 = iconst.i64 25
+    v4 = iconst.i64 30
+    v5 = iconst.i64 35
+    v6 = iconst.i64 40
+    v7 = iconst.i64 45
+    v8 = iconst.i64 50
+    v9 = iconst.i64 55
+    v10 = iconst.i64 60
+    v11 = iconst.i64 65
+    v12 = iconst.i64 70
+    v13 = iconst.i64 75
+    v14 = iconst.i64 80
+    v15 = iconst.i64 85
+    v16 = iconst.i64 90
+    v17 = iconst.i64 95
+    v18 = iconst.i64 100
+    v19 = iconst.i64 105
+    v20 = iconst.i64 110
+    v21 = iconst.i64 115
+    v22 = iconst.i64 120
+    v23 = iconst.i64 125
+    v24 = iconst.i64 130
+    v25 = iconst.i64 135
+    v26 = func_addr.i64 fn0
+    return_call_indirect sig0, v26(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25)
+}
+
+; VCode:
+;   addi sp,sp,-16
+;   sd ra,8(sp)
+;   sd fp,0(sp)
+;   mv fp,sp
+;   addi sp,sp,-32
+; block0:
+;   li s1,10
+;   sd s1,16(nominal_sp)
+;   li a0,15
+;   sd a0,8(nominal_sp)
+;   li a1,20
+;   li a2,25
+;   sd a2,0(nominal_sp)
+;   li a3,30
+;   li a4,35
+;   li a5,40
+;   li a6,45
+;   li a7,50
+;   li s2,55
+;   li s3,60
+;   li s4,65
+;   li s5,70
+;   li s6,75
+;   li s7,80
+;   li s8,85
+;   li s9,90
+;   li s10,95
+;   li s11,100
+;   li t3,105
+;   li t4,110
+;   li t0,115
+;   li t1,120
+;   li t2,125
+;   li s1,130
+;   li a0,135
+;   load_sym a2,%tail_callee_stack_args+0
+;   addi sp,sp,-48
+;   virtual_sp_offset_adj +48
+;   sd t0,0(sp)
+;   sd t1,8(sp)
+;   sd t2,16(sp)
+;   sd s1,24(sp)
+;   sd a0,32(sp)
+;   ld a0,8(nominal_sp)
+;   ld s1,16(nominal_sp)
+;   mv t0,a2
+;   ld a2,0(nominal_sp)
+;   return_call_ind t0 old_stack_arg_size:0 new_stack_arg_size:48 s1=s1 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7 s2=s2 s3=s3 s4=s4 s5=s5 s6=s6 s7=s7 s8=s8 s9=s9 s10=s10 s11=s11 t3=t3 t4=t4
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   addi sp, sp, -0x10
+;   sd ra, 8(sp)
+;   sd s0, 0(sp)
+;   mv s0, sp
+;   addi sp, sp, -0x20
+; block1: ; offset 0x14
+;   addi s1, zero, 0xa
+;   sd s1, 0x10(sp)
+;   addi a0, zero, 0xf
+;   sd a0, 8(sp)
+;   addi a1, zero, 0x14
+;   addi a2, zero, 0x19
+;   sd a2, 0(sp)
+;   addi a3, zero, 0x1e
+;   addi a4, zero, 0x23
+;   addi a5, zero, 0x28
+;   addi a6, zero, 0x2d
+;   addi a7, zero, 0x32
+;   addi s2, zero, 0x37
+;   addi s3, zero, 0x3c
+;   addi s4, zero, 0x41
+;   addi s5, zero, 0x46
+;   addi s6, zero, 0x4b
+;   addi s7, zero, 0x50
+;   addi s8, zero, 0x55
+;   addi s9, zero, 0x5a
+;   addi s10, zero, 0x5f
+;   addi s11, zero, 0x64
+;   addi t3, zero, 0x69
+;   addi t4, zero, 0x6e
+;   addi t0, zero, 0x73
+;   addi t1, zero, 0x78
+;   addi t2, zero, 0x7d
+;   addi s1, zero, 0x82
+;   addi a0, zero, 0x87
+;   auipc a2, 0
+;   ld a2, 0xc(a2)
+;   j 0xc
+;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args 0
+;   .byte 0x00, 0x00, 0x00, 0x00
+;   addi sp, sp, -0x30
+;   sd t0, 0(sp)
+;   sd t1, 8(sp)
+;   sd t2, 0x10(sp)
+;   sd s1, 0x18(sp)
+;   sd a0, 0x20(sp)
+;   ld a0, 0x38(sp)
+;   ld s1, 0x40(sp)
+;   mv t0, a2
+;   ld a2, 0x30(sp)
+;   ld ra, 8(s0)
+;   ld t6, 0(s0)
+;   ld t5, 0x28(sp)
+;   sd t5, 8(s0)
+;   ld t5, 0x20(sp)
+;   sd t5, 0(s0)
+;   ld t5, 0x18(sp)
+;   sd t5, -8(s0)
+;   ld t5, 0x10(sp)
+;   sd t5, -0x10(s0)
+;   ld t5, 8(sp)
+;   sd t5, -0x18(s0)
+;   ld t5, 0(sp)
+;   sd t5, -0x20(s0)
+;   addi sp, s0, -0x20
+;   mv s0, t6
+;   jr t0
+

--- a/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
@@ -208,3 +208,269 @@ block0(v0: i8):
 ;   popq %rbp
 ;   jmpq *%rax
 
+;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %tail_caller_stack_args() -> i64 tail {
+    fn0 = %tail_callee_stack_args(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64 tail
+
+block0:
+    v0 = iconst.i64 10
+    v1 = iconst.i64 15
+    v2 = iconst.i64 20
+    v3 = iconst.i64 25
+    v4 = iconst.i64 30
+    v5 = iconst.i64 35
+    v6 = iconst.i64 40
+    v7 = iconst.i64 45
+    v8 = iconst.i64 50
+    v9 = iconst.i64 55
+    v10 = iconst.i64 60
+    v11 = iconst.i64 65
+    v12 = iconst.i64 70
+    v13 = iconst.i64 75
+    v14 = iconst.i64 80
+    v15 = iconst.i64 85
+    v16 = iconst.i64 90
+    v17 = iconst.i64 95
+    v18 = iconst.i64 100
+    v19 = iconst.i64 105
+    v20 = iconst.i64 110
+    v21 = iconst.i64 115
+    v22 = iconst.i64 120
+    v23 = iconst.i64 125
+    v24 = iconst.i64 130
+    v25 = iconst.i64 135
+    v26 = func_addr.i64 fn0
+    return_call_indirect sig0, v26(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25)
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+;   subq    %rsp, $160, %rsp
+;   movq    %rbx, 112(%rsp)
+;   movq    %r12, 120(%rsp)
+;   movq    %r13, 128(%rsp)
+;   movq    %r14, 136(%rsp)
+;   movq    %r15, 144(%rsp)
+; block0:
+;   movl    $10, %edi
+;   movq    %rdi, rsp(104 + virtual offset)
+;   movl    $15, %esi
+;   movq    %rsi, rsp(96 + virtual offset)
+;   movl    $20, %edx
+;   movq    %rdx, rsp(88 + virtual offset)
+;   movl    $25, %ecx
+;   movq    %rcx, rsp(80 + virtual offset)
+;   movl    $30, %r8d
+;   movq    %r8, rsp(72 + virtual offset)
+;   movl    $35, %r9d
+;   movq    %r9, rsp(64 + virtual offset)
+;   movl    $40, %eax
+;   movl    $45, %r10d
+;   movl    $50, %r11d
+;   movl    $55, %r13d
+;   movl    $60, %r14d
+;   movl    $65, %r15d
+;   movl    $70, %ebx
+;   movl    $75, %r12d
+;   movl    $80, %edi
+;   movl    $85, %esi
+;   movq    %rsi, rsp(56 + virtual offset)
+;   movl    $90, %edx
+;   movl    $95, %ecx
+;   movl    $100, %r8d
+;   movl    $105, %r9d
+;   movl    $110, %esi
+;   movq    %rsi, rsp(48 + virtual offset)
+;   movl    $115, %esi
+;   movq    %rsi, rsp(40 + virtual offset)
+;   movl    $120, %esi
+;   movq    %rsi, rsp(32 + virtual offset)
+;   movl    $125, %esi
+;   movq    %rsi, rsp(24 + virtual offset)
+;   movl    $130, %esi
+;   movq    %rsi, rsp(16 + virtual offset)
+;   movl    $135, %esi
+;   movq    %rsi, rsp(8 + virtual offset)
+;   load_ext_name %tail_callee_stack_args+0, %rsi
+;   movq    %rsi, rsp(0 + virtual offset)
+;   grow_argument_area 160 %rsi
+;   movq    %rax, 16(%rbp)
+;   movq    %r10, 24(%rbp)
+;   movq    %r11, 32(%rbp)
+;   movq    %r13, 40(%rbp)
+;   movq    %r14, 48(%rbp)
+;   movq    %r15, 56(%rbp)
+;   movq    %rbx, 64(%rbp)
+;   movq    %r12, 72(%rbp)
+;   movq    %rdi, 80(%rbp)
+;   movq    rsp(56 + virtual offset), %rdi
+;   movq    %rdi, 88(%rbp)
+;   movq    %rdx, 96(%rbp)
+;   movq    %rcx, 104(%rbp)
+;   movq    %r8, 112(%rbp)
+;   movq    %r9, 120(%rbp)
+;   movq    rsp(48 + virtual offset), %rsi
+;   movq    %rsi, 128(%rbp)
+;   movq    rsp(40 + virtual offset), %rsi
+;   movq    %rsi, 136(%rbp)
+;   movq    rsp(32 + virtual offset), %rsi
+;   movq    %rsi, 144(%rbp)
+;   movq    rsp(24 + virtual offset), %rsi
+;   movq    %rsi, 152(%rbp)
+;   movq    rsp(16 + virtual offset), %rsi
+;   movq    %rsi, 160(%rbp)
+;   movq    rsp(8 + virtual offset), %rsi
+;   movq    %rsi, 168(%rbp)
+;   movq    rsp(0 + virtual offset), %rax
+;   movq    rsp(80 + virtual offset), %rcx
+;   movq    rsp(88 + virtual offset), %rdx
+;   movq    rsp(96 + virtual offset), %rsi
+;   movq    rsp(104 + virtual offset), %rdi
+;   movq    rsp(72 + virtual offset), %r8
+;   movq    rsp(64 + virtual offset), %r9
+;   return_call_unknown %rax %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+;   subq $0xa0, %rsp
+;   movq %rbx, 0x70(%rsp)
+;   movq %r12, 0x78(%rsp)
+;   movq %r13, 0x80(%rsp)
+;   movq %r14, 0x88(%rsp)
+;   movq %r15, 0x90(%rsp)
+; block1: ; offset 0x2d
+;   movl $0xa, %edi
+;   movq %rdi, 0x68(%rsp)
+;   movl $0xf, %esi
+;   movq %rsi, 0x60(%rsp)
+;   movl $0x14, %edx
+;   movq %rdx, 0x58(%rsp)
+;   movl $0x19, %ecx
+;   movq %rcx, 0x50(%rsp)
+;   movl $0x1e, %r8d
+;   movq %r8, 0x48(%rsp)
+;   movl $0x23, %r9d
+;   movq %r9, 0x40(%rsp)
+;   movl $0x28, %eax
+;   movl $0x2d, %r10d
+;   movl $0x32, %r11d
+;   movl $0x37, %r13d
+;   movl $0x3c, %r14d
+;   movl $0x41, %r15d
+;   movl $0x46, %ebx
+;   movl $0x4b, %r12d
+;   movl $0x50, %edi
+;   movl $0x55, %esi
+;   movq %rsi, 0x38(%rsp)
+;   movl $0x5a, %edx
+;   movl $0x5f, %ecx
+;   movl $0x64, %r8d
+;   movl $0x69, %r9d
+;   movl $0x6e, %esi
+;   movq %rsi, 0x30(%rsp)
+;   movl $0x73, %esi
+;   movq %rsi, 0x28(%rsp)
+;   movl $0x78, %esi
+;   movq %rsi, 0x20(%rsp)
+;   movl $0x7d, %esi
+;   movq %rsi, 0x18(%rsp)
+;   movl $0x82, %esi
+;   movq %rsi, 0x10(%rsp)
+;   movl $0x87, %esi
+;   movq %rsi, 8(%rsp)
+;   movabsq $0, %rsi ; reloc_external Abs8 %tail_callee_stack_args 0
+;   movq %rsi, (%rsp)
+;   subq $0xa0, %rsp
+;   subq $0xa0, %rbp
+;   movq 0xa0(%rsp), %rsi
+;   movq %rsi, (%rsp)
+;   movq 0xa8(%rsp), %rsi
+;   movq %rsi, 8(%rsp)
+;   movq 0xb0(%rsp), %rsi
+;   movq %rsi, 0x10(%rsp)
+;   movq 0xb8(%rsp), %rsi
+;   movq %rsi, 0x18(%rsp)
+;   movq 0xc0(%rsp), %rsi
+;   movq %rsi, 0x20(%rsp)
+;   movq 0xc8(%rsp), %rsi
+;   movq %rsi, 0x28(%rsp)
+;   movq 0xd0(%rsp), %rsi
+;   movq %rsi, 0x30(%rsp)
+;   movq 0xd8(%rsp), %rsi
+;   movq %rsi, 0x38(%rsp)
+;   movq 0xe0(%rsp), %rsi
+;   movq %rsi, 0x40(%rsp)
+;   movq 0xe8(%rsp), %rsi
+;   movq %rsi, 0x48(%rsp)
+;   movq 0xf0(%rsp), %rsi
+;   movq %rsi, 0x50(%rsp)
+;   movq 0xf8(%rsp), %rsi
+;   movq %rsi, 0x58(%rsp)
+;   movq 0x100(%rsp), %rsi
+;   movq %rsi, 0x60(%rsp)
+;   movq 0x108(%rsp), %rsi
+;   movq %rsi, 0x68(%rsp)
+;   movq 0x110(%rsp), %rsi
+;   movq %rsi, 0x70(%rsp)
+;   movq 0x118(%rsp), %rsi
+;   movq %rsi, 0x78(%rsp)
+;   movq 0x120(%rsp), %rsi
+;   movq %rsi, 0x80(%rsp)
+;   movq 0x128(%rsp), %rsi
+;   movq %rsi, 0x88(%rsp)
+;   movq 0x130(%rsp), %rsi
+;   movq %rsi, 0x90(%rsp)
+;   movq 0x138(%rsp), %rsi
+;   movq %rsi, 0x98(%rsp)
+;   movq 0x140(%rsp), %rsi
+;   movq %rsi, 0xa0(%rsp)
+;   movq 0x148(%rsp), %rsi
+;   movq %rsi, 0xa8(%rsp)
+;   movq %rax, 0x10(%rbp)
+;   movq %r10, 0x18(%rbp)
+;   movq %r11, 0x20(%rbp)
+;   movq %r13, 0x28(%rbp)
+;   movq %r14, 0x30(%rbp)
+;   movq %r15, 0x38(%rbp)
+;   movq %rbx, 0x40(%rbp)
+;   movq %r12, 0x48(%rbp)
+;   movq %rdi, 0x50(%rbp)
+;   movq 0x38(%rsp), %rdi
+;   movq %rdi, 0x58(%rbp)
+;   movq %rdx, 0x60(%rbp)
+;   movq %rcx, 0x68(%rbp)
+;   movq %r8, 0x70(%rbp)
+;   movq %r9, 0x78(%rbp)
+;   movq 0x30(%rsp), %rsi
+;   movq %rsi, 0x80(%rbp)
+;   movq 0x28(%rsp), %rsi
+;   movq %rsi, 0x88(%rbp)
+;   movq 0x20(%rsp), %rsi
+;   movq %rsi, 0x90(%rbp)
+;   movq 0x18(%rsp), %rsi
+;   movq %rsi, 0x98(%rbp)
+;   movq 0x10(%rsp), %rsi
+;   movq %rsi, 0xa0(%rbp)
+;   movq 8(%rsp), %rsi
+;   movq %rsi, 0xa8(%rbp)
+;   movq (%rsp), %rax
+;   movq 0x50(%rsp), %rcx
+;   movq 0x58(%rsp), %rdx
+;   movq 0x60(%rsp), %rsi
+;   movq 0x68(%rsp), %rdi
+;   movq 0x48(%rsp), %r8
+;   movq 0x40(%rsp), %r9
+;   movq 0x70(%rsp), %rbx
+;   movq 0x78(%rsp), %r12
+;   movq 0x80(%rsp), %r13
+;   movq 0x88(%rsp), %r14
+;   movq 0x90(%rsp), %r15
+;   addq $0xa0, %rsp
+;   movq %rbp, %rsp
+;   popq %rbp
+;   jmpq *%rax
+

--- a/cranelift/filetests/filetests/runtests/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/runtests/return-call-indirect.clif
@@ -79,3 +79,45 @@ block0(v0: i8):
 }
 ; run: %call_i8(1) == 0
 ; run: %call_i8(0) == 1
+
+;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+function %tail_callee_stack_args(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64 tail {
+block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v8: i64, v9: i64, v10: i64, v11: i64, v12: i64, v13: i64, v14: i64, v15: i64, v16: i64, v17: i64, v18: i64, v19: i64, v20: i64, v21: i64, v22: i64, v23: i64, v24: i64, v25: i64):
+    return v25
+}
+
+function %tail_caller_stack_args() -> i64 tail {
+    fn0 = %tail_callee_stack_args(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64 tail
+
+block0:
+    v0 = iconst.i64 10
+    v1 = iconst.i64 15
+    v2 = iconst.i64 20
+    v3 = iconst.i64 25
+    v4 = iconst.i64 30
+    v5 = iconst.i64 35
+    v6 = iconst.i64 40
+    v7 = iconst.i64 45
+    v8 = iconst.i64 50
+    v9 = iconst.i64 55
+    v10 = iconst.i64 60
+    v11 = iconst.i64 65
+    v12 = iconst.i64 70
+    v13 = iconst.i64 75
+    v14 = iconst.i64 80
+    v15 = iconst.i64 85
+    v16 = iconst.i64 90
+    v17 = iconst.i64 95
+    v18 = iconst.i64 100
+    v19 = iconst.i64 105
+    v20 = iconst.i64 110
+    v21 = iconst.i64 115
+    v22 = iconst.i64 120
+    v23 = iconst.i64 125
+    v24 = iconst.i64 130
+    v25 = iconst.i64 135
+    v26 = func_addr.i64 fn0
+    return_call_indirect sig0, v26(v0, v1, v2, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15, v16, v17, v18, v19, v20, v21, v22, v23, v24, v25)
+}
+; run: %tail_caller_stack_args() == 135


### PR DESCRIPTION
x64 now uses a dedicated codegen strategy for tail-calls which writes the callee's stack arguments directly into their final location, but aarch64 and riscv64 still use our previous strategy of setting up for a normal function call and then moving the new stack frame up to overwrite the old one. In order to emit correct code for a normal function call, we need to fake a normal Call/CallIndirect opcode rather than ReturnCall/ReturnCallIndirect.

The new tests are a combination of x64's compile-tests for return-call-indirect.clif, plus a large-stack-frame test from aarch64/riscv64's return-call.clif modified to do an indirect call.