### PR TITLE
Make wasi-http handler public

### DIFF
--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -144,7 +144,11 @@ pub fn default_send_request(
     HostFutureIncomingResponse::pending(handle)
 }
 
-async fn handler(
+/// The underlying implementation of how an outgoing request is sent. This should likely be spawned
+/// in a task.
+///
+/// This is called from [default_send_request] to actually send the request.
+pub async fn handler(
     mut request: hyper::Request<HyperOutgoingBody>,
     OutgoingRequestConfig {
         use_tls,

--- a/crates/wasi-http/src/types.rs
+++ b/crates/wasi-http/src/types.rs
@@ -140,7 +140,9 @@ pub fn default_send_request(
     request: hyper::Request<HyperOutgoingBody>,
     config: OutgoingRequestConfig,
 ) -> HostFutureIncomingResponse {
-    let handle = wasmtime_wasi::runtime::spawn(async move { Ok(handler(request, config).await) });
+    let handle = wasmtime_wasi::runtime::spawn(async move {
+        Ok(default_send_request_handler(request, config).await)
+    });
     HostFutureIncomingResponse::pending(handle)
 }
 
@@ -148,7 +150,7 @@ pub fn default_send_request(
 /// in a task.
 ///
 /// This is called from [default_send_request] to actually send the request.
-pub async fn handler(
+pub async fn default_send_request_handler(
     mut request: hyper::Request<HyperOutgoingBody>,
     OutgoingRequestConfig {
         use_tls,


### PR DESCRIPTION
Downstream dependencies may want to own the work of `spawn(handler())` themselves. This enables that.