### PR TITLE
Remove the worker field from HostIncomingResponse

### DIFF
--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -82,7 +82,7 @@ pub struct HostIncomingBody {
     /// An optional worker task to keep alive while this body is being read.
     /// This ensures that if the parent of this body is dropped before the body
     /// then the backing data behind this worker is kept alive.
-    worker: Option<Arc<AbortOnDropJoinHandle<()>>>,
+    worker: Option<AbortOnDropJoinHandle<()>>,
 }
 
 enum IncomingBodyState {
@@ -117,9 +117,9 @@ impl HostIncomingBody {
         }
     }
 
-    pub fn retain_worker(&mut self, worker: &Arc<AbortOnDropJoinHandle<()>>) {
+    pub fn retain_worker(&mut self, worker: AbortOnDropJoinHandle<()>) {
         assert!(self.worker.is_none());
-        self.worker = Some(worker.clone());
+        self.worker = Some(worker);
     }
 
     pub fn take_stream(&mut self) -> Option<HostIncomingBodyStream> {

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -10,7 +10,6 @@ use crate::{
 use http_body_util::BodyExt;
 use hyper::header::HeaderName;
 use std::any::Any;
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::TcpStream;
 use tokio::time::timeout;
@@ -267,7 +266,7 @@ async fn handler(
 
     Ok(IncomingResponseInternal {
         resp,
-        worker: Arc::new(worker),
+        worker,
         between_bytes_timeout,
     })
 }
@@ -358,7 +357,6 @@ pub struct HostIncomingResponse {
     pub status: u16,
     pub headers: FieldMap,
     pub body: Option<HostIncomingBody>,
-    pub worker: Arc<AbortOnDropJoinHandle<()>>,
 }
 
 pub struct HostOutgoingResponse {
@@ -409,7 +407,7 @@ pub enum HostFields {
 
 pub struct IncomingResponseInternal {
     pub resp: hyper::Response<HyperIncomingBody>,
-    pub worker: Arc<AbortOnDropJoinHandle<()>>,
+    pub worker: AbortOnDropJoinHandle<()>,
     pub between_bytes_timeout: std::time::Duration,
 }
 

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -846,10 +846,9 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFutureIncomingResponse f
             headers: parts.headers,
             body: Some({
                 let mut body = HostIncomingBody::new(body, resp.between_bytes_timeout);
-                body.retain_worker(&resp.worker);
+                body.retain_worker(resp.worker);
                 body
             }),
-            worker: resp.worker,
         })?;
 
         Ok(Some(Ok(Ok(resp))))

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -278,7 +278,7 @@ async fn do_wasi_http_hash_all(override_send_request: bool) -> Result<()> {
                 let response = handle(request.into_parts().0).map(|resp| {
                     Ok(IncomingResponseInternal {
                         resp,
-                        worker: Arc::new(wasmtime_wasi::runtime::spawn(future::ready(()))),
+                        worker: wasmtime_wasi::runtime::spawn(future::ready(())),
                         between_bytes_timeout,
                     })
                 });


### PR DESCRIPTION
The worker is a handle to a tokio task where the connection is being read from. It should be kept alive in order to continue to be able to read the response body. However, the worker _is_ kept alive on `HostIncomingBody`. Arguably this the exact place where the task should be kept as once that type is dropped there's no longer a need to keep the worker around.

The original motivation for this change is in a project where an actual HTTP request is not being made and the response are simply mocks. In this case, there's no need to start a worker task as there is no actual connection to keep alive. An alternative to this change would be to make the `worker` field an `Option` allowing those who don't need to keep a worker alive to simply set the field to `None`. However, a closer inspection of the code made it seem that this field is actually not necessary as the worker is being kept alive elsewhere. 
