### PR TITLE
Error when `wasmtime::component::bindgen` has unused with param.

### DIFF
--- a/crates/component-macro/src/bindgen.rs
+++ b/crates/component-macro/src/bindgen.rs
@@ -25,7 +25,10 @@ pub fn expand(input: &Config) -> Result<TokenStream> {
         ));
     }
 
-    let mut src = input.opts.generate(&input.resolve, input.world);
+    let mut src = match input.opts.generate(&input.resolve, input.world) {
+        Ok(s) => s,
+        Err(e) => return Err(Error::new(Span::call_site(), e.to_string())),
+    };
 
     // If a magical `WASMTIME_DEBUG_BINDGEN` environment variable is set then
     // place a formatted version of the expanded code into a file. This file


### PR DESCRIPTION
Instead of silently dropping unused with parameters on the floor, we instead error letting the user know that this option is being ignored.

I don't believe there's scaffolding for testing errors produced by the `bindgen!` macro, so I'm not sure if this can currently be tested.
 
Fixes https://github.com/bytecodealliance/wasmtime/issues/8304


