### PR TITLE
Update wiggle's `BorrowChecker` implementation

### DIFF
--- a/crates/wiggle/src/guest_type.rs
+++ b/crates/wiggle/src/guest_type.rs
@@ -81,7 +81,7 @@ macro_rules! integer_primitives {
                 //
                 // Note that shared memories don't allow borrows and other
                 // shared borrows are ok to overlap with this.
-                if ptr.mem().is_mut_borrowed(region) {
+                if !ptr.mem().can_read(region) {
                     return Err(GuestError::PtrBorrowed(region));
                 }
 
@@ -106,7 +106,7 @@ macro_rules! integer_primitives {
                 let offset = ptr.offset();
                 let (host_ptr, region) = super::validate_size_align::<Self>(ptr.mem(), offset, 1)?;
                 let host_ptr = &host_ptr[0];
-                if ptr.mem().is_shared_borrowed(region) || ptr.mem().is_mut_borrowed(region) {
+                if !ptr.mem().can_write(region) {
                     return Err(GuestError::PtrBorrowed(region));
                 }
                 let atomic_value_ref: &$ty_atomic =
@@ -139,7 +139,7 @@ macro_rules! float_primitives {
                     1,
                 )?;
                 let host_ptr = &host_ptr[0];
-                if ptr.mem().is_mut_borrowed(region) {
+                if !ptr.mem().can_read(region) {
                     return Err(GuestError::PtrBorrowed(region));
                 }
                 let atomic_value_ref: &$ty_atomic =
@@ -158,7 +158,7 @@ macro_rules! float_primitives {
                     1,
                 )?;
                 let host_ptr = &host_ptr[0];
-                if ptr.mem().is_shared_borrowed(region) || ptr.mem().is_mut_borrowed(region) {
+                if !ptr.mem().can_write(region) {
                     return Err(GuestError::PtrBorrowed(region));
                 }
                 let atomic_value_ref: &$ty_atomic =

--- a/crates/wiggle/src/wasmtime.rs
+++ b/crates/wiggle/src/wasmtime.rs
@@ -63,16 +63,12 @@ unsafe impl GuestMemory for WasmtimeGuestMemory<'_> {
     // checking a flag before calling the more expensive borrow-checker methods.
 
     #[inline]
-    fn has_outstanding_borrows(&self) -> bool {
-        !self.shared && self.bc.has_outstanding_borrows()
+    fn can_read(&self, r: Region) -> bool {
+        self.shared || self.bc.can_read(r)
     }
     #[inline]
-    fn is_shared_borrowed(&self, r: Region) -> bool {
-        !self.shared && self.bc.is_shared_borrowed(r)
-    }
-    #[inline]
-    fn is_mut_borrowed(&self, r: Region) -> bool {
-        !self.shared && self.bc.is_mut_borrowed(r)
+    fn can_write(&self, r: Region) -> bool {
+        self.shared || self.bc.can_write(r)
     }
     #[inline]
     fn shared_borrow(&self, r: Region) -> Result<BorrowHandle, GuestError> {

--- a/crates/wiggle/test-helpers/src/lib.rs
+++ b/crates/wiggle/test-helpers/src/lib.rs
@@ -121,14 +121,11 @@ unsafe impl GuestMemory for HostMemory {
         let ptr = self.buffer.cell.get();
         unsafe { std::slice::from_raw_parts(ptr.cast(), (*ptr).len()) }
     }
-    fn has_outstanding_borrows(&self) -> bool {
-        self.bc.has_outstanding_borrows()
+    fn can_read(&self, r: Region) -> bool {
+        self.bc.can_read(r)
     }
-    fn is_shared_borrowed(&self, r: Region) -> bool {
-        self.bc.is_shared_borrowed(r)
-    }
-    fn is_mut_borrowed(&self, r: Region) -> bool {
-        self.bc.is_mut_borrowed(r)
+    fn can_write(&self, r: Region) -> bool {
+        self.bc.can_write(r)
     }
     fn mut_borrow(&self, r: Region) -> Result<BorrowHandle, GuestError> {
         self.bc.mut_borrow(r)


### PR DESCRIPTION
This commit is a refactoring and modernization of wiggle's `BorrowChecker` implementation. This type is quite old and predates everything related to the component model for example. This type additionally predates the implementation of WASI threads for Wasmtime as well. In general, this type is old and has not been updated in a long time.

Originally a `BorrowChecker` was intended to be a somewhat cheap method of enabling the host to have active safe shared and mutable borrows to guest memory. Over time though this hasn't really panned out. The WASI threads proposal, for example, doesn't allow safe shared or mutable borrows at all. Instead everything must be modeled as a copy in or copy out of data. This means that all of `wasmtime-wasi` and `wasi-common` have largely already been rewritten in such a way to minimize borrows into linear memory.

Nowadays the only types that represent safe borrows are the `GuestSlice` type and its equivalents (e.g. `GuestSliceMut`, `GuestStr`, etc). These are minimally used throughout `wasi-common` and `wasmtime-wasi` and when they are used they're typically isolated to a small region of memory.

This is all coupled with the facst that `BorrowChecker` never ended up being optimized. It's a `Mutex<HashMap<..>>` effectively and a pretty expensive one at that. The `Mutex` is required because `&BorrowChecker` must both allow mutations and be `Sync`. The `HashMap` is used to implement precise byte-level region checking to fulfill the original design requirements of what `wiggle` was envisioned to be.

Given all that, this commit guts `BorrowChecker`'s implementation and functionality. The type is now effectively a glorified `RefCell` for the entire span of linear memory. Regions are no longer considered when borrows are made and instead a shared borrow is considered as borrowing the entirety of shared memory. This means that it's not possible to simultaneously have a safe shared and mutable borrow, even if they're disjoint, at the same time.

The goal of this commit is to address performance issues seen in #7973 which I've seen locally as well. The heavyweight implementation of `BorrowChecker` isn't really buying us much nowadays, especially with much development having since moved on to the component model. The hope is that this much coarser way of implementing borrow checking, which should be much more easily optimizable, is sufficient for the needs of WASI and not a whole lot else.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
