### PR TITLE
Eagerly reserve tail call stack arg space

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -412,9 +412,9 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             insts.extend(Self::gen_sp_reg_adjust(16));
         }
 
-        if call_conv == isa::CallConv::Tail && frame_layout.stack_args_size > 0 {
+        if call_conv == isa::CallConv::Tail && frame_layout.incoming_args_size > 0 {
             insts.extend(Self::gen_sp_reg_adjust(
-                frame_layout.stack_args_size.try_into().unwrap(),
+                frame_layout.incoming_args_size.try_into().unwrap(),
             ));
         }
 
@@ -683,7 +683,8 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         _sig: &Signature,
         regs: &[Writable<RealReg>],
         is_leaf: bool,
-        stack_args_size: u32,
+        incoming_args_size: u32,
+        tail_args_size: u32,
         fixed_frame_storage_size: u32,
         outgoing_args_size: u32,
     ) -> FrameLayout {
@@ -703,7 +704,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
             || !is_leaf
             // The function arguments that are passed on the stack are addressed
             // relative to the Frame Pointer.
-            || stack_args_size > 0
+            || incoming_args_size > 0
             || clobber_size > 0
             || fixed_frame_storage_size > 0
         {
@@ -714,7 +715,8 @@ impl ABIMachineSpec for Riscv64MachineDeps {
 
         // Return FrameLayout structure.
         FrameLayout {
-            stack_args_size,
+            incoming_args_size,
+            tail_args_size,
             setup_area_size,
             clobber_size,
             fixed_frame_storage_size,

--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -200,7 +200,7 @@ impl Into<AMode> for StackAMode {
     fn into(self) -> AMode {
         match self {
             // Argument area begins after saved lr + fp.
-            StackAMode::IncomingArg(offset) => AMode::FPOffset(offset + 16),
+            StackAMode::IncomingArg(offset, _) => AMode::FPOffset(offset + 16),
             StackAMode::OutgoingArg(offset) => AMode::SPOffset(offset),
             StackAMode::Slot(offset) => AMode::NominalSPOffset(offset),
         }

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -583,7 +583,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     ) -> SmallInstVec<Self::I> {
         // Emit return instruction.
         let stack_bytes_to_pop = if call_conv == isa::CallConv::Tail {
-            frame_layout.stack_args_size
+            frame_layout.tail_args_size
         } else {
             0
         };
@@ -640,7 +640,55 @@ impl ABIMachineSpec for X64ABIMachineSpec {
     ) -> SmallVec<[Self::I; 16]> {
         let mut insts = SmallVec::new();
 
-        if flags.unwind_info() && frame_layout.setup_area_size > 0 {
+        // When a return_call within this function required more stack arguments than we have
+        // present, resize the incoming argument area of the frame to accommodate those arguments.
+        let incoming_args_diff = frame_layout.tail_args_size - frame_layout.incoming_args_size;
+        if incoming_args_diff > 0 {
+            // Decrement the stack pointer to make space for the new arguments
+            insts.push(Inst::alu_rmi_r(
+                OperandSize::Size64,
+                AluRmiROpcode::Sub,
+                RegMemImm::imm(incoming_args_diff),
+                Writable::from_reg(regs::rsp()),
+            ));
+
+            // Make sure to keep the frame pointer and stack pointer in sync at this point
+            insts.push(Inst::mov_r_r(
+                OperandSize::Size64,
+                regs::rsp(),
+                Writable::from_reg(regs::rbp()),
+            ));
+
+            let incoming_args_diff = i32::try_from(incoming_args_diff).unwrap();
+
+            // Move the saved frame pointer down by `incoming_args_diff`
+            insts.push(Inst::mov64_m_r(
+                Amode::imm_reg(incoming_args_diff, regs::rsp()),
+                Writable::from_reg(regs::r11()),
+            ));
+            insts.push(Inst::mov_r_m(
+                OperandSize::Size64,
+                regs::r11(),
+                Amode::imm_reg(0, regs::rsp()),
+            ));
+
+            // Move the saved return address down by `incoming_args_diff`
+            insts.push(Inst::mov64_m_r(
+                Amode::imm_reg(incoming_args_diff + 8, regs::rsp()),
+                Writable::from_reg(regs::r11()),
+            ));
+            insts.push(Inst::mov_r_m(
+                OperandSize::Size64,
+                regs::r11(),
+                Amode::imm_reg(8, regs::rsp()),
+            ));
+        }
+
+        // We need to factor `incoming_args_diff` into the offset upward here, as we have grown
+        // the argument area -- `setup_area_size` alone will not be the correct offset up to the
+        // original caller's SP.
+        let offset_upward_to_caller_sp = frame_layout.setup_area_size + incoming_args_diff;
+        if flags.unwind_info() && offset_upward_to_caller_sp > 0 {
             // Emit unwind info: start the frame. The frame (from unwind
             // consumers' point of view) starts at clobbbers, just below
             // the FP and return address. Spill slots and stack slots are
@@ -648,7 +696,7 @@ impl ABIMachineSpec for X64ABIMachineSpec {
             insts.push(Inst::Unwind {
                 inst: UnwindInst::DefineNewFrame {
                     offset_downward_to_clobbers: frame_layout.clobber_size,
-                    offset_upward_to_caller_sp: frame_layout.setup_area_size,
+                    offset_upward_to_caller_sp,
                 },
             });
         }
@@ -925,10 +973,13 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         _sig: &Signature,
         regs: &[Writable<RealReg>],
         _is_leaf: bool,
-        stack_args_size: u32,
+        incoming_args_size: u32,
+        tail_args_size: u32,
         fixed_frame_storage_size: u32,
         outgoing_args_size: u32,
     ) -> FrameLayout {
+        debug_assert!(tail_args_size >= incoming_args_size);
+
         let mut regs: Vec<Writable<RealReg>> = match call_conv {
             // The `winch` calling convention doesn't have any callee-save
             // registers.
@@ -958,7 +1009,8 @@ impl ABIMachineSpec for X64ABIMachineSpec {
 
         // Return FrameLayout structure.
         FrameLayout {
-            stack_args_size,
+            incoming_args_size,
+            tail_args_size: align_to(tail_args_size, 16),
             setup_area_size,
             clobber_size,
             fixed_frame_storage_size,
@@ -972,25 +1024,8 @@ impl X64CallSite {
     pub fn emit_return_call(mut self, ctx: &mut Lower<Inst>, args: isle::ValueSlice) {
         let new_stack_arg_size =
             u32::try_from(self.sig(ctx.sigs()).sized_stack_arg_space()).unwrap();
-        let old_stack_arg_size = ctx.abi().stack_args_size(ctx.sigs());
 
-        match new_stack_arg_size.cmp(&old_stack_arg_size) {
-            core::cmp::Ordering::Equal => {}
-            core::cmp::Ordering::Less => {
-                let tmp = ctx.temp_writable_gpr();
-                ctx.emit(Inst::ShrinkArgumentArea {
-                    amount: old_stack_arg_size - new_stack_arg_size,
-                    tmp,
-                });
-            }
-            core::cmp::Ordering::Greater => {
-                let tmp = ctx.temp_writable_gpr();
-                ctx.emit(Inst::GrowArgumentArea {
-                    amount: new_stack_arg_size - old_stack_arg_size,
-                    tmp,
-                });
-            }
-        }
+        ctx.abi_mut().accumulate_tail_args_size(new_stack_arg_size);
 
         // Put all arguments in registers and stack slots (within that newly
         // allocated stack space).
@@ -1000,6 +1035,7 @@ impl X64CallSite {
         // Finally, do the actual tail call!
         let dest = self.dest().clone();
         let info = Box::new(ReturnCallInfo {
+            new_stack_arg_size,
             uses: self.take_uses(),
         });
         match dest {
@@ -1032,16 +1068,13 @@ impl From<StackAMode> for SyntheticAmode {
         // We enforce a 128 MB stack-frame size limit above, so these
         // `expect()`s should never fail.
         match amode {
-            StackAMode::IncomingArg(off) => {
-                let off = i32::try_from(off + 16) // frame pointer + return address
-                    .expect(
-                        "Offset in IncomingArg is greater than 2GB; should hit impl limit first",
-                    );
-                SyntheticAmode::Real(Amode::ImmReg {
-                    simm32: off,
-                    base: regs::rbp(),
-                    flags: MemFlags::trusted(),
-                })
+            StackAMode::IncomingArg(off, stack_args_size) => {
+                let offset = u32::try_from(off).expect(
+                    "Offset in IncomingArg is greater than 4GB; should hit impl limit first",
+                );
+                SyntheticAmode::IncomingArg {
+                    offset: stack_args_size - offset,
+                }
             }
             StackAMode::Slot(off) => {
                 let off = i32::try_from(off)

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -541,23 +541,6 @@
        (ReturnCallUnknown (callee RegMem)
                           (info BoxReturnCallInfo))
 
-       ;; GrowArgumentArea does a memmove of everything in the frame except for
-       ;; the argument area, to make room for more arguments. That includes all
-       ;; the stack slots, the callee-saved registers, and the saved FP and
-       ;; return address. To keep the stack pointers in sync with that change,
-       ;; it also subtracts the given amount from both the FP and SP registers.
-       (GrowArgumentArea (amount u32)
-                         (tmp WritableGpr))
-
-       ;; ShrinkArgumentArea does a memmove of everything in the frame except
-       ;; for the argument area, to trim space for fewer arguments. That
-       ;; includes all the stack slots, the callee-saved registers, and the
-       ;; saved FP and return address. To keep the stack pointers in sync with
-       ;; that change, it also adds the given amount to both the FP and SP
-       ;; registers.
-       (ShrinkArgumentArea (amount u32)
-                           (tmp WritableGpr))
-
        ;; A pseudo-instruction that captures register arguments in vregs.
        (Args
         (args VecArgPair))

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -808,8 +808,6 @@ pub(crate) fn check(
         | Inst::ReturnCallKnown { .. }
         | Inst::JmpKnown { .. }
         | Inst::Ret { .. }
-        | Inst::GrowArgumentArea { .. }
-        | Inst::ShrinkArgumentArea { .. }
         | Inst::JmpIf { .. }
         | Inst::JmpCond { .. }
         | Inst::TrapIf { .. }
@@ -926,9 +924,9 @@ fn check_mem<'a>(
 ) -> PccResult<Option<Fact>> {
     match amode {
         SyntheticAmode::Real(amode) if !amode.get_flags().checked() => return Ok(None),
-        SyntheticAmode::NominalSPOffset { .. } | SyntheticAmode::ConstantOffset(_) => {
-            return Ok(None)
-        }
+        SyntheticAmode::IncomingArg { .. }
+        | SyntheticAmode::NominalSPOffset { .. }
+        | SyntheticAmode::ConstantOffset(_) => return Ok(None),
         _ => {}
     }
 
@@ -997,6 +995,7 @@ fn compute_addr(
             Some(sum)
         }
         SyntheticAmode::Real(Amode::RipRelative { .. })
+        | SyntheticAmode::IncomingArg { .. }
         | SyntheticAmode::ConstantOffset(_)
         | SyntheticAmode::NominalSPOffset { .. } => None,
     }

--- a/cranelift/filetests/filetests/isa/x64/call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/call-conv.clif
@@ -200,10 +200,10 @@ block0(
 ;   movq    %rsi, %rdx
 ;   movq    %rdi, %rsi
 ;   movq    %rax, %rdi
-;   movq    16(%rbp), %r10
-;   movq    24(%rbp), %r11
-;   movss   32(%rbp), %xmm11
-;   movsd   40(%rbp), %xmm13
+;   movq    rbp(stack args max - 32), %r10
+;   movq    rbp(stack args max - 24), %r11
+;   movss   rbp(stack args max - 16), %xmm11
+;   movsd   rbp(stack args max - 8), %xmm13
 ;   movq    %r8, 32(%rsp)
 ;   movq    %r9, 40(%rsp)
 ;   movsd   %xmm0, 48(%rsp)

--- a/cranelift/filetests/filetests/isa/x64/fastcall.clif
+++ b/cranelift/filetests/filetests/isa/x64/fastcall.clif
@@ -180,8 +180,8 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64):
 ;   movq    %rsp, %rbp
 ;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ; block0:
-;   movq    48(%rbp), %r8
-;   movq    56(%rbp), %rax
+;   movq    rbp(stack args max - 16), %r8
+;   movq    rbp(stack args max - 8), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret
@@ -208,9 +208,9 @@ block0(v0: i128, v1: i64, v2: i128, v3: i128):
 ;   movq    %rsp, %rbp
 ;   unwind DefineNewFrame { offset_upward_to_caller_sp: 16, offset_downward_to_clobbers: 0 }
 ; block0:
-;   movq    48(%rbp), %r8
-;   movq    56(%rbp), %rax
-;   movq    64(%rbp), %rdx
+;   movq    rbp(stack args max - 32), %r8
+;   movq    rbp(stack args max - 24), %rax
+;   movq    rbp(stack args max - 16), %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/i128.clif
+++ b/cranelift/filetests/filetests/isa/x64/i128.clif
@@ -1292,11 +1292,11 @@ block0(v0: i128, v1: i128, v2: i64, v3: i128, v4: i128, v5: i128):
 ; block0:
 ;   movq    %rdx, %rbx
 ;   movq    %rcx, %r14
-;   movq    16(%rbp), %rcx
-;   movq    24(%rbp), %rax
-;   movq    32(%rbp), %rdx
-;   movq    40(%rbp), %r11
-;   movq    48(%rbp), %r10
+;   movq    rbp(stack args max - 48), %rcx
+;   movq    rbp(stack args max - 40), %rax
+;   movq    rbp(stack args max - 32), %rdx
+;   movq    rbp(stack args max - 24), %r11
+;   movq    rbp(stack args max - 16), %r10
 ;   addq    %rdi, %rbx, %rdi
 ;   movq    %r14, %r15
 ;   adcq    %rsi, %r15, %rsi

--- a/cranelift/filetests/filetests/isa/x64/llvm-abi-no-split-stack-u128.clif
+++ b/cranelift/filetests/filetests/isa/x64/llvm-abi-no-split-stack-u128.clif
@@ -11,8 +11,8 @@ block0(v0: i64, v1: i128, v2: i128, v3: i128):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    16(%rbp), %rax
-;   movq    24(%rbp), %rdx
+;   movq    rbp(stack args max - 16), %rax
+;   movq    rbp(stack args max - 8), %rdx
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret

--- a/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call-indirect.clif
@@ -43,7 +43,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %callee_i64+0, %rax
-;   return_call_unknown %rax %rdi=%rdi
+;   return_call_unknown %rax (0) %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -71,7 +71,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %callee_i64+0, %rax
-;   return_call_unknown %rax %rdi=%rdi
+;   return_call_unknown %rax (0) %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -140,7 +140,7 @@ block0(v0: f64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %callee_f64+0, %rax
-;   return_call_unknown %rax %xmm0=%xmm0
+;   return_call_unknown %rax (0) %xmm0=%xmm0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -196,7 +196,7 @@ block0(v0: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %callee_i8+0, %rax
-;   return_call_unknown %rax %rdi=%rdi
+;   return_call_unknown %rax (0) %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -248,6 +248,12 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $160, %rsp
+;   movq    %rsp, %rbp
+;   movq    160(%rsp), %r11
+;   movq    %r11, 0(%rsp)
+;   movq    168(%rsp), %r11
+;   movq    %r11, 8(%rsp)
+;   subq    %rsp, $160, %rsp
 ;   movq    %rbx, 112(%rsp)
 ;   movq    %r12, 120(%rsp)
 ;   movq    %r13, 128(%rsp)
@@ -266,83 +272,88 @@ block0:
 ;   movq    %r8, rsp(72 + virtual offset)
 ;   movl    $35, %r9d
 ;   movq    %r9, rsp(64 + virtual offset)
-;   movl    $40, %eax
-;   movl    $45, %r10d
-;   movl    $50, %r11d
-;   movl    $55, %r13d
-;   movl    $60, %r14d
-;   movl    $65, %r15d
-;   movl    $70, %ebx
-;   movl    $75, %r12d
+;   movl    $40, %esi
+;   movq    %rsi, rsp(56 + virtual offset)
+;   movl    $45, %eax
+;   movl    $50, %r10d
+;   movl    $55, %r12d
+;   movl    $60, %r13d
+;   movl    $65, %r14d
+;   movl    $70, %r15d
+;   movl    $75, %ebx
 ;   movl    $80, %edi
 ;   movl    $85, %esi
-;   movq    %rsi, rsp(56 + virtual offset)
 ;   movl    $90, %edx
 ;   movl    $95, %ecx
 ;   movl    $100, %r8d
 ;   movl    $105, %r9d
-;   movl    $110, %esi
-;   movq    %rsi, rsp(48 + virtual offset)
-;   movl    $115, %esi
-;   movq    %rsi, rsp(40 + virtual offset)
-;   movl    $120, %esi
-;   movq    %rsi, rsp(32 + virtual offset)
-;   movl    $125, %esi
-;   movq    %rsi, rsp(24 + virtual offset)
-;   movl    $130, %esi
-;   movq    %rsi, rsp(16 + virtual offset)
-;   movl    $135, %esi
-;   movq    %rsi, rsp(8 + virtual offset)
-;   load_ext_name %tail_callee_stack_args+0, %rsi
-;   movq    %rsi, rsp(0 + virtual offset)
-;   grow_argument_area 160 %rsi
-;   movq    %rax, 16(%rbp)
-;   movq    %r10, 24(%rbp)
-;   movq    %r11, 32(%rbp)
-;   movq    %r13, 40(%rbp)
-;   movq    %r14, 48(%rbp)
-;   movq    %r15, 56(%rbp)
-;   movq    %rbx, 64(%rbp)
-;   movq    %r12, 72(%rbp)
-;   movq    %rdi, 80(%rbp)
-;   movq    rsp(56 + virtual offset), %rdi
-;   movq    %rdi, 88(%rbp)
-;   movq    %rdx, 96(%rbp)
-;   movq    %rcx, 104(%rbp)
-;   movq    %r8, 112(%rbp)
-;   movq    %r9, 120(%rbp)
-;   movq    rsp(48 + virtual offset), %rsi
-;   movq    %rsi, 128(%rbp)
-;   movq    rsp(40 + virtual offset), %rsi
-;   movq    %rsi, 136(%rbp)
-;   movq    rsp(32 + virtual offset), %rsi
-;   movq    %rsi, 144(%rbp)
-;   movq    rsp(24 + virtual offset), %rsi
-;   movq    %rsi, 152(%rbp)
-;   movq    rsp(16 + virtual offset), %rsi
-;   movq    %rsi, 160(%rbp)
-;   movq    rsp(8 + virtual offset), %rsi
-;   movq    %rsi, 168(%rbp)
-;   movq    rsp(0 + virtual offset), %rax
+;   movl    $110, %r11d
+;   movq    %r11, rsp(48 + virtual offset)
+;   movl    $115, %r11d
+;   movq    %r11, rsp(40 + virtual offset)
+;   movl    $120, %r11d
+;   movq    %r11, rsp(32 + virtual offset)
+;   movl    $125, %r11d
+;   movq    %r11, rsp(24 + virtual offset)
+;   movl    $130, %r11d
+;   movq    %r11, rsp(16 + virtual offset)
+;   movl    $135, %r11d
+;   movq    %r11, rsp(8 + virtual offset)
+;   load_ext_name %tail_callee_stack_args+0, %r11
+;   movq    %r11, rsp(0 + virtual offset)
+;   movq    rsp(56 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 160)
+;   movq    %rax, rbp(stack args max - 152)
+;   movq    %r10, rbp(stack args max - 144)
+;   movq    %r12, rbp(stack args max - 136)
+;   movq    %r13, rbp(stack args max - 128)
+;   movq    %r14, rbp(stack args max - 120)
+;   movq    %r15, rbp(stack args max - 112)
+;   movq    %rbx, rbp(stack args max - 104)
+;   movq    %rdi, rbp(stack args max - 96)
+;   movq    %rsi, rbp(stack args max - 88)
+;   movq    %rdx, rbp(stack args max - 80)
+;   movq    %rcx, rbp(stack args max - 72)
+;   movq    %r8, rbp(stack args max - 64)
+;   movq    %r9, rbp(stack args max - 56)
+;   movq    rsp(48 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 48)
+;   movq    rsp(40 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 40)
+;   movq    rsp(32 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 32)
+;   movq    rsp(24 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 24)
+;   movq    rsp(16 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 16)
+;   movq    rsp(8 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 8)
 ;   movq    rsp(80 + virtual offset), %rcx
 ;   movq    rsp(88 + virtual offset), %rdx
 ;   movq    rsp(96 + virtual offset), %rsi
 ;   movq    rsp(104 + virtual offset), %rdi
 ;   movq    rsp(72 + virtual offset), %r8
 ;   movq    rsp(64 + virtual offset), %r9
-;   return_call_unknown %rax %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
+;   movq    rsp(0 + virtual offset), %r11
+;   return_call_unknown %r11 (160) %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0xa0, %rsp
+;   movq %rsp, %rbp
+;   movq 0xa0(%rsp), %r11
+;   movq %r11, (%rsp)
+;   movq 0xa8(%rsp), %r11
+;   movq %r11, 8(%rsp)
+;   subq $0xa0, %rsp
 ;   movq %rbx, 0x70(%rsp)
 ;   movq %r12, 0x78(%rsp)
 ;   movq %r13, 0x80(%rsp)
 ;   movq %r14, 0x88(%rsp)
 ;   movq %r15, 0x90(%rsp)
-; block1: ; offset 0x2d
+; block1: ; offset 0x50
 ;   movl $0xa, %edi
 ;   movq %rdi, 0x68(%rsp)
 ;   movl $0xf, %esi
@@ -355,115 +366,69 @@ block0:
 ;   movq %r8, 0x48(%rsp)
 ;   movl $0x23, %r9d
 ;   movq %r9, 0x40(%rsp)
-;   movl $0x28, %eax
-;   movl $0x2d, %r10d
-;   movl $0x32, %r11d
-;   movl $0x37, %r13d
-;   movl $0x3c, %r14d
-;   movl $0x41, %r15d
-;   movl $0x46, %ebx
-;   movl $0x4b, %r12d
+;   movl $0x28, %esi
+;   movq %rsi, 0x38(%rsp)
+;   movl $0x2d, %eax
+;   movl $0x32, %r10d
+;   movl $0x37, %r12d
+;   movl $0x3c, %r13d
+;   movl $0x41, %r14d
+;   movl $0x46, %r15d
+;   movl $0x4b, %ebx
 ;   movl $0x50, %edi
 ;   movl $0x55, %esi
-;   movq %rsi, 0x38(%rsp)
 ;   movl $0x5a, %edx
 ;   movl $0x5f, %ecx
 ;   movl $0x64, %r8d
 ;   movl $0x69, %r9d
-;   movl $0x6e, %esi
-;   movq %rsi, 0x30(%rsp)
-;   movl $0x73, %esi
-;   movq %rsi, 0x28(%rsp)
-;   movl $0x78, %esi
-;   movq %rsi, 0x20(%rsp)
-;   movl $0x7d, %esi
-;   movq %rsi, 0x18(%rsp)
-;   movl $0x82, %esi
-;   movq %rsi, 0x10(%rsp)
-;   movl $0x87, %esi
-;   movq %rsi, 8(%rsp)
-;   movabsq $0, %rsi ; reloc_external Abs8 %tail_callee_stack_args 0
-;   movq %rsi, (%rsp)
-;   subq $0xa0, %rsp
-;   subq $0xa0, %rbp
-;   movq 0xa0(%rsp), %rsi
-;   movq %rsi, (%rsp)
-;   movq 0xa8(%rsp), %rsi
-;   movq %rsi, 8(%rsp)
-;   movq 0xb0(%rsp), %rsi
-;   movq %rsi, 0x10(%rsp)
-;   movq 0xb8(%rsp), %rsi
-;   movq %rsi, 0x18(%rsp)
-;   movq 0xc0(%rsp), %rsi
-;   movq %rsi, 0x20(%rsp)
-;   movq 0xc8(%rsp), %rsi
-;   movq %rsi, 0x28(%rsp)
-;   movq 0xd0(%rsp), %rsi
-;   movq %rsi, 0x30(%rsp)
-;   movq 0xd8(%rsp), %rsi
-;   movq %rsi, 0x38(%rsp)
-;   movq 0xe0(%rsp), %rsi
-;   movq %rsi, 0x40(%rsp)
-;   movq 0xe8(%rsp), %rsi
-;   movq %rsi, 0x48(%rsp)
-;   movq 0xf0(%rsp), %rsi
-;   movq %rsi, 0x50(%rsp)
-;   movq 0xf8(%rsp), %rsi
-;   movq %rsi, 0x58(%rsp)
-;   movq 0x100(%rsp), %rsi
-;   movq %rsi, 0x60(%rsp)
-;   movq 0x108(%rsp), %rsi
-;   movq %rsi, 0x68(%rsp)
-;   movq 0x110(%rsp), %rsi
-;   movq %rsi, 0x70(%rsp)
-;   movq 0x118(%rsp), %rsi
-;   movq %rsi, 0x78(%rsp)
-;   movq 0x120(%rsp), %rsi
-;   movq %rsi, 0x80(%rsp)
-;   movq 0x128(%rsp), %rsi
-;   movq %rsi, 0x88(%rsp)
-;   movq 0x130(%rsp), %rsi
-;   movq %rsi, 0x90(%rsp)
-;   movq 0x138(%rsp), %rsi
-;   movq %rsi, 0x98(%rsp)
-;   movq 0x140(%rsp), %rsi
-;   movq %rsi, 0xa0(%rsp)
-;   movq 0x148(%rsp), %rsi
-;   movq %rsi, 0xa8(%rsp)
-;   movq %rax, 0x10(%rbp)
-;   movq %r10, 0x18(%rbp)
-;   movq %r11, 0x20(%rbp)
-;   movq %r13, 0x28(%rbp)
-;   movq %r14, 0x30(%rbp)
-;   movq %r15, 0x38(%rbp)
-;   movq %rbx, 0x40(%rbp)
-;   movq %r12, 0x48(%rbp)
+;   movl $0x6e, %r11d
+;   movq %r11, 0x30(%rsp)
+;   movl $0x73, %r11d
+;   movq %r11, 0x28(%rsp)
+;   movl $0x78, %r11d
+;   movq %r11, 0x20(%rsp)
+;   movl $0x7d, %r11d
+;   movq %r11, 0x18(%rsp)
+;   movl $0x82, %r11d
+;   movq %r11, 0x10(%rsp)
+;   movl $0x87, %r11d
+;   movq %r11, 8(%rsp)
+;   movabsq $0, %r11 ; reloc_external Abs8 %tail_callee_stack_args 0
+;   movq %r11, (%rsp)
+;   movq 0x38(%rsp), %r11
+;   movq %r11, 0x10(%rbp)
+;   movq %rax, 0x18(%rbp)
+;   movq %r10, 0x20(%rbp)
+;   movq %r12, 0x28(%rbp)
+;   movq %r13, 0x30(%rbp)
+;   movq %r14, 0x38(%rbp)
+;   movq %r15, 0x40(%rbp)
+;   movq %rbx, 0x48(%rbp)
 ;   movq %rdi, 0x50(%rbp)
-;   movq 0x38(%rsp), %rdi
-;   movq %rdi, 0x58(%rbp)
+;   movq %rsi, 0x58(%rbp)
 ;   movq %rdx, 0x60(%rbp)
 ;   movq %rcx, 0x68(%rbp)
 ;   movq %r8, 0x70(%rbp)
 ;   movq %r9, 0x78(%rbp)
-;   movq 0x30(%rsp), %rsi
-;   movq %rsi, 0x80(%rbp)
-;   movq 0x28(%rsp), %rsi
-;   movq %rsi, 0x88(%rbp)
-;   movq 0x20(%rsp), %rsi
-;   movq %rsi, 0x90(%rbp)
-;   movq 0x18(%rsp), %rsi
-;   movq %rsi, 0x98(%rbp)
-;   movq 0x10(%rsp), %rsi
-;   movq %rsi, 0xa0(%rbp)
-;   movq 8(%rsp), %rsi
-;   movq %rsi, 0xa8(%rbp)
-;   movq (%rsp), %rax
+;   movq 0x30(%rsp), %r11
+;   movq %r11, 0x80(%rbp)
+;   movq 0x28(%rsp), %r11
+;   movq %r11, 0x88(%rbp)
+;   movq 0x20(%rsp), %r11
+;   movq %r11, 0x90(%rbp)
+;   movq 0x18(%rsp), %r11
+;   movq %r11, 0x98(%rbp)
+;   movq 0x10(%rsp), %r11
+;   movq %r11, 0xa0(%rbp)
+;   movq 8(%rsp), %r11
+;   movq %r11, 0xa8(%rbp)
 ;   movq 0x50(%rsp), %rcx
 ;   movq 0x58(%rsp), %rdx
 ;   movq 0x60(%rsp), %rsi
 ;   movq 0x68(%rsp), %rdi
 ;   movq 0x48(%rsp), %r8
 ;   movq 0x40(%rsp), %r9
+;   movq (%rsp), %r11
 ;   movq 0x70(%rsp), %rbx
 ;   movq 0x78(%rsp), %r12
 ;   movq 0x80(%rsp), %r13
@@ -472,5 +437,5 @@ block0:
 ;   addq $0xa0, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   jmpq *%rax
+;   jmpq *%r11
 

--- a/cranelift/filetests/filetests/isa/x64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/x64/return-call.clif
@@ -41,7 +41,7 @@ block0(v0: i64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %callee_i64+0, %rax
-;   return_call_unknown %rax %rdi=%rdi
+;   return_call_unknown %rax (0) %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -66,7 +66,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   return_call_known TestCase(%callee_i64) %rdi=%rdi
+;   return_call_known TestCase(%callee_i64) (0) %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -132,7 +132,7 @@ block0(v0: f64):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %callee_f64+0, %rax
-;   return_call_unknown %rax %xmm0=%xmm0
+;   return_call_unknown %rax (0) %xmm0=%xmm0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -186,7 +186,7 @@ block0(v0: i8):
 ;   movq    %rsp, %rbp
 ; block0:
 ;   load_ext_name %callee_i8+0, %rax
-;   return_call_unknown %rax %rdi=%rdi
+;   return_call_unknown %rax (0) %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -209,7 +209,7 @@ block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    16(%rbp), %r10
+;   movq    rbp(stack args max - 16), %r10
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret 16
@@ -235,41 +235,35 @@ block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    %r8, %r10
 ;   movq    %rdx, %rdi
 ;   movq    %rcx, %rsi
+;   movq    %r8, %rdx
 ;   movq    %r9, %rcx
-;   movq    16(%rbp), %r8
-;   movq    24(%rbp), %r9
-;   movq    32(%rbp), %rax
-;   shrink_argument_area 16 %rdx
-;   movl    %eax, 16(%rbp)
-;   movq    %r10, %rdx
-;   return_call_known TestCase(%one_stack_arg) %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
+;   movq    rbp(stack args max - 32), %r8
+;   movq    rbp(stack args max - 24), %r9
+;   movq    rbp(stack args max - 16), %rax
+;   movl    %eax, rbp(stack args max - 16)
+;   return_call_known TestCase(%one_stack_arg) (16) %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movq %r8, %r10
 ;   movq %rdx, %rdi
 ;   movq %rcx, %rsi
+;   movq %r8, %rdx
 ;   movq %r9, %rcx
 ;   movq 0x10(%rbp), %r8
 ;   movq 0x18(%rbp), %r9
 ;   movq 0x20(%rbp), %rax
-;   movq 8(%rsp), %rdx
-;   movq %rdx, 0x18(%rsp)
-;   movq (%rsp), %rdx
-;   movq %rdx, 0x10(%rsp)
-;   addq $0x10, %rsp
-;   addq $0x10, %rbp
-;   movl %eax, 0x10(%rbp)
-;   movq %r10, %rdx
+;   movl %eax, 0x20(%rbp)
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   jmp 0x46 ; reloc_external CallPCRel4 %one_stack_arg -4
+;   movq (%rsp), %r11
+;   movq %r11, 0x10(%rsp)
+;   addq $0x10, %rsp
+;   jmp 0x35 ; reloc_external CallPCRel4 %one_stack_arg -4
 
 function %call_zero_stack_args(i32, i32, i32, i32, i32, i32, i32, i32, i8) -> i8 tail {
     fn0 = colocated %callee_i8(i8) -> i8 tail
@@ -282,11 +276,10 @@ block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    16(%rbp), %r10
-;   movq    24(%rbp), %rsi
-;   movq    32(%rbp), %rdi
-;   shrink_argument_area 32 %rdx
-;   return_call_known TestCase(%callee_i8) %rdi=%rdi
+;   movq    rbp(stack args max - 32), %r10
+;   movq    rbp(stack args max - 24), %rsi
+;   movq    rbp(stack args max - 16), %rdi
+;   return_call_known TestCase(%callee_i8) (0) %rdi=%rdi
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -296,15 +289,12 @@ block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32, v7: i32, v
 ;   movq 0x10(%rbp), %r10
 ;   movq 0x18(%rbp), %rsi
 ;   movq 0x20(%rbp), %rdi
-;   movq 8(%rsp), %rdx
-;   movq %rdx, 0x28(%rsp)
-;   movq (%rsp), %rdx
-;   movq %rdx, 0x20(%rsp)
-;   addq $0x20, %rsp
-;   addq $0x20, %rbp
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   jmp 0x34 ; reloc_external CallPCRel4 %callee_i8 -4
+;   movq (%rsp), %r11
+;   movq %r11, 0x20(%rsp)
+;   addq $0x20, %rsp
+;   jmp 0x26 ; reloc_external CallPCRel4 %callee_i8 -4
 
 ;;;; Test growing the argument area when it's non-empty ;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -318,36 +308,41 @@ block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ; VCode:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
+;   subq    %rsp, $16, %rsp
+;   movq    %rsp, %rbp
+;   movq    16(%rsp), %r11
+;   movq    %r11, 0(%rsp)
+;   movq    24(%rsp), %r11
+;   movq    %r11, 8(%rsp)
 ; block0:
 ;   movq    %rdx, %r10
 ;   movq    %rcx, %rdx
 ;   movq    %r8, %rcx
 ;   movq    %r9, %r8
-;   movq    16(%rbp), %r9
-;   grow_argument_area 16 %rax
-;   movl    %edi, 16(%rbp)
-;   movl    %edi, 24(%rbp)
-;   movl    %esi, 32(%rbp)
+;   movq    rbp(stack args max - 16), %r9
+;   movl    %edi, rbp(stack args max - 32)
+;   movl    %edi, rbp(stack args max - 24)
+;   movl    %esi, rbp(stack args max - 16)
 ;   movq    %rsi, %rdi
 ;   movq    %r10, %rsi
-;   return_call_known TestCase(%call_one_stack_arg) %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
+;   return_call_known TestCase(%call_one_stack_arg) (32) %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
-; block1: ; offset 0x4
+;   subq $0x10, %rsp
+;   movq %rsp, %rbp
+;   movq 0x10(%rsp), %r11
+;   movq %r11, (%rsp)
+;   movq 0x18(%rsp), %r11
+;   movq %r11, 8(%rsp)
+; block1: ; offset 0x1e
 ;   movq %rdx, %r10
 ;   movq %rcx, %rdx
 ;   movq %r8, %rcx
 ;   movq %r9, %r8
-;   movq 0x10(%rbp), %r9
-;   subq $0x10, %rsp
-;   subq $0x10, %rbp
-;   movq 0x10(%rsp), %rax
-;   movq %rax, (%rsp)
-;   movq 0x18(%rsp), %rax
-;   movq %rax, 8(%rsp)
+;   movq 0x20(%rbp), %r9
 ;   movl %edi, 0x10(%rbp)
 ;   movl %edi, 0x18(%rbp)
 ;   movl %esi, 0x20(%rbp)
@@ -355,7 +350,7 @@ block0(v0: i32, v1: i32, v2: i32, v3: i32, v4: i32, v5: i32, v6: i32):
 ;   movq %r10, %rsi
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   jmp 0x47 ; reloc_external CallPCRel4 %call_one_stack_arg -4
+;   jmp 0x46 ; reloc_external CallPCRel4 %call_one_stack_arg -4
 
 ;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -368,26 +363,26 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    16(%rbp), %r10
-;   movq    24(%rbp), %rsi
-;   movq    32(%rbp), %rax
-;   movq    40(%rbp), %rdx
-;   movq    48(%rbp), %r9
-;   movq    56(%rbp), %r11
-;   movq    64(%rbp), %rdi
-;   movq    72(%rbp), %rcx
-;   movq    80(%rbp), %r8
-;   movq    88(%rbp), %r10
-;   movq    96(%rbp), %rsi
-;   movq    104(%rbp), %rax
-;   movq    112(%rbp), %rdx
-;   movq    120(%rbp), %r9
-;   movq    128(%rbp), %r11
-;   movq    136(%rbp), %rdi
-;   movq    144(%rbp), %rcx
-;   movq    152(%rbp), %r8
-;   movq    160(%rbp), %r10
-;   movq    168(%rbp), %rax
+;   movq    rbp(stack args max - 160), %r10
+;   movq    rbp(stack args max - 152), %rsi
+;   movq    rbp(stack args max - 144), %rax
+;   movq    rbp(stack args max - 136), %rdx
+;   movq    rbp(stack args max - 128), %r9
+;   movq    rbp(stack args max - 120), %r11
+;   movq    rbp(stack args max - 112), %rdi
+;   movq    rbp(stack args max - 104), %rcx
+;   movq    rbp(stack args max - 96), %r8
+;   movq    rbp(stack args max - 88), %r10
+;   movq    rbp(stack args max - 80), %rsi
+;   movq    rbp(stack args max - 72), %rax
+;   movq    rbp(stack args max - 64), %rdx
+;   movq    rbp(stack args max - 56), %r9
+;   movq    rbp(stack args max - 48), %r11
+;   movq    rbp(stack args max - 40), %rdi
+;   movq    rbp(stack args max - 32), %rcx
+;   movq    rbp(stack args max - 24), %r8
+;   movq    rbp(stack args max - 16), %r10
+;   movq    rbp(stack args max - 8), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret 160
@@ -458,6 +453,12 @@ block0:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ;   subq    %rsp, $160, %rsp
+;   movq    %rsp, %rbp
+;   movq    160(%rsp), %r11
+;   movq    %r11, 0(%rsp)
+;   movq    168(%rsp), %r11
+;   movq    %r11, 8(%rsp)
+;   subq    %rsp, $160, %rsp
 ;   movq    %rbx, 112(%rsp)
 ;   movq    %r12, 120(%rsp)
 ;   movq    %r13, 128(%rsp)
@@ -476,81 +477,86 @@ block0:
 ;   movq    %r8, rsp(64 + virtual offset)
 ;   movl    $35, %r9d
 ;   movq    %r9, rsp(56 + virtual offset)
-;   movl    $40, %eax
-;   movl    $45, %r10d
-;   movl    $50, %r11d
-;   movl    $55, %r13d
-;   movl    $60, %r14d
-;   movl    $65, %r15d
-;   movl    $70, %ebx
-;   movl    $75, %r12d
+;   movl    $40, %esi
+;   movq    %rsi, rsp(48 + virtual offset)
+;   movl    $45, %eax
+;   movl    $50, %r10d
+;   movl    $55, %r12d
+;   movl    $60, %r13d
+;   movl    $65, %r14d
+;   movl    $70, %r15d
+;   movl    $75, %ebx
 ;   movl    $80, %edi
 ;   movl    $85, %esi
-;   movq    %rsi, rsp(48 + virtual offset)
 ;   movl    $90, %edx
 ;   movl    $95, %ecx
 ;   movl    $100, %r8d
 ;   movl    $105, %r9d
-;   movl    $110, %esi
-;   movq    %rsi, rsp(40 + virtual offset)
-;   movl    $115, %esi
-;   movq    %rsi, rsp(32 + virtual offset)
-;   movl    $120, %esi
-;   movq    %rsi, rsp(24 + virtual offset)
-;   movl    $125, %esi
-;   movq    %rsi, rsp(16 + virtual offset)
-;   movl    $130, %esi
-;   movq    %rsi, rsp(8 + virtual offset)
-;   movl    $135, %esi
-;   movq    %rsi, rsp(0 + virtual offset)
-;   grow_argument_area 160 %rsi
-;   movq    %rax, 16(%rbp)
-;   movq    %r10, 24(%rbp)
-;   movq    %r11, 32(%rbp)
-;   movq    %r13, 40(%rbp)
-;   movq    %r14, 48(%rbp)
-;   movq    %r15, 56(%rbp)
-;   movq    %rbx, 64(%rbp)
-;   movq    %r12, 72(%rbp)
-;   movq    %rdi, 80(%rbp)
-;   movq    rsp(48 + virtual offset), %rdi
-;   movq    %rdi, 88(%rbp)
-;   movq    %rdx, 96(%rbp)
-;   movq    %rcx, 104(%rbp)
-;   movq    %r8, 112(%rbp)
-;   movq    %r9, 120(%rbp)
-;   movq    rsp(40 + virtual offset), %rsi
-;   movq    %rsi, 128(%rbp)
-;   movq    rsp(32 + virtual offset), %rsi
-;   movq    %rsi, 136(%rbp)
-;   movq    rsp(24 + virtual offset), %rsi
-;   movq    %rsi, 144(%rbp)
-;   movq    rsp(16 + virtual offset), %rsi
-;   movq    %rsi, 152(%rbp)
-;   movq    rsp(8 + virtual offset), %rsi
-;   movq    %rsi, 160(%rbp)
-;   movq    rsp(0 + virtual offset), %rsi
-;   movq    %rsi, 168(%rbp)
-;   load_ext_name %tail_callee_stack_args+0, %r10
+;   movl    $110, %r11d
+;   movq    %r11, rsp(40 + virtual offset)
+;   movl    $115, %r11d
+;   movq    %r11, rsp(32 + virtual offset)
+;   movl    $120, %r11d
+;   movq    %r11, rsp(24 + virtual offset)
+;   movl    $125, %r11d
+;   movq    %r11, rsp(16 + virtual offset)
+;   movl    $130, %r11d
+;   movq    %r11, rsp(8 + virtual offset)
+;   movl    $135, %r11d
+;   movq    %r11, rsp(0 + virtual offset)
+;   movq    rsp(48 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 160)
+;   movq    %rax, rbp(stack args max - 152)
+;   movq    %r10, rbp(stack args max - 144)
+;   movq    %r12, rbp(stack args max - 136)
+;   movq    %r13, rbp(stack args max - 128)
+;   movq    %r14, rbp(stack args max - 120)
+;   movq    %r15, rbp(stack args max - 112)
+;   movq    %rbx, rbp(stack args max - 104)
+;   movq    %rdi, rbp(stack args max - 96)
+;   movq    %rsi, rbp(stack args max - 88)
+;   movq    %rdx, rbp(stack args max - 80)
+;   movq    %rcx, rbp(stack args max - 72)
+;   movq    %r8, rbp(stack args max - 64)
+;   movq    %r9, rbp(stack args max - 56)
+;   movq    rsp(40 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 48)
+;   movq    rsp(32 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 40)
+;   movq    rsp(24 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 32)
+;   movq    rsp(16 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 24)
+;   movq    rsp(8 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 16)
+;   movq    rsp(0 + virtual offset), %r11
+;   movq    %r11, rbp(stack args max - 8)
+;   load_ext_name %tail_callee_stack_args+0, %rax
 ;   movq    rsp(72 + virtual offset), %rcx
 ;   movq    rsp(80 + virtual offset), %rdx
 ;   movq    rsp(88 + virtual offset), %rsi
 ;   movq    rsp(96 + virtual offset), %rdi
 ;   movq    rsp(64 + virtual offset), %r8
 ;   movq    rsp(56 + virtual offset), %r9
-;   return_call_unknown %r10 %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
+;   return_call_unknown %rax (160) %rdi=%rdi %rsi=%rsi %rdx=%rdx %rcx=%rcx %r8=%r8 %r9=%r9
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ;   subq $0xa0, %rsp
+;   movq %rsp, %rbp
+;   movq 0xa0(%rsp), %r11
+;   movq %r11, (%rsp)
+;   movq 0xa8(%rsp), %r11
+;   movq %r11, 8(%rsp)
+;   subq $0xa0, %rsp
 ;   movq %rbx, 0x70(%rsp)
 ;   movq %r12, 0x78(%rsp)
 ;   movq %r13, 0x80(%rsp)
 ;   movq %r14, 0x88(%rsp)
 ;   movq %r15, 0x90(%rsp)
-; block1: ; offset 0x2d
+; block1: ; offset 0x50
 ;   movl $0xa, %edi
 ;   movq %rdi, 0x60(%rsp)
 ;   movl $0xf, %esi
@@ -563,107 +569,61 @@ block0:
 ;   movq %r8, 0x40(%rsp)
 ;   movl $0x23, %r9d
 ;   movq %r9, 0x38(%rsp)
-;   movl $0x28, %eax
-;   movl $0x2d, %r10d
-;   movl $0x32, %r11d
-;   movl $0x37, %r13d
-;   movl $0x3c, %r14d
-;   movl $0x41, %r15d
-;   movl $0x46, %ebx
-;   movl $0x4b, %r12d
+;   movl $0x28, %esi
+;   movq %rsi, 0x30(%rsp)
+;   movl $0x2d, %eax
+;   movl $0x32, %r10d
+;   movl $0x37, %r12d
+;   movl $0x3c, %r13d
+;   movl $0x41, %r14d
+;   movl $0x46, %r15d
+;   movl $0x4b, %ebx
 ;   movl $0x50, %edi
 ;   movl $0x55, %esi
-;   movq %rsi, 0x30(%rsp)
 ;   movl $0x5a, %edx
 ;   movl $0x5f, %ecx
 ;   movl $0x64, %r8d
 ;   movl $0x69, %r9d
-;   movl $0x6e, %esi
-;   movq %rsi, 0x28(%rsp)
-;   movl $0x73, %esi
-;   movq %rsi, 0x20(%rsp)
-;   movl $0x78, %esi
-;   movq %rsi, 0x18(%rsp)
-;   movl $0x7d, %esi
-;   movq %rsi, 0x10(%rsp)
-;   movl $0x82, %esi
-;   movq %rsi, 8(%rsp)
-;   movl $0x87, %esi
-;   movq %rsi, (%rsp)
-;   subq $0xa0, %rsp
-;   subq $0xa0, %rbp
-;   movq 0xa0(%rsp), %rsi
-;   movq %rsi, (%rsp)
-;   movq 0xa8(%rsp), %rsi
-;   movq %rsi, 8(%rsp)
-;   movq 0xb0(%rsp), %rsi
-;   movq %rsi, 0x10(%rsp)
-;   movq 0xb8(%rsp), %rsi
-;   movq %rsi, 0x18(%rsp)
-;   movq 0xc0(%rsp), %rsi
-;   movq %rsi, 0x20(%rsp)
-;   movq 0xc8(%rsp), %rsi
-;   movq %rsi, 0x28(%rsp)
-;   movq 0xd0(%rsp), %rsi
-;   movq %rsi, 0x30(%rsp)
-;   movq 0xd8(%rsp), %rsi
-;   movq %rsi, 0x38(%rsp)
-;   movq 0xe0(%rsp), %rsi
-;   movq %rsi, 0x40(%rsp)
-;   movq 0xe8(%rsp), %rsi
-;   movq %rsi, 0x48(%rsp)
-;   movq 0xf0(%rsp), %rsi
-;   movq %rsi, 0x50(%rsp)
-;   movq 0xf8(%rsp), %rsi
-;   movq %rsi, 0x58(%rsp)
-;   movq 0x100(%rsp), %rsi
-;   movq %rsi, 0x60(%rsp)
-;   movq 0x108(%rsp), %rsi
-;   movq %rsi, 0x68(%rsp)
-;   movq 0x110(%rsp), %rsi
-;   movq %rsi, 0x70(%rsp)
-;   movq 0x118(%rsp), %rsi
-;   movq %rsi, 0x78(%rsp)
-;   movq 0x120(%rsp), %rsi
-;   movq %rsi, 0x80(%rsp)
-;   movq 0x128(%rsp), %rsi
-;   movq %rsi, 0x88(%rsp)
-;   movq 0x130(%rsp), %rsi
-;   movq %rsi, 0x90(%rsp)
-;   movq 0x138(%rsp), %rsi
-;   movq %rsi, 0x98(%rsp)
-;   movq 0x140(%rsp), %rsi
-;   movq %rsi, 0xa0(%rsp)
-;   movq 0x148(%rsp), %rsi
-;   movq %rsi, 0xa8(%rsp)
-;   movq %rax, 0x10(%rbp)
-;   movq %r10, 0x18(%rbp)
-;   movq %r11, 0x20(%rbp)
-;   movq %r13, 0x28(%rbp)
-;   movq %r14, 0x30(%rbp)
-;   movq %r15, 0x38(%rbp)
-;   movq %rbx, 0x40(%rbp)
-;   movq %r12, 0x48(%rbp)
+;   movl $0x6e, %r11d
+;   movq %r11, 0x28(%rsp)
+;   movl $0x73, %r11d
+;   movq %r11, 0x20(%rsp)
+;   movl $0x78, %r11d
+;   movq %r11, 0x18(%rsp)
+;   movl $0x7d, %r11d
+;   movq %r11, 0x10(%rsp)
+;   movl $0x82, %r11d
+;   movq %r11, 8(%rsp)
+;   movl $0x87, %r11d
+;   movq %r11, (%rsp)
+;   movq 0x30(%rsp), %r11
+;   movq %r11, 0x10(%rbp)
+;   movq %rax, 0x18(%rbp)
+;   movq %r10, 0x20(%rbp)
+;   movq %r12, 0x28(%rbp)
+;   movq %r13, 0x30(%rbp)
+;   movq %r14, 0x38(%rbp)
+;   movq %r15, 0x40(%rbp)
+;   movq %rbx, 0x48(%rbp)
 ;   movq %rdi, 0x50(%rbp)
-;   movq 0x30(%rsp), %rdi
-;   movq %rdi, 0x58(%rbp)
+;   movq %rsi, 0x58(%rbp)
 ;   movq %rdx, 0x60(%rbp)
 ;   movq %rcx, 0x68(%rbp)
 ;   movq %r8, 0x70(%rbp)
 ;   movq %r9, 0x78(%rbp)
-;   movq 0x28(%rsp), %rsi
-;   movq %rsi, 0x80(%rbp)
-;   movq 0x20(%rsp), %rsi
-;   movq %rsi, 0x88(%rbp)
-;   movq 0x18(%rsp), %rsi
-;   movq %rsi, 0x90(%rbp)
-;   movq 0x10(%rsp), %rsi
-;   movq %rsi, 0x98(%rbp)
-;   movq 8(%rsp), %rsi
-;   movq %rsi, 0xa0(%rbp)
-;   movq (%rsp), %rsi
-;   movq %rsi, 0xa8(%rbp)
-;   movabsq $0, %r10 ; reloc_external Abs8 %tail_callee_stack_args 0
+;   movq 0x28(%rsp), %r11
+;   movq %r11, 0x80(%rbp)
+;   movq 0x20(%rsp), %r11
+;   movq %r11, 0x88(%rbp)
+;   movq 0x18(%rsp), %r11
+;   movq %r11, 0x90(%rbp)
+;   movq 0x10(%rsp), %r11
+;   movq %r11, 0x98(%rbp)
+;   movq 8(%rsp), %r11
+;   movq %r11, 0xa0(%rbp)
+;   movq (%rsp), %r11
+;   movq %r11, 0xa8(%rbp)
+;   movabsq $0, %rax ; reloc_external Abs8 %tail_callee_stack_args 0
 ;   movq 0x48(%rsp), %rcx
 ;   movq 0x50(%rsp), %rdx
 ;   movq 0x58(%rsp), %rsi
@@ -678,5 +638,5 @@ block0:
 ;   addq $0xa0, %rsp
 ;   movq %rbp, %rsp
 ;   popq %rbp
-;   jmpq *%r10
+;   jmpq *%rax
 

--- a/cranelift/filetests/filetests/isa/x64/struct-arg.clif
+++ b/cranelift/filetests/filetests/isa/x64/struct-arg.clif
@@ -11,7 +11,7 @@ block0(v0: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lea     16(%rbp), %rsi
+;   lea     rbp(stack args max - 64), %rsi
 ;   movzbq  0(%rsi), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
@@ -40,7 +40,7 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lea     16(%rbp), %rcx
+;   lea     rbp(stack args max - 64), %rcx
 ;   movzbq  0(%rdi), %rax
 ;   movzbq  0(%rcx), %r9
 ;   addl    %eax, %r9d, %eax
@@ -163,8 +163,8 @@ block0(v0: i64, v1: i64):
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   lea     16(%rbp), %rsi
-;   lea     144(%rbp), %rcx
+;   lea     rbp(stack args max - 192), %rsi
+;   lea     rbp(stack args max - 64), %rcx
 ;   movzbq  0(%rsi), %rax
 ;   movzbq  0(%rcx), %r9
 ;   addl    %eax, %r9d, %eax

--- a/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/x64/tail-call-conv.clif
@@ -12,15 +12,15 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movq    16(%rbp), %r10
-;   movq    24(%rbp), %rsi
-;   movq    32(%rbp), %rax
-;   movq    40(%rbp), %rdx
-;   movq    48(%rbp), %r9
-;   movq    56(%rbp), %r11
-;   movq    64(%rbp), %rdi
-;   movq    72(%rbp), %rcx
-;   movq    80(%rbp), %rax
+;   movq    rbp(stack args max - 80), %r10
+;   movq    rbp(stack args max - 72), %rsi
+;   movq    rbp(stack args max - 64), %rax
+;   movq    rbp(stack args max - 56), %rdx
+;   movq    rbp(stack args max - 48), %r9
+;   movq    rbp(stack args max - 40), %r11
+;   movq    rbp(stack args max - 32), %rdi
+;   movq    rbp(stack args max - 24), %rcx
+;   movq    rbp(stack args max - 16), %rax
 ;   movq    %rbp, %rsp
 ;   popq    %rbp
 ;   ret 80
@@ -475,34 +475,34 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   movq    %rcx, rsp(24 + virtual offset)
 ;   movq    %r8, rsp(32 + virtual offset)
 ;   movq    %r9, rsp(40 + virtual offset)
-;   movq    16(%rbp), %r9
+;   movq    rbp(stack args max - 176), %r9
 ;   movq    %r9, rsp(48 + virtual offset)
-;   movq    24(%rbp), %r10
+;   movq    rbp(stack args max - 168), %r10
 ;   movq    %r10, rsp(56 + virtual offset)
-;   movq    32(%rbp), %r11
+;   movq    rbp(stack args max - 160), %r11
 ;   movq    %r11, rsp(64 + virtual offset)
-;   movq    40(%rbp), %rdx
-;   movq    48(%rbp), %r9
+;   movq    rbp(stack args max - 152), %rdx
+;   movq    rbp(stack args max - 144), %r9
 ;   movq    %r9, rsp(72 + virtual offset)
-;   movq    56(%rbp), %r11
+;   movq    rbp(stack args max - 136), %r11
 ;   movq    %r11, rsp(80 + virtual offset)
-;   movq    64(%rbp), %r11
-;   movq    72(%rbp), %r10
-;   movq    80(%rbp), %r9
-;   movq    88(%rbp), %rsi
+;   movq    rbp(stack args max - 128), %r11
+;   movq    rbp(stack args max - 120), %r10
+;   movq    rbp(stack args max - 112), %r9
+;   movq    rbp(stack args max - 104), %rsi
 ;   movq    %rsi, rsp(88 + virtual offset)
-;   movq    96(%rbp), %r13
-;   movq    104(%rbp), %r15
-;   movq    112(%rbp), %r12
-;   movq    120(%rbp), %r14
-;   movq    128(%rbp), %rbx
-;   movq    136(%rbp), %rdi
+;   movq    rbp(stack args max - 96), %r13
+;   movq    rbp(stack args max - 88), %r15
+;   movq    rbp(stack args max - 80), %r12
+;   movq    rbp(stack args max - 72), %r14
+;   movq    rbp(stack args max - 64), %rbx
+;   movq    rbp(stack args max - 56), %rdi
 ;   movq    %rdi, rsp(96 + virtual offset)
-;   movq    144(%rbp), %rcx
-;   movq    152(%rbp), %r8
-;   movq    160(%rbp), %rdi
-;   movq    168(%rbp), %rsi
-;   movq    176(%rbp), %rax
+;   movq    rbp(stack args max - 48), %rcx
+;   movq    rbp(stack args max - 40), %r8
+;   movq    rbp(stack args max - 32), %rdi
+;   movq    rbp(stack args max - 24), %rsi
+;   movq    rbp(stack args max - 16), %rax
 ;   movq    %rdx, 0(%rax)
 ;   movq    rsp(72 + virtual offset), %rdx
 ;   movq    %rdx, 8(%rax)

--- a/cranelift/filetests/filetests/isa/x64/tail-stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/x64/tail-stack-limit.clif
@@ -25,10 +25,10 @@ block0(v0: i64, v1: i8, v2: i8, v3: i8, v4: i8, v5: i8, v6: i8, v7: i8, v8: i128
 ;   jnbe #trap=stk_ovf
 ;   subq    %rsp, $16, %rsp
 ; block0:
-;   movq    16(%rbp), %r10
-;   movq    24(%rbp), %rsi
-;   movq    32(%rbp), %rax
-;   movq    40(%rbp), %rcx
+;   movq    rbp(stack args max - 32), %r10
+;   movq    rbp(stack args max - 24), %rsi
+;   movq    rbp(stack args max - 16), %rax
+;   movq    rbp(stack args max - 8), %rcx
 ;   addq    %rsp, $16, %rsp
 ;   movq    %rbp, %rsp
 ;   popq    %rbp


### PR DESCRIPTION
`return_call` instructions reuse the incoming argument area of the caller's frame. As such if the caller's incoming argument area is  not exactly the right size for the callee, some resizing will need to take place to ensure that the return address, frame pointer, clobbers, and stack slots don't get overwritten. The current solution on the main branch for the x64 backend is to explicitly resize the frame via `ShrinkArgumentArea` or `GrowArgumentArea` right before the `return_call` arguments are written to the stack, ensuring that there is sufficient space. While this does work, it does make a `return_call` more expensive when the resizing is necessary.

To simplify this, we instead resize the incoming argument area in the function prologue to accommodate the largest possible argument area of any `return_call` instruction in the function. We then shrink back down when necessary before an individual `return_call`. This simplifies the implementation of tail calls on x86_64, as we no longer need to move the entire frame, just the return address before we jump to the tail-callee.

Co-authored-by: Jamey Sharp <jsharp@fastly.com>

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
