### PR TITLE
[20.0.0]: Backport fixes from main to the release branch

### DIFF
--- a/cranelift/codegen/src/bitset.rs
+++ b/cranelift/codegen/src/bitset.rs
@@ -10,12 +10,34 @@ use core::mem::size_of;
 use core::ops::{Add, BitOr, Shl, Sub};
 
 /// A small bitset built on a single primitive integer type
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[derive(Clone, Copy, Default, PartialEq, Eq)]
 #[cfg_attr(
     feature = "enable-serde",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
 )]
 pub struct BitSet<T>(pub T);
+
+impl<T> std::fmt::Debug for BitSet<T>
+where
+    T: Into<u32>
+        + From<u8>
+        + BitOr<T, Output = T>
+        + Shl<u8, Output = T>
+        + Sub<T, Output = T>
+        + Add<T, Output = T>
+        + PartialEq
+        + Copy,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut s = f.debug_struct(std::any::type_name::<Self>());
+        for i in 0..Self::bits() {
+            use std::string::ToString;
+            let i = u32::try_from(i).unwrap();
+            s.field(&i.to_string(), &self.contains(i));
+        }
+        s.finish()
+    }
+}
 
 impl<T> BitSet<T>
 where

--- a/cranelift/codegen/src/isa/aarch64/abi.rs
+++ b/cranelift/codegen/src/isa/aarch64/abi.rs
@@ -1166,7 +1166,6 @@ impl ABIMachineSpec for AArch64MachineDeps {
         };
 
         // Return FrameLayout structure.
-        debug_assert!(outgoing_args_size == 0);
         FrameLayout {
             stack_args_size,
             setup_area_size,

--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -703,7 +703,6 @@ impl ABIMachineSpec for Riscv64MachineDeps {
         };
 
         // Return FrameLayout structure.
-        debug_assert!(outgoing_args_size == 0);
         FrameLayout {
             stack_args_size,
             setup_area_size,

--- a/cranelift/codegen/src/isa/x64/abi.rs
+++ b/cranelift/codegen/src/isa/x64/abi.rs
@@ -943,7 +943,6 @@ impl ABIMachineSpec for X64ABIMachineSpec {
         let setup_area_size = 16; // RBP, return address
 
         // Return FrameLayout structure.
-        debug_assert!(outgoing_args_size == 0);
         FrameLayout {
             stack_args_size,
             setup_area_size,

--- a/cranelift/codegen/src/machinst/abi.rs
+++ b/cranelift/codegen/src/machinst/abi.rs
@@ -1806,9 +1806,25 @@ impl<M: ABIMachineSpec> Callee<M> {
             &frame_layout,
         ));
 
+        // The stack limit check needs to cover all the stack adjustments we
+        // might make, up to the next stack limit check in any function we
+        // call. Since this happens after frame setup, the current function's
+        // setup area needs to be accounted for in the caller's stack limit
+        // check, but we need to account for any setup area that our callees
+        // might need. Note that s390x may also use the outgoing args area for
+        // backtrace support even in leaf functions, so that should be accounted
+        // for unconditionally.
+        let total_stacksize = frame_layout.clobber_size
+            + frame_layout.fixed_frame_storage_size
+            + frame_layout.outgoing_args_size
+            + if self.is_leaf {
+                0
+            } else {
+                frame_layout.setup_area_size
+            };
+
         // Leaf functions with zero stack don't need a stack check if one's
         // specified, otherwise always insert the stack check.
-        let total_stacksize = frame_layout.fixed_frame_storage_size;
         if total_stacksize > 0 || !self.is_leaf {
             if let Some((reg, stack_limit_load)) = &self.stack_limit {
                 insts.extend(stack_limit_load.clone());

--- a/cranelift/codegen/src/machinst/buffer.rs
+++ b/cranelift/codegen/src/machinst/buffer.rs
@@ -1675,7 +1675,7 @@ impl<I: VCodeInst> MachBuffer<I> {
                 (start_offset, end_offset)
             }
         };
-        trace!("Adding stack map for offsets {start:#x}..{end:#x}");
+        trace!("Adding stack map for offsets {start:#x}..{end:#x}: {stack_map:?}");
         self.stack_maps.push(MachStackMap {
             offset: start,
             offset_end: end,

--- a/cranelift/codegen/src/machinst/isle.rs
+++ b/cranelift/codegen/src/machinst/isle.rs
@@ -838,6 +838,12 @@ macro_rules! isle_prelude_method_helpers {
             mut caller: $abicaller,
             args: ValueSlice,
         ) -> InstOutput {
+            let off = self.lower_ctx.sigs()[abi].sized_stack_arg_space()
+                + self.lower_ctx.sigs()[abi].sized_stack_ret_space();
+            self.lower_ctx
+                .abi_mut()
+                .accumulate_outgoing_args_size(off as u32);
+
             caller.emit_stack_pre_adjust(self.lower_ctx);
 
             self.gen_call_common_args(&mut caller, args);

--- a/cranelift/filetests/filetests/egraph/bitcast-ref.clif
+++ b/cranelift/filetests/filetests/egraph/bitcast-ref.clif
@@ -1,0 +1,71 @@
+test optimize precise-output
+set opt_level=speed
+target x86_64
+
+function %bitcast_from_r64(i64 vmctx, r64) -> i32 fast {
+    sig0 = (i32) fast
+    fn0 = colocated %foo sig0
+
+block0(v0: i64, v1: r64):
+    v2 = bitcast.i64 v1
+    v3 = ireduce.i32 v2
+
+    call fn0(v3)
+
+    ;; We MUST NOT dedupe the bitcast *from* the reference type, as that would
+    ;; make `v1` no longer live across the `call`, which would mean that it
+    ;; would not show up in the `call`'s safepoint's stack map, which could
+    ;; result in the collector reclaiming an object too early, which is basically
+    ;; a use-after-free bug.
+    v4 = bitcast.i64 v1
+    v5 = ireduce.i32 v4
+
+    return v5
+}
+
+; function %bitcast_from_r64(i64 vmctx, r64) -> i32 fast {
+;     sig0 = (i32) fast
+;     fn0 = colocated %foo sig0
+;
+; block0(v0: i64, v1: r64):
+;     v2 = bitcast.i64 v1
+;     v3 = ireduce.i32 v2
+;     call fn0(v3)
+;     v4 = bitcast.i64 v1
+;     v5 = ireduce.i32 v4
+;     return v5
+; }
+
+function %bitcast_to_r64(i64 vmctx, i32) -> r64 fast {
+    sig0 = (r64) fast
+    fn0 = colocated %foo sig0
+
+block0(v0: i64, v1: i32):
+    v2 = uextend.i64 v1
+    v3 = bitcast.r64 v2
+
+    call fn0(v3)
+
+    ;; On the other hand, it is technically fine to dedupe bitcasts *to*
+    ;; reference types. Doing so extends the live range of the GC reference --
+    ;; potentially adding it to more stack maps than it otherwise would have
+    ;; been in, which means it might unnecessarily survive a GC it otherwise
+    ;; wouldn't have -- but that is okay. Shrinking live ranges of GC
+    ;; references, and removing them from stack maps they otherwise would have
+    ;; been in, is the problematic transformation.
+    v4 = uextend.i64 v1
+    v5 = bitcast.r64 v4
+
+    return v5
+}
+
+; function %bitcast_to_r64(i64 vmctx, i32) -> r64 fast {
+;     sig0 = (r64) fast
+;     fn0 = colocated %foo sig0
+;
+; block0(v0: i64, v1: i32):
+;     v2 = uextend.i64 v1
+;     v3 = bitcast.r64 v2
+;     call fn0(v3)
+;     return v3
+; }

--- a/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/stack-limit.clif
@@ -55,7 +55,8 @@ block0(v0: i64):
 ; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
-;   subs xzr, sp, x0, UXTX
+;   add x16, x0, #16
+;   subs xzr, sp, x16, UXTX
 ;   b.lo #trap=stk_ovf
 ; block0:
 ;   load_ext_name x2, TestCase(%foo)+0
@@ -67,11 +68,12 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-;   cmp sp, x0
-;   b.lo #0x2c
-; block1: ; offset 0x10
-;   ldr x2, #0x18
-;   b #0x20
+;   add x16, x0, #0x10
+;   cmp sp, x16
+;   b.lo #0x30
+; block1: ; offset 0x14
+;   ldr x2, #0x1c
+;   b #0x24
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %foo 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   blr x2
@@ -95,6 +97,7 @@ block0(v0: i64):
 ;   mov fp, sp
 ;   ldr x16, [x0]
 ;   ldr x16, [x16, #4]
+;   add x16, x16, #16
 ;   subs xzr, sp, x16, UXTX
 ;   b.lo #trap=stk_ovf
 ; block0:
@@ -109,11 +112,12 @@ block0(v0: i64):
 ;   mov x29, sp
 ;   ldur x16, [x0]
 ;   ldur x16, [x16, #4]
+;   add x16, x16, #0x10
 ;   cmp sp, x16
-;   b.lo #0x34
-; block1: ; offset 0x18
-;   ldr x2, #0x20
-;   b #0x28
+;   b.lo #0x38
+; block1: ; offset 0x1c
+;   ldr x2, #0x24
+;   b #0x2c
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %foo 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   blr x2

--- a/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/stack-limit.clif
@@ -58,7 +58,8 @@ block0(v0: i64):
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   trap_if stk_ovf##(sp ult a0)
+;   addi t6,a0,16
+;   trap_if stk_ovf##(sp ult t6)
 ; block0:
 ;   load_sym a2,%foo+0
 ;   callind a2
@@ -73,9 +74,10 @@ block0(v0: i64):
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   bgeu sp, a0, 8
+;   addi t6, a0, 0x10
+;   bgeu sp, t6, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
-; block1: ; offset 0x18
+; block1: ; offset 0x1c
 ;   auipc a2, 0
 ;   ld a2, 0xc(a2)
 ;   j 0xc
@@ -105,6 +107,7 @@ block0(v0: i64):
 ;   mv fp,sp
 ;   ld t6,0(a0)
 ;   ld t6,4(t6)
+;   addi t6,t6,16
 ;   trap_if stk_ovf##(sp ult t6)
 ; block0:
 ;   load_sym a2,%foo+0
@@ -122,9 +125,10 @@ block0(v0: i64):
 ;   mv s0, sp
 ;   ld t6, 0(a0)
 ;   ld t6, 4(t6)
+;   addi t6, t6, 0x10
 ;   bgeu sp, t6, 8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; trap: stk_ovf
-; block1: ; offset 0x20
+; block1: ; offset 0x24
 ;   auipc a2, 0
 ;   ld a2, 0xc(a2)
 ;   j 0xc

--- a/cranelift/filetests/filetests/isa/s390x/stack-limit.clif
+++ b/cranelift/filetests/filetests/isa/s390x/stack-limit.clif
@@ -52,7 +52,8 @@ block0(v0: i64):
 }
 
 ; VCode:
-;   clgrtle %r15, %r2
+;   la %r1, 160(%r2)
+;   clgrtle %r15, %r1
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
 ;   virtual_sp_offset_adjust 160
@@ -64,11 +65,12 @@ block0(v0: i64):
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   clgrtle %r15, %r2 ; trap: stk_ovf
+;   la %r1, 0xa0(%r2)
+;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block1: ; offset 0xe
-;   bras %r1, 0x1a
+; block1: ; offset 0x12
+;   bras %r1, 0x1e
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %foo 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00
@@ -92,6 +94,7 @@ block0(v0: i64):
 ; VCode:
 ;   lg %r1, 0(%r2)
 ;   lg %r1, 4(%r1)
+;   la %r1, 160(%r1)
 ;   clgrtle %r15, %r1
 ;   stmg %r14, %r15, 112(%r15)
 ;   aghi %r15, -160
@@ -106,11 +109,12 @@ block0(v0: i64):
 ; block0: ; offset 0x0
 ;   lg %r1, 0(%r2)
 ;   lg %r1, 4(%r1)
+;   la %r1, 0xa0(%r1)
 ;   clgrtle %r15, %r1 ; trap: stk_ovf
 ;   stmg %r14, %r15, 0x70(%r15)
 ;   aghi %r15, -0xa0
-; block1: ; offset 0x1a
-;   bras %r1, 0x26
+; block1: ; offset 0x1e
+;   bras %r1, 0x2a
 ;   .byte 0x00, 0x00 ; reloc_external Abs8 %foo 0
 ;   .byte 0x00, 0x00
 ;   .byte 0x00, 0x00

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -107,6 +107,33 @@ mod with_key_and_resources {
     }
 }
 
+mod trappable_errors_with_versioned_and_unversioned_packages {
+    wasmtime::component::bindgen!({
+        inline: "
+            package foo:foo@0.1.0;
+
+            interface a {
+                variant error {
+                    other(string),
+                }
+
+                f: func() -> result<_, error>;
+            }
+
+            world foo {
+                import a;
+            }
+        ",
+        path: "tests/codegen/unversioned-foo.wit",
+        trappable_error_type: {
+            "foo:foo/a@0.1.0/error" => MyX,
+        },
+    });
+
+    #[allow(dead_code)]
+    type MyX = u64;
+}
+
 mod trappable_errors {
     wasmtime::component::bindgen!({
         inline: "

--- a/crates/component-macro/tests/codegen/unversioned-foo.wit
+++ b/crates/component-macro/tests/codegen/unversioned-foo.wit
@@ -1,0 +1,12 @@
+package foo:foo;
+
+interface a {
+    variant error {
+        other(string),
+    }
+    g: func() -> result<_, error>;
+}
+
+world nope {
+    import a;
+}

--- a/crates/runtime/src/gc/host_data.rs
+++ b/crates/runtime/src/gc/host_data.rs
@@ -39,11 +39,14 @@ impl ExternRefHostDataTable {
     /// Allocate a new `externref` host data value.
     pub fn alloc(&mut self, value: Box<dyn Any + Send + Sync>) -> ExternRefHostDataId {
         let id = self.slab.alloc(value);
-        ExternRefHostDataId(id)
+        let id = ExternRefHostDataId(id);
+        log::trace!("allocated new externref host data: {id:?}");
+        id
     }
 
     /// Deallocate an `externref` host data value.
     pub fn dealloc(&mut self, id: ExternRefHostDataId) -> Box<dyn Any + Send + Sync> {
+        log::trace!("deallocated externref host data: {id:?}");
         self.slab.dealloc(id.0)
     }
 

--- a/crates/runtime/src/libcalls.rs
+++ b/crates/runtime/src/libcalls.rs
@@ -380,6 +380,7 @@ unsafe fn drop_gc_ref(instance: &mut Instance, gc_ref: *mut u8) {
     let gc_ref = VMGcRef::from_r64(u64::try_from(gc_ref as usize).unwrap())
         .expect("valid r64")
         .expect("non-null VMGcRef");
+    log::trace!("libcalls::drop_gc_ref({gc_ref:?})");
     (*instance.store()).gc_store().drop_gc_ref(gc_ref);
 }
 

--- a/crates/runtime/src/table.rs
+++ b/crates/runtime/src/table.rs
@@ -467,16 +467,16 @@ impl Table {
             TableElement::FuncRef(f) => {
                 self.funcrefs_mut()[start..end].fill(TaggedFuncRef::from(f));
             }
-            TableElement::GcRef(e) => {
+            TableElement::GcRef(r) => {
                 // Clone the init GC reference into each table slot.
                 for slot in &mut self.gc_refs_mut()[start..end] {
-                    gc_store.write_gc_ref(slot, e.as_ref());
+                    gc_store.write_gc_ref(slot, r.as_ref());
                 }
 
                 // Drop the init GC reference, since we aren't holding onto this
                 // reference anymore, only the clones in the table.
-                if let Some(e) = e {
-                    gc_store.drop_gc_ref(e);
+                if let Some(r) = r {
+                    gc_store.drop_gc_ref(r);
                 }
             }
             TableElement::UninitFunc => {

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -213,7 +213,9 @@ impl Global {
             if let Some(gc_ref) = unsafe { (*store[self.0].definition).as_gc_ref() } {
                 let gc_ref = NonNull::from(gc_ref);
                 let gc_ref = SendSyncPtr::new(gc_ref);
-                gc_roots_list.add_root(gc_ref);
+                unsafe {
+                    gc_roots_list.add_root(gc_ref);
+                }
             }
         }
     }

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -387,7 +387,9 @@ impl Table {
             if let Some(gc_ref) = gc_ref {
                 let gc_ref = NonNull::from(gc_ref);
                 let gc_ref = SendSyncPtr::new(gc_ref);
-                gc_roots_list.add_root(gc_ref);
+                unsafe {
+                    gc_roots_list.add_root(gc_ref);
+                }
             }
         }
     }

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -370,12 +370,21 @@ struct LifoRoot {
 
 impl RootSet {
     pub(crate) fn trace_roots(&mut self, gc_roots_list: &mut GcRootsList) {
+        log::trace!("Begin trace user LIFO roots");
         for root in &mut self.lifo_roots {
-            gc_roots_list.add_root((&mut root.gc_ref).into());
+            unsafe {
+                gc_roots_list.add_root((&mut root.gc_ref).into());
+            }
         }
+        log::trace!("End trace user LIFO roots");
+
+        log::trace!("Begin trace user manual roots");
         for (_id, root) in self.manually_rooted.iter_mut() {
-            gc_roots_list.add_root(root.into());
+            unsafe {
+                gc_roots_list.add_root(root.into());
+            }
         }
+        log::trace!("End trace user manual roots");
     }
 
     /// Enter a LIFO rooting scope.

--- a/crates/wasmtime/src/runtime/store.rs
+++ b/crates/wasmtime/src/runtime/store.rs
@@ -1691,8 +1691,11 @@ impl StoreOpaque {
                     .expect("we should never use the high 32 bits of an r64");
 
                 if gc_ref.is_some() {
-                    gc_roots_list
-                        .add_wasm_stack_root(SendSyncPtr::new(NonNull::new(stack_slot).unwrap()));
+                    unsafe {
+                        gc_roots_list.add_wasm_stack_root(SendSyncPtr::new(
+                            NonNull::new(stack_slot).unwrap(),
+                        ));
+                    }
                 }
             }
 

--- a/tests/all/component_model/aot.rs
+++ b/tests/all/component_model/aot.rs
@@ -164,3 +164,46 @@ fn reflect_resource_import() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn truncated_component_binaries_dont_panic() -> Result<()> {
+    let engine = super::engine();
+
+    let binary = wat::parse_str(
+        r#"
+        (component
+            (import "a" (core module $m0
+                (import "" "" (func))
+            ))
+
+            (core module $m1
+                (func (export ""))
+            )
+            (core instance $i1 (instantiate (module $m1)))
+            (func $f (canon lift (core func $i1 "f")))
+
+            (component $c1
+                (import "f" (func))
+                (core module $m2
+                    (func (export "g"))
+                )
+                (core instance $i2 (instantiate $m2))
+                (func (export "g")
+                    (canon lift (core func $i2 "g"))
+                )
+            )
+            (instance $i3 (instantiate $c1 (with "f" (func $f))))
+            (func (export "g") (alias export $i3 "g"))
+        )
+        "#,
+    )?;
+
+    // Check that if we feed each truncation of the component binary into
+    // `Component::new` we don't get any panics.
+    for i in 1..binary.len() - 1 {
+        let _ = Component::from_binary(&engine, &binary[0..i]);
+    }
+
+    Ok(())
+}

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -28,7 +32,7 @@
 ;;       llgfr   %r3, %r3
 ;;       aghi    %r4, -4
 ;;       clgr    %r3, %r4
-;;       jgh     0x44
+;;       jgh     0x58
 ;;       lg      %r4, 0x60(%r2)
 ;;       strv    %r5, 0(%r3, %r4)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -36,6 +40,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -45,7 +53,7 @@
 ;;       llgfr   %r3, %r5
 ;;       aghi    %r4, -4
 ;;       clgr    %r3, %r4
-;;       jgh     0x8c
+;;       jgh     0xb4
 ;;       lg      %r4, 0x60(%r2)
 ;;       lrv     %r2, 0(%r3, %r4)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -28,7 +32,7 @@
 ;;       llgfr   %r3, %r3
 ;;       aghi    %r4, -0x1004
 ;;       clgr    %r3, %r4
-;;       jgh     0x48
+;;       jgh     0x5c
 ;;       ag      %r3, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       strv    %r5, 0(%r2, %r3)
@@ -37,6 +41,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -45,7 +53,7 @@
 ;;       llgfr   %r5, %r4
 ;;       aghi    %r3, -0x1004
 ;;       clgr    %r5, %r3
-;;       jgh     0x90
+;;       jgh     0xb8
 ;;       ag      %r5, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       lrv     %r2, 0(%r2, %r5)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r12, %r15, 0x60(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -26,10 +30,10 @@
 ;;       llgfr   %r12, %r4
 ;;       llilf   %r3, 0xffff0004
 ;;       algfr   %r3, %r4
-;;       jgnle   0x24
+;;       jgnle   0x38
 ;;       lg      %r4, 0x68(%r2)
 ;;       clgr    %r3, %r4
-;;       jgh     0x50
+;;       jgh     0x64
 ;;       ag      %r12, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       strv    %r5, 0(%r3, %r12)
@@ -38,6 +42,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -45,10 +53,10 @@
 ;;       llgfr   %r5, %r4
 ;;       llilf   %r3, 0xffff0004
 ;;       algfr   %r3, %r4
-;;       jgnle   0x78
+;;       jgnle   0xa0
 ;;       lg      %r4, 0x68(%r2)
 ;;       clgr    %r3, %r4
-;;       jgh     0xa4
+;;       jgh     0xcc
 ;;       ag      %r5, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       lrv     %r2, 0(%r3, %r5)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -27,7 +31,7 @@
 ;;       lg      %r4, 0x68(%r2)
 ;;       llgfr   %r3, %r3
 ;;       clgr    %r3, %r4
-;;       jghe    0x3e
+;;       jghe    0x52
 ;;       lg      %r4, 0x60(%r2)
 ;;       stc     %r5, 0(%r3, %r4)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -35,6 +39,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -42,7 +50,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       llgfr   %r5, %r4
 ;;       clgr    %r5, %r3
-;;       jghe    0x7c
+;;       jghe    0xa4
 ;;       lg      %r3, 0x60(%r2)
 ;;       llc     %r2, 0(%r5, %r3)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -28,7 +32,7 @@
 ;;       llgfr   %r3, %r3
 ;;       aghi    %r4, -0x1001
 ;;       clgr    %r3, %r4
-;;       jgh     0x46
+;;       jgh     0x5a
 ;;       ag      %r3, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       stc     %r5, 0(%r2, %r3)
@@ -37,6 +41,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -45,7 +53,7 @@
 ;;       llgfr   %r5, %r4
 ;;       aghi    %r3, -0x1001
 ;;       clgr    %r5, %r3
-;;       jgh     0x8c
+;;       jgh     0xb4
 ;;       ag      %r5, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       llc     %r2, 0(%r2, %r5)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r12, %r15, 0x60(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -26,10 +30,10 @@
 ;;       llgfr   %r12, %r4
 ;;       llilf   %r3, 0xffff0001
 ;;       algfr   %r3, %r4
-;;       jgnle   0x24
+;;       jgnle   0x38
 ;;       lg      %r4, 0x68(%r2)
 ;;       clgr    %r3, %r4
-;;       jgh     0x4e
+;;       jgh     0x62
 ;;       ag      %r12, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       stc     %r5, 0(%r3, %r12)
@@ -38,6 +42,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -45,10 +53,10 @@
 ;;       llgfr   %r5, %r4
 ;;       llilf   %r3, 0xffff0001
 ;;       algfr   %r3, %r4
-;;       jgnle   0x74
+;;       jgnle   0x9c
 ;;       lg      %r4, 0x68(%r2)
 ;;       clgr    %r3, %r4
-;;       jgh     0xa0
+;;       jgh     0xc8
 ;;       ag      %r5, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       llc     %r2, 0(%r3, %r5)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -36,6 +40,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r8, %r15, 0x40(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -38,6 +42,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r8, %r15, 0x40(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -27,7 +31,7 @@
 ;;       llgfr   %r3, %r4
 ;;       llilf   %r2, 0xffff0004
 ;;       algfr   %r2, %r4
-;;       jgnle   0x28
+;;       jgnle   0x3c
 ;;       lgr     %r6, %r11
 ;;       lg      %r11, 0x68(%r6)
 ;;       lghi    %r4, 0
@@ -41,6 +45,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -49,7 +57,7 @@
 ;;       llgfr   %r3, %r4
 ;;       llilf   %r2, 0xffff0004
 ;;       algfr   %r2, %r4
-;;       jgnle   0x88
+;;       jgnle   0xb0
 ;;       lgr     %r6, %r5
 ;;       lg      %r5, 0x68(%r6)
 ;;       lghi    %r4, 0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r8, %r15, 0x40(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -38,6 +42,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r8, %r15, 0x40(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -27,7 +31,7 @@
 ;;       llgfr   %r3, %r4
 ;;       llilf   %r2, 0xffff0001
 ;;       algfr   %r2, %r4
-;;       jgnle   0x28
+;;       jgnle   0x3c
 ;;       lgr     %r6, %r11
 ;;       lg      %r11, 0x68(%r6)
 ;;       lghi    %r4, 0
@@ -41,6 +45,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -49,7 +57,7 @@
 ;;       llgfr   %r3, %r4
 ;;       llilf   %r2, 0xffff0001
 ;;       algfr   %r2, %r4
-;;       jgnle   0x84
+;;       jgnle   0xac
 ;;       lgr     %r6, %r5
 ;;       lg      %r5, 0x68(%r6)
 ;;       lghi    %r4, 0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -27,7 +31,7 @@
 ;;       lg      %r4, 0x68(%r2)
 ;;       llgfr   %r3, %r3
 ;;       clgr    %r3, %r4
-;;       jgh     0x40
+;;       jgh     0x54
 ;;       lg      %r4, 0x60(%r2)
 ;;       strv    %r5, 0(%r3, %r4)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -35,6 +39,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -42,7 +50,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       llgfr   %r5, %r4
 ;;       clgr    %r5, %r3
-;;       jgh     0x80
+;;       jgh     0xa8
 ;;       lg      %r3, 0x60(%r2)
 ;;       lrv     %r2, 0(%r5, %r3)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -27,7 +31,7 @@
 ;;       lg      %r4, 0x68(%r2)
 ;;       llgfr   %r3, %r3
 ;;       clgr    %r3, %r4
-;;       jgh     0x44
+;;       jgh     0x58
 ;;       ag      %r3, 0x60(%r2)
 ;;       lghi    %r4, 0x1000
 ;;       strv    %r5, 0(%r4, %r3)
@@ -36,6 +40,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -43,7 +51,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       llgfr   %r5, %r4
 ;;       clgr    %r5, %r3
-;;       jgh     0x88
+;;       jgh     0xb0
 ;;       ag      %r5, 0x60(%r2)
 ;;       lghi    %r4, 0x1000
 ;;       lrv     %r2, 0(%r4, %r5)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -27,7 +31,7 @@
 ;;       lg      %r4, 0x68(%r2)
 ;;       llgfr   %r3, %r3
 ;;       clgr    %r3, %r4
-;;       jgh     0x44
+;;       jgh     0x58
 ;;       ag      %r3, 0x60(%r2)
 ;;       llilh   %r4, 0xffff
 ;;       strv    %r5, 0(%r4, %r3)
@@ -36,6 +40,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -43,7 +51,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       llgfr   %r5, %r4
 ;;       clgr    %r5, %r3
-;;       jgh     0x88
+;;       jgh     0xb0
 ;;       ag      %r5, 0x60(%r2)
 ;;       llilh   %r4, 0xffff
 ;;       lrv     %r2, 0(%r4, %r5)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -27,7 +31,7 @@
 ;;       lg      %r4, 0x68(%r2)
 ;;       llgfr   %r3, %r3
 ;;       clgr    %r3, %r4
-;;       jghe    0x3e
+;;       jghe    0x52
 ;;       lg      %r4, 0x60(%r2)
 ;;       stc     %r5, 0(%r3, %r4)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -35,6 +39,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -42,7 +50,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       llgfr   %r5, %r4
 ;;       clgr    %r5, %r3
-;;       jghe    0x7c
+;;       jghe    0xa4
 ;;       lg      %r3, 0x60(%r2)
 ;;       llc     %r2, 0(%r5, %r3)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -27,7 +31,7 @@
 ;;       lg      %r4, 0x68(%r2)
 ;;       llgfr   %r3, %r3
 ;;       clgr    %r3, %r4
-;;       jgh     0x42
+;;       jgh     0x56
 ;;       ag      %r3, 0x60(%r2)
 ;;       lghi    %r4, 0x1000
 ;;       stc     %r5, 0(%r4, %r3)
@@ -36,6 +40,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -43,7 +51,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       llgfr   %r5, %r4
 ;;       clgr    %r5, %r3
-;;       jgh     0x84
+;;       jgh     0xac
 ;;       ag      %r5, 0x60(%r2)
 ;;       lghi    %r4, 0x1000
 ;;       llc     %r2, 0(%r4, %r5)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -27,7 +31,7 @@
 ;;       lg      %r4, 0x68(%r2)
 ;;       llgfr   %r3, %r3
 ;;       clgr    %r3, %r4
-;;       jgh     0x42
+;;       jgh     0x56
 ;;       ag      %r3, 0x60(%r2)
 ;;       llilh   %r4, 0xffff
 ;;       stc     %r5, 0(%r4, %r3)
@@ -36,6 +40,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -43,7 +51,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       llgfr   %r5, %r4
 ;;       clgr    %r5, %r3
-;;       jgh     0x84
+;;       jgh     0xac
 ;;       ag      %r5, 0x60(%r2)
 ;;       llilh   %r4, 0xffff
 ;;       llc     %r2, 0(%r4, %r5)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -36,6 +40,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r8, %r15, 0x40(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -37,6 +41,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r8, %r15, 0x40(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -36,6 +40,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r8, %r15, 0x40(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -37,6 +41,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r8, %r15, 0x40(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -26,7 +30,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       aghi    %r3, -4
 ;;       clgr    %r4, %r3
-;;       jgh     0x3c
+;;       jgh     0x50
 ;;       lg      %r3, 0x60(%r2)
 ;;       strv    %r5, 0(%r4, %r3)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -34,6 +38,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -41,7 +49,7 @@
 ;;       lg      %r5, 0x68(%r2)
 ;;       aghi    %r5, -4
 ;;       clgr    %r4, %r5
-;;       jgh     0x7c
+;;       jgh     0xa4
 ;;       lg      %r3, 0x60(%r2)
 ;;       lrv     %r2, 0(%r4, %r3)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -26,7 +30,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       aghi    %r3, -0x1004
 ;;       clgr    %r4, %r3
-;;       jgh     0x40
+;;       jgh     0x54
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       strv    %r5, 0(%r2, %r4)
@@ -35,6 +39,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -42,7 +50,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       aghi    %r3, -0x1004
 ;;       clgr    %r4, %r3
-;;       jgh     0x84
+;;       jgh     0xac
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r5, 0x1000
 ;;       lrv     %r2, 0(%r5, %r4)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,16 +19,20 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lgr     %r3, %r4
 ;;       algfi   %r3, 0xffff0004
-;;       jgnle   0x20
+;;       jgnle   0x34
 ;;       lg      %r6, 0x68(%r2)
 ;;       clgr    %r3, %r6
-;;       jgh     0x4c
+;;       jgh     0x60
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r2, 0xffff
 ;;       strv    %r5, 0(%r2, %r4)
@@ -37,16 +41,20 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lgr     %r3, %r4
 ;;       algfi   %r3, 0xffff0004
-;;       jgnle   0x70
+;;       jgnle   0x98
 ;;       lg      %r5, 0x68(%r2)
 ;;       clgr    %r3, %r5
-;;       jgh     0x9c
+;;       jgh     0xc4
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r5, 0xffff
 ;;       lrv     %r2, 0(%r5, %r4)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,13 +19,17 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r3, 0x68(%r2)
 ;;       clgr    %r4, %r3
-;;       jghe    0x36
+;;       jghe    0x4a
 ;;       lg      %r2, 0x60(%r2)
 ;;       stc     %r5, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -33,13 +37,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r5, 0x68(%r2)
 ;;       clgr    %r4, %r5
-;;       jghe    0x70
+;;       jghe    0x98
 ;;       lg      %r2, 0x60(%r2)
 ;;       llc     %r2, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -26,7 +30,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       aghi    %r3, -0x1001
 ;;       clgr    %r4, %r3
-;;       jgh     0x3e
+;;       jgh     0x52
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       stc     %r5, 0(%r2, %r4)
@@ -35,6 +39,10 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -42,7 +50,7 @@
 ;;       lg      %r3, 0x68(%r2)
 ;;       aghi    %r3, -0x1001
 ;;       clgr    %r4, %r3
-;;       jgh     0x80
+;;       jgh     0xa8
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r5, 0x1000
 ;;       llc     %r2, 0(%r5, %r4)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,16 +19,20 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lgr     %r3, %r4
 ;;       algfi   %r3, 0xffff0001
-;;       jgnle   0x20
+;;       jgnle   0x34
 ;;       lg      %r6, 0x68(%r2)
 ;;       clgr    %r3, %r6
-;;       jgh     0x4a
+;;       jgh     0x5e
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r2, 0xffff
 ;;       stc     %r5, 0(%r2, %r4)
@@ -37,16 +41,20 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lgr     %r3, %r4
 ;;       algfi   %r3, 0xffff0001
-;;       jgnle   0x6c
+;;       jgnle   0x94
 ;;       lg      %r5, 0x68(%r2)
 ;;       clgr    %r3, %r5
-;;       jgh     0x98
+;;       jgh     0xc0
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r5, 0xffff
 ;;       llc     %r2, 0(%r5, %r4)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -36,6 +40,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,13 +19,17 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r8, %r15, 0x40(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lgr     %r8, %r4
 ;;       algfi   %r8, 0xffff0004
-;;       jgnle   0x20
+;;       jgnle   0x34
 ;;       lg      %r9, 0x68(%r2)
 ;;       lghi    %r3, 0
 ;;       ag      %r4, 0x60(%r2)
@@ -38,13 +42,17 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r9, %r15, 0x48(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lgr     %r5, %r4
 ;;       algfi   %r5, 0xffff0004
-;;       jgnle   0x74
+;;       jgnle   0x9c
 ;;       lg      %r9, 0x68(%r2)
 ;;       lghi    %r3, 0
 ;;       ag      %r4, 0x60(%r2)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r13, %r15, 0x68(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -34,6 +38,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r13, %r15, 0x68(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -36,6 +40,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,13 +19,17 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r8, %r15, 0x40(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lgr     %r8, %r4
 ;;       algfi   %r8, 0xffff0001
-;;       jgnle   0x20
+;;       jgnle   0x34
 ;;       lg      %r9, 0x68(%r2)
 ;;       lghi    %r3, 0
 ;;       ag      %r4, 0x60(%r2)
@@ -38,13 +42,17 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r9, %r15, 0x48(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lgr     %r5, %r4
 ;;       algfi   %r5, 0xffff0001
-;;       jgnle   0x70
+;;       jgnle   0x98
 ;;       lg      %r9, 0x68(%r2)
 ;;       lghi    %r3, 0
 ;;       ag      %r4, 0x60(%r2)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,13 +19,17 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r3, 0x68(%r2)
 ;;       clgr    %r4, %r3
-;;       jgh     0x38
+;;       jgh     0x4c
 ;;       lg      %r2, 0x60(%r2)
 ;;       strv    %r5, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -33,13 +37,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r5, 0x68(%r2)
 ;;       clgr    %r4, %r5
-;;       jgh     0x74
+;;       jgh     0x9c
 ;;       lg      %r2, 0x60(%r2)
 ;;       lrv     %r2, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,13 +19,17 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r3, 0x68(%r2)
 ;;       clgr    %r4, %r3
-;;       jgh     0x3c
+;;       jgh     0x50
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r3, 0x1000
 ;;       strv    %r5, 0(%r3, %r4)
@@ -34,13 +38,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r5, 0x68(%r2)
 ;;       clgr    %r4, %r5
-;;       jgh     0x7c
+;;       jgh     0xa4
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r3, 0x1000
 ;;       lrv     %r2, 0(%r3, %r4)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,13 +19,17 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r3, 0x68(%r2)
 ;;       clgr    %r4, %r3
-;;       jgh     0x3c
+;;       jgh     0x50
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       strv    %r5, 0(%r3, %r4)
@@ -34,13 +38,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r5, 0x68(%r2)
 ;;       clgr    %r4, %r5
-;;       jgh     0x7c
+;;       jgh     0xa4
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       lrv     %r2, 0(%r3, %r4)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,13 +19,17 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r3, 0x68(%r2)
 ;;       clgr    %r4, %r3
-;;       jghe    0x36
+;;       jghe    0x4a
 ;;       lg      %r2, 0x60(%r2)
 ;;       stc     %r5, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -33,13 +37,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r5, 0x68(%r2)
 ;;       clgr    %r4, %r5
-;;       jghe    0x70
+;;       jghe    0x98
 ;;       lg      %r2, 0x60(%r2)
 ;;       llc     %r2, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,13 +19,17 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r3, 0x68(%r2)
 ;;       clgr    %r4, %r3
-;;       jgh     0x3a
+;;       jgh     0x4e
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r3, 0x1000
 ;;       stc     %r5, 0(%r3, %r4)
@@ -34,13 +38,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r5, 0x68(%r2)
 ;;       clgr    %r4, %r5
-;;       jgh     0x78
+;;       jgh     0xa0
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r3, 0x1000
 ;;       llc     %r2, 0(%r3, %r4)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,13 +19,17 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r3, 0x68(%r2)
 ;;       clgr    %r4, %r3
-;;       jgh     0x3a
+;;       jgh     0x4e
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       stc     %r5, 0(%r3, %r4)
@@ -34,13 +38,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       lg      %r5, 0x68(%r2)
 ;;       clgr    %r4, %r5
-;;       jgh     0x78
+;;       jgh     0xa0
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       llc     %r2, 0(%r3, %r4)

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r13, %r15, 0x68(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -34,6 +38,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r13, %r15, 0x68(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -36,6 +40,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r13, %r15, 0x68(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -34,6 +38,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r13, %r15, 0x68(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_dynamic_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -36,6 +40,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,13 +19,17 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       llgfr   %r4, %r4
 ;;       clgfi   %r4, 0xfffffffc
-;;       jgh     0x38
+;;       jgh     0x4c
 ;;       lg      %r2, 0x60(%r2)
 ;;       strv    %r5, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -33,13 +37,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       llgfr   %r4, %r4
 ;;       clgfi   %r4, 0xfffffffc
-;;       jgh     0x74
+;;       jgh     0x9c
 ;;       lg      %r2, 0x60(%r2)
 ;;       lrv     %r2, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,13 +19,17 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       llgfr   %r4, %r4
 ;;       clgfi   %r4, 0xffffeffc
-;;       jgh     0x3c
+;;       jgh     0x50
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r3, 0x1000
 ;;       strv    %r5, 0(%r3, %r4)
@@ -34,13 +38,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       llgfr   %r4, %r4
 ;;       clgfi   %r4, 0xffffeffc
-;;       jgh     0x7c
+;;       jgh     0xa4
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r3, 0x1000
 ;;       lrv     %r2, 0(%r3, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,13 +19,17 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       llgfr   %r4, %r4
 ;;       clgfi   %r4, 0xfffc
-;;       jgh     0x3c
+;;       jgh     0x50
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       strv    %r5, 0(%r3, %r4)
@@ -34,13 +38,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       llgfr   %r4, %r4
 ;;       clgfi   %r4, 0xfffc
-;;       jgh     0x7c
+;;       jgh     0xa4
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       lrv     %r2, 0(%r3, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -32,6 +36,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,13 +19,17 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       llgfr   %r4, %r4
 ;;       clgfi   %r4, 0xffffefff
-;;       jgh     0x3a
+;;       jgh     0x4e
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r3, 0x1000
 ;;       stc     %r5, 0(%r3, %r4)
@@ -34,13 +38,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       llgfr   %r4, %r4
 ;;       clgfi   %r4, 0xffffefff
-;;       jgh     0x78
+;;       jgh     0xa0
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r3, 0x1000
 ;;       llc     %r2, 0(%r3, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,13 +19,17 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       llgfr   %r4, %r4
 ;;       clgfi   %r4, 0xffff
-;;       jgh     0x3a
+;;       jgh     0x4e
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       stc     %r5, 0(%r3, %r4)
@@ -34,13 +38,17 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       llgfr   %r4, %r4
 ;;       clgfi   %r4, 0xffff
-;;       jgh     0x78
+;;       jgh     0xa0
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r3, 0xffff
 ;;       llc     %r2, 0(%r3, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -36,6 +40,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -38,6 +42,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -32,6 +36,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -38,6 +42,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -32,6 +36,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -31,6 +35,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -31,6 +35,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -32,6 +36,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -31,6 +35,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -31,6 +35,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -32,6 +36,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -31,6 +35,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -31,6 +35,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -32,6 +36,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -31,6 +35,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i32_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -31,6 +35,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0_offset.wat
@@ -19,12 +19,16 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xfffffffc
-;;       jgh     0x34
+;;       jgh     0x48
 ;;       lg      %r2, 0x60(%r2)
 ;;       strv    %r5, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -32,12 +36,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xfffffffc
-;;       jgh     0x6c
+;;       jgh     0x94
 ;;       lg      %r5, 0x60(%r2)
 ;;       lrv     %r2, 0(%r4, %r5)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,12 +19,16 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffeffc
-;;       jgh     0x38
+;;       jgh     0x4c
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       strv    %r5, 0(%r2, %r4)
@@ -33,12 +37,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffeffc
-;;       jgh     0x74
+;;       jgh     0x9c
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       lrv     %r2, 0(%r2, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,12 +19,16 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xfffc
-;;       jgh     0x38
+;;       jgh     0x4c
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r2, 0xffff
 ;;       strv    %r5, 0(%r2, %r4)
@@ -33,12 +37,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xfffc
-;;       jgh     0x74
+;;       jgh     0x9c
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r2, 0xffff
 ;;       lrv     %r2, 0(%r2, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0_offset.wat
@@ -19,12 +19,16 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffffff
-;;       jgh     0x32
+;;       jgh     0x46
 ;;       lg      %r2, 0x60(%r2)
 ;;       stc     %r5, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -32,12 +36,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffffff
-;;       jgh     0x68
+;;       jgh     0x90
 ;;       lg      %r5, 0x60(%r2)
 ;;       llc     %r2, 0(%r4, %r5)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,12 +19,16 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffefff
-;;       jgh     0x36
+;;       jgh     0x4a
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       stc     %r5, 0(%r2, %r4)
@@ -33,12 +37,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffefff
-;;       jgh     0x70
+;;       jgh     0x98
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       llc     %r2, 0(%r2, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,12 +19,16 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffff
-;;       jgh     0x36
+;;       jgh     0x4a
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r2, 0xffff
 ;;       stc     %r5, 0(%r2, %r4)
@@ -33,12 +37,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffff
-;;       jgh     0x70
+;;       jgh     0x98
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r2, 0xffff
 ;;       llc     %r2, 0(%r2, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -34,6 +38,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -34,6 +38,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -34,6 +38,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -34,6 +38,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0_offset.wat
@@ -19,12 +19,16 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xfffffffc
-;;       jgh     0x34
+;;       jgh     0x48
 ;;       lg      %r2, 0x60(%r2)
 ;;       strv    %r5, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -32,12 +36,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xfffffffc
-;;       jgh     0x6c
+;;       jgh     0x94
 ;;       lg      %r5, 0x60(%r2)
 ;;       lrv     %r2, 0(%r4, %r5)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0x1000_offset.wat
@@ -19,12 +19,16 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffeffc
-;;       jgh     0x38
+;;       jgh     0x4c
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       strv    %r5, 0(%r2, %r4)
@@ -33,12 +37,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffeffc
-;;       jgh     0x74
+;;       jgh     0x9c
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       lrv     %r2, 0(%r2, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i32_access_0xffff0000_offset.wat
@@ -19,12 +19,16 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xfffc
-;;       jgh     0x38
+;;       jgh     0x4c
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r2, 0xffff
 ;;       strv    %r5, 0(%r2, %r4)
@@ -33,12 +37,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xfffc
-;;       jgh     0x74
+;;       jgh     0x9c
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r2, 0xffff
 ;;       lrv     %r2, 0(%r2, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0_offset.wat
@@ -19,12 +19,16 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffffff
-;;       jgh     0x32
+;;       jgh     0x46
 ;;       lg      %r2, 0x60(%r2)
 ;;       stc     %r5, 0(%r4, %r2)
 ;;       lmg     %r14, %r15, 0x110(%r15)
@@ -32,12 +36,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffffff
-;;       jgh     0x68
+;;       jgh     0x90
 ;;       lg      %r5, 0x60(%r2)
 ;;       llc     %r2, 0(%r4, %r5)
 ;;       lmg     %r14, %r15, 0x110(%r15)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0x1000_offset.wat
@@ -19,12 +19,16 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffefff
-;;       jgh     0x36
+;;       jgh     0x4a
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       stc     %r5, 0(%r2, %r4)
@@ -33,12 +37,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffffefff
-;;       jgh     0x70
+;;       jgh     0x98
 ;;       ag      %r4, 0x60(%r2)
 ;;       lghi    %r2, 0x1000
 ;;       llc     %r2, 0(%r2, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_no_spectre_i8_access_0xffff0000_offset.wat
@@ -19,12 +19,16 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffff
-;;       jgh     0x36
+;;       jgh     0x4a
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r2, 0xffff
 ;;       stc     %r5, 0(%r2, %r4)
@@ -33,12 +37,16 @@
 ;;       .byte   0x00, 0x00
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
 ;;       stg     %r1, 0(%r15)
 ;;       clgfi   %r4, 0xffff
-;;       jgh     0x70
+;;       jgh     0x98
 ;;       ag      %r4, 0x60(%r2)
 ;;       llilh   %r2, 0xffff
 ;;       llc     %r2, 0(%r2, %r4)

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -34,6 +38,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -34,6 +38,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i32_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r7, %r15, 0x38(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -34,6 +38,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0x1000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0x1000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -34,6 +38,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0

--- a/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
+++ b/tests/disas/load-store/s390x/load_store_static_kind_i64_index_0xffffffff_guard_yes_spectre_i8_access_0xffff0000_offset.wat
@@ -19,6 +19,10 @@
     i32.load8_u offset=0xffff0000))
 
 ;; wasm[0]::function[0]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r6, %r15, 0x30(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0
@@ -35,6 +39,10 @@
 ;;       br      %r14
 ;;
 ;; wasm[0]::function[1]:
+;;       lg      %r1, 8(%r2)
+;;       lg      %r1, 0(%r1)
+;;       la      %r1, 0xa0(%r1)
+;;       clgrtle %r15, %r1
 ;;       stmg    %r14, %r15, 0x70(%r15)
 ;;       lgr     %r1, %r15
 ;;       aghi    %r15, -0xa0


### PR DESCRIPTION
* https://github.com/bytecodealliance/wasmtime/pull/8301 - not security related but still a good bug fix to get in earlier
* https://github.com/bytecodealliance/wasmtime/pull/8305 - this is being backported to 18/19 so also have it present on 20
* https://github.com/bytecodealliance/wasmtime/pull/8317 - required for safety on the 20 branch
* https://github.com/bytecodealliance/wasmtime/pull/8323 - being backported to 19 so also have in 20