### PR TITLE
Release Wasmtime 19.0.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
 name = "byte-array-literals"
-version = "19.0.1"
+version = "19.0.2"
 
 [[package]]
 name = "byteorder"
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-frontend",
@@ -567,14 +567,14 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -602,25 +602,25 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.106.1"
+version = "0.106.2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "serde",
  "serde_derive",
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "cranelift-codegen",
  "hashbrown 0.14.0",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-interpreter"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -697,7 +697,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "codespan-reporting",
  "log",
@@ -706,7 +706,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-jit"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "anyhow",
  "cranelift",
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -739,7 +739,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -748,7 +748,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-object"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-reader"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -773,7 +773,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-serde"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "clap",
  "cranelift-codegen",
@@ -820,7 +820,7 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.106.1"
+version = "0.106.2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1030,7 +1030,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "embedding"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "dlmalloc",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "min-platform-host"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "libloading",
@@ -2954,7 +2954,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "verify-component-adapter"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "wasmparser",
@@ -3004,7 +3004,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi-common"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "wasi-preview1-component-adapter"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "byte-array-literals",
  "object",
@@ -3231,7 +3231,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "addr2line",
  "anyhow",
@@ -3277,14 +3277,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-bench-api"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3300,14 +3300,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "wasmtime-c-api-impl",
 ]
 
 [[package]]
 name = "wasmtime-c-api-impl"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-c-api-macros"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3332,7 +3332,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cache"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "base64",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cli-flags"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3425,7 +3425,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "component-macro-test-helpers",
@@ -3441,11 +3441,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "19.0.1"
+version = "19.0.2"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -3468,7 +3468,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-cranelift-shared"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3482,7 +3482,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -3523,7 +3523,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-explorer"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "capstone",
@@ -3537,7 +3537,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-fiber"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -3606,7 +3606,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-debug"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "object",
  "once_cell",
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "cfg-if",
  "libc",
@@ -3625,7 +3625,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-runtime"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "cc",
@@ -3656,11 +3656,11 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "19.0.1"
+version = "19.0.2"
 
 [[package]]
 name = "wasmtime-types"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "cranelift-entity",
  "serde",
@@ -3671,7 +3671,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3680,7 +3680,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3713,7 +3713,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-http"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-nn"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "cap-std",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wasi-threads"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wast"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "log",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-winch"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -3802,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-wmemcheck"
-version = "19.0.1"
+version = "19.0.2"
 
 [[package]]
 name = "wast"
@@ -3864,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3881,7 +3881,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-generate"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "anyhow",
  "heck",
@@ -3894,7 +3894,7 @@ dependencies = [
 
 [[package]]
 name = "wiggle-macro"
-version = "19.0.1"
+version = "19.0.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3949,7 +3949,7 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "winch-codegen"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "cranelift-codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,7 +130,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "19.0.1"
+version = "19.0.2"
 authors = ["The Wasmtime Project Developers"]
 edition = "2021"
 # Wasmtime's current policy is that this number can be no larger than the
@@ -152,58 +152,58 @@ all = 'allow'
 
 [workspace.dependencies]
 arbitrary = { version = "1.3.1" }
-wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=19.0.1" }
-wasmtime = { path = "crates/wasmtime", version = "19.0.1", default-features = false }
-wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=19.0.1" }
-wasmtime-cache = { path = "crates/cache", version = "=19.0.1" }
-wasmtime-cli-flags = { path = "crates/cli-flags", version = "=19.0.1" }
-wasmtime-cranelift = { path = "crates/cranelift", version = "=19.0.1" }
-wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=19.0.1" }
-wasmtime-winch = { path = "crates/winch", version = "=19.0.1" }
-wasmtime-environ = { path = "crates/environ", version = "=19.0.1" }
-wasmtime-explorer = { path = "crates/explorer", version = "=19.0.1" }
-wasmtime-fiber = { path = "crates/fiber", version = "=19.0.1" }
-wasmtime-types = { path = "crates/types", version = "19.0.1" }
-wasmtime-jit-debug = { path = "crates/jit-debug", version = "=19.0.1" }
-wasmtime-runtime = { path = "crates/runtime", version = "=19.0.1" }
-wasmtime-wast = { path = "crates/wast", version = "=19.0.1" }
-wasmtime-wasi = { path = "crates/wasi", version = "19.0.1", default-features = false }
-wasmtime-wasi-http = { path = "crates/wasi-http", version = "=19.0.1", default-features = false }
-wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "19.0.1" }
-wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "19.0.1" }
-wasmtime-component-util = { path = "crates/component-util", version = "=19.0.1" }
-wasmtime-component-macro = { path = "crates/component-macro", version = "=19.0.1" }
-wasmtime-asm-macros = { path = "crates/asm-macros", version = "=19.0.1" }
-wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=19.0.1" }
-wasmtime-slab = { path = "crates/slab", version = "=19.0.1" }
+wasmtime-wmemcheck = { path = "crates/wmemcheck", version = "=19.0.2" }
+wasmtime = { path = "crates/wasmtime", version = "19.0.2", default-features = false }
+wasmtime-c-api-macros = { path = "crates/c-api-macros", version = "=19.0.2" }
+wasmtime-cache = { path = "crates/cache", version = "=19.0.2" }
+wasmtime-cli-flags = { path = "crates/cli-flags", version = "=19.0.2" }
+wasmtime-cranelift = { path = "crates/cranelift", version = "=19.0.2" }
+wasmtime-cranelift-shared = { path = "crates/cranelift-shared", version = "=19.0.2" }
+wasmtime-winch = { path = "crates/winch", version = "=19.0.2" }
+wasmtime-environ = { path = "crates/environ", version = "=19.0.2" }
+wasmtime-explorer = { path = "crates/explorer", version = "=19.0.2" }
+wasmtime-fiber = { path = "crates/fiber", version = "=19.0.2" }
+wasmtime-types = { path = "crates/types", version = "19.0.2" }
+wasmtime-jit-debug = { path = "crates/jit-debug", version = "=19.0.2" }
+wasmtime-runtime = { path = "crates/runtime", version = "=19.0.2" }
+wasmtime-wast = { path = "crates/wast", version = "=19.0.2" }
+wasmtime-wasi = { path = "crates/wasi", version = "19.0.2", default-features = false }
+wasmtime-wasi-http = { path = "crates/wasi-http", version = "=19.0.2", default-features = false }
+wasmtime-wasi-nn = { path = "crates/wasi-nn", version = "19.0.2" }
+wasmtime-wasi-threads = { path = "crates/wasi-threads", version = "19.0.2" }
+wasmtime-component-util = { path = "crates/component-util", version = "=19.0.2" }
+wasmtime-component-macro = { path = "crates/component-macro", version = "=19.0.2" }
+wasmtime-asm-macros = { path = "crates/asm-macros", version = "=19.0.2" }
+wasmtime-versioned-export-macros = { path = "crates/versioned-export-macros", version = "=19.0.2" }
+wasmtime-slab = { path = "crates/slab", version = "=19.0.2" }
 component-test-util = { path = "crates/misc/component-test-util" }
 component-fuzz-util = { path = "crates/misc/component-fuzz-util" }
-wiggle = { path = "crates/wiggle", version = "=19.0.1", default-features = false }
-wiggle-macro = { path = "crates/wiggle/macro", version = "=19.0.1" }
-wiggle-generate = { path = "crates/wiggle/generate", version = "=19.0.1" }
-wasi-common = { path = "crates/wasi-common", version = "=19.0.1", default-features = false }
+wiggle = { path = "crates/wiggle", version = "=19.0.2", default-features = false }
+wiggle-macro = { path = "crates/wiggle/macro", version = "=19.0.2" }
+wiggle-generate = { path = "crates/wiggle/generate", version = "=19.0.2" }
+wasi-common = { path = "crates/wasi-common", version = "=19.0.2", default-features = false }
 wasmtime-fuzzing = { path = "crates/fuzzing" }
-wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=19.0.1" }
-wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=19.0.1" }
+wasmtime-jit-icache-coherence = { path = "crates/jit-icache-coherence", version = "=19.0.2" }
+wasmtime-wit-bindgen = { path = "crates/wit-bindgen", version = "=19.0.2" }
 test-programs-artifacts = { path = 'crates/test-programs/artifacts' }
 
-cranelift-wasm = { path = "cranelift/wasm", version = "0.106.1" }
-cranelift-codegen = { path = "cranelift/codegen", version = "0.106.1", default-features = false, features = ["std", "unwind"] }
-cranelift-frontend = { path = "cranelift/frontend", version = "0.106.1" }
-cranelift-entity = { path = "cranelift/entity", version = "0.106.1" }
-cranelift-native = { path = "cranelift/native", version = "0.106.1" }
-cranelift-module = { path = "cranelift/module", version = "0.106.1" }
-cranelift-interpreter = { path = "cranelift/interpreter", version = "0.106.1" }
-cranelift-reader = { path = "cranelift/reader", version = "0.106.1" }
+cranelift-wasm = { path = "cranelift/wasm", version = "0.106.2" }
+cranelift-codegen = { path = "cranelift/codegen", version = "0.106.2", default-features = false, features = ["std", "unwind"] }
+cranelift-frontend = { path = "cranelift/frontend", version = "0.106.2" }
+cranelift-entity = { path = "cranelift/entity", version = "0.106.2" }
+cranelift-native = { path = "cranelift/native", version = "0.106.2" }
+cranelift-module = { path = "cranelift/module", version = "0.106.2" }
+cranelift-interpreter = { path = "cranelift/interpreter", version = "0.106.2" }
+cranelift-reader = { path = "cranelift/reader", version = "0.106.2" }
 cranelift-filetests = { path = "cranelift/filetests" }
-cranelift-object = { path = "cranelift/object", version = "0.106.1" }
-cranelift-jit = { path = "cranelift/jit", version = "0.106.1" }
+cranelift-object = { path = "cranelift/object", version = "0.106.2" }
+cranelift-jit = { path = "cranelift/jit", version = "0.106.2" }
 cranelift-fuzzgen = { path = "cranelift/fuzzgen" }
-cranelift-bforest = { path = "cranelift/bforest", version = "0.106.1" }
-cranelift-control = { path = "cranelift/control", version = "0.106.1" }
-cranelift = { path = "cranelift/umbrella", version = "0.106.1" }
+cranelift-bforest = { path = "cranelift/bforest", version = "0.106.2" }
+cranelift-control = { path = "cranelift/control", version = "0.106.2" }
+cranelift = { path = "cranelift/umbrella", version = "0.106.2" }
 
-winch-codegen = { path = "winch/codegen", version = "=0.17.1" }
+winch-codegen = { path = "winch/codegen", version = "=0.17.2" }
 winch-filetests = { path = "winch/filetests" }
 winch-test-macros = { path = "winch/test-macros" }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,9 @@ Released 2024-04-11.
   packages.
   [#8305](https://github.com/bytecodealliance/wasmtime/pull/8305)
 
+* cranelift: Include clobbers and outgoing args in stack limit.
+  [#8334](https://github.com/bytecodealliance/wasmtime/pull/8334)
+
 --------------------------------------------------------------------------------
 
 ## 19.0.1

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,10 @@ Released 2024-04-10.
 * Fix a panic when compiling invalid components.
   [#8322](https://github.com/bytecodealliance/wasmtime/issues/8322)
 
+* Fix `bindgen!` with `trappable_error_type` using unversioned/versioned
+  packages.
+  [#8305](https://github.com/bytecodealliance/wasmtime/pull/8305)
+
 --------------------------------------------------------------------------------
 
 ## 19.0.1

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,7 +2,7 @@
 
 ## 19.0.2
 
-Released 2024-04-10.
+Released 2024-04-11.
 
 * Fix a panic when compiling invalid components.
   [#8322](https://github.com/bytecodealliance/wasmtime/issues/8322)

--- a/cranelift/bforest/Cargo.toml
+++ b/cranelift/bforest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-bforest"
-version = "0.106.1"
+version = "0.106.2"
 description = "A forest of B+-trees"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-bforest"

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen"
-version = "0.106.1"
+version = "0.106.2"
 description = "Low-level code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-codegen"
@@ -19,7 +19,7 @@ workspace = true
 anyhow = { workspace = true, optional = true }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
-cranelift-codegen-shared = { path = "./shared", version = "0.106.1" }
+cranelift-codegen-shared = { path = "./shared", version = "0.106.2" }
 cranelift-entity = { workspace = true }
 cranelift-bforest = { workspace = true }
 cranelift-control = { workspace = true }
@@ -44,8 +44,8 @@ criterion = { version = "0.5.0", features = ["html_reports"] }
 similar = "2.1.0"
 
 [build-dependencies]
-cranelift-codegen-meta = { path = "meta", version = "0.106.1" }
-cranelift-isle = { path = "../isle/isle", version = "=0.106.1" }
+cranelift-codegen-meta = { path = "meta", version = "0.106.2" }
+cranelift-isle = { path = "../isle/isle", version = "=0.106.2" }
 
 [features]
 default = ["std", "unwind", "host-arch", "timing"]

--- a/cranelift/codegen/meta/Cargo.toml
+++ b/cranelift/codegen/meta/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cranelift-codegen-meta"
 authors = ["The Cranelift Project Developers"]
-version = "0.106.1"
+version = "0.106.2"
 description = "Metaprogram for cranelift-codegen code generator library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
@@ -15,4 +15,4 @@ workspace = true
 rustdoc-args = [ "--document-private-items" ]
 
 [dependencies]
-cranelift-codegen-shared = { path = "../shared", version = "0.106.1" }
+cranelift-codegen-shared = { path = "../shared", version = "0.106.2" }

--- a/cranelift/codegen/shared/Cargo.toml
+++ b/cranelift/codegen/shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-codegen-shared"
-version = "0.106.1"
+version = "0.106.2"
 description = "For code shared between cranelift-codegen-meta and cranelift-codegen"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/control/Cargo.toml
+++ b/cranelift/control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-control"
-version = "0.106.1"
+version = "0.106.2"
 description = "White-box fuzz testing framework"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/entity/Cargo.toml
+++ b/cranelift/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-entity"
-version = "0.106.1"
+version = "0.106.2"
 description = "Data structures using entity references as mapping keys"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-entity"

--- a/cranelift/frontend/Cargo.toml
+++ b/cranelift/frontend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-frontend"
-version = "0.106.1"
+version = "0.106.2"
 description = "Cranelift IR builder helper"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-frontend"

--- a/cranelift/interpreter/Cargo.toml
+++ b/cranelift/interpreter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-interpreter"
-version = "0.106.1"
+version = "0.106.2"
 authors = ["The Cranelift Project Developers"]
 description = "Interpret Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/isle/isle/Cargo.toml
+++ b/cranelift/isle/isle/Cargo.toml
@@ -6,7 +6,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 name = "cranelift-isle"
 readme = "../README.md"
 repository = "https://github.com/bytecodealliance/wasmtime/tree/main/cranelift/isle"
-version = "0.106.1"
+version = "0.106.2"
 
 [lints]
 workspace = true

--- a/cranelift/jit/Cargo.toml
+++ b/cranelift/jit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-jit"
-version = "0.106.1"
+version = "0.106.2"
 authors = ["The Cranelift Project Developers"]
 description = "A JIT library backed by Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-module"
-version = "0.106.1"
+version = "0.106.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for linking functions and data with Cranelift"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/native/Cargo.toml
+++ b/cranelift/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-native"
-version = "0.106.1"
+version = "0.106.2"
 authors = ["The Cranelift Project Developers"]
 description = "Support for targeting the host with Cranelift"
 documentation = "https://docs.rs/cranelift-native"

--- a/cranelift/object/Cargo.toml
+++ b/cranelift/object/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-object"
-version = "0.106.1"
+version = "0.106.2"
 authors = ["The Cranelift Project Developers"]
 description = "Emit Cranelift output to native object files with `object`"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift-reader"
-version = "0.106.1"
+version = "0.106.2"
 description = "Cranelift textual IR reader"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift-reader"

--- a/cranelift/serde/Cargo.toml
+++ b/cranelift/serde/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-serde"
-version = "0.106.1"
+version = "0.106.2"
 authors = ["The Cranelift Project Developers"]
 description = "Serializer/Deserializer for Cranelift IR"
 repository = "https://github.com/bytecodealliance/wasmtime"

--- a/cranelift/umbrella/Cargo.toml
+++ b/cranelift/umbrella/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Cranelift Project Developers"]
 name = "cranelift"
-version = "0.106.1"
+version = "0.106.2"
 description = "Umbrella for commonly-used cranelift crates"
 license = "Apache-2.0 WITH LLVM-exception"
 documentation = "https://docs.rs/cranelift"

--- a/cranelift/wasm/Cargo.toml
+++ b/cranelift/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cranelift-wasm"
-version = "0.106.1"
+version = "0.106.2"
 authors = ["The Cranelift Project Developers"]
 description = "Translator from WebAssembly to Cranelift IR"
 documentation = "https://docs.rs/cranelift-wasm"

--- a/crates/c-api/include/wasmtime.h
+++ b/crates/c-api/include/wasmtime.h
@@ -206,7 +206,7 @@
 /**
  * \brief Wasmtime version string.
  */
-#define WASMTIME_VERSION "19.0.1"
+#define WASMTIME_VERSION "19.0.2"
 /**
  * \brief Wasmtime major version number.
  */
@@ -218,7 +218,7 @@
 /**
  * \brief Wasmtime patch version number.
  */
-#define WASMTIME_VERSION_PATCH 1
+#define WASMTIME_VERSION_PATCH 2
 
 #ifdef __cplusplus
 extern "C" {

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -9,6 +9,10 @@ audited_as = "0.104.1"
 version = "0.106.1"
 audited_as = "0.106.0"
 
+[[unpublished.cranelift]]
+version = "0.106.2"
+audited_as = "0.106.1"
+
 [[unpublished.cranelift-bforest]]
 version = "0.106.0"
 audited_as = "0.104.1"
@@ -16,6 +20,10 @@ audited_as = "0.104.1"
 [[unpublished.cranelift-bforest]]
 version = "0.106.1"
 audited_as = "0.106.0"
+
+[[unpublished.cranelift-bforest]]
+version = "0.106.2"
+audited_as = "0.106.1"
 
 [[unpublished.cranelift-codegen]]
 version = "0.106.0"
@@ -25,6 +33,10 @@ audited_as = "0.104.1"
 version = "0.106.1"
 audited_as = "0.106.0"
 
+[[unpublished.cranelift-codegen]]
+version = "0.106.2"
+audited_as = "0.106.1"
+
 [[unpublished.cranelift-codegen-meta]]
 version = "0.106.0"
 audited_as = "0.104.1"
@@ -32,6 +44,10 @@ audited_as = "0.104.1"
 [[unpublished.cranelift-codegen-meta]]
 version = "0.106.1"
 audited_as = "0.106.0"
+
+[[unpublished.cranelift-codegen-meta]]
+version = "0.106.2"
+audited_as = "0.106.1"
 
 [[unpublished.cranelift-codegen-shared]]
 version = "0.106.0"
@@ -41,6 +57,10 @@ audited_as = "0.104.1"
 version = "0.106.1"
 audited_as = "0.106.0"
 
+[[unpublished.cranelift-codegen-shared]]
+version = "0.106.2"
+audited_as = "0.106.1"
+
 [[unpublished.cranelift-control]]
 version = "0.106.0"
 audited_as = "0.104.1"
@@ -48,6 +68,10 @@ audited_as = "0.104.1"
 [[unpublished.cranelift-control]]
 version = "0.106.1"
 audited_as = "0.106.0"
+
+[[unpublished.cranelift-control]]
+version = "0.106.2"
+audited_as = "0.106.1"
 
 [[unpublished.cranelift-entity]]
 version = "0.106.0"
@@ -57,6 +81,10 @@ audited_as = "0.104.1"
 version = "0.106.1"
 audited_as = "0.106.0"
 
+[[unpublished.cranelift-entity]]
+version = "0.106.2"
+audited_as = "0.106.1"
+
 [[unpublished.cranelift-frontend]]
 version = "0.106.0"
 audited_as = "0.104.1"
@@ -64,6 +92,10 @@ audited_as = "0.104.1"
 [[unpublished.cranelift-frontend]]
 version = "0.106.1"
 audited_as = "0.106.0"
+
+[[unpublished.cranelift-frontend]]
+version = "0.106.2"
+audited_as = "0.106.1"
 
 [[unpublished.cranelift-interpreter]]
 version = "0.106.0"
@@ -73,6 +105,10 @@ audited_as = "0.104.1"
 version = "0.106.1"
 audited_as = "0.106.0"
 
+[[unpublished.cranelift-interpreter]]
+version = "0.106.2"
+audited_as = "0.106.1"
+
 [[unpublished.cranelift-isle]]
 version = "0.106.0"
 audited_as = "0.104.1"
@@ -80,6 +116,10 @@ audited_as = "0.104.1"
 [[unpublished.cranelift-isle]]
 version = "0.106.1"
 audited_as = "0.106.0"
+
+[[unpublished.cranelift-isle]]
+version = "0.106.2"
+audited_as = "0.106.1"
 
 [[unpublished.cranelift-jit]]
 version = "0.106.0"
@@ -89,6 +129,10 @@ audited_as = "0.104.1"
 version = "0.106.1"
 audited_as = "0.106.0"
 
+[[unpublished.cranelift-jit]]
+version = "0.106.2"
+audited_as = "0.106.1"
+
 [[unpublished.cranelift-module]]
 version = "0.106.0"
 audited_as = "0.104.1"
@@ -96,6 +140,10 @@ audited_as = "0.104.1"
 [[unpublished.cranelift-module]]
 version = "0.106.1"
 audited_as = "0.106.0"
+
+[[unpublished.cranelift-module]]
+version = "0.106.2"
+audited_as = "0.106.1"
 
 [[unpublished.cranelift-native]]
 version = "0.106.0"
@@ -105,6 +153,10 @@ audited_as = "0.104.1"
 version = "0.106.1"
 audited_as = "0.106.0"
 
+[[unpublished.cranelift-native]]
+version = "0.106.2"
+audited_as = "0.106.1"
+
 [[unpublished.cranelift-object]]
 version = "0.106.0"
 audited_as = "0.104.1"
@@ -112,6 +164,10 @@ audited_as = "0.104.1"
 [[unpublished.cranelift-object]]
 version = "0.106.1"
 audited_as = "0.106.0"
+
+[[unpublished.cranelift-object]]
+version = "0.106.2"
+audited_as = "0.106.1"
 
 [[unpublished.cranelift-reader]]
 version = "0.106.0"
@@ -121,6 +177,10 @@ audited_as = "0.104.1"
 version = "0.106.1"
 audited_as = "0.106.0"
 
+[[unpublished.cranelift-reader]]
+version = "0.106.2"
+audited_as = "0.106.1"
+
 [[unpublished.cranelift-serde]]
 version = "0.106.0"
 audited_as = "0.104.1"
@@ -128,6 +188,10 @@ audited_as = "0.104.1"
 [[unpublished.cranelift-serde]]
 version = "0.106.1"
 audited_as = "0.106.0"
+
+[[unpublished.cranelift-serde]]
+version = "0.106.2"
+audited_as = "0.106.1"
 
 [[unpublished.cranelift-wasm]]
 version = "0.106.0"
@@ -137,6 +201,10 @@ audited_as = "0.104.1"
 version = "0.106.1"
 audited_as = "0.106.0"
 
+[[unpublished.cranelift-wasm]]
+version = "0.106.2"
+audited_as = "0.106.1"
+
 [[unpublished.wasi-common]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -144,6 +212,10 @@ audited_as = "17.0.1"
 [[unpublished.wasi-common]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasi-common]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime]]
 version = "19.0.0"
@@ -153,6 +225,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-asm-macros]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -160,6 +236,10 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-asm-macros]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-asm-macros]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime-c-api-impl]]
 version = "19.0.0"
@@ -177,6 +257,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-cache]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-cli]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -184,6 +268,10 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-cli]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-cli]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime-cli-flags]]
 version = "19.0.0"
@@ -193,6 +281,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-cli-flags]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-component-macro]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -200,6 +292,10 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-component-macro]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-component-macro]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime-component-util]]
 version = "19.0.0"
@@ -209,6 +305,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-component-util]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-cranelift]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -216,6 +316,10 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-cranelift]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-cranelift]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime-cranelift-shared]]
 version = "19.0.0"
@@ -225,6 +329,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-cranelift-shared]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-environ]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -232,6 +340,10 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-environ]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-environ]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime-explorer]]
 version = "19.0.0"
@@ -241,6 +353,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-explorer]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-fiber]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -248,6 +364,10 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-fiber]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-fiber]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime-jit-debug]]
 version = "19.0.0"
@@ -257,6 +377,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-jit-debug]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-jit-icache-coherence]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -265,6 +389,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-jit-icache-coherence]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-runtime]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -272,11 +400,19 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-runtime]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-runtime]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime-slab]]
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-slab]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-types]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -284,6 +420,10 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-types]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-types]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime-wasi]]
 version = "19.0.0"
@@ -293,6 +433,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-wasi]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-wasi-http]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -300,6 +444,10 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-wasi-http]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-wasi-http]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime-wasi-nn]]
 version = "19.0.0"
@@ -309,6 +457,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-wasi-nn]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-wasi-threads]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -316,6 +468,10 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-wasi-threads]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-wasi-threads]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime-wast]]
 version = "19.0.0"
@@ -325,6 +481,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-wast]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-winch]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -332,6 +492,10 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-winch]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-winch]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wasmtime-wit-bindgen]]
 version = "19.0.0"
@@ -341,6 +505,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wasmtime-wit-bindgen]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wasmtime-wmemcheck]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -348,6 +516,10 @@ audited_as = "17.0.1"
 [[unpublished.wasmtime-wmemcheck]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wasmtime-wmemcheck]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wiggle]]
 version = "19.0.0"
@@ -357,6 +529,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wiggle]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wiggle-generate]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -365,6 +541,10 @@ audited_as = "17.0.1"
 version = "19.0.1"
 audited_as = "19.0.0"
 
+[[unpublished.wiggle-generate]]
+version = "19.0.2"
+audited_as = "19.0.1"
+
 [[unpublished.wiggle-macro]]
 version = "19.0.0"
 audited_as = "17.0.1"
@@ -372,6 +552,10 @@ audited_as = "17.0.1"
 [[unpublished.wiggle-macro]]
 version = "19.0.1"
 audited_as = "19.0.0"
+
+[[unpublished.wiggle-macro]]
+version = "19.0.2"
+audited_as = "19.0.1"
 
 [[unpublished.wiggle-test]]
 version = "0.0.0"
@@ -384,6 +568,10 @@ audited_as = "0.15.1"
 [[unpublished.winch-codegen]]
 version = "0.17.1"
 audited_as = "0.17.0"
+
+[[unpublished.winch-codegen]]
+version = "0.17.2"
+audited_as = "0.17.1"
 
 [[publisher.aho-corasick]]
 version = "1.0.2"
@@ -565,6 +753,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift]]
+version = "0.106.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-bforest]]
 version = "0.104.1"
 when = "2024-02-07"
@@ -574,6 +768,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-bforest]]
 version = "0.106.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-bforest]]
+version = "0.106.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -589,6 +789,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen]]
+version = "0.106.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-codegen-meta]]
 version = "0.104.1"
 when = "2024-02-07"
@@ -598,6 +804,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-codegen-meta]]
 version = "0.106.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-codegen-meta]]
+version = "0.106.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -613,6 +825,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-codegen-shared]]
+version = "0.106.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-control]]
 version = "0.104.1"
 when = "2024-02-07"
@@ -622,6 +840,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-control]]
 version = "0.106.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-control]]
+version = "0.106.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -637,6 +861,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-entity]]
+version = "0.106.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-frontend]]
 version = "0.104.1"
 when = "2024-02-07"
@@ -646,6 +876,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-frontend]]
 version = "0.106.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-frontend]]
+version = "0.106.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -661,6 +897,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-interpreter]]
+version = "0.106.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-isle]]
 version = "0.104.1"
 when = "2024-02-07"
@@ -670,6 +912,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-isle]]
 version = "0.106.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-isle]]
+version = "0.106.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -685,6 +933,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-jit]]
+version = "0.106.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-module]]
 version = "0.104.1"
 when = "2024-02-07"
@@ -694,6 +948,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-module]]
 version = "0.106.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-module]]
+version = "0.106.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -709,6 +969,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-native]]
+version = "0.106.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-object]]
 version = "0.104.1"
 when = "2024-02-07"
@@ -718,6 +984,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-object]]
 version = "0.106.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-object]]
+version = "0.106.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -733,6 +1005,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-reader]]
+version = "0.106.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-serde]]
 version = "0.104.1"
 when = "2024-02-07"
@@ -745,6 +1023,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.cranelift-serde]]
+version = "0.106.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.cranelift-wasm]]
 version = "0.104.1"
 when = "2024-02-07"
@@ -754,6 +1038,12 @@ user-login = "wasmtime-publish"
 [[publisher.cranelift-wasm]]
 version = "0.106.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.cranelift-wasm]]
+version = "0.106.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1111,6 +1401,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasi-common]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasm-bindgen]]
 version = "0.2.87"
 when = "2023-06-12"
@@ -1272,6 +1568,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-asm-macros]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1281,6 +1583,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-asm-macros]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-asm-macros]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1296,6 +1604,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cache]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cli]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1305,6 +1619,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cli]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cli]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1320,6 +1640,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cli-flags]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-component-macro]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1329,6 +1655,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-component-macro]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-component-macro]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1344,6 +1676,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-component-util]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-cranelift]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1353,6 +1691,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-cranelift]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-cranelift]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1368,6 +1712,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-cranelift-shared]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-environ]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1377,6 +1727,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-environ]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-environ]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1392,6 +1748,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-explorer]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-fiber]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1401,6 +1763,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-fiber]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-fiber]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1416,6 +1784,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-debug]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-jit-icache-coherence]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1428,6 +1802,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-jit-icache-coherence]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-runtime]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1437,6 +1817,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-runtime]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-runtime]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1446,6 +1832,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-slab]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-types]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1455,6 +1847,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-types]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-types]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1470,6 +1868,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-http]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1479,6 +1883,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-http]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-http]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1494,6 +1904,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wasi-nn]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wasi-threads]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1503,6 +1919,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wasi-threads]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wasi-threads]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1518,6 +1940,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wast]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-winch]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1527,6 +1955,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-winch]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-winch]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1542,6 +1976,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wasmtime-wit-bindgen]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wasmtime-wmemcheck]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1551,6 +1991,12 @@ user-login = "wasmtime-publish"
 [[publisher.wasmtime-wmemcheck]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wasmtime-wmemcheck]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1604,6 +2050,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-generate]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1616,6 +2068,12 @@ when = "2024-03-20"
 user-id = 73222
 user-login = "wasmtime-publish"
 
+[[publisher.wiggle-generate]]
+version = "19.0.1"
+when = "2024-04-02"
+user-id = 73222
+user-login = "wasmtime-publish"
+
 [[publisher.wiggle-macro]]
 version = "17.0.1"
 when = "2024-02-07"
@@ -1625,6 +2083,12 @@ user-login = "wasmtime-publish"
 [[publisher.wiggle-macro]]
 version = "19.0.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.wiggle-macro]]
+version = "19.0.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 
@@ -1651,6 +2115,12 @@ user-login = "wasmtime-publish"
 [[publisher.winch-codegen]]
 version = "0.17.0"
 when = "2024-03-20"
+user-id = 73222
+user-login = "wasmtime-publish"
+
+[[publisher.winch-codegen]]
+version = "0.17.1"
+when = "2024-04-02"
 user-id = 73222
 user-login = "wasmtime-publish"
 

--- a/winch/codegen/Cargo.toml
+++ b/winch/codegen/Cargo.toml
@@ -4,7 +4,7 @@ name = "winch-codegen"
 description = "Winch code generation library"
 license = "Apache-2.0 WITH LLVM-exception"
 repository = "https://github.com/bytecodealliance/wasmtime"
-version = "0.17.1"
+version = "0.17.2"
 edition.workspace = true
 
 [lints]


### PR DESCRIPTION
This is an [automated pull request][process] from CI to create a patch release for Wasmtime 19.0.2, requested by @alexcrichton.

It's recommended that maintainers double-check that [RELEASES.md] is up-to-date and that there are no known issues before merging this PR. When this PR is merged a release tag will automatically be created, crates will be published, and CI artifacts will be produced.

[RELEASES.md]: https://github.com/bytecodealliance/wasmtime/blob/main/RELEASES.md
[process]: https://docs.wasmtime.dev/contributing-release-process.html
