### PR TITLE
Enable all function references spec tests

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -257,25 +257,6 @@ fn ignore(testsuite: &str, testname: &str, strategy: &str) -> bool {
         return true;
     }
 
-    if testsuite == "function_references" {
-        // The following tests fail due to function references not yet
-        // being exposed in the public API.
-        if testname == "ref_null" || testname == "local_init" {
-            return true;
-        }
-        // This test fails due to incomplete support for the various
-        // table/elem syntactic sugar in wasm-tools/wast.
-        if testname == "br_table" {
-            return true;
-        }
-        // This test fails due to the current implementation of type
-        // canonicalisation being broken as a result of
-        // #[derive(hash)] on WasmHeapType.
-        if testname == "type_equivalence" {
-            return true;
-        }
-    }
-
     if testsuite == "gc" {
         if [
             "array_copy",


### PR DESCRIPTION
These are all passing now that we support typed function references in the embedder API and our `wasmparser` and `wast` deps have been updated to versions that fix the issues referenced in the old comments.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
