### PR TITLE
Tidy up some headers related to shared memory

### DIFF
--- a/crates/c-api/include/wasmtime/extern.h
+++ b/crates/c-api/include/wasmtime/extern.h
@@ -9,6 +9,7 @@
 
 #include <wasmtime/module.h>
 #include <wasmtime/store.h>
+#include <wasmtime/sharedmemory.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -88,8 +89,6 @@ typedef uint8_t wasmtime_extern_kind_t;
 /// \brief Value of #wasmtime_extern_kind_t meaning that #wasmtime_extern_t is a
 /// shared memory
 #define WASMTIME_EXTERN_SHAREDMEMORY 4
-
-struct wasmtime_sharedmemory;
 
 /**
  * \typedef wasmtime_extern_union_t

--- a/crates/c-api/include/wasmtime/extern.h
+++ b/crates/c-api/include/wasmtime/extern.h
@@ -8,8 +8,8 @@
 #define WASMTIME_EXTERN_H
 
 #include <wasmtime/module.h>
-#include <wasmtime/store.h>
 #include <wasmtime/sharedmemory.h>
+#include <wasmtime/store.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/crates/c-api/include/wasmtime/sharedmemory.h
+++ b/crates/c-api/include/wasmtime/sharedmemory.h
@@ -57,18 +57,6 @@ WASM_API_EXTERN wasmtime_sharedmemory_t *
 wasmtime_sharedmemory_clone(const wasmtime_sharedmemory_t *memory);
 
 /**
- * \brief Moves shared linear memory into wasmtime_extern_t object
- *
- * \param memory memory to be moved
- * \param out where to store resulting `wasmtime_extern_t`
- *
- * This function moves ownership of `memory` into resulting `wasmtime_extern_t`.
- */
-WASM_API_EXTERN void
-wasmtime_sharedmemory_into_extern(wasmtime_sharedmemory_t *memory,
-                                  wasmtime_extern_t *out);
-
-/**
  * \brief Returns the type of the shared memory specified
  */
 WASM_API_EXTERN wasm_memorytype_t *

--- a/crates/c-api/src/sharedmemory.rs
+++ b/crates/c-api/src/sharedmemory.rs
@@ -1,7 +1,6 @@
-use crate::{handle_result, wasm_memorytype_t, wasmtime_error_t, wasmtime_extern_t};
+use crate::{handle_result, wasm_memorytype_t, wasmtime_error_t};
 use std::cell::UnsafeCell;
-use std::mem::MaybeUninit;
-use wasmtime::{Extern, SharedMemory};
+use wasmtime::SharedMemory;
 
 type wasmtime_sharedmemory_t = SharedMemory;
 
@@ -25,14 +24,6 @@ pub extern "C" fn wasmtime_sharedmemory_clone(
     mem: &wasmtime_sharedmemory_t,
 ) -> Box<wasmtime_sharedmemory_t> {
     Box::new(mem.clone())
-}
-
-#[no_mangle]
-pub extern "C" fn wasmtime_sharedmemory_into_extern(
-    mem: Box<wasmtime_sharedmemory_t>,
-    ext: &mut MaybeUninit<wasmtime_extern_t>,
-) {
-    crate::initialize(ext, Extern::from(*mem).into());
 }
 
 #[no_mangle]


### PR DESCRIPTION
* Don't declare an anonymous `struct wasmtime_sharedmemory`, instead `#include` the actual definition.
* Fix an issue where a header in `sharedmemory.h` referred to a type in `extern.h` which wasn't `#include`'d. This function, `wasmtime_sharedmemory_into_extern`, additionally isn't necessary as it's no different than manually constructing it. Fix this by removing this function.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
