### PR TITLE
Release Wasmtime 18.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,7 +224,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "18.0.3"
+version = "18.0.4"
 
 [[package]]
 name = "byteorder"
@@ -558,7 +558,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -566,14 +566,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -601,25 +601,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.105.3"
+version = "0.105.4"
 
 [[package]]
 name = "cranelift-control"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "serde",
  "serde_derive",
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.0",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -696,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -705,7 +705,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -726,7 +726,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -738,7 +738,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -762,7 +762,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -772,7 +772,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -819,7 +819,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.105.3"
+version = "0.105.4"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -2877,7 +2877,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "wasmparser 0.121.0",
@@ -2927,7 +2927,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -2966,7 +2966,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "byte-array-literals",
  "object",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3216,14 +3216,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3239,14 +3239,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3272,7 +3272,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "base64",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3381,11 +3381,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "18.0.3"
+version = "18.0.4"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3408,7 +3408,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3422,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3463,7 +3463,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3477,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3546,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "object",
  "once_cell",
@@ -3556,7 +3556,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3565,7 +3565,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "cc",
@@ -3596,7 +3596,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-types"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3652,7 +3652,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3678,7 +3678,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "log",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "log",
@@ -3715,7 +3715,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "heck",
@@ -3740,7 +3740,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "18.0.3"
+version = "18.0.4"
 
 [[package]]
 name = "wast"
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "anyhow",
  "heck",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "18.0.3"
+version = "18.0.4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3887,7 +3887,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.16.3"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "18.0.3"
+version = "18.0.4"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -156,57 +156,57 @@ all = 'allow'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=18.0.3" }
-wasmtime = { path = "crates/wasmtime", version = "18.0.3", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=18.0.3" }
-wasmtime-cache = { path = "crates/cache", version = "=18.0.3" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=18.0.3" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=18.0.3" }
-wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=18.0.3" }
-wasmtime-winch = { path = "crates/winch", version = "=18.0.3" }
-wasmtime-environ = { path = "crates/environ", version = "=18.0.3" }
-wasmtime-explorer = { path = "crates/explorer", version = "=18.0.3" }
-wasmtime-fiber = { path = "crates/fiber", version = "=18.0.3" }
-wasmtime-types = { path = "crates/types", version = "18.0.3" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=18.0.3" }
-wasmtime-runtime = { path = "crates/runtime", version = "=18.0.3" }
-wasmtime-wast = { path = "crates/wast", version = "=18.0.3" }
-wasmtime-wasi = { path = "crates/wasi", version = "18.0.3", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=18.0.3", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "18.0.3" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "18.0.3" }
-wasmtime-component-util = { path = "crates/component-util", version = "=18.0.3" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=18.0.3" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=18.0.3" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=18.0.3" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=18.0.4" }
+wasmtime = { path = "crates/wasmtime", version = "18.0.4", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=18.0.4" }
+wasmtime-cache = { path = "crates/cache", version = "=18.0.4" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=18.0.4" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=18.0.4" }
+wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=18.0.4" }
+wasmtime-winch = { path = "crates/winch", version = "=18.0.4" }
+wasmtime-environ = { path = "crates/environ", version = "=18.0.4" }
+wasmtime-explorer = { path = "crates/explorer", version = "=18.0.4" }
+wasmtime-fiber = { path = "crates/fiber", version = "=18.0.4" }
+wasmtime-types = { path = "crates/types", version = "18.0.4" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=18.0.4" }
+wasmtime-runtime = { path = "crates/runtime", version = "=18.0.4" }
+wasmtime-wast = { path = "crates/wast", version = "=18.0.4" }
+wasmtime-wasi = { path = "crates/wasi", version = "18.0.4", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=18.0.4", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "18.0.4" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "18.0.4" }
+wasmtime-component-util = { path = "crates/component-util", version = "=18.0.4" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=18.0.4" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=18.0.4" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=18.0.4" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=18.0.3", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=18.0.3" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=18.0.3" }
-wasi-common = { path = "crates/wasi-common", version = "=18.0.3", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=18.0.4", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=18.0.4" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=18.0.4" }
+wasi-common = { path = "crates/wasi-common", version = "=18.0.4", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=18.0.3" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=18.0.3" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=18.0.4" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=18.0.4" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.105.3" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.105.3", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.105.3" }
-cranelift-entity = { path = "cranelift/entity", version = "0.105.3" }
-cranelift-native = { path = "cranelift/native", version = "0.105.3" }
-cranelift-module = { path = "cranelift/module", version = "0.105.3" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.105.3" }
-cranelift-reader = { path = "cranelift/reader", version = "0.105.3" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.105.4" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.105.4", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.105.4" }
+cranelift-entity = { path = "cranelift/entity", version = "0.105.4" }
+cranelift-native = { path = "cranelift/native", version = "0.105.4" }
+cranelift-module = { path = "cranelift/module", version = "0.105.4" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.105.4" }
+cranelift-reader = { path = "cranelift/reader", version = "0.105.4" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.105.3" }
-cranelift-jit = { path = "cranelift/jit", version = "0.105.3" }
+cranelift-object = { path = "cranelift/object", version = "0.105.4" }
+cranelift-jit = { path = "cranelift/jit", version = "0.105.4" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.105.3" }
-cranelift-control = { path = "cranelift/control", version = "0.105.3" }
-cranelift = { path = "cranelift/umbrella", version = "0.105.3" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.105.4" }
+cranelift-control = { path = "cranelift/control", version = "0.105.4" }
+cranelift = { path = "cranelift/umbrella", version = "0.105.4" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.16.3" }
+winch-codegen = { path = "winch/codegen", version = "=0.16.4" }
 winch-filetests = { path = "winch/filetests" }
 winch-test-macros = { path = "winch/test-macros" }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,6 +13,9 @@ Released 2024-04-11
 * cranelift: Include clobbers and outgoing args in stack limit.
   [#8334](https://github.com/bytecodealliance/wasmtime/pull/8334)
 
+* Fix a panic when compiling invalid components.
+  [#8322](https://github.com/bytecodealliance/wasmtime/issues/8322)
+
 --------------------------------------------------------------------------------
 
 ## 18.0.3

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,9 @@ Released 2024-04-11
   packages.
   [#8305](https://github.com/bytecodealliance/wasmtime/pull/8305)
 
+* cranelift: Include clobbers and outgoing args in stack limit.
+  [#8334](https://github.com/bytecodealliance/wasmtime/pull/8334)
+
 --------------------------------------------------------------------------------
 
 ## 18.0.3

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,17 @@
 --------------------------------------------------------------------------------
 
+## 18.0.4
+
+Released 2024-04-11
+
+### Fixed
+
+* Fix `bindgen!` with `trappable_error_type` using unversioned/versioned
+  packages.
+  [#8305](https://github.com/bytecodealliance/wasmtime/pull/8305)
+
+--------------------------------------------------------------------------------
+
 ## 18.0.3
 
 Released 2024-03-12

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.105.3"
+version = "0.105.4"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.105.3"
+version = "0.105.4"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.105.3" }
+cranelift-codegen-shared = { path = "./shared", version = "0.105.4" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -44,8 +44,8 @@ criterion = { version = "0.5.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.105.3" }
-cranelift-isle = { path = "../isle/isle", version = "=0.105.3" }
+cranelift-codegen-meta = { path = "meta", version = "0.105.4" }
+cranelift-isle = { path = "../isle/isle", version = "=0.105.4" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.105.3"
+version = "0.105.4"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.105.3" }
+cranelift-codegen-shared = { path = "../shared", version = "0.105.4" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.105.3"
+version = "0.105.4"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.105.3"
+version = "0.105.4"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.105.3"
+version = "0.105.4"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.105.3"
+version = "0.105.4"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.105.3"
+version = "0.105.4"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.105.3"
+version = "0.105.4"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.105.3"
+version = "0.105.4"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.105.3"
+version = "0.105.4"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.105.3"
+version = "0.105.4"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.105.3"
+version = "0.105.4"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.105.3"
+version = "0.105.4"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.105.3"
+version = "0.105.4"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.105.3"
+version = "0.105.4"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.105.3"
+version = "0.105.4"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -205,7 +205,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "18.0.3"
+#define WASMTIME_VERSION "18.0.4"
 /**
  * \brief Wasmtime major version number.
  */
@@ -217,7 +217,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 3
+#define WASMTIME_VERSION_PATCH 4
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -17,6 +17,10 @@ audited_as = "0.105.1"
 version = "0.105.3"
 audited_as = "0.105.2"
 
+[[unpublished.cranelift]]
+version = "0.105.4"
+audited_as = "0.105.3"
+
 [[unpublished.cranelift-bforest]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -32,6 +36,10 @@ audited_as = "0.105.1"
 [[unpublished.cranelift-bforest]]
 version = "0.105.3"
 audited_as = "0.105.2"
+
+[[unpublished.cranelift-bforest]]
+version = "0.105.4"
+audited_as = "0.105.3"
 
 [[unpublished.cranelift-codegen]]
 version = "0.105.0"
@@ -49,6 +57,10 @@ audited_as = "0.105.1"
 version = "0.105.3"
 audited_as = "0.105.2"
 
+[[unpublished.cranelift-codegen]]
+version = "0.105.4"
+audited_as = "0.105.3"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -64,6 +76,10 @@ audited_as = "0.105.1"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.105.3"
 audited_as = "0.105.2"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.105.4"
+audited_as = "0.105.3"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.105.0"
@@ -81,6 +97,10 @@ audited_as = "0.105.1"
 version = "0.105.3"
 audited_as = "0.105.2"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.105.4"
+audited_as = "0.105.3"
+
 [[unpublished.cranelift-control]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -96,6 +116,10 @@ audited_as = "0.105.1"
 [[unpublished.cranelift-control]]
 version = "0.105.3"
 audited_as = "0.105.2"
+
+[[unpublished.cranelift-control]]
+version = "0.105.4"
+audited_as = "0.105.3"
 
 [[unpublished.cranelift-entity]]
 version = "0.105.0"
@@ -113,6 +137,10 @@ audited_as = "0.105.1"
 version = "0.105.3"
 audited_as = "0.105.2"
 
+[[unpublished.cranelift-entity]]
+version = "0.105.4"
+audited_as = "0.105.3"
+
 [[unpublished.cranelift-frontend]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -128,6 +156,10 @@ audited_as = "0.105.1"
 [[unpublished.cranelift-frontend]]
 version = "0.105.3"
 audited_as = "0.105.2"
+
+[[unpublished.cranelift-frontend]]
+version = "0.105.4"
+audited_as = "0.105.3"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.105.0"
@@ -145,6 +177,10 @@ audited_as = "0.105.1"
 version = "0.105.3"
 audited_as = "0.105.2"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.105.4"
+audited_as = "0.105.3"
+
 [[unpublished.cranelift-isle]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -160,6 +196,10 @@ audited_as = "0.105.1"
 [[unpublished.cranelift-isle]]
 version = "0.105.3"
 audited_as = "0.105.2"
+
+[[unpublished.cranelift-isle]]
+version = "0.105.4"
+audited_as = "0.105.3"
 
 [[unpublished.cranelift-jit]]
 version = "0.105.0"
@@ -177,6 +217,10 @@ audited_as = "0.105.1"
 version = "0.105.3"
 audited_as = "0.105.2"
 
+[[unpublished.cranelift-jit]]
+version = "0.105.4"
+audited_as = "0.105.3"
+
 [[unpublished.cranelift-module]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -192,6 +236,10 @@ audited_as = "0.105.1"
 [[unpublished.cranelift-module]]
 version = "0.105.3"
 audited_as = "0.105.2"
+
+[[unpublished.cranelift-module]]
+version = "0.105.4"
+audited_as = "0.105.3"
 
 [[unpublished.cranelift-native]]
 version = "0.105.0"
@@ -209,6 +257,10 @@ audited_as = "0.105.1"
 version = "0.105.3"
 audited_as = "0.105.2"
 
+[[unpublished.cranelift-native]]
+version = "0.105.4"
+audited_as = "0.105.3"
+
 [[unpublished.cranelift-object]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -224,6 +276,10 @@ audited_as = "0.105.1"
 [[unpublished.cranelift-object]]
 version = "0.105.3"
 audited_as = "0.105.2"
+
+[[unpublished.cranelift-object]]
+version = "0.105.4"
+audited_as = "0.105.3"
 
 [[unpublished.cranelift-reader]]
 version = "0.105.0"
@@ -241,6 +297,10 @@ audited_as = "0.105.1"
 version = "0.105.3"
 audited_as = "0.105.2"
 
+[[unpublished.cranelift-reader]]
+version = "0.105.4"
+audited_as = "0.105.3"
+
 [[unpublished.cranelift-serde]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -257,6 +317,10 @@ audited_as = "0.105.1"
 version = "0.105.3"
 audited_as = "0.105.2"
 
+[[unpublished.cranelift-serde]]
+version = "0.105.4"
+audited_as = "0.105.3"
+
 [[unpublished.cranelift-wasm]]
 version = "0.105.0"
 audited_as = "0.104.0"
@@ -272,6 +336,10 @@ audited_as = "0.105.1"
 [[unpublished.cranelift-wasm]]
 version = "0.105.3"
 audited_as = "0.105.2"
+
+[[unpublished.cranelift-wasm]]
+version = "0.105.4"
+audited_as = "0.105.3"
 
 [[unpublished.wasi-cap-std-sync]]
 version = "18.0.0"
@@ -293,6 +361,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasi-common]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasi-tokio]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -313,6 +385,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -329,6 +405,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-asm-macros]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-c-api-impl]]
 version = "18.0.2"
 audited_as = "18.0.1"
@@ -336,6 +416,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-c-api-impl]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-c-api-impl]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wasmtime-c-api-impl]]
 version = "19.0.0"
@@ -350,6 +434,10 @@ version = "18.0.3"
 audited_as = "18.0.2"
 
 [[unpublished.wasmtime-c-api-macros]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
+[[unpublished.wasmtime-c-api-macros]]
 version = "19.0.0"
 audited_as = "18.0.1"
 
@@ -369,6 +457,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-cache]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-cli]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -384,6 +476,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-cli]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-cli]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "18.0.0"
@@ -401,6 +497,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-component-macro]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -416,6 +516,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-component-macro]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-component-macro]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wasmtime-component-util]]
 version = "18.0.0"
@@ -433,6 +537,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-component-util]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-cranelift]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -448,6 +556,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-cranelift]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "18.0.0"
@@ -465,6 +577,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-cranelift-shared]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-environ]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -480,6 +596,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-environ]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-environ]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wasmtime-explorer]]
 version = "18.0.0"
@@ -497,6 +617,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-explorer]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-fiber]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -512,6 +636,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-fiber]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-fiber]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "18.0.0"
@@ -529,6 +657,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -544,6 +676,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wasmtime-runtime]]
 version = "18.0.0"
@@ -561,6 +697,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-runtime]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-types]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -576,6 +716,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-types]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-types]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wasmtime-wasi]]
 version = "18.0.0"
@@ -593,6 +737,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-wasi]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -608,6 +756,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-wasi-http]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "18.0.0"
@@ -625,6 +777,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -640,6 +796,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-wasi-threads]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wasmtime-wast]]
 version = "18.0.0"
@@ -657,6 +817,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-wast]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-winch]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -672,6 +836,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-winch]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-winch]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "18.0.0"
@@ -689,6 +857,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -704,6 +876,10 @@ audited_as = "18.0.1"
 [[unpublished.wasmtime-wmemcheck]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wiggle]]
 version = "18.0.0"
@@ -721,6 +897,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wiggle]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wiggle-generate]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -737,6 +917,10 @@ audited_as = "18.0.1"
 version = "18.0.3"
 audited_as = "18.0.2"
 
+[[unpublished.wiggle-generate]]
+version = "18.0.4"
+audited_as = "18.0.3"
+
 [[unpublished.wiggle-macro]]
 version = "18.0.0"
 audited_as = "17.0.0"
@@ -752,6 +936,10 @@ audited_as = "18.0.1"
 [[unpublished.wiggle-macro]]
 version = "18.0.3"
 audited_as = "18.0.2"
+
+[[unpublished.wiggle-macro]]
+version = "18.0.4"
+audited_as = "18.0.3"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -772,6 +960,10 @@ audited_as = "0.16.1"
 [[unpublished.winch-codegen]]
 version = "0.16.3"
 audited_as = "0.16.2"
+
+[[unpublished.winch-codegen]]
+version = "0.16.4"
+audited_as = "0.16.3"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -965,6 +1157,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.105.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -986,6 +1184,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.105.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.105.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1013,6 +1217,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.105.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -1034,6 +1244,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-meta]]
 version = "0.105.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.105.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1061,6 +1277,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.105.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -1082,6 +1304,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-control]]
 version = "0.105.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.105.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1109,6 +1337,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.105.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -1130,6 +1364,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-frontend]]
 version = "0.105.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.105.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1157,6 +1397,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.105.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -1178,6 +1424,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-isle]]
 version = "0.105.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.105.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1205,6 +1457,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.105.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -1226,6 +1484,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-module]]
 version = "0.105.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.105.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1253,6 +1517,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.105.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -1274,6 +1544,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-object]]
 version = "0.105.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.105.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1301,6 +1577,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.105.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -1325,6 +1607,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.105.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.104.0"
 when = "2024-01-25"
@@ -1346,6 +1634,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.105.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.105.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1687,6 +1981,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -1802,6 +2102,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1823,6 +2129,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1838,15 +2150,27 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
-[[publisher.wasmtime-c-api-macros]]
-version = "18.0.1"
-when = "2024-02-20"
+[[publisher.wasmtime-c-api-impl]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
 [[publisher.wasmtime-c-api-macros]]
+version = "18.0.1"
+when = "2024-02-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-c-api-macros]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-c-api-macros]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1874,6 +2198,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1895,6 +2225,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1922,6 +2258,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1943,6 +2285,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1970,6 +2318,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -1991,6 +2345,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2018,6 +2378,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cranelift-shared]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-environ]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -2039,6 +2405,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-environ]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-environ]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2066,6 +2438,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-explorer]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-fiber]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -2087,6 +2465,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-fiber]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-fiber]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2114,6 +2498,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-debug]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -2135,6 +2525,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2162,6 +2558,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-runtime]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-types]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -2183,6 +2585,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-types]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-types]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2210,6 +2618,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -2231,6 +2645,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2258,6 +2678,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-nn]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -2279,6 +2705,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2306,6 +2738,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -2330,6 +2768,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-winch]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wit-bindgen]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -2354,6 +2798,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -2375,6 +2825,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2416,6 +2872,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -2440,6 +2902,12 @@ when = "2024-02-28"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "18.0.3"
+when = "2024-03-12"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "17.0.0"
 when = "2024-01-25"
@@ -2461,6 +2929,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "18.0.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "18.0.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -2499,6 +2973,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.16.2"
 when = "2024-02-28"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.16.3"
+when = "2024-03-12"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.16.3"
+version = "0.16.4"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch
release for Wasmtime 18.0.4, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md]
is up-to-date and that there are no known issues before merging this
PR. When this PR is merged a release tag will automatically be
created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
