### PR TITLE
Ignore errors in the triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -25,14 +25,17 @@ jobs:
     - uses: bytecodealliance/labeler@schedule-fork
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      continue-on-error: true
 
     # @-mention people who are subscribed to a label when an issue/PR is given
     # that label.
     - uses: bytecodealliance/subscribe-to-label-action@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      continue-on-error: true
 
     # Leave pre-determined comments on issues/PRs that are given a certain label.
     - uses: bytecodealliance/label-messager-action@v1
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      continue-on-error: true


### PR DESCRIPTION
Along the same lines as #8280 I occasionally get emails about failures here but that's not too too useful, so ignore the errors here to get triaged elsewhere if necessary.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
