### PR TITLE
ir.md: Remove references to `bconst`

### DIFF
--- a/cranelift/docs/ir.md
+++ b/cranelift/docs/ir.md
@@ -556,7 +556,7 @@ GV = [colocated] symbol Name
 
 A few instructions have variants that take immediate operands, but in general
 an instruction is required to load a constant into an SSA value: `iconst`,
-`f32const`, `f64const` and `bconst` serve this purpose.
+`f32const` and `f64const` serve this purpose.
 
 ### Bitwise operations
 


### PR DESCRIPTION
It was removed in #5031

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
