### PR TITLE
Add support for recursion groups in the types registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -454,7 +454,7 @@ jobs:
       with:
         toolchain: nightly-2024-03-21
 
-    # Ensure that fuzzers sitll build.
+    # Ensure that fuzzers still build.
     #
     # Install the OCaml packages necessary for fuzz targets that use the
     # `wasm-spec-interpreter`.

--- a/crates/environ/examples/factc.rs
+++ b/crates/environ/examples/factc.rs
@@ -82,8 +82,6 @@ impl Factc {
     fn execute(self) -> Result<()> {
         env_logger::init();
 
-        let mut types = ComponentTypesBuilder::default();
-
         // Manufactures a unique `CoreDef` so all function imports get unique
         // function imports.
         let mut next_def = 0;
@@ -118,9 +116,11 @@ impl Factc {
             }
         };
 
+        let mut validator = Validator::new();
+        let mut types = ComponentTypesBuilder::new(&validator);
+
         let mut adapters = Vec::new();
         let input = wat::parse_file(&self.input)?;
-        let mut validator = Validator::new();
         let wasm_types = validator
             .validate_all(&input)
             .context("failed to validate input wasm")?;

--- a/crates/environ/src/component/translate/adapt.rs
+++ b/crates/environ/src/component/translate/adapt.rs
@@ -119,7 +119,6 @@ use crate::component::translate::*;
 use crate::fact;
 use crate::EntityType;
 use std::collections::HashSet;
-use wasmparser::WasmFeatures;
 
 /// Metadata information about a fused adapter.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -212,12 +211,10 @@ impl<'data> Translator<'_, 'data> {
             // specifically enabled here since the adapter module is highly
             // likely to use that if anything is actually indirected through
             // memory.
-            let mut validator = Validator::new_with_features(
-                *self.validator.features() | WasmFeatures::MULTI_MEMORY,
-            );
+            self.validator.reset();
             let translation = ModuleEnvironment::new(
                 self.tunables,
-                &mut validator,
+                &mut self.validator,
                 self.types.module_types_builder(),
             )
             .translate(Parser::new(0), wasm)

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -476,26 +476,6 @@ pub enum TableElementExpression {
     Null,
 }
 
-/// Different types that can appear in a module.
-///
-/// Note that each of these variants are intended to index further into a
-/// separate table.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
-#[allow(missing_docs)]
-pub enum ModuleType {
-    Function(ModuleInternedTypeIndex),
-}
-
-impl ModuleType {
-    /// Asserts this is a `ModuleType::Function`, returning the underlying
-    /// `SignatureIndex`.
-    pub fn unwrap_function(&self) -> ModuleInternedTypeIndex {
-        match self {
-            ModuleType::Function(f) => *f,
-        }
-    }
-}
-
 /// A translated WebAssembly module, excluding the function bodies and
 /// memory initializers.
 #[derive(Default, Debug, Serialize, Deserialize)]
@@ -528,7 +508,7 @@ pub struct Module {
     pub passive_data_map: BTreeMap<DataIndex, Range<u32>>,
 
     /// Types declared in the wasm module.
-    pub types: PrimaryMap<TypeIndex, ModuleType>,
+    pub types: PrimaryMap<TypeIndex, ModuleInternedTypeIndex>,
 
     /// Number of imported or aliased functions in the module.
     pub num_imported_funcs: usize,

--- a/crates/environ/src/module_environ.rs
+++ b/crates/environ/src/module_environ.rs
@@ -1,6 +1,6 @@
 use crate::module::{
     FuncRefIndex, Initializer, MemoryInitialization, MemoryInitializer, MemoryPlan, Module,
-    ModuleType, TableElementExpression, TablePlan, TableSegment, TableSegmentElements,
+    TableElementExpression, TablePlan, TableSegment, TableSegmentElements,
 };
 use crate::{
     DataIndex, DefinedFuncIndex, ElemIndex, EntityIndex, EntityType, FuncIndex, GlobalIndex,
@@ -15,11 +15,10 @@ use std::collections::HashMap;
 use std::mem;
 use std::path::PathBuf;
 use std::sync::Arc;
-use wasmparser::types::{CoreTypeId, Types};
 use wasmparser::{
-    CompositeType, CustomSectionReader, DataKind, ElementItems, ElementKind, Encoding,
-    ExternalKind, FuncToValidate, FunctionBody, NameSectionReader, Naming, Operator, Parser,
-    Payload, TypeRef, Validator, ValidatorResources, WasmFeatures,
+    types::Types, CustomSectionReader, DataKind, ElementItems, ElementKind, Encoding, ExternalKind,
+    FuncToValidate, FunctionBody, NameSectionReader, Naming, Operator, Parser, Payload, TypeRef,
+    Validator, ValidatorResources, WasmFeatures,
 };
 use wasmtime_types::ModuleInternedTypeIndex;
 
@@ -236,14 +235,56 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
 
             Payload::TypeSection(types) => {
                 self.validator.type_section(&types)?;
-                let num = usize::try_from(types.count()).unwrap();
-                self.result.module.types.reserve(num);
-                self.types.reserve_wasm_signatures(num);
 
-                for i in 0..types.count() {
-                    let types = self.validator.types(0).unwrap();
-                    let ty = types.core_type_at(i);
-                    self.declare_type(ty.unwrap_sub())?;
+                let count = types.count();
+                let capacity = usize::try_from(count).unwrap();
+                self.result.module.types.reserve(capacity);
+                self.types.reserve_wasm_signatures(capacity);
+
+                // Iterate over each *rec group* -- not type -- defined in the
+                // types section. Rec groups are the unit of canonicalization
+                // and therefore the unit at which we need to process at a
+                // time. `wasmparser` has already done the hard work of
+                // de-duplicating and canonicalizing the rec groups within the
+                // module for us, we just need to translate them into our data
+                // structures. Note that, if the Wasm defines duplicate rec
+                // groups, we need copy the duplicates over (shallowly) as well,
+                // so that our types index space doesn't have holes.
+                let mut type_index = 0;
+                for _ in 0..count {
+                    let validator_types = self.validator.types(0).unwrap();
+
+                    // Get the rec group for the current type index, which is
+                    // always the first type defined in a rec group.
+                    let core_type_id = validator_types.core_type_at(type_index).unwrap_sub();
+                    log::trace!(
+                        "about to intern rec group for {core_type_id:?} = {:?}",
+                        validator_types[core_type_id]
+                    );
+                    let rec_group_id = validator_types.rec_group_id_of(core_type_id);
+                    debug_assert_eq!(
+                        validator_types
+                            .rec_group_elements(rec_group_id)
+                            .position(|id| id == core_type_id),
+                        Some(0)
+                    );
+
+                    // Intern the rec group and then fill in this module's types
+                    // index space.
+                    let interned = self.types.intern_rec_group(
+                        &self.result.module,
+                        validator_types,
+                        rec_group_id,
+                    )?;
+                    let elems = self.types.rec_group_elements(interned);
+                    let len = elems.len();
+                    self.result.module.types.reserve(len);
+                    for ty in elems {
+                        self.result.module.types.push(ty);
+                    }
+
+                    // Advance `type_index` to the start of the next rec group.
+                    type_index += u32::try_from(len).unwrap();
                 }
             }
 
@@ -258,11 +299,11 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                     let ty = match import.ty {
                         TypeRef::Func(index) => {
                             let index = TypeIndex::from_u32(index);
-                            let sig_index = self.result.module.types[index].unwrap_function();
+                            let interned_index = self.result.module.types[index];
                             self.result.module.num_imported_funcs += 1;
                             self.result.debuginfo.wasm_file.imported_func_count += 1;
                             EntityType::Function(wasmtime_types::EngineOrModuleTypeIndex::Module(
-                                sig_index,
+                                interned_index,
                             ))
                         }
                         TypeRef::Memory(ty) => {
@@ -294,8 +335,8 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                 for entry in functions {
                     let sigindex = entry?;
                     let ty = TypeIndex::from_u32(sigindex);
-                    let sig_index = self.result.module.types[ty].unwrap_function();
-                    self.result.module.push_function(sig_index);
+                    let interned_index = self.result.module.types[ty];
+                    self.result.module.push_function(interned_index);
                 }
             }
 
@@ -842,25 +883,6 @@ and for re-adding support for interface types you can see this issue:
         self.result.module.num_escaped_funcs += 1;
     }
 
-    fn declare_type(&mut self, id: CoreTypeId) -> WasmResult<()> {
-        let types = self.validator.types(0).unwrap();
-        let ty = &types[id];
-        assert!(ty.is_final);
-        assert!(ty.supertype_idx.is_none());
-        match &ty.composite_type {
-            CompositeType::Func(ty) => {
-                let wasm = self.convert_func_type(ty);
-                let sig_index = self.types.wasm_func_type(id, wasm);
-                self.result
-                    .module
-                    .types
-                    .push(ModuleType::Function(sig_index));
-            }
-            CompositeType::Array(_) | CompositeType::Struct(_) => unimplemented!(),
-        }
-        Ok(())
-    }
-
     /// Parses the Name section of the wasm module.
     fn name_section(&mut self, names: NameSectionReader<'data>) -> WasmResult<()> {
         for subsection in names {
@@ -933,11 +955,7 @@ and for re-adding support for interface types you can see this issue:
 
 impl TypeConvert for ModuleEnvironment<'_, '_> {
     fn lookup_heap_type(&self, index: wasmparser::UnpackedIndex) -> WasmHeapType {
-        WasmparserTypeConverter {
-            types: &self.types,
-            module: &self.result.module,
-        }
-        .lookup_heap_type(index)
+        WasmparserTypeConverter::new(&self.types, &self.result.module).lookup_heap_type(index)
     }
 }
 

--- a/crates/environ/src/module_types.rs
+++ b/crates/environ/src/module_types.rs
@@ -1,10 +1,15 @@
-use crate::{Module, ModuleType, PrimaryMap, TypeConvert, WasmFuncType, WasmHeapType};
+use crate::{Module, PrimaryMap, TypeConvert, TypeIndex, WasmFuncType, WasmHeapType};
+use cranelift_entity::EntityRef;
 use serde_derive::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::ops::Index;
-use wasmparser::types::CoreTypeId;
-use wasmparser::UnpackedIndex;
-use wasmtime_types::{EngineOrModuleTypeIndex, ModuleInternedTypeIndex, TypeIndex};
+use std::{
+    collections::HashMap,
+    ops::{Index, Range},
+};
+use wasmparser::{CompositeType, UnpackedIndex, Validator, ValidatorId};
+use wasmtime_types::{
+    wasm_unsupported, EngineOrModuleTypeIndex, ModuleInternedRecGroupIndex,
+    ModuleInternedTypeIndex, WasmResult,
+};
 
 /// All types used in a core wasm module.
 ///
@@ -14,16 +19,41 @@ use wasmtime_types::{EngineOrModuleTypeIndex, ModuleInternedTypeIndex, TypeIndex
 /// Note that accesing this type is primarily done through the `Index`
 /// implementations for this type.
 #[derive(Default, Serialize, Deserialize)]
-#[allow(missing_docs)]
 pub struct ModuleTypes {
+    rec_groups: PrimaryMap<ModuleInternedRecGroupIndex, Range<ModuleInternedTypeIndex>>,
     wasm_types: PrimaryMap<ModuleInternedTypeIndex, WasmFuncType>,
 }
 
 impl ModuleTypes {
     /// Returns an iterator over all the wasm function signatures found within
     /// this module.
-    pub fn wasm_types(&self) -> impl Iterator<Item = (ModuleInternedTypeIndex, &WasmFuncType)> {
+    pub fn wasm_types(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (ModuleInternedTypeIndex, &WasmFuncType)> {
         self.wasm_types.iter()
+    }
+
+    /// Get the type at the specified index.
+    pub fn get(&self, ty: ModuleInternedTypeIndex) -> &WasmFuncType {
+        &self.wasm_types[ty]
+    }
+
+    /// Get an iterator over all recursion groups defined in this module and
+    /// their elements.
+    pub fn rec_groups(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (ModuleInternedRecGroupIndex, Range<ModuleInternedTypeIndex>)> + '_
+    {
+        self.rec_groups.iter().map(|(k, v)| (k, v.clone()))
+    }
+
+    /// Get the elements within an already-defined rec group.
+    pub fn rec_group_elements(
+        &self,
+        rec_group: ModuleInternedRecGroupIndex,
+    ) -> impl ExactSizeIterator<Item = ModuleInternedTypeIndex> {
+        let range = &self.rec_groups[rec_group];
+        (range.start.as_u32()..range.end.as_u32()).map(|i| ModuleInternedTypeIndex::from_u32(i))
     }
 }
 
@@ -35,43 +65,248 @@ impl Index<ModuleInternedTypeIndex> for ModuleTypes {
     }
 }
 
+/// A type marking the start of a recursion group's definition.
+///
+/// This is initialized by `ModuleTypesBuilder::start_rec_group` and then
+/// finished in `ModuleTypes::end_rec_group` after all of the types in the rec
+/// group have been defined.
+struct RecGroupStart {
+    rec_group_index: ModuleInternedRecGroupIndex,
+    start: ModuleInternedTypeIndex,
+    end: ModuleInternedTypeIndex,
+}
+
 /// A builder for [`ModuleTypes`].
-#[derive(Default)]
-#[allow(missing_docs)]
 pub struct ModuleTypesBuilder {
+    /// The ID of the validator that this builder is configured for. Using a
+    /// different validator, or multiple validators, with this builder would
+    /// result in silliness because our `wasmparser::types::*Id`s are only
+    /// unique within the context of a particular validator. Getting this wrong
+    /// could result in generating calls to functions of the wrong type, for
+    /// example. So therefore we always assert that a builder instances is only
+    /// ever paired with a particular validator context.
+    validator_id: ValidatorId,
+
+    /// The canonicalized and deduplicated set of types we are building.
     types: ModuleTypes,
-    interned_func_types: HashMap<WasmFuncType, ModuleInternedTypeIndex>,
-    wasmparser_to_wasmtime: HashMap<CoreTypeId, ModuleInternedTypeIndex>,
+
+    /// A map from already-interned `wasmparser` types to their corresponding
+    /// Wasmtime type.
+    wasmparser_to_wasmtime: HashMap<wasmparser::types::CoreTypeId, ModuleInternedTypeIndex>,
+
+    /// The set of recursion groups we have already seen and interned.
+    already_seen: HashMap<wasmparser::types::RecGroupId, ModuleInternedRecGroupIndex>,
+
+    /// If we are in the middle of defining a recursion group, this is the
+    /// metadata about the recursion group we started defining.
+    defining_rec_group: Option<RecGroupStart>,
 }
 
 impl ModuleTypesBuilder {
+    /// Construct a new `ModuleTypesBuilder` using the given validator.
+    pub fn new(validator: &Validator) -> Self {
+        Self {
+            validator_id: validator.id(),
+            types: ModuleTypes::default(),
+            wasmparser_to_wasmtime: HashMap::default(),
+            already_seen: HashMap::default(),
+            defining_rec_group: None,
+        }
+    }
+
     /// Reserves space for `amt` more type signatures.
     pub fn reserve_wasm_signatures(&mut self, amt: usize) {
         self.types.wasm_types.reserve(amt);
+        self.wasmparser_to_wasmtime.reserve(amt);
+        self.already_seen.reserve(amt);
     }
 
-    /// Interns the `sig` specified and returns a unique `SignatureIndex` that
-    /// can be looked up within [`ModuleTypes`] to recover the [`WasmFuncType`]
-    /// at runtime.
-    pub fn wasm_func_type(&mut self, id: CoreTypeId, sig: WasmFuncType) -> ModuleInternedTypeIndex {
-        let sig = self.intern_func_type(sig);
-        self.wasmparser_to_wasmtime.insert(id, sig);
-        sig
+    /// Get the id of the validator that this builder is configured for.
+    pub fn validator_id(&self) -> ValidatorId {
+        self.validator_id
     }
 
-    fn intern_func_type(&mut self, sig: WasmFuncType) -> ModuleInternedTypeIndex {
-        if let Some(idx) = self.interned_func_types.get(&sig) {
-            return *idx;
+    /// Intern a recursion group and all of its types into this builder.
+    ///
+    /// If the recursion group has already been interned, then it is reused.
+    ///
+    /// Panics if given types from a different validator than the one that this
+    /// builder is associated with.
+    pub fn intern_rec_group(
+        &mut self,
+        module: &Module,
+        validator_types: wasmparser::types::TypesRef<'_>,
+        rec_group_id: wasmparser::types::RecGroupId,
+    ) -> WasmResult<ModuleInternedRecGroupIndex> {
+        assert_eq!(validator_types.id(), self.validator_id);
+
+        if let Some(interned) = self.already_seen.get(&rec_group_id) {
+            return Ok(*interned);
         }
 
-        let idx = self.types.wasm_types.push(sig.clone());
-        self.interned_func_types.insert(sig, idx);
-        return idx;
+        self.define_new_rec_group(module, validator_types, rec_group_id)
+    }
+
+    /// Define a new recursion group that we haven't already interned.
+    fn define_new_rec_group(
+        &mut self,
+        module: &Module,
+        validator_types: wasmparser::types::TypesRef<'_>,
+        rec_group_id: wasmparser::types::RecGroupId,
+    ) -> WasmResult<ModuleInternedRecGroupIndex> {
+        assert_eq!(validator_types.id(), self.validator_id);
+
+        self.start_rec_group(
+            validator_types,
+            validator_types.rec_group_elements(rec_group_id),
+        );
+
+        for id in validator_types.rec_group_elements(rec_group_id) {
+            let ty = &validator_types[id];
+            if ty.supertype_idx.is_some() {
+                return Err(wasm_unsupported!("wasm gc: explicit subtyping"));
+            }
+            match &ty.composite_type {
+                CompositeType::Func(ty) => {
+                    let wasm_ty = WasmparserTypeConverter::new(self, module).convert_func_type(ty);
+                    self.wasm_func_type_in_rec_group(id, wasm_ty);
+                }
+                CompositeType::Array(_) => return Err(wasm_unsupported!("wasm gc: array types")),
+                CompositeType::Struct(_) => return Err(wasm_unsupported!("wasm gc: struct types")),
+            }
+        }
+
+        Ok(self.end_rec_group(rec_group_id))
+    }
+
+    /// Start defining a recursion group.
+    fn start_rec_group(
+        &mut self,
+        validator_types: wasmparser::types::TypesRef<'_>,
+        elems: impl ExactSizeIterator<Item = wasmparser::types::CoreTypeId>,
+    ) {
+        log::trace!("Starting rec group of length {}", elems.len());
+
+        assert!(self.defining_rec_group.is_none());
+        assert_eq!(validator_types.id(), self.validator_id);
+
+        // Eagerly define the reverse map's entries for this rec group's types
+        // so that we can use them when converting `wasmparser` types to our
+        // types.
+        let len = elems.len();
+        for (i, wasmparser_id) in elems.enumerate() {
+            let interned = ModuleInternedTypeIndex::new(self.types.wasm_types.len() + i);
+            log::trace!(
+                "Reserving {interned:?} for {wasmparser_id:?} = {:?}",
+                validator_types[wasmparser_id]
+            );
+
+            let old_entry = self.wasmparser_to_wasmtime.insert(wasmparser_id, interned);
+            debug_assert_eq!(
+                old_entry, None,
+                "should not have already inserted {wasmparser_id:?}"
+            );
+        }
+
+        self.defining_rec_group = Some(RecGroupStart {
+            rec_group_index: self.types.rec_groups.next_key(),
+            start: self.types.wasm_types.next_key(),
+            end: ModuleInternedTypeIndex::new(self.types.wasm_types.len() + len),
+        });
+    }
+
+    /// Finish defining a recursion group.
+    fn end_rec_group(
+        &mut self,
+        rec_group_id: wasmparser::types::RecGroupId,
+    ) -> ModuleInternedRecGroupIndex {
+        let RecGroupStart {
+            rec_group_index,
+            start,
+            end,
+        } = self
+            .defining_rec_group
+            .take()
+            .expect("should be defining a rec group");
+
+        log::trace!("Ending rec group {start:?}..{end:?}");
+
+        debug_assert!(start.index() < self.types.wasm_types.len());
+        debug_assert_eq!(
+            end,
+            self.types.wasm_types.next_key(),
+            "should have defined the number of types declared in `start_rec_group`"
+        );
+
+        let idx = self.types.rec_groups.push(start..end);
+        debug_assert_eq!(idx, rec_group_index);
+
+        self.already_seen.insert(rec_group_id, rec_group_index);
+        rec_group_index
+    }
+
+    /// Intern a type into this builder and get its Wasmtime index.
+    ///
+    /// This will intern not only the single given type, but the type's entire
+    /// rec group. This helper method is provided as a convenience so that
+    /// callers don't have to get the type's rec group, intern the rec group,
+    /// and then look up the Wasmtime index for the original type themselves.
+    pub fn intern_type(
+        &mut self,
+        module: &Module,
+        validator_types: wasmparser::types::TypesRef<'_>,
+        id: wasmparser::types::CoreTypeId,
+    ) -> WasmResult<ModuleInternedTypeIndex> {
+        assert!(self.defining_rec_group.is_none());
+        assert_eq!(validator_types.id(), self.validator_id);
+
+        let rec_group_id = validator_types.rec_group_id_of(id);
+        debug_assert!(validator_types
+            .rec_group_elements(rec_group_id)
+            .any(|e| e == id));
+
+        let interned_rec_group = self.intern_rec_group(module, validator_types, rec_group_id)?;
+
+        let interned_type = self.wasmparser_to_wasmtime[&id];
+        debug_assert!(self
+            .rec_group_elements(interned_rec_group)
+            .any(|e| e == interned_type));
+
+        Ok(interned_type)
+    }
+
+    /// Define a new Wasm function type while we are defining a rec group.
+    fn wasm_func_type_in_rec_group(
+        &mut self,
+        id: wasmparser::types::CoreTypeId,
+        func_ty: WasmFuncType,
+    ) -> ModuleInternedTypeIndex {
+        assert!(
+            self.defining_rec_group.is_some(),
+            "must be defining a rec group to define new types"
+        );
+
+        let module_interned_index = self.types.wasm_types.push(func_ty);
+        debug_assert_eq!(
+            self.wasmparser_to_wasmtime.get(&id),
+            Some(&module_interned_index),
+            "should have reserved the right module-interned index for this wasmparser type already"
+        );
+
+        module_interned_index
     }
 
     /// Returns the result [`ModuleTypes`] of this builder.
     pub fn finish(self) -> ModuleTypes {
         self.types
+    }
+
+    /// Get the elements within an already-defined rec group.
+    pub fn rec_group_elements(
+        &self,
+        rec_group: ModuleInternedRecGroupIndex,
+    ) -> impl ExactSizeIterator<Item = ModuleInternedTypeIndex> {
+        self.types.rec_group_elements(rec_group)
     }
 
     /// Returns an iterator over all the wasm function signatures found within
@@ -95,10 +330,17 @@ where
     }
 }
 
-#[allow(missing_docs)]
+/// A convert from `wasmparser` types to Wasmtime types.
 pub struct WasmparserTypeConverter<'a> {
-    pub types: &'a ModuleTypesBuilder,
-    pub module: &'a Module,
+    types: &'a ModuleTypesBuilder,
+    module: &'a Module,
+}
+
+impl<'a> WasmparserTypeConverter<'a> {
+    /// Construct a new type converter from `wasmparser` types to Wasmtime types.
+    pub fn new(types: &'a ModuleTypesBuilder, module: &'a Module) -> Self {
+        Self { types, module }
+    }
 }
 
 impl TypeConvert for WasmparserTypeConverter<'_> {
@@ -108,15 +350,12 @@ impl TypeConvert for WasmparserTypeConverter<'_> {
                 let signature = self.types.wasmparser_to_wasmtime[&id];
                 WasmHeapType::Concrete(EngineOrModuleTypeIndex::Module(signature))
             }
-            UnpackedIndex::RecGroup(_) => unreachable!(),
-            UnpackedIndex::Module(i) => {
-                let i = TypeIndex::from_u32(i);
-                match self.module.types[i] {
-                    ModuleType::Function(sig) => {
-                        WasmHeapType::Concrete(EngineOrModuleTypeIndex::Module(sig))
-                    }
-                }
+            UnpackedIndex::Module(module_index) => {
+                let module_index = TypeIndex::from_u32(module_index);
+                let interned_index = self.module.types[module_index];
+                WasmHeapType::Concrete(EngineOrModuleTypeIndex::Module(interned_index))
             }
+            UnpackedIndex::RecGroup(_) => unreachable!(),
         }
     }
 }

--- a/crates/wasmtime/src/runtime/externals/global.rs
+++ b/crates/wasmtime/src/runtime/externals/global.rs
@@ -227,7 +227,7 @@ impl Global {
         wasmtime_export
             .global
             .wasm_ty
-            .canonicalize(&mut |module_index| {
+            .canonicalize_for_runtime_usage(&mut |module_index| {
                 wasmtime_runtime::Instance::from_vmctx(wasmtime_export.vmctx, |instance| {
                     instance.engine_type_index(module_index)
                 })

--- a/crates/wasmtime/src/runtime/externals/table.rs
+++ b/crates/wasmtime/src/runtime/externals/table.rs
@@ -403,7 +403,7 @@ impl Table {
             .table
             .table
             .wasm_ty
-            .canonicalize(&mut |module_index| {
+            .canonicalize_for_runtime_usage(&mut |module_index| {
                 wasmtime_runtime::Instance::from_vmctx(wasmtime_export.vmctx, |instance| {
                     instance.engine_type_index(module_index)
                 })

--- a/crates/wasmtime/src/runtime/instance.rs
+++ b/crates/wasmtime/src/runtime/instance.rs
@@ -982,7 +982,7 @@ fn typecheck<I>(
     }
     let cx = matching::MatchCx::new(module.engine());
     for ((name, field, mut expected_ty), actual) in env_module.imports().zip(imports) {
-        expected_ty.canonicalize(&mut |module_index| {
+        expected_ty.canonicalize_for_runtime_usage(&mut |module_index| {
             module.signatures().shared_type(module_index).unwrap()
         });
 

--- a/crates/wasmtime/src/runtime/trampoline/table.rs
+++ b/crates/wasmtime/src/runtime/trampoline/table.rs
@@ -2,7 +2,7 @@ use crate::store::{InstanceId, StoreOpaque};
 use crate::trampoline::create_handle;
 use crate::TableType;
 use anyhow::Result;
-use wasmtime_environ::{EngineOrModuleTypeIndex, EntityIndex, Module, TypeTrace};
+use wasmtime_environ::{EntityIndex, Module, TypeTrace};
 
 pub fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<InstanceId> {
     let mut module = Module::new();
@@ -10,17 +10,11 @@ pub fn create_table(store: &mut StoreOpaque, table: &TableType) -> Result<Instan
     let wasmtime_table = table.wasmtime_table().clone();
     let tunables = store.engine().tunables();
 
-    if cfg!(debug_assertions) {
-        wasmtime_table
-            .wasm_ty
-            .trace(&mut |idx| match idx {
-                EngineOrModuleTypeIndex::Engine(_) => Ok(()),
-                EngineOrModuleTypeIndex::Module(module_idx) => Err(format!(
-                    "found module-level canonicalized type index: {module_idx:?}"
-                )),
-            })
-            .expect("element type should be engine-level canonicalized");
-    }
+    debug_assert!(
+        wasmtime_table.wasm_ty.is_canonicalized_for_runtime_usage(),
+        "should be canonicalized for runtime usage: {:?}",
+        wasmtime_table.wasm_ty
+    );
 
     let table_plan = wasmtime_environ::TablePlan::for_table(wasmtime_table, tunables);
     let table_id = module.table_plans.push(table_plan);

--- a/crates/wasmtime/src/runtime/type_registry.rs
+++ b/crates/wasmtime/src/runtime/type_registry.rs
@@ -1,7 +1,7 @@
 //! Implement a registry of types: function, struct, and array definitions.
 //!
 //! Helps implement fast indirect call signature checking, reference type
-//! casting, and etc.
+//! downcasting, and etc...
 
 use crate::Engine;
 use std::{
@@ -9,7 +9,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::Debug,
     hash::{Hash, Hasher},
-    ops::Deref,
+    ops::Range,
     sync::{
         atomic::{
             AtomicUsize,
@@ -19,17 +19,12 @@ use std::{
     },
 };
 use wasmtime_environ::{
-    EngineOrModuleTypeIndex, ModuleInternedTypeIndex, ModuleTypes, PrimaryMap, TypeTrace,
-    VMSharedTypeIndex, WasmFuncType,
+    iter_entity_range, EngineOrModuleTypeIndex, ModuleInternedTypeIndex, ModuleTypes, PrimaryMap,
+    TypeTrace, VMSharedTypeIndex, WasmFuncType, WasmRecGroup,
 };
 use wasmtime_slab::{Id as SlabId, Slab};
 
 // ### Notes on the Lifetime Management of Types
-//
-// (The below refers to recursion groups even though at the time of writing we
-// don't support Wasm GC yet, which introduced recursion groups. Until that
-// time, you can think of each type implicitly being in a singleton recursion
-// group, so types and recursion groups are effectively one to one.)
 //
 // All defined types from all Wasm modules loaded into Wasmtime are interned
 // into their engine's `TypeRegistry`.
@@ -38,18 +33,18 @@ use wasmtime_slab::{Id as SlabId, Slab};
 // cared about canonicalizing types so that `call_indirect` was fast and we
 // didn't waste memory on many copies of the same function type definition.
 // Function types could only take and return simple scalars (i32/f64/etc...) and
-// there were no type-to-type references. We could simply deduplicate types and
-// reference count their entries in the registry.
+// there were no type-to-type references. We could simply deduplicate function
+// types and reference count their entries in the registry.
 //
 // The typed function references and GC proposals change everything. The former
 // introduced function types that take a reference to a function of another
 // specific type. This is a type-to-type reference. The latter introduces struct
 // and array types that can have references to other struct, array, and function
 // types, as well as recursion groups that allow cyclic references between
-// types. Now type canonicalization additionally enables fast type checks
-// *across* modules: so that two modules which define the same struct type, for
-// example, can pass instances of that struct type to each other, and we can
-// quickly check that those instances are in fact of the expected types.
+// types. Now type canonicalization additionally enables fast type checks and
+// downcasts *across* modules: so that two modules which define the same struct
+// type, for example, can pass instances of that struct type to each other, and
+// we can quickly check that those instances are in fact of the expected types.
 //
 // But how do we manage the lifetimes of types that can reference other types as
 // Wasm modules are dynamically loaded and unloaded from the engine? These
@@ -87,6 +82,7 @@ use wasmtime_slab::{Id as SlabId, Slab};
 /// when dropped.
 pub struct TypeCollection {
     engine: Engine,
+    rec_groups: Vec<RecGroupEntry>,
     types: PrimaryMap<ModuleInternedTypeIndex, VMSharedTypeIndex>,
     reverse_types: HashMap<VMSharedTypeIndex, ModuleInternedTypeIndex>,
 }
@@ -95,10 +91,12 @@ impl Debug for TypeCollection {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let TypeCollection {
             engine: _,
+            rec_groups,
             types,
             reverse_types: _,
         } = self;
         f.debug_struct("TypeCollection")
+            .field("rec_groups", rec_groups)
             .field("types", types)
             .finish_non_exhaustive()
     }
@@ -109,11 +107,12 @@ impl TypeCollection {
     pub fn new_for_module(engine: &Engine, types: &ModuleTypes) -> Self {
         let engine = engine.clone();
         let registry = engine.signatures();
-        let types = registry.0.write().unwrap().register_for_module(types);
+        let (rec_groups, types) = registry.0.write().unwrap().register_module_types(types);
         let reverse_types = types.iter().map(|(k, v)| (*v, k)).collect();
 
         Self {
             engine,
+            rec_groups,
             types,
             reverse_types,
         }
@@ -142,7 +141,7 @@ impl TypeCollection {
 
 impl Drop for TypeCollection {
     fn drop(&mut self) {
-        if !self.types.is_empty() {
+        if !self.rec_groups.is_empty() {
             self.engine
                 .signatures()
                 .0
@@ -173,14 +172,22 @@ fn slab_id_to_shared_type_index(id: SlabId) -> VMSharedTypeIndex {
 /// Dereferences to its underlying `WasmFuncType`.
 pub struct RegisteredType {
     engine: Engine,
-    entry: Entry,
+    entry: RecGroupEntry,
+    ty: Arc<WasmFuncType>,
+    index: VMSharedTypeIndex,
 }
 
 impl Debug for RegisteredType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let RegisteredType { engine: _, entry } = self;
+        let RegisteredType {
+            engine: _,
+            entry: _,
+            ty,
+            index,
+        } = self;
         f.debug_struct("RegisteredType")
-            .field("entry", entry)
+            .field("index", index)
+            .field("ty", ty)
             .finish_non_exhaustive()
     }
 }
@@ -191,6 +198,8 @@ impl Clone for RegisteredType {
         RegisteredType {
             engine: self.engine.clone(),
             entry: self.entry.clone(),
+            ty: self.ty.clone(),
+            index: self.index,
         }
     }
 }
@@ -203,7 +212,7 @@ impl Drop for RegisteredType {
                 .0
                 .write()
                 .unwrap()
-                .unregister_entry(self.entry.0.index);
+                .unregister_entry(self.entry.clone());
         }
     }
 }
@@ -212,7 +221,7 @@ impl std::ops::Deref for RegisteredType {
     type Target = WasmFuncType;
 
     fn deref(&self) -> &Self::Target {
-        &self.entry.0.ty
+        &self.ty
     }
 }
 
@@ -223,11 +232,9 @@ impl PartialEq for RegisteredType {
         if cfg!(debug_assertions) {
             if eq {
                 assert!(Engine::same(&self.engine, &other.engine));
+                assert_eq!(self.ty, other.ty);
             } else {
-                assert!(
-                    self.entry.0.index != other.entry.0.index
-                        || !Engine::same(&self.engine, &other.engine)
-                );
+                assert!(self.ty != other.ty || !Engine::same(&self.engine, &other.engine));
             }
         }
 
@@ -248,23 +255,29 @@ impl RegisteredType {
     /// Constructs a new `RegisteredType`, registering the given type with the
     /// engine's `TypeRegistry`.
     pub fn new(engine: &Engine, ty: WasmFuncType) -> RegisteredType {
-        let entry = {
-            let mut inner = engine.signatures().0.write().unwrap();
-
+        let (entry, index, ty) = {
             log::trace!("RegisteredType::new({ty:?})");
 
-            // It shouldn't be possible for users to construct non-canonical types
-            // via the embedding API, and the only other types they can get are
-            // already-canonicalized types from modules, so we shouldn't ever get
-            // non-canonical types here.
-            assert!(
-                inner.is_canonicalized(&ty),
-                "ty is not already canonicalized: {ty:?}"
-            );
+            let mut inner = engine.signatures().0.write().unwrap();
 
-            inner.register_canonicalized(ty)
+            // It shouldn't be possible for users to construct non-canonical
+            // types via the embedding API, and the only other types they can
+            // get are already-canonicalized types from modules, so we shouldn't
+            // ever get non-canonical types here. Furthermore, this is only
+            // called internally to Wasmtime, so we shouldn't ever have an
+            // engine mismatch; those should be caught earlier.
+            inner.assert_canonicalized_for_runtime_usage_in_this_registry(&ty);
+
+            let entry = inner.register_singleton_rec_group(ty);
+
+            let index = entry.0.shared_type_indices[0];
+            let id = shared_type_index_to_slab_id(index);
+            let ty = inner.types[id].clone();
+
+            (entry, index, ty)
         };
-        RegisteredType::from_parts(engine.clone(), entry)
+
+        RegisteredType::from_parts(engine.clone(), entry, index, ty)
     }
 
     /// Create an owning handle to the given index's associated type.
@@ -275,10 +288,12 @@ impl RegisteredType {
     /// Returns `None` if `index` is not registered in the given engine's
     /// registry.
     pub fn root(engine: &Engine, index: VMSharedTypeIndex) -> Option<RegisteredType> {
-        let entry = {
+        let (entry, ty) = {
             let id = shared_type_index_to_slab_id(index);
             let inner = engine.signatures().0.read().unwrap();
-            let e = inner.entries.get(id)?;
+
+            let ty = inner.types.get(id)?.clone();
+            let entry = inner.type_to_rec_group[&index].clone();
 
             // NB: make sure to incref while the lock is held to prevent:
             //
@@ -286,26 +301,36 @@ impl RegisteredType {
             // * Other thread: drops `RegisteredType` for entry E, decref
             //   reaches zero, write locks registry, unregisters entry
             // * This thread: increfs entry, but it isn't in the registry anymore
-            e.incref("RegisteredType::root");
+            entry.incref("RegisteredType::root");
 
-            e.clone()
+            (entry, ty)
         };
 
-        Some(RegisteredType::from_parts(engine.clone(), entry))
+        Some(RegisteredType::from_parts(engine.clone(), entry, index, ty))
     }
 
     /// Construct a new `RegisteredType`.
     ///
     /// It is the caller's responsibility to ensure that the entry's reference
     /// count has already been incremented.
-    fn from_parts(engine: Engine, entry: Entry) -> Self {
+    fn from_parts(
+        engine: Engine,
+        entry: RecGroupEntry,
+        index: VMSharedTypeIndex,
+        ty: Arc<WasmFuncType>,
+    ) -> Self {
         debug_assert!(entry.0.registrations.load(Acquire) != 0);
-        RegisteredType { engine, entry }
+        RegisteredType {
+            engine,
+            entry,
+            ty,
+            index,
+        }
     }
 
     /// Get this registered type's index.
     pub fn index(&self) -> VMSharedTypeIndex {
-        self.entry.0.index
+        self.index
     }
 
     /// Get the engine whose registry this type is registered within.
@@ -314,55 +339,66 @@ impl RegisteredType {
     }
 }
 
-/// A Wasm function type, its `VMSharedTypeIndex`, and its registration count.
-#[derive(Debug)]
-struct EntryInner {
-    ty: WasmFuncType,
-    index: VMSharedTypeIndex,
+/// An entry in the type registry.
+///
+/// Implements `Borrow`, `Eq`, and `Hash` by forwarding to the underlying Wasm
+/// rec group, so that this can be a hash consing key. (We can't use
+/// `Arc<RecGroupEntryInner>` directly for this purpose because `Arc<T>` doesn't
+/// implement `Borrow<U>` when `T: Borrow<U>`).
+#[derive(Clone)]
+struct RecGroupEntry(Arc<RecGroupEntryInner>);
+
+impl Debug for RecGroupEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        struct Ptr<'a, P>(&'a P);
+        impl<P: std::fmt::Pointer> Debug for Ptr<'_, P> {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{:#p}", *self.0)
+            }
+        }
+
+        f.debug_struct("RecGroupEntry")
+            .field("ptr", &Ptr(&self.0))
+            .field("shared_type_indices", &self.0.shared_type_indices)
+            .field("hash_consing_key", &self.0.hash_consing_key)
+            .field("registrations", &self.0.registrations.load(Acquire))
+            .finish()
+    }
+}
+
+struct RecGroupEntryInner {
+    /// The Wasm rec group, canonicalized for hash consing.
+    hash_consing_key: WasmRecGroup,
+    shared_type_indices: Box<[VMSharedTypeIndex]>,
     registrations: AtomicUsize,
 }
 
-/// Implements `Borrow`, `Eq`, and `Hash` by forwarding to the underlying Wasm
-/// function type, so that this can be a hash consing key in
-/// `TypeRegistryInner::map`.
-#[derive(Clone, Debug)]
-struct Entry(Arc<EntryInner>);
-
-impl Deref for Entry {
-    type Target = WasmFuncType;
-
-    fn deref(&self) -> &Self::Target {
-        &self.0.ty
-    }
-}
-
-impl PartialEq for Entry {
+impl PartialEq for RecGroupEntry {
     fn eq(&self, other: &Self) -> bool {
-        self.0.ty == other.0.ty
+        self.0.hash_consing_key == other.0.hash_consing_key
     }
 }
 
-impl Eq for Entry {}
+impl Eq for RecGroupEntry {}
 
-impl Hash for Entry {
+impl Hash for RecGroupEntry {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.0.ty.hash(state);
+        self.0.hash_consing_key.hash(state);
     }
 }
 
-impl Borrow<WasmFuncType> for Entry {
-    fn borrow(&self) -> &WasmFuncType {
-        &self.0.ty
+impl Borrow<WasmRecGroup> for RecGroupEntry {
+    fn borrow(&self) -> &WasmRecGroup {
+        &self.0.hash_consing_key
     }
 }
 
-impl Entry {
+impl RecGroupEntry {
     /// Increment the registration count.
     fn incref(&self, why: &str) {
         let old_count = self.0.registrations.fetch_add(1, AcqRel);
         log::trace!(
-            "increment registration count for {:?} (registrations -> {}): {why}",
-            self.0.index,
+            "increment registration count for {self:?} (registrations -> {}): {why}",
             old_count + 1
         );
     }
@@ -374,8 +410,7 @@ impl Entry {
         let old_count = self.0.registrations.fetch_sub(1, AcqRel);
         debug_assert_ne!(old_count, 0);
         log::trace!(
-            "decrement registration count for {:?} (registrations -> {}): {why}",
-            self.0.index,
+            "decrement registration count for {self:?} (registrations -> {}): {why}",
             old_count - 1
         );
         old_count == 1
@@ -384,156 +419,272 @@ impl Entry {
 
 #[derive(Debug, Default)]
 struct TypeRegistryInner {
-    // A map from the Wasm function type to a `VMSharedTypeIndex`, for all
-    // the Wasm function types we have already registered.
-    map: HashSet<Entry>,
+    // A hash map from a canonicalized-for-hash-consing rec group to its
+    // `VMSharedTypeIndex`es.
+    //
+    // There is an entry in this map for every rec group we have already
+    // registered. Before registering new rec groups, we first check this map to
+    // see if we've already registered an identical rec group that we should
+    // reuse instead.
+    hash_consing_map: HashSet<RecGroupEntry>,
 
     // A map from `VMSharedTypeIndex::bits()` to the type index's associated
     // Wasm type.
-    entries: Slab<Entry>,
+    //
+    // These types are always canonicalized for runtime usage.
+    types: Slab<Arc<WasmFuncType>>,
+
+    // A map that lets you walk backwards from a `VMSharedTypeIndex` to its
+    // `RecGroupEntry`.
+    type_to_rec_group: HashMap<VMSharedTypeIndex, RecGroupEntry>,
 
     // An explicit stack of entries that we are in the middle of dropping. Used
     // to avoid recursion when dropping a type that is holding the last
     // reference to another type, etc...
-    drop_stack: Vec<VMSharedTypeIndex>,
+    drop_stack: Vec<RecGroupEntry>,
 }
 
 impl TypeRegistryInner {
-    fn register_for_module(
+    fn register_module_types(
         &mut self,
         types: &ModuleTypes,
-    ) -> PrimaryMap<ModuleInternedTypeIndex, VMSharedTypeIndex> {
-        log::trace!("Registering module types");
-        let mut map = PrimaryMap::default();
-        for (idx, ty) in types.wasm_types() {
-            let mut ty = ty.clone();
-            self.canonicalize(&map, &mut ty);
-            let entry = self.register_canonicalized(ty);
-            let map_idx = map.push(entry.0.index);
-            assert_eq!(idx, map_idx);
-        }
-        map
-    }
-
-    /// Is the given type canonicalized for this registry?
-    fn is_canonicalized(&self, ty: &WasmFuncType) -> bool {
-        let result = ty.trace::<_, ()>(&mut |index| match index {
-            EngineOrModuleTypeIndex::Module(_) => Err(()),
-            EngineOrModuleTypeIndex::Engine(id) => {
-                let id = shared_type_index_to_slab_id(id);
-                assert!(
-                    self.entries.contains(id),
-                    "canonicalized in a different engine? {ty:?}"
-                );
-                Ok(())
-            }
-        });
-        result.is_ok()
-    }
-
-    /// Canonicalize a type, such that its type-to-type references are via
-    /// engine-level `VMSharedTypeIndex`es rather than module-local via
-    /// `ModuleInternedTypeIndex`es.
-    ///
-    /// This makes the type suitable for deduplication in the registry.
-    ///
-    /// Panics on already-canonicalized types. They might be canonicalized for
-    /// another engine's registry, and we wouldn't know how to recanonicalize
-    /// them for this registry.
-    fn canonicalize(
-        &self,
-        module_to_shared: &PrimaryMap<ModuleInternedTypeIndex, VMSharedTypeIndex>,
-        ty: &mut WasmFuncType,
+    ) -> (
+        Vec<RecGroupEntry>,
+        PrimaryMap<ModuleInternedTypeIndex, VMSharedTypeIndex>,
     ) {
-        ty.canonicalize(&mut |module_index| module_to_shared[module_index]);
-        debug_assert!(self.is_canonicalized(ty))
-    }
+        log::trace!("Start registering module types");
 
-    /// Add a new type to this registry.
-    ///
-    /// The type must be canonicalized and must not already exist in the
-    /// registry.
-    ///
-    /// Initializes the new entry's registration count to one, and callers
-    /// should not further increment the registration count.
-    fn register_new(&mut self, ty: WasmFuncType) -> Entry {
-        assert!(
-            self.is_canonicalized(&ty),
-            "ty is not already canonicalized: {ty:?}"
+        let mut entries = Vec::with_capacity(types.rec_groups().len());
+        let mut map = PrimaryMap::<ModuleInternedTypeIndex, VMSharedTypeIndex>::with_capacity(
+            types.wasm_types().len(),
         );
 
-        // Increment the ref count of each existing type that is referenced from
-        // this new type. Those types shouldn't be dropped while this type is
-        // still alive.
-        ty.trace::<_, ()>(&mut |idx| match idx {
-            EngineOrModuleTypeIndex::Engine(id) => {
-                let i = shared_type_index_to_slab_id(id);
-                let e = &self.entries[i];
-                e.incref("new type references existing type in TypeRegistryInner::register_new");
-                Ok(())
-            }
-            EngineOrModuleTypeIndex::Module(_) => unreachable!("should be canonicalized"),
-        })
-        .unwrap();
+        for (_rec_group_index, module_group) in types.rec_groups() {
+            let entry = self.register_rec_group(
+                &map,
+                module_group.clone(),
+                iter_entity_range(module_group.clone()).map(|ty| types.get(ty).clone()),
+            );
 
-        let id = self.entries.next_id();
-        let index = slab_id_to_shared_type_index(id);
-        log::trace!("create {index:?} = {ty:?} (registrations -> 1)");
-        let entry = Entry(Arc::new(EntryInner {
-            ty,
-            index,
+            for (module_ty, engine_ty) in
+                iter_entity_range(module_group).zip(entry.0.shared_type_indices.iter())
+            {
+                let module_ty2 = map.push(*engine_ty);
+                assert_eq!(module_ty, module_ty2);
+            }
+
+            entries.push(entry);
+        }
+
+        log::trace!("End registering module types");
+
+        (entries, map)
+    }
+
+    /// Register a rec group in this registry.
+    ///
+    /// The rec group may be either module-level canonical (i.e. straight from
+    /// `wasmparser`) or engine-level canonicalized for runtime usage in this
+    /// registry. It may *not* be engine-level canonicalized for hash consing or
+    /// engine-level canonicalized for a different type registry instance.
+    ///
+    /// If this rec group is determined to be a duplicate of an
+    /// already-registered rec group, the existing rec group is reused.
+    ///
+    /// Parameters:
+    ///
+    /// * `map`: A map that we use to canonicalize inter-group type references
+    ///   from module-canonical to engine-canonical indices. This must contain
+    ///   entries for each inter-group type reference that this rec group
+    ///   contains.
+    ///
+    /// * `range`: The range of (module-level) types defined by this rec
+    ///   group. This is used to determine which type references inside this rec
+    ///   group are inter- vs intra-group.
+    ///
+    /// * `types`: The types defined within this rec group. Must have the same
+    ///   length as `range`.
+    ///
+    /// The returned entry will have already had its reference count incremented
+    /// on behalf of callers.
+    fn register_rec_group(
+        &mut self,
+        map: &PrimaryMap<ModuleInternedTypeIndex, VMSharedTypeIndex>,
+        range: Range<ModuleInternedTypeIndex>,
+        types: impl ExactSizeIterator<Item = WasmFuncType>,
+    ) -> RecGroupEntry {
+        debug_assert_eq!(iter_entity_range(range.clone()).len(), types.len());
+
+        let mut non_canon_types = Vec::with_capacity(types.len());
+        let hash_consing_key = WasmRecGroup {
+            types: types
+                .zip(iter_entity_range(range.clone()))
+                .map(|(mut ty, module_index)| {
+                    non_canon_types.push((module_index, ty.clone()));
+                    ty.canonicalize_for_hash_consing(range.clone(), &mut |idx| {
+                        debug_assert!(idx < range.clone().start);
+                        map[idx]
+                    });
+                    ty
+                })
+                .collect::<Box<[_]>>(),
+        };
+
+        // If we've already registered this rec group before, reuse it.
+        if let Some(entry) = self.hash_consing_map.get(&hash_consing_key) {
+            entry.incref(
+                "hash consed to already-registered type in `TypeRegistryInner::register_rec_group`",
+            );
+            return entry.clone();
+        }
+
+        // Inter-group edges: increment the referenced group's ref
+        // count, because these other rec groups shouldn't be dropped
+        // while this rec group is still alive.
+        hash_consing_key
+            .trace_engine_indices::<_, ()>(&mut |index| {
+                let entry = &self.type_to_rec_group[&index];
+                entry.incref(
+                    "new cross-group type reference to existing type in `register_rec_group`",
+                );
+                Ok(())
+            })
+            .unwrap();
+
+        // Register the individual types.
+        //
+        // Note that we can't update the reverse type-to-rec-group map until
+        // after we've constructed the `RecGroupEntry`, since that map needs to
+        // the fully-constructed entry for its values.
+        let module_rec_group_start = range.start;
+        let engine_rec_group_start = u32::try_from(self.types.len()).unwrap();
+        let shared_type_indices = non_canon_types
+            .into_iter()
+            .map(|(module_index, mut ty)| {
+                ty.canonicalize_for_runtime_usage(&mut |idx| {
+                    if idx < module_rec_group_start {
+                        map[idx]
+                    } else {
+                        let rec_group_offset = idx.as_u32() - module_rec_group_start.as_u32();
+                        VMSharedTypeIndex::from_u32(engine_rec_group_start + rec_group_offset)
+                    }
+                });
+                self.insert_one_type_from_rec_group(module_index, ty)
+            })
+            .collect();
+
+        let entry = RecGroupEntry(Arc::new(RecGroupEntryInner {
+            hash_consing_key,
+            shared_type_indices,
             registrations: AtomicUsize::new(1),
         }));
-        let is_new_entry = self.map.insert(entry.clone());
-        assert!(is_new_entry);
+        log::trace!("create new entry {entry:?} (registrations -> 1)");
 
-        let id = self.entries.alloc(entry.clone());
-        assert_eq!(id, shared_type_index_to_slab_id(index));
+        let is_new_entry = self.hash_consing_map.insert(entry.clone());
+        debug_assert!(is_new_entry);
+
+        // Now that we've construct the entry, we can update the reverse
+        // type-to-rec-group map.
+        for ty in entry.0.shared_type_indices.iter() {
+            let old_entry = self.type_to_rec_group.insert(*ty, entry.clone());
+            debug_assert!(old_entry.is_none());
+        }
 
         entry
     }
 
-    /// Register the given canonicalized type, incrementing its reference count.
-    fn register_canonicalized(&mut self, ty: WasmFuncType) -> Entry {
-        assert!(
-            self.is_canonicalized(&ty),
-            "type is not already canonicalized: {ty:?}"
-        );
-
-        if let Some(entry) = self.map.get(&ty) {
-            entry.incref(
-                "registering already-registered type in TypeRegistryInner::register_canonicalized",
-            );
-            entry.clone()
-        } else {
-            self.register_new(ty)
-        }
+    /// Is the given type canonicalized for runtime usage this registry?
+    fn assert_canonicalized_for_runtime_usage_in_this_registry(&self, ty: &WasmFuncType) {
+        ty.trace::<_, ()>(&mut |index| match index {
+            EngineOrModuleTypeIndex::RecGroup(_) | EngineOrModuleTypeIndex::Module(_) => {
+                panic!("not canonicalized for runtime usage: {ty:?}")
+            }
+            EngineOrModuleTypeIndex::Engine(idx) => {
+                let id = shared_type_index_to_slab_id(idx);
+                assert!(
+                    self.types.contains(id),
+                    "canonicalized in a different engine? {ty:?}"
+                );
+                Ok(())
+            }
+        })
+        .unwrap();
     }
 
+    /// Insert a new type as part of registering a new rec group.
+    ///
+    /// The type must be canonicalized for runtime usage in this registry and
+    /// its rec group must be a new one that we are currently registering, not
+    /// an already-registered rec group.
+    fn insert_one_type_from_rec_group(
+        &mut self,
+        module_index: ModuleInternedTypeIndex,
+        ty: WasmFuncType,
+    ) -> VMSharedTypeIndex {
+        // Despite being canonicalized for runtime usage, this type may still
+        // have forward references to other types in the rec group we haven't
+        // yet registered. Therefore, we can't use our usual
+        // `assert_canonicalized_for_runtime_usage_in_this_registry` helper here
+        // as that will see the forward references and think they must be
+        // references to types in other registries.
+        assert!(
+            ty.is_canonicalized_for_runtime_usage(),
+            "type is not canonicalized for runtime usage: {ty:?}"
+        );
+
+        let id = self.types.alloc(Arc::new(ty));
+        let engine_index = slab_id_to_shared_type_index(id);
+        log::trace!(
+            "registered type {module_index:?} as {engine_index:?} = {:?}",
+            &self.types[id]
+        );
+        engine_index
+    }
+
+    /// Register a rec group consisting of a single type.
+    ///
+    /// The type must already be canonicalized for runtime usage in this
+    /// registry.
+    ///
+    /// The returned entry will have already had its reference count incremented
+    /// on behalf of callers.
+    fn register_singleton_rec_group(&mut self, ty: WasmFuncType) -> RecGroupEntry {
+        self.assert_canonicalized_for_runtime_usage_in_this_registry(&ty);
+
+        // This type doesn't have any module-level type references, since it is
+        // already canonicalized for runtime usage in this registry, so an empty
+        // map suffices.
+        let map = PrimaryMap::default();
+
+        // This must have `range.len() == 1`, even though we know this type
+        // doesn't have any intra-group type references, to satisfy
+        // `register_rec_group`'s preconditions.
+        let range = ModuleInternedTypeIndex::from_bits(u32::MAX - 1)
+            ..ModuleInternedTypeIndex::from_bits(u32::MAX);
+
+        self.register_rec_group(&map, range, std::iter::once(ty))
+    }
+
+    /// Unregister all of a type collection's rec groups.
     fn unregister_type_collection(&mut self, collection: &TypeCollection) {
-        for (_, id) in collection.types.iter() {
-            let i = shared_type_index_to_slab_id(*id);
-            let e = &self.entries[i];
-            if e.decref("TypeRegistryInner::unregister_type_collection") {
-                self.unregister_entry(*id);
+        for entry in &collection.rec_groups {
+            if entry.decref("TypeRegistryInner::unregister_type_collection") {
+                self.unregister_entry(entry.clone());
             }
         }
     }
 
-    /// Remove an entry from the registry.
+    /// Remove a zero-refcount entry from the registry.
     ///
     /// This does *not* decrement the entry's registration count, it should
-    /// instead be invoked after a previous decrement operation observed zero
-    /// remaining registrations.
-    fn unregister_entry(&mut self, index: VMSharedTypeIndex) {
-        log::trace!("unregistering {index:?}");
-
+    /// instead be invoked only after a previous decrement operation observed
+    /// zero remaining registrations.
+    fn unregister_entry(&mut self, entry: RecGroupEntry) {
         debug_assert!(self.drop_stack.is_empty());
-        self.drop_stack.push(index);
+        self.drop_stack.push(entry);
 
-        while let Some(index) = self.drop_stack.pop() {
-            let slab_id = shared_type_index_to_slab_id(index);
-            let entry = &self.entries[slab_id];
+        while let Some(entry) = self.drop_stack.pop() {
+            log::trace!("Start unregistering {entry:?}");
 
             // We need to double check whether the entry is still at zero
             // registrations: Between the time that we observed a zero and
@@ -548,37 +699,52 @@ impl TypeRegistryInner {
             let registrations = entry.0.registrations.load(Acquire);
             if registrations != 0 {
                 log::trace!(
-                    "{index:?} was concurrently resurrected and no longer has zero \
-                     registrations (registrations -> {registrations})"
+                    "{entry:?} was concurrently resurrected and no longer has \
+                     zero registrations (registrations -> {registrations})",
                 );
                 continue;
             }
 
-            // Decrement any other types that this type was
-            // (shallowly/non-transitively) keeping alive.
+            // Decrement any other types that this type was shallowly
+            // (i.e. non-transitively) referencing and keeping alive. If this
+            // was the last thing keeping them registered, its okay to
+            // unregister them as well now.
+            debug_assert!(entry.0.hash_consing_key.is_canonicalized_for_hash_consing());
             entry
                 .0
-                .ty
-                .trace::<_, ()>(&mut |child_index| match child_index {
-                    EngineOrModuleTypeIndex::Engine(child_index) => {
-                        let child_slab_id = shared_type_index_to_slab_id(child_index);
-                        let child_entry = &self.entries[child_slab_id];
-                        if child_entry.decref(
-                            "referenced by unregistered type in TypeCollection::unregister_entry",
-                        ) {
-                            self.drop_stack.push(child_index);
-                        }
-                        Ok(())
+                .hash_consing_key
+                .trace_engine_indices::<_, ()>(&mut |other_index| {
+                    let other_entry = self.type_to_rec_group[&other_index].clone();
+                    if other_entry.decref(
+                        "referenced by dropped entry in \
+                         `TypeCollection::unregister_entry`",
+                    ) {
+                        self.drop_stack.push(other_entry);
                     }
-                    EngineOrModuleTypeIndex::Module(_) => {
-                        unreachable!("should be canonicalized")
-                    }
+                    Ok(())
                 })
                 .unwrap();
 
-            log::trace!("removing {index:?} from registry");
-            self.map.remove(entry);
-            self.entries.dealloc(slab_id);
+            // Remove the entry from the hash-consing map. If we register a
+            // duplicate definition of this rec group again in the future, it
+            // will be as if it is the first time it has ever been registered,
+            // and it will be inserted into the hash-consing map again at that
+            // time.
+            self.hash_consing_map.remove(&entry);
+
+            // Similarly, remove the rec group's types from the registry, as
+            // well as their entries from the reverse type-to-rec-group map.
+            for ty in entry.0.shared_type_indices.iter() {
+                log::trace!("removing {ty:?} from registry");
+
+                let removed_entry = self.type_to_rec_group.remove(ty);
+                debug_assert_eq!(removed_entry.unwrap(), entry);
+
+                let id = shared_type_index_to_slab_id(*ty);
+                self.types.dealloc(id);
+            }
+
+            log::trace!("End unregistering {entry:?}");
         }
     }
 }
@@ -588,13 +754,27 @@ impl TypeRegistryInner {
 #[cfg(debug_assertions)]
 impl Drop for TypeRegistryInner {
     fn drop(&mut self) {
+        let TypeRegistryInner {
+            hash_consing_map,
+            types,
+            type_to_rec_group,
+            drop_stack,
+        } = self;
         assert!(
-            self.map.is_empty(),
-            "type registry not empty: still have registered types in self.map"
+            hash_consing_map.is_empty(),
+            "type registry not empty: hash consing map is not empty"
         );
         assert!(
-            self.entries.is_empty(),
-            "type registry not empty: not all entries are vacant"
+            types.is_empty(),
+            "type registry not empty: types slab is not empty"
+        );
+        assert!(
+            type_to_rec_group.is_empty(),
+            "type registry not empty: type-to-rec-group map is not empty"
+        );
+        assert!(
+            drop_stack.is_empty(),
+            "type registry not empty: drop stack is not empty"
         );
     }
 }
@@ -620,9 +800,9 @@ impl TypeRegistry {
     /// still using the resulting value! Use the `RegisteredType::root`
     /// constructor if you need to ensure that property and you don't have some
     /// other mechanism already keeping the type registered.
-    pub fn borrow(&self, index: VMSharedTypeIndex) -> Option<impl Deref<Target = WasmFuncType>> {
+    pub fn borrow(&self, index: VMSharedTypeIndex) -> Option<Arc<WasmFuncType>> {
         let id = shared_type_index_to_slab_id(index);
         let inner = self.0.read().unwrap();
-        inner.entries.get(id).cloned()
+        inner.types.get(id).cloned()
     }
 }

--- a/crates/wasmtime/src/runtime/types/matching.rs
+++ b/crates/wasmtime/src/runtime/types/matching.rs
@@ -1,8 +1,8 @@
 use crate::{linker::DefinitionType, Engine, FuncType};
 use anyhow::{anyhow, bail, Result};
 use wasmtime_environ::{
-    EngineOrModuleTypeIndex, EntityType, Global, Memory, ModuleTypes, Table, TypeTrace,
-    VMSharedTypeIndex, WasmFuncType, WasmHeapType, WasmRefType, WasmValType,
+    EntityType, Global, Memory, ModuleTypes, Table, TypeTrace, VMSharedTypeIndex, WasmFuncType,
+    WasmHeapType, WasmRefType, WasmValType,
 };
 
 pub struct MatchCx<'a> {
@@ -245,25 +245,14 @@ fn match_ref(expected: WasmRefType, actual: WasmRefType, desc: &str) -> Result<(
 fn match_ty(expected: WasmValType, actual: WasmValType, desc: &str) -> Result<()> {
     // Assert that both our types are engine-level canonicalized. We can't
     // compare types otherwise.
-    if cfg!(debug_assertions) {
-        expected
-            .trace(&mut |idx| match idx {
-                EngineOrModuleTypeIndex::Engine(_) => Ok(()),
-                EngineOrModuleTypeIndex::Module(mod_idx) => {
-                    Err(format!("found module-level index: {mod_idx:?}"))
-                }
-            })
-            .expect("expected type should be engine-level canonicalized");
-
-        actual
-            .trace(&mut |idx| match idx {
-                EngineOrModuleTypeIndex::Engine(_) => Ok(()),
-                EngineOrModuleTypeIndex::Module(mod_idx) => {
-                    Err(format!("found module-level index: {mod_idx:?}"))
-                }
-            })
-            .expect("actual type should be engine-level canonicalized");
-    }
+    debug_assert!(
+        expected.is_canonicalized_for_runtime_usage(),
+        "expected type should be canonicalized for runtime usage: {expected:?}"
+    );
+    debug_assert!(
+        actual.is_canonicalized_for_runtime_usage(),
+        "actual type should be canonicalized for runtime usage: {actual:?}"
+    );
 
     match (actual, expected) {
         (WasmValType::Ref(actual), WasmValType::Ref(expected)) => match_ref(expected, actual, desc),
@@ -274,25 +263,14 @@ fn match_ty(expected: WasmValType, actual: WasmValType, desc: &str) -> Result<()
 fn equal_ty(expected: WasmValType, actual: WasmValType, desc: &str) -> Result<()> {
     // Assert that both our types are engine-level canonicalized. We can't
     // compare types otherwise.
-    if cfg!(debug_assertions) {
-        expected
-            .trace(&mut |idx| match idx {
-                EngineOrModuleTypeIndex::Engine(_) => Ok(()),
-                EngineOrModuleTypeIndex::Module(mod_idx) => {
-                    Err(format!("found module-level index: {mod_idx:?}"))
-                }
-            })
-            .expect("expected type should be engine-level canonicalized");
-
-        actual
-            .trace(&mut |idx| match idx {
-                EngineOrModuleTypeIndex::Engine(_) => Ok(()),
-                EngineOrModuleTypeIndex::Module(mod_idx) => {
-                    Err(format!("found module-level index: {mod_idx:?}"))
-                }
-            })
-            .expect("actual type should be engine-level canonicalized");
-    }
+    debug_assert!(
+        expected.is_canonicalized_for_runtime_usage(),
+        "expected type should be canonicalized for runtime usage: {expected:?}"
+    );
+    debug_assert!(
+        actual.is_canonicalized_for_runtime_usage(),
+        "actual type should be canonicalized for runtime usage: {actual:?}"
+    );
 
     if expected == actual {
         return Ok(());

--- a/tests/all/wast.rs
+++ b/tests/all/wast.rs
@@ -23,7 +23,8 @@ fn run_wast(wast: &str, strategy: Strategy, pooling: bool) -> anyhow::Result<()>
     let wast = Path::new(wast);
 
     let memory64 = feature_found(wast, "memory64");
-    let multi_memory = feature_found(wast, "multi-memory");
+    let multi_memory =
+        feature_found(wast, "multi-memory") || feature_found(wast, "component-model");
     let threads = feature_found(wast, "threads");
     let gc = feature_found(wast, "gc");
     let function_references = gc || feature_found(wast, "function-references");

--- a/tests/misc_testsuite/gc/rec-group-funcs.wast
+++ b/tests/misc_testsuite/gc/rec-group-funcs.wast
@@ -1,0 +1,38 @@
+;; Test that we properly canonicalize function types across modules, at the
+;; engine level. We rely on this canonicalization to make cross-module imports
+;; work among other things.
+
+(module $m1
+  ;; A pair of recursive types.
+  (rec (type $type_a (sub final (func (result i32 (ref null $type_b)))))
+       (type $type_b (sub final (func (result i32 (ref null $type_a))))))
+
+  (func (export "func_a") (type $type_a)
+    i32.const 1234
+    ref.null $type_b
+  )
+
+  (func (export "func_b") (type $type_b)
+    i32.const 4321
+    ref.null $type_a
+  )
+)
+(register "m1")
+
+(module $m2
+  ;; The same pair of recursive types.
+  (rec (type $type_a (sub final (func (result i32 (ref null $type_b)))))
+       (type $type_b (sub final (func (result i32 (ref null $type_a))))))
+
+  (import "m1" "func_a" (func $func_a (type $type_a)))
+  (import "m1" "func_b" (func $func_b (type $type_b)))
+
+  (func (export "call") (result i32 i32)
+    call $func_a
+    drop
+    call $func_b
+    drop
+  )
+)
+
+(assert_return (invoke "call") (i32.const 1234) (i32.const 4321))

--- a/winch/codegen/src/codegen/env.rs
+++ b/winch/codegen/src/codegen/env.rs
@@ -197,8 +197,7 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
                 BlockSig::new(control::BlockType::single(ty))
             }
             FuncType(idx) => {
-                let sig_index =
-                    self.translation.module.types[TypeIndex::from_u32(idx)].unwrap_function();
+                let sig_index = self.translation.module.types[TypeIndex::from_u32(idx)];
                 let sig = &self.types[sig_index];
                 BlockSig::new(control::BlockType::func(sig.clone()))
             }
@@ -340,7 +339,7 @@ impl<'a, 'translation, 'data, P: PtrSize> FuncEnv<'a, 'translation, 'data, P> {
             }
             Callee::FuncRef(idx) => {
                 let val = || {
-                    let sig_index = self.translation.module.types[*idx].unwrap_function();
+                    let sig_index = self.translation.module.types[*idx];
                     let ty = &self.types[sig_index];
                     let sig = wasm_sig::<A>(ty);
                     sig
@@ -392,11 +391,8 @@ pub(crate) struct TypeConverter<'a, 'data: 'a> {
 
 impl TypeConvert for TypeConverter<'_, '_> {
     fn lookup_heap_type(&self, idx: wasmparser::UnpackedIndex) -> WasmHeapType {
-        wasmtime_environ::WasmparserTypeConverter {
-            module: &self.translation.module,
-            types: self.types,
-        }
-        .lookup_heap_type(idx)
+        wasmtime_environ::WasmparserTypeConverter::new(self.types, &self.translation.module)
+            .lookup_heap_type(idx)
     }
 }
 

--- a/winch/codegen/src/codegen/mod.rs
+++ b/winch/codegen/src/codegen/mod.rs
@@ -323,7 +323,7 @@ where
         let ptr_size: OperandSize = self.env.ptr_type().into();
         let sig_index_bytes = self.env.vmoffsets.size_of_vmshared_type_index();
         let sig_size = OperandSize::from_bytes(sig_index_bytes);
-        let sig_index = self.env.translation.module.types[type_index].unwrap_function();
+        let sig_index = self.env.translation.module.types[type_index];
         let sig_offset = sig_index
             .as_u32()
             .checked_mul(sig_index_bytes.into())


### PR DESCRIPTION
This adds support for recursion groups in Wasmtime's type registry, but still just for function types. Adding struct and array types should be relatively easy after this. At least, we won't have to be concerned with canonicalization, just updating heap type matching everywhere and all that.

Depends on https://github.com/bytecodealliance/wasm-tools/pull/1506 and updating the `wasm-tools` crates before this can land.