### PR TITLE
Record cargo-vet violations for older zstd versions

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -3223,13 +3223,9 @@ version = "1.2.0"
 notes = "This crate contains `unsafe` calls to libc `extattr_*` functions as one would expect from the crate's purpose."
 
 [[audits.zstd]]
-who = "Alex Crichton <alex@alexcrichton.com>"
+who = "Jamey Sharp <jsharp@fastly.com>"
 criteria = "safe-to-deploy"
-delta = "0.11.1+zstd.1.5.2 -> 0.13.0"
-notes = """
-No major updates to the crate here. Small updates to `unsafe` code which are
-refactorings of what was there prior.
-"""
+version = "0.13.0"
 
 [[audits.zstd]]
 who = "Jamey Sharp <jsharp@fastly.com>"
@@ -3238,14 +3234,9 @@ violation = "<0.13.0"
 notes = "Buffer overrun fixed in https://github.com/gyscos/zstd-rs/pull/231"
 
 [[audits.zstd-safe]]
-who = "Alex Crichton <alex@alexcrichton.com>"
+who = "Jamey Sharp <jsharp@fastly.com>"
 criteria = "safe-to-deploy"
-delta = "5.0.1+zstd.1.5.2 -> 7.0.0"
-notes = """
-Lots of new comments around methods and refactorings for updates in zstd itself.
-Does contain new unsafe code, notably an implementation of an internal trait for
-the standard library `io::Cursor` type.
-"""
+version = "7.0.0"
 
 [[audits.zstd-safe]]
 who = "Jamey Sharp <jsharp@fastly.com>"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -663,14 +663,6 @@ criteria = "safe-to-deploy"
 version = "1.7.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.zstd]]
-version = "0.11.1+zstd.1.5.2"
-criteria = "safe-to-deploy"
-
-[[exemptions.zstd-safe]]
-version = "5.0.1+zstd.1.5.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.zstd-sys]]
 version = "2.0.9+zstd.1.5.5"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
When I tried to audit our previous exemption for zstd, I found two buffer overruns which were reachable from safe Rust, although not reachable from Wasmtime. I got them fixed upstream but didn't update our cargo-vet audits to reflect the issue with the older versions.

Alex updated our dependencies to pull in the fixed versions in #7870, and this PR notes for the benefit of anyone importing the Bytecode Alliance audit set that older versions should not be used.

See https://github.com/gyscos/zstd-rs/pull/231