### PR TITLE
Fix a panic using tables with the wrong type

### DIFF
--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -801,7 +801,12 @@ impl Instance {
         // disconnected from the lifetime of `self`.
         let module = self.module().clone();
 
-        let empty = TableSegmentElements::Functions(Box::new([]));
+        // NB: fall back to an expressions-based list of elements which doesn't
+        // have static type information (as opposed to `Functions`) since we
+        // don't know just yet what type the table has. The type will be be
+        // inferred in the next step within `table_init_segment`.
+        let empty = TableSegmentElements::Expressions(Box::new([]));
+
         let elements = match module.passive_elements_map.get(&elem_index) {
             Some(index) if !self.dropped_elements.contains(elem_index) => {
                 &module.passive_elements[*index]

--- a/tests/misc_testsuite/externref-table-dropped-segment-issue-8281.wast
+++ b/tests/misc_testsuite/externref-table-dropped-segment-issue-8281.wast
@@ -1,0 +1,39 @@
+(module
+  (table $t 0 0 externref)
+
+  (func (export "f1")
+    (i32.const 0)
+    (i32.const 0)
+    (i32.const 0)
+    (table.init $t $declared)
+  )
+
+  (func (export "f2")
+    (i32.const 0)
+    (i32.const 0)
+    (i32.const 0)
+    (table.init $t $passive)
+
+    (elem.drop $passive)
+
+    (i32.const 0)
+    (i32.const 0)
+    (i32.const 0)
+    (table.init $t $passive)
+  )
+
+  (func (export "f3")
+    (i32.const 0)
+    (i32.const 0)
+    (i32.const 0)
+    (table.init $t $active)
+  )
+
+  (elem $declared declare externref)
+  (elem $passive externref)
+  (elem $active (i32.const 0) externref)
+)
+
+(assert_return (invoke "f1"))
+(assert_return (invoke "f2"))
+(assert_return (invoke "f3"))


### PR DESCRIPTION
This commit fixes an accidental issue introduced in #8018 where using an element segment which had been dropped with an `externref` table would cause a panic. The panic happened due to an assertion that tables are being used with the right type of item and that was being mismatched. The underlying issue was that dropped element segments are modeled as an empty element segment but the empty element segment was using the "functions" encoding as opposed to the "expressions" encoding. This meant that code later assumed that due to the use of functions the table must be a table-of-functions, but this was not correct for externref-based tables.

The fix in this commit is to instead model the encoding as an "expressions" list which means that the table type is dispatched on to call the appropriate initializer.

There is no memory safety issue with this mistake as the assertion was specifically targetted at preventing memory safety. This does, however, enable any WebAssembly module to panic a host.

Closes #8281

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
