### PR TITLE
c-api: Create `RootScope` where necessary

### DIFF
--- a/crates/c-api/src/async.rs
+++ b/crates/c-api/src/async.rs
@@ -117,7 +117,7 @@ async fn invoke_c_async_callback<'a>(
         params
             .iter()
             .cloned()
-            .map(|p| wasmtime_val_t::from_val_unrooted(&mut caller, p)),
+            .map(|p| wasmtime_val_t::from_val_unscoped(&mut caller, p)),
     );
     hostcall_val_storage.extend((0..results.len()).map(|_| wasmtime_val_t {
         kind: WASMTIME_I32,
@@ -156,7 +156,7 @@ async fn invoke_c_async_callback<'a>(
     // Translate the `wasmtime_val_t` results into the `results` space
     for (i, result) in out_results.iter().enumerate() {
         unsafe {
-            results[i] = result.to_val_unrooted(&mut caller.caller);
+            results[i] = result.to_val_unscoped(&mut caller.caller);
         }
     }
     // Move our `vals` storage back into the store now that we no longer

--- a/crates/c-api/src/async.rs
+++ b/crates/c-api/src/async.rs
@@ -7,8 +7,9 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::{ptr, str};
-
-use wasmtime::{AsContextMut, Func, Instance, Result, StackCreator, StackMemory, Trap, Val};
+use wasmtime::{
+    AsContextMut, Func, Instance, Result, RootScope, StackCreator, StackMemory, Trap, Val,
+};
 
 use crate::{
     bad_utf8, handle_result, to_str, translate_args, wasm_config_t, wasm_functype_t, wasm_trap_t,
@@ -116,7 +117,7 @@ async fn invoke_c_async_callback<'a>(
         params
             .iter()
             .cloned()
-            .map(|p| wasmtime_val_t::from_val(&mut caller, p)),
+            .map(|p| wasmtime_val_t::from_val_unrooted(&mut caller, p)),
     );
     hostcall_val_storage.extend((0..results.len()).map(|_| wasmtime_val_t {
         kind: WASMTIME_I32,
@@ -155,7 +156,7 @@ async fn invoke_c_async_callback<'a>(
     // Translate the `wasmtime_val_t` results into the `results` space
     for (i, result) in out_results.iter().enumerate() {
         unsafe {
-            results[i] = result.to_val(&mut caller.caller);
+            results[i] = result.to_val_unrooted(&mut caller.caller);
         }
     }
     // Move our `vals` storage back into the store now that we no longer
@@ -218,15 +219,14 @@ fn handle_call_error(
 }
 
 async fn do_func_call_async(
-    mut store: WasmtimeStoreContextMut<'_>,
+    mut store: RootScope<WasmtimeStoreContextMut<'_>>,
     func: &Func,
     args: impl ExactSizeIterator<Item = Val>,
     results: &mut [MaybeUninit<wasmtime_val_t>],
     trap_ret: &mut *mut wasm_trap_t,
     err_ret: &mut *mut wasmtime_error_t,
 ) {
-    let mut store = store.as_context_mut();
-    let mut params = mem::take(&mut store.data_mut().wasm_val_storage);
+    let mut params = mem::take(&mut store.as_context_mut().data_mut().wasm_val_storage);
     let (wt_params, wt_results) = translate_args(&mut params, args, results.len());
     let result = func.call_async(&mut store, wt_params, wt_results).await;
 
@@ -236,7 +236,7 @@ async fn do_func_call_async(
                 crate::initialize(slot, wasmtime_val_t::from_val(&mut store, val.clone()));
             }
             params.truncate(0);
-            store.data_mut().wasm_val_storage = params;
+            store.as_context_mut().data_mut().wasm_val_storage = params;
         }
         Err(err) => handle_call_error(err, trap_ret, err_ret),
     }
@@ -244,7 +244,7 @@ async fn do_func_call_async(
 
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_func_call_async<'a>(
-    mut store: WasmtimeStoreContextMut<'a>,
+    store: WasmtimeStoreContextMut<'a>,
     func: &'a Func,
     args: *const wasmtime_val_t,
     nargs: usize,
@@ -253,13 +253,14 @@ pub unsafe extern "C" fn wasmtime_func_call_async<'a>(
     trap_ret: &'a mut *mut wasm_trap_t,
     err_ret: &'a mut *mut wasmtime_error_t,
 ) -> Box<wasmtime_call_future_t<'a>> {
+    let mut scope = RootScope::new(store);
     let args = crate::slice_from_raw_parts(args, nargs)
         .iter()
-        .map(|i| i.to_val(&mut store))
+        .map(|i| i.to_val(&mut scope))
         .collect::<Vec<_>>();
     let results = crate::slice_from_raw_parts_mut(results, nresults);
     let fut = Box::pin(do_func_call_async(
-        store,
+        scope,
         func,
         args.into_iter(),
         results,

--- a/crates/c-api/src/func.rs
+++ b/crates/c-api/src/func.rs
@@ -271,7 +271,7 @@ pub(crate) unsafe fn c_callback_to_rust_fn(
             params
                 .iter()
                 .cloned()
-                .map(|p| wasmtime_val_t::from_val_unrooted(&mut caller, p)),
+                .map(|p| wasmtime_val_t::from_val_unscoped(&mut caller, p)),
         );
         vals.extend((0..results.len()).map(|_| wasmtime_val_t {
             kind: crate::WASMTIME_I32,
@@ -295,7 +295,7 @@ pub(crate) unsafe fn c_callback_to_rust_fn(
 
         // Translate the `wasmtime_val_t` results into the `results` space
         for (i, result) in out_results.iter().enumerate() {
-            results[i] = result.to_val_unrooted(&mut caller);
+            results[i] = result.to_val_unscoped(&mut caller);
         }
 
         // Move our `vals` storage back into the store now that we no longer

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -184,7 +184,7 @@ impl wasmtime_val_t {
     /// prevent GC. Callers should prefer this API where possible, creating a
     /// temporary `RootScope` when needed.
     pub fn from_val(cx: &mut RootScope<impl AsContextMut>, val: Val) -> wasmtime_val_t {
-        Self::from_val_unrooted(cx, val)
+        Self::from_val_unscoped(cx, val)
     }
 
     /// Equivalent of [`wasmtime_val_t::from_val`] except that a `RootScope`
@@ -194,7 +194,7 @@ impl wasmtime_val_t {
     /// elsewhere on the stack. For example this is used when we call back out
     /// to the embedder. In such a situation we know we previously entered with
     /// some other call so the root scope is on the stack there.
-    pub fn from_val_unrooted(cx: impl AsContextMut, val: Val) -> wasmtime_val_t {
+    pub fn from_val_unscoped(cx: impl AsContextMut, val: Val) -> wasmtime_val_t {
         match val {
             Val::I32(i) => wasmtime_val_t {
                 kind: crate::WASMTIME_I32,
@@ -257,14 +257,14 @@ impl wasmtime_val_t {
     /// `RootScope` if we don't want the value to live for the entire lifetime
     /// of the `Store`.
     pub unsafe fn to_val(&self, cx: &mut RootScope<impl AsContextMut>) -> Val {
-        self.to_val_unrooted(cx)
+        self.to_val_unscoped(cx)
     }
 
     /// Equivalent of `to_val` except doesn't require a `RootScope`.
     ///
-    /// See notes on [`wasmtime_val_t::from_val_unrooted`] for notes on when to
+    /// See notes on [`wasmtime_val_t::from_val_unscoped`] for notes on when to
     /// use this.
-    pub unsafe fn to_val_unrooted(&self, cx: impl AsContextMut) -> Val {
+    pub unsafe fn to_val_unscoped(&self, cx: impl AsContextMut) -> Val {
         match self.kind {
             crate::WASMTIME_I32 => Val::I32(self.of.i32),
             crate::WASMTIME_I64 => Val::I64(self.of.i64),


### PR DESCRIPTION
This commit changes the `wasmtime_val_t::{from_val, to_val}` methods to take a `RootScope` instead of any `AsContextMut`. This then required a number of refactorings in callers to ensure that a `RootScope` was created for any function that needed one. This is required to ensure that GC references in the C API aren't forced to live for the entire lifetime of the store.

This additionally added `*_unrooted` variants which do the same thing but don't require `RootScope`. This was needed for when the C API calls out to the embedder through a function call because a new `RootScope` wouldn't work for return values (they're bound to a scope within the closure when we want them to outlive the closure). In these situations though we know a `RootScope` is already present at the entrypoint.

Closes #8367

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
