### PR TITLE
wasmtime-wasi-http collection of small refactors

### DIFF
--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -98,7 +98,6 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
             request,
             OutgoingRequestConfig {
                 use_tls,
-                authority,
                 connect_timeout,
                 first_byte_timeout,
                 between_bytes_timeout,

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -94,7 +94,7 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
             .body(body)
             .map_err(|err| internal_error(err.to_string()))?;
 
-        self.send_request(
+        let future = self.send_request(
             request,
             OutgoingRequestConfig {
                 use_tls,
@@ -102,6 +102,8 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
                 first_byte_timeout,
                 between_bytes_timeout,
             },
-        )
+        )?;
+
+        Ok(self.table().push(future)?)
     }
 }

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -4,7 +4,7 @@ use crate::{
         types::{self, Scheme},
     },
     http_request_error, internal_error,
-    types::{HostFutureIncomingResponse, HostOutgoingRequest, OutgoingRequest},
+    types::{HostFutureIncomingResponse, HostOutgoingRequest, OutgoingRequestConfig},
     WasiHttpView,
 };
 use bytes::Bytes;
@@ -94,13 +94,15 @@ impl<T: WasiHttpView> outgoing_handler::Host for T {
             .body(body)
             .map_err(|err| internal_error(err.to_string()))?;
 
-        self.send_request(OutgoingRequest {
-            use_tls,
-            authority,
+        self.send_request(
             request,
-            connect_timeout,
-            first_byte_timeout,
-            between_bytes_timeout,
-        })
+            OutgoingRequestConfig {
+                use_tls,
+                authority,
+                connect_timeout,
+                first_byte_timeout,
+                between_bytes_timeout,
+            },
+        )
     }
 }

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -17,7 +17,16 @@ use wasmtime::component::{Resource, ResourceTable};
 use wasmtime_wasi::{runtime::AbortOnDropJoinHandle, Subscribe};
 
 /// Capture the state necessary for use in the wasi-http API implementation.
-pub struct WasiHttpCtx;
+pub struct WasiHttpCtx {
+    _priv: (),
+}
+
+impl WasiHttpCtx {
+    /// Create a new context.
+    pub fn new() -> Self {
+        Self { _priv: () }
+    }
+}
 
 pub struct OutgoingRequest {
     pub use_tls: bool,

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -323,12 +323,14 @@ impl TryInto<http::Method> for types::Method {
     }
 }
 
+/// The concrete type behind a `wasi:http/types/incoming-request` resource.
 pub struct HostIncomingRequest {
     pub(crate) parts: http::request::Parts,
     pub body: Option<HostIncomingBody>,
 }
 
 impl HostIncomingRequest {
+    /// Create a new `HostIncomingRequest`.
     pub fn new(
         view: &mut dyn WasiHttpView,
         mut parts: http::request::Parts,
@@ -339,33 +341,13 @@ impl HostIncomingRequest {
     }
 }
 
+/// The concrete type behind a `was:http/types/response-outparam` resource.
 pub struct HostResponseOutparam {
     pub result:
         tokio::sync::oneshot::Sender<Result<hyper::Response<HyperOutgoingBody>, types::ErrorCode>>,
 }
 
-pub struct HostOutgoingRequest {
-    pub method: Method,
-    pub scheme: Option<Scheme>,
-    pub path_with_query: Option<String>,
-    pub authority: Option<String>,
-    pub headers: FieldMap,
-    pub body: Option<HyperOutgoingBody>,
-}
-
-#[derive(Default)]
-pub struct HostRequestOptions {
-    pub connect_timeout: Option<std::time::Duration>,
-    pub first_byte_timeout: Option<std::time::Duration>,
-    pub between_bytes_timeout: Option<std::time::Duration>,
-}
-
-pub struct HostIncomingResponse {
-    pub status: u16,
-    pub headers: FieldMap,
-    pub body: Option<HostIncomingBody>,
-}
-
+/// The concrete type behind a `wasi:http/types/outgoing-response` resource.
 pub struct HostOutgoingResponse {
     pub status: http::StatusCode,
     pub headers: FieldMap,
@@ -393,6 +375,30 @@ impl TryFrom<HostOutgoingResponse> for hyper::Response<HyperOutgoingBody> {
             ),
         }
     }
+}
+
+/// The concrete type behind a `wasi:http/types/outgoing-request` resource.
+pub struct HostOutgoingRequest {
+    pub method: Method,
+    pub scheme: Option<Scheme>,
+    pub path_with_query: Option<String>,
+    pub authority: Option<String>,
+    pub headers: FieldMap,
+    pub body: Option<HyperOutgoingBody>,
+}
+
+#[derive(Default)]
+pub struct HostRequestOptions {
+    pub connect_timeout: Option<std::time::Duration>,
+    pub first_byte_timeout: Option<std::time::Duration>,
+    pub between_bytes_timeout: Option<std::time::Duration>,
+}
+
+/// The concrete type behind a `wasi:http/types/incoming-response` resource.
+pub struct HostIncomingResponse {
+    pub status: u16,
+    pub headers: FieldMap,
+    pub body: Option<HostIncomingBody>,
 }
 
 pub type FieldMap = hyper::HeaderMap;

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -273,7 +273,7 @@ async fn handler(
 
     Ok(IncomingResponse {
         resp,
-        worker,
+        worker: Some(worker),
         between_bytes_timeout,
     })
 }
@@ -429,8 +429,8 @@ pub type FutureIncomingResponseHandle =
 pub struct IncomingResponse {
     /// The response itself.
     pub resp: hyper::Response<HyperIncomingBody>,
-    /// The worker task that is processing the response.
-    pub worker: AbortOnDropJoinHandle<()>,
+    /// Optional worker task that continues to process the response.
+    pub worker: Option<AbortOnDropJoinHandle<()>>,
     /// The timeout between chunks of the response.
     pub between_bytes_timeout: std::time::Duration,
 }

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -381,8 +381,8 @@ impl TryFrom<HostOutgoingResponse> for hyper::Response<HyperOutgoingBody> {
 pub struct HostOutgoingRequest {
     pub method: Method,
     pub scheme: Option<Scheme>,
-    pub path_with_query: Option<String>,
     pub authority: Option<String>,
+    pub path_with_query: Option<String>,
     pub headers: FieldMap,
     pub body: Option<HyperOutgoingBody>,
 }
@@ -401,8 +401,7 @@ pub struct HostIncomingResponse {
     pub body: Option<HostIncomingBody>,
 }
 
-pub type FieldMap = hyper::HeaderMap;
-
+/// The concrete type behind a `wasi:http/types/fields` resource.
 pub enum HostFields {
     Ref {
         parent: u32,
@@ -417,6 +416,9 @@ pub enum HostFields {
         fields: FieldMap,
     },
 }
+
+/// An owned version of `HostFields`
+pub type FieldMap = hyper::HeaderMap;
 
 pub struct IncomingResponseInternal {
     pub resp: hyper::Response<HyperIncomingBody>,

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -846,7 +846,9 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostFutureIncomingResponse f
             headers: parts.headers,
             body: Some({
                 let mut body = HostIncomingBody::new(body, resp.between_bytes_timeout);
-                body.retain_worker(resp.worker);
+                if let Some(worker) = resp.worker {
+                    body.retain_worker(worker);
+                }
                 body
             }),
         })?;

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -16,7 +16,7 @@ use wasmtime_wasi_http::{
     bindings::http::types::ErrorCode,
     body::{HyperIncomingBody, HyperOutgoingBody},
     io::TokioIo,
-    types::{self, HostFutureIncomingResponse, IncomingResponseInternal, OutgoingRequestConfig},
+    types::{self, HostFutureIncomingResponse, IncomingResponse, OutgoingRequestConfig},
     HttpResult, WasiHttpCtx, WasiHttpView,
 };
 
@@ -282,7 +282,7 @@ async fn do_wasi_http_hash_all(override_send_request: bool) -> Result<()> {
                       ..
                   }| {
                 let response = handle(request.into_parts().0).map(|resp| {
-                    Ok(IncomingResponseInternal {
+                    Ok(IncomingResponse {
                         resp,
                         worker: wasmtime_wasi::runtime::spawn(future::ready(())),
                         between_bytes_timeout,

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -90,7 +90,7 @@ fn store(engine: &Engine, server: &Server) -> Store<Ctx> {
     let ctx = Ctx {
         table: ResourceTable::new(),
         wasi: builder.build(),
-        http: WasiHttpCtx {},
+        http: WasiHttpCtx::new(),
         stderr,
         stdout,
         send_request: None,
@@ -147,7 +147,7 @@ async fn run_wasi_http(
     builder.stdout(stdout.clone());
     builder.stderr(stderr.clone());
     let wasi = builder.build();
-    let http = WasiHttpCtx;
+    let http = WasiHttpCtx::new();
     let ctx = Ctx {
         table,
         wasi,

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -66,7 +66,8 @@ impl WasiHttpView for Ctx {
         config: OutgoingRequestConfig,
     ) -> HttpResult<Resource<HostFutureIncomingResponse>> {
         if let Some(rejected_authority) = &self.rejected_authority {
-            let (auth, _port) = config.authority.split_once(':').unwrap();
+            let authority = request.uri().authority().map(ToString::to_string).unwrap();
+            let (auth, _port) = authority.split_once(':').unwrap();
             if auth == rejected_authority {
                 return Err(ErrorCode::HttpRequestDenied.into());
             }

--- a/crates/wasi-http/tests/all/main.rs
+++ b/crates/wasi-http/tests/all/main.rs
@@ -279,7 +279,7 @@ async fn do_wasi_http_hash_all(override_send_request: bool) -> Result<()> {
                 let response = handle(request.into_parts().0).map(|resp| {
                     Ok(IncomingResponse {
                         resp,
-                        worker: wasmtime_wasi::runtime::spawn(future::ready(())),
+                        worker: None,
                         between_bytes_timeout,
                     })
                 });

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -697,7 +697,7 @@ impl RunCommand {
                     }
                 }
 
-                store.data_mut().wasi_http = Some(Arc::new(WasiHttpCtx {}));
+                store.data_mut().wasi_http = Some(Arc::new(WasiHttpCtx::new()));
             }
         }
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -149,7 +149,7 @@ impl ServeCommand {
         let mut host = Host {
             table: wasmtime::component::ResourceTable::new(),
             ctx: builder.build(),
-            http: WasiHttpCtx,
+            http: WasiHttpCtx::new(),
 
             limits: StoreLimits::default(),
 


### PR DESCRIPTION
This is a collection of refactors of `wasmtime-wasi-http` in an attempt to make the API slightly easier to use and more documented.

The various refactorings are all small enough that it seems appropriate to batch them into one PR. Each individual commit should be reviewable as a standalone refactor and any of them should be able to be dropped from the PR should there not be consensus that the refactor is appropriate. 