### PR TITLE
Fix running wasi-common tests on CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,6 +3161,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "wasi-common",
  "wasmtime",
  "wiggle",
  "windows-sys 0.52.0",

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -54,6 +54,7 @@ features = [
 ]
 
 [dev-dependencies]
+wasi-common = { workspace = true, features = ['tokio'] }
 tempfile = { workspace = true }
 test-log = { workspace = true }
 tracing-subscriber = { workspace = true }
@@ -98,4 +99,3 @@ all-features = true
 
 [[test]]
 name = "all"
-required-features = ["wasmtime", "sync", "tokio"]

--- a/crates/wasi-common/Cargo.toml
+++ b/crates/wasi-common/Cargo.toml
@@ -54,7 +54,7 @@ features = [
 ]
 
 [dev-dependencies]
-wasi-common = { workspace = true, features = ['tokio'] }
+wasi-common = { path = '.', features = ['tokio'] }
 tempfile = { workspace = true }
 test-log = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/wasi-common/src/snapshots/preview_1.rs
+++ b/crates/wasi-common/src/snapshots/preview_1.rs
@@ -417,13 +417,15 @@ impl wasi_snapshot_preview1::WasiSnapshotPreview1 for WasiCtx {
                 return Ok(0);
             }
         } else {
-            // Convert all of the unsafe guest slices to safe ones--this uses
-            // Wiggle's internal borrow checker to ensure no overlaps. We assume
-            // here that, because the memory is not shared, there are no other
-            // threads to access it while it is written to.
+            // Convert unsafe guest slices to safe ones -- this uses Wiggle's
+            // internal borrow checker to ensure no overlaps. Note that borrow
+            // checking is coarse at this time so at most one non-empty slice is
+            // chosen.
             let mut guest_slices: Vec<wiggle::GuestSliceMut<u8>> = iovs
                 .into_iter()
+                .filter(|iov| iov.len() > 0)
                 .map(|iov| Ok(iov.as_slice_mut()?.unwrap()))
+                .take(1)
                 .collect::<Result<_, Error>>()?;
 
             // Read directly into the Wasm memory.


### PR DESCRIPTION
Turns out we haven't been running wasi-common tests for some time in CI and they've started failing. Force enable the test at all times and then fix the test failures. The test failures here were introduced in #8277 and weren't caught due to the test not running and the fix was to relax the implementation of `fd_pread` to avoid taking multiple mutable borrows.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
