### PR TITLE
Disable traps by default in `bindgen!` imports

### DIFF
--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -20,6 +20,7 @@ pub mod bindings {
         ",
         tracing: true,
         async: false,
+        trappable_imports: true,
         with: {
             // Upstream package dependencies
             "wasi:io": wasmtime_wasi::bindings::io,

--- a/crates/wasi-nn/src/wit.rs
+++ b/crates/wasi-nn/src/wit.rs
@@ -20,7 +20,11 @@ use std::{error::Error, fmt, hash::Hash, str::FromStr};
 
 /// Generate the traits and types from the `wasi-nn` WIT specification.
 mod gen_ {
-    wasmtime::component::bindgen!("ml" in "spec/wit/wasi-nn.wit");
+    wasmtime::component::bindgen!({
+        world: "ml",
+        path: "spec/wit/wasi-nn.wit",
+        trappable_imports: true,
+    });
 }
 use gen_::wasi::nn as gen; // Shortcut to the module containing the types we need.
 

--- a/crates/wasi/src/bindings.rs
+++ b/crates/wasi/src/bindings.rs
@@ -14,6 +14,7 @@ pub mod sync {
                 "wasi:io/streams/stream-error" => StreamError,
                 "wasi:filesystem/types/error-code" => FsError,
             },
+            trappable_imports: true,
             with: {
                 // These interfaces come from the outer module, as it's
                 // sync/async agnostic.
@@ -118,6 +119,7 @@ mod async_io {
         path: "wit",
         world: "wasi:cli/command",
         tracing: true,
+        trappable_imports: true,
         async: {
             // Only these functions are `async` and everything else is sync
             // meaning that it basically doesn't need to block. These functions

--- a/crates/wasmtime/src/runtime/component/mod.rs
+++ b/crates/wasmtime/src/runtime/component/mod.rs
@@ -209,8 +209,8 @@ pub(crate) use self::store::ComponentStoreData;
 /// impl HelloWorldImports for MyState {
 ///     // Note the `Result` return value here where `Ok` is returned back to
 ///     // the component and `Err` will raise a trap.
-///     fn name(&mut self) -> wasmtime::Result<String> {
-///         Ok(self.name.clone())
+///     fn name(&mut self) -> String {
+///         self.name.clone()
 ///     }
 /// }
 ///
@@ -315,13 +315,13 @@ pub(crate) use self::store::ComponentStoreData;
 ///
 /// // Note that the trait here is per-interface and within a submodule now.
 /// impl Host for MyState {
-///     fn gen_random_integer(&mut self) -> wasmtime::Result<u32> {
+///     fn gen_random_integer(&mut self) -> u32 {
 /// #       panic!();
 /// #       #[cfg(FALSE)]
-///         Ok(rand::thread_rng().gen())
+///         rand::thread_rng().gen()
 ///     }
 ///
-///     fn sha256(&mut self, bytes: Vec<u8>) -> wasmtime::Result<String> {
+///     fn sha256(&mut self, bytes: Vec<u8>) -> String {
 ///         // ...
 /// #       panic!()
 ///     }
@@ -432,6 +432,21 @@ pub(crate) use self::store::ComponentStoreData;
 ///         only_imports: ["foo", "bar"],
 ///     },
 ///
+///     // This option is used to indicate whether imports can trap.
+///     //
+///     // Imports that may trap have their return types wrapped in
+///     // `wasmtime::Result<T>` where the `Err` variant indicates that a
+///     // trap will be raised in the guest.
+///     //
+///     // By default imports cannot trap and the return value is the return
+///     // value from the WIT bindings itself. This value can be set to `true`
+///     // to indicate that any import can trap. This value can also be set to
+///     // an array-of-strings to indicate that only a set list of imports
+///     // can trap.
+///     trappable_imports: false,             // no imports can trap (default)
+///     // trappable_imports: true,           // all imports can trap
+///     // trappable_imports: ["foo", "bar"], // only these can trap
+///
 ///     // This can be used to translate WIT return values of the form
 ///     // `result<T, error-type>` into `Result<T, RustErrorType>` in Rust.
 ///     // Users must define `RustErrorType` and the `Host` trait for the
@@ -440,7 +455,8 @@ pub(crate) use self::store::ComponentStoreData;
 ///     // into `wasmtime::Result<ErrorType>`. This conversion can either
 ///     // return the raw WIT error (`ErrorType` here) or a trap.
 ///     //
-///     // By default this option is not specified.
+///     // By default this option is not specified. This option only takes
+///     // effect when `trappable_imports` is set for some imports.
 ///     trappable_error_type: {
 ///         "wasi:io/streams/stream-error" => RustErrorType,
 ///     },

--- a/examples/component/main.rs
+++ b/examples/component/main.rs
@@ -13,8 +13,8 @@ struct HostComponent;
 
 // Implmentation of the host interface defined in the wit file.
 impl host::Host for HostComponent {
-    fn multiply(&mut self, a: f32, b: f32) -> wasmtime::Result<f32> {
-        Ok(a * b)
+    fn multiply(&mut self, a: f32, b: f32) -> f32 {
+        a * b
     }
 }
 

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -105,9 +105,8 @@ mod one_import {
         }
 
         impl foo::Host for MyImports {
-            fn foo(&mut self) -> Result<()> {
+            fn foo(&mut self) {
                 self.hit = true;
-                Ok(())
             }
         }
 
@@ -181,9 +180,9 @@ mod resources_at_world_level {
         }
 
         impl HostX for MyImports {
-            fn new(&mut self) -> Result<Resource<X>> {
+            fn new(&mut self) -> Resource<X> {
                 self.ctor_hit = true;
-                Ok(Resource::new_own(80))
+                Resource::new_own(80)
             }
 
             fn drop(&mut self, val: Resource<X>) -> Result<()> {
@@ -286,9 +285,9 @@ mod resources_at_interface_level {
         use foo::foo::def::X;
 
         impl foo::foo::def::HostX for MyImports {
-            fn new(&mut self) -> Result<Resource<X>> {
+            fn new(&mut self) -> Resource<X> {
                 self.ctor_hit = true;
-                Ok(Resource::new_own(80))
+                Resource::new_own(80)
             }
 
             fn drop(&mut self, val: Resource<X>) -> Result<()> {
@@ -337,13 +336,9 @@ mod async_config {
 
     #[async_trait::async_trait]
     impl T1Imports for T {
-        async fn x(&mut self) -> Result<()> {
-            Ok(())
-        }
+        async fn x(&mut self) {}
 
-        async fn y(&mut self) -> Result<()> {
-            Ok(())
-        }
+        async fn y(&mut self) {}
     }
 
     async fn _test_t1(t1: &T1, store: &mut Store<()>) {
@@ -367,13 +362,9 @@ mod async_config {
 
     #[async_trait::async_trait]
     impl T2Imports for T {
-        fn x(&mut self) -> Result<()> {
-            Ok(())
-        }
+        fn x(&mut self) {}
 
-        async fn y(&mut self) -> Result<()> {
-            Ok(())
-        }
+        async fn y(&mut self) {}
     }
 
     async fn _test_t2(t2: &T2, store: &mut Store<()>) {
@@ -397,13 +388,9 @@ mod async_config {
 
     #[async_trait::async_trait]
     impl T3Imports for T {
-        async fn x(&mut self) -> Result<()> {
-            Ok(())
-        }
+        async fn x(&mut self) {}
 
-        fn y(&mut self) -> Result<()> {
-            Ok(())
-        }
+        fn y(&mut self) {}
     }
 
     async fn _test_t3(t3: &T3, store: &mut Store<()>) {
@@ -468,11 +455,11 @@ mod exported_resources {
     }
 
     impl a::HostX for MyImports {
-        fn new(&mut self) -> Result<Resource<a::X>> {
+        fn new(&mut self) -> Resource<a::X> {
             let rep = self.next_a_x;
             self.next_a_x += 1;
             self.hostcalls.push(Hostcall::NewA);
-            Ok(Resource::new_own(rep))
+            Resource::new_own(rep)
         }
 
         fn drop(&mut self, val: Resource<a::X>) -> Result<()> {

--- a/tests/all/component_model/bindgen/results.rs
+++ b/tests/all/component_model/bindgen/results.rs
@@ -17,6 +17,7 @@ mod empty_error {
 
             export empty-error: func(a: float64) -> result<float64>;
         }",
+        trappable_imports: true,
     });
 
     #[test]
@@ -118,6 +119,7 @@ mod string_error {
 
             export string-error: func(a: float64) -> result<float64, string>;
         }",
+        trappable_imports: true,
     });
 
     #[test]
@@ -238,7 +240,8 @@ mod enum_error {
                 enum-error: func(a: float64) -> result<float64, e1>;
             }
         }",
-        trappable_error_type: { "inline:inline/imports/e1" => TrappableE1 }
+        trappable_error_type: { "inline:inline/imports/e1" => TrappableE1 },
+        trappable_imports: true,
     });
 
     // You can create concrete trap types which make it all the way out to the
@@ -418,7 +421,8 @@ mod record_error {
                 record-error: func(a: float64) -> result<float64, e2>;
             }
         }",
-        trappable_error_type: { "inline:inline/imports/e2" => TrappableE2 }
+        trappable_error_type: { "inline:inline/imports/e2" => TrappableE2 },
+        trappable_imports: true,
     });
 
     pub enum TrappableE2 {
@@ -589,7 +593,8 @@ mod variant_error {
                 variant-error: func(a: float64) -> result<float64, e3>;
             }
         }",
-        trappable_error_type: { "inline:inline/imports/e3" => TrappableE3 }
+        trappable_error_type: { "inline:inline/imports/e3" => TrappableE3 },
+        trappable_imports: true,
     });
 
     pub enum TrappableE3 {
@@ -784,7 +789,8 @@ mod multiple_interfaces_error {
                 enum-error: func(a: float64) -> result<float64, e1>;
             }
         }",
-        trappable_error_type: { "inline:inline/types/e1" => TrappableE1 }
+        trappable_error_type: { "inline:inline/types/e1" => TrappableE1 },
+        trappable_imports: true,
     });
 
     pub enum TrappableE1 {
@@ -967,6 +973,7 @@ mod with_remapping {
             import imports: interface {
                 empty-error: func(a: float64) -> result<float64>;
             }",
+            trappable_imports: true,
         });
     }
 
@@ -983,6 +990,7 @@ mod with_remapping {
         with: {
             "imports": interfaces::imports,
         },
+        trappable_imports: true,
     });
 
     #[test]


### PR DESCRIPTION
By default previously all return types were wrapped in `wasmtime::Result<T>` to enable any import to return a trap to the wasm guest. This is a fair bit of boilerplate, however, and it's easy to accidentally turn a normal error into a trap. This is additionally somewhat of a power-user method as many imports probably don't end up wanting to trap.

This commit adds a new configuration option to `bindgen!`: `trappable_imports`, and switches the default to `false`. The previous behavior can be recovered with `trappable_imports: true`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
