### PR TITLE
`wasmtime-c-api`: Add support for GC references in `wasmtime.h` APIs

### DIFF
--- a/crates/c-api/include/wasmtime/config.h
+++ b/crates/c-api/include/wasmtime/config.h
@@ -165,6 +165,21 @@ WASMTIME_CONFIG_PROP(void, wasm_tail_call, bool)
 WASMTIME_CONFIG_PROP(void, wasm_reference_types, bool)
 
 /**
+ * \brief Configures whether the WebAssembly typed function reference types
+ * proposal is enabled.
+ *
+ * This setting is `false` by default.
+ */
+WASMTIME_CONFIG_PROP(void, wasm_function_references, bool)
+
+/**
+ * \brief Configures whether the WebAssembly GC proposal is enabled.
+ *
+ * This setting is `false` by default.
+ */
+WASMTIME_CONFIG_PROP(void, wasm_gc, bool)
+
+/**
  * \brief Configures whether the WebAssembly SIMD proposal is
  * enabled.
  *

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -14,6 +14,175 @@
 extern "C" {
 #endif
 
+/**
+ * \typedef wasmtime_anyref_t
+ * \brief Convenience alias for #wasmtime_anyref
+ *
+ * \struct wasmtime_anyref
+ * \brief A host-defined un-forgeable reference to pass into WebAssembly.
+ *
+ * This structure represents an `anyref` that can be passed to WebAssembly.
+ * It cannot be forged by WebAssembly itself and is guaranteed to have been
+ * created by the host.
+ */
+typedef struct wasmtime_anyref wasmtime_anyref_t;
+
+/**
+ * \brief Creates a shallow copy of the `anyref` argument, returning a
+ * separately owned pointer (depending on the configured collector this might
+ * increase a reference count or create a new GC root).
+ */
+WASM_API_EXTERN wasmtime_anyref_t *
+wasmtime_anyref_clone(wasmtime_context_t *context, wasmtime_anyref_t *ref);
+
+/**
+ * \brief Drops an owned pointer to `ref`, potentially deleting it if it's the
+ * last reference, or allowing it to be collected during the next GC.
+ */
+WASM_API_EXTERN void wasmtime_anyref_delete(wasmtime_context_t *context,
+                                            wasmtime_anyref_t *ref);
+
+/**
+ * \brief Converts a raw `anyref` value coming from #wasmtime_val_raw_t into
+ * a #wasmtime_anyref_t.
+ *
+ * Note that the returned #wasmtime_anyref_t is an owned value that must be
+ * deleted via #wasmtime_anyref_delete by the caller if it is non-null.
+ */
+WASM_API_EXTERN wasmtime_anyref_t *
+wasmtime_anyref_from_raw(wasmtime_context_t *context, uint32_t raw);
+
+/**
+ * \brief Converts a #wasmtime_anyref_t to a raw value suitable for storing
+ * into a #wasmtime_val_raw_t.
+ *
+ * Note that the returned underlying value is not tracked by Wasmtime's garbage
+ * collector until it enters WebAssembly. This means that a GC may release the
+ * context's reference to the raw value, making the raw value invalid within the
+ * context of the store. Do not perform a GC between calling this function and
+ * passing it to WebAssembly.
+ */
+WASM_API_EXTERN uint32_t wasmtime_anyref_to_raw(wasmtime_context_t *context,
+                                                const wasmtime_anyref_t *ref);
+
+/**
+ * \brief Create a new `i31ref` value.
+ *
+ * Creates a new `i31ref` value (which is a subtype of `anyref`) and returns a
+ * pointer to it.
+ *
+ * If `i31val` does not fit in 31 bits, it is wrapped.
+ */
+WASM_API_EXTERN wasmtime_anyref_t *
+wasmtime_anyref_from_i31(wasmtime_context_t *context, uint32_t i31val);
+
+/**
+ * \brief Get the `anyref`'s underlying `i31ref` value, zero extended, if any.
+ *
+ * If the given `anyref` is an instance of `i31ref`, then its value is zero
+ * extended to 32 bits, written to `dst`, and `true` is returned.
+ *
+ * If the given `anyref` is not an instance of `i31ref`, then `false` is
+ * returned and `dst` is left unmodified.
+ */
+WASM_API_EXTERN bool wasmtime_anyref_i31_get_u(wasmtime_context_t *context,
+                                               wasmtime_anyref_t *anyref,
+                                               uint32_t *dst);
+
+/**
+ * \brief Get the `anyref`'s underlying `i31ref` value, sign extended, if any.
+ *
+ * If the given `anyref` is an instance of `i31ref`, then its value is sign
+ * extended to 32 bits, written to `dst`, and `true` is returned.
+ *
+ * If the given `anyref` is not an instance of `i31ref`, then `false` is
+ * returned and `dst` is left unmodified.
+ */
+WASM_API_EXTERN bool wasmtime_anyref_i31_get_s(wasmtime_context_t *context,
+                                               wasmtime_anyref_t *anyref,
+                                               int32_t *dst);
+
+/**
+ * \typedef wasmtime_externref_t
+ * \brief Convenience alias for #wasmtime_externref
+ *
+ * \struct wasmtime_externref
+ * \brief A host-defined un-forgeable reference to pass into WebAssembly.
+ *
+ * This structure represents an `externref` that can be passed to WebAssembly.
+ * It cannot be forged by WebAssembly itself and is guaranteed to have been
+ * created by the host.
+ */
+typedef struct wasmtime_externref wasmtime_externref_t;
+
+/**
+ * \brief Create a new `externref` value.
+ *
+ * Creates a new `externref` value wrapping the provided data, returning the
+ * pointer to the externref.
+ *
+ * \param context the store context to allocate this externref within
+ * \param data the host-specific data to wrap
+ * \param finalizer an optional finalizer for `data`
+ *
+ * When the reference is reclaimed, the wrapped data is cleaned up with the
+ * provided `finalizer`.
+ *
+ * The returned value must be deleted with #wasmtime_externref_delete and may
+ * not be used after the context is destroyed.
+ */
+WASM_API_EXTERN wasmtime_externref_t *
+wasmtime_externref_new(wasmtime_context_t *context, void *data,
+                       void (*finalizer)(void *));
+
+/**
+ * \brief Get an `externref`'s wrapped data
+ *
+ * Returns the original `data` passed to #wasmtime_externref_new. It is required
+ * that `data` is not `NULL`.
+ */
+WASM_API_EXTERN void *wasmtime_externref_data(wasmtime_context_t *context,
+                                              wasmtime_externref_t *data);
+
+/**
+ * \brief Creates a shallow copy of the `externref` argument, returning a
+ * separately owned pointer (depending on the configured collector this might
+ * increase a reference count or create a new GC root).
+ */
+WASM_API_EXTERN wasmtime_externref_t *
+wasmtime_externref_clone(wasmtime_context_t *context,
+                         wasmtime_externref_t *ref);
+
+/**
+ * \brief Drops an owned pointer to `ref`, potentially deleting it if it's the
+ * last reference, or allowing it to be collected during the next GC.
+ */
+WASM_API_EXTERN void wasmtime_externref_delete(wasmtime_context_t *context,
+                                               wasmtime_externref_t *ref);
+
+/**
+ * \brief Converts a raw `externref` value coming from #wasmtime_val_raw_t into
+ * a #wasmtime_externref_t.
+ *
+ * Note that the returned #wasmtime_externref_t is an owned value that must be
+ * deleted via #wasmtime_externref_delete by the caller if it is non-null.
+ */
+WASM_API_EXTERN wasmtime_externref_t *
+wasmtime_externref_from_raw(wasmtime_context_t *context, uint32_t raw);
+
+/**
+ * \brief Converts a #wasmtime_externref_t to a raw value suitable for storing
+ * into a #wasmtime_val_raw_t.
+ *
+ * Note that the returned underlying value is not tracked by Wasmtime's garbage
+ * collector until it enters WebAssembly. This means that a GC may release the
+ * context's reference to the raw value, making the raw value invalid within the
+ * context of the store. Do not perform a GC between calling this function and
+ * passing it to WebAssembly.
+ */
+WASM_API_EXTERN uint32_t wasmtime_externref_to_raw(
+    wasmtime_context_t *context, const wasmtime_externref_t *ref);
+
 /// \brief Discriminant stored in #wasmtime_val::kind
 typedef uint8_t wasmtime_valkind_t;
 /// \brief Value of #wasmtime_valkind_t meaning that #wasmtime_val_t is an i32
@@ -29,6 +198,12 @@ typedef uint8_t wasmtime_valkind_t;
 /// \brief Value of #wasmtime_valkind_t meaning that #wasmtime_val_t is a
 /// funcref
 #define WASMTIME_FUNCREF 5
+/// \brief Value of #wasmtime_valkind_t meaning that #wasmtime_val_t is an
+/// externref
+#define WASMTIME_EXTERNREF 6
+/// \brief Value of #wasmtime_valkind_t meaning that #wasmtime_val_t is an
+/// anyref
+#define WASMTIME_ANYREF 7
 
 /// \brief A 128-bit value representing the WebAssembly `v128` type. Bytes are
 /// stored in little-endian order.
@@ -53,6 +228,16 @@ typedef union wasmtime_valunion {
   float32_t f32;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_F64
   float64_t f64;
+  /// Field used if #wasmtime_val_t::kind is #WASMTIME_ANYREF
+  ///
+  /// If this value represents a `ref.null any` value then this pointer will
+  /// be `NULL`.
+  wasmtime_anyref_t *anyref;
+  /// Field used if #wasmtime_val_t::kind is #WASMTIME_EXTERNREF
+  ///
+  /// If this value represents a `ref.null extern` value then this pointer will
+  /// be `NULL`.
+  wasmtime_externref_t *externref;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_FUNCREF
   ///
   /// If this value represents a `ref.null func` value then the `store_id` field
@@ -96,6 +281,22 @@ typedef union wasmtime_val_raw {
   ///
   /// Note that this field is always stored in a little-endian format.
   wasmtime_v128 v128;
+  /// Field for when this val is a WebAssembly `anyref` value.
+  ///
+  /// If this is set to 0 then it's a null anyref, otherwise this must be
+  /// passed to `wasmtime_anyref_from_raw` to determine the
+  /// `wasmtime_anyref_t`.
+  ///
+  /// Note that this field is always stored in a little-endian format.
+  uint32_t anyref;
+  /// Field for when this val is a WebAssembly `externref` value.
+  ///
+  /// If this is set to 0 then it's a null externref, otherwise this must be
+  /// passed to `wasmtime_externref_from_raw` to determine the
+  /// `wasmtime_externref_t`.
+  ///
+  /// Note that this field is always stored in a little-endian format.
+  uint32_t externref;
   /// Field for when this val is a WebAssembly `funcref` value.
   ///
   /// If this is set to 0 then it's a null funcref, otherwise this must be
@@ -112,9 +313,11 @@ typedef union wasmtime_val_raw {
  * \union wasmtime_val
  * \brief Container for different kinds of wasm values.
  *
- * APIs which consume a #wasmtime_val_t do not take ownership, but APIs that
- * return #wasmtime_val_t require that #wasmtime_val_delete is called to
- * deallocate the value.
+ * Note that this structure may contain an owned value, namely rooted GC
+ * references, depending on the context in which this is used. APIs which
+ * consume a #wasmtime_val_t do not take ownership, but APIs that return
+ * #wasmtime_val_t require that #wasmtime_val_delete is called to deallocate the
+ * value.
  */
 typedef struct wasmtime_val {
   /// Discriminant of which field of #of is valid.

--- a/crates/c-api/src/config.rs
+++ b/crates/c-api/src/config.rs
@@ -87,6 +87,19 @@ pub extern "C" fn wasmtime_config_wasm_reference_types_set(c: &mut wasm_config_t
 }
 
 #[no_mangle]
+pub extern "C" fn wasmtime_config_wasm_function_references_set(
+    c: &mut wasm_config_t,
+    enable: bool,
+) {
+    c.config.wasm_function_references(enable);
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_config_wasm_gc_set(c: &mut wasm_config_t, enable: bool) {
+    c.config.wasm_gc(enable);
+}
+
+#[no_mangle]
 pub extern "C" fn wasmtime_config_wasm_simd_set(c: &mut wasm_config_t, enable: bool) {
     c.config.wasm_simd(enable);
 }

--- a/crates/c-api/src/ref.rs
+++ b/crates/c-api/src/ref.rs
@@ -1,6 +1,6 @@
-use crate::abort;
-use std::os::raw::c_void;
-use wasmtime::{Ref, Val};
+use crate::{abort, WasmtimeStoreContextMut};
+use std::{mem::MaybeUninit, os::raw::c_void, ptr};
+use wasmtime::{AnyRef, ExternRef, ManuallyRooted, Ref, RootScope, Val, I31};
 
 /// `*mut wasm_ref_t` is a reference type (`externref` or `funcref`), as seen by
 /// the C API. Because we do not have a uniform representation for `funcref`s
@@ -180,4 +180,159 @@ wasmtime_c_api_macros::declare_ref!(wasm_foreign_t);
 #[no_mangle]
 pub extern "C" fn wasm_foreign_new(_store: &crate::wasm_store_t) -> Box<wasm_foreign_t> {
     abort("wasm_foreign_new")
+}
+
+pub type wasmtime_anyref_t = ManuallyRooted<AnyRef>;
+pub type wasmtime_externref_t = ManuallyRooted<ExternRef>;
+
+#[no_mangle]
+pub extern "C" fn wasmtime_anyref_clone(
+    cx: WasmtimeStoreContextMut<'_>,
+    anyref: Option<&wasmtime_anyref_t>,
+) -> Option<Box<wasmtime_anyref_t>> {
+    let anyref = anyref?;
+    Some(Box::new((*anyref).clone(cx)))
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_anyref_delete(
+    cx: WasmtimeStoreContextMut<'_>,
+    val: Option<Box<wasmtime_anyref_t>>,
+) {
+    if let Some(e) = val {
+        e.unroot(cx);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasmtime_anyref_to_raw(
+    cx: WasmtimeStoreContextMut<'_>,
+    val: Option<&wasmtime_anyref_t>,
+) -> u32 {
+    val.and_then(|e| e.to_raw(cx).ok()).unwrap_or_default()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasmtime_anyref_from_raw(
+    cx: WasmtimeStoreContextMut<'_>,
+    raw: u32,
+) -> Option<Box<wasmtime_anyref_t>> {
+    let mut scope = RootScope::new(cx);
+    let e = AnyRef::from_raw(&mut scope, raw)?;
+    Some(Box::new(
+        e.to_manually_rooted(&mut scope).expect("in scope"),
+    ))
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_anyref_from_i31(
+    cx: WasmtimeStoreContextMut<'_>,
+    val: u32,
+) -> Box<wasmtime_anyref_t> {
+    let mut scope = RootScope::new(cx);
+    let anyref = AnyRef::from_i31(&mut scope, I31::wrapping_u32(val));
+    let anyref = anyref.to_manually_rooted(&mut scope).expect("in scope");
+    Box::new(anyref)
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_anyref_i31_get_u(
+    cx: WasmtimeStoreContextMut<'_>,
+    anyref: Option<&wasmtime_anyref_t>,
+    dst: &mut MaybeUninit<u32>,
+) -> bool {
+    match anyref {
+        Some(anyref) if anyref.is_i31(&cx).expect("ManuallyRooted always in scope") => {
+            let val = anyref
+                .unwrap_i31(&cx)
+                .expect("ManuallyRooted always in scope")
+                .get_u32();
+            crate::initialize(dst, val);
+            true
+        }
+        _ => false,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_anyref_i31_get_s(
+    cx: WasmtimeStoreContextMut<'_>,
+    anyref: Option<&wasmtime_anyref_t>,
+    dst: &mut MaybeUninit<i32>,
+) -> bool {
+    match anyref {
+        Some(anyref) if anyref.is_i31(&cx).expect("ManuallyRooted always in scope") => {
+            let val = anyref
+                .unwrap_i31(&cx)
+                .expect("ManuallyRooted always in scope")
+                .get_i32();
+            crate::initialize(dst, val);
+            true
+        }
+        _ => false,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_externref_new(
+    cx: WasmtimeStoreContextMut<'_>,
+    data: *mut c_void,
+    finalizer: Option<extern "C" fn(*mut c_void)>,
+) -> Option<Box<wasmtime_externref_t>> {
+    let mut scope = RootScope::new(cx);
+    let e = ExternRef::new(&mut scope, crate::ForeignData { data, finalizer }).ok()?;
+    let e = e.to_manually_rooted(&mut scope).expect("in scope");
+    Some(Box::new(e))
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_externref_data(
+    cx: WasmtimeStoreContextMut<'_>,
+    externref: Option<&wasmtime_externref_t>,
+) -> *mut c_void {
+    externref
+        .and_then(|e| {
+            let data = e.data(cx).ok()?;
+            Some(data.downcast_ref::<crate::ForeignData>().unwrap().data)
+        })
+        .unwrap_or(ptr::null_mut())
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_externref_clone(
+    cx: WasmtimeStoreContextMut<'_>,
+    externref: Option<&wasmtime_externref_t>,
+) -> Option<Box<wasmtime_externref_t>> {
+    let externref = externref?;
+    Some(Box::new((*externref).clone(cx)))
+}
+
+#[no_mangle]
+pub extern "C" fn wasmtime_externref_delete(
+    cx: WasmtimeStoreContextMut<'_>,
+    val: Option<Box<wasmtime_externref_t>>,
+) {
+    if let Some(e) = val {
+        e.unroot(cx);
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasmtime_externref_to_raw(
+    cx: WasmtimeStoreContextMut<'_>,
+    val: Option<&wasmtime_externref_t>,
+) -> u32 {
+    val.and_then(|e| e.to_raw(cx).ok()).unwrap_or_default()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasmtime_externref_from_raw(
+    cx: WasmtimeStoreContextMut<'_>,
+    raw: u32,
+) -> Option<Box<wasmtime_externref_t>> {
+    let mut scope = RootScope::new(cx);
+    let e = ExternRef::from_raw(&mut scope, raw)?;
+    Some(Box::new(
+        e.to_manually_rooted(&mut scope).expect("in scope"),
+    ))
 }

--- a/crates/c-api/src/types/val.rs
+++ b/crates/c-api/src/types/val.rs
@@ -64,3 +64,4 @@ pub const WASMTIME_F64: wasmtime_valkind_t = 3;
 pub const WASMTIME_V128: wasmtime_valkind_t = 4;
 pub const WASMTIME_FUNCREF: wasmtime_valkind_t = 5;
 pub const WASMTIME_EXTERNREF: wasmtime_valkind_t = 6;
+pub const WASMTIME_ANYREF: wasmtime_valkind_t = 7;

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -43,7 +43,9 @@ endfunction()
 enable_testing()
 
 # Add all examples
+create_target(anyref anyref.c)
 create_target(async async.cpp)
+create_target(externref externref.c)
 create_target(fib-debug fib-debug/main.c)
 create_target(fuel fuel.c)
 create_target(gcd gcd.c)
@@ -58,11 +60,13 @@ create_target(threads threads.c)
 create_target(wasi wasi/main.c)
 
 # Add rust tests
+create_rust_test(anyref)
 create_rust_wasm(fib-debug wasm32-unknown-unknown)
 create_rust_wasm(tokio wasm32-wasi)
 create_rust_wasm(wasi wasm32-wasi)
 create_rust_wasm(component wasm32-unknown-unknown)
 create_rust_test(epochs)
+create_rust_test(externref)
 create_rust_test(fib-debug)
 create_rust_test(fuel)
 create_rust_test(gcd)

--- a/examples/anyref.c
+++ b/examples/anyref.c
@@ -1,0 +1,227 @@
+/*
+Example of using `anyref` values.
+
+You can compile and run this example on Linux with:
+
+   cargo build --release -p wasmtime-c-api
+   cc examples/anyref.c \
+       -I crates/c-api/include \
+       -I crates/c-api/wasm-c-api/include \
+       target/release/libwasmtime.a \
+       -lpthread -ldl -lm \
+       -o anyref
+   ./anyref
+
+Note that on Windows and macOS the command will be similar, but you'll need
+to tweak the `-lpthread` and such annotations as well as the name of the
+`libwasmtime.a` file on Windows.
+
+You can also build using cmake:
+
+mkdir build && cd build && cmake .. && \
+  cmake --build . --target wasmtime-anyref
+*/
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wasm.h>
+#include <wasmtime.h>
+
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
+
+int main() {
+  bool ok = true;
+  // Create a new configuration with Wasm GC enabled.
+  printf("Initializing...\n");
+  wasm_config_t *config = wasm_config_new();
+  assert(config != NULL);
+  wasmtime_config_wasm_reference_types_set(config, true);
+  wasmtime_config_wasm_function_references_set(config, true);
+  wasmtime_config_wasm_gc_set(config, true);
+
+  // Create an *engine*, which is a compilation context, with our configured
+  // options.
+  wasm_engine_t *engine = wasm_engine_new_with_config(config);
+  assert(engine != NULL);
+
+  // With an engine we can create a *store* which is a group of wasm instances
+  // that can interact with each other.
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  assert(store != NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
+
+  // Read our input file, which in this case is a wasm text file.
+  FILE *file = fopen("examples/anyref.wat", "r");
+  assert(file != NULL);
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
+  fclose(file);
+
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t wasm;
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
+
+  // Now that we've got our binary webassembly we can compile our module.
+  printf("Compiling module...\n");
+  wasmtime_module_t *module = NULL;
+  error = wasmtime_module_new(engine, (uint8_t *)wasm.data, wasm.size, &module);
+  wasm_byte_vec_delete(&wasm);
+  if (error != NULL)
+    exit_with_error("failed to compile module", error, NULL);
+
+  // Instantiate the module.
+  printf("Instantiating module...\n");
+  wasm_trap_t *trap = NULL;
+  wasmtime_instance_t instance;
+  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
+
+  printf("Creating new `anyref` from i31...\n");
+
+  // Create a new `anyref` value from an i31 (`i31ref` is a subtype of
+  // `anyref`).
+  wasmtime_anyref_t *anyref = wasmtime_anyref_from_i31(context, 1234);
+  assert(anyref != NULL);
+
+  // The `anyref`'s inner i31 value should be 1234.
+  uint32_t i31val = 0;
+  bool is_i31 = wasmtime_anyref_i31_get_u(context, anyref, &i31val);
+  assert(is_i31);
+  assert(i31val == 1234);
+
+  printf("Touching `anyref` table...\n");
+
+  wasmtime_extern_t item;
+
+  // Lookup the `table` export.
+  ok = wasmtime_instance_export_get(context, &instance, "table",
+                                    strlen("table"), &item);
+  assert(ok);
+  assert(item.kind == WASMTIME_EXTERN_TABLE);
+
+  // Set `table[3]` to our `anyref`.
+  wasmtime_val_t anyref_val;
+  anyref_val.kind = WASMTIME_ANYREF;
+  anyref_val.of.anyref = anyref;
+  error = wasmtime_table_set(context, &item.of.table, 3, &anyref_val);
+  if (error != NULL)
+    exit_with_error("failed to set table", error, NULL);
+
+  // `table[3]` should now be our `anyref`.
+  wasmtime_val_t elem;
+  ok = wasmtime_table_get(context, &item.of.table, 3, &elem);
+  assert(ok);
+  assert(elem.kind == WASMTIME_ANYREF);
+  is_i31 = false;
+  i31val = 0;
+  is_i31 = wasmtime_anyref_i31_get_u(context, elem.of.anyref, &i31val);
+  assert(is_i31);
+  assert(i31val == 1234);
+  wasmtime_val_delete(context, &elem);
+
+  printf("Touching `anyref` global...\n");
+
+  // Lookup the `global` export.
+  ok = wasmtime_instance_export_get(context, &instance, "global",
+                                    strlen("global"), &item);
+  assert(ok);
+  assert(item.kind == WASMTIME_EXTERN_GLOBAL);
+
+  // Set the global to our `anyref`.
+  error = wasmtime_global_set(context, &item.of.global, &anyref_val);
+  if (error != NULL)
+    exit_with_error("failed to set global", error, NULL);
+
+  // Get the global, and it should return our `anyref` again.
+  wasmtime_val_t global_val;
+  wasmtime_global_get(context, &item.of.global, &global_val);
+  assert(global_val.kind == WASMTIME_ANYREF);
+  is_i31 = false;
+  i31val = 0;
+  is_i31 = wasmtime_anyref_i31_get_u(context, global_val.of.anyref, &i31val);
+  assert(is_i31);
+  assert(i31val == 1234);
+  wasmtime_val_delete(context, &global_val);
+
+  printf("Passing `anyref` into func...\n");
+
+  // Lookup the `take_anyref` export.
+  ok = wasmtime_instance_export_get(context, &instance, "take_anyref",
+                                    strlen("take_anyref"), &item);
+  assert(ok);
+  assert(item.kind == WASMTIME_EXTERN_FUNC);
+
+  // And call it!
+  error = wasmtime_func_call(context, &item.of.func, &anyref_val, 1, NULL, 0,
+                             &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call function", error, trap);
+
+  printf("Getting `anyref` from func...\n");
+
+  // Lookup the `return_anyref` export.
+  ok = wasmtime_instance_export_get(context, &instance, "return_anyref",
+                                    strlen("return_anyref"), &item);
+  assert(ok);
+  assert(item.kind == WASMTIME_EXTERN_FUNC);
+
+  // And call it!
+  wasmtime_val_t results[1];
+  error =
+      wasmtime_func_call(context, &item.of.func, NULL, 0, results, 1, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call function", error, trap);
+
+  // `return_anyfunc` returns an `i31ref` that wraps `42`.
+  assert(results[0].kind == WASMTIME_ANYREF);
+  is_i31 = false;
+  i31val = 0;
+  is_i31 = wasmtime_anyref_i31_get_u(context, results[0].of.anyref, &i31val);
+  assert(is_i31);
+  assert(i31val == 42);
+  wasmtime_val_delete(context, &results[0]);
+  wasmtime_val_delete(context, &anyref_val);
+
+  // We can GC any now-unused references to our anyref that the store is
+  // holding.
+  printf("GCing within the store...\n");
+  wasmtime_context_gc(context);
+
+  // Clean up after ourselves at this point
+  printf("All finished!\n");
+
+  wasmtime_store_delete(store);
+  wasmtime_module_delete(module);
+  wasm_engine_delete(engine);
+  return 0;
+}
+
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+    wasmtime_error_delete(error);
+  } else {
+    wasm_trap_message(trap, &error_message);
+    wasm_trap_delete(trap);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
+}

--- a/examples/anyref.rs
+++ b/examples/anyref.rs
@@ -1,0 +1,61 @@
+//! Small example of how to use `anyref`s.
+
+// You can execute this example with `cargo run --example anyref`
+
+use wasmtime::*;
+
+fn main() -> Result<()> {
+    println!("Initializing...");
+    let mut config = Config::new();
+    config.wasm_reference_types(true);
+    config.wasm_function_references(true);
+    config.wasm_gc(true);
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    println!("Compiling module...");
+    let module = Module::from_file(&engine, "examples/anyref.wat")?;
+
+    println!("Instantiating module...");
+    let instance = Instance::new(&mut store, &module, &[])?;
+
+    println!("Creating new `anyref` from i31...");
+    let i31 = I31::wrapping_u32(1234);
+    let anyref = AnyRef::from_i31(&mut store, i31);
+    assert!(anyref.is_i31(&store)?);
+    assert_eq!(anyref.as_i31(&store)?, Some(i31));
+
+    println!("Touching `anyref` table...");
+    let table = instance.get_table(&mut store, "table").unwrap();
+    table.set(&mut store, 3, anyref.into())?;
+    let elem = table
+        .get(&mut store, 3)
+        .unwrap() // assert in bounds
+        .unwrap_any() // assert it's an anyref table
+        .copied()
+        .unwrap(); // assert the anyref isn't null
+    assert!(Rooted::ref_eq(&store, &elem, &anyref)?);
+
+    println!("Touching `anyref` global...");
+    let global = instance.get_global(&mut store, "global").unwrap();
+    global.set(&mut store, Some(anyref.clone()).into())?;
+    let global_val = global.get(&mut store).unwrap_anyref().copied().unwrap();
+    assert!(Rooted::ref_eq(&store, &global_val, &anyref)?);
+
+    println!("Passing `anyref` into func...");
+    let func = instance.get_typed_func::<Option<Rooted<AnyRef>>, ()>(&mut store, "take_anyref")?;
+    func.call(&mut store, Some(anyref))?;
+
+    println!("Getting `anyref` from func...");
+    let func =
+        instance.get_typed_func::<(), Option<Rooted<AnyRef>>>(&mut store, "return_anyref")?;
+    let ret = func.call(&mut store, ())?;
+    assert!(ret.is_some());
+    assert_eq!(ret.unwrap().unwrap_i31(&store)?, I31::wrapping_u32(42));
+
+    println!("GCing within the store...");
+    store.gc();
+
+    println!("Done.");
+    Ok(())
+}

--- a/examples/anyref.wat
+++ b/examples/anyref.wat
@@ -1,0 +1,14 @@
+(module
+  (table $table (export "table") 10 anyref)
+
+  (global $global (export "global") (mut anyref) (ref.null any))
+
+  (func (export "take_anyref") (param anyref)
+    nop
+  )
+
+  (func (export "return_anyref") (result anyref)
+    i32.const 42
+    ref.i31
+  )
+)

--- a/examples/externref.c
+++ b/examples/externref.c
@@ -1,0 +1,204 @@
+/*
+Example of using `externref` values.
+
+You can compile and run this example on Linux with:
+
+   cargo build --release -p wasmtime-c-api
+   cc examples/externref.c \
+       -I crates/c-api/include \
+       -I crates/c-api/wasm-c-api/include \
+       target/release/libwasmtime.a \
+       -lpthread -ldl -lm \
+       -o externref
+   ./externref
+
+Note that on Windows and macOS the command will be similar, but you'll need
+to tweak the `-lpthread` and such annotations as well as the name of the
+`libwasmtime.a` file on Windows.
+
+You can also build using cmake:
+
+mkdir build && cd build && cmake .. && \
+  cmake --build . --target wasmtime-externref
+*/
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <wasm.h>
+#include <wasmtime.h>
+
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap);
+
+int main() {
+  bool ok = true;
+  // Create a new configuration with Wasm reference types enabled.
+  printf("Initializing...\n");
+  wasm_config_t *config = wasm_config_new();
+  assert(config != NULL);
+  wasmtime_config_wasm_reference_types_set(config, true);
+
+  // Create an *engine*, which is a compilation context, with our configured
+  // options.
+  wasm_engine_t *engine = wasm_engine_new_with_config(config);
+  assert(engine != NULL);
+
+  // With an engine we can create a *store* which is a group of wasm instances
+  // that can interact with each other.
+  wasmtime_store_t *store = wasmtime_store_new(engine, NULL, NULL);
+  assert(store != NULL);
+  wasmtime_context_t *context = wasmtime_store_context(store);
+
+  // Read our input file, which in this case is a wasm text file.
+  FILE *file = fopen("examples/externref.wat", "r");
+  assert(file != NULL);
+  fseek(file, 0L, SEEK_END);
+  size_t file_size = ftell(file);
+  fseek(file, 0L, SEEK_SET);
+  wasm_byte_vec_t wat;
+  wasm_byte_vec_new_uninitialized(&wat, file_size);
+  if (fread(wat.data, file_size, 1, file) != 1) {
+    printf("> Error loading module!\n");
+    return 1;
+  }
+  fclose(file);
+
+  // Parse the wat into the binary wasm format
+  wasm_byte_vec_t wasm;
+  wasmtime_error_t *error = wasmtime_wat2wasm(wat.data, wat.size, &wasm);
+  if (error != NULL)
+    exit_with_error("failed to parse wat", error, NULL);
+  wasm_byte_vec_delete(&wat);
+
+  // Now that we've got our binary webassembly we can compile our module.
+  printf("Compiling module...\n");
+  wasmtime_module_t *module = NULL;
+  error = wasmtime_module_new(engine, (uint8_t *)wasm.data, wasm.size, &module);
+  wasm_byte_vec_delete(&wasm);
+  if (error != NULL)
+    exit_with_error("failed to compile module", error, NULL);
+
+  // Instantiate the module.
+  printf("Instantiating module...\n");
+  wasm_trap_t *trap = NULL;
+  wasmtime_instance_t instance;
+  error = wasmtime_instance_new(context, module, NULL, 0, &instance, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to instantiate", error, trap);
+
+  printf("Creating new `externref`...\n");
+
+  // Create a new `externref` value.
+  //
+  // Note that the NULL here is a finalizer callback, but we don't need one for
+  // this example.
+  wasmtime_externref_t *externref =
+      wasmtime_externref_new(context, "Hello, World!", NULL);
+
+  // The `externref`'s wrapped data should be the string "Hello, World!".
+  void *data = wasmtime_externref_data(context, externref);
+  assert(strcmp((char *)data, "Hello, World!") == 0);
+
+  printf("Touching `externref` table...\n");
+
+  wasmtime_extern_t item;
+
+  // Lookup the `table` export.
+  ok = wasmtime_instance_export_get(context, &instance, "table",
+                                    strlen("table"), &item);
+  assert(ok);
+  assert(item.kind == WASMTIME_EXTERN_TABLE);
+
+  // Set `table[3]` to our `externref`.
+  wasmtime_val_t externref_val;
+  externref_val.kind = WASMTIME_EXTERNREF;
+  externref_val.of.externref = externref;
+  error = wasmtime_table_set(context, &item.of.table, 3, &externref_val);
+  if (error != NULL)
+    exit_with_error("failed to set table", error, NULL);
+
+  // `table[3]` should now be our `externref`.
+  wasmtime_val_t elem;
+  ok = wasmtime_table_get(context, &item.of.table, 3, &elem);
+  assert(ok);
+  assert(elem.kind == WASMTIME_EXTERNREF);
+  assert(strcmp((char *)wasmtime_externref_data(context, elem.of.externref),
+                "Hello, World!") == 0);
+  wasmtime_val_delete(context, &elem);
+
+  printf("Touching `externref` global...\n");
+
+  // Lookup the `global` export.
+  ok = wasmtime_instance_export_get(context, &instance, "global",
+                                    strlen("global"), &item);
+  assert(ok);
+  assert(item.kind == WASMTIME_EXTERN_GLOBAL);
+
+  // Set the global to our `externref`.
+  error = wasmtime_global_set(context, &item.of.global, &externref_val);
+  if (error != NULL)
+    exit_with_error("failed to set global", error, NULL);
+
+  // Get the global, and it should return our `externref` again.
+  wasmtime_val_t global_val;
+  wasmtime_global_get(context, &item.of.global, &global_val);
+  assert(global_val.kind == WASMTIME_EXTERNREF);
+  assert(strcmp((char *)wasmtime_externref_data(context, elem.of.externref),
+                "Hello, World!") == 0);
+  wasmtime_val_delete(context, &global_val);
+
+  printf("Calling `externref` func...\n");
+
+  // Lookup the `func` export.
+  ok = wasmtime_instance_export_get(context, &instance, "func", strlen("func"),
+                                    &item);
+  assert(ok);
+  assert(item.kind == WASMTIME_EXTERN_FUNC);
+
+  // And call it!
+  wasmtime_val_t results[1];
+  error = wasmtime_func_call(context, &item.of.func, &externref_val, 1, results,
+                             1, &trap);
+  if (error != NULL || trap != NULL)
+    exit_with_error("failed to call function", error, trap);
+
+  // `func` returns the same reference we gave it, so `results[0]` should be our
+  // `externref`.
+  assert(results[0].kind == WASMTIME_EXTERNREF);
+  assert(
+      strcmp((char *)wasmtime_externref_data(context, results[0].of.externref),
+             "Hello, World!") == 0);
+  wasmtime_val_delete(context, &results[0]);
+  wasmtime_val_delete(context, &externref_val);
+
+  // We can GC any now-unused references to our externref that the store is
+  // holding.
+  printf("GCing within the store...\n");
+  wasmtime_context_gc(context);
+
+  // Clean up after ourselves at this point
+  printf("All finished!\n");
+
+  wasmtime_store_delete(store);
+  wasmtime_module_delete(module);
+  wasm_engine_delete(engine);
+  return 0;
+}
+
+static void exit_with_error(const char *message, wasmtime_error_t *error,
+                            wasm_trap_t *trap) {
+  fprintf(stderr, "error: %s\n", message);
+  wasm_byte_vec_t error_message;
+  if (error != NULL) {
+    wasmtime_error_message(error, &error_message);
+    wasmtime_error_delete(error);
+  } else {
+    wasm_trap_message(trap, &error_message);
+    wasm_trap_delete(trap);
+  }
+  fprintf(stderr, "%.*s\n", (int)error_message.size, error_message.data);
+  wasm_byte_vec_delete(&error_message);
+  exit(1);
+}


### PR DESCRIPTION
Builds on top of https://github.com/bytecodealliance/wasmtime/pull/8344

-------

Restores support for `externref` in `wasmtime_val_t`, methods for manipulating them and getting their wrapped host data, and examples/tests for these things.

Additionally adds support for `anyref` in `wasmtime_val_t`, clone/delete methods similar to those for `externref`, and a few `i31ref`-specific methods. Also adds C and Rust example / test for working with `anyref`.
