### PR TITLE
winch: Add support for address maps

### DIFF
--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1635,6 +1635,7 @@ impl<I: VCodeInst> MachBuffer<I> {
 
     /// Set the `SourceLoc` for code from this offset until the offset at the
     /// next call to `end_srcloc()`.
+    /// Returns the current [CodeOffset] and [RelSourceLoc].
     pub fn start_srcloc(&mut self, loc: RelSourceLoc) -> (CodeOffset, RelSourceLoc) {
         let cur = (self.cur_offset(), loc);
         self.cur_srcloc = Some(cur);

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1635,8 +1635,10 @@ impl<I: VCodeInst> MachBuffer<I> {
 
     /// Set the `SourceLoc` for code from this offset until the offset at the
     /// next call to `end_srcloc()`.
-    pub fn start_srcloc(&mut self, loc: RelSourceLoc) {
-        self.cur_srcloc = Some((self.cur_offset(), loc));
+    pub fn start_srcloc(&mut self, loc: RelSourceLoc) -> (CodeOffset, RelSourceLoc) {
+        let cur = (self.cur_offset(), loc);
+        self.cur_srcloc = Some(cur);
+        cur
     }
 
     /// Mark the end of the `SourceLoc` segment started at the last

--- a/crates/winch/src/builder.rs
+++ b/crates/winch/src/builder.rs
@@ -3,13 +3,14 @@ use anyhow::{bail, Result};
 use std::sync::Arc;
 use target_lexicon::Triple;
 use wasmtime_cranelift::isa_builder::IsaBuilder;
-use wasmtime_environ::{CompilerBuilder, Setting};
+use wasmtime_environ::{CompilerBuilder, Setting, Tunables};
 use winch_codegen::{isa, TargetIsa};
 
 /// Compiler builder.
 struct Builder {
     inner: IsaBuilder<Result<Box<dyn TargetIsa>>>,
     cranelift: Box<dyn CompilerBuilder>,
+    tunables: Option<Tunables>,
 }
 
 pub fn builder(triple: Option<Triple>) -> Result<Box<dyn CompilerBuilder>> {
@@ -17,7 +18,11 @@ pub fn builder(triple: Option<Triple>) -> Result<Box<dyn CompilerBuilder>> {
         isa::lookup(triple).map_err(|e| e.into())
     })?;
     let cranelift = wasmtime_cranelift::builder(triple)?;
-    Ok(Box::new(Builder { inner, cranelift }))
+    Ok(Box::new(Builder {
+        inner,
+        cranelift,
+        tunables: None,
+    }))
 }
 
 impl CompilerBuilder for Builder {
@@ -47,8 +52,9 @@ impl CompilerBuilder for Builder {
         self.inner.settings()
     }
 
-    fn set_tunables(&mut self, tunables: wasmtime_environ::Tunables) -> Result<()> {
+    fn set_tunables(&mut self, tunables: Tunables) -> Result<()> {
         assert!(tunables.winch_callable);
+        self.tunables = Some(tunables.clone());
         self.cranelift.set_tunables(tunables)?;
         Ok(())
     }
@@ -56,7 +62,12 @@ impl CompilerBuilder for Builder {
     fn build(&self) -> Result<Box<dyn wasmtime_environ::Compiler>> {
         let isa = self.inner.build()?;
         let cranelift = self.cranelift.build()?;
-        Ok(Box::new(Compiler::new(isa, cranelift)))
+        let tunables = self
+            .tunables
+            .as_ref()
+            .expect("set_tunables not called")
+            .clone();
+        Ok(Box::new(Compiler::new(isa, cranelift, tunables)))
     }
 
     fn enable_incremental_compilation(

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -3,7 +3,7 @@
 use super::{address::Address, regs};
 use crate::{masm::OperandSize, reg::Reg};
 use cranelift_codegen::{
-    ir::MemFlags,
+    ir::{MemFlags, SourceLoc},
     isa::aarch64::inst::{
         self,
         emit::{EmitInfo, EmitState},
@@ -46,12 +46,12 @@ impl Assembler {
 
 impl Assembler {
     /// Return the emitted code.
-    pub fn finalize(mut self) -> MachBufferFinalized<Final> {
+    pub fn finalize(mut self, loc: Option<SourceLoc>) -> MachBufferFinalized<Final> {
         let constants = Default::default();
         let stencil = self
             .buffer
             .finish(&constants, self.emit_state.ctrl_plane_mut());
-        stencil.apply_base_srcloc(Default::default())
+        stencil.apply_base_srcloc(loc.unwrap_or_default())
     }
 
     fn emit(&mut self, inst: Inst) {
@@ -243,5 +243,10 @@ impl Assembler {
     /// machine buffer.
     pub fn buffer_mut(&mut self) -> &mut MachBuffer<Inst> {
         &mut self.buffer
+    }
+
+    /// Get a reference to the underlying machine buffer.
+    pub fn buffer(&self) -> &MachBuffer<Inst> {
+        &self.buffer
     }
 }

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -9,7 +9,11 @@ use crate::{
         StackSlot, TrapCode, TruncKind,
     },
 };
-use cranelift_codegen::{settings, Final, MachBufferFinalized, MachLabel};
+use cranelift_codegen::{
+    binemit::CodeOffset,
+    ir::{RelSourceLoc, SourceLoc},
+    settings, Final, MachBufferFinalized, MachLabel,
+};
 use wasmtime_environ::PtrSize;
 
 /// Aarch64 MacroAssembler.
@@ -201,8 +205,8 @@ impl Masm for MacroAssembler {
         SPOffset::from_u32(self.sp_offset)
     }
 
-    fn finalize(self) -> MachBufferFinalized<Final> {
-        self.asm.finalize()
+    fn finalize(self, base: Option<SourceLoc>) -> MachBufferFinalized<Final> {
+        self.asm.finalize(base)
     }
 
     fn mov(&mut self, src: RegImm, dst: Reg, size: OperandSize) {
@@ -529,6 +533,18 @@ impl Masm for MacroAssembler {
 
     fn trapif(&mut self, _cc: IntCmpKind, _code: TrapCode) {
         todo!()
+    }
+
+    fn start_source_loc(&mut self, loc: RelSourceLoc) -> (CodeOffset, RelSourceLoc) {
+        self.asm.buffer_mut().start_srcloc(loc)
+    }
+
+    fn end_source_loc(&mut self) {
+        self.asm.buffer_mut().end_srcloc();
+    }
+
+    fn current_code_offset(&self) -> CodeOffset {
+        self.asm.buffer().cur_offset()
     }
 }
 

--- a/winch/codegen/src/isa/aarch64/mod.rs
+++ b/winch/codegen/src/isa/aarch64/mod.rs
@@ -124,8 +124,9 @@ impl TargetIsa for Aarch64 {
 
         codegen.emit(&mut body, validator)?;
         let names = codegen.env.take_name_map();
+        let base = codegen.source_location.base;
         Ok(CompiledFunction::new(
-            masm.finalize(),
+            masm.finalize(base),
             names,
             self.function_alignment(),
         ))

--- a/winch/codegen/src/isa/x64/asm.rs
+++ b/winch/codegen/src/isa/x64/asm.rs
@@ -6,7 +6,8 @@ use crate::{
 };
 use cranelift_codegen::{
     ir::{
-        types, ConstantPool, ExternalName, LibCall, MemFlags, Opcode, TrapCode, UserExternalNameRef,
+        types, ConstantPool, ExternalName, LibCall, MemFlags, Opcode, SourceLoc, TrapCode,
+        UserExternalNameRef,
     },
     isa::{
         unwind::UnwindInst,
@@ -199,6 +200,11 @@ impl Assembler {
         &mut self.buffer
     }
 
+    /// Get a reference to the underlying machine buffer.
+    pub fn buffer(&self) -> &MachBuffer<Inst> {
+        &self.buffer
+    }
+
     /// Adds a constant to the constant pool and returns its address.
     pub fn add_constant(&mut self, constant: &[u8]) -> Address {
         let handle = self.pool.insert(constant.into());
@@ -206,11 +212,11 @@ impl Assembler {
     }
 
     /// Return the emitted code.
-    pub fn finalize(mut self) -> MachBufferFinalized<Final> {
+    pub fn finalize(mut self, loc: Option<SourceLoc>) -> MachBufferFinalized<Final> {
         let stencil = self
             .buffer
             .finish(&self.constants, self.emit_state.ctrl_plane_mut());
-        stencil.apply_base_srcloc(Default::default())
+        stencil.apply_base_srcloc(loc.unwrap_or_default())
     }
 
     fn emit(&mut self, inst: Inst) {

--- a/winch/codegen/src/isa/x64/mod.rs
+++ b/winch/codegen/src/isa/x64/mod.rs
@@ -136,10 +136,11 @@ impl TargetIsa for X64 {
         let mut codegen = CodeGen::new(&mut masm, codegen_context, env, abi_sig);
 
         codegen.emit(&mut body, validator)?;
+        let base = codegen.source_location.base;
 
         let names = codegen.env.take_name_map();
         Ok(CompiledFunction::new(
-            masm.finalize(),
+            masm.finalize(base),
             names,
             self.function_alignment(),
         ))


### PR DESCRIPTION
Closes https://github.com/bytecodealliance/wasmtime/issues/8095

This commit adds support for generating address maps for Winch. 

Given that source code locations and machine code offsets are machine independent, one objective of this change is introduce minimal methods to the MacroAssesmbler and Asssembler implementations and tries to accomodate the bulk of the work in the ISA independent `CodeGen` module.

Address maps also enable using the `wasmtime explore` command with Winch via `wasmtime explore -C compiler=winch <module.wasm>`


<img width="1488" alt="Screenshot 2024-04-03 at 10 11 02 AM" src="https://github.com/bytecodealliance/wasmtime/assets/1423601/a5f3c6fd-ed7e-400e-823b-cefd1719d145">



<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
