### PR TITLE
`wasmtime-wasi-http` docs

### DIFF
--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -501,7 +501,7 @@ impl HostOutgoingBody {
             let written = w.written();
             if written != w.expected {
                 let _ = sender.send(FinishMessage::Abort);
-                return Err(self.context.as_body_error(written));
+                return Err(self.context.as_body_size_error(written));
             }
         }
 
@@ -547,8 +547,8 @@ pub enum StreamContext {
 }
 
 impl StreamContext {
-    /// Construct an http request or response body size error.
-    pub fn as_body_error(&self, size: u64) -> types::ErrorCode {
+    /// Construct the correct [`types::ErrorCode`] body size error.
+    pub fn as_body_size_error(&self, size: u64) -> types::ErrorCode {
         match self {
             StreamContext::Request => types::ErrorCode::HttpRequestBodySize(Some(size)),
             StreamContext::Response => types::ErrorCode::HttpResponseBodySize(Some(size)),
@@ -596,7 +596,7 @@ impl HostOutputStream for BodyWriteStream {
                         let total = written.written();
                         return Err(StreamError::LastOperationFailed(anyhow!(self
                             .context
-                            .as_body_error(total))));
+                            .as_body_size_error(total))));
                     }
                 }
 

--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -411,7 +411,7 @@ impl WrittenState {
 /// The concrete type behind a `wasi:http/types/outgoing-body` resource.
 pub struct HostOutgoingBody {
     /// The output stream that the body is written to.
-    pub body_output_stream: Option<Box<dyn HostOutputStream>>,
+    body_output_stream: Option<Box<dyn HostOutputStream>>,
     context: StreamContext,
     written: Option<WrittenState>,
     finish_sender: Option<tokio::sync::oneshot::Sender<FinishMessage>>,
@@ -486,6 +486,11 @@ impl HostOutgoingBody {
             },
             body_impl,
         )
+    }
+
+    /// Take the output stream, if it's available.
+    pub fn take_output_stream(&mut self) -> Option<Box<dyn HostOutputStream>> {
+        self.body_output_stream.take()
     }
 
     /// Finish the body, optionally with trailers.

--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -1,3 +1,5 @@
+//! Implementation of the `wasi:http/types` interface's various body types.
+
 use crate::{bindings::http::types, types::FieldMap};
 use anyhow::anyhow;
 use bytes::Bytes;
@@ -14,9 +16,73 @@ use wasmtime_wasi::{
     HostInputStream, HostOutputStream, StreamError, Subscribe,
 };
 
+/// Common type for incoming bodies.
 pub type HyperIncomingBody = BoxBody<Bytes, types::ErrorCode>;
 
-/// Small wrapper around `BoxBody` which adds a timeout to every frame.
+/// Common type for outgoing bodies.
+pub type HyperOutgoingBody = BoxBody<Bytes, types::ErrorCode>;
+
+/// The concrete type behind a `was:http/types/incoming-body` resource.
+pub struct HostIncomingBody {
+    body: IncomingBodyState,
+    /// An optional worker task to keep alive while this body is being read.
+    /// This ensures that if the parent of this body is dropped before the body
+    /// then the backing data behind this worker is kept alive.
+    worker: Option<AbortOnDropJoinHandle<()>>,
+}
+
+impl HostIncomingBody {
+    /// Create a new `HostIncomingBody` with the given `body` and a per-frame timeout
+    pub fn new(body: HyperIncomingBody, between_bytes_timeout: Duration) -> HostIncomingBody {
+        let body = BodyWithTimeout::new(body, between_bytes_timeout);
+        HostIncomingBody {
+            body: IncomingBodyState::Start(body),
+            worker: None,
+        }
+    }
+
+    /// Retain a worker task that needs to be kept alive while this body is being read.
+    pub fn retain_worker(&mut self, worker: AbortOnDropJoinHandle<()>) {
+        assert!(self.worker.is_none());
+        self.worker = Some(worker);
+    }
+
+    /// Try taking the stream of this body, if it's available.
+    pub fn take_stream(&mut self) -> Option<HostIncomingBodyStream> {
+        match &mut self.body {
+            IncomingBodyState::Start(_) => {}
+            IncomingBodyState::InBodyStream(_) => return None,
+        }
+        let (tx, rx) = oneshot::channel();
+        let body = match mem::replace(&mut self.body, IncomingBodyState::InBodyStream(rx)) {
+            IncomingBodyState::Start(b) => b,
+            IncomingBodyState::InBodyStream(_) => unreachable!(),
+        };
+        Some(HostIncomingBodyStream {
+            state: IncomingBodyStreamState::Open { body, tx },
+            buffer: Bytes::new(),
+            error: None,
+        })
+    }
+
+    pub fn into_future_trailers(self) -> HostFutureTrailers {
+        HostFutureTrailers::Waiting(self)
+    }
+}
+
+/// Internal state of a [`HostIncomingBody`].
+enum IncomingBodyState {
+    /// The body is stored here meaning that within `HostIncomingBody` the
+    /// `take_stream` method can be called for example.
+    Start(BodyWithTimeout),
+
+    /// The body is within a `HostIncomingBodyStream` meaning that it's not
+    /// currently owned here. The body will be sent back over this channel when
+    /// it's done, however.
+    InBodyStream(oneshot::Receiver<StreamEnd>),
+}
+
+/// Small wrapper around [`HyperIncomingBody`] which adds a timeout to every frame.
 struct BodyWithTimeout {
     /// Underlying stream that frames are coming from.
     inner: HyperIncomingBody,
@@ -77,25 +143,6 @@ impl Body for BodyWithTimeout {
     }
 }
 
-pub struct HostIncomingBody {
-    body: IncomingBodyState,
-    /// An optional worker task to keep alive while this body is being read.
-    /// This ensures that if the parent of this body is dropped before the body
-    /// then the backing data behind this worker is kept alive.
-    worker: Option<AbortOnDropJoinHandle<()>>,
-}
-
-enum IncomingBodyState {
-    /// The body is stored here meaning that within `HostIncomingBody` the
-    /// `take_stream` method can be called for example.
-    Start(BodyWithTimeout),
-
-    /// The body is within a `HostIncomingBodyStream` meaning that it's not
-    /// currently owned here. The body will be sent back over this channel when
-    /// it's done, however.
-    InBodyStream(oneshot::Receiver<StreamEnd>),
-}
-
 /// Message sent when a `HostIncomingBodyStream` is done to the
 /// `HostFutureTrailers` state.
 enum StreamEnd {
@@ -108,46 +155,57 @@ enum StreamEnd {
     Trailers(Option<FieldMap>),
 }
 
-impl HostIncomingBody {
-    pub fn new(body: HyperIncomingBody, between_bytes_timeout: Duration) -> HostIncomingBody {
-        let body = BodyWithTimeout::new(body, between_bytes_timeout);
-        HostIncomingBody {
-            body: IncomingBodyState::Start(body),
-            worker: None,
-        }
-    }
-
-    pub fn retain_worker(&mut self, worker: AbortOnDropJoinHandle<()>) {
-        assert!(self.worker.is_none());
-        self.worker = Some(worker);
-    }
-
-    pub fn take_stream(&mut self) -> Option<HostIncomingBodyStream> {
-        match &mut self.body {
-            IncomingBodyState::Start(_) => {}
-            IncomingBodyState::InBodyStream(_) => return None,
-        }
-        let (tx, rx) = oneshot::channel();
-        let body = match mem::replace(&mut self.body, IncomingBodyState::InBodyStream(rx)) {
-            IncomingBodyState::Start(b) => b,
-            IncomingBodyState::InBodyStream(_) => unreachable!(),
-        };
-        Some(HostIncomingBodyStream {
-            state: IncomingBodyStreamState::Open { body, tx },
-            buffer: Bytes::new(),
-            error: None,
-        })
-    }
-
-    pub fn into_future_trailers(self) -> HostFutureTrailers {
-        HostFutureTrailers::Waiting(self)
-    }
-}
-
+/// The concrete type behind the `wasi:io/streams/input-stream` resource returned
+/// by `wasi:http/types/incoming-body`'s `stream` method.
 pub struct HostIncomingBodyStream {
     state: IncomingBodyStreamState,
     buffer: Bytes,
     error: Option<anyhow::Error>,
+}
+
+impl HostIncomingBodyStream {
+    fn record_frame(&mut self, frame: Option<Result<Frame<Bytes>, types::ErrorCode>>) {
+        match frame {
+            Some(Ok(frame)) => match frame.into_data() {
+                // A data frame was received, so queue up the buffered data for
+                // the next `read` call.
+                Ok(bytes) => {
+                    assert!(self.buffer.is_empty());
+                    self.buffer = bytes;
+                }
+
+                // Trailers were received meaning that this was the final frame.
+                // Throw away the body and send the trailers along the
+                // `tx` channel to make them available.
+                Err(trailers) => {
+                    let trailers = trailers.into_trailers().unwrap();
+                    let tx = match mem::replace(&mut self.state, IncomingBodyStreamState::Closed) {
+                        IncomingBodyStreamState::Open { body: _, tx } => tx,
+                        IncomingBodyStreamState::Closed => unreachable!(),
+                    };
+
+                    // NB: ignore send failures here because if this fails then
+                    // no one was interested in the trailers.
+                    let _ = tx.send(StreamEnd::Trailers(Some(trailers)));
+                }
+            },
+
+            // An error was received meaning that the stream is now done.
+            // Destroy the body to terminate the stream while enqueueing the
+            // error to get returned from the next call to `read`.
+            Some(Err(e)) => {
+                self.error = Some(e.into());
+                self.state = IncomingBodyStreamState::Closed;
+            }
+
+            // No more frames are going to be received again, so drop the `body`
+            // and the `tx` channel we'd send the body back onto because it's
+            // not needed as frames are done.
+            None => {
+                self.state = IncomingBodyStreamState::Closed;
+            }
+        }
+    }
 }
 
 enum IncomingBodyStreamState {
@@ -219,51 +277,6 @@ impl Subscribe for HostIncomingBodyStream {
     }
 }
 
-impl HostIncomingBodyStream {
-    fn record_frame(&mut self, frame: Option<Result<Frame<Bytes>, types::ErrorCode>>) {
-        match frame {
-            Some(Ok(frame)) => match frame.into_data() {
-                // A data frame was received, so queue up the buffered data for
-                // the next `read` call.
-                Ok(bytes) => {
-                    assert!(self.buffer.is_empty());
-                    self.buffer = bytes;
-                }
-
-                // Trailers were received meaning that this was the final frame.
-                // Throw away the body and send the trailers along the
-                // `tx` channel to make them available.
-                Err(trailers) => {
-                    let trailers = trailers.into_trailers().unwrap();
-                    let tx = match mem::replace(&mut self.state, IncomingBodyStreamState::Closed) {
-                        IncomingBodyStreamState::Open { body: _, tx } => tx,
-                        IncomingBodyStreamState::Closed => unreachable!(),
-                    };
-
-                    // NB: ignore send failures here because if this fails then
-                    // no one was interested in the trailers.
-                    let _ = tx.send(StreamEnd::Trailers(Some(trailers)));
-                }
-            },
-
-            // An error was received meaning that the stream is now done.
-            // Destroy the body to terminate the stream while enqueueing the
-            // error to get returned from the next call to `read`.
-            Some(Err(e)) => {
-                self.error = Some(e.into());
-                self.state = IncomingBodyStreamState::Closed;
-            }
-
-            // No more frames are going to be received again, so drop the `body`
-            // and the `tx` channel we'd send the body back onto because it's
-            // not needed as frames are done.
-            None => {
-                self.state = IncomingBodyStreamState::Closed;
-            }
-        }
-    }
-}
-
 impl Drop for HostIncomingBodyStream {
     fn drop(&mut self) {
         // When a body stream is dropped, for whatever reason, attempt to send
@@ -278,6 +291,7 @@ impl Drop for HostIncomingBodyStream {
     }
 }
 
+/// The concrete type behind a `wasi:http/types/future-trailers` resource.
 pub enum HostFutureTrailers {
     /// Trailers aren't here yet.
     ///
@@ -363,8 +377,6 @@ impl Subscribe for HostFutureTrailers {
     }
 }
 
-pub type HyperOutgoingBody = BoxBody<Bytes, types::ErrorCode>;
-
 pub enum FinishMessage {
     Finished,
     Trailers(hyper::HeaderMap),
@@ -401,6 +413,7 @@ impl WrittenState {
     }
 }
 
+/// The concrete type behind a `wasi:http/types/outgoing-body` resource.
 pub struct HostOutgoingBody {
     pub body_output_stream: Option<Box<dyn HostOutputStream>>,
     context: StreamContext,
@@ -409,6 +422,7 @@ pub struct HostOutgoingBody {
 }
 
 impl HostOutgoingBody {
+    /// Create a new `HostOutgoingBody`
     pub fn new(context: StreamContext, size: Option<u64>) -> (Self, HyperOutgoingBody) {
         let written = size.map(WrittenState::new);
 
@@ -478,7 +492,8 @@ impl HostOutgoingBody {
         )
     }
 
-    pub fn finish(mut self, ts: Option<FieldMap>) -> Result<(), types::ErrorCode> {
+    /// Finish the body, optionally with trailers.
+    pub fn finish(mut self, trailers: Option<FieldMap>) -> Result<(), types::ErrorCode> {
         // Make sure that the output stream has been dropped, so that the BodyImpl poll function
         // will immediately pick up the finish sender.
         drop(self.body_output_stream);
@@ -496,7 +511,7 @@ impl HostOutgoingBody {
             }
         }
 
-        let message = if let Some(ts) = ts {
+        let message = if let Some(ts) = trailers {
             FinishMessage::Trailers(ts)
         } else {
             FinishMessage::Finished
@@ -508,6 +523,7 @@ impl HostOutgoingBody {
         Ok(())
     }
 
+    /// Abort the body.
     pub fn abort(mut self) {
         // Make sure that the output stream has been dropped, so that the BodyImpl poll function
         // will immediately pick up the finish sender.
@@ -522,6 +538,7 @@ impl HostOutgoingBody {
     }
 }
 
+/// Whether the body is a request or response body.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StreamContext {
     Request,

--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -65,6 +65,7 @@ impl HostIncomingBody {
         })
     }
 
+    /// Convert this body into a `HostFutureTrailers` resource.
     pub fn into_future_trailers(self) -> HostFutureTrailers {
         HostFutureTrailers::Waiting(self)
     }
@@ -409,6 +410,7 @@ impl WrittenState {
 
 /// The concrete type behind a `wasi:http/types/outgoing-body` resource.
 pub struct HostOutgoingBody {
+    /// The output stream that the body is written to.
     pub body_output_stream: Option<Box<dyn HostOutputStream>>,
     context: StreamContext,
     written: Option<WrittenState>,
@@ -542,7 +544,9 @@ enum FinishMessage {
 /// Whether the body is a request or response body.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum StreamContext {
+    /// The body is a request body.
     Request,
+    /// The body is a response body.
     Response,
 }
 

--- a/crates/wasi-http/src/body.rs
+++ b/crates/wasi-http/src/body.rs
@@ -377,12 +377,6 @@ impl Subscribe for HostFutureTrailers {
     }
 }
 
-pub enum FinishMessage {
-    Finished,
-    Trailers(hyper::HeaderMap),
-    Abort,
-}
-
 #[derive(Clone)]
 struct WrittenState {
     expected: u64,
@@ -536,6 +530,13 @@ impl HostOutgoingBody {
 
         let _ = sender.send(FinishMessage::Abort);
     }
+}
+
+/// Message sent to end the `[HostOutgoingBody]` stream.
+enum FinishMessage {
+    Finished,
+    Trailers(hyper::HeaderMap),
+    Abort,
 }
 
 /// Whether the body is a request or response body.

--- a/crates/wasi-http/src/error.rs
+++ b/crates/wasi-http/src/error.rs
@@ -3,6 +3,7 @@ use std::error::Error;
 use std::fmt;
 use wasmtime_wasi::ResourceTableError;
 
+/// A [`Result`] type where the error type defaults to [`HttpError`].
 pub type HttpResult<T, E = HttpError> = Result<T, E>;
 
 /// A `wasi:http`-specific error type used to represent either a trap or an
@@ -15,14 +16,17 @@ pub struct HttpError {
 }
 
 impl HttpError {
+    /// Create a new `HttpError` that represents a trap.
     pub fn trap(err: impl Into<anyhow::Error>) -> HttpError {
         HttpError { err: err.into() }
     }
 
+    /// Downcast this error to an [`ErrorCode`].
     pub fn downcast(self) -> anyhow::Result<ErrorCode> {
         self.err.downcast()
     }
 
+    /// Downcast this error to a reference to an [`ErrorCode`]
     pub fn downcast_ref(&self) -> Option<&ErrorCode> {
         self.err.downcast_ref()
     }

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -1,3 +1,5 @@
+//! Implementation of the `wasi:http/outgoing-handler` interface.
+
 use crate::{
     bindings::http::{
         outgoing_handler,

--- a/crates/wasi-http/src/http_impl.rs
+++ b/crates/wasi-http/src/http_impl.rs
@@ -3,7 +3,8 @@ use crate::{
         outgoing_handler,
         types::{self, Scheme},
     },
-    http_request_error, internal_error,
+    error::internal_error,
+    http_request_error,
     types::{HostFutureIncomingResponse, HostOutgoingRequest, OutgoingRequestConfig},
     WasiHttpView,
 };

--- a/crates/wasi-http/src/io.rs
+++ b/crates/wasi-http/src/io.rs
@@ -1,14 +1,19 @@
+//! I/O utility for bridging between `tokio::io` and `hyper::rt`.
+
 use hyper::rt::{Read, ReadBufCursor, Write};
 use std::io::Error;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
+/// A type that wraps any type implementing [`tokio::io::AsyncRead`] and [`tokio::io::AsyncWrite`]
+/// and itself implements [`hyper::rt::Read`] and [`hyper::rt::Write`].
 pub struct TokioIo<T> {
     inner: T,
 }
 
 impl<T> TokioIo<T> {
+    /// Create a new `TokioIo` wrapping the given inner type.
     pub fn new(inner: T) -> TokioIo<T> {
         TokioIo { inner }
     }

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -33,6 +33,8 @@
 //!    targeting the `wasi:http/proxy` world, you can instantiate the component with
 //!    [`proxy::Proxy::instantiate_async`] or [`proxy::sync::Proxy::instantiate`] functions.
 
+#![deny(missing_docs)]
+
 mod error;
 mod http_impl;
 mod types_impl;
@@ -44,6 +46,7 @@ pub mod types;
 
 /// Raw bindings to the `wasi:http` package.
 pub mod bindings {
+    #![allow(missing_docs)]
     wasmtime::component::bindgen!({
         path: "wit",
         interfaces: "

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -1,10 +1,11 @@
-pub mod body;
 mod error;
 mod http_impl;
+mod types_impl;
+
+pub mod body;
 pub mod io;
 pub mod proxy;
 pub mod types;
-pub mod types_impl;
 
 /// Raw bindings to the `wasi:http` package.
 pub mod bindings {

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod body;
 mod error;
-pub mod http_impl;
+mod http_impl;
 pub mod io;
 pub mod proxy;
 pub mod types;

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -48,4 +48,5 @@ pub mod bindings {
 pub use crate::error::{
     http_request_error, hyper_request_error, hyper_response_error, HttpError, HttpResult,
 };
+#[doc(inline)]
 pub use crate::types::{WasiHttpCtx, WasiHttpView};

--- a/crates/wasi-http/src/lib.rs
+++ b/crates/wasi-http/src/lib.rs
@@ -1,3 +1,38 @@
+//! Wasmtime's WASI HTTP Implementation
+//!
+//! This crate's implementation is primarily built on top of [`hyper`].
+//!
+//! # WASI HTTP Interfaces
+//!
+//! This crate contains implementations of the following interfaces:
+//!
+//! * `wasi:http/incoming-handler`
+//! * `wasi:http/outgoing-handler`
+//! * `wasi:http/types`
+//!
+//! The crate also contains an implementation of the [`wasi:http/proxy`] world.
+//!
+//! [`wasi:http/proxy`]: crate::proxy
+
+//! All traits are implemented in terms of a [`WasiHttpView`] trait which provides
+//! basic access to [`WasiHttpCtx`], configuration for WASI HTTP, and a [`wasmtime_wasi::ResourceTable`],
+//! the state for all host-defined component model resources.
+
+//! # Examples
+//!
+//! Usage of this crate is done through a few steps to get everything hooked up:
+//!
+//! 1. First implement [`WasiHttpView`] for your type which is the `T` in
+//!    [`wasmtime::Store<T>`].
+//! 2. Add WASI HTTP interfaces to a [`wasmtime::component::Linker<T>`]. This is either
+//!    done through functions like [`proxy::add_to_linker`] (which bundles all interfaces
+//!    in the `wasi:http/proxy` world together) or through individual interfaces like the
+//!    [`bindings::http::outgoing_handler::add_to_linker`] function.
+//! 3. Use the previous [`wasmtime::component::Linker<T>::instantiate`] to instantiate
+//!    a [`wasmtime::component::Component`] within a [`wasmtime::Store<T>`]. If you're
+//!    targeting the `wasi:http/proxy` world, you can instantiate the component with
+//!    [`proxy::Proxy::instantiate_async`] or [`proxy::sync::Proxy::instantiate`] functions.
+
 mod error;
 mod http_impl;
 mod types_impl;

--- a/crates/wasi-http/src/proxy.rs
+++ b/crates/wasi-http/src/proxy.rs
@@ -23,9 +23,61 @@ pub use bindings::exports;
 /// Bindings to the `wasi:http/proxy` world.
 pub use bindings::Proxy;
 
-/// Add support for the `wasi:http/proxy` world to a [`wasmtime::component::Linker`].
+/// Add all of the `wasi:http/proxy` world's interfaces to a [`wasmtime::component::Linker`].
 ///
-/// This should be used in async contexts. For sync contexts, use [`sync::add_to_linker`].
+/// This function will add the `async` variant of all interfaces into the
+/// `Linker` provided. By `async` this means that this function is only
+/// compatible with [`Config::async_support(true)`][async]. For embeddings with
+/// async support disabled see [`sync::add_to_linker`] instead.
+///
+/// [async]: wasmtime::Config::async_support
+///
+/// # Example
+///
+/// ```
+/// use wasmtime::{Engine, Result, Store, Config};
+/// use wasmtime::component::{ResourceTable, Linker};
+/// use wasmtime_wasi::{WasiCtx, WasiView, WasiCtxBuilder};
+/// use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
+///
+/// fn main() -> Result<()> {
+///     let mut config = Config::new();
+///     config.async_support(true);
+///     let engine = Engine::new(&config)?;
+///
+///     let mut linker = Linker::<MyState>::new(&engine);
+///     wasmtime_wasi_http::proxy::add_to_linker(&mut linker)?;
+///     // ... add any further functionality to `linker` if desired ...
+///
+///     let mut store = Store::new(
+///         &engine,
+///         MyState {
+///             ctx: WasiCtxBuilder::new().build(),
+///             http_ctx: WasiHttpCtx::new(),
+///             table: ResourceTable::new(),
+///         },
+///     );
+///
+///     // use `linker.instantiate_async` to instantiate within `store`
+///
+///     Ok(())
+/// }
+///
+/// struct MyState {
+///     ctx: WasiCtx,
+///     http_ctx: WasiHttpCtx,
+///     table: ResourceTable,
+/// }
+///
+/// impl WasiHttpView for MyState {
+///     fn ctx(&mut self) -> &mut WasiHttpCtx { &mut self.http_ctx }
+///     fn table(&mut self) -> &mut ResourceTable { &mut self.table }
+/// }
+/// impl WasiView for MyState {
+///     fn ctx(&mut self) -> &mut WasiCtx { &mut self.ctx }
+///     fn table(&mut self) -> &mut ResourceTable { &mut self.table }
+/// }
+/// ```
 pub fn add_to_linker<T>(l: &mut wasmtime::component::Linker<T>) -> anyhow::Result<()>
 where
     T: WasiHttpView + wasmtime_wasi::WasiView,
@@ -58,20 +110,75 @@ where
 pub mod sync {
     use crate::WasiHttpView;
 
-    wasmtime::component::bindgen!({
-        world: "wasi:http/proxy",
-        tracing: true,
-        async: false,
-        with: {
-            "wasi:http": crate::bindings::http, // http is in this crate
-            "wasi:io": wasmtime_wasi::bindings::sync, // io is sync
-            "wasi": wasmtime_wasi::bindings, // everything else
-        },
-    });
+    mod bindings {
+        wasmtime::component::bindgen!({
+            world: "wasi:http/proxy",
+            tracing: true,
+            async: false,
+            with: {
+                "wasi:http": crate::bindings::http, // http is in this crate
+                "wasi:io": wasmtime_wasi::bindings::sync, // io is sync
+                "wasi": wasmtime_wasi::bindings, // everything else
+            },
+        });
+    }
 
-    /// Add support for the `wasi:http/proxy` world to a [`wasmtime::component::Linker`].
+    /// Raw bindings to the `wasi:http/proxy` exports.
+    pub use bindings::exports;
+
+    /// Bindings to the `wasi:http/proxy` world.
+    pub use bindings::Proxy;
+
+    /// Add all of the `wasi:http/proxy` world's interfaces to a [`wasmtime::component::Linker`].
     ///
-    /// This should be used in sync contexts. For async contexts, use [`super::add_to_linker`].
+    /// This function will add the `sync` variant of all interfaces into the
+    /// `Linker` provided. For embeddings with async support see [`super::add_to_linker`] instead.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use wasmtime::{Engine, Result, Store, Config};
+    /// use wasmtime::component::{ResourceTable, Linker};
+    /// use wasmtime_wasi::{WasiCtx, WasiView, WasiCtxBuilder};
+    /// use wasmtime_wasi_http::{WasiHttpCtx, WasiHttpView};
+    ///
+    /// fn main() -> Result<()> {
+    ///     let config = Config::default();
+    ///     let engine = Engine::new(&config)?;
+    ///
+    ///     let mut linker = Linker::<MyState>::new(&engine);
+    ///     wasmtime_wasi_http::proxy::sync::add_to_linker(&mut linker)?;
+    ///     // ... add any further functionality to `linker` if desired ...
+    ///
+    ///     let mut store = Store::new(
+    ///         &engine,
+    ///         MyState {
+    ///             ctx: WasiCtxBuilder::new().build(),
+    ///             http_ctx: WasiHttpCtx::new(),
+    ///             table: ResourceTable::new(),
+    ///         },
+    ///     );
+    ///
+    ///     // use `linker.instantiate` to instantiate within `store`
+    ///
+    ///     Ok(())
+    /// }
+    ///
+    /// struct MyState {
+    ///     ctx: WasiCtx,
+    ///     http_ctx: WasiHttpCtx,
+    ///     table: ResourceTable,
+    /// }
+    ///
+    /// impl WasiHttpView for MyState {
+    ///     fn ctx(&mut self) -> &mut WasiHttpCtx { &mut self.http_ctx }
+    ///     fn table(&mut self) -> &mut ResourceTable { &mut self.table }
+    /// }
+    /// impl WasiView for MyState {
+    ///     fn ctx(&mut self) -> &mut WasiCtx { &mut self.ctx }
+    ///     fn table(&mut self) -> &mut ResourceTable { &mut self.table }
+    /// }
+    /// ```
     pub fn add_to_linker<T>(l: &mut wasmtime::component::Linker<T>) -> anyhow::Result<()>
     where
         T: WasiHttpView + wasmtime_wasi::WasiView,

--- a/crates/wasi-http/src/proxy.rs
+++ b/crates/wasi-http/src/proxy.rs
@@ -6,6 +6,7 @@
 use crate::WasiHttpView;
 
 mod bindings {
+    #![allow(missing_docs)]
     wasmtime::component::bindgen!({
         world: "wasi:http/proxy",
         tracing: true,
@@ -111,6 +112,7 @@ pub mod sync {
     use crate::WasiHttpView;
 
     mod bindings {
+        #![allow(missing_docs)]
         wasmtime::component::bindgen!({
             world: "wasi:http/proxy",
             tracing: true,

--- a/crates/wasi-http/src/proxy.rs
+++ b/crates/wasi-http/src/proxy.rs
@@ -1,15 +1,31 @@
-use crate::{bindings, WasiHttpView};
+//! Implementation of the `wasi:http/proxy` world.
+//!
+//! The implementation at the top of the module for use in async contexts,
+//! while the `sync` module provides implementation for use in sync contexts.
 
-wasmtime::component::bindgen!({
-    world: "wasi:http/proxy",
-    tracing: true,
-    async: true,
-    with: {
-        "wasi:http": bindings::http,
-        "wasi": wasmtime_wasi::bindings,
-    },
-});
+use crate::WasiHttpView;
 
+mod bindings {
+    wasmtime::component::bindgen!({
+        world: "wasi:http/proxy",
+        tracing: true,
+        async: true,
+        with: {
+            "wasi:http": crate::bindings::http,
+            "wasi": wasmtime_wasi::bindings,
+        },
+    });
+}
+
+/// Raw bindings to the `wasi:http/proxy` exports.
+pub use bindings::exports;
+
+/// Bindings to the `wasi:http/proxy` world.
+pub use bindings::Proxy;
+
+/// Add support for the `wasi:http/proxy` world to a [`wasmtime::component::Linker`].
+///
+/// This should be used in async contexts. For sync contexts, use [`sync::add_to_linker`].
 pub fn add_to_linker<T>(l: &mut wasmtime::component::Linker<T>) -> anyhow::Result<()>
 where
     T: WasiHttpView + wasmtime_wasi::WasiView,
@@ -30,28 +46,32 @@ where
 #[doc(hidden)]
 pub fn add_only_http_to_linker<T>(l: &mut wasmtime::component::Linker<T>) -> anyhow::Result<()>
 where
-    T: WasiHttpView + wasmtime_wasi::WasiView + bindings::http::types::Host,
+    T: WasiHttpView + wasmtime_wasi::WasiView + crate::bindings::http::types::Host,
 {
-    bindings::http::outgoing_handler::add_to_linker(l, |t| t)?;
-    bindings::http::types::add_to_linker(l, |t| t)?;
+    crate::bindings::http::outgoing_handler::add_to_linker(l, |t| t)?;
+    crate::bindings::http::types::add_to_linker(l, |t| t)?;
 
     Ok(())
 }
 
+/// Sync implementation of the `wasi:http/proxy` world.
 pub mod sync {
-    use crate::{bindings, WasiHttpView};
+    use crate::WasiHttpView;
 
     wasmtime::component::bindgen!({
         world: "wasi:http/proxy",
         tracing: true,
         async: false,
         with: {
-            "wasi:http": bindings::http, // http is in this crate
+            "wasi:http": crate::bindings::http, // http is in this crate
             "wasi:io": wasmtime_wasi::bindings::sync, // io is sync
             "wasi": wasmtime_wasi::bindings, // everything else
         },
     });
 
+    /// Add support for the `wasi:http/proxy` world to a [`wasmtime::component::Linker`].
+    ///
+    /// This should be used in sync contexts. For async contexts, use [`super::add_to_linker`].
     pub fn add_to_linker<T>(l: &mut wasmtime::component::Linker<T>) -> anyhow::Result<()>
     where
         T: WasiHttpView + wasmtime_wasi::WasiView,
@@ -75,10 +95,10 @@ pub mod sync {
     // TODO: This is temporary solution until the wasmtime_wasi command functions can be removed
     pub fn add_only_http_to_linker<T>(l: &mut wasmtime::component::Linker<T>) -> anyhow::Result<()>
     where
-        T: WasiHttpView + wasmtime_wasi::WasiView + bindings::http::types::Host,
+        T: WasiHttpView + wasmtime_wasi::WasiView + crate::bindings::http::types::Host,
     {
-        bindings::http::outgoing_handler::add_to_linker(l, |t| t)?;
-        bindings::http::types::add_to_linker(l, |t| t)?;
+        crate::bindings::http::outgoing_handler::add_to_linker(l, |t| t)?;
+        crate::bindings::http::types::add_to_linker(l, |t| t)?;
 
         Ok(())
     }

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -78,6 +78,7 @@ pub trait WasiHttpView: Send {
         Ok(default_send_request(request, config))
     }
 
+    /// Whether a given header should be considered forbidden and not allowed.
     fn is_forbidden_header(&mut self, _name: &HeaderName) -> bool {
         false
     }
@@ -327,6 +328,7 @@ impl TryInto<http::Method> for types::Method {
 /// The concrete type behind a `wasi:http/types/incoming-request` resource.
 pub struct HostIncomingRequest {
     pub(crate) parts: http::request::Parts,
+    /// The body of the incoming request.
     pub body: Option<HostIncomingBody>,
 }
 
@@ -344,14 +346,18 @@ impl HostIncomingRequest {
 
 /// The concrete type behind a `wasi:http/types/response-outparam` resource.
 pub struct HostResponseOutparam {
+    /// The sender for sending a response.
     pub result:
         tokio::sync::oneshot::Sender<Result<hyper::Response<HyperOutgoingBody>, types::ErrorCode>>,
 }
 
 /// The concrete type behind a `wasi:http/types/outgoing-response` resource.
 pub struct HostOutgoingResponse {
+    /// The status of the response.
     pub status: http::StatusCode,
+    /// The headers of the response.
     pub headers: FieldMap,
+    /// The body of the response.
     pub body: Option<HyperOutgoingBody>,
 }
 
@@ -380,41 +386,58 @@ impl TryFrom<HostOutgoingResponse> for hyper::Response<HyperOutgoingBody> {
 
 /// The concrete type behind a `wasi:http/types/outgoing-request` resource.
 pub struct HostOutgoingRequest {
+    /// The method of the request.
     pub method: Method,
+    /// The scheme of the request.
     pub scheme: Option<Scheme>,
+    /// The authority of the request.
     pub authority: Option<String>,
+    /// The path and query of the request.
     pub path_with_query: Option<String>,
+    /// The request headers.
     pub headers: FieldMap,
+    /// The request body.
     pub body: Option<HyperOutgoingBody>,
 }
 
 /// The concrete type behind a `wasi:http/types/request-options` resource.
 #[derive(Default)]
 pub struct HostRequestOptions {
+    /// How long to wait for a connection to be established.
     pub connect_timeout: Option<std::time::Duration>,
+    /// How long to wait for the first byte of the response body.
     pub first_byte_timeout: Option<std::time::Duration>,
+    /// How long to wait between frames of the response body.
     pub between_bytes_timeout: Option<std::time::Duration>,
 }
 
 /// The concrete type behind a `wasi:http/types/incoming-response` resource.
 pub struct HostIncomingResponse {
+    /// The response status
     pub status: u16,
+    /// The response headers
     pub headers: FieldMap,
+    /// The response body
     pub body: Option<HostIncomingBody>,
 }
 
 /// The concrete type behind a `wasi:http/types/fields` resource.
 pub enum HostFields {
+    /// A reference to the fields of a parent entry.
     Ref {
+        /// The parent resource rep.
         parent: u32,
 
+        /// The function to get the fields from the parent.
         // NOTE: there's not failure in the result here because we assume that HostFields will
         // always be registered as a child of the entry with the `parent` id. This ensures that the
         // entry will always exist while this `HostFields::Ref` entry exists in the table, thus we
         // don't need to account for failure when fetching the fields ref from the parent.
         get_fields: for<'a> fn(elem: &'a mut (dyn Any + 'static)) -> &'a mut FieldMap,
     },
+    /// An owned version of the fields.
     Owned {
+        /// The fields themselves.
         fields: FieldMap,
     },
 }

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -5,7 +5,8 @@ use crate::io::TokioIo;
 use crate::{
     bindings::http::types::{self, Method, Scheme},
     body::{HostIncomingBody, HyperIncomingBody, HyperOutgoingBody},
-    dns_error, hyper_request_error,
+    error::dns_error,
+    hyper_request_error,
 };
 use http_body_util::BodyExt;
 use hyper::header::HeaderName;

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -342,7 +342,7 @@ impl HostIncomingRequest {
     }
 }
 
-/// The concrete type behind a `was:http/types/response-outparam` resource.
+/// The concrete type behind a `wasi:http/types/response-outparam` resource.
 pub struct HostResponseOutparam {
     pub result:
         tokio::sync::oneshot::Sender<Result<hyper::Response<HyperOutgoingBody>, types::ErrorCode>>,

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -872,7 +872,7 @@ impl<T: WasiHttpView> crate::bindings::http::types::HostOutgoingBody for T {
         id: Resource<HostOutgoingBody>,
     ) -> wasmtime::Result<Result<Resource<OutputStream>, ()>> {
         let body = self.table().get_mut(&id)?;
-        if let Some(stream) = body.body_output_stream.take() {
+        if let Some(stream) = body.take_output_stream() {
             let id = self.table().push_child(stream, &id)?;
             Ok(Ok(id))
         } else {

--- a/crates/wasi-http/src/types_impl.rs
+++ b/crates/wasi-http/src/types_impl.rs
@@ -1,3 +1,5 @@
+//! Implementation for the `wasi:http/types` interface.
+
 use crate::{
     bindings::http::types::{self, Headers, Method, Scheme, StatusCode, Trailers},
     body::{HostFutureTrailers, HostIncomingBody, HostOutgoingBody, StreamContext},


### PR DESCRIPTION
This documents almost all of `wasmtime-wasi-http` (excluding raw bindings) and adds `#![deny(missing_docs)]` to the crate. Along with documentation changes there are a few small changes in the same vain as #8332. 

It's probably easiest to go commit by commit to see each individual change.