### PR TITLE
[19.0.0] Add vet entries for `wasmtime-slab`

### DIFF
--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -3610,6 +3610,12 @@ user-id = 73222 # wasmtime-publish
 start = "2024-02-15"
 end = "2025-02-16"
 
+[[trusted.wasmtime-slab]]
+criteria = "safe-to-deploy"
+user-id = 73222 # wasmtime-publish
+start = "2024-03-20"
+end = "2025-04-02"
+
 [[trusted.wasmtime-wmemcheck]]
 criteria = "safe-to-deploy"
 user-id = 73222 # wasmtime-publish

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -139,6 +139,9 @@ audit-as-crates-io = true
 [policy.wasmtime-runtime]
 audit-as-crates-io = true
 
+[policy.wasmtime-slab]
+audit-as-crates-io = true
+
 [policy.wasmtime-types]
 audit-as-crates-io = true
 

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -1054,6 +1054,12 @@ when = "2024-02-07"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-slab]]
+version = "19.0.0"
+when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-types]]
 version = "17.0.1"
 when = "2024-02-07"


### PR DESCRIPTION
Same as https://github.com/bytecodealliance/wasmtime/pull/8285, but adapted for the 19.0.0 release branch