### PR TITLE
Move c-api testing into a separate build job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -482,6 +482,38 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
 
+  # Perform all tests of the c-api
+  test_capi:
+    needs: determine
+    name: Test C-API ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    if: needs.determine.outputs.test-capi
+
+    strategy:
+      fail-fast: true
+      matrix:
+        os: [ubuntu-latest, macos-latest, macos-14, windows-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+    - uses: ./.github/actions/install-rust
+
+    # Build and test the C API with example C programs along with the example
+    # Rust programs. Note that this only executes if the `determine` step told
+    # us to test the capi which is off-by-default for PRs.
+    - run: cmake -Sexamples -Bexamples/build -DBUILD_SHARED_LIBS=OFF
+    - run: cmake --build examples/build --config Debug
+    - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target RUN_TESTS
+      env:
+        RUST_BACKTRACE: 1
+      if: matrix.os == 'windows-latest'
+    - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target test
+      env:
+        RUST_BACKTRACE: 1
+      if: matrix.os != 'windows-latest'
+
   # Perform all tests (debug mode) for `wasmtime`.
   #
   # Note that the full matrix for what may run here is defined within
@@ -566,22 +598,6 @@ jobs:
         ninja -C build install
         touch ${{ runner.tool_cache }}/qemu/built
       if: matrix.gcc != ''
-
-    # Build and test the C API with example C programs along with the example
-    # Rust programs. Note that this only executes if the `determine` step told
-    # us to test the capi which is off-by-default for PRs.
-    - run: cmake -Sexamples -Bexamples/build -DBUILD_SHARED_LIBS=OFF
-      if: matrix.target == '' && needs.determine.outputs.test-capi
-    - run: cmake --build examples/build --config Debug
-      if: matrix.target == '' && needs.determine.outputs.test-capi
-    - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target RUN_TESTS
-      env:
-        RUST_BACKTRACE: 1
-      if: matrix.target == '' && matrix.os == 'windows-latest' && needs.determine.outputs.test-capi
-    - run: cmake -E env CTEST_OUTPUT_ON_FAILURE=1 cmake --build examples/build --config Debug --target test
-      env:
-        RUST_BACKTRACE: 1
-      if: matrix.target == '' && matrix.os != 'windows-latest' && needs.determine.outputs.test-capi
 
     # Record some CPU details; this is helpful information if tests fail due
     # to CPU-specific features.
@@ -868,6 +884,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - test
+      - test_capi
       - build
       - rustfmt
       - clangformat


### PR DESCRIPTION
We're less constrained for action runners these days, so let's build the c-api tests in parallel with other tests. This shortens the long-pole for tests that are required for a merge to main, as well as ci time for PRs that touch the c-api.

One effect of this change is that we're no longer building the c-api changes when testing on Qemu, but we are still testing on linux, windows, and macos.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
