### PR TITLE
Move `VMSharedTypeIndex` to the `wasmtime-types` crate

### DIFF
--- a/crates/runtime/src/component.rs
+++ b/crates/runtime/src/component.rs
@@ -8,7 +8,7 @@
 
 use crate::{
     SendSyncPtr, Store, VMArrayCallFunction, VMFuncRef, VMGlobalDefinition, VMMemoryDefinition,
-    VMNativeCallFunction, VMOpaqueContext, VMSharedTypeIndex, VMWasmCallFunction, ValRaw,
+    VMNativeCallFunction, VMOpaqueContext, VMWasmCallFunction, ValRaw,
 };
 use anyhow::Result;
 use memoffset::offset_of;
@@ -21,7 +21,7 @@ use std::ops::Deref;
 use std::ptr::{self, NonNull};
 use std::sync::Arc;
 use wasmtime_environ::component::*;
-use wasmtime_environ::{HostPtr, PrimaryMap};
+use wasmtime_environ::{HostPtr, PrimaryMap, VMSharedTypeIndex};
 
 const INVALID_PTR: usize = 0xdead_dead_beef_beef_u64 as usize;
 

--- a/crates/runtime/src/gc/gc_ref.rs
+++ b/crates/runtime/src/gc/gc_ref.rs
@@ -1,7 +1,7 @@
-use crate::{GcHeap, GcStore, VMSharedTypeIndex, I31};
+use crate::{GcHeap, GcStore, I31};
 use anyhow::{Context, Result};
 use std::num::NonZeroU32;
-use wasmtime_environ::VMGcKind;
+use wasmtime_environ::{VMGcKind, VMSharedTypeIndex};
 
 /// The common header for all objects allocated in a GC heap.
 ///

--- a/crates/runtime/src/instance.rs
+++ b/crates/runtime/src/instance.rs
@@ -12,7 +12,7 @@ use crate::vmcontext::{
 };
 use crate::{
     ExportFunction, ExportGlobal, ExportMemory, ExportTable, GcStore, Imports, ModuleRuntimeInfo,
-    SendSyncPtr, Store, VMFunctionBody, VMGcRef, VMSharedTypeIndex, WasmFault, I31,
+    SendSyncPtr, Store, VMFunctionBody, VMGcRef, WasmFault, I31,
 };
 use anyhow::Error;
 use anyhow::Result;
@@ -29,8 +29,8 @@ use wasmtime_environ::{
     packed_option::ReservedValue, DataIndex, DefinedGlobalIndex, DefinedMemoryIndex,
     DefinedTableIndex, ElemIndex, EntityIndex, EntityRef, EntitySet, FuncIndex, GlobalIndex,
     GlobalInit, HostPtr, MemoryIndex, MemoryPlan, Module, PrimaryMap, TableElementExpression,
-    TableIndex, TableInitialValue, TableSegmentElements, Trap, VMOffsets, WasmRefType, WasmValType,
-    VMCONTEXT_MAGIC,
+    TableIndex, TableInitialValue, TableSegmentElements, Trap, VMOffsets, VMSharedTypeIndex,
+    WasmRefType, WasmValType, VMCONTEXT_MAGIC,
 };
 #[cfg(feature = "wmemcheck")]
 use wasmtime_wmemcheck::Wmemcheck;

--- a/crates/runtime/src/lib.rs
+++ b/crates/runtime/src/lib.rs
@@ -10,6 +10,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 use wasmtime_environ::{
     DefinedFuncIndex, DefinedMemoryIndex, HostPtr, ModuleInternedTypeIndex, VMOffsets,
+    VMSharedTypeIndex,
 };
 
 mod arch;
@@ -67,8 +68,7 @@ pub use crate::vmcontext::{
     VMArrayCallFunction, VMArrayCallHostFuncContext, VMContext, VMFuncRef, VMFunctionBody,
     VMFunctionImport, VMGlobalDefinition, VMGlobalImport, VMInvokeArgument, VMMemoryDefinition,
     VMMemoryImport, VMNativeCallFunction, VMNativeCallHostFuncContext, VMOpaqueContext,
-    VMRuntimeLimits, VMSharedTypeIndex, VMTableDefinition, VMTableImport, VMWasmCallFunction,
-    ValRaw,
+    VMRuntimeLimits, VMTableDefinition, VMTableImport, VMWasmCallFunction, ValRaw,
 };
 pub use send_sync_ptr::SendSyncPtr;
 

--- a/crates/runtime/src/vmcontext.rs
+++ b/crates/runtime/src/vmcontext.rs
@@ -13,6 +13,7 @@ use std::ptr::{self, NonNull};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::u32;
 pub use vm_host_func_context::{VMArrayCallHostFuncContext, VMNativeCallHostFuncContext};
+use wasmtime_environ::VMSharedTypeIndex;
 use wasmtime_environ::{BuiltinFunctionIndex, DefinedMemoryIndex, Unsigned, VMCONTEXT_MAGIC};
 
 /// A function pointer that exposes the array calling convention.
@@ -569,12 +570,6 @@ impl VMGlobalDefinition {
     }
 }
 
-/// An index into the shared type registry, usable for checking signatures
-/// at indirect calls.
-#[repr(C)]
-#[derive(Debug, Eq, PartialEq, Clone, Copy, Hash)]
-pub struct VMSharedTypeIndex(u32);
-
 #[cfg(test)]
 mod test_vmshared_type_index {
     use super::VMSharedTypeIndex;
@@ -589,32 +584,6 @@ mod test_vmshared_type_index {
             size_of::<VMSharedTypeIndex>(),
             usize::from(offsets.size_of_vmshared_type_index())
         );
-    }
-}
-
-impl VMSharedTypeIndex {
-    /// Create a new `VMSharedTypeIndex`.
-    #[inline]
-    pub fn new(value: u32) -> Self {
-        assert_ne!(
-            value,
-            u32::MAX,
-            "u32::MAX is reserved for the default value"
-        );
-        Self(value)
-    }
-
-    /// Returns the underlying bits of the index.
-    #[inline]
-    pub fn bits(&self) -> u32 {
-        self.0
-    }
-}
-
-impl Default for VMSharedTypeIndex {
-    #[inline]
-    fn default() -> Self {
-        Self(u32::MAX)
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/instance.rs
+++ b/crates/wasmtime/src/runtime/component/instance.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use wasmtime_environ::{component::*, EngineOrModuleTypeIndex};
 use wasmtime_environ::{EntityIndex, EntityType, Global, PrimaryMap, WasmValType};
 use wasmtime_runtime::component::{ComponentInstance, OwnedComponentInstance};
-use wasmtime_runtime::{VMFuncRef, VMSharedTypeIndex};
+use wasmtime_runtime::VMFuncRef;
 
 /// An instantiated component.
 ///
@@ -500,7 +500,7 @@ impl<'a> Instantiator<'a> {
         // can't fall through to the case below
         if let wasmtime_runtime::Export::Function(f) = &export {
             let expected = match expected.unwrap_func() {
-                EngineOrModuleTypeIndex::Engine(e) => Some(VMSharedTypeIndex::new(e)),
+                EngineOrModuleTypeIndex::Engine(e) => Some(e),
                 EngineOrModuleTypeIndex::Module(m) => module.signatures().shared_type(m),
             };
             let actual = unsafe { f.func_ref.as_ref().type_index };

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -229,7 +229,7 @@ impl Global {
             .wasm_ty
             .canonicalize(&mut |module_index| {
                 wasmtime_runtime::Instance::from_vmctx(wasmtime_export.vmctx, |instance| {
-                    instance.engine_type_index(module_index).bits()
+                    instance.engine_type_index(module_index)
                 })
             });
 

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -405,7 +405,7 @@ impl Table {
             .wasm_ty
             .canonicalize(&mut |module_index| {
                 wasmtime_runtime::Instance::from_vmctx(wasmtime_export.vmctx, |instance| {
-                    instance.engine_type_index(module_index).bits()
+                    instance.engine_type_index(module_index)
                 })
             });
 

--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -13,9 +13,10 @@ use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::ptr::{self, NonNull};
 use std::sync::Arc;
+use wasmtime_environ::VMSharedTypeIndex;
 use wasmtime_runtime::{
     ExportFunction, SendSyncPtr, StoreBox, VMArrayCallHostFuncContext, VMContext, VMFuncRef,
-    VMFunctionImport, VMNativeCallHostFuncContext, VMOpaqueContext, VMSharedTypeIndex,
+    VMFunctionImport, VMNativeCallHostFuncContext, VMOpaqueContext,
 };
 
 /// A reference to the abstract `nofunc` heap value.

--- a/crates/wasmtime/src/runtime/func/typed.rs
+++ b/crates/wasmtime/src/runtime/func/typed.rs
@@ -10,9 +10,8 @@ use std::mem::{self, MaybeUninit};
 use std::num::NonZeroUsize;
 use std::os::raw::c_void;
 use std::ptr::{self, NonNull};
-use wasmtime_runtime::{
-    VMContext, VMFuncRef, VMNativeCallFunction, VMOpaqueContext, VMSharedTypeIndex,
-};
+use wasmtime_environ::VMSharedTypeIndex;
+use wasmtime_runtime::{VMContext, VMFuncRef, VMNativeCallFunction, VMOpaqueContext};
 
 /// A statically typed WebAssembly function.
 ///

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -978,11 +978,7 @@ fn typecheck<I>(
     let cx = matching::MatchCx::new(module.engine());
     for ((name, field, mut expected_ty), actual) in env_module.imports().zip(imports) {
         expected_ty.canonicalize(&mut |module_index| {
-            module
-                .signatures()
-                .shared_type(module_index)
-                .unwrap()
-                .bits()
+            module.signatures().shared_type(module_index).unwrap()
         });
 
         check(&cx, &expected_ty, actual)

--- a/crates/wasmtime/src/runtime/linker.rs
+++ b/crates/wasmtime/src/runtime/linker.rs
@@ -122,7 +122,7 @@ pub(crate) enum Definition {
 /// size of the table/memory.
 #[derive(Clone)]
 pub(crate) enum DefinitionType {
-    Func(wasmtime_runtime::VMSharedTypeIndex),
+    Func(wasmtime_environ::VMSharedTypeIndex),
     Global(wasmtime_environ::Global),
     // Note that tables and memories store not only the original type
     // information but additionally the current size of the table/memory, as

--- a/crates/wasmtime/src/runtime/module.rs
+++ b/crates/wasmtime/src/runtime/module.rs
@@ -17,11 +17,11 @@ use std::sync::Arc;
 use wasmparser::{Parser, ValidPayload, Validator};
 use wasmtime_environ::{
     CompiledModuleInfo, DefinedFuncIndex, DefinedMemoryIndex, EntityIndex, HostPtr, ModuleTypes,
-    ObjectKind, VMOffsets,
+    ObjectKind, VMOffsets, VMSharedTypeIndex,
 };
 use wasmtime_runtime::{
     CompiledModuleId, MemoryImage, MmapVec, ModuleMemoryImages, VMArrayCallFunction,
-    VMNativeCallFunction, VMSharedTypeIndex, VMWasmCallFunction,
+    VMNativeCallFunction, VMWasmCallFunction,
 };
 
 mod registry;

--- a/crates/wasmtime/src/runtime/module/registry.rs
+++ b/crates/wasmtime/src/runtime/module/registry.rs
@@ -11,7 +11,8 @@ use std::{
     ptr::NonNull,
     sync::{Arc, RwLock},
 };
-use wasmtime_runtime::{VMSharedTypeIndex, VMWasmCallFunction};
+use wasmtime_environ::VMSharedTypeIndex;
+use wasmtime_runtime::VMWasmCallFunction;
 
 /// Used for registering modules with a store.
 ///

--- a/crates/wasmtime/src/runtime/trampoline.rs
+++ b/crates/wasmtime/src/runtime/trampoline.rs
@@ -17,10 +17,10 @@ use crate::{MemoryType, TableType};
 use anyhow::Result;
 use std::any::Any;
 use std::sync::Arc;
-use wasmtime_environ::{MemoryIndex, Module, TableIndex};
+use wasmtime_environ::{MemoryIndex, Module, TableIndex, VMSharedTypeIndex};
 use wasmtime_runtime::{
     Imports, InstanceAllocationRequest, InstanceAllocator, OnDemandInstanceAllocator, SharedMemory,
-    StorePtr, VMFunctionImport, VMSharedTypeIndex,
+    StorePtr, VMFunctionImport,
 };
 
 fn create_handle(

--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -20,9 +20,8 @@ use std::{
 };
 use wasmtime_environ::{
     EngineOrModuleTypeIndex, ModuleInternedTypeIndex, ModuleTypes, PrimaryMap, TypeTrace,
-    WasmFuncType,
+    VMSharedTypeIndex, WasmFuncType,
 };
-use wasmtime_runtime::VMSharedTypeIndex;
 use wasmtime_slab::{Id as SlabId, Slab};
 
 // ### Notes on the Lifetime Management of Types
@@ -421,7 +420,6 @@ impl TypeRegistryInner {
         let result = ty.trace::<_, ()>(&mut |index| match index {
             EngineOrModuleTypeIndex::Module(_) => Err(()),
             EngineOrModuleTypeIndex::Engine(id) => {
-                let id = VMSharedTypeIndex::new(id);
                 let id = shared_type_index_to_slab_id(id);
                 assert!(
                     self.entries.contains(id),
@@ -447,7 +445,7 @@ impl TypeRegistryInner {
         module_to_shared: &PrimaryMap<ModuleInternedTypeIndex, VMSharedTypeIndex>,
         ty: &mut WasmFuncType,
     ) {
-        ty.canonicalize(&mut |module_index| module_to_shared[module_index].bits());
+        ty.canonicalize(&mut |module_index| module_to_shared[module_index]);
         debug_assert!(self.is_canonicalized(ty))
     }
 
@@ -469,7 +467,6 @@ impl TypeRegistryInner {
         // still alive.
         ty.trace::<_, ()>(&mut |idx| match idx {
             EngineOrModuleTypeIndex::Engine(id) => {
-                let id = VMSharedTypeIndex::new(id);
                 let i = shared_type_index_to_slab_id(id);
                 let e = &self.entries[i];
                 e.incref("new type references existing type in TypeRegistryInner::register_new");
@@ -564,7 +561,6 @@ impl TypeRegistryInner {
                 .ty
                 .trace::<_, ()>(&mut |child_index| match child_index {
                     EngineOrModuleTypeIndex::Engine(child_index) => {
-                        let child_index = VMSharedTypeIndex::new(child_index);
                         let child_slab_id = shared_type_index_to_slab_id(child_index);
                         let child_entry = &self.entries[child_slab_id];
                         if child_entry.decref(

--- a/crates/wasmtime/src/runtime/types.rs
+++ b/crates/wasmtime/src/runtime/types.rs
@@ -2,9 +2,8 @@ use anyhow::{bail, Result};
 use std::fmt::{self, Display};
 use wasmtime_environ::{
     EngineOrModuleTypeIndex, EntityType, Global, Memory, ModuleTypes, Table, TypeTrace,
-    WasmFuncType, WasmHeapType, WasmRefType, WasmValType,
+    VMSharedTypeIndex, WasmFuncType, WasmHeapType, WasmRefType, WasmValType,
 };
-use wasmtime_runtime::VMSharedTypeIndex;
 
 use crate::{type_registry::RegisteredType, Engine};
 
@@ -656,7 +655,7 @@ impl HeapType {
             HeapType::I31 => WasmHeapType::I31,
             HeapType::None => WasmHeapType::None,
             HeapType::Concrete(f) => {
-                WasmHeapType::Concrete(EngineOrModuleTypeIndex::Engine(f.type_index().bits()))
+                WasmHeapType::Concrete(EngineOrModuleTypeIndex::Engine(f.type_index()))
             }
         }
     }
@@ -670,8 +669,7 @@ impl HeapType {
             WasmHeapType::I31 => HeapType::I31,
             WasmHeapType::None => HeapType::None,
             WasmHeapType::Concrete(EngineOrModuleTypeIndex::Engine(idx)) => {
-                let idx = VMSharedTypeIndex::new(*idx);
-                HeapType::Concrete(FuncType::from_shared_type_index(engine, idx))
+                HeapType::Concrete(FuncType::from_shared_type_index(engine, *idx))
             }
             WasmHeapType::Concrete(EngineOrModuleTypeIndex::Module(_)) => {
                 panic!("HeapType::from_wasm_type on non-canonical heap type")
@@ -766,7 +764,7 @@ impl ExternType {
         match ty {
             EntityType::Function(idx) => match idx {
                 EngineOrModuleTypeIndex::Engine(e) => {
-                    FuncType::from_shared_type_index(engine, VMSharedTypeIndex::new(*e)).into()
+                    FuncType::from_shared_type_index(engine, *e).into()
                 }
                 EngineOrModuleTypeIndex::Module(m) => {
                     FuncType::from_wasm_func_type(engine, types[*m].clone()).into()

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -2,9 +2,8 @@ use crate::{linker::DefinitionType, Engine, FuncType};
 use anyhow::{anyhow, bail, Result};
 use wasmtime_environ::{
     EngineOrModuleTypeIndex, EntityType, Global, Memory, ModuleTypes, Table, TypeTrace,
-    WasmFuncType, WasmHeapType, WasmRefType, WasmValType,
+    VMSharedTypeIndex, WasmFuncType, WasmHeapType, WasmRefType, WasmValType,
 };
-use wasmtime_runtime::VMSharedTypeIndex;
 
 pub struct MatchCx<'a> {
     engine: &'a Engine,
@@ -60,10 +59,9 @@ impl MatchCx<'_> {
                 _ => bail!("expected memory, but found {}", actual.desc()),
             },
             EntityType::Function(expected) => match actual {
-                DefinitionType::Func(actual) => self.type_reference(
-                    VMSharedTypeIndex::new(expected.unwrap_engine_type_index()),
-                    *actual,
-                ),
+                DefinitionType::Func(actual) => {
+                    self.type_reference(expected.unwrap_engine_type_index(), *actual)
+                }
                 _ => bail!("expected func, but found {}", actual.desc()),
             },
             EntityType::Tag(_) => unimplemented!(),


### PR DESCRIPTION
Previously, `wasmtime_types::EngineOrModuleTypeIndex` had a raw `u32` for its engine-level-canonicalized variant. This change allows it to store a `VMSharedTypeIndex` directly, giving us some additional static assurance that we aren't messing up our different index types and lets us remove a ton of conversions back and forth between raw `u32`s and `VMSharedTypeIndex`.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
