### PR TITLE
cranelift/riscv64: Remove unused type parameters from address modes

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -301,12 +301,12 @@ impl ABIMachineSpec for Riscv64MachineDeps {
     }
 
     fn gen_load_base_offset(into_reg: Writable<Reg>, base: Reg, offset: i32, ty: Type) -> Inst {
-        let mem = AMode::RegOffset(base, offset as i64, ty);
+        let mem = AMode::RegOffset(base, offset as i64);
         Inst::gen_load(into_reg, mem, ty, MemFlags::trusted())
     }
 
     fn gen_store_base_offset(base: Reg, offset: i32, from_reg: Reg, ty: Type) -> Inst {
-        let mem = AMode::RegOffset(base, offset as i64, ty);
+        let mem = AMode::RegOffset(base, offset as i64);
         Inst::gen_store(mem, from_reg, ty, MemFlags::trusted())
     }
 
@@ -359,13 +359,13 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             // mv   fp,sp        ;; set fp to sp.
             insts.extend(Self::gen_sp_reg_adjust(-16));
             insts.push(Inst::gen_store(
-                AMode::SPOffset(8, I64),
+                AMode::SPOffset(8),
                 link_reg(),
                 I64,
                 MemFlags::trusted(),
             ));
             insts.push(Inst::gen_store(
-                AMode::SPOffset(0, I64),
+                AMode::SPOffset(0),
                 fp_reg(),
                 I64,
                 MemFlags::trusted(),
@@ -399,13 +399,13 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         if frame_layout.setup_area_size > 0 {
             insts.push(Inst::gen_load(
                 writable_link_reg(),
-                AMode::SPOffset(8, I64),
+                AMode::SPOffset(8),
                 I64,
                 MemFlags::trusted(),
             ));
             insts.push(Inst::gen_load(
                 writable_fp_reg(),
-                AMode::SPOffset(0, I64),
+                AMode::SPOffset(0),
                 I64,
                 MemFlags::trusted(),
             ));
@@ -488,7 +488,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                     });
                 }
                 insts.push(Inst::gen_store(
-                    AMode::SPOffset(-(cur_offset as i64), ty),
+                    AMode::SPOffset(-(cur_offset as i64)),
                     real_reg_to_reg(reg.to_reg()),
                     ty,
                     MemFlags::trusted(),
@@ -521,7 +521,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             };
             insts.push(Inst::gen_load(
                 Writable::from_reg(real_reg_to_reg(reg.to_reg())),
-                AMode::SPOffset(-cur_offset, ty),
+                AMode::SPOffset(-cur_offset),
                 ty,
                 MemFlags::trusted(),
             ));
@@ -1096,7 +1096,7 @@ impl Riscv64MachineDeps {
             });
 
             insts.push(Inst::gen_store(
-                AMode::SPOffset(0, I8),
+                AMode::SPOffset(0),
                 zero_reg(),
                 I32,
                 MemFlags::trusted(),

--- a/cranelift/codegen/src/isa/riscv64/inst.isle
+++ b/cranelift/codegen/src/isa/riscv64/inst.isle
@@ -2280,19 +2280,19 @@
     (writable_reg_to_reg sum)))
 
 ;; Generates a AMode that points to a register plus an offset.
-(decl gen_reg_offset_amode (Reg i64 Type) AMode)
+(decl gen_reg_offset_amode (Reg i64) AMode)
 (extern constructor gen_reg_offset_amode gen_reg_offset_amode)
 
 ;; Generates a AMode that an offset from the stack pointer.
-(decl gen_sp_offset_amode (i64 Type) AMode)
+(decl gen_sp_offset_amode (i64) AMode)
 (extern constructor gen_sp_offset_amode gen_sp_offset_amode)
 
 ;; Generates a AMode that an offset from the frame pointer.
-(decl gen_fp_offset_amode (i64 Type) AMode)
+(decl gen_fp_offset_amode (i64) AMode)
 (extern constructor gen_fp_offset_amode gen_fp_offset_amode)
 
 ;; Generates an AMode that points to a stack slot + offset.
-(decl gen_stack_slot_amode (StackSlot i64 Type) AMode)
+(decl gen_stack_slot_amode (StackSlot i64) AMode)
 (extern constructor gen_stack_slot_amode gen_stack_slot_amode)
 
 ;; Generates a AMode that points to a constant in the constant pool.
@@ -2302,41 +2302,41 @@
 
 
 ;; Tries to match a Value + Offset into an AMode
-(decl amode (Value i32 Type) AMode)
-(rule 0 (amode addr offset ty) (amode_inner addr offset ty))
+(decl amode (Value i32) AMode)
+(rule 0 (amode addr offset) (amode_inner addr offset))
 
 ;; If we are adding a constant offset with an iadd we can instead make that
 ;; offset part of the amode offset.
 ;;
 ;; We can't recurse into `amode` again since that could cause stack overflows.
 ;; See: https://github.com/bytecodealliance/wasmtime/pull/6968
-(rule 1 (amode (iadd addr (iconst (simm32 y))) offset ty)
+(rule 1 (amode (iadd addr (iconst (simm32 y))) offset)
   (if-let new_offset (s32_add_fallible y offset))
-  (amode_inner addr new_offset ty))
-(rule 2 (amode (iadd (iconst (simm32 x)) addr) offset ty)
+  (amode_inner addr new_offset))
+(rule 2 (amode (iadd (iconst (simm32 x)) addr) offset)
   (if-let new_offset (s32_add_fallible x offset))
-  (amode_inner addr new_offset ty))
+  (amode_inner addr new_offset))
 
 
 ;; These are the normal rules for generating an AMode.
-(decl amode_inner (Value i32 Type) AMode)
+(decl amode_inner (Value i32) AMode)
 
 ;; In the simplest case we just lower into a Reg+Offset
-(rule 0 (amode_inner r @ (value_type (ty_addr64 _)) offset ty)
-  (gen_reg_offset_amode r offset ty))
+(rule 0 (amode_inner r @ (value_type (ty_addr64 _)) offset)
+  (gen_reg_offset_amode r offset))
 
 ;; If the value is a `get_frame_pointer`, we can just use the offset from that.
-(rule 1 (amode_inner (get_frame_pointer) offset ty)
-  (gen_fp_offset_amode offset ty))
+(rule 1 (amode_inner (get_frame_pointer) offset)
+  (gen_fp_offset_amode offset))
 
 ;; If the value is a `get_stack_pointer`, we can just use the offset from that.
-(rule 1 (amode_inner (get_stack_pointer) offset ty)
-  (gen_sp_offset_amode offset ty))
+(rule 1 (amode_inner (get_stack_pointer) offset)
+  (gen_sp_offset_amode offset))
 
 ;; Similarly if the value is a `stack_addr` we can also turn that into an sp offset.
-(rule 1 (amode_inner (stack_addr ss ss_offset) amode_offset ty)
+(rule 1 (amode_inner (stack_addr ss ss_offset) amode_offset)
   (if-let combined_offset (s32_add_fallible ss_offset amode_offset))
-  (gen_stack_slot_amode ss combined_offset ty))
+  (gen_stack_slot_amode ss combined_offset))
 
 
 

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -80,12 +80,12 @@ newtype_of_reg!(VReg, WritableVReg, |reg| reg.class() == RegClass::Vector);
 pub enum AMode {
     /// Arbitrary offset from a register. Converted to generation of large
     /// offsets with multiple instructions as necessary during code emission.
-    RegOffset(Reg, i64, Type),
+    RegOffset(Reg, i64),
     /// Offset from the stack pointer.
-    SPOffset(i64, Type),
+    SPOffset(i64),
 
     /// Offset from the frame pointer.
-    FPOffset(i64, Type),
+    FPOffset(i64),
 
     /// Offset from the "nominal stack pointer", which is where the real SP is
     /// just after stack and spill slots are allocated in the function prologue.
@@ -99,7 +99,7 @@ pub enum AMode {
     /// SP" is where the actual SP is after the function prologue and before
     /// clobber pushes. See the diagram in the documentation for
     /// [crate::isa::riscv64::abi](the ABI module) for more details.
-    NominalSPOffset(i64, Type),
+    NominalSPOffset(i64),
 
     /// A reference to a constant which is placed outside of the function's
     /// body, typically at the end.
@@ -112,7 +112,7 @@ pub enum AMode {
 impl AMode {
     pub(crate) fn with_allocs(self, allocs: &mut AllocationConsumer<'_>) -> Self {
         match self {
-            AMode::RegOffset(reg, offset, ty) => AMode::RegOffset(allocs.next(reg), offset, ty),
+            AMode::RegOffset(reg, offset) => AMode::RegOffset(allocs.next(reg), offset),
             AMode::SPOffset(..)
             | AMode::FPOffset(..)
             | AMode::NominalSPOffset(..)
@@ -146,10 +146,10 @@ impl AMode {
 
     pub(crate) fn get_offset_with_state(&self, state: &EmitState) -> i64 {
         match self {
-            &AMode::NominalSPOffset(offset, _) => offset + state.virtual_sp_offset,
-            &AMode::RegOffset(_, offset, ..) => offset,
-            &AMode::SPOffset(offset, _) => offset,
-            &AMode::FPOffset(offset, _) => offset,
+            &AMode::NominalSPOffset(offset) => offset + state.virtual_sp_offset,
+            &AMode::RegOffset(_, offset) => offset,
+            &AMode::SPOffset(offset) => offset,
+            &AMode::FPOffset(offset) => offset,
             &AMode::Const(_) | &AMode::Label(_) => 0,
         }
     }
@@ -200,9 +200,9 @@ impl Into<AMode> for StackAMode {
     fn into(self) -> AMode {
         match self {
             // Argument area begins after saved lr + fp.
-            StackAMode::ArgOffset(offset, ty) => AMode::FPOffset(offset + 16, ty),
-            StackAMode::SPOffset(offset, ty) => AMode::SPOffset(offset, ty),
-            StackAMode::NominalSPOffset(offset, ty) => AMode::NominalSPOffset(offset, ty),
+            StackAMode::ArgOffset(offset, _ty) => AMode::FPOffset(offset + 16),
+            StackAMode::SPOffset(offset, _ty) => AMode::SPOffset(offset),
+            StackAMode::NominalSPOffset(offset, _ty) => AMode::NominalSPOffset(offset),
         }
     }
 }

--- a/cranelift/codegen/src/isa/riscv64/inst/emit.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit.rs
@@ -1951,7 +1951,7 @@ impl Inst {
                         rd,
                         op: LoadOP::Ld,
                         flags: MemFlags::trusted(),
-                        from: AMode::RegOffset(rd.to_reg(), 0, I64),
+                        from: AMode::RegOffset(rd.to_reg(), 0),
                     }
                     .emit_uncompressed(sink, emit_info, state, start_off);
                 } else {
@@ -2083,7 +2083,7 @@ impl Inst {
                     rd: rd,
                     op: LoadOP::from_type(ty),
                     flags: MemFlags::new(),
-                    from: AMode::RegOffset(p, 0, ty),
+                    from: AMode::RegOffset(p, 0),
                 }
                 .emit(&[], sink, emit_info, state);
                 Inst::Fence {
@@ -2099,7 +2099,7 @@ impl Inst {
                 }
                 .emit(&[], sink, emit_info, state);
                 Inst::Store {
-                    to: AMode::RegOffset(p, 0, ty),
+                    to: AMode::RegOffset(p, 0),
                     op: StoreOP::from_type(ty),
                     flags: MemFlags::new(),
                     src,
@@ -2599,7 +2599,7 @@ impl Inst {
                 }
                 .emit(&[], sink, emit_info, state);
                 Inst::Store {
-                    to: AMode::RegOffset(spilltmp_reg2(), 0, I8),
+                    to: AMode::RegOffset(spilltmp_reg2(), 0),
                     op: StoreOP::Sb,
                     flags: MemFlags::new(),
                     src: zero_reg(),
@@ -3404,12 +3404,12 @@ fn emit_return_call_common_sequence(
 
     Inst::gen_load(
         writable_link_reg(),
-        AMode::FPOffset(8, I64),
+        AMode::FPOffset(8),
         I64,
         MemFlags::trusted(),
     )
     .emit(&[], sink, emit_info, state);
-    Inst::gen_load(tmp1, AMode::FPOffset(0, I64), I64, MemFlags::trusted()).emit(
+    Inst::gen_load(tmp1, AMode::FPOffset(0), I64, MemFlags::trusted()).emit(
         &[],
         sink,
         emit_info,
@@ -3422,7 +3422,7 @@ fn emit_return_call_common_sequence(
         // space.
         Inst::gen_load(
             tmp2,
-            AMode::SPOffset(i64::from(i * 8), types::I64),
+            AMode::SPOffset(i64::from(i * 8)),
             types::I64,
             ir::MemFlags::trusted(),
         )
@@ -3431,7 +3431,7 @@ fn emit_return_call_common_sequence(
         // Store it to its final destination on the stack, overwriting our
         // current frame.
         Inst::gen_store(
-            AMode::FPOffset(fp_to_callee_sp + i64::from(i * 8), types::I64),
+            AMode::FPOffset(fp_to_callee_sp + i64::from(i * 8)),
             tmp2.to_reg(),
             types::I64,
             ir::MemFlags::trusted(),

--- a/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/emit_tests.rs
@@ -631,7 +631,7 @@ fn test_riscv64_binemit() {
             rd: writable_a0(),
             op: LoadOP::Lb,
             flags: MemFlags::new(),
-            from: AMode::RegOffset(a1(), 100, I8),
+            from: AMode::RegOffset(a1(), 100),
         },
         "lb a0,100(a1)",
         0x6458503,
@@ -641,7 +641,7 @@ fn test_riscv64_binemit() {
             rd: writable_a0(),
             op: LoadOP::Lh,
             flags: MemFlags::new(),
-            from: AMode::RegOffset(a1(), 100, I16),
+            from: AMode::RegOffset(a1(), 100),
         },
         "lh a0,100(a1)",
         0x6459503,
@@ -652,7 +652,7 @@ fn test_riscv64_binemit() {
             rd: writable_a0(),
             op: LoadOP::Lw,
             flags: MemFlags::new(),
-            from: AMode::RegOffset(a1(), 100, I32),
+            from: AMode::RegOffset(a1(), 100),
         },
         "lw a0,100(a1)",
         0x645a503,
@@ -663,7 +663,7 @@ fn test_riscv64_binemit() {
             rd: writable_a0(),
             op: LoadOP::Ld,
             flags: MemFlags::new(),
-            from: AMode::RegOffset(a1(), 100, I64),
+            from: AMode::RegOffset(a1(), 100),
         },
         "ld a0,100(a1)",
         0x645b503,
@@ -673,7 +673,7 @@ fn test_riscv64_binemit() {
             rd: Writable::from_reg(fa0()),
             op: LoadOP::Flw,
             flags: MemFlags::new(),
-            from: AMode::RegOffset(a1(), 100, I64),
+            from: AMode::RegOffset(a1(), 100),
         },
         "flw fa0,100(a1)",
         0x645a507,
@@ -684,14 +684,14 @@ fn test_riscv64_binemit() {
             rd: Writable::from_reg(fa0()),
             op: LoadOP::Fld,
             flags: MemFlags::new(),
-            from: AMode::RegOffset(a1(), 100, I64),
+            from: AMode::RegOffset(a1(), 100),
         },
         "fld fa0,100(a1)",
         0x645b507,
     ));
     insns.push(TestUnit::new(
         Inst::Store {
-            to: AMode::SPOffset(100, I8),
+            to: AMode::SPOffset(100),
             op: StoreOP::Sb,
             flags: MemFlags::new(),
             src: a0(),
@@ -701,7 +701,7 @@ fn test_riscv64_binemit() {
     ));
     insns.push(TestUnit::new(
         Inst::Store {
-            to: AMode::SPOffset(100, I16),
+            to: AMode::SPOffset(100),
             op: StoreOP::Sh,
             flags: MemFlags::new(),
             src: a0(),
@@ -711,7 +711,7 @@ fn test_riscv64_binemit() {
     ));
     insns.push(TestUnit::new(
         Inst::Store {
-            to: AMode::SPOffset(100, I32),
+            to: AMode::SPOffset(100),
             op: StoreOP::Sw,
             flags: MemFlags::new(),
             src: a0(),
@@ -721,7 +721,7 @@ fn test_riscv64_binemit() {
     ));
     insns.push(TestUnit::new(
         Inst::Store {
-            to: AMode::SPOffset(100, I64),
+            to: AMode::SPOffset(100),
             op: StoreOP::Sd,
             flags: MemFlags::new(),
             src: a0(),
@@ -731,7 +731,7 @@ fn test_riscv64_binemit() {
     ));
     insns.push(TestUnit::new(
         Inst::Store {
-            to: AMode::SPOffset(100, I64),
+            to: AMode::SPOffset(100),
             op: StoreOP::Fsw,
             flags: MemFlags::new(),
             src: fa0(),
@@ -741,7 +741,7 @@ fn test_riscv64_binemit() {
     ));
     insns.push(TestUnit::new(
         Inst::Store {
-            to: AMode::SPOffset(100, I64),
+            to: AMode::SPOffset(100),
             op: StoreOP::Fsd,
             flags: MemFlags::new(),
             src: fa0(),

--- a/cranelift/codegen/src/isa/riscv64/lower.isle
+++ b/cranelift/codegen/src/isa/riscv64/lower.isle
@@ -1979,41 +1979,41 @@
 
 ;;;;;  Rules for `uload8`;;;;;;;;;
 (rule (lower (uload8 flags addr offset))
-  (gen_load (amode addr offset $I8) (LoadOP.Lbu) flags))
+  (gen_load (amode addr offset) (LoadOP.Lbu) flags))
 
 ;;;;;  Rules for `sload8`;;;;;;;;;
 (rule (lower (sload8 flags addr offset))
-  (gen_load (amode addr offset $I8) (LoadOP.Lb) flags))
+  (gen_load (amode addr offset) (LoadOP.Lb) flags))
 
 ;;;;;  Rules for `uload16`;;;;;;;;;
 (rule (lower (uload16 flags addr offset))
-  (gen_load (amode addr offset $I16) (LoadOP.Lhu) flags))
+  (gen_load (amode addr offset) (LoadOP.Lhu) flags))
 
 ;;;;;  Rules for `iload16`;;;;;;;;;
 (rule (lower (sload16 flags addr offset))
-  (gen_load (amode addr offset $I16) (LoadOP.Lh) flags))
+  (gen_load (amode addr offset) (LoadOP.Lh) flags))
 
 ;;;;;  Rules for `uload32`;;;;;;;;;
 (rule (lower (uload32 flags addr offset))
-  (gen_load (amode addr offset $I32) (LoadOP.Lwu) flags))
+  (gen_load (amode addr offset) (LoadOP.Lwu) flags))
 
 ;;;;;  Rules for `sload32`;;;;;;;;;
 (rule (lower (sload32 flags addr offset))
-  (gen_load (amode addr offset $I32) (LoadOP.Lw) flags))
+  (gen_load (amode addr offset) (LoadOP.Lw) flags))
 
 ;;;;;  Rules for `load`;;;;;;;;;
 (rule (lower (has_type ty (load flags addr offset)))
-  (gen_load (amode addr offset ty) (load_op ty) flags))
+  (gen_load (amode addr offset) (load_op ty) flags))
 
 (rule 1 (lower (has_type $I128 (load flags addr offset)))
   (if-let offset_plus_8 (s32_add_fallible offset 8))
-  (let ((lo XReg (gen_load (amode addr offset $I64) (LoadOP.Ld) flags))
-        (hi XReg (gen_load (amode addr offset_plus_8 $I64) (LoadOP.Ld) flags)))
+  (let ((lo XReg (gen_load (amode addr offset) (LoadOP.Ld) flags))
+        (hi XReg (gen_load (amode addr offset_plus_8) (LoadOP.Ld) flags)))
     (value_regs lo hi)))
 
 (rule 2 (lower (has_type (ty_vec_fits_in_register ty) (load flags addr offset)))
   (let ((eew VecElementWidth (element_width_from_type ty))
-        (amode AMode (amode addr offset ty)))
+        (amode AMode (amode addr offset)))
     (vec_load eew (VecAMode.UnitStride amode) flags (unmasked) ty)))
 
 ;;;;;  Rules for Load + Extend Combos ;;;;;;;;;
@@ -2039,52 +2039,52 @@
 
 ;;;;;  Rules for `uload8x8`;;;;;;;;;;
 (rule (lower (has_type (ty_vec_fits_in_register ty @ $I16X8) (uload8x8 flags addr offset)))
-  (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset ty)))
+  (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset)))
 
 ;;;;;  Rules for `uload16x4`;;;;;;;;;
 (rule (lower (has_type (ty_vec_fits_in_register ty @ $I32X4) (uload16x4 flags addr offset)))
-  (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset ty)))
+  (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset)))
 
 ;;;;;  Rules for `uload32x2`;;;;;;;;;
 (rule (lower (has_type (ty_vec_fits_in_register ty @ $I64X2) (uload32x2 flags addr offset)))
-  (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset ty)))
+  (gen_load64_extend ty (ExtendOp.Zero) flags (amode addr offset)))
 
 ;;;;;  Rules for `sload8x8`;;;;;;;;;;
 (rule (lower (has_type (ty_vec_fits_in_register ty @ $I16X8) (sload8x8 flags addr offset)))
-  (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset ty)))
+  (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset)))
 
 ;;;;;  Rules for `sload16x4`;;;;;;;;;
 (rule (lower (has_type (ty_vec_fits_in_register ty @ $I32X4) (sload16x4 flags addr offset)))
-  (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset ty)))
+  (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset)))
 
 ;;;;;  Rules for `sload32x2`;;;;;;;;;
 (rule (lower (has_type (ty_vec_fits_in_register ty @ $I64X2) (sload32x2 flags addr offset)))
-  (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset ty)))
+  (gen_load64_extend ty (ExtendOp.Signed) flags (amode addr offset)))
 
 ;;;;;  Rules for `istore8`;;;;;;;;;
 (rule (lower (istore8 flags src addr offset))
-  (gen_store (amode addr offset $I8) (StoreOP.Sb) flags src))
+  (gen_store (amode addr offset) (StoreOP.Sb) flags src))
 
 ;;;;;  Rules for `istore16`;;;;;;;;;
 (rule (lower (istore16 flags src addr offset))
-  (gen_store (amode addr offset $I16) (StoreOP.Sh) flags src))
+  (gen_store (amode addr offset) (StoreOP.Sh) flags src))
 
 ;;;;;  Rules for `istore32`;;;;;;;;;
 (rule (lower (istore32 flags src addr offset))
-  (gen_store (amode addr offset $I32) (StoreOP.Sw) flags src))
+  (gen_store (amode addr offset) (StoreOP.Sw) flags src))
 
 ;;;;;  Rules for `store`;;;;;;;;;
 (rule (lower (store flags src @ (value_type ty) addr offset))
-  (gen_store (amode addr offset ty) (store_op ty) flags src))
+  (gen_store (amode addr offset) (store_op ty) flags src))
 
 (rule 1 (lower (store flags src @ (value_type $I128) addr offset))
   (if-let offset_plus_8 (s32_add_fallible offset 8))
-  (let ((_ InstOutput (gen_store (amode addr offset $I64) (StoreOP.Sd) flags (value_regs_get src 0))))
-    (gen_store (amode addr offset_plus_8 $I64) (StoreOP.Sd) flags (value_regs_get src 1))))
+  (let ((_ InstOutput (gen_store (amode addr offset) (StoreOP.Sd) flags (value_regs_get src 0))))
+    (gen_store (amode addr offset_plus_8) (StoreOP.Sd) flags (value_regs_get src 1))))
 
 (rule 2 (lower (store flags src @ (value_type (ty_vec_fits_in_register ty)) addr offset))
   (let ((eew VecElementWidth (element_width_from_type ty))
-        (amode AMode (amode addr offset ty)))
+        (amode AMode (amode addr offset)))
     (vec_store eew (VecAMode.UnitStride amode) src flags (unmasked) ty)))
 
 

--- a/cranelift/codegen/src/isa/riscv64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/riscv64/lower/isle.rs
@@ -177,7 +177,7 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
                 rd: tmp,
                 op: LoadOP::Ld,
                 flags: MemFlags::trusted(),
-                from: AMode::FPOffset(8, I64),
+                from: AMode::FPOffset(8),
             });
             tmp.to_reg()
         } else {
@@ -385,24 +385,24 @@ impl generated_code::Context for RV64IsleContext<'_, '_, MInst, Riscv64Backend> 
         self.backend.isa_flags.has_zbs()
     }
 
-    fn gen_reg_offset_amode(&mut self, base: Reg, offset: i64, ty: Type) -> AMode {
-        AMode::RegOffset(base, offset, ty)
+    fn gen_reg_offset_amode(&mut self, base: Reg, offset: i64) -> AMode {
+        AMode::RegOffset(base, offset)
     }
 
-    fn gen_sp_offset_amode(&mut self, offset: i64, ty: Type) -> AMode {
-        AMode::SPOffset(offset, ty)
+    fn gen_sp_offset_amode(&mut self, offset: i64) -> AMode {
+        AMode::SPOffset(offset)
     }
 
-    fn gen_fp_offset_amode(&mut self, offset: i64, ty: Type) -> AMode {
-        AMode::FPOffset(offset, ty)
+    fn gen_fp_offset_amode(&mut self, offset: i64) -> AMode {
+        AMode::FPOffset(offset)
     }
 
-    fn gen_stack_slot_amode(&mut self, ss: StackSlot, offset: i64, ty: Type) -> AMode {
+    fn gen_stack_slot_amode(&mut self, ss: StackSlot, offset: i64) -> AMode {
         // Offset from beginning of stackslot area, which is at nominal SP (see
         // [MemArg::NominalSPOffset] for more details on nominal SP tracking).
         let stack_off = self.lower_ctx.abi().sized_stackslot_offsets()[ss] as i64;
         let sp_off: i64 = stack_off + offset;
-        AMode::NominalSPOffset(sp_off, ty)
+        AMode::NominalSPOffset(sp_off)
     }
 
     fn gen_const_amode(&mut self, c: VCodeConstant) -> AMode {


### PR DESCRIPTION
This backend copied the general style of the aarch64 backend's address modes but has no use for a type field in address modes. Just delete them.

Between this and #8308, there are no types in target dependent address modes now. The next step is to delete them from the target independent `StackAMode` as well.