### PR TITLE
cranelift: Specialize StackAMode::FPOffset

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -35,7 +35,8 @@ static STACK_ARG_RET_SIZE_LIMIT: u32 = 128 * 1024 * 1024;
 impl Into<AMode> for StackAMode {
     fn into(self) -> AMode {
         match self {
-            StackAMode::FPOffset(off, ty) => AMode::FPOffset { off, ty },
+            // Argument area begins after saved frame pointer + return address.
+            StackAMode::ArgOffset(off, ty) => AMode::FPOffset { off: off + 16, ty },
             StackAMode::NominalSPOffset(off, ty) => AMode::NominalSPOffset { off, ty },
             StackAMode::SPOffset(off, ty) => AMode::SPOffset { off, ty },
         }
@@ -363,10 +364,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
         }
 
         Ok((next_stack, extra_arg))
-    }
-
-    fn fp_to_arg_offset(_call_conv: isa::CallConv, _flags: &settings::Flags) -> i64 {
-        16 // frame pointer + return address.
     }
 
     fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Inst {

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -205,11 +205,6 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         Ok((next_stack, pos))
     }
 
-    fn fp_to_arg_offset(_call_conv: isa::CallConv, _flags: &settings::Flags) -> i64 {
-        // lr fp.
-        16
-    }
-
     fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Inst {
         Inst::gen_load(into_reg, mem.into(), ty, MemFlags::trusted())
     }

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -147,16 +147,9 @@ impl AMode {
     pub(crate) fn get_offset_with_state(&self, state: &EmitState) -> i64 {
         match self {
             &AMode::NominalSPOffset(offset, _) => offset + state.virtual_sp_offset,
-            _ => self.get_offset(),
-        }
-    }
-
-    fn get_offset(&self) -> i64 {
-        match self {
             &AMode::RegOffset(_, offset, ..) => offset,
             &AMode::SPOffset(offset, _) => offset,
             &AMode::FPOffset(offset, _) => offset,
-            &AMode::NominalSPOffset(offset, _) => offset,
             &AMode::Const(_) | &AMode::Label(_) => 0,
         }
     }
@@ -206,7 +199,8 @@ impl Display for AMode {
 impl Into<AMode> for StackAMode {
     fn into(self) -> AMode {
         match self {
-            StackAMode::FPOffset(offset, ty) => AMode::FPOffset(offset, ty),
+            // Argument area begins after saved lr + fp.
+            StackAMode::ArgOffset(offset, ty) => AMode::FPOffset(offset + 16, ty),
             StackAMode::SPOffset(offset, ty) => AMode::SPOffset(offset, ty),
             StackAMode::NominalSPOffset(offset, ty) => AMode::NominalSPOffset(offset, ty),
         }

--- a/cranelift/codegen/src/isa/s390x/abi.rs
+++ b/cranelift/codegen/src/isa/s390x/abi.rs
@@ -191,7 +191,8 @@ pub static REG_SAVE_AREA_SIZE: u32 = 160;
 impl Into<MemArg> for StackAMode {
     fn into(self) -> MemArg {
         match self {
-            StackAMode::FPOffset(off, _ty) => MemArg::InitialSPOffset { off },
+            // Argument area always begins at the initial SP.
+            StackAMode::ArgOffset(off, _ty) => MemArg::InitialSPOffset { off },
             StackAMode::NominalSPOffset(off, _ty) => MemArg::NominalSPOffset { off },
             StackAMode::SPOffset(off, _ty) => {
                 MemArg::reg_plus_off(stack_reg(), off, MemFlags::trusted())
@@ -402,10 +403,6 @@ impl ABIMachineSpec for S390xMachineDeps {
         }
 
         Ok((next_stack, extra_arg))
-    }
-
-    fn fp_to_arg_offset(_call_conv: isa::CallConv, _flags: &settings::Flags) -> i64 {
-        0
     }
 
     fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Inst {

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -1020,10 +1020,13 @@ impl From<StackAMode> for SyntheticAmode {
         // `expect()`s should never fail.
         match amode {
             StackAMode::ArgOffset(off, _ty) => {
-                let off = i32::try_from(off)
-                    .expect("Offset in FPOffset is greater than 2GB; should hit impl limit first");
+                let off =
+                    i32::try_from(off + 16) // frame pointer + return address
+                        .expect(
+                            "Offset in ArgOffset is greater than 2GB; should hit impl limit first",
+                        );
                 SyntheticAmode::Real(Amode::ImmReg {
-                    simm32: off + 16, // frame pointer + return address
+                    simm32: off,
                     base: regs::rbp(),
                     flags: MemFlags::trusted(),
                 })

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -405,10 +405,6 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         Ok((next_stack, extra_arg))
     }
 
-    fn fp_to_arg_offset(_call_conv: isa::CallConv, _flags: &settings::Flags) -> i64 {
-        16 // frame pointer + return address.
-    }
-
     fn gen_load_stack(mem: StackAMode, into_reg: Writable<Reg>, ty: Type) -> Self::I {
         // For integer-typed values, we always load a full 64 bits (and we always spill a full 64
         // bits as well -- see `Inst::store()`).
@@ -1023,11 +1019,11 @@ impl From<StackAMode> for SyntheticAmode {
         // We enforce a 128 MB stack-frame size limit above, so these
         // `expect()`s should never fail.
         match amode {
-            StackAMode::FPOffset(off, _ty) => {
+            StackAMode::ArgOffset(off, _ty) => {
                 let off = i32::try_from(off)
                     .expect("Offset in FPOffset is greater than 2GB; should hit impl limit first");
                 SyntheticAmode::Real(Amode::ImmReg {
-                    simm32: off,
+                    simm32: off + 16, // frame pointer + return address
                     base: regs::rbp(),
                     flags: MemFlags::trusted(),
                 })


### PR DESCRIPTION
The StackAMode::FPOffset address mode was always used together with fp_to_arg_offset, to compute addresses within the current stack frame's argument area.

Instead, introduce a new StackAMode::ArgOffset variant specifically for stack addresses within the current frame's argument area. The details of how to find the argument area are folded into the conversion from the target-independent StackAMode into target-dependent address-mode types.

Currently, fp_to_arg_offset returns a target-specific constant, so I've preserved that constant in each backend's address-mode conversion.

However, in general the location of the argument area may depend on calling convention, flags, or other concerns. Also, it may not always be desirable to use a frame pointer register as the base to find the argument area. I expect some backends will eventually need to introduce new synthetic addressing modes to resolve argument-area offsets after register allocation, when the full frame layout is known.

I also cleaned up a couple minor things while I was in the area:
- Determining argument extension type was written in a confusing way and also had a typo in the comment describing it.
- riscv64's AMode::offset was only used in one place and is clearer when inlined.