### PR TITLE
cranelift: Simplify checking whether probestack is needed

### DIFF
--- a/cranelift/codegen/meta/src/shared/settings.rs
+++ b/cranelift/codegen/meta/src/shared/settings.rs
@@ -244,13 +244,6 @@ pub(crate) fn define() -> SettingGroup {
         false,
     );
 
-    settings.add_bool(
-        "probestack_func_adjusts_sp",
-        "Enable if the stack probe adjusts the stack pointer.",
-        "",
-        false,
-    );
-
     settings.add_num(
         "probestack_size_log2",
         "The log2 of the size of the stack guard region.",

--- a/cranelift/codegen/src/settings.rs
+++ b/cranelift/codegen/src/settings.rs
@@ -532,7 +532,6 @@ unwind_info = true
 preserve_frame_pointers = false
 machine_code_cfg_info = false
 enable_probestack = false
-probestack_func_adjusts_sp = false
 enable_jump_tables = true
 enable_heap_access_spectre_mitigation = true
 enable_table_access_spectre_mitigation = true

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -333,7 +333,6 @@ impl Engine {
             | "tls_model" // wasmtime doesn't use tls right now
             | "opt_level" // opt level doesn't change semantics
             | "enable_alias_analysis" // alias analysis-based opts don't change semantics
-            | "probestack_func_adjusts_sp" // probestack above asserted disabled
             | "probestack_size_log2" // probestack above asserted disabled
             | "regalloc" // shouldn't change semantics
             | "enable_incremental_compilation_cache_checks" // shouldn't change semantics


### PR DESCRIPTION
`Callee::probestack_min_frame` was always set to the guard-page size. That is the same as the `guard_size` local in `gen_prologue`, which was also the only place which used `probestack_min_frame`. So don't even bother storing it, just compute it from the flags as needed.

Also, remove the long-obsolete `probestack_func_adjusts_sp` setting, which hasn't been used since at least 2021. We may actually want to do something like what that setting described, but even if we do, it should be a choice the backend makes rather than a global setting.