### PR TITLE
cranelift: Specialize uses of StackAMode::SPOffset

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1190,10 +1190,11 @@ impl AArch64MachineDeps {
         for _ in 0..probe_count {
             insts.extend(Self::gen_sp_reg_adjust(-(guard_size as i32)));
 
-            insts.push(Self::gen_store_stack(
-                StackAMode::SPOffset(0, I8),
+            insts.push(Inst::gen_store(
+                AMode::SPOffset { off: 0, ty: I8 },
                 zero_reg(),
                 I32,
+                MemFlags::trusted(),
             ));
         }
 

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -358,15 +358,17 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             // sd   fp,0(sp)     ;; store old fp.
             // mv   fp,sp        ;; set fp to sp.
             insts.extend(Self::gen_sp_reg_adjust(-16));
-            insts.push(Self::gen_store_stack(
-                StackAMode::SPOffset(8, I64),
+            insts.push(Inst::gen_store(
+                AMode::SPOffset(8, I64),
                 link_reg(),
                 I64,
+                MemFlags::trusted(),
             ));
-            insts.push(Self::gen_store_stack(
-                StackAMode::SPOffset(0, I64),
+            insts.push(Inst::gen_store(
+                AMode::SPOffset(0, I64),
                 fp_reg(),
                 I64,
+                MemFlags::trusted(),
             ));
 
             if flags.unwind_info() {
@@ -395,15 +397,17 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         let mut insts = SmallVec::new();
 
         if frame_layout.setup_area_size > 0 {
-            insts.push(Self::gen_load_stack(
-                StackAMode::SPOffset(8, I64),
+            insts.push(Inst::gen_load(
                 writable_link_reg(),
+                AMode::SPOffset(8, I64),
                 I64,
+                MemFlags::trusted(),
             ));
-            insts.push(Self::gen_load_stack(
-                StackAMode::SPOffset(0, I64),
+            insts.push(Inst::gen_load(
                 writable_fp_reg(),
+                AMode::SPOffset(0, I64),
                 I64,
+                MemFlags::trusted(),
             ));
             insts.extend(Self::gen_sp_reg_adjust(16));
         }
@@ -483,10 +487,11 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                         },
                     });
                 }
-                insts.push(Self::gen_store_stack(
-                    StackAMode::SPOffset(-(cur_offset as i64), ty),
+                insts.push(Inst::gen_store(
+                    AMode::SPOffset(-(cur_offset as i64), ty),
                     real_reg_to_reg(reg.to_reg()),
                     ty,
+                    MemFlags::trusted(),
                 ));
                 cur_offset += 8
             }
@@ -514,10 +519,11 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 RegClass::Float => F64,
                 RegClass::Vector => unimplemented!("Vector Clobber Restores"),
             };
-            insts.push(Self::gen_load_stack(
-                StackAMode::SPOffset(-cur_offset, ty),
+            insts.push(Inst::gen_load(
                 Writable::from_reg(real_reg_to_reg(reg.to_reg())),
+                AMode::SPOffset(-cur_offset, ty),
                 ty,
+                MemFlags::trusted(),
             ));
             cur_offset += 8
         }
@@ -1090,10 +1096,11 @@ impl Riscv64MachineDeps {
                 rs2: tmp.to_reg(),
             });
 
-            insts.push(Self::gen_store_stack(
-                StackAMode::SPOffset(0, I8),
+            insts.push(Inst::gen_store(
+                AMode::SPOffset(0, I8),
                 zero_reg(),
                 I32,
+                MemFlags::trusted(),
             ));
         }
 

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -40,10 +40,10 @@ impl X64ABIMachineSpec {
 
             // TODO: It would be nice if we could store the imm 0, but we don't have insts for those
             // so store the stack pointer. Any register will do, since the stack is undefined at this point
-            insts.push(Self::gen_store_stack(
-                StackAMode::SPOffset(0, I8),
-                regs::rsp(),
+            insts.push(Inst::store(
                 I32,
+                regs::rsp(),
+                Amode::imm_reg(0, regs::rsp()),
             ));
         }
 


### PR DESCRIPTION
When this variant is used within a specific target backend, we know exactly which address-mode to generate, so using the target independent `StackAMode` doesn't buy us anything.

This PR ensures that `StackAMode` is only constructed by target independent code in machinst::abi, so that it's easier to figure out how each of the variants are used.