### PR TITLE
cranelift: Represent RealReg using PReg, not VReg

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/abi.rs
+++ b/cranelift/codegen/src/isa/riscv64/abi.rs
@@ -491,7 +491,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 }
                 insts.push(Inst::gen_store(
                     AMode::SPOffset(-(cur_offset as i64)),
-                    real_reg_to_reg(reg.to_reg()),
+                    Reg::from(reg.to_reg()),
                     ty,
                     MemFlags::trusted(),
                 ));
@@ -530,7 +530,7 @@ impl ABIMachineSpec for Riscv64MachineDeps {
                 RegClass::Vector => unimplemented!("Vector Clobber Restores"),
             };
             insts.push(Inst::gen_load(
-                Writable::from_reg(real_reg_to_reg(reg.to_reg())),
+                reg.map(Reg::from),
                 AMode::SPOffset(-cur_offset),
                 ty,
                 MemFlags::trusted(),

--- a/cranelift/codegen/src/isa/riscv64/inst/regs.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/regs.rs
@@ -3,12 +3,10 @@
 
 use crate::machinst::{Reg, Writable};
 
-use crate::machinst::RealReg;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use regalloc2::VReg;
-use regalloc2::{PReg, RegClass};
+use regalloc2::{PReg, RegClass, VReg};
 
 // first argument of function call
 #[inline]
@@ -154,11 +152,6 @@ pub fn f_reg(enc: usize) -> Reg {
 }
 pub const fn pf_reg(enc: usize) -> PReg {
     PReg::new(enc, RegClass::Float)
-}
-#[inline]
-pub(crate) fn real_reg_to_reg(x: RealReg) -> Reg {
-    let v_reg = VReg::new(x.hw_enc() as usize, x.class());
-    Reg::from(v_reg)
 }
 
 #[allow(dead_code)]

--- a/winch/codegen/src/isa/reg.rs
+++ b/winch/codegen/src/isa/reg.rs
@@ -1,6 +1,5 @@
-use cranelift_codegen::RealReg;
+use regalloc2::PReg;
 pub use regalloc2::RegClass;
-use regalloc2::{PReg, VReg};
 
 /// A newtype abstraction on top of a physical register.
 //
@@ -70,17 +69,5 @@ impl From<Reg> for cranelift_codegen::Reg {
 impl std::fmt::Debug for Reg {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-impl Into<VReg> for Reg {
-    fn into(self) -> VReg {
-        VReg::new(self.inner().index(), self.class())
-    }
-}
-
-impl Into<RealReg> for Reg {
-    fn into(self) -> RealReg {
-        Into::<VReg>::into(self).into()
     }
 }


### PR DESCRIPTION
Semantically, a "real register" is supposed to be a physical register, so let's use the type dedicated for that purpose.

This has the advantage that `PReg` is only one byte while `VReg` is four bytes, so the arrays where we record collections of `RealReg` become smaller.

There was an implementation of `From<VReg> for RealReg` which was not a sensible conversion, because not all `VReg`s are valid `RealReg`s. I could have replaced it with a `TryFrom` implementation but it wasn't used anywhere important, so I'm just deleting it instead.

Winch was using that `VReg`->`RealReg` conversion, but only in the implementation of another conversion that was itself unused, so I'm deleting that conversion as well. It's easy to implement correctly (the Winch `Reg` type is identical to `RealReg`, so all conversions for the latter are readily available) but as far as I can tell Winch doesn't need to use Cranelift's register wrappers or RA2's virtual register type, so it's simpler to just delete those conversions.

The riscv64 backend was relying on quirks of the existing conversions between `RealReg` and `VReg` when emitting clobber saves and restores. Just using the generic conversions between `RealReg` and `Reg` is simpler and works correctly with the rest of these changes.

cc: @elliottt