### PR TITLE
cranelift/aarch64: Remove types from address-modes

### DIFF
--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -36,9 +36,9 @@ impl Into<AMode> for StackAMode {
     fn into(self) -> AMode {
         match self {
             // Argument area begins after saved frame pointer + return address.
-            StackAMode::ArgOffset(off, ty) => AMode::FPOffset { off: off + 16, ty },
-            StackAMode::NominalSPOffset(off, ty) => AMode::NominalSPOffset { off, ty },
-            StackAMode::SPOffset(off, ty) => AMode::SPOffset { off, ty },
+            StackAMode::ArgOffset(off, _ty) => AMode::FPOffset { off: off + 16 },
+            StackAMode::NominalSPOffset(off, _ty) => AMode::NominalSPOffset { off },
+            StackAMode::SPOffset(off, _ty) => AMode::SPOffset { off },
         }
     }
 }
@@ -471,7 +471,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
         let mem = AMode::RegOffset {
             rn: base,
             off: offset as i64,
-            ty,
         };
         Inst::gen_load(into_reg, mem, ty, MemFlags::trusted())
     }
@@ -480,7 +479,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
         let mem = AMode::RegOffset {
             rn: base,
             off: offset as i64,
-            ty,
         };
         Inst::gen_store(mem, from_reg, ty, MemFlags::trusted())
     }
@@ -1190,7 +1188,7 @@ impl AArch64MachineDeps {
             insts.extend(Self::gen_sp_reg_adjust(-(guard_size as i32)));
 
             insts.push(Inst::gen_store(
-                AMode::SPOffset { off: 0, ty: I8 },
+                AMode::SPOffset { off: 0 },
                 zero_reg(),
                 I32,
                 MemFlags::trusted(),

--- a/cranelift/codegen/src/isa/aarch64/inst.isle
+++ b/cranelift/codegen/src/isa/aarch64/inst.isle
@@ -1119,15 +1119,13 @@
         ;; Register plus register offset, scaled by type's size.
         (RegScaled
          (rn Reg)
-         (rm Reg)
-         (ty Type))
+         (rm Reg))
 
         ;; Register plus register offset, scaled by type's size, with index
         ;; sign- or zero-extended first.
         (RegScaledExtended
          (rn Reg)
          (rm Reg)
-         (ty Type)
          (extendop ExtendOp))
 
         ;; Register plus register offset, with index sign- or zero-extended
@@ -1157,18 +1155,15 @@
         ;; offsets with multiple instructions as necessary during code emission.
         (RegOffset
          (rn Reg)
-         (off i64)
-         (ty Type))
+         (off i64))
 
         ;; Offset from the stack pointer.
         (SPOffset
-         (off i64)
-         (ty Type))
+         (off i64))
 
         ;; Offset from the frame pointer.
         (FPOffset
-         (off i64)
-         (ty Type))
+         (off i64))
 
         ;; A reference to a constant which is placed outside of the function's
         ;; body, typically at the end.
@@ -1188,8 +1183,7 @@
         ;; clobber pushes. See the diagram in the documentation for
         ;; [crate::isa::aarch64::abi](the ABI module) for more details.
         (NominalSPOffset
-         (off i64)
-         (ty Type))))
+         (off i64))))
 
 ;; A memory argument to a load/store-pair.
 (type PairAMode (enum
@@ -3169,18 +3163,18 @@
 ;; first and then if that succeeds afterwards try to find an extend.
 (rule 6 (amode_no_more_iconst ty (iadd x (ishl y (iconst (u64_from_imm64 n)))) offset)
         (if-let $true (u64_eq (ty_bytes ty) (u64_shl 1 n)))
-        (amode_reg_scaled (amode_add x offset) y ty))
+        (amode_reg_scaled (amode_add x offset) y))
 (rule 7 (amode_no_more_iconst ty (iadd (ishl y (iconst (u64_from_imm64 n))) x) offset)
         (if-let $true (u64_eq (ty_bytes ty) (u64_shl 1 n)))
-        (amode_reg_scaled (amode_add x offset) y ty))
+        (amode_reg_scaled (amode_add x offset) y))
 
-(decl amode_reg_scaled (Reg Value Type) AMode)
-(rule 0 (amode_reg_scaled base index ty)
-        (AMode.RegScaled base index ty))
-(rule 1 (amode_reg_scaled base (uextend index @ (value_type $I32)) ty)
-        (AMode.RegScaledExtended base index ty (ExtendOp.UXTW)))
-(rule 2 (amode_reg_scaled base (sextend index @ (value_type $I32)) ty)
-        (AMode.RegScaledExtended base index ty (ExtendOp.SXTW)))
+(decl amode_reg_scaled (Reg Value) AMode)
+(rule 0 (amode_reg_scaled base index)
+        (AMode.RegScaled base index))
+(rule 1 (amode_reg_scaled base (uextend index @ (value_type $I32)))
+        (AMode.RegScaledExtended base index (ExtendOp.UXTW)))
+(rule 1 (amode_reg_scaled base (sextend index @ (value_type $I32)))
+        (AMode.RegScaledExtended base index (ExtendOp.SXTW)))
 
 ;; Helper to add a 32-bit signed immediate to the register provided. This will
 ;; select an appropriate `add` instruction to use.
@@ -3519,7 +3513,7 @@
             ;; the frame record that corresponds to the current subroutine on
             ;; the stack; the presence of the record is guaranteed by the
             ;; `preserve_frame_pointers` setting.
-            (addr AMode (AMode.FPOffset 8 $I64))
+            (addr AMode (AMode.FPOffset 8))
             (_ Unit (emit (MInst.ULoad64 dst addr (mem_flags_trusted)))))
            dst))
 
@@ -3529,7 +3523,7 @@
       ;; the frame record. Furthermore, we can use LR as a scratch register
       ;; because the function will set it to the return address immediately
       ;; before returning.
-      (let ((addr AMode (AMode.FPOffset 8 $I64))
+      (let ((addr AMode (AMode.FPOffset 8))
             (lr WritableReg (writable_link_reg))
             (_ Unit (emit (MInst.ULoad64 lr addr (mem_flags_trusted))))
             (_ Unit (emit (MInst.Xpaclri))))

--- a/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/emit_tests.rs
@@ -1551,7 +1551,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(2),
                 rm: xreg(3),
-                ty: I16,
             },
             flags: MemFlags::trusted(),
         },
@@ -1588,7 +1587,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(20),
                 rm: xreg(20),
-                ty: I16,
             },
             flags: MemFlags::trusted(),
         },
@@ -1625,7 +1623,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(2),
                 rm: xreg(12),
-                ty: I32,
             },
             flags: MemFlags::trusted(),
         },
@@ -1662,7 +1659,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(5),
                 rm: xreg(1),
-                ty: I32,
             },
             flags: MemFlags::trusted(),
         },
@@ -1735,7 +1731,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(2),
                 rm: xreg(3),
-                ty: I64,
             },
             flags: MemFlags::trusted(),
         },
@@ -1748,7 +1743,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaledExtended {
                 rn: xreg(2),
                 rm: xreg(3),
-                ty: I64,
                 extendop: ExtendOp::SXTW,
             },
             flags: MemFlags::trusted(),
@@ -1805,7 +1799,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: AMode::FPOffset { off: 32768, ty: I8 },
+            mem: AMode::FPOffset { off: 32768 },
             flags: MemFlags::trusted(),
         },
         "100090D2A1EB70F8",
@@ -1814,10 +1808,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: AMode::FPOffset {
-                off: -32768,
-                ty: I8,
-            },
+            mem: AMode::FPOffset { off: -32768 },
             flags: MemFlags::trusted(),
         },
         "F0FF8F92A1EB70F8",
@@ -1826,10 +1817,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: AMode::FPOffset {
-                off: 1048576,
-                ty: I8,
-            }, // 2^20
+            mem: AMode::FPOffset { off: 1048576 }, // 2^20
             flags: MemFlags::trusted(),
         },
         "1002A0D2A1EB70F8",
@@ -1838,10 +1826,7 @@ fn test_aarch64_binemit() {
     insns.push((
         Inst::ULoad64 {
             rd: writable_xreg(1),
-            mem: AMode::FPOffset {
-                off: 1048576 + 1,
-                ty: I8,
-            }, // 2^20 + 1
+            mem: AMode::FPOffset { off: 1048576 + 1 }, // 2^20 + 1
             flags: MemFlags::trusted(),
         },
         "300080521002A072A1EB70F8",
@@ -1854,7 +1839,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegOffset {
                 rn: xreg(7),
                 off: 8,
-                ty: I64,
             },
             flags: MemFlags::trusted(),
         },
@@ -1868,7 +1852,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegOffset {
                 rn: xreg(7),
                 off: 1024,
-                ty: I64,
             },
             flags: MemFlags::trusted(),
         },
@@ -1882,7 +1865,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegOffset {
                 rn: xreg(7),
                 off: 1048576,
-                ty: I64,
             },
             flags: MemFlags::trusted(),
         },
@@ -2004,7 +1986,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(2),
                 rm: xreg(3),
-                ty: I64,
             },
             flags: MemFlags::trusted(),
         },
@@ -2017,7 +1998,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaledExtended {
                 rn: xreg(2),
                 rm: xreg(3),
-                ty: I64,
                 extendop: ExtendOp::UXTW,
             },
             flags: MemFlags::trusted(),
@@ -6692,7 +6672,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(8),
                 rm: xreg(9),
-                ty: F32,
             },
             flags: MemFlags::trusted(),
         },
@@ -6706,7 +6685,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(8),
                 rm: xreg(9),
-                ty: F64,
             },
             flags: MemFlags::trusted(),
         },
@@ -6720,7 +6698,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(8),
                 rm: xreg(9),
-                ty: I128,
             },
             flags: MemFlags::trusted(),
         },
@@ -6770,7 +6747,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(8),
                 rm: xreg(9),
-                ty: F32,
             },
             flags: MemFlags::trusted(),
         },
@@ -6784,7 +6760,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(8),
                 rm: xreg(9),
-                ty: F64,
             },
             flags: MemFlags::trusted(),
         },
@@ -6798,7 +6773,6 @@ fn test_aarch64_binemit() {
             mem: AMode::RegScaled {
                 rn: xreg(8),
                 rm: xreg(9),
-                ty: I128,
             },
             flags: MemFlags::trusted(),
         },

--- a/cranelift/codegen/src/isa/aarch64/inst/imms.rs
+++ b/cranelift/codegen/src/isa/aarch64/inst/imms.rs
@@ -220,9 +220,9 @@ impl SImm9 {
 #[derive(Clone, Copy, Debug)]
 pub struct UImm12Scaled {
     /// The value.
-    pub value: u16,
+    value: u16,
     /// multiplied by the size of this type
-    pub scale_ty: Type,
+    scale_ty: Type,
 }
 
 impl UImm12Scaled {
@@ -256,11 +256,6 @@ impl UImm12Scaled {
     /// Value after scaling.
     pub fn value(&self) -> u32 {
         self.value as u32
-    }
-
-    /// The value type which is the scaling base.
-    pub fn scale_ty(&self) -> Type {
-        self.scale_ty
     }
 }
 

--- a/cranelift/codegen/src/isa/aarch64/pcc.rs
+++ b/cranelift/codegen/src/isa/aarch64/pcc.rs
@@ -38,7 +38,8 @@ pub(crate) fn check(
     inst_idx: InsnIndex,
     state: &mut FactFlowState,
 ) -> PccResult<()> {
-    trace!("Checking facts on inst: {:?}", vcode[inst_idx]);
+    let inst = &vcode[inst_idx];
+    trace!("Checking facts on inst: {:?}", inst);
 
     // We only persist flag state for one instruction, because we
     // can't exhaustively enumerate all flags-effecting ops; so take
@@ -47,28 +48,29 @@ pub(crate) fn check(
     let cmp_flags = state.cmp_flags.take();
     trace!(" * with cmp_flags = {cmp_flags:?}");
 
-    match vcode[inst_idx] {
+    match *inst {
         Inst::Args { .. } => {
             // Defs on the args have "axiomatic facts": we trust the
             // ABI code to pass through the values unharmed, so the
             // facts given to us in the CLIF should still be true.
             Ok(())
         }
-        Inst::ULoad8 { rd, ref mem, flags } | Inst::SLoad8 { rd, ref mem, flags } => {
-            check_load(ctx, Some(rd.to_reg()), flags, mem, vcode, I8)
+        Inst::ULoad8 { rd, ref mem, flags }
+        | Inst::SLoad8 { rd, ref mem, flags }
+        | Inst::ULoad16 { rd, ref mem, flags }
+        | Inst::SLoad16 { rd, ref mem, flags }
+        | Inst::ULoad32 { rd, ref mem, flags }
+        | Inst::SLoad32 { rd, ref mem, flags }
+        | Inst::ULoad64 { rd, ref mem, flags } => {
+            let access_ty = inst.mem_type().unwrap();
+            check_load(ctx, Some(rd.to_reg()), flags, mem, vcode, access_ty)
         }
-        Inst::ULoad16 { rd, ref mem, flags } | Inst::SLoad16 { rd, ref mem, flags } => {
-            check_load(ctx, Some(rd.to_reg()), flags, mem, vcode, I16)
+        Inst::FpuLoad32 { ref mem, flags, .. }
+        | Inst::FpuLoad64 { ref mem, flags, .. }
+        | Inst::FpuLoad128 { ref mem, flags, .. } => {
+            let access_ty = inst.mem_type().unwrap();
+            check_load(ctx, None, flags, mem, vcode, access_ty)
         }
-        Inst::ULoad32 { rd, ref mem, flags } | Inst::SLoad32 { rd, ref mem, flags } => {
-            check_load(ctx, Some(rd.to_reg()), flags, mem, vcode, I32)
-        }
-        Inst::ULoad64 { rd, ref mem, flags } => {
-            check_load(ctx, Some(rd.to_reg()), flags, mem, vcode, I64)
-        }
-        Inst::FpuLoad32 { ref mem, flags, .. } => check_load(ctx, None, flags, mem, vcode, F32),
-        Inst::FpuLoad64 { ref mem, flags, .. } => check_load(ctx, None, flags, mem, vcode, F64),
-        Inst::FpuLoad128 { ref mem, flags, .. } => check_load(ctx, None, flags, mem, vcode, I8X16),
         Inst::LoadP64 { ref mem, flags, .. } => check_load_pair(ctx, flags, mem, vcode, 16),
         Inst::FpuLoadP64 { ref mem, flags, .. } => check_load_pair(ctx, flags, mem, vcode, 16),
         Inst::FpuLoadP128 { ref mem, flags, .. } => check_load_pair(ctx, flags, mem, vcode, 32),
@@ -82,14 +84,18 @@ pub(crate) fn check(
             ..
         } => check_load_addr(ctx, flags, rn, vcode, access_ty),
 
-        Inst::Store8 { rd, ref mem, flags } => check_store(ctx, Some(rd), flags, mem, vcode, I8),
-        Inst::Store16 { rd, ref mem, flags } => check_store(ctx, Some(rd), flags, mem, vcode, I16),
-        Inst::Store32 { rd, ref mem, flags } => check_store(ctx, Some(rd), flags, mem, vcode, I32),
-        Inst::Store64 { rd, ref mem, flags } => check_store(ctx, Some(rd), flags, mem, vcode, I64),
-        Inst::FpuStore32 { ref mem, flags, .. } => check_store(ctx, None, flags, mem, vcode, F32),
-        Inst::FpuStore64 { ref mem, flags, .. } => check_store(ctx, None, flags, mem, vcode, F64),
-        Inst::FpuStore128 { ref mem, flags, .. } => {
-            check_store(ctx, None, flags, mem, vcode, I8X16)
+        Inst::Store8 { rd, ref mem, flags }
+        | Inst::Store16 { rd, ref mem, flags }
+        | Inst::Store32 { rd, ref mem, flags }
+        | Inst::Store64 { rd, ref mem, flags } => {
+            let access_ty = inst.mem_type().unwrap();
+            check_store(ctx, Some(rd), flags, mem, vcode, access_ty)
+        }
+        Inst::FpuStore32 { ref mem, flags, .. }
+        | Inst::FpuStore64 { ref mem, flags, .. }
+        | Inst::FpuStore128 { ref mem, flags, .. } => {
+            let access_ty = inst.mem_type().unwrap();
+            check_store(ctx, None, flags, mem, vcode, access_ty)
         }
         Inst::StoreP64 { ref mem, flags, .. } => check_store_pair(ctx, flags, mem, vcode, 16),
         Inst::FpuStoreP64 { ref mem, flags, .. } => check_store_pair(ctx, flags, mem, vcode, 16),
@@ -444,19 +450,14 @@ fn check_addr<'a>(
             trace!("rn = {rn:?} rm = {rm:?} sum = {sum:?}");
             check(&sum, ty)
         }
-        &AMode::RegScaled { rn, rm, ty } => {
+        &AMode::RegScaled { rn, rm } => {
             let rn = get_fact_or_default(vcode, rn, 64);
             let rm = get_fact_or_default(vcode, rm, 64);
             let rm_scaled = fail_if_missing(ctx.scale(&rm, 64, ty.bytes()))?;
             let sum = fail_if_missing(ctx.add(&rn, &rm_scaled, 64))?;
             check(&sum, ty)
         }
-        &AMode::RegScaledExtended {
-            rn,
-            rm,
-            ty,
-            extendop,
-        } => {
+        &AMode::RegScaledExtended { rn, rm, extendop } => {
             let rn = get_fact_or_default(vcode, rn, 64);
             let rm = get_fact_or_default(vcode, rm, 64);
             let rm_extended = fail_if_missing(extend_fact(ctx, &rm, extendop))?;
@@ -485,7 +486,7 @@ fn check_addr<'a>(
             // 32760 (= 4095 * 8) for I64s. The `UImm12Scaled` type
             // stores the *scaled* value, so we don't need to multiply
             // (again) by the type's size here.
-            let offset: u64 = uimm12.value.into();
+            let offset: u64 = uimm12.value().into();
             // This `unwrap()` will always succeed because the value
             // will always be positive and much smaller than
             // `i64::MAX` (see above).

--- a/winch/codegen/src/isa/aarch64/address.rs
+++ b/winch/codegen/src/isa/aarch64/address.rs
@@ -137,7 +137,6 @@ impl TryFrom<Address> for AMode {
             Offset { base, offset } => Ok(AMode::RegOffset {
                 rn: base.into(),
                 off: offset,
-                ty: types::I64,
             }),
         }
     }


### PR DESCRIPTION
Previously, the precondition on every use of AMode::*Offset was that the type specified in the address mode must be the same size as the access type of the memory instruction where the address mode was used.

However, at the point where we replace these magic address modes with real modes that the target architecture understands, we know what instruction is using the address, so we can get the type from there.

This simplifies constructing addresses while also ensuring that the types are always correct.

The changes here center around threading the access type through `mem_finalize` and `AMode::pretty_print`, then deleting it from all `AMode` variants.

In the process I introduced a helper method on `Inst` to centralize the mapping from instruction to access type, and used that everywhere.