### PR TITLE
Use callee-save registers for the riscv64 tail calling convention

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -414,14 +414,7 @@ fn riscv64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             collector.reg_clobbers(info.clobbers);
         }
         &Inst::CallInd { ref info } => {
-            if info.callee_callconv == CallConv::Tail {
-                // TODO(https://github.com/bytecodealliance/regalloc2/issues/145):
-                // This shouldn't be a fixed register constraint.
-                collector.reg_fixed_use(info.rn, x_reg(5));
-            } else {
-                collector.reg_use(info.rn);
-            }
-
+            collector.reg_use(info.rn);
             for u in &info.uses {
                 collector.reg_fixed_use(u.vreg, u.preg);
             }

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -439,7 +439,10 @@ fn riscv64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut Operan
             }
         }
         &Inst::ReturnCallInd { ref info, callee } => {
-            collector.reg_use(callee);
+            // TODO(https://github.com/bytecodealliance/regalloc2/issues/145):
+            // This shouldn't be a fixed register constraint.
+            collector.reg_fixed_use(callee, x_reg(5));
+
             for u in &info.uses {
                 collector.reg_fixed_use(u.vreg, u.preg);
             }

--- a/cranelift/filetests/filetests/isa/riscv64/fuzzbug-60035.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fuzzbug-60035.clif
@@ -20,12 +20,9 @@ block0:
 ;   addi sp,sp,-16
 ;   sd s1,8(sp)
 ; block0:
-;   load_sym t0,userextname0+0
-;   mv s1,t0
-;   mv t0,s1
-;   callind t0
-;   mv t0,s1
-;   callind t0
+;   load_sym s1,userextname0+0
+;   callind s1
+;   callind s1
 ;   ld s1,8(sp)
 ;   addi sp,sp,16
 ;   ld ra,8(sp)
@@ -42,16 +39,13 @@ block0:
 ;   addi sp, sp, -0x10
 ;   sd s1, 8(sp)
 ; block1: ; offset 0x18
-;   auipc t0, 0
-;   ld t0, 0xc(t0)
+;   auipc s1, 0
+;   ld s1, 0xc(s1)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 u1:7 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   mv s1, t0
-;   mv t0, s1
-;   jalr t0
-;   mv t0, s1
-;   jalr t0
+;   jalr s1
+;   jalr s1
 ;   ld s1, 8(sp)
 ;   addi sp, sp, 0x10
 ;   ld ra, 8(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/fuzzbug-60035.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/fuzzbug-60035.clif
@@ -17,57 +17,17 @@ block0:
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-192
-;   sd s1,184(sp)
-;   sd s2,176(sp)
-;   sd s3,168(sp)
-;   sd s4,160(sp)
-;   sd s5,152(sp)
-;   sd s6,144(sp)
-;   sd s7,136(sp)
-;   sd s8,128(sp)
-;   sd s9,120(sp)
-;   sd s10,112(sp)
-;   sd s11,104(sp)
-;   fsd fs2,96(sp)
-;   fsd fs3,88(sp)
-;   fsd fs4,80(sp)
-;   fsd fs5,72(sp)
-;   fsd fs6,64(sp)
-;   fsd fs7,56(sp)
-;   fsd fs8,48(sp)
-;   fsd fs9,40(sp)
-;   fsd fs10,32(sp)
-;   fsd fs11,24(sp)
+;   addi sp,sp,-16
+;   sd s1,8(sp)
 ; block0:
 ;   load_sym t0,userextname0+0
-;   sd t0,0(nominal_sp)
-;   ld t0,0(nominal_sp)
+;   mv s1,t0
+;   mv t0,s1
 ;   callind t0
-;   ld t0,0(nominal_sp)
+;   mv t0,s1
 ;   callind t0
-;   ld s1,184(sp)
-;   ld s2,176(sp)
-;   ld s3,168(sp)
-;   ld s4,160(sp)
-;   ld s5,152(sp)
-;   ld s6,144(sp)
-;   ld s7,136(sp)
-;   ld s8,128(sp)
-;   ld s9,120(sp)
-;   ld s10,112(sp)
-;   ld s11,104(sp)
-;   fld fs2,96(sp)
-;   fld fs3,88(sp)
-;   fld fs4,80(sp)
-;   fld fs5,72(sp)
-;   fld fs6,64(sp)
-;   fld fs7,56(sp)
-;   fld fs8,48(sp)
-;   fld fs9,40(sp)
-;   fld fs10,32(sp)
-;   fld fs11,24(sp)
-;   addi sp,sp,192
+;   ld s1,8(sp)
+;   addi sp,sp,16
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -79,61 +39,21 @@ block0:
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0xc0
-;   sd s1, 0xb8(sp)
-;   sd s2, 0xb0(sp)
-;   sd s3, 0xa8(sp)
-;   sd s4, 0xa0(sp)
-;   sd s5, 0x98(sp)
-;   sd s6, 0x90(sp)
-;   sd s7, 0x88(sp)
-;   sd s8, 0x80(sp)
-;   sd s9, 0x78(sp)
-;   sd s10, 0x70(sp)
-;   sd s11, 0x68(sp)
-;   fsd fs2, 0x60(sp)
-;   fsd fs3, 0x58(sp)
-;   fsd fs4, 0x50(sp)
-;   fsd fs5, 0x48(sp)
-;   fsd fs6, 0x40(sp)
-;   fsd fs7, 0x38(sp)
-;   fsd fs8, 0x30(sp)
-;   fsd fs9, 0x28(sp)
-;   fsd fs10, 0x20(sp)
-;   fsd fs11, 0x18(sp)
-; block1: ; offset 0x68
+;   addi sp, sp, -0x10
+;   sd s1, 8(sp)
+; block1: ; offset 0x18
 ;   auipc t0, 0
 ;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 u1:7 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   sd t0, 0(sp)
-;   ld t0, 0(sp)
+;   mv s1, t0
+;   mv t0, s1
 ;   jalr t0
-;   ld t0, 0(sp)
+;   mv t0, s1
 ;   jalr t0
-;   ld s1, 0xb8(sp)
-;   ld s2, 0xb0(sp)
-;   ld s3, 0xa8(sp)
-;   ld s4, 0xa0(sp)
-;   ld s5, 0x98(sp)
-;   ld s6, 0x90(sp)
-;   ld s7, 0x88(sp)
-;   ld s8, 0x80(sp)
-;   ld s9, 0x78(sp)
-;   ld s10, 0x70(sp)
-;   ld s11, 0x68(sp)
-;   fld fs2, 0x60(sp)
-;   fld fs3, 0x58(sp)
-;   fld fs4, 0x50(sp)
-;   fld fs5, 0x48(sp)
-;   fld fs6, 0x40(sp)
-;   fld fs7, 0x38(sp)
-;   fld fs8, 0x30(sp)
-;   fld fs9, 0x28(sp)
-;   fld fs10, 0x20(sp)
-;   fld fs11, 0x18(sp)
-;   addi sp, sp, 0xc0
+;   ld s1, 8(sp)
+;   addi sp, sp, 0x10
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/return-call-indirect.clif
@@ -12,12 +12,12 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   addi s1,s1,10
+;   addi a0,a0,10
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi s1, s1, 0xa
+;   addi a0, a0, 0xa
 ;   ret
 
 function %call_i64(i64) -> i64 tail {
@@ -35,8 +35,8 @@ block0(v0: i64):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   load_sym a2,%callee_i64+0
-;   return_call_ind a2 new_stack_arg_size:0 s1=s1
+;   load_sym t0,%callee_i64+0
+;   return_call_ind t0 new_stack_arg_size:0 a0=a0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -45,15 +45,15 @@ block0(v0: i64):
 ;   sd s0, 0(sp)
 ;   mv s0, sp
 ; block1: ; offset 0x10
-;   auipc a2, 0
-;   ld a2, 0xc(a2)
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i64 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   jr a2
+;   jr t0
 
 ;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -72,8 +72,8 @@ block0(v0: i64):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   load_sym a2,%callee_i64+0
-;   return_call_ind a2 new_stack_arg_size:0 s1=s1
+;   load_sym t0,%callee_i64+0
+;   return_call_ind t0 new_stack_arg_size:0 a0=a0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -82,15 +82,15 @@ block0(v0: i64):
 ;   sd s0, 0(sp)
 ;   mv s0, sp
 ; block1: ; offset 0x10
-;   auipc a2, 0
-;   ld a2, 0xc(a2)
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i64 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   jr a2
+;   jr t0
 
 ;;;; Test passing `f64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -106,7 +106,7 @@ block0(v0: f64):
 ;   lui a3,1027
 ;   slli a5,a3,40
 ;   fmv.d.x fa1,a5
-;   fadd.d ft0,ft0,fa1,rne
+;   fadd.d fa0,fa0,fa1,rne
 ;   ret
 ;
 ; Disassembled:
@@ -114,7 +114,7 @@ block0(v0: f64):
 ;   lui a3, 0x403
 ;   slli a5, a3, 0x28
 ;   fmv.d.x fa1, a5
-;   fadd.d ft0, ft0, fa1, rne
+;   fadd.d fa0, fa0, fa1, rne
 ;   ret
 
 function %call_f64(f64) -> f64 tail {
@@ -132,8 +132,8 @@ block0(v0: f64):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   load_sym a2,%callee_f64+0
-;   return_call_ind a2 new_stack_arg_size:0 ft0=ft0
+;   load_sym t0,%callee_f64+0
+;   return_call_ind t0 new_stack_arg_size:0 fa0=fa0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -142,15 +142,15 @@ block0(v0: f64):
 ;   sd s0, 0(sp)
 ;   mv s0, sp
 ; block1: ; offset 0x10
-;   auipc a2, 0
-;   ld a2, 0xc(a2)
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_f64 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   jr a2
+;   jr t0
 
 ;;;; Test passing `i8`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -163,14 +163,14 @@ block0(v0: i8):
 
 ; VCode:
 ; block0:
-;   andi a2,s1,255
-;   seqz s1,a2
+;   andi a2,a0,255
+;   seqz a0,a2
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   andi a2, s1, 0xff
-;   seqz s1, a2
+;   andi a2, a0, 0xff
+;   seqz a0, a2
 ;   ret
 
 function %call_i8(i8) -> i8 tail {
@@ -188,8 +188,8 @@ block0(v0: i8):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   load_sym a2,%callee_i8+0
-;   return_call_ind a2 new_stack_arg_size:0 s1=s1
+;   load_sym t0,%callee_i8+0
+;   return_call_ind t0 new_stack_arg_size:0 a0=a0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -198,15 +198,15 @@ block0(v0: i8):
 ;   sd s0, 0(sp)
 ;   mv s0, sp
 ; block1: ; offset 0x10
-;   auipc a2, 0
-;   ld a2, 0xc(a2)
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i8 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   jr a2
+;   jr t0
 
 ;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -249,53 +249,77 @@ block0:
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-48
+;   addi sp,sp,-144
 ;   sd ra,8(sp)
-;   ld fp,48(sp)
+;   ld fp,144(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-32
+;   addi sp,sp,-128
+;   sd s1,120(sp)
+;   sd s2,112(sp)
+;   sd s3,104(sp)
+;   sd s4,96(sp)
+;   sd s5,88(sp)
+;   sd s6,80(sp)
+;   sd s7,72(sp)
+;   sd s8,64(sp)
+;   sd s9,56(sp)
+;   sd s10,48(sp)
+;   sd s11,40(sp)
 ; block0:
-;   li s1,10
-;   sd s1,16(nominal_sp)
-;   li a0,15
-;   sd a0,8(nominal_sp)
-;   li a1,20
-;   li a2,25
+;   li a0,10
+;   sd a0,16(nominal_sp)
+;   li a1,15
+;   sd a1,8(nominal_sp)
+;   li a2,20
 ;   sd a2,0(nominal_sp)
-;   li a3,30
-;   li a4,35
-;   li a5,40
-;   li a6,45
-;   li a7,50
-;   li s2,55
-;   li s3,60
-;   li s4,65
-;   li s5,70
-;   li s6,75
-;   li s7,80
-;   li s8,85
-;   li s9,90
-;   li s10,95
-;   li s11,100
-;   li t3,105
-;   li t4,110
-;   li t0,115
-;   li t1,120
-;   li t2,125
-;   li s1,130
-;   li a0,135
+;   li a3,25
+;   li a4,30
+;   li a5,35
+;   li a6,40
+;   li a7,45
+;   li s2,50
+;   li s3,55
+;   li s4,60
+;   li s5,65
+;   li s6,70
+;   li s7,75
+;   li s8,80
+;   li s9,85
+;   li s10,90
+;   li s11,95
+;   li t0,100
+;   li t1,105
+;   li t2,110
+;   li t3,115
+;   li t4,120
+;   li s1,125
+;   li a0,130
+;   li a1,135
 ;   load_sym a2,%tail_callee_stack_args+0
-;   sd t0,-48(incoming_arg)
-;   sd t1,-40(incoming_arg)
-;   sd t2,-32(incoming_arg)
+;   sd s2,-144(incoming_arg)
+;   sd s3,-136(incoming_arg)
+;   sd s4,-128(incoming_arg)
+;   sd s5,-120(incoming_arg)
+;   sd s6,-112(incoming_arg)
+;   sd s7,-104(incoming_arg)
+;   sd s8,-96(incoming_arg)
+;   sd s9,-88(incoming_arg)
+;   sd s10,-80(incoming_arg)
+;   sd s11,-72(incoming_arg)
+;   sd t0,-64(incoming_arg)
+;   sd t1,-56(incoming_arg)
+;   sd t2,-48(incoming_arg)
+;   sd t3,-40(incoming_arg)
+;   sd t4,-32(incoming_arg)
 ;   sd s1,-24(incoming_arg)
 ;   sd a0,-16(incoming_arg)
-;   ld a0,8(nominal_sp)
-;   ld s1,16(nominal_sp)
+;   sd a1,-8(incoming_arg)
+;   ld a1,8(nominal_sp)
+;   ld a0,16(nominal_sp)
 ;   mv t0,a2
 ;   ld a2,0(nominal_sp)
-;   return_call_ind t0 new_stack_arg_size:48 s1=s1 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7 s2=s2 s3=s3 s4=s4 s5=s5 s6=s6 s7=s7 s8=s8 s9=s9 s10=s10 s11=s11 t3=t3 t4=t4
+;   return_call_ind t0 new_stack_arg_size:144 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -303,58 +327,93 @@ block0:
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0x30
+;   addi sp, sp, -0x90
 ;   sd ra, 8(sp)
-;   ld s0, 0x30(sp)
+;   ld s0, 0x90(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0x20
-; block1: ; offset 0x28
-;   addi s1, zero, 0xa
-;   sd s1, 0x10(sp)
-;   addi a0, zero, 0xf
-;   sd a0, 8(sp)
-;   addi a1, zero, 0x14
-;   addi a2, zero, 0x19
+;   addi sp, sp, -0x80
+;   sd s1, 0x78(sp)
+;   sd s2, 0x70(sp)
+;   sd s3, 0x68(sp)
+;   sd s4, 0x60(sp)
+;   sd s5, 0x58(sp)
+;   sd s6, 0x50(sp)
+;   sd s7, 0x48(sp)
+;   sd s8, 0x40(sp)
+;   sd s9, 0x38(sp)
+;   sd s10, 0x30(sp)
+;   sd s11, 0x28(sp)
+; block1: ; offset 0x54
+;   addi a0, zero, 0xa
+;   sd a0, 0x10(sp)
+;   addi a1, zero, 0xf
+;   sd a1, 8(sp)
+;   addi a2, zero, 0x14
 ;   sd a2, 0(sp)
-;   addi a3, zero, 0x1e
-;   addi a4, zero, 0x23
-;   addi a5, zero, 0x28
-;   addi a6, zero, 0x2d
-;   addi a7, zero, 0x32
-;   addi s2, zero, 0x37
-;   addi s3, zero, 0x3c
-;   addi s4, zero, 0x41
-;   addi s5, zero, 0x46
-;   addi s6, zero, 0x4b
-;   addi s7, zero, 0x50
-;   addi s8, zero, 0x55
-;   addi s9, zero, 0x5a
-;   addi s10, zero, 0x5f
-;   addi s11, zero, 0x64
-;   addi t3, zero, 0x69
-;   addi t4, zero, 0x6e
-;   addi t0, zero, 0x73
-;   addi t1, zero, 0x78
-;   addi t2, zero, 0x7d
-;   addi s1, zero, 0x82
-;   addi a0, zero, 0x87
+;   addi a3, zero, 0x19
+;   addi a4, zero, 0x1e
+;   addi a5, zero, 0x23
+;   addi a6, zero, 0x28
+;   addi a7, zero, 0x2d
+;   addi s2, zero, 0x32
+;   addi s3, zero, 0x37
+;   addi s4, zero, 0x3c
+;   addi s5, zero, 0x41
+;   addi s6, zero, 0x46
+;   addi s7, zero, 0x4b
+;   addi s8, zero, 0x50
+;   addi s9, zero, 0x55
+;   addi s10, zero, 0x5a
+;   addi s11, zero, 0x5f
+;   addi t0, zero, 0x64
+;   addi t1, zero, 0x69
+;   addi t2, zero, 0x6e
+;   addi t3, zero, 0x73
+;   addi t4, zero, 0x78
+;   addi s1, zero, 0x7d
+;   addi a0, zero, 0x82
+;   addi a1, zero, 0x87
 ;   auipc a2, 0
 ;   ld a2, 0xc(a2)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   sd t0, 0x30(sp)
-;   sd t1, 0x38(sp)
-;   sd t2, 0x40(sp)
-;   sd s1, 0x48(sp)
-;   sd a0, 0x50(sp)
-;   ld a0, 8(sp)
-;   ld s1, 0x10(sp)
+;   sd s2, 0x90(sp)
+;   sd s3, 0x98(sp)
+;   sd s4, 0xa0(sp)
+;   sd s5, 0xa8(sp)
+;   sd s6, 0xb0(sp)
+;   sd s7, 0xb8(sp)
+;   sd s8, 0xc0(sp)
+;   sd s9, 0xc8(sp)
+;   sd s10, 0xd0(sp)
+;   sd s11, 0xd8(sp)
+;   sd t0, 0xe0(sp)
+;   sd t1, 0xe8(sp)
+;   sd t2, 0xf0(sp)
+;   sd t3, 0xf8(sp)
+;   sd t4, 0x100(sp)
+;   sd s1, 0x108(sp)
+;   sd a0, 0x110(sp)
+;   sd a1, 0x118(sp)
+;   ld a1, 8(sp)
+;   ld a0, 0x10(sp)
 ;   mv t0, a2
 ;   ld a2, 0(sp)
-;   ld ra, 0x28(sp)
-;   ld s0, 0x20(sp)
-;   addi sp, sp, 0x30
+;   ld s1, 0x78(sp)
+;   ld s2, 0x70(sp)
+;   ld s3, 0x68(sp)
+;   ld s4, 0x60(sp)
+;   ld s5, 0x58(sp)
+;   ld s6, 0x50(sp)
+;   ld s7, 0x48(sp)
+;   ld s8, 0x40(sp)
+;   ld s9, 0x38(sp)
+;   ld s10, 0x30(sp)
+;   ld s11, 0x28(sp)
+;   ld ra, 0x88(sp)
+;   ld s0, 0x80(sp)
+;   addi sp, sp, 0x90
 ;   jr t0
 

--- a/cranelift/filetests/filetests/isa/riscv64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/return-call.clif
@@ -12,12 +12,12 @@ block0(v0: i64):
 
 ; VCode:
 ; block0:
-;   addi s1,s1,10
+;   addi a0,a0,10
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   addi s1, s1, 0xa
+;   addi a0, a0, 0xa
 ;   ret
 
 function %call_i64(i64) -> i64 tail {
@@ -33,8 +33,8 @@ block0(v0: i64):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   load_sym a2,%callee_i64+0
-;   return_call_ind a2 new_stack_arg_size:0 s1=s1
+;   load_sym t0,%callee_i64+0
+;   return_call_ind t0 new_stack_arg_size:0 a0=a0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -43,15 +43,15 @@ block0(v0: i64):
 ;   sd s0, 0(sp)
 ;   mv s0, sp
 ; block1: ; offset 0x10
-;   auipc a2, 0
-;   ld a2, 0xc(a2)
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i64 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   jr a2
+;   jr t0
 
 ;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -68,7 +68,7 @@ block0(v0: i64):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   return_call TestCase(%callee_i64) new_stack_arg_size:0 s1=s1
+;   return_call TestCase(%callee_i64) new_stack_arg_size:0 a0=a0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -97,7 +97,7 @@ block0(v0: f64):
 ;   lui a3,1027
 ;   slli a5,a3,40
 ;   fmv.d.x fa1,a5
-;   fadd.d ft0,ft0,fa1,rne
+;   fadd.d fa0,fa0,fa1,rne
 ;   ret
 ;
 ; Disassembled:
@@ -105,7 +105,7 @@ block0(v0: f64):
 ;   lui a3, 0x403
 ;   slli a5, a3, 0x28
 ;   fmv.d.x fa1, a5
-;   fadd.d ft0, ft0, fa1, rne
+;   fadd.d fa0, fa0, fa1, rne
 ;   ret
 
 function %call_f64(f64) -> f64 tail {
@@ -121,8 +121,8 @@ block0(v0: f64):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   load_sym a2,%callee_f64+0
-;   return_call_ind a2 new_stack_arg_size:0 ft0=ft0
+;   load_sym t0,%callee_f64+0
+;   return_call_ind t0 new_stack_arg_size:0 fa0=fa0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -131,15 +131,15 @@ block0(v0: f64):
 ;   sd s0, 0(sp)
 ;   mv s0, sp
 ; block1: ; offset 0x10
-;   auipc a2, 0
-;   ld a2, 0xc(a2)
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_f64 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   jr a2
+;   jr t0
 
 ;;;; Test passing `i8`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -152,14 +152,14 @@ block0(v0: i8):
 
 ; VCode:
 ; block0:
-;   andi a2,s1,255
-;   seqz s1,a2
+;   andi a2,a0,255
+;   seqz a0,a2
 ;   ret
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
-;   andi a2, s1, 0xff
-;   seqz s1, a2
+;   andi a2, a0, 0xff
+;   seqz a0, a2
 ;   ret
 
 function %call_i8(i8) -> i8 tail {
@@ -175,8 +175,8 @@ block0(v0: i8):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   load_sym a2,%callee_i8+0
-;   return_call_ind a2 new_stack_arg_size:0 s1=s1
+;   load_sym t0,%callee_i8+0
+;   return_call_ind t0 new_stack_arg_size:0 a0=a0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -185,15 +185,15 @@ block0(v0: i8):
 ;   sd s0, 0(sp)
 ;   mv s0, sp
 ; block1: ; offset 0x10
-;   auipc a2, 0
-;   ld a2, 0xc(a2)
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i8 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   jr a2
+;   jr t0
 
 ;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -208,15 +208,28 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   ld a4,-48(incoming_arg)
-;   ld a0,-40(incoming_arg)
-;   ld a2,-32(incoming_arg)
-;   ld a4,-24(incoming_arg)
-;   ld s1,-16(incoming_arg)
+;   ld a3,-144(incoming_arg)
+;   ld a5,-136(incoming_arg)
+;   ld a1,-128(incoming_arg)
+;   ld a3,-120(incoming_arg)
+;   ld a5,-112(incoming_arg)
+;   ld a1,-104(incoming_arg)
+;   ld a3,-96(incoming_arg)
+;   ld a5,-88(incoming_arg)
+;   ld a1,-80(incoming_arg)
+;   ld a3,-72(incoming_arg)
+;   ld a5,-64(incoming_arg)
+;   ld a1,-56(incoming_arg)
+;   ld a3,-48(incoming_arg)
+;   ld a5,-40(incoming_arg)
+;   ld a1,-32(incoming_arg)
+;   ld a3,-24(incoming_arg)
+;   ld a5,-16(incoming_arg)
+;   ld a0,-8(incoming_arg)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
-;   addi sp,sp,48
+;   addi sp,sp,144
 ;   ret
 ;
 ; Disassembled:
@@ -226,15 +239,28 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   sd s0, 0(sp)
 ;   mv s0, sp
 ; block1: ; offset 0x10
-;   ld a4, 0x10(sp)
-;   ld a0, 0x18(sp)
-;   ld a2, 0x20(sp)
-;   ld a4, 0x28(sp)
-;   ld s1, 0x30(sp)
+;   ld a3, 0x10(sp)
+;   ld a5, 0x18(sp)
+;   ld a1, 0x20(sp)
+;   ld a3, 0x28(sp)
+;   ld a5, 0x30(sp)
+;   ld a1, 0x38(sp)
+;   ld a3, 0x40(sp)
+;   ld a5, 0x48(sp)
+;   ld a1, 0x50(sp)
+;   ld a3, 0x58(sp)
+;   ld a5, 0x60(sp)
+;   ld a1, 0x68(sp)
+;   ld a3, 0x70(sp)
+;   ld a5, 0x78(sp)
+;   ld a1, 0x80(sp)
+;   ld a3, 0x88(sp)
+;   ld a5, 0x90(sp)
+;   ld a0, 0x98(sp)
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   addi sp, sp, 0x30
+;   addi sp, sp, 0x90
 ;   ret
 
 function %tail_caller_stack_args() -> i64 tail {
@@ -275,50 +301,74 @@ block0:
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-48
+;   addi sp,sp,-144
 ;   sd ra,8(sp)
-;   ld fp,48(sp)
+;   ld fp,144(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-16
+;   addi sp,sp,-112
+;   sd s1,104(sp)
+;   sd s2,96(sp)
+;   sd s3,88(sp)
+;   sd s4,80(sp)
+;   sd s5,72(sp)
+;   sd s6,64(sp)
+;   sd s7,56(sp)
+;   sd s8,48(sp)
+;   sd s9,40(sp)
+;   sd s10,32(sp)
+;   sd s11,24(sp)
 ; block0:
-;   li s1,10
-;   sd s1,8(nominal_sp)
-;   li a0,15
-;   sd a0,0(nominal_sp)
-;   li a1,20
-;   li a2,25
-;   li a3,30
-;   li a4,35
-;   li a5,40
-;   li a6,45
-;   li a7,50
-;   li s2,55
-;   li s3,60
-;   li s4,65
-;   li s5,70
-;   li s6,75
-;   li s7,80
-;   li s8,85
-;   li s9,90
-;   li s10,95
-;   li s11,100
-;   li t3,105
-;   li t4,110
-;   li t0,115
-;   li t1,120
-;   li t2,125
-;   li s1,130
-;   li a0,135
-;   sd t0,-48(incoming_arg)
-;   sd t1,-40(incoming_arg)
-;   sd t2,-32(incoming_arg)
+;   li a0,10
+;   sd a0,8(nominal_sp)
+;   li a1,15
+;   sd a1,0(nominal_sp)
+;   li a2,20
+;   li a3,25
+;   li a4,30
+;   li a5,35
+;   li a6,40
+;   li a7,45
+;   li s2,50
+;   li s3,55
+;   li s4,60
+;   li s5,65
+;   li s6,70
+;   li s7,75
+;   li s8,80
+;   li s9,85
+;   li s10,90
+;   li s11,95
+;   li t0,100
+;   li t1,105
+;   li t2,110
+;   li t3,115
+;   li t4,120
+;   li s1,125
+;   li a0,130
+;   li a1,135
+;   sd s2,-144(incoming_arg)
+;   sd s3,-136(incoming_arg)
+;   sd s4,-128(incoming_arg)
+;   sd s5,-120(incoming_arg)
+;   sd s6,-112(incoming_arg)
+;   sd s7,-104(incoming_arg)
+;   sd s8,-96(incoming_arg)
+;   sd s9,-88(incoming_arg)
+;   sd s10,-80(incoming_arg)
+;   sd s11,-72(incoming_arg)
+;   sd t0,-64(incoming_arg)
+;   sd t1,-56(incoming_arg)
+;   sd t2,-48(incoming_arg)
+;   sd t3,-40(incoming_arg)
+;   sd t4,-32(incoming_arg)
 ;   sd s1,-24(incoming_arg)
 ;   sd a0,-16(incoming_arg)
+;   sd a1,-8(incoming_arg)
 ;   load_sym t0,%tail_callee_stack_args+0
-;   ld s1,8(nominal_sp)
-;   ld a0,0(nominal_sp)
-;   return_call_ind t0 new_stack_arg_size:48 s1=s1 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7 s2=s2 s3=s3 s4=s4 s5=s5 s6=s6 s7=s7 s8=s8 s9=s9 s10=s10 s11=s11 t3=t3 t4=t4
+;   ld a0,8(nominal_sp)
+;   ld a1,0(nominal_sp)
+;   return_call_ind t0 new_stack_arg_size:144 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -326,56 +376,91 @@ block0:
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0x30
+;   addi sp, sp, -0x90
 ;   sd ra, 8(sp)
-;   ld s0, 0x30(sp)
+;   ld s0, 0x90(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0x10
-; block1: ; offset 0x28
-;   addi s1, zero, 0xa
-;   sd s1, 8(sp)
-;   addi a0, zero, 0xf
-;   sd a0, 0(sp)
-;   addi a1, zero, 0x14
-;   addi a2, zero, 0x19
-;   addi a3, zero, 0x1e
-;   addi a4, zero, 0x23
-;   addi a5, zero, 0x28
-;   addi a6, zero, 0x2d
-;   addi a7, zero, 0x32
-;   addi s2, zero, 0x37
-;   addi s3, zero, 0x3c
-;   addi s4, zero, 0x41
-;   addi s5, zero, 0x46
-;   addi s6, zero, 0x4b
-;   addi s7, zero, 0x50
-;   addi s8, zero, 0x55
-;   addi s9, zero, 0x5a
-;   addi s10, zero, 0x5f
-;   addi s11, zero, 0x64
-;   addi t3, zero, 0x69
-;   addi t4, zero, 0x6e
-;   addi t0, zero, 0x73
-;   addi t1, zero, 0x78
-;   addi t2, zero, 0x7d
-;   addi s1, zero, 0x82
-;   addi a0, zero, 0x87
-;   sd t0, 0x20(sp)
-;   sd t1, 0x28(sp)
-;   sd t2, 0x30(sp)
-;   sd s1, 0x38(sp)
-;   sd a0, 0x40(sp)
+;   addi sp, sp, -0x70
+;   sd s1, 0x68(sp)
+;   sd s2, 0x60(sp)
+;   sd s3, 0x58(sp)
+;   sd s4, 0x50(sp)
+;   sd s5, 0x48(sp)
+;   sd s6, 0x40(sp)
+;   sd s7, 0x38(sp)
+;   sd s8, 0x30(sp)
+;   sd s9, 0x28(sp)
+;   sd s10, 0x20(sp)
+;   sd s11, 0x18(sp)
+; block1: ; offset 0x54
+;   addi a0, zero, 0xa
+;   sd a0, 8(sp)
+;   addi a1, zero, 0xf
+;   sd a1, 0(sp)
+;   addi a2, zero, 0x14
+;   addi a3, zero, 0x19
+;   addi a4, zero, 0x1e
+;   addi a5, zero, 0x23
+;   addi a6, zero, 0x28
+;   addi a7, zero, 0x2d
+;   addi s2, zero, 0x32
+;   addi s3, zero, 0x37
+;   addi s4, zero, 0x3c
+;   addi s5, zero, 0x41
+;   addi s6, zero, 0x46
+;   addi s7, zero, 0x4b
+;   addi s8, zero, 0x50
+;   addi s9, zero, 0x55
+;   addi s10, zero, 0x5a
+;   addi s11, zero, 0x5f
+;   addi t0, zero, 0x64
+;   addi t1, zero, 0x69
+;   addi t2, zero, 0x6e
+;   addi t3, zero, 0x73
+;   addi t4, zero, 0x78
+;   addi s1, zero, 0x7d
+;   addi a0, zero, 0x82
+;   addi a1, zero, 0x87
+;   sd s2, 0x80(sp)
+;   sd s3, 0x88(sp)
+;   sd s4, 0x90(sp)
+;   sd s5, 0x98(sp)
+;   sd s6, 0xa0(sp)
+;   sd s7, 0xa8(sp)
+;   sd s8, 0xb0(sp)
+;   sd s9, 0xb8(sp)
+;   sd s10, 0xc0(sp)
+;   sd s11, 0xc8(sp)
+;   sd t0, 0xd0(sp)
+;   sd t1, 0xd8(sp)
+;   sd t2, 0xe0(sp)
+;   sd t3, 0xe8(sp)
+;   sd t4, 0xf0(sp)
+;   sd s1, 0xf8(sp)
+;   sd a0, 0x100(sp)
+;   sd a1, 0x108(sp)
 ;   auipc t0, 0
 ;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ld s1, 8(sp)
-;   ld a0, 0(sp)
-;   ld ra, 0x18(sp)
-;   ld s0, 0x10(sp)
-;   addi sp, sp, 0x20
+;   ld a0, 8(sp)
+;   ld a1, 0(sp)
+;   ld s1, 0x68(sp)
+;   ld s2, 0x60(sp)
+;   ld s3, 0x58(sp)
+;   ld s4, 0x50(sp)
+;   ld s5, 0x48(sp)
+;   ld s6, 0x40(sp)
+;   ld s7, 0x38(sp)
+;   ld s8, 0x30(sp)
+;   ld s9, 0x28(sp)
+;   ld s10, 0x20(sp)
+;   ld s11, 0x18(sp)
+;   ld ra, 0x78(sp)
+;   ld s0, 0x70(sp)
+;   addi sp, sp, 0x80
 ;   jr t0
 
 ;;;; Test diff blocks with diff return calls with diff # of stack args ;;;;;;;;;
@@ -391,15 +476,28 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   ld a4,-48(incoming_arg)
-;   ld a0,-40(incoming_arg)
-;   ld a2,-32(incoming_arg)
-;   ld a4,-24(incoming_arg)
-;   ld s1,-16(incoming_arg)
+;   ld a3,-144(incoming_arg)
+;   ld a5,-136(incoming_arg)
+;   ld a1,-128(incoming_arg)
+;   ld a3,-120(incoming_arg)
+;   ld a5,-112(incoming_arg)
+;   ld a1,-104(incoming_arg)
+;   ld a3,-96(incoming_arg)
+;   ld a5,-88(incoming_arg)
+;   ld a1,-80(incoming_arg)
+;   ld a3,-72(incoming_arg)
+;   ld a5,-64(incoming_arg)
+;   ld a1,-56(incoming_arg)
+;   ld a3,-48(incoming_arg)
+;   ld a5,-40(incoming_arg)
+;   ld a1,-32(incoming_arg)
+;   ld a3,-24(incoming_arg)
+;   ld a5,-16(incoming_arg)
+;   ld a0,-8(incoming_arg)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
-;   addi sp,sp,48
+;   addi sp,sp,144
 ;   ret
 ;
 ; Disassembled:
@@ -409,15 +507,28 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   sd s0, 0(sp)
 ;   mv s0, sp
 ; block1: ; offset 0x10
-;   ld a4, 0x10(sp)
-;   ld a0, 0x18(sp)
-;   ld a2, 0x20(sp)
-;   ld a4, 0x28(sp)
-;   ld s1, 0x30(sp)
+;   ld a3, 0x10(sp)
+;   ld a5, 0x18(sp)
+;   ld a1, 0x20(sp)
+;   ld a3, 0x28(sp)
+;   ld a5, 0x30(sp)
+;   ld a1, 0x38(sp)
+;   ld a3, 0x40(sp)
+;   ld a5, 0x48(sp)
+;   ld a1, 0x50(sp)
+;   ld a3, 0x58(sp)
+;   ld a5, 0x60(sp)
+;   ld a1, 0x68(sp)
+;   ld a3, 0x70(sp)
+;   ld a5, 0x78(sp)
+;   ld a1, 0x80(sp)
+;   ld a3, 0x88(sp)
+;   ld a5, 0x90(sp)
+;   ld a0, 0x98(sp)
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   addi sp, sp, 0x30
+;   addi sp, sp, 0x90
 ;   ret
 
 function %different_callee2(i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64, i64) -> i64 tail {
@@ -431,16 +542,29 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   ld a4,-48(incoming_arg)
-;   ld a0,-40(incoming_arg)
-;   ld a2,-32(incoming_arg)
-;   ld a4,-24(incoming_arg)
+;   ld a3,-160(incoming_arg)
+;   ld a5,-152(incoming_arg)
+;   ld a1,-144(incoming_arg)
+;   ld a3,-136(incoming_arg)
+;   ld a5,-128(incoming_arg)
+;   ld a1,-120(incoming_arg)
+;   ld a3,-112(incoming_arg)
+;   ld a5,-104(incoming_arg)
+;   ld a1,-96(incoming_arg)
+;   ld a3,-88(incoming_arg)
+;   ld a5,-80(incoming_arg)
+;   ld a1,-72(incoming_arg)
+;   ld a3,-64(incoming_arg)
+;   ld a5,-56(incoming_arg)
+;   ld a1,-48(incoming_arg)
+;   ld a3,-40(incoming_arg)
+;   ld a5,-32(incoming_arg)
+;   ld a1,-24(incoming_arg)
 ;   ld a0,-16(incoming_arg)
-;   ld s1,-8(incoming_arg)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
-;   addi sp,sp,48
+;   addi sp,sp,160
 ;   ret
 ;
 ; Disassembled:
@@ -450,16 +574,29 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   sd s0, 0(sp)
 ;   mv s0, sp
 ; block1: ; offset 0x10
-;   ld a4, 0x10(sp)
-;   ld a0, 0x18(sp)
-;   ld a2, 0x20(sp)
-;   ld a4, 0x28(sp)
-;   ld a0, 0x30(sp)
-;   ld s1, 0x38(sp)
+;   ld a3, 0x10(sp)
+;   ld a5, 0x18(sp)
+;   ld a1, 0x20(sp)
+;   ld a3, 0x28(sp)
+;   ld a5, 0x30(sp)
+;   ld a1, 0x38(sp)
+;   ld a3, 0x40(sp)
+;   ld a5, 0x48(sp)
+;   ld a1, 0x50(sp)
+;   ld a3, 0x58(sp)
+;   ld a5, 0x60(sp)
+;   ld a1, 0x68(sp)
+;   ld a3, 0x70(sp)
+;   ld a5, 0x78(sp)
+;   ld a1, 0x80(sp)
+;   ld a3, 0x88(sp)
+;   ld a5, 0x90(sp)
+;   ld a1, 0x98(sp)
+;   ld a0, 0xa0(sp)
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   addi sp, sp, 0x30
+;   addi sp, sp, 0xa0
 ;   ret
 
 function %caller_of_different_callees(i64) -> i64 tail {
@@ -508,67 +645,104 @@ block2:
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-48
+;   addi sp,sp,-160
 ;   sd ra,8(sp)
-;   ld fp,48(sp)
+;   ld fp,160(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-32
+;   addi sp,sp,-128
+;   sd s1,120(sp)
+;   sd s2,112(sp)
+;   sd s3,104(sp)
+;   sd s4,96(sp)
+;   sd s5,88(sp)
+;   sd s6,80(sp)
+;   sd s7,72(sp)
+;   sd s8,64(sp)
+;   sd s9,56(sp)
+;   sd s10,48(sp)
+;   sd s11,40(sp)
 ; block0:
-;   li a0,10
-;   sd a0,16(nominal_sp)
-;   li a0,15
-;   sd a0,8(nominal_sp)
-;   li a1,20
-;   sd a1,0(nominal_sp)
-;   li a2,25
-;   li a3,30
-;   li a4,35
-;   li a5,40
-;   li a6,45
-;   li a7,50
-;   li s2,55
-;   li s3,60
+;   li a1,10
+;   sd a1,16(nominal_sp)
+;   li a1,15
+;   sd a1,8(nominal_sp)
+;   li a2,20
+;   sd a2,0(nominal_sp)
+;   li a3,25
+;   li a4,30
+;   li a5,35
+;   li a6,40
+;   li a7,45
+;   li a2,50
+;   li a1,55
+;   li s5,60
 ;   li s4,65
-;   li s5,70
-;   li s6,75
-;   li s7,80
-;   li s8,85
-;   li s9,90
-;   li s10,95
-;   li s11,100
-;   li t3,105
-;   li t4,110
-;   li a1,115
-;   li a0,120
-;   li t2,125
-;   li t1,130
-;   li t0,135
-;   bne s1,zero,taken(label2),not_taken(label1)
+;   li s3,70
+;   li s2,75
+;   li s1,80
+;   li t4,85
+;   li t3,90
+;   li t2,95
+;   li t1,100
+;   li t0,105
+;   li s11,110
+;   li s10,115
+;   li s9,120
+;   li s8,125
+;   li s7,130
+;   li s6,135
+;   bne a0,zero,taken(label2),not_taken(label1)
 ; block1:
-;   li s1,140
-;   sd a1,-48(incoming_arg)
-;   sd a0,-40(incoming_arg)
-;   sd t2,-32(incoming_arg)
-;   sd t1,-24(incoming_arg)
-;   sd t0,-16(incoming_arg)
-;   sd s1,-8(incoming_arg)
-;   load_sym t1,%different_callee2+0
-;   ld s1,16(nominal_sp)
-;   ld a0,8(nominal_sp)
-;   ld a1,0(nominal_sp)
-;   return_call_ind t1 new_stack_arg_size:48 s1=s1 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7 s2=s2 s3=s3 s4=s4 s5=s5 s6=s6 s7=s7 s8=s8 s9=s9 s10=s10 s11=s11 t3=t3 t4=t4
+;   li a0,140
+;   sd a2,-160(incoming_arg)
+;   sd a1,-152(incoming_arg)
+;   sd s5,-144(incoming_arg)
+;   sd s4,-136(incoming_arg)
+;   sd s3,-128(incoming_arg)
+;   sd s2,-120(incoming_arg)
+;   sd s1,-112(incoming_arg)
+;   sd t4,-104(incoming_arg)
+;   sd t3,-96(incoming_arg)
+;   sd t2,-88(incoming_arg)
+;   sd t1,-80(incoming_arg)
+;   sd t0,-72(incoming_arg)
+;   sd s11,-64(incoming_arg)
+;   sd s10,-56(incoming_arg)
+;   sd s9,-48(incoming_arg)
+;   sd s8,-40(incoming_arg)
+;   sd s7,-32(incoming_arg)
+;   sd s6,-24(incoming_arg)
+;   sd a0,-16(incoming_arg)
+;   load_sym t0,%different_callee2+0
+;   ld a0,16(nominal_sp)
+;   ld a1,8(nominal_sp)
+;   ld a2,0(nominal_sp)
+;   return_call_ind t0 new_stack_arg_size:160 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7
 ; block2:
-;   ld s1,16(nominal_sp)
-;   sd a1,-48(incoming_arg)
-;   sd a0,-40(incoming_arg)
-;   sd t2,-32(incoming_arg)
-;   sd t1,-24(incoming_arg)
-;   sd t0,-16(incoming_arg)
+;   ld a0,16(nominal_sp)
+;   sd a2,-144(incoming_arg)
+;   sd a1,-136(incoming_arg)
+;   sd s5,-128(incoming_arg)
+;   sd s4,-120(incoming_arg)
+;   sd s3,-112(incoming_arg)
+;   sd s2,-104(incoming_arg)
+;   sd s1,-96(incoming_arg)
+;   sd t4,-88(incoming_arg)
+;   sd t3,-80(incoming_arg)
+;   sd t2,-72(incoming_arg)
+;   sd t1,-64(incoming_arg)
+;   sd t0,-56(incoming_arg)
+;   sd s11,-48(incoming_arg)
+;   sd s10,-40(incoming_arg)
+;   sd s9,-32(incoming_arg)
+;   sd s8,-24(incoming_arg)
+;   sd s7,-16(incoming_arg)
+;   sd s6,-8(incoming_arg)
 ;   load_sym t0,%different_callee1+0
-;   ld a0,8(nominal_sp)
-;   ld a1,0(nominal_sp)
-;   return_call_ind t0 new_stack_arg_size:48 s1=s1 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7 s2=s2 s3=s3 s4=s4 s5=s5 s6=s6 s7=s7 s8=s8 s9=s9 s10=s10 s11=s11 t3=t3 t4=t4
+;   ld a1,8(nominal_sp)
+;   ld a2,0(nominal_sp)
+;   return_call_ind t0 new_stack_arg_size:144 a0=a0 a1=a1 a2=a2 a3=a3 a4=a4 a5=a5 a6=a6 a7=a7
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -576,79 +750,138 @@ block2:
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0x30
+;   addi sp, sp, -0xa0
 ;   sd ra, 8(sp)
-;   ld s0, 0x30(sp)
+;   ld s0, 0xa0(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0x20
-; block1: ; offset 0x28
-;   addi a0, zero, 0xa
-;   sd a0, 0x10(sp)
-;   addi a0, zero, 0xf
-;   sd a0, 8(sp)
-;   addi a1, zero, 0x14
-;   sd a1, 0(sp)
-;   addi a2, zero, 0x19
-;   addi a3, zero, 0x1e
-;   addi a4, zero, 0x23
-;   addi a5, zero, 0x28
-;   addi a6, zero, 0x2d
-;   addi a7, zero, 0x32
-;   addi s2, zero, 0x37
-;   addi s3, zero, 0x3c
+;   addi sp, sp, -0x80
+;   sd s1, 0x78(sp)
+;   sd s2, 0x70(sp)
+;   sd s3, 0x68(sp)
+;   sd s4, 0x60(sp)
+;   sd s5, 0x58(sp)
+;   sd s6, 0x50(sp)
+;   sd s7, 0x48(sp)
+;   sd s8, 0x40(sp)
+;   sd s9, 0x38(sp)
+;   sd s10, 0x30(sp)
+;   sd s11, 0x28(sp)
+; block1: ; offset 0x54
+;   addi a1, zero, 0xa
+;   sd a1, 0x10(sp)
+;   addi a1, zero, 0xf
+;   sd a1, 8(sp)
+;   addi a2, zero, 0x14
+;   sd a2, 0(sp)
+;   addi a3, zero, 0x19
+;   addi a4, zero, 0x1e
+;   addi a5, zero, 0x23
+;   addi a6, zero, 0x28
+;   addi a7, zero, 0x2d
+;   addi a2, zero, 0x32
+;   addi a1, zero, 0x37
+;   addi s5, zero, 0x3c
 ;   addi s4, zero, 0x41
-;   addi s5, zero, 0x46
-;   addi s6, zero, 0x4b
-;   addi s7, zero, 0x50
-;   addi s8, zero, 0x55
-;   addi s9, zero, 0x5a
-;   addi s10, zero, 0x5f
-;   addi s11, zero, 0x64
-;   addi t3, zero, 0x69
-;   addi t4, zero, 0x6e
-;   addi a1, zero, 0x73
-;   addi a0, zero, 0x78
-;   addi t2, zero, 0x7d
-;   addi t1, zero, 0x82
-;   addi t0, zero, 0x87
-;   bnez s1, 0x50
-; block2: ; offset 0xa0
-;   addi s1, zero, 0x8c
-;   sd a1, 0x30(sp)
-;   sd a0, 0x38(sp)
-;   sd t2, 0x40(sp)
-;   sd t1, 0x48(sp)
-;   sd t0, 0x50(sp)
-;   sd s1, 0x58(sp)
-;   auipc t1, 0
-;   ld t1, 0xc(t1)
+;   addi s3, zero, 0x46
+;   addi s2, zero, 0x4b
+;   addi s1, zero, 0x50
+;   addi t4, zero, 0x55
+;   addi t3, zero, 0x5a
+;   addi t2, zero, 0x5f
+;   addi t1, zero, 0x64
+;   addi t0, zero, 0x69
+;   addi s11, zero, 0x6e
+;   addi s10, zero, 0x73
+;   addi s9, zero, 0x78
+;   addi s8, zero, 0x7d
+;   addi s7, zero, 0x82
+;   addi s6, zero, 0x87
+;   bnez a0, 0xb0
+; block2: ; offset 0xcc
+;   addi a0, zero, 0x8c
+;   sd a2, 0x90(sp)
+;   sd a1, 0x98(sp)
+;   sd s5, 0xa0(sp)
+;   sd s4, 0xa8(sp)
+;   sd s3, 0xb0(sp)
+;   sd s2, 0xb8(sp)
+;   sd s1, 0xc0(sp)
+;   sd t4, 0xc8(sp)
+;   sd t3, 0xd0(sp)
+;   sd t2, 0xd8(sp)
+;   sd t1, 0xe0(sp)
+;   sd t0, 0xe8(sp)
+;   sd s11, 0xf0(sp)
+;   sd s10, 0xf8(sp)
+;   sd s9, 0x100(sp)
+;   sd s8, 0x108(sp)
+;   sd s7, 0x110(sp)
+;   sd s6, 0x118(sp)
+;   sd a0, 0x120(sp)
+;   auipc t0, 0
+;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %different_callee2 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ld s1, 0x10(sp)
-;   ld a0, 8(sp)
-;   ld a1, 0(sp)
-;   ld ra, 0x28(sp)
-;   ld s0, 0x20(sp)
-;   addi sp, sp, 0x30
-;   jr t1
-; block3: ; offset 0xec
-;   ld s1, 0x10(sp)
-;   sd a1, 0x30(sp)
-;   sd a0, 0x38(sp)
-;   sd t2, 0x40(sp)
-;   sd t1, 0x48(sp)
-;   sd t0, 0x50(sp)
+;   ld a0, 0x10(sp)
+;   ld a1, 8(sp)
+;   ld a2, 0(sp)
+;   ld s1, 0x78(sp)
+;   ld s2, 0x70(sp)
+;   ld s3, 0x68(sp)
+;   ld s4, 0x60(sp)
+;   ld s5, 0x58(sp)
+;   ld s6, 0x50(sp)
+;   ld s7, 0x48(sp)
+;   ld s8, 0x40(sp)
+;   ld s9, 0x38(sp)
+;   ld s10, 0x30(sp)
+;   ld s11, 0x28(sp)
+;   ld ra, 0x88(sp)
+;   ld s0, 0x80(sp)
+;   addi sp, sp, 0x90
+;   jr t0
+; block3: ; offset 0x178
+;   ld a0, 0x10(sp)
+;   sd a2, 0xa0(sp)
+;   sd a1, 0xa8(sp)
+;   sd s5, 0xb0(sp)
+;   sd s4, 0xb8(sp)
+;   sd s3, 0xc0(sp)
+;   sd s2, 0xc8(sp)
+;   sd s1, 0xd0(sp)
+;   sd t4, 0xd8(sp)
+;   sd t3, 0xe0(sp)
+;   sd t2, 0xe8(sp)
+;   sd t1, 0xf0(sp)
+;   sd t0, 0xf8(sp)
+;   sd s11, 0x100(sp)
+;   sd s10, 0x108(sp)
+;   sd s9, 0x110(sp)
+;   sd s8, 0x118(sp)
+;   sd s7, 0x120(sp)
+;   sd s6, 0x128(sp)
 ;   auipc t0, 0
 ;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %different_callee1 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ld a0, 8(sp)
-;   ld a1, 0(sp)
-;   ld ra, 0x28(sp)
-;   ld s0, 0x20(sp)
-;   addi sp, sp, 0x30
+;   ld a1, 8(sp)
+;   ld a2, 0(sp)
+;   ld s1, 0x78(sp)
+;   ld s2, 0x70(sp)
+;   ld s3, 0x68(sp)
+;   ld s4, 0x60(sp)
+;   ld s5, 0x58(sp)
+;   ld s6, 0x50(sp)
+;   ld s7, 0x48(sp)
+;   ld s8, 0x40(sp)
+;   ld s9, 0x38(sp)
+;   ld s10, 0x30(sp)
+;   ld s11, 0x28(sp)
+;   ld ra, 0x88(sp)
+;   ld s0, 0x80(sp)
+;   addi sp, sp, 0xa0
 ;   jr t0
 

--- a/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
@@ -14,15 +14,28 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   ld a4,-48(incoming_arg)
-;   ld a0,-40(incoming_arg)
-;   ld a2,-32(incoming_arg)
-;   ld a4,-24(incoming_arg)
-;   ld s1,-16(incoming_arg)
+;   ld a3,-144(incoming_arg)
+;   ld a5,-136(incoming_arg)
+;   ld a1,-128(incoming_arg)
+;   ld a3,-120(incoming_arg)
+;   ld a5,-112(incoming_arg)
+;   ld a1,-104(incoming_arg)
+;   ld a3,-96(incoming_arg)
+;   ld a5,-88(incoming_arg)
+;   ld a1,-80(incoming_arg)
+;   ld a3,-72(incoming_arg)
+;   ld a5,-64(incoming_arg)
+;   ld a1,-56(incoming_arg)
+;   ld a3,-48(incoming_arg)
+;   ld a5,-40(incoming_arg)
+;   ld a1,-32(incoming_arg)
+;   ld a3,-24(incoming_arg)
+;   ld a5,-16(incoming_arg)
+;   ld a0,-8(incoming_arg)
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
-;   addi sp,sp,48
+;   addi sp,sp,144
 ;   ret
 ;
 ; Disassembled:
@@ -32,15 +45,28 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   sd s0, 0(sp)
 ;   mv s0, sp
 ; block1: ; offset 0x10
-;   ld a4, 0x10(sp)
-;   ld a0, 0x18(sp)
-;   ld a2, 0x20(sp)
-;   ld a4, 0x28(sp)
-;   ld s1, 0x30(sp)
+;   ld a3, 0x10(sp)
+;   ld a5, 0x18(sp)
+;   ld a1, 0x20(sp)
+;   ld a3, 0x28(sp)
+;   ld a5, 0x30(sp)
+;   ld a1, 0x38(sp)
+;   ld a3, 0x40(sp)
+;   ld a5, 0x48(sp)
+;   ld a1, 0x50(sp)
+;   ld a3, 0x58(sp)
+;   ld a5, 0x60(sp)
+;   ld a1, 0x68(sp)
+;   ld a3, 0x70(sp)
+;   ld a5, 0x78(sp)
+;   ld a1, 0x80(sp)
+;   ld a3, 0x88(sp)
+;   ld a5, 0x90(sp)
+;   ld a0, 0x98(sp)
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   addi sp, sp, 0x30
+;   addi sp, sp, 0x90
 ;   ret
 
 function %tail_caller_stack_args() -> i64 tail {
@@ -82,49 +108,84 @@ block0:
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-64
-;   virtual_sp_offset_adj +48
+;   addi sp,sp,-256
+;   virtual_sp_offset_adj +144
+;   sd s1,248(sp)
+;   sd s2,240(sp)
+;   sd s3,232(sp)
+;   sd s4,224(sp)
+;   sd s5,216(sp)
+;   sd s6,208(sp)
+;   sd s7,200(sp)
+;   sd s8,192(sp)
+;   sd s9,184(sp)
+;   sd s10,176(sp)
+;   sd s11,168(sp)
 ; block0:
-;   li s1,10
-;   sd s1,8(nominal_sp)
-;   li a0,15
-;   sd a0,0(nominal_sp)
-;   li a1,20
-;   li a2,25
-;   li a3,30
-;   li a4,35
-;   li a5,40
-;   li a6,45
-;   li a7,50
-;   li s2,55
-;   li s3,60
-;   li s4,65
-;   li s5,70
-;   li s6,75
-;   li s7,80
-;   li s8,85
-;   li s9,90
-;   li s10,95
-;   li s11,100
-;   li t3,105
-;   li t4,110
-;   li t0,115
-;   li t1,120
-;   li t2,125
-;   li s1,130
-;   li a0,135
-;   sd t0,0(sp)
-;   sd t1,8(sp)
-;   sd t2,16(sp)
-;   sd s1,24(sp)
-;   sd a0,32(sp)
+;   li a0,10
+;   sd a0,8(nominal_sp)
+;   li a1,15
+;   sd a1,0(nominal_sp)
+;   li a2,20
+;   li a3,25
+;   li a4,30
+;   li a5,35
+;   li a6,40
+;   li a7,45
+;   li s3,50
+;   li s4,55
+;   li s5,60
+;   li s6,65
+;   li s7,70
+;   li s8,75
+;   li s9,80
+;   li s10,85
+;   li s11,90
+;   li t0,95
+;   li t1,100
+;   li t2,105
+;   li t3,110
+;   li t4,115
+;   li s1,120
+;   li s2,125
+;   li a0,130
+;   li a1,135
+;   sd s3,0(sp)
+;   sd s4,8(sp)
+;   sd s5,16(sp)
+;   sd s6,24(sp)
+;   sd s7,32(sp)
+;   sd s8,40(sp)
+;   sd s9,48(sp)
+;   sd s10,56(sp)
+;   sd s11,64(sp)
+;   sd t0,72(sp)
+;   sd t1,80(sp)
+;   sd t2,88(sp)
+;   sd t3,96(sp)
+;   sd t4,104(sp)
+;   sd s1,112(sp)
+;   sd s2,120(sp)
+;   sd a0,128(sp)
+;   sd a1,136(sp)
 ;   load_sym t0,%tail_callee_stack_args+0
-;   ld s1,8(nominal_sp)
-;   ld a0,0(nominal_sp)
+;   ld a0,8(nominal_sp)
+;   ld a1,0(nominal_sp)
 ;   callind t0
-;   addi sp,sp,-48
-;   virtual_sp_offset_adj +48
-;   addi sp,sp,64
+;   addi sp,sp,-144
+;   virtual_sp_offset_adj +144
+;   ld s1,248(sp)
+;   ld s2,240(sp)
+;   ld s3,232(sp)
+;   ld s4,224(sp)
+;   ld s5,216(sp)
+;   ld s6,208(sp)
+;   ld s7,200(sp)
+;   ld s8,192(sp)
+;   ld s9,184(sp)
+;   ld s10,176(sp)
+;   ld s11,168(sp)
+;   addi sp,sp,256
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -136,51 +197,86 @@ block0:
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0x40
-; block1: ; offset 0x14
-;   addi s1, zero, 0xa
-;   sd s1, 0x38(sp)
-;   addi a0, zero, 0xf
-;   sd a0, 0x30(sp)
-;   addi a1, zero, 0x14
-;   addi a2, zero, 0x19
-;   addi a3, zero, 0x1e
-;   addi a4, zero, 0x23
-;   addi a5, zero, 0x28
-;   addi a6, zero, 0x2d
-;   addi a7, zero, 0x32
-;   addi s2, zero, 0x37
-;   addi s3, zero, 0x3c
-;   addi s4, zero, 0x41
-;   addi s5, zero, 0x46
-;   addi s6, zero, 0x4b
-;   addi s7, zero, 0x50
-;   addi s8, zero, 0x55
-;   addi s9, zero, 0x5a
-;   addi s10, zero, 0x5f
-;   addi s11, zero, 0x64
-;   addi t3, zero, 0x69
-;   addi t4, zero, 0x6e
-;   addi t0, zero, 0x73
-;   addi t1, zero, 0x78
-;   addi t2, zero, 0x7d
-;   addi s1, zero, 0x82
-;   addi a0, zero, 0x87
-;   sd t0, 0(sp)
-;   sd t1, 8(sp)
-;   sd t2, 0x10(sp)
-;   sd s1, 0x18(sp)
-;   sd a0, 0x20(sp)
+;   addi sp, sp, -0x100
+;   sd s1, 0xf8(sp)
+;   sd s2, 0xf0(sp)
+;   sd s3, 0xe8(sp)
+;   sd s4, 0xe0(sp)
+;   sd s5, 0xd8(sp)
+;   sd s6, 0xd0(sp)
+;   sd s7, 0xc8(sp)
+;   sd s8, 0xc0(sp)
+;   sd s9, 0xb8(sp)
+;   sd s10, 0xb0(sp)
+;   sd s11, 0xa8(sp)
+; block1: ; offset 0x40
+;   addi a0, zero, 0xa
+;   sd a0, 0x98(sp)
+;   addi a1, zero, 0xf
+;   sd a1, 0x90(sp)
+;   addi a2, zero, 0x14
+;   addi a3, zero, 0x19
+;   addi a4, zero, 0x1e
+;   addi a5, zero, 0x23
+;   addi a6, zero, 0x28
+;   addi a7, zero, 0x2d
+;   addi s3, zero, 0x32
+;   addi s4, zero, 0x37
+;   addi s5, zero, 0x3c
+;   addi s6, zero, 0x41
+;   addi s7, zero, 0x46
+;   addi s8, zero, 0x4b
+;   addi s9, zero, 0x50
+;   addi s10, zero, 0x55
+;   addi s11, zero, 0x5a
+;   addi t0, zero, 0x5f
+;   addi t1, zero, 0x64
+;   addi t2, zero, 0x69
+;   addi t3, zero, 0x6e
+;   addi t4, zero, 0x73
+;   addi s1, zero, 0x78
+;   addi s2, zero, 0x7d
+;   addi a0, zero, 0x82
+;   addi a1, zero, 0x87
+;   sd s3, 0(sp)
+;   sd s4, 8(sp)
+;   sd s5, 0x10(sp)
+;   sd s6, 0x18(sp)
+;   sd s7, 0x20(sp)
+;   sd s8, 0x28(sp)
+;   sd s9, 0x30(sp)
+;   sd s10, 0x38(sp)
+;   sd s11, 0x40(sp)
+;   sd t0, 0x48(sp)
+;   sd t1, 0x50(sp)
+;   sd t2, 0x58(sp)
+;   sd t3, 0x60(sp)
+;   sd t4, 0x68(sp)
+;   sd s1, 0x70(sp)
+;   sd s2, 0x78(sp)
+;   sd a0, 0x80(sp)
+;   sd a1, 0x88(sp)
 ;   auipc t0, 0
 ;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ld s1, 0x38(sp)
-;   ld a0, 0x30(sp)
+;   ld a0, 0x98(sp)
+;   ld a1, 0x90(sp)
 ;   jalr t0
-;   addi sp, sp, -0x30
-;   addi sp, sp, 0x40
+;   addi sp, sp, -0x90
+;   ld s1, 0xf8(sp)
+;   ld s2, 0xf0(sp)
+;   ld s3, 0xe8(sp)
+;   ld s4, 0xe0(sp)
+;   ld s5, 0xd8(sp)
+;   ld s6, 0xd0(sp)
+;   ld s7, 0xc8(sp)
+;   ld s8, 0xc0(sp)
+;   ld s9, 0xb8(sp)
+;   ld s10, 0xb0(sp)
+;   ld s11, 0xa8(sp)
+;   addi sp, sp, 0x100
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -224,46 +320,89 @@ block0:
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-32
+;   addi sp,sp,-128
+;   sd s1,120(sp)
+;   sd s2,112(sp)
+;   sd s3,104(sp)
+;   sd s4,96(sp)
+;   sd s5,88(sp)
+;   sd s6,80(sp)
+;   sd s7,72(sp)
+;   sd s8,64(sp)
+;   sd s9,56(sp)
+;   sd s10,48(sp)
+;   sd s11,40(sp)
 ; block0:
 ;   li a3,10
-;   sd a3,16(nominal_sp)
-;   li a0,15
-;   sd a0,8(nominal_sp)
-;   li a1,20
-;   sd a1,0(nominal_sp)
-;   li a2,25
-;   li a3,30
-;   li a4,35
-;   li a5,40
-;   li a6,45
-;   li a7,50
-;   li s2,55
-;   li s3,60
-;   li s4,65
-;   li s5,70
-;   li s6,75
-;   li s7,80
-;   li s8,85
-;   li s9,90
-;   li s10,95
-;   li s11,100
-;   li t3,105
-;   li t4,110
-;   li t0,115
-;   li t1,120
-;   li t2,125
-;   li a0,130
-;   li a1,135
-;   sd t0,0(s1)
-;   sd t1,8(s1)
-;   sd t2,16(s1)
-;   sd a0,24(s1)
-;   sd a1,32(s1)
-;   ld s1,16(nominal_sp)
-;   ld a0,8(nominal_sp)
-;   ld a1,0(nominal_sp)
-;   addi sp,sp,32
+;   sd a3,24(nominal_sp)
+;   li a1,15
+;   sd a1,16(nominal_sp)
+;   li a4,20
+;   sd a4,8(nominal_sp)
+;   li a4,25
+;   li a5,30
+;   li a2,35
+;   li s3,40
+;   li s4,45
+;   li s5,50
+;   li s6,55
+;   li s7,60
+;   li s8,65
+;   li s9,70
+;   li s10,75
+;   li s11,80
+;   li t0,85
+;   li t1,90
+;   li t2,95
+;   li a6,100
+;   li a7,105
+;   li t3,110
+;   li t4,115
+;   li s1,120
+;   li s2,125
+;   li a1,130
+;   li a3,135
+;   sd a3,0(nominal_sp)
+;   ld a3,8(nominal_sp)
+;   sd a3,0(a0)
+;   sd a4,8(a0)
+;   sd a5,16(a0)
+;   sd a2,24(a0)
+;   sd s3,32(a0)
+;   sd s4,40(a0)
+;   sd s5,48(a0)
+;   sd s6,56(a0)
+;   sd s7,64(a0)
+;   sd s8,72(a0)
+;   sd s9,80(a0)
+;   sd s10,88(a0)
+;   sd s11,96(a0)
+;   sd t0,104(a0)
+;   sd t1,112(a0)
+;   sd t2,120(a0)
+;   sd a6,128(a0)
+;   sd a7,136(a0)
+;   sd t3,144(a0)
+;   sd t4,152(a0)
+;   sd s1,160(a0)
+;   sd s2,168(a0)
+;   sd a1,176(a0)
+;   ld a3,0(nominal_sp)
+;   sd a3,184(a0)
+;   ld a0,24(nominal_sp)
+;   ld a1,16(nominal_sp)
+;   ld s1,120(sp)
+;   ld s2,112(sp)
+;   ld s3,104(sp)
+;   ld s4,96(sp)
+;   ld s5,88(sp)
+;   ld s6,80(sp)
+;   ld s7,72(sp)
+;   ld s8,64(sp)
+;   ld s9,56(sp)
+;   ld s10,48(sp)
+;   ld s11,40(sp)
+;   addi sp,sp,128
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -275,46 +414,89 @@ block0:
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0x20
-; block1: ; offset 0x14
+;   addi sp, sp, -0x80
+;   sd s1, 0x78(sp)
+;   sd s2, 0x70(sp)
+;   sd s3, 0x68(sp)
+;   sd s4, 0x60(sp)
+;   sd s5, 0x58(sp)
+;   sd s6, 0x50(sp)
+;   sd s7, 0x48(sp)
+;   sd s8, 0x40(sp)
+;   sd s9, 0x38(sp)
+;   sd s10, 0x30(sp)
+;   sd s11, 0x28(sp)
+; block1: ; offset 0x40
 ;   addi a3, zero, 0xa
-;   sd a3, 0x10(sp)
-;   addi a0, zero, 0xf
-;   sd a0, 8(sp)
-;   addi a1, zero, 0x14
-;   sd a1, 0(sp)
-;   addi a2, zero, 0x19
-;   addi a3, zero, 0x1e
-;   addi a4, zero, 0x23
-;   addi a5, zero, 0x28
-;   addi a6, zero, 0x2d
-;   addi a7, zero, 0x32
-;   addi s2, zero, 0x37
-;   addi s3, zero, 0x3c
-;   addi s4, zero, 0x41
-;   addi s5, zero, 0x46
-;   addi s6, zero, 0x4b
-;   addi s7, zero, 0x50
-;   addi s8, zero, 0x55
-;   addi s9, zero, 0x5a
-;   addi s10, zero, 0x5f
-;   addi s11, zero, 0x64
-;   addi t3, zero, 0x69
-;   addi t4, zero, 0x6e
-;   addi t0, zero, 0x73
-;   addi t1, zero, 0x78
-;   addi t2, zero, 0x7d
-;   addi a0, zero, 0x82
-;   addi a1, zero, 0x87
-;   sd t0, 0(s1)
-;   sd t1, 8(s1)
-;   sd t2, 0x10(s1)
-;   sd a0, 0x18(s1)
-;   sd a1, 0x20(s1)
-;   ld s1, 0x10(sp)
-;   ld a0, 8(sp)
-;   ld a1, 0(sp)
-;   addi sp, sp, 0x20
+;   sd a3, 0x18(sp)
+;   addi a1, zero, 0xf
+;   sd a1, 0x10(sp)
+;   addi a4, zero, 0x14
+;   sd a4, 8(sp)
+;   addi a4, zero, 0x19
+;   addi a5, zero, 0x1e
+;   addi a2, zero, 0x23
+;   addi s3, zero, 0x28
+;   addi s4, zero, 0x2d
+;   addi s5, zero, 0x32
+;   addi s6, zero, 0x37
+;   addi s7, zero, 0x3c
+;   addi s8, zero, 0x41
+;   addi s9, zero, 0x46
+;   addi s10, zero, 0x4b
+;   addi s11, zero, 0x50
+;   addi t0, zero, 0x55
+;   addi t1, zero, 0x5a
+;   addi t2, zero, 0x5f
+;   addi a6, zero, 0x64
+;   addi a7, zero, 0x69
+;   addi t3, zero, 0x6e
+;   addi t4, zero, 0x73
+;   addi s1, zero, 0x78
+;   addi s2, zero, 0x7d
+;   addi a1, zero, 0x82
+;   addi a3, zero, 0x87
+;   sd a3, 0(sp)
+;   ld a3, 8(sp)
+;   sd a3, 0(a0)
+;   sd a4, 8(a0)
+;   sd a5, 0x10(a0)
+;   sd a2, 0x18(a0)
+;   sd s3, 0x20(a0)
+;   sd s4, 0x28(a0)
+;   sd s5, 0x30(a0)
+;   sd s6, 0x38(a0)
+;   sd s7, 0x40(a0)
+;   sd s8, 0x48(a0)
+;   sd s9, 0x50(a0)
+;   sd s10, 0x58(a0)
+;   sd s11, 0x60(a0)
+;   sd t0, 0x68(a0)
+;   sd t1, 0x70(a0)
+;   sd t2, 0x78(a0)
+;   sd a6, 0x80(a0)
+;   sd a7, 0x88(a0)
+;   sd t3, 0x90(a0)
+;   sd t4, 0x98(a0)
+;   sd s1, 0xa0(a0)
+;   sd s2, 0xa8(a0)
+;   sd a1, 0xb0(a0)
+;   ld a3, 0(sp)
+;   sd a3, 0xb8(a0)
+;   ld a0, 0x18(sp)
+;   ld a1, 0x10(sp)
+;   ld s1, 0x78(sp)
+;   ld s2, 0x70(sp)
+;   ld s3, 0x68(sp)
+;   ld s4, 0x60(sp)
+;   ld s5, 0x58(sp)
+;   ld s6, 0x50(sp)
+;   ld s7, 0x48(sp)
+;   ld s8, 0x40(sp)
+;   ld s9, 0x38(sp)
+;   ld s10, 0x30(sp)
+;   ld s11, 0x28(sp)
+;   addi sp, sp, 0x80
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -333,18 +515,37 @@ block0:
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-48
-;   virtual_sp_offset_adj +48
+;   addi sp,sp,-192
+;   virtual_sp_offset_adj +192
 ; block0:
-;   load_addr s1,0(sp)
+;   load_addr a0,0(sp)
 ;   load_sym t0,%tail_callee_stack_rets+0
 ;   callind t0
-;   ld a0,0(sp)
-;   ld a2,8(sp)
-;   ld a4,16(sp)
-;   ld a0,24(sp)
-;   ld s1,32(sp)
-;   addi sp,sp,48
+;   ld a5,0(sp)
+;   ld a1,8(sp)
+;   ld a3,16(sp)
+;   ld a5,24(sp)
+;   ld a1,32(sp)
+;   ld a3,40(sp)
+;   ld a5,48(sp)
+;   ld a1,56(sp)
+;   ld a3,64(sp)
+;   ld a5,72(sp)
+;   ld a1,80(sp)
+;   ld a3,88(sp)
+;   ld a5,96(sp)
+;   ld a1,104(sp)
+;   ld a3,112(sp)
+;   ld a5,120(sp)
+;   ld a1,128(sp)
+;   ld a3,136(sp)
+;   ld a5,144(sp)
+;   ld a1,152(sp)
+;   ld a3,160(sp)
+;   ld a5,168(sp)
+;   ld a1,176(sp)
+;   ld a0,184(sp)
+;   addi sp,sp,192
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -356,21 +557,40 @@ block0:
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0x30
+;   addi sp, sp, -0xc0
 ; block1: ; offset 0x14
-;   mv s1, sp
+;   mv a0, sp
 ;   auipc t0, 0
 ;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_rets 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   jalr t0
-;   ld a0, 0(sp)
-;   ld a2, 8(sp)
-;   ld a4, 0x10(sp)
-;   ld a0, 0x18(sp)
-;   ld s1, 0x20(sp)
-;   addi sp, sp, 0x30
+;   ld a5, 0(sp)
+;   ld a1, 8(sp)
+;   ld a3, 0x10(sp)
+;   ld a5, 0x18(sp)
+;   ld a1, 0x20(sp)
+;   ld a3, 0x28(sp)
+;   ld a5, 0x30(sp)
+;   ld a1, 0x38(sp)
+;   ld a3, 0x40(sp)
+;   ld a5, 0x48(sp)
+;   ld a1, 0x50(sp)
+;   ld a3, 0x58(sp)
+;   ld a5, 0x60(sp)
+;   ld a1, 0x68(sp)
+;   ld a3, 0x70(sp)
+;   ld a5, 0x78(sp)
+;   ld a1, 0x80(sp)
+;   ld a3, 0x88(sp)
+;   ld a5, 0x90(sp)
+;   ld a1, 0x98(sp)
+;   ld a3, 0xa0(sp)
+;   ld a5, 0xa8(sp)
+;   ld a1, 0xb0(sp)
+;   ld a0, 0xb8(sp)
+;   addi sp, sp, 0xc0
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
@@ -389,30 +609,84 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-32
+;   addi sp,sp,-128
+;   sd s1,120(sp)
+;   sd s2,112(sp)
+;   sd s3,104(sp)
+;   sd s4,96(sp)
+;   sd s5,88(sp)
+;   sd s6,80(sp)
+;   sd s7,72(sp)
+;   sd s8,64(sp)
+;   sd s9,56(sp)
+;   sd s10,48(sp)
+;   sd s11,40(sp)
 ; block0:
 ;   sd a0,0(nominal_sp)
-;   sd a2,8(nominal_sp)
-;   sd a4,16(nominal_sp)
-;   ld a4,-48(incoming_arg)
+;   sd a1,8(nominal_sp)
+;   ld s4,-160(incoming_arg)
+;   ld s6,-152(incoming_arg)
+;   ld s8,-144(incoming_arg)
+;   ld s10,-136(incoming_arg)
+;   ld t0,-128(incoming_arg)
+;   ld t1,-120(incoming_arg)
+;   ld t4,-112(incoming_arg)
+;   ld t3,-104(incoming_arg)
+;   ld s1,-96(incoming_arg)
+;   ld s3,-88(incoming_arg)
+;   ld s5,-80(incoming_arg)
+;   ld s7,-72(incoming_arg)
+;   ld s9,-64(incoming_arg)
+;   ld s11,-56(incoming_arg)
+;   ld a1,-48(incoming_arg)
 ;   ld a0,-40(incoming_arg)
-;   ld t2,-32(incoming_arg)
-;   ld t1,-24(incoming_arg)
-;   ld t0,-16(incoming_arg)
-;   ld a2,-8(incoming_arg)
-;   sd a4,0(a2)
-;   sd a0,8(a2)
-;   sd t2,16(a2)
-;   sd t1,24(a2)
-;   sd t0,32(a2)
+;   ld s2,-32(incoming_arg)
+;   ld t2,-24(incoming_arg)
+;   sd t2,16(nominal_sp)
+;   ld t2,-16(incoming_arg)
+;   sd a2,0(t2)
+;   sd a3,8(t2)
+;   sd a4,16(t2)
+;   sd a5,24(t2)
+;   sd a6,32(t2)
+;   sd a7,40(t2)
+;   sd s4,48(t2)
+;   sd s6,56(t2)
+;   sd s8,64(t2)
+;   sd s10,72(t2)
+;   sd t0,80(t2)
+;   sd t1,88(t2)
+;   sd t4,96(t2)
+;   sd t3,104(t2)
+;   sd s1,112(t2)
+;   sd s3,120(t2)
+;   sd s5,128(t2)
+;   sd s7,136(t2)
+;   sd s9,144(t2)
+;   sd s11,152(t2)
+;   sd a1,160(t2)
+;   sd a0,168(t2)
+;   sd s2,176(t2)
+;   ld a1,16(nominal_sp)
+;   sd a1,184(t2)
 ;   ld a0,0(nominal_sp)
-;   ld a2,8(nominal_sp)
-;   ld a4,16(nominal_sp)
-;   addi sp,sp,32
+;   ld a1,8(nominal_sp)
+;   ld s1,120(sp)
+;   ld s2,112(sp)
+;   ld s3,104(sp)
+;   ld s4,96(sp)
+;   ld s5,88(sp)
+;   ld s6,80(sp)
+;   ld s7,72(sp)
+;   ld s8,64(sp)
+;   ld s9,56(sp)
+;   ld s10,48(sp)
+;   ld s11,40(sp)
+;   addi sp,sp,128
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
-;   addi sp,sp,48
+;   addi sp,sp,160
 ;   ret
 ;
 ; Disassembled:
@@ -421,30 +695,84 @@ block0(v0: i64, v1: i64, v2: i64, v3: i64, v4: i64, v5: i64, v6: i64, v7: i64, v
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0x20
-; block1: ; offset 0x14
+;   addi sp, sp, -0x80
+;   sd s1, 0x78(sp)
+;   sd s2, 0x70(sp)
+;   sd s3, 0x68(sp)
+;   sd s4, 0x60(sp)
+;   sd s5, 0x58(sp)
+;   sd s6, 0x50(sp)
+;   sd s7, 0x48(sp)
+;   sd s8, 0x40(sp)
+;   sd s9, 0x38(sp)
+;   sd s10, 0x30(sp)
+;   sd s11, 0x28(sp)
+; block1: ; offset 0x40
 ;   sd a0, 0(sp)
-;   sd a2, 8(sp)
-;   sd a4, 0x10(sp)
-;   ld a4, 0x30(sp)
-;   ld a0, 0x38(sp)
-;   ld t2, 0x40(sp)
-;   ld t1, 0x48(sp)
-;   ld t0, 0x50(sp)
-;   ld a2, 0x58(sp)
-;   sd a4, 0(a2)
-;   sd a0, 8(a2)
-;   sd t2, 0x10(a2)
-;   sd t1, 0x18(a2)
-;   sd t0, 0x20(a2)
+;   sd a1, 8(sp)
+;   ld s4, 0x90(sp)
+;   ld s6, 0x98(sp)
+;   ld s8, 0xa0(sp)
+;   ld s10, 0xa8(sp)
+;   ld t0, 0xb0(sp)
+;   ld t1, 0xb8(sp)
+;   ld t4, 0xc0(sp)
+;   ld t3, 0xc8(sp)
+;   ld s1, 0xd0(sp)
+;   ld s3, 0xd8(sp)
+;   ld s5, 0xe0(sp)
+;   ld s7, 0xe8(sp)
+;   ld s9, 0xf0(sp)
+;   ld s11, 0xf8(sp)
+;   ld a1, 0x100(sp)
+;   ld a0, 0x108(sp)
+;   ld s2, 0x110(sp)
+;   ld t2, 0x118(sp)
+;   sd t2, 0x10(sp)
+;   ld t2, 0x120(sp)
+;   sd a2, 0(t2)
+;   sd a3, 8(t2)
+;   sd a4, 0x10(t2)
+;   sd a5, 0x18(t2)
+;   sd a6, 0x20(t2)
+;   sd a7, 0x28(t2)
+;   sd s4, 0x30(t2)
+;   sd s6, 0x38(t2)
+;   sd s8, 0x40(t2)
+;   sd s10, 0x48(t2)
+;   sd t0, 0x50(t2)
+;   sd t1, 0x58(t2)
+;   sd t4, 0x60(t2)
+;   sd t3, 0x68(t2)
+;   sd s1, 0x70(t2)
+;   sd s3, 0x78(t2)
+;   sd s5, 0x80(t2)
+;   sd s7, 0x88(t2)
+;   sd s9, 0x90(t2)
+;   sd s11, 0x98(t2)
+;   sd a1, 0xa0(t2)
+;   sd a0, 0xa8(t2)
+;   sd s2, 0xb0(t2)
+;   ld a1, 0x10(sp)
+;   sd a1, 0xb8(t2)
 ;   ld a0, 0(sp)
-;   ld a2, 8(sp)
-;   ld a4, 0x10(sp)
-;   addi sp, sp, 0x20
+;   ld a1, 8(sp)
+;   ld s1, 0x78(sp)
+;   ld s2, 0x70(sp)
+;   ld s3, 0x68(sp)
+;   ld s4, 0x60(sp)
+;   ld s5, 0x58(sp)
+;   ld s6, 0x50(sp)
+;   ld s7, 0x48(sp)
+;   ld s8, 0x40(sp)
+;   ld s9, 0x38(sp)
+;   ld s10, 0x30(sp)
+;   ld s11, 0x28(sp)
+;   addi sp, sp, 0x80
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10
-;   addi sp, sp, 0x30
+;   addi sp, sp, 0xa0
 ;   ret
 
 function %tail_caller_stack_args_and_rets() -> i64 tail {
@@ -486,56 +814,110 @@ block0:
 ;   sd ra,8(sp)
 ;   sd fp,0(sp)
 ;   mv fp,sp
-;   addi sp,sp,-112
-;   virtual_sp_offset_adj +96
+;   addi sp,sp,-464
+;   virtual_sp_offset_adj +352
+;   sd s1,456(sp)
+;   sd s2,448(sp)
+;   sd s3,440(sp)
+;   sd s4,432(sp)
+;   sd s5,424(sp)
+;   sd s6,416(sp)
+;   sd s7,408(sp)
+;   sd s8,400(sp)
+;   sd s9,392(sp)
+;   sd s10,384(sp)
+;   sd s11,376(sp)
 ; block0:
-;   li s1,10
-;   sd s1,8(nominal_sp)
-;   li a0,15
-;   sd a0,0(nominal_sp)
-;   li a1,20
-;   li a2,25
-;   li a3,30
-;   li a4,35
-;   li a5,40
-;   li a6,45
-;   li a7,50
-;   li s2,55
-;   li s3,60
-;   li s4,65
-;   li s5,70
-;   li s6,75
-;   li s7,80
-;   li s8,85
-;   li s9,90
-;   li s10,95
-;   li s11,100
-;   li t3,105
-;   li t4,110
-;   li t0,115
-;   li t1,120
-;   li t2,125
-;   li s1,130
-;   li a0,135
-;   sd t0,0(sp)
-;   sd t1,8(sp)
-;   sd t2,16(sp)
-;   sd s1,24(sp)
-;   sd a0,32(sp)
-;   load_addr a0,48(sp)
-;   sd a0,40(sp)
+;   li a0,10
+;   sd a0,8(nominal_sp)
+;   li a1,15
+;   sd a1,0(nominal_sp)
+;   li a2,20
+;   li a3,25
+;   li a4,30
+;   li a5,35
+;   li a6,40
+;   li a7,45
+;   li s11,50
+;   li t0,55
+;   li t1,60
+;   li t2,65
+;   li t3,70
+;   li t4,75
+;   li s1,80
+;   li s2,85
+;   li s3,90
+;   li s4,95
+;   li s5,100
+;   li s6,105
+;   li s7,110
+;   li s8,115
+;   li s9,120
+;   li s10,125
+;   li a0,130
+;   li a1,135
+;   sd s11,0(sp)
+;   sd t0,8(sp)
+;   sd t1,16(sp)
+;   sd t2,24(sp)
+;   sd t3,32(sp)
+;   sd t4,40(sp)
+;   sd s1,48(sp)
+;   sd s2,56(sp)
+;   sd s3,64(sp)
+;   sd s4,72(sp)
+;   sd s5,80(sp)
+;   sd s6,88(sp)
+;   sd s7,96(sp)
+;   sd s8,104(sp)
+;   sd s9,112(sp)
+;   sd s10,120(sp)
+;   sd a0,128(sp)
+;   sd a1,136(sp)
+;   load_addr a0,160(sp)
+;   sd a0,144(sp)
 ;   load_sym t0,%tail_callee_stack_args_and_rets+0
-;   ld s1,8(nominal_sp)
-;   ld a0,0(nominal_sp)
+;   ld a0,8(nominal_sp)
+;   ld a1,0(nominal_sp)
 ;   callind t0
-;   addi sp,sp,-48
-;   virtual_sp_offset_adj +48
-;   ld a4,48(sp)
-;   ld a0,56(sp)
-;   ld a2,64(sp)
-;   ld a4,72(sp)
-;   ld s1,80(sp)
-;   addi sp,sp,112
+;   addi sp,sp,-160
+;   virtual_sp_offset_adj +160
+;   ld a4,160(sp)
+;   ld a0,168(sp)
+;   ld a2,176(sp)
+;   ld a4,184(sp)
+;   ld a0,192(sp)
+;   ld a2,200(sp)
+;   ld a4,208(sp)
+;   ld a0,216(sp)
+;   ld a2,224(sp)
+;   ld a4,232(sp)
+;   ld a0,240(sp)
+;   ld a2,248(sp)
+;   ld a4,256(sp)
+;   ld a0,264(sp)
+;   ld a2,272(sp)
+;   ld a4,280(sp)
+;   ld a0,288(sp)
+;   ld a2,296(sp)
+;   ld a4,304(sp)
+;   ld a0,312(sp)
+;   ld a2,320(sp)
+;   ld a4,328(sp)
+;   ld a0,336(sp)
+;   ld a0,344(sp)
+;   ld s1,456(sp)
+;   ld s2,448(sp)
+;   ld s3,440(sp)
+;   ld s4,432(sp)
+;   ld s5,424(sp)
+;   ld s6,416(sp)
+;   ld s7,408(sp)
+;   ld s8,400(sp)
+;   ld s9,392(sp)
+;   ld s10,384(sp)
+;   ld s11,376(sp)
+;   addi sp,sp,464
 ;   ld ra,8(sp)
 ;   ld fp,0(sp)
 ;   addi sp,sp,16
@@ -547,58 +929,112 @@ block0:
 ;   sd ra, 8(sp)
 ;   sd s0, 0(sp)
 ;   mv s0, sp
-;   addi sp, sp, -0x70
-; block1: ; offset 0x14
-;   addi s1, zero, 0xa
-;   sd s1, 0x68(sp)
-;   addi a0, zero, 0xf
-;   sd a0, 0x60(sp)
-;   addi a1, zero, 0x14
-;   addi a2, zero, 0x19
-;   addi a3, zero, 0x1e
-;   addi a4, zero, 0x23
-;   addi a5, zero, 0x28
-;   addi a6, zero, 0x2d
-;   addi a7, zero, 0x32
-;   addi s2, zero, 0x37
-;   addi s3, zero, 0x3c
-;   addi s4, zero, 0x41
-;   addi s5, zero, 0x46
-;   addi s6, zero, 0x4b
-;   addi s7, zero, 0x50
-;   addi s8, zero, 0x55
-;   addi s9, zero, 0x5a
-;   addi s10, zero, 0x5f
-;   addi s11, zero, 0x64
-;   addi t3, zero, 0x69
-;   addi t4, zero, 0x6e
-;   addi t0, zero, 0x73
-;   addi t1, zero, 0x78
-;   addi t2, zero, 0x7d
-;   addi s1, zero, 0x82
-;   addi a0, zero, 0x87
-;   sd t0, 0(sp)
-;   sd t1, 8(sp)
-;   sd t2, 0x10(sp)
-;   sd s1, 0x18(sp)
-;   sd a0, 0x20(sp)
-;   addi a0, sp, 0x30
-;   sd a0, 0x28(sp)
+;   addi sp, sp, -0x1d0
+;   sd s1, 0x1c8(sp)
+;   sd s2, 0x1c0(sp)
+;   sd s3, 0x1b8(sp)
+;   sd s4, 0x1b0(sp)
+;   sd s5, 0x1a8(sp)
+;   sd s6, 0x1a0(sp)
+;   sd s7, 0x198(sp)
+;   sd s8, 0x190(sp)
+;   sd s9, 0x188(sp)
+;   sd s10, 0x180(sp)
+;   sd s11, 0x178(sp)
+; block1: ; offset 0x40
+;   addi a0, zero, 0xa
+;   sd a0, 0x168(sp)
+;   addi a1, zero, 0xf
+;   sd a1, 0x160(sp)
+;   addi a2, zero, 0x14
+;   addi a3, zero, 0x19
+;   addi a4, zero, 0x1e
+;   addi a5, zero, 0x23
+;   addi a6, zero, 0x28
+;   addi a7, zero, 0x2d
+;   addi s11, zero, 0x32
+;   addi t0, zero, 0x37
+;   addi t1, zero, 0x3c
+;   addi t2, zero, 0x41
+;   addi t3, zero, 0x46
+;   addi t4, zero, 0x4b
+;   addi s1, zero, 0x50
+;   addi s2, zero, 0x55
+;   addi s3, zero, 0x5a
+;   addi s4, zero, 0x5f
+;   addi s5, zero, 0x64
+;   addi s6, zero, 0x69
+;   addi s7, zero, 0x6e
+;   addi s8, zero, 0x73
+;   addi s9, zero, 0x78
+;   addi s10, zero, 0x7d
+;   addi a0, zero, 0x82
+;   addi a1, zero, 0x87
+;   sd s11, 0(sp)
+;   sd t0, 8(sp)
+;   sd t1, 0x10(sp)
+;   sd t2, 0x18(sp)
+;   sd t3, 0x20(sp)
+;   sd t4, 0x28(sp)
+;   sd s1, 0x30(sp)
+;   sd s2, 0x38(sp)
+;   sd s3, 0x40(sp)
+;   sd s4, 0x48(sp)
+;   sd s5, 0x50(sp)
+;   sd s6, 0x58(sp)
+;   sd s7, 0x60(sp)
+;   sd s8, 0x68(sp)
+;   sd s9, 0x70(sp)
+;   sd s10, 0x78(sp)
+;   sd a0, 0x80(sp)
+;   sd a1, 0x88(sp)
+;   addi a0, sp, 0xa0
+;   sd a0, 0x90(sp)
 ;   auipc t0, 0
 ;   ld t0, 0xc(t0)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args_and_rets 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   ld s1, 0x68(sp)
-;   ld a0, 0x60(sp)
+;   ld a0, 0x168(sp)
+;   ld a1, 0x160(sp)
 ;   jalr t0
-;   addi sp, sp, -0x30
-;   ld a4, 0x30(sp)
-;   ld a0, 0x38(sp)
-;   ld a2, 0x40(sp)
-;   ld a4, 0x48(sp)
-;   ld s1, 0x50(sp)
-;   addi sp, sp, 0x70
+;   addi sp, sp, -0xa0
+;   ld a4, 0xa0(sp)
+;   ld a0, 0xa8(sp)
+;   ld a2, 0xb0(sp)
+;   ld a4, 0xb8(sp)
+;   ld a0, 0xc0(sp)
+;   ld a2, 0xc8(sp)
+;   ld a4, 0xd0(sp)
+;   ld a0, 0xd8(sp)
+;   ld a2, 0xe0(sp)
+;   ld a4, 0xe8(sp)
+;   ld a0, 0xf0(sp)
+;   ld a2, 0xf8(sp)
+;   ld a4, 0x100(sp)
+;   ld a0, 0x108(sp)
+;   ld a2, 0x110(sp)
+;   ld a4, 0x118(sp)
+;   ld a0, 0x120(sp)
+;   ld a2, 0x128(sp)
+;   ld a4, 0x130(sp)
+;   ld a0, 0x138(sp)
+;   ld a2, 0x140(sp)
+;   ld a4, 0x148(sp)
+;   ld a0, 0x150(sp)
+;   ld a0, 0x158(sp)
+;   ld s1, 0x1c8(sp)
+;   ld s2, 0x1c0(sp)
+;   ld s3, 0x1b8(sp)
+;   ld s4, 0x1b0(sp)
+;   ld s5, 0x1a8(sp)
+;   ld s6, 0x1a0(sp)
+;   ld s7, 0x198(sp)
+;   ld s8, 0x190(sp)
+;   ld s9, 0x188(sp)
+;   ld s10, 0x180(sp)
+;   ld s11, 0x178(sp)
+;   addi sp, sp, 0x1d0
 ;   ld ra, 8(sp)
 ;   ld s0, 0(sp)
 ;   addi sp, sp, 0x10

--- a/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/tail-call-conv.clif
@@ -168,10 +168,10 @@ block0:
 ;   sd s2,120(sp)
 ;   sd a0,128(sp)
 ;   sd a1,136(sp)
-;   load_sym t0,%tail_callee_stack_args+0
+;   load_sym s3,%tail_callee_stack_args+0
 ;   ld a0,8(nominal_sp)
 ;   ld a1,0(nominal_sp)
-;   callind t0
+;   callind s3
 ;   addi sp,sp,-144
 ;   virtual_sp_offset_adj +144
 ;   ld s1,248(sp)
@@ -256,14 +256,14 @@ block0:
 ;   sd s2, 0x78(sp)
 ;   sd a0, 0x80(sp)
 ;   sd a1, 0x88(sp)
-;   auipc t0, 0
-;   ld t0, 0xc(t0)
+;   auipc s3, 0
+;   ld s3, 0xc(s3)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ld a0, 0x98(sp)
 ;   ld a1, 0x90(sp)
-;   jalr t0
+;   jalr s3
 ;   addi sp, sp, -0x90
 ;   ld s1, 0xf8(sp)
 ;   ld s2, 0xf0(sp)
@@ -519,8 +519,8 @@ block0:
 ;   virtual_sp_offset_adj +192
 ; block0:
 ;   load_addr a0,0(sp)
-;   load_sym t0,%tail_callee_stack_rets+0
-;   callind t0
+;   load_sym a4,%tail_callee_stack_rets+0
+;   callind a4
 ;   ld a5,0(sp)
 ;   ld a1,8(sp)
 ;   ld a3,16(sp)
@@ -560,12 +560,12 @@ block0:
 ;   addi sp, sp, -0xc0
 ; block1: ; offset 0x14
 ;   mv a0, sp
-;   auipc t0, 0
-;   ld t0, 0xc(t0)
+;   auipc a4, 0
+;   ld a4, 0xc(a4)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_rets 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   jalr t0
+;   jalr a4
 ;   ld a5, 0(sp)
 ;   ld a1, 8(sp)
 ;   ld a3, 0x10(sp)
@@ -876,10 +876,10 @@ block0:
 ;   sd a1,136(sp)
 ;   load_addr a0,160(sp)
 ;   sd a0,144(sp)
-;   load_sym t0,%tail_callee_stack_args_and_rets+0
+;   load_sym t1,%tail_callee_stack_args_and_rets+0
 ;   ld a0,8(nominal_sp)
 ;   ld a1,0(nominal_sp)
-;   callind t0
+;   callind t1
 ;   addi sp,sp,-160
 ;   virtual_sp_offset_adj +160
 ;   ld a4,160(sp)
@@ -990,14 +990,14 @@ block0:
 ;   sd a1, 0x88(sp)
 ;   addi a0, sp, 0xa0
 ;   sd a0, 0x90(sp)
-;   auipc t0, 0
-;   ld t0, 0xc(t0)
+;   auipc t1, 0
+;   ld t1, 0xc(t1)
 ;   j 0xc
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args_and_rets 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ld a0, 0x168(sp)
 ;   ld a1, 0x160(sp)
-;   jalr t0
+;   jalr t1
 ;   addi sp, sp, -0xa0
 ;   ld a4, 0xa0(sp)
 ;   ld a0, 0xa8(sp)

--- a/cranelift/filetests/filetests/isa/riscv64/zca.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/zca.clif
@@ -183,8 +183,8 @@ block0(v0: i8):
 ;   sd fp,0(sp)
 ;   mv fp,sp
 ; block0:
-;   load_sym a2,%callee_i8+0
-;   return_call_ind a2 new_stack_arg_size:0 s1=s1
+;   load_sym t0,%callee_i8+0
+;   return_call_ind t0 new_stack_arg_size:0 a0=a0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -193,8 +193,8 @@ block0(v0: i8):
 ;   c.sdsp s0, 0(sp)
 ;   c.mv s0, sp
 ; block1: ; offset 0x8
-;   auipc a2, 0
-;   ld a2, 0xa(a2)
+;   auipc t0, 0
+;   ld t0, 0xa(t0)
 ;   c.j 0xa
 ;   c.unimp ; reloc_external Abs8 %callee_i8 0
 ;   c.unimp
@@ -203,7 +203,7 @@ block0(v0: i8):
 ;   c.ldsp ra, 8(sp)
 ;   c.ldsp s0, 0(sp)
 ;   c.addi16sp sp, 0x10
-;   c.jr a2
+;   c.jr t0
 
 function %c_ret(i32) -> i32 {
 block0(v0: i32):


### PR DESCRIPTION
Switch to using the same set of callee saved registers as the default calling convention on riscv64. This also introduces the contraint that indirect tail calls store their destination in `t0`, which was an assumption of indirect calls before, but not indirect return calls.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
