### PR TITLE
Separate TCP implementation from the host bindings

### DIFF
--- a/crates/wasi/src/host/tcp.rs
+++ b/crates/wasi/src/host/tcp.rs
@@ -1,5 +1,4 @@
 use crate::network::SocketAddrUse;
-use crate::tcp::{TcpReadStream, TcpWriteStream};
 use crate::{
     bindings::{
         io::streams::{InputStream, OutputStream},
@@ -70,10 +69,7 @@ impl<T: WasiView> crate::host::tcp::tcp::HostTcpSocket for T {
         let table = self.table();
         let socket = table.get_mut(&this)?;
 
-        let stream = socket.finish_connect()?;
-
-        let input: InputStream = InputStream::Host(Box::new(TcpReadStream::new(stream.clone())));
-        let output: OutputStream = Box::new(TcpWriteStream::new(stream));
+        let (input, output) = socket.finish_connect()?;
 
         let input_stream = self.table().push_child(input, &this)?;
         let output_stream = self.table().push_child(output, &this)?;

--- a/crates/wasi/src/host/tcp.rs
+++ b/crates/wasi/src/host/tcp.rs
@@ -290,7 +290,7 @@ impl<T: WasiView> crate::host::tcp::tcp::HostTcpSocket for T {
             ShutdownType::Send => std::net::Shutdown::Write,
             ShutdownType::Both => std::net::Shutdown::Both,
         };
-        socket.shutdown(how)
+        Ok(socket.shutdown(how)?)
     }
 
     fn drop(&mut self, this: Resource<tcp::TcpSocket>) -> Result<(), anyhow::Error> {

--- a/crates/wasi/src/host/tcp.rs
+++ b/crates/wasi/src/host/tcp.rs
@@ -1,4 +1,3 @@
-use crate::host::network::util;
 use crate::network::SocketAddrUse;
 use crate::tcp::{TcpReadStream, TcpState, TcpWriteStream};
 use crate::{
@@ -11,7 +10,6 @@ use crate::{
 };
 use crate::{Pollable, SocketResult, WasiView};
 use io_lifetimes::AsSocketlike;
-use rustix::net::sockopt;
 use std::net::SocketAddr;
 use std::time::Duration;
 use wasmtime::component::Resource;
@@ -168,49 +166,19 @@ impl<T: WasiView> crate::host::tcp::tcp::HostTcpSocket for T {
         this: Resource<tcp::TcpSocket>,
         value: u64,
     ) -> SocketResult<()> {
-        const MIN_BACKLOG: u32 = 1;
-        const MAX_BACKLOG: u32 = i32::MAX as u32; // OS'es will most likely limit it down even further.
-
         let table = self.table();
         let socket = table.get_mut(&this)?;
 
-        if value == 0 {
-            return Err(ErrorCode::InvalidArgument.into());
-        }
-
         // Silently clamp backlog size. This is OK for us to do, because operating systems do this too.
-        let value = value
-            .try_into()
-            .unwrap_or(u32::MAX)
-            .clamp(MIN_BACKLOG, MAX_BACKLOG);
+        let value = value.try_into().unwrap_or(u32::MAX);
 
-        match &socket.tcp_state {
-            TcpState::Default(..) | TcpState::Bound(..) => {
-                // Socket not listening yet. Stash value for first invocation to `listen`.
-                socket.listen_backlog_size = value;
-
-                Ok(())
-            }
-            TcpState::Listening { listener, .. } => {
-                // Try to update the backlog by calling `listen` again.
-                // Not all platforms support this. We'll only update our own value if the OS supports changing the backlog size after the fact.
-
-                rustix::net::listen(&listener, value.try_into().unwrap())
-                    .map_err(|_| ErrorCode::NotSupported)?;
-
-                socket.listen_backlog_size = value;
-
-                Ok(())
-            }
-            _ => Err(ErrorCode::InvalidState.into()),
-        }
+        socket.set_listen_backlog_size(value)
     }
 
     fn keep_alive_enabled(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<bool> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let view = &*socket.as_std_view()?;
-        Ok(sockopt::get_socket_keepalive(view)?)
+        socket.keep_alive_enabled()
     }
 
     fn set_keep_alive_enabled(
@@ -220,15 +188,13 @@ impl<T: WasiView> crate::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let view = &*socket.as_std_view()?;
-        Ok(sockopt::set_socket_keepalive(view, value)?)
+        socket.set_keep_alive_enabled(value)
     }
 
     fn keep_alive_idle_time(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u64> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let view = &*socket.as_std_view()?;
-        Ok(sockopt::get_tcp_keepidle(view)?.as_nanos() as u64)
+        Ok(socket.keep_alive_idle_time()?.as_nanos() as u64)
     }
 
     fn set_keep_alive_idle_time(
@@ -239,25 +205,13 @@ impl<T: WasiView> crate::host::tcp::tcp::HostTcpSocket for T {
         let table = self.table();
         let socket = table.get_mut(&this)?;
         let duration = Duration::from_nanos(value);
-        {
-            let view = &*socket.as_std_view()?;
-
-            util::set_tcp_keepidle(view, duration)?;
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            socket.keep_alive_idle_time = Some(duration);
-        }
-
-        Ok(())
+        socket.set_keep_alive_idle_time(duration)
     }
 
     fn keep_alive_interval(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u64> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let view = &*socket.as_std_view()?;
-        Ok(sockopt::get_tcp_keepintvl(view)?.as_nanos() as u64)
+        Ok(socket.keep_alive_interval()?.as_nanos() as u64)
     }
 
     fn set_keep_alive_interval(
@@ -267,15 +221,13 @@ impl<T: WasiView> crate::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let view = &*socket.as_std_view()?;
-        Ok(util::set_tcp_keepintvl(view, Duration::from_nanos(value))?)
+        socket.set_keep_alive_interval(Duration::from_nanos(value))
     }
 
     fn keep_alive_count(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u32> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let view = &*socket.as_std_view()?;
-        Ok(sockopt::get_tcp_keepcnt(view)?)
+        socket.keep_alive_count()
     }
 
     fn set_keep_alive_count(
@@ -285,50 +237,26 @@ impl<T: WasiView> crate::host::tcp::tcp::HostTcpSocket for T {
     ) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let view = &*socket.as_std_view()?;
-        Ok(util::set_tcp_keepcnt(view, value)?)
+        socket.set_keep_alive_count(value)
     }
 
     fn hop_limit(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u8> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let view = &*socket.as_std_view()?;
-
-        let ttl = match socket.family {
-            SocketAddressFamily::Ipv4 => util::get_ip_ttl(view)?,
-            SocketAddressFamily::Ipv6 => util::get_ipv6_unicast_hops(view)?,
-        };
-
-        Ok(ttl)
+        socket.hop_limit()
     }
 
     fn set_hop_limit(&mut self, this: Resource<tcp::TcpSocket>, value: u8) -> SocketResult<()> {
         let table = self.table();
         let socket = table.get_mut(&this)?;
-        {
-            let view = &*socket.as_std_view()?;
-
-            match socket.family {
-                SocketAddressFamily::Ipv4 => util::set_ip_ttl(view, value)?,
-                SocketAddressFamily::Ipv6 => util::set_ipv6_unicast_hops(view, value)?,
-            }
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            socket.hop_limit = Some(value);
-        }
-
-        Ok(())
+        socket.set_hop_limit(value)
     }
 
     fn receive_buffer_size(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u64> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let view = &*socket.as_std_view()?;
 
-        let value = util::get_socket_recv_buffer_size(view)?;
-        Ok(value as u64)
+        Ok(socket.receive_buffer_size()? as u64)
     }
 
     fn set_receive_buffer_size(
@@ -339,27 +267,14 @@ impl<T: WasiView> crate::host::tcp::tcp::HostTcpSocket for T {
         let table = self.table();
         let socket = table.get_mut(&this)?;
         let value = value.try_into().unwrap_or(usize::MAX);
-        {
-            let view = &*socket.as_std_view()?;
-
-            util::set_socket_recv_buffer_size(view, value)?;
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            socket.receive_buffer_size = Some(value);
-        }
-
-        Ok(())
+        socket.set_receive_buffer_size(value)
     }
 
     fn send_buffer_size(&mut self, this: Resource<tcp::TcpSocket>) -> SocketResult<u64> {
         let table = self.table();
         let socket = table.get(&this)?;
-        let view = &*socket.as_std_view()?;
 
-        let value = util::get_socket_send_buffer_size(view)?;
-        Ok(value as u64)
+        Ok(socket.send_buffer_size()? as u64)
     }
 
     fn set_send_buffer_size(
@@ -370,18 +285,7 @@ impl<T: WasiView> crate::host::tcp::tcp::HostTcpSocket for T {
         let table = self.table();
         let socket = table.get_mut(&this)?;
         let value = value.try_into().unwrap_or(usize::MAX);
-        {
-            let view = &*socket.as_std_view()?;
-
-            util::set_socket_send_buffer_size(view, value)?;
-        }
-
-        #[cfg(target_os = "macos")]
-        {
-            socket.send_buffer_size = Some(value);
-        }
-
-        Ok(())
+        socket.set_send_buffer_size(value)
     }
 
     fn subscribe(&mut self, this: Resource<tcp::TcpSocket>) -> anyhow::Result<Resource<Pollable>> {

--- a/crates/wasi/src/tcp.rs
+++ b/crates/wasi/src/tcp.rs
@@ -523,6 +523,18 @@ impl TcpSocket {
 
         Ok(())
     }
+
+    pub fn shutdown(&self, how: std::net::Shutdown) -> SocketResult<()> {
+        let stream = match &self.tcp_state {
+            TcpState::Connected(stream) => stream,
+            _ => return Err(ErrorCode::InvalidState.into()),
+        };
+
+        stream
+            .as_socketlike_view::<std::net::TcpStream>()
+            .shutdown(how)?;
+        Ok(())
+    }
 }
 
 pub(crate) struct TcpReadStream {

--- a/crates/wasi/src/tcp.rs
+++ b/crates/wasi/src/tcp.rs
@@ -2,7 +2,10 @@ use crate::bindings::sockets::tcp::ErrorCode;
 use crate::host::network;
 use crate::network::SocketAddressFamily;
 use crate::runtime::{with_ambient_tokio_runtime, AbortOnDropJoinHandle};
-use crate::{HostInputStream, HostOutputStream, SocketResult, StreamError, Subscribe};
+use crate::{
+    HostInputStream, HostOutputStream, InputStream, OutputStream, SocketResult, StreamError,
+    Subscribe,
+};
 use anyhow::{Error, Result};
 use cap_net_ext::AddressFamily;
 use futures::Future;
@@ -249,6 +252,95 @@ impl TcpSocket {
                 })
             }
         }
+    }
+
+    pub fn accept(&mut self) -> SocketResult<(Self, InputStream, OutputStream)> {
+        let TcpState::Listening {
+            listener,
+            pending_accept,
+        } = &mut self.tcp_state
+        else {
+            return Err(ErrorCode::InvalidState.into());
+        };
+
+        let result = match pending_accept.take() {
+            Some(result) => result,
+            None => {
+                let mut cx = std::task::Context::from_waker(futures::task::noop_waker_ref());
+                match with_ambient_tokio_runtime(|| listener.poll_accept(&mut cx))
+                    .map_ok(|(stream, _)| stream)
+                {
+                    Poll::Ready(result) => result,
+                    Poll::Pending => Err(Errno::WOULDBLOCK.into()),
+                }
+            }
+        };
+
+        let client = result.map_err(|err| match Errno::from_io_error(&err) {
+            // From: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-accept#:~:text=WSAEINPROGRESS
+            // > WSAEINPROGRESS: A blocking Windows Sockets 1.1 call is in progress,
+            // > or the service provider is still processing a callback function.
+            //
+            // wasi-sockets doesn't have an equivalent to the EINPROGRESS error,
+            // because in POSIX this error is only returned by a non-blocking
+            // `connect` and wasi-sockets has a different solution for that.
+            #[cfg(windows)]
+            Some(Errno::INPROGRESS) => Errno::INTR.into(),
+
+            // Normalize Linux' non-standard behavior.
+            //
+            // From https://man7.org/linux/man-pages/man2/accept.2.html:
+            // > Linux accept() passes already-pending network errors on the
+            // > new socket as an error code from accept(). This behavior
+            // > differs from other BSD socket implementations. (...)
+            #[cfg(target_os = "linux")]
+            Some(
+                Errno::CONNRESET
+                | Errno::NETRESET
+                | Errno::HOSTUNREACH
+                | Errno::HOSTDOWN
+                | Errno::NETDOWN
+                | Errno::NETUNREACH
+                | Errno::PROTO
+                | Errno::NOPROTOOPT
+                | Errno::NONET
+                | Errno::OPNOTSUPP,
+            ) => Errno::CONNABORTED.into(),
+
+            _ => err,
+        })?;
+
+        #[cfg(target_os = "macos")]
+        {
+            // Manually inherit socket options from listener. We only have to
+            // do this on platforms that don't already do this automatically
+            // and only if a specific value was explicitly set on the listener.
+
+            if let Some(size) = self.receive_buffer_size {
+                _ = network::util::set_socket_recv_buffer_size(&client, size); // Ignore potential error.
+            }
+
+            if let Some(size) = self.send_buffer_size {
+                _ = network::util::set_socket_send_buffer_size(&client, size); // Ignore potential error.
+            }
+
+            // For some reason, IP_TTL is inherited, but IPV6_UNICAST_HOPS isn't.
+            if let (SocketAddressFamily::Ipv6, Some(ttl)) = (self.family, self.hop_limit) {
+                _ = network::util::set_ipv6_unicast_hops(&client, ttl); // Ignore potential error.
+            }
+
+            if let Some(value) = self.keep_alive_idle_time {
+                _ = network::util::set_tcp_keepidle(&client, value); // Ignore potential error.
+            }
+        }
+
+        let client = Arc::new(client);
+
+        let input: InputStream = InputStream::Host(Box::new(TcpReadStream::new(client.clone())));
+        let output: OutputStream = Box::new(TcpWriteStream::new(client.clone()));
+        let tcp_socket = TcpSocket::from_state(TcpState::Connected(client), self.family)?;
+
+        Ok((tcp_socket, input, output))
     }
 }
 

--- a/crates/wasi/src/tcp.rs
+++ b/crates/wasi/src/tcp.rs
@@ -558,10 +558,15 @@ impl TcpSocket {
         Ok(())
     }
 
-    pub fn shutdown(&self, how: std::net::Shutdown) -> SocketResult<()> {
+    pub fn shutdown(&self, how: std::net::Shutdown) -> io::Result<()> {
         let stream = match &self.tcp_state {
             TcpState::Connected(stream) => stream,
-            _ => return Err(ErrorCode::InvalidState.into()),
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "socket not connected",
+                ))
+            }
         };
 
         stream


### PR DESCRIPTION
Part of #7705 was moving the implementation of TCP (and UDP) out of the host bindings and into their own types. This PR starts this process (only for TCP) by doing a simple lift and shift of the code from the host bindings into the `TcpSocket` type. This should make next steps easier as the border between host bindings and implementation become much clearer with this change.

In the future, we may choose to make `TcpSocket` a trait object allowing users to swap in their own implementations, but that's left for a future change.

You may notice that some of `TcpSocket`'s methods return `io::Result` while most return `SocketResult`. It would be nice to move `TcpSocket` over completely to `io::Result` so that the implementation is completely free of any host bindings. However, there are some unclear/missing mappings between `io::Error` and `ErrorCode`. For example, when the socket is in an invalid state, we currently return `ErrorCode::InvalidState`. However, there is no `io::Error` or `Errno` that maps 1 to 1 to this `ErrorCode`. We'll need to figure out exactly how we want to do this mapping, but I'm leaving that for a future PR.