### PR TITLE
cranelift: Minimize ways to manipulate instruction results

### DIFF
--- a/cranelift/codegen/src/alias_analysis.rs
+++ b/cranelift/codegen/src/alias_analysis.rs
@@ -385,7 +385,7 @@ impl<'a> AliasAnalysis<'a> {
             while let Some(inst) = pos.next_inst() {
                 if let Some(replaced_result) = self.process_inst(pos.func, &mut state, inst) {
                     let result = pos.func.dfg.inst_results(inst)[0];
-                    pos.func.dfg.detach_results(inst);
+                    pos.func.dfg.clear_results(inst);
                     pos.func.dfg.change_to_alias(result, replaced_result);
                     pos.remove_inst_and_step_back();
                 }

--- a/cranelift/codegen/src/verifier/mod.rs
+++ b/cranelift/codegen/src/verifier/mod.rs
@@ -1834,7 +1834,7 @@ mod tests {
             args: Default::default(),
         });
 
-        func.dfg.append_result(test_inst, ctrl_typevar);
+        func.dfg.make_inst_results(test_inst, ctrl_typevar);
         func.layout.append_inst(test_inst, block0);
         func.layout.append_inst(end_inst, block0);
 
@@ -1920,13 +1920,11 @@ mod tests {
         let block0 = func.dfg.make_block();
         func.layout.append_block(block0);
 
-        // Build instruction: v0, v1 = iconst 42
-        let inst = func.dfg.make_inst(InstructionData::UnaryImm {
-            opcode: Opcode::Iconst,
-            imm: 42.into(),
+        // Build instruction "f64const 0.0" (missing one required result)
+        let inst = func.dfg.make_inst(InstructionData::UnaryIeee64 {
+            opcode: Opcode::F64const,
+            imm: 0.into(),
         });
-        func.dfg.append_result(inst, types::I32);
-        func.dfg.append_result(inst, types::I32);
         func.layout.append_inst(inst, block0);
 
         // Setup verifier.
@@ -1935,11 +1933,11 @@ mod tests {
         let verifier = Verifier::new(&func, flags.into());
 
         // Now the error message, when printed, should contain the instruction sequence causing the
-        // error (i.e. v0, v1 = iconst.i32 42) and not only its entity value (i.e. inst0)
+        // error (i.e. f64const 0.0) and not only its entity value (i.e. inst0)
         let _ = verifier.typecheck_results(inst, types::I32, &mut errors);
         assert_eq!(
             format!("{}", errors.0[0]),
-            "inst0 (v0, v1 = iconst.i32 42): has more result values than expected"
+            "inst0 (f64const 0.0): has fewer result values than expected"
         )
     }
 


### PR DESCRIPTION
In particular, remove support for detaching/attaching/appending instruction results.

The AliasAnalysis pass used detach_results, but leaked the detached ValueList; using clear_results instead is better.

The verifier's `test_printing_contextual_errors` needed to get the verifier to produce an error containing a pretty-printed instruction, and did so by appending too many results. Instead, failing to append any results gets a similar error out of the verifier, without requiring that we expose the easy-to-misuse append_result method. However, `iconst` is not a suitable instruction for this version of the test because its result type is its controlling type, so failing to create any results caused assertion failures rather than the desired verifier error. I switched to `f64const` which has a non-polymorphic type.

The DFG's `aliases` test cleared both results of an instruction and then reattached one of them. Since we have access to DFG internals in these tests, it's easier to directly manipulate the relevant ValueList than to use these unsafe methods.

The only other use of attach/append was in `make_inst_results_reusing` which decided which to use based on whether a particular result was supposed to reuse an existing value. Inlining both methods there revealed that they were nearly identical and could have most of their code factored out.

While I was looking at uses of `DataFlowGraph::results`, I also simplified replace_with_aliases a little bit.