### PR TITLE
Fix calculation of gc refs in functions

### DIFF
--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -371,24 +371,8 @@ impl TypeTrace for WasmFuncType {
 impl WasmFuncType {
     #[inline]
     pub fn new(params: Box<[WasmValType]>, returns: Box<[WasmValType]>) -> Self {
-        let non_i31_gc_ref_params_count = params
-            .iter()
-            .filter(|p| match **p {
-                WasmValType::Ref(rt) => {
-                    rt.heap_type != WasmHeapType::I31 && rt.heap_type != WasmHeapType::Func
-                }
-                _ => false,
-            })
-            .count();
-        let non_i31_gc_ref_returns_count = returns
-            .iter()
-            .filter(|r| match **r {
-                WasmValType::Ref(rt) => {
-                    rt.heap_type != WasmHeapType::I31 && rt.heap_type != WasmHeapType::Func
-                }
-                _ => false,
-            })
-            .count();
+        let non_i31_gc_ref_params_count = params.iter().filter(|p| p.is_gc_heap_type()).count();
+        let non_i31_gc_ref_returns_count = returns.iter().filter(|r| r.is_gc_heap_type()).count();
         WasmFuncType {
             params,
             non_i31_gc_ref_params_count,

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -374,14 +374,18 @@ impl WasmFuncType {
         let non_i31_gc_ref_params_count = params
             .iter()
             .filter(|p| match **p {
-                WasmValType::Ref(rt) => rt.heap_type != WasmHeapType::I31,
+                WasmValType::Ref(rt) => {
+                    rt.heap_type != WasmHeapType::I31 && rt.heap_type != WasmHeapType::Func
+                }
                 _ => false,
             })
             .count();
         let non_i31_gc_ref_returns_count = returns
             .iter()
             .filter(|r| match **r {
-                WasmValType::Ref(rt) => rt.heap_type != WasmHeapType::I31,
+                WasmValType::Ref(rt) => {
+                    rt.heap_type != WasmHeapType::I31 && rt.heap_type != WasmHeapType::Func
+                }
                 _ => false,
             })
             .count();

--- a/tests/all/func.rs
+++ b/tests/all/func.rs
@@ -2112,3 +2112,20 @@ fn wrap_and_typed_i31ref() -> Result<()> {
     assert_eq!(HITS.load(Ordering::SeqCst), 2);
     Ok(())
 }
+
+#[test]
+fn call_func_with_funcref_both_typed_and_untyped() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_function_references(true);
+    config.wasm_gc(true);
+
+    let engine = Engine::new(&config)?;
+    let mut store = Store::new(&engine, ());
+
+    let f1 = Func::wrap(&mut store, |_: Option<Func>| {});
+    let f2 = Func::wrap(&mut store, || {});
+
+    f1.typed::<Func, ()>(&mut store)?.call(&mut store, f2)?;
+    f1.call(&mut store, &[Val::FuncRef(Some(f2))], &mut [])?;
+    Ok(())
+}


### PR DESCRIPTION
In addition to excluding i31 also exclude funcrefs.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
