### PR TITLE
PPC: Fix validation error on PolyBenchC

### DIFF
--- a/cranelift/codegen/src/egraph.rs
+++ b/cranelift/codegen/src/egraph.rs
@@ -209,7 +209,7 @@ where
                 }
             };
 
-            self.attach_constant_fact(inst, result);
+            self.attach_constant_fact(inst, result, ty);
 
             self.available_block[result] = self.get_available_block(inst);
             let opt_value = self.optimize_pure_enode(inst);
@@ -485,7 +485,7 @@ where
     /// Helper to propagate facts on constant values: if PCC is
     /// enabled, then unconditionally add a fact attesting to the
     /// Value's concrete value.
-    fn attach_constant_fact(&mut self, inst: Inst, value: Value) {
+    fn attach_constant_fact(&mut self, inst: Inst, value: Value, ty: Type) {
         if self.flags.enable_pcc() {
             if let InstructionData::UnaryImm {
                 opcode: Opcode::Iconst,
@@ -493,7 +493,8 @@ where
             } = self.func.dfg.insts[inst]
             {
                 let imm: i64 = imm.into();
-                self.func.dfg.facts[value] = Some(Fact::constant(64, imm as u64));
+                self.func.dfg.facts[value] =
+                    Some(Fact::constant(ty.bits().try_into().unwrap(), imm as u64));
             }
         }
     }

--- a/cranelift/codegen/src/isa/aarch64/lower/isle.rs
+++ b/cranelift/codegen/src/isa/aarch64/lower/isle.rs
@@ -386,6 +386,8 @@ impl Context for IsleContext<'_, '_, MInst, AArch64Backend> {
                 let imm = MoveWideConst::maybe_with_shift(imm16 as u16, shift).unwrap();
                 self.emit(&MInst::MovK { rd, rn, imm, size });
                 if pcc {
+                    let mask = 0xffff << shift;
+                    running_value &= !mask;
                     running_value |= imm16 << shift;
                     self.lower_ctx
                         .add_range_fact(rd.to_reg(), 64, running_value, running_value);

--- a/cranelift/codegen/src/isa/aarch64/pcc.rs
+++ b/cranelift/codegen/src/isa/aarch64/pcc.rs
@@ -306,7 +306,7 @@ pub(crate) fn check(
             if let Some(input_constant) = input.as_const(64) {
                 let mask = 0xffff << (imm.shift * 16);
                 let constant = u64::from(imm.bits) << (imm.shift * 16);
-                let constant = input_constant & !mask | constant;
+                let constant = (input_constant & !mask) | constant;
                 check_constant(ctx, vcode, rd, 64, constant)
             } else {
                 check_output(ctx, vcode, rd, &[], |_vcode| {

--- a/cranelift/codegen/src/isa/aarch64/pcc.rs
+++ b/cranelift/codegen/src/isa/aarch64/pcc.rs
@@ -304,8 +304,9 @@ pub(crate) fn check(
         Inst::MovK { rd, rn, imm, .. } => {
             let input = get_fact_or_default(vcode, rn, 64);
             if let Some(input_constant) = input.as_const(64) {
+                let mask = 0xffff << (imm.shift * 16);
                 let constant = u64::from(imm.bits) << (imm.shift * 16);
-                let constant = input_constant | constant;
+                let constant = input_constant & !mask | constant;
                 check_constant(ctx, vcode, rd, 64, constant)
             } else {
                 check_output(ctx, vcode, rd, &[], |_vcode| {

--- a/cranelift/filetests/filetests/pcc/succeed/const.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/const.clif
@@ -37,6 +37,6 @@ block0:
 
 function %f4() -> i64 {
 block0:
-    v0 ! range(64, 0x1_0001_ffff_ffff, 0x1_0001_ffff_ffff)= iconst.i64 0x1_0001_ffff_ffff
+    v0 ! range(64, 0x1_0001_ffff_ffff, 0x1_0001_ffff_ffff) = iconst.i64 0x1_0001_ffff_ffff
     return v0
 }

--- a/cranelift/filetests/filetests/pcc/succeed/const.clif
+++ b/cranelift/filetests/filetests/pcc/succeed/const.clif
@@ -34,3 +34,9 @@ block0:
     v0 = iconst.i64 0xffff_fff7
     return v0
 }
+
+function %f4() -> i64 {
+block0:
+    v0 ! range(64, 0x1_0001_ffff_ffff, 0x1_0001_ffff_ffff)= iconst.i64 0x1_0001_ffff_ffff
+    return v0
+}


### PR DESCRIPTION
Hi team, please consider.
As described in #8380, when running PCC validation on workloads like PolyBenchC, it will report an `UnsupportedFact` error.
Based on the analysis of trace logs, I think `attach_constant_fact` introduced by #8173 should also consider the type of constant when adding facts for iconsts. After #8173, we may generate the following facts for i32 constants:
```
block9:
  v4339 ! range(64, 0xea28, 0xea28) = iconst.i32 0xea28
  v2858 ! range(64, 0x8, 0x8) = iconst.i32 8
  v4406 ! range(64, 0x115a0, 0x115a0) = iconst.i32 0x0001_15a0
  v4407 ! range(64, 0x115a8, 0x115a8) = iadd v4406, v2858  ; v4406 = 0x0001_15a0, v2858 = 8
```
These i32 constants have their `bit_width` set to 64, causing the error.

#8173 also exposes another issue on AArch64 when generating facts for `MovK`, we should calculate the running value for `MovK` with the field mask.


<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
