### PR TITLE
Add link to what-is-a-security-bug to SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,11 @@
 # Security Policy
 
-Please refer to the [Bytecode Alliance security policy](https://bytecodealliance.org/security) for details on how to report security issues in Wasmtime, our disclosure policy, and how to receive notifications about security issues.
+Please refer to the [Bytecode Alliance security
+policy](https://bytecodealliance.org/security) for details on how to report
+security issues in Wasmtime, our disclosure policy, and how to receive
+notifications about security issues.
+
+For classification of what is and what isn't a security issue please see our
+[online
+documentation](https://docs.wasmtime.dev/security-what-is-considered-a-security-vulnerability.html)
+on the subject.


### PR DESCRIPTION
Seemed like an appropriate place to list such documentation as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
