### PR TITLE
Support `.wat` files in the `explore` command

### DIFF
--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -32,8 +32,10 @@ impl ExploreCommand {
 
         let config = self.common.config(self.target.as_deref())?;
 
-        let wasm = std::fs::read(&self.module)
+        let bytes = std::fs::read(&self.module)
             .with_context(|| format!("failed to read Wasm module: {}", self.module.display()))?;
+        let wasm = wat::parse_bytes(&bytes)
+            .with_context(|| format!("failed to parse Wasm module: {}", self.module.display()))?;
 
         let output = self
             .output

--- a/src/commands/explore.rs
+++ b/src/commands/explore.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Context, Result};
 use clap::Parser;
-use std::path::PathBuf;
+use std::{borrow::Cow, path::PathBuf};
 use wasmtime_cli_flags::CommonOptions;
 
 /// Explore the compilation of a WebAssembly module to native code.
@@ -32,10 +32,15 @@ impl ExploreCommand {
 
         let config = self.common.config(self.target.as_deref())?;
 
-        let bytes = std::fs::read(&self.module)
-            .with_context(|| format!("failed to read Wasm module: {}", self.module.display()))?;
-        let wasm = wat::parse_bytes(&bytes)
-            .with_context(|| format!("failed to parse Wasm module: {}", self.module.display()))?;
+        let bytes =
+            Cow::Owned(std::fs::read(&self.module).with_context(|| {
+                format!("failed to read Wasm module: {}", self.module.display())
+            })?);
+        #[cfg(feature = "wat")]
+        let bytes = wat::parse_bytes(&bytes).map_err(|mut e| {
+            e.set_path(&self.module);
+            e
+        })?;
 
         let output = self
             .output
@@ -45,7 +50,7 @@ impl ExploreCommand {
             .with_context(|| format!("failed to create file: {}", output.display()))?;
         let mut output_file = std::io::BufWriter::new(output_file);
 
-        wasmtime_explorer::generate(&config, self.target.as_deref(), &wasm, &mut output_file)?;
+        wasmtime_explorer::generate(&config, self.target.as_deref(), &bytes, &mut output_file)?;
         println!("Exploration written to {}", output.display());
         Ok(())
     }


### PR DESCRIPTION
Many on the `wasmtime` subcommands work with either `.wasm` or `.wat` files, but `explore` only works with `.wasm`. This change accepts `.wat` as well.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
