### PR TITLE
Allow cargo-audit workflow to fail

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -13,3 +13,6 @@ jobs:
       - uses: rustsec/audit-check@v1.4.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+        # This seems to hit rate limits about 50% of the time, unclear why, but
+        # emailing us once every few days is not the most useful thing.
+        continue-on-error: true


### PR DESCRIPTION
Currently this workflow fails about 50% of the time due to what appears to be rate limiting issues. I'm personally receiving emails every time this fails and would rather not continue to receive emails. I've updated this to allow failure to hopefully stop notifying me about this.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
