### PR TITLE
aarch64: Fixed destination register for return_call_indirect

### DIFF
--- a/cranelift/filetests/filetests/isa/aarch64/call-pauth-bkey.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call-pauth-bkey.clif
@@ -99,8 +99,8 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   load_ext_name x3, TestCase(%g)+0
-;   return_call_ind x3 new_stack_arg_size:0 x2=x2
+;   load_ext_name x1, TestCase(%g)+0
+;   return_call_ind x1 new_stack_arg_size:0 x2=x2
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -108,11 +108,11 @@ block0(v0: i64):
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0xc
-;   ldr x3, #0x14
+;   ldr x1, #0x14
 ;   b #0x1c
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ldp x29, x30, [sp], #0x10
 ;   autibz
-;   br x3
+;   br x1
 

--- a/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/call-pauth.clif
@@ -100,8 +100,8 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   load_ext_name x3, TestCase(%g)+0
-;   return_call_ind x3 new_stack_arg_size:0 x2=x2
+;   load_ext_name x1, TestCase(%g)+0
+;   return_call_ind x1 new_stack_arg_size:0 x2=x2
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -109,11 +109,11 @@ block0(v0: i64):
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0xc
-;   ldr x3, #0x14
+;   ldr x1, #0x14
 ;   b #0x1c
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %g 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ldp x29, x30, [sp], #0x10
 ;   autiaz
-;   br x3
+;   br x1
 

--- a/cranelift/filetests/filetests/isa/aarch64/fuzzbug-60035.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/fuzzbug-60035.clif
@@ -15,15 +15,12 @@ block0:
 ; VCode:
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
-;   str x20, [sp, #-16]!
+;   str x19, [sp, #-16]!
 ; block0:
-;   load_ext_name x1, User(userextname0)+0
-;   mov x20, x1
-;   mov x1, x20
-;   blr x1
-;   mov x1, x20
-;   blr x1
-;   ldr x20, [sp], #16
+;   load_ext_name x19, User(userextname0)+0
+;   blr x19
+;   blr x19
+;   ldr x19, [sp], #16
 ;   ldp fp, lr, [sp], #16
 ;   ret
 ;
@@ -31,18 +28,15 @@ block0:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
-;   str x20, [sp, #-0x10]!
+;   str x19, [sp, #-0x10]!
 ; block1: ; offset 0xc
-;   ldr x1, #0x14
+;   ldr x19, #0x14
 ;   b #0x1c
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 u1:7 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   mov x20, x1
-;   mov x1, x20
-;   blr x1
-;   mov x1, x20
-;   blr x1
-;   ldr x20, [sp], #0x10
+;   blr x19
+;   blr x19
+;   ldr x19, [sp], #0x10
 ;   ldp x29, x30, [sp], #0x10
 ;   ret
 

--- a/cranelift/filetests/filetests/isa/aarch64/return-call-indirect.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/return-call-indirect.clif
@@ -33,20 +33,20 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   load_ext_name x3, TestCase(%callee_i64)+0
-;   return_call_ind x3 new_stack_arg_size:0 x2=x2
+;   load_ext_name x1, TestCase(%callee_i64)+0
+;   return_call_ind x1 new_stack_arg_size:0 x2=x2
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0x8
-;   ldr x3, #0x10
+;   ldr x1, #0x10
 ;   b #0x18
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i64 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ldp x29, x30, [sp], #0x10
-;   br x3
+;   br x1
 
 ;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -63,20 +63,20 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   load_ext_name x3, TestCase(%callee_i64)+0
-;   return_call_ind x3 new_stack_arg_size:0 x2=x2
+;   load_ext_name x1, TestCase(%callee_i64)+0
+;   return_call_ind x1 new_stack_arg_size:0 x2=x2
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0x8
-;   ldr x3, #0x10
+;   ldr x1, #0x10
 ;   b #0x18
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i64 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ldp x29, x30, [sp], #0x10
-;   br x3
+;   br x1
 
 ;;;; Test passing `f64`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -112,20 +112,20 @@ block0(v0: f64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   load_ext_name x2, TestCase(%callee_f64)+0
-;   return_call_ind x2 new_stack_arg_size:0 v0=v0
+;   load_ext_name x1, TestCase(%callee_f64)+0
+;   return_call_ind x1 new_stack_arg_size:0 v0=v0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0x8
-;   ldr x2, #0x10
+;   ldr x1, #0x10
 ;   b #0x18
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_f64 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ldp x29, x30, [sp], #0x10
-;   br x2
+;   br x1
 
 ;;;; Test passing `i8`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -163,20 +163,20 @@ block0(v0: i8):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   load_ext_name x3, TestCase(%callee_i8)+0
-;   return_call_ind x3 new_stack_arg_size:0 x2=x2
+;   load_ext_name x1, TestCase(%callee_i8)+0
+;   return_call_ind x1 new_stack_arg_size:0 x2=x2
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0x8
-;   ldr x3, #0x10
+;   ldr x1, #0x10
 ;   b #0x18
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i8 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ldp x29, x30, [sp], #0x10
-;   br x3
+;   br x1
 
 ;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -276,9 +276,9 @@ block0:
 ;   str x23, [sp, #248]
 ;   str x24, [sp, #256]
 ;   str x25, [sp, #264]
-;   mov x10, x2
+;   mov x1, x2
 ;   ldr x2, [sp]
-;   return_call_ind x10 new_stack_arg_size:160 x2=x2 x3=x3 x4=x4 x5=x5 x6=x6 x7=x7
+;   return_call_ind x1 new_stack_arg_size:160 x2=x2 x3=x3 x4=x4 x5=x5 x6=x6 x7=x7
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -346,7 +346,7 @@ block0:
 ;   stur x23, [sp, #0xf8]
 ;   str x24, [sp, #0x100]
 ;   str x25, [sp, #0x108]
-;   mov x10, x2
+;   mov x1, x2
 ;   ldur x2, [sp]
 ;   add sp, sp, #0x10
 ;   ldp x19, x20, [sp], #0x10
@@ -355,5 +355,5 @@ block0:
 ;   ldp x25, x26, [sp], #0x10
 ;   ldp x27, x28, [sp], #0x10
 ;   ldp x29, x30, [sp], #0x10
-;   br x10
+;   br x1
 

--- a/cranelift/filetests/filetests/isa/aarch64/return-call.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/return-call.clif
@@ -31,20 +31,20 @@ block0(v0: i64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   load_ext_name x3, TestCase(%callee_i64)+0
-;   return_call_ind x3 new_stack_arg_size:0 x2=x2
+;   load_ext_name x1, TestCase(%callee_i64)+0
+;   return_call_ind x1 new_stack_arg_size:0 x2=x2
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0x8
-;   ldr x3, #0x10
+;   ldr x1, #0x10
 ;   b #0x18
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i64 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ldp x29, x30, [sp], #0x10
-;   br x3
+;   br x1
 
 ;;;; Test colocated tail calls ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -101,20 +101,20 @@ block0(v0: f64):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   load_ext_name x2, TestCase(%callee_f64)+0
-;   return_call_ind x2 new_stack_arg_size:0 v0=v0
+;   load_ext_name x1, TestCase(%callee_f64)+0
+;   return_call_ind x1 new_stack_arg_size:0 v0=v0
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0x8
-;   ldr x2, #0x10
+;   ldr x1, #0x10
 ;   b #0x18
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_f64 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ldp x29, x30, [sp], #0x10
-;   br x2
+;   br x1
 
 ;;;; Test passing `i8`s ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -150,20 +150,20 @@ block0(v0: i8):
 ;   stp fp, lr, [sp, #-16]!
 ;   mov fp, sp
 ; block0:
-;   load_ext_name x3, TestCase(%callee_i8)+0
-;   return_call_ind x3 new_stack_arg_size:0 x2=x2
+;   load_ext_name x1, TestCase(%callee_i8)+0
+;   return_call_ind x1 new_stack_arg_size:0 x2=x2
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
 ;   stp x29, x30, [sp, #-0x10]!
 ;   mov x29, sp
 ; block1: ; offset 0x8
-;   ldr x3, #0x10
+;   ldr x1, #0x10
 ;   b #0x18
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %callee_i8 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
 ;   ldp x29, x30, [sp], #0x10
-;   br x3
+;   br x1
 
 ;;;; Test passing many arguments on stack ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -321,8 +321,8 @@ block0:
 ;   str x23, [sp, #232]
 ;   str x24, [sp, #240]
 ;   str x25, [sp, #248]
-;   load_ext_name x14, TestCase(%tail_callee_stack_args)+0
-;   return_call_ind x14 new_stack_arg_size:160 x2=x2 x3=x3 x4=x4 x5=x5 x6=x6 x7=x7
+;   load_ext_name x1, TestCase(%tail_callee_stack_args)+0
+;   return_call_ind x1 new_stack_arg_size:160 x2=x2 x3=x3 x4=x4 x5=x5 x6=x6 x7=x7
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -384,7 +384,7 @@ block0:
 ;   stur x23, [sp, #0xe8]
 ;   stur x24, [sp, #0xf0]
 ;   stur x25, [sp, #0xf8]
-;   ldr x14, #0xec
+;   ldr x1, #0xec
 ;   b #0xf4
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
@@ -394,7 +394,7 @@ block0:
 ;   ldp x25, x26, [sp], #0x10
 ;   ldp x27, x28, [sp], #0x10
 ;   ldp x29, x30, [sp], #0x10
-;   br x14
+;   br x1
 
 ;;;; Test diff blocks with diff return calls with diff # of stack args ;;;;;;;;;
 
@@ -630,9 +630,9 @@ block2:
 ;   str x15, [sp, #256]
 ;   str x14, [sp, #264]
 ;   str x2, [sp, #272]
-;   load_ext_name x8, TestCase(%different_callee2)+0
+;   load_ext_name x1, TestCase(%different_callee2)+0
 ;   ldr x2, [sp]
-;   return_call_ind x8 new_stack_arg_size:176 x2=x2 x3=x3 x4=x4 x5=x5 x6=x6 x7=x7
+;   return_call_ind x1 new_stack_arg_size:176 x2=x2 x3=x3 x4=x4 x5=x5 x6=x6 x7=x7
 ; block2:
 ;   ldr x2, [sp]
 ;   str x21, [sp, #128]
@@ -655,8 +655,8 @@ block2:
 ;   str x0, [sp, #264]
 ;   str x15, [sp, #272]
 ;   str x14, [sp, #280]
-;   load_ext_name x9, TestCase(%different_callee1)+0
-;   return_call_ind x9 new_stack_arg_size:160 x2=x2 x3=x3 x4=x4 x5=x5 x6=x6 x7=x7
+;   load_ext_name x1, TestCase(%different_callee1)+0
+;   return_call_ind x1 new_stack_arg_size:160 x2=x2 x3=x3 x4=x4 x5=x5 x6=x6 x7=x7
 ;
 ; Disassembled:
 ; block0: ; offset 0x0
@@ -724,7 +724,7 @@ block2:
 ;   str x15, [sp, #0x100]
 ;   str x14, [sp, #0x108]
 ;   str x2, [sp, #0x110]
-;   ldr x8, #0x100
+;   ldr x1, #0x100
 ;   b #0x108
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %different_callee2 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
@@ -736,7 +736,7 @@ block2:
 ;   ldp x25, x26, [sp], #0x10
 ;   ldp x27, x28, [sp], #0x10
 ;   ldp x29, x30, [sp], #0x10
-;   br x8
+;   br x1
 ; block3: ; offset 0x12c
 ;   ldur x2, [sp]
 ;   stur x21, [sp, #0x80]
@@ -759,7 +759,7 @@ block2:
 ;   str x0, [sp, #0x108]
 ;   str x15, [sp, #0x110]
 ;   str x14, [sp, #0x118]
-;   ldr x9, #0x188
+;   ldr x1, #0x188
 ;   b #0x190
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %different_callee1 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
@@ -771,5 +771,5 @@ block2:
 ;   ldp x27, x28, [sp], #0x10
 ;   ldp x29, x30, [sp], #0x10
 ;   add sp, sp, #0x10
-;   br x9
+;   br x1
 

--- a/cranelift/filetests/filetests/isa/aarch64/tail-call-conv.clif
+++ b/cranelift/filetests/filetests/isa/aarch64/tail-call-conv.clif
@@ -156,8 +156,8 @@ block0:
 ;   str x24, [sp, #136]
 ;   str x25, [sp, #144]
 ;   str x26, [sp, #152]
-;   load_ext_name x1, TestCase(%tail_callee_stack_args)+0
-;   blr x1
+;   load_ext_name x15, TestCase(%tail_callee_stack_args)+0
+;   blr x15
 ;   sub sp, sp, #160
 ;   virtual_sp_offset_adjust 160
 ;   add sp, sp, #160
@@ -226,11 +226,11 @@ block0:
 ;   stur x24, [sp, #0x88]
 ;   stur x25, [sp, #0x90]
 ;   stur x26, [sp, #0x98]
-;   ldr x1, #0xe0
+;   ldr x15, #0xe0
 ;   b #0xe8
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   blr x1
+;   blr x15
 ;   sub sp, sp, #0xa0
 ;   add sp, sp, #0xa0
 ;   ldp x19, x20, [sp], #0x10
@@ -424,8 +424,8 @@ block0:
 ;   virtual_sp_offset_adjust 160
 ; block0:
 ;   mov x0, sp
-;   load_ext_name x1, TestCase(%tail_callee_stack_rets)+0
-;   blr x1
+;   load_ext_name x12, TestCase(%tail_callee_stack_rets)+0
+;   blr x12
 ;   ldr x9, [sp]
 ;   ldr x11, [sp, #8]
 ;   ldr x13, [sp, #16]
@@ -457,11 +457,11 @@ block0:
 ;   sub sp, sp, #0xa0
 ; block1: ; offset 0xc
 ;   mov x0, sp
-;   ldr x1, #0x18
+;   ldr x12, #0x18
 ;   b #0x20
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_rets 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   blr x1
+;   blr x12
 ;   ldur x9, [sp]
 ;   ldur x11, [sp, #8]
 ;   ldur x13, [sp, #0x10]
@@ -711,8 +711,8 @@ block0:
 ;   str x20, [sp, #144]
 ;   str x22, [sp, #152]
 ;   add x0, sp, #160
-;   load_ext_name x1, TestCase(%tail_callee_stack_args_and_rets)+0
-;   blr x1
+;   load_ext_name x10, TestCase(%tail_callee_stack_args_and_rets)+0
+;   blr x10
 ;   sub sp, sp, #160
 ;   virtual_sp_offset_adjust 160
 ;   ldr x9, [sp, #160]
@@ -802,11 +802,11 @@ block0:
 ;   stur x20, [sp, #0x90]
 ;   stur x22, [sp, #0x98]
 ;   add x0, sp, #0xa0
-;   ldr x1, #0xe4
+;   ldr x10, #0xe4
 ;   b #0xec
 ;   .byte 0x00, 0x00, 0x00, 0x00 ; reloc_external Abs8 %tail_callee_stack_args_and_rets 0
 ;   .byte 0x00, 0x00, 0x00, 0x00
-;   blr x1
+;   blr x10
 ;   sub sp, sp, #0xa0
 ;   ldur x9, [sp, #0xa0]
 ;   ldur x11, [sp, #0xa8]


### PR DESCRIPTION
After switching to using callee-saved registers with the tail calling convention on aarch64, we missed using a fixed constraint for the destination of indirect return calls. This omission introduces a situation where the destination could be placed in a callee-saved register, and then clobbered as part of the call to `emit_return_call_common_sequence`.

This PR fixes the problem by always using `x1` for return call destinations, and relaxes the same constraint on indirect calls of tail call functions, as callee-saved registers can be used for normal indirect calls now.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
