### PR TITLE
c-api: Fix alignment of `wasmtime_val_*`

### DIFF
--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -7,6 +7,7 @@
 #ifndef WASMTIME_VAL_H
 #define WASMTIME_VAL_H
 
+#include <stdalign.h>
 #include <wasm.h>
 #include <wasmtime/extern.h>
 
@@ -305,6 +306,15 @@ typedef union wasmtime_val_raw {
   /// Note that this field is always stored in a little-endian format.
   void *funcref;
 } wasmtime_val_raw_t;
+
+// Assert that the shape of this type is as expected since it needs to match
+// Rust.
+static inline void __wasmtime_val_assertions() {
+  static_assert(sizeof(wasmtime_valunion_t) == 16, "should be 16-bytes large");
+  static_assert(alignof(wasmtime_valunion_t) == 8, "should be 8-byte aligned");
+  static_assert(sizeof(wasmtime_val_raw_t) == 16, "should be 16 bytes large");
+  static_assert(alignof(wasmtime_val_raw_t) == 8, "should be 8-byte aligned");
+}
 
 /**
  * \typedef wasmtime_val_t

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -311,9 +311,10 @@ typedef union wasmtime_val_raw {
 // Rust.
 static inline void __wasmtime_val_assertions() {
   static_assert(sizeof(wasmtime_valunion_t) == 16, "should be 16-bytes large");
-  static_assert(alignof(wasmtime_valunion_t) == 8, "should be 8-byte aligned");
+  static_assert(__alignof(wasmtime_valunion_t) == 8,
+                "should be 8-byte aligned");
   static_assert(sizeof(wasmtime_val_raw_t) == 16, "should be 16 bytes large");
-  static_assert(alignof(wasmtime_val_raw_t) == 8, "should be 8-byte aligned");
+  static_assert(__alignof(wasmtime_val_raw_t) == 8, "should be 8-byte aligned");
 }
 
 /**

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -150,6 +150,11 @@ pub union wasmtime_val_union {
     pub v128: [u8; 16],
 }
 
+const _: () = {
+    assert!(std::mem::size_of::<wasmtime_val_union>() == 16);
+    assert!(std::mem::align_of::<wasmtime_val_union>() == 8);
+};
+
 // The raw pointers are actually optional boxes.
 unsafe impl Send for wasmtime_val_union
 where

--- a/crates/cranelift/src/compiler.rs
+++ b/crates/cranelift/src/compiler.rs
@@ -963,7 +963,9 @@ impl Compiler {
         // despite this load/store being unrelated to execution in wasm itself.
         // For more details on this see the `ValRaw` type in the
         // `wasmtime-runtime` crate.
-        let flags = ir::MemFlags::trusted().with_endianness(ir::Endianness::Little);
+        let flags = ir::MemFlags::new()
+            .with_notrap()
+            .with_endianness(ir::Endianness::Little);
 
         let value_size = mem::size_of::<u128>();
         for (i, (val, ty)) in values.iter().copied().zip(types).enumerate() {
@@ -1000,7 +1002,9 @@ impl Compiler {
 
         // Note that this is little-endian like `store_values_to_array` above,
         // see notes there for more information.
-        let flags = MemFlags::trusted().with_endianness(ir::Endianness::Little);
+        let flags = MemFlags::new()
+            .with_notrap()
+            .with_endianness(ir::Endianness::Little);
 
         let mut results = Vec::new();
         for (i, ty) in types.iter().enumerate() {


### PR DESCRIPTION


This commit fixes an issue where `wasmtime_val_raw_t` had an incorrect
alignment. In Rust `ValRaw` contains a `u128` which has an alignment of
16 but in C the representation had a smaller alignment meaning that the
alignment of the two structures was different. This was seen to cause
alignment faults when structure were passed from C++ to Rust, for
example.

This commit changes the Rust representation of `ValRaw`'s `v128` field
to do the same as C which is to use `[u8; 16]`. This avoids the need to
raise the alignment in C which appears to be nontrivial. Cranelift is
appropriately adjusted to understand that loads/stores from `ValRaw` are
no longer aligned. Technically this only applies to the `v128` field but
it's not too bad to apply it to the other fields as well.

