### PR TITLE
wasmtime-c-api: Add support for GC references to the `wasm_*` C API functions

### DIFF
--- a/crates/c-api/src/async.rs
+++ b/crates/c-api/src/async.rs
@@ -15,7 +15,7 @@ use wasmtime::{
 use crate::{
     bad_utf8, handle_result, to_str, translate_args, wasm_config_t, wasm_functype_t, wasm_trap_t,
     wasmtime_caller_t, wasmtime_error_t, wasmtime_instance_pre_t, wasmtime_linker_t,
-    wasmtime_module_t, wasmtime_val_t, wasmtime_val_union, CStoreContextMut, WASMTIME_I32,
+    wasmtime_module_t, wasmtime_val_t, wasmtime_val_union, WasmtimeStoreContextMut, WASMTIME_I32,
 };
 
 #[no_mangle]
@@ -30,7 +30,7 @@ pub extern "C" fn wasmtime_config_async_stack_size_set(c: &mut wasm_config_t, si
 
 #[no_mangle]
 pub extern "C" fn wasmtime_context_epoch_deadline_async_yield_and_update(
-    mut store: CStoreContextMut<'_>,
+    mut store: WasmtimeStoreContextMut<'_>,
     delta: u64,
 ) {
     store.epoch_deadline_async_yield_and_update(delta);
@@ -38,7 +38,7 @@ pub extern "C" fn wasmtime_context_epoch_deadline_async_yield_and_update(
 
 #[no_mangle]
 pub extern "C" fn wasmtime_context_fuel_async_yield_interval(
-    mut store: CStoreContextMut<'_>,
+    mut store: WasmtimeStoreContextMut<'_>,
     interval: Option<NonZeroU64>,
 ) -> Option<Box<wasmtime_error_t>> {
     handle_result(
@@ -103,7 +103,7 @@ pub type wasmtime_func_async_continuation_callback_t = extern "C" fn(*mut c_void
 async fn invoke_c_async_callback<'a>(
     cb: wasmtime_func_async_callback_t,
     data: CallbackDataPtr,
-    mut caller: Caller<'a, crate::StoreData>,
+    mut caller: Caller<'a, crate::WasmtimeStoreData>,
     params: &'a [Val],
     results: &'a mut [Val],
 ) -> Result<()> {
@@ -172,7 +172,7 @@ unsafe fn c_async_callback_to_rust_fn(
     data: *mut c_void,
     finalizer: Option<extern "C" fn(*mut std::ffi::c_void)>,
 ) -> impl for<'a> Fn(
-    Caller<'a, crate::StoreData>,
+    Caller<'a, crate::WasmtimeStoreData>,
     &'a [Val],
     &'a mut [Val],
 ) -> Box<dyn Future<Output = Result<()>> + Send + 'a>
@@ -219,7 +219,7 @@ fn handle_call_error(
 }
 
 async fn do_func_call_async(
-    mut store: CStoreContextMut<'_>,
+    mut store: WasmtimeStoreContextMut<'_>,
     func: &Func,
     args: impl ExactSizeIterator<Item = Val>,
     results: &mut [MaybeUninit<wasmtime_val_t>],
@@ -245,7 +245,7 @@ async fn do_func_call_async(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_func_call_async<'a>(
-    mut store: CStoreContextMut<'a>,
+    mut store: WasmtimeStoreContextMut<'a>,
     func: &'a Func,
     args: *const wasmtime_val_t,
     nargs: usize,
@@ -295,7 +295,7 @@ pub unsafe extern "C" fn wasmtime_linker_define_async_func(
 
 async fn do_linker_instantiate_async(
     linker: &wasmtime_linker_t,
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     module: &wasmtime_module_t,
     instance_ptr: &mut Instance,
     trap_ret: &mut *mut wasm_trap_t,
@@ -311,7 +311,7 @@ async fn do_linker_instantiate_async(
 #[no_mangle]
 pub extern "C" fn wasmtime_linker_instantiate_async<'a>(
     linker: &'a wasmtime_linker_t,
-    store: CStoreContextMut<'a>,
+    store: WasmtimeStoreContextMut<'a>,
     module: &'a wasmtime_module_t,
     instance_ptr: &'a mut Instance,
     trap_ret: &'a mut *mut wasm_trap_t,
@@ -330,7 +330,7 @@ pub extern "C" fn wasmtime_linker_instantiate_async<'a>(
 
 async fn do_instance_pre_instantiate_async(
     instance_pre: &wasmtime_instance_pre_t,
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     instance_ptr: &mut Instance,
     trap_ret: &mut *mut wasm_trap_t,
     err_ret: &mut *mut wasmtime_error_t,
@@ -345,7 +345,7 @@ async fn do_instance_pre_instantiate_async(
 #[no_mangle]
 pub extern "C" fn wasmtime_instance_pre_instantiate_async<'a>(
     instance_pre: &'a wasmtime_instance_pre_t,
-    store: CStoreContextMut<'a>,
+    store: WasmtimeStoreContextMut<'a>,
     instance_ptr: &'a mut Instance,
     trap_ret: &'a mut *mut wasm_trap_t,
     err_ret: &'a mut *mut wasmtime_error_t,

--- a/crates/c-api/src/extern.rs
+++ b/crates/c-api/src/extern.rs
@@ -1,6 +1,6 @@
 use crate::{
     wasm_externkind_t, wasm_externtype_t, wasm_func_t, wasm_global_t, wasm_memory_t, wasm_table_t,
-    CStoreContext, StoreRef,
+    StoreRef, WasmtimeStoreContext,
 };
 use std::mem::ManuallyDrop;
 use wasmtime::{Extern, Func, Global, Memory, SharedMemory, Table};
@@ -152,7 +152,7 @@ pub unsafe extern "C" fn wasmtime_extern_delete(e: &mut ManuallyDrop<wasmtime_ex
 
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_extern_type(
-    store: CStoreContext<'_>,
+    store: WasmtimeStoreContext<'_>,
     e: &wasmtime_extern_t,
 ) -> Box<wasm_externtype_t> {
     Box::new(wasm_externtype_t::from_extern_type(e.to_extern().ty(store)))

--- a/crates/c-api/src/instance.rs
+++ b/crates/c-api/src/instance.rs
@@ -1,6 +1,6 @@
 use crate::{
     wasm_extern_t, wasm_extern_vec_t, wasm_module_t, wasm_store_t, wasm_trap_t, wasmtime_error_t,
-    wasmtime_extern_t, wasmtime_module_t, CStoreContextMut, StoreData, StoreRef,
+    wasmtime_extern_t, wasmtime_module_t, StoreRef, WasmtimeStoreContextMut, WasmtimeStoreData,
 };
 use std::mem::MaybeUninit;
 use wasmtime::{Instance, InstancePre, Trap};
@@ -70,7 +70,7 @@ pub unsafe extern "C" fn wasm_instance_exports(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_instance_new(
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     module: &wasmtime_module_t,
     imports: *const wasmtime_extern_t,
     nimports: usize,
@@ -111,7 +111,7 @@ pub(crate) fn handle_instantiate(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_instance_export_get(
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     instance: &Instance,
     name: *const u8,
     name_len: usize,
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn wasmtime_instance_export_get(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_instance_export_nth(
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     instance: &Instance,
     index: usize,
     name_ptr: &mut *const u8,
@@ -153,7 +153,7 @@ pub unsafe extern "C" fn wasmtime_instance_export_nth(
 
 #[repr(transparent)]
 pub struct wasmtime_instance_pre_t {
-    pub(crate) underlying: InstancePre<StoreData>,
+    pub(crate) underlying: InstancePre<WasmtimeStoreData>,
 }
 
 #[no_mangle]
@@ -163,7 +163,7 @@ pub unsafe extern "C" fn wasmtime_instance_pre_delete(_instance_pre: Box<wasmtim
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_instance_pre_instantiate(
     instance_pre: &wasmtime_instance_pre_t,
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     instance_ptr: &mut Instance,
     trap_ptr: &mut *mut wasm_trap_t,
 ) -> Option<Box<wasmtime_error_t>> {

--- a/crates/c-api/src/linker.rs
+++ b/crates/c-api/src/linker.rs
@@ -1,6 +1,7 @@
 use crate::{
     bad_utf8, handle_result, wasm_engine_t, wasm_functype_t, wasm_trap_t, wasmtime_error_t,
-    wasmtime_extern_t, wasmtime_instance_pre_t, wasmtime_module_t, CStoreContext, CStoreContextMut,
+    wasmtime_extern_t, wasmtime_instance_pre_t, wasmtime_module_t, WasmtimeStoreContext,
+    WasmtimeStoreContextMut,
 };
 use std::ffi::c_void;
 use std::mem::MaybeUninit;
@@ -9,7 +10,7 @@ use wasmtime::{Func, Instance, Linker};
 
 #[repr(C)]
 pub struct wasmtime_linker_t {
-    pub(crate) linker: Linker<crate::StoreData>,
+    pub(crate) linker: Linker<crate::WasmtimeStoreData>,
 }
 
 wasmtime_c_api_macros::declare_own!(wasmtime_linker_t);
@@ -50,7 +51,7 @@ pub(crate) use to_str;
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_linker_define(
     linker: &mut wasmtime_linker_t,
-    store: CStoreContext<'_>,
+    store: WasmtimeStoreContext<'_>,
     module: *const u8,
     module_len: usize,
     name: *const u8,
@@ -123,7 +124,7 @@ pub extern "C" fn wasmtime_linker_define_wasi(
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_linker_define_instance(
     linker: &mut wasmtime_linker_t,
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     name: *const u8,
     name_len: usize,
     instance: &Instance,
@@ -136,7 +137,7 @@ pub unsafe extern "C" fn wasmtime_linker_define_instance(
 #[no_mangle]
 pub extern "C" fn wasmtime_linker_instantiate(
     linker: &wasmtime_linker_t,
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     module: &wasmtime_module_t,
     instance_ptr: &mut Instance,
     trap_ptr: &mut *mut wasm_trap_t,
@@ -161,7 +162,7 @@ pub unsafe extern "C" fn wasmtime_linker_instantiate_pre(
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_linker_module(
     linker: &mut wasmtime_linker_t,
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     name: *const u8,
     name_len: usize,
     module: &wasmtime_module_t,
@@ -174,7 +175,7 @@ pub unsafe extern "C" fn wasmtime_linker_module(
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_linker_get_default(
     linker: &wasmtime_linker_t,
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     name: *const u8,
     name_len: usize,
     func: &mut Func,
@@ -187,7 +188,7 @@ pub unsafe extern "C" fn wasmtime_linker_get_default(
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_linker_get(
     linker: &wasmtime_linker_t,
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     module: *const u8,
     module_len: usize,
     name: *const u8,

--- a/crates/c-api/src/memory.rs
+++ b/crates/c-api/src/memory.rs
@@ -1,6 +1,6 @@
 use crate::{
-    handle_result, wasm_extern_t, wasm_memorytype_t, wasm_store_t, wasmtime_error_t, CStoreContext,
-    CStoreContextMut,
+    handle_result, wasm_extern_t, wasm_memorytype_t, wasm_store_t, wasmtime_error_t,
+    WasmtimeStoreContext, WasmtimeStoreContextMut,
 };
 use std::convert::TryFrom;
 use wasmtime::{Extern, Memory};
@@ -88,7 +88,7 @@ pub unsafe extern "C" fn wasm_memory_grow(
 
 #[no_mangle]
 pub extern "C" fn wasmtime_memory_new(
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     ty: &wasm_memorytype_t,
     ret: &mut Memory,
 ) -> Option<Box<wasmtime_error_t>> {
@@ -97,30 +97,33 @@ pub extern "C" fn wasmtime_memory_new(
 
 #[no_mangle]
 pub extern "C" fn wasmtime_memory_type(
-    store: CStoreContext<'_>,
+    store: WasmtimeStoreContext<'_>,
     mem: &Memory,
 ) -> Box<wasm_memorytype_t> {
     Box::new(wasm_memorytype_t::new(mem.ty(store)))
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_memory_data(store: CStoreContext<'_>, mem: &Memory) -> *const u8 {
+pub extern "C" fn wasmtime_memory_data(store: WasmtimeStoreContext<'_>, mem: &Memory) -> *const u8 {
     mem.data(store).as_ptr()
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_memory_data_size(store: CStoreContext<'_>, mem: &Memory) -> usize {
+pub extern "C" fn wasmtime_memory_data_size(
+    store: WasmtimeStoreContext<'_>,
+    mem: &Memory,
+) -> usize {
     mem.data(store).len()
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_memory_size(store: CStoreContext<'_>, mem: &Memory) -> u64 {
+pub extern "C" fn wasmtime_memory_size(store: WasmtimeStoreContext<'_>, mem: &Memory) -> u64 {
     mem.size(store)
 }
 
 #[no_mangle]
 pub extern "C" fn wasmtime_memory_grow(
-    store: CStoreContextMut<'_>,
+    store: WasmtimeStoreContextMut<'_>,
     mem: &Memory,
     delta: u64,
     prev_size: &mut u64,

--- a/crates/c-api/src/vec.rs
+++ b/crates/c-api/src/vec.rs
@@ -54,6 +54,16 @@ macro_rules! declare_vecs {
                 }
             }
 
+            pub fn as_slice_mut(&mut self) -> &mut [$elem_ty] {
+                // Same as above: no null pointer.
+                if self.size == 0 {
+                    &mut []
+                } else {
+                    assert!(!self.data.is_null());
+                    unsafe { slice::from_raw_parts_mut(self.data, self.size) }
+                }
+            }
+
             pub fn as_uninit_slice(&mut self) -> &mut [MaybeUninit<$elem_ty>] {
                 // Note that we're careful to not create a slice with a null
                 // pointer as the data pointer, since that isn't defined


### PR DESCRIPTION
Does not add support for the `wasmtime_*` functions yet.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
