### PR TITLE
Remove `wasi_config_preopen_socket` from C header

### DIFF
--- a/crates/c-api/include/wasi.h
+++ b/crates/c-api/include/wasi.h
@@ -168,21 +168,6 @@ WASI_API_EXTERN bool wasi_config_preopen_dir(wasi_config_t *config,
                                              const char *path,
                                              const char *guest_path);
 
-/**
- * \brief Configures a "preopened" listen socket to be available to WASI APIs.
- *
- * By default WASI programs do not have access to open up network sockets on
- * the host. This API can be used to grant WASI programs access to a network
- * socket file descriptor on the host.
- *
- * The fd_num argument is the number of the file descriptor by which it will be
- * known in WASM and the host_port is the IP address and port (e.g.
- * "127.0.0.1:8080") requested to listen on.
- */
-WASI_API_EXTERN bool wasi_config_preopen_socket(wasi_config_t *config,
-                                                uint32_t fd_num,
-                                                const char *host_port);
-
 #undef own
 
 #ifdef __cplusplus


### PR DESCRIPTION
This was removed in #8066

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
