### PR TITLE
x64: Add AVX-encoded versions of `ucomis{s,d}` and `ptest`

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2820,11 +2820,9 @@
 ;; Helper for creating floating-point comparison instructions (`UCOMIS[S|D]`).
 (decl x64_ucomis (Value Value) ProducesFlags)
 (rule (x64_ucomis src1 @ (value_type $F32) src2)
-      ;; N.B.: cmp can be generated more than once, so cannot do a
-      ;; load-op merge. So `put_in_xmm` for src1, not `put_in_xmm_mem`.
-      (xmm_cmp_rm_r (SseOpcode.Ucomiss) (put_in_xmm src1) (put_in_xmm src2)))
+      (xmm_cmp_rm_r (SseOpcode.Ucomiss) src1 src2))
 (rule (x64_ucomis src1 @ (value_type $F64) src2)
-      (xmm_cmp_rm_r (SseOpcode.Ucomisd) (put_in_xmm src1) (put_in_xmm src2)))
+      (xmm_cmp_rm_r (SseOpcode.Ucomisd) src1 src2))
 
 ;; Helper for creating `test` instructions.
 (decl x64_test (OperandSize GprMemImm Gpr) ProducesFlags)

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -2818,10 +2818,10 @@
        (MInst.XmmCmpRmR opcode src1 src2)))
 
 ;; Helper for creating floating-point comparison instructions (`UCOMIS[S|D]`).
-(decl x64_ucomis (Value Value) ProducesFlags)
-(rule (x64_ucomis src1 @ (value_type $F32) src2)
+(decl x64_ucomis (Type Xmm XmmMem) ProducesFlags)
+(rule (x64_ucomis $F32 src1 src2)
       (xmm_cmp_rm_r (SseOpcode.Ucomiss) src1 src2))
-(rule (x64_ucomis src1 @ (value_type $F64) src2)
+(rule (x64_ucomis $F64 src1 src2)
       (xmm_cmp_rm_r (SseOpcode.Ucomisd) src1 src2))
 
 ;; Helper for creating `test` instructions.
@@ -4879,46 +4879,46 @@
 ;;  - equal assigns        Z = 1, P = 0, C = 0
 (decl emit_fcmp (FloatCC Value Value) FcmpCondResult)
 
-(rule (emit_fcmp (FloatCC.Equal) a @ (value_type (ty_scalar_float _)) b)
-      (FcmpCondResult.AndCondition (x64_ucomis a b) (CC.NP) (CC.Z)))
+(rule (emit_fcmp (FloatCC.Equal) a @ (value_type (ty_scalar_float ty)) b)
+      (FcmpCondResult.AndCondition (x64_ucomis ty a b) (CC.NP) (CC.Z)))
 
-(rule (emit_fcmp (FloatCC.NotEqual) a @ (value_type (ty_scalar_float _)) b)
-      (FcmpCondResult.OrCondition (x64_ucomis a b) (CC.P) (CC.NZ)))
+(rule (emit_fcmp (FloatCC.NotEqual) a @ (value_type (ty_scalar_float ty)) b)
+      (FcmpCondResult.OrCondition (x64_ucomis ty a b) (CC.P) (CC.NZ)))
 
 ;; Some scalar lowerings correspond to one condition code.
 
 (rule (emit_fcmp (FloatCC.Ordered) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis a b) (CC.NP)))
+      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.NP)))
 (rule (emit_fcmp (FloatCC.Unordered) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis a b) (CC.P)))
+      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.P)))
 (rule (emit_fcmp (FloatCC.OrderedNotEqual) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis a b) (CC.NZ)))
+      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.NZ)))
 (rule (emit_fcmp (FloatCC.UnorderedOrEqual) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis a b) (CC.Z)))
+      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.Z)))
 (rule (emit_fcmp (FloatCC.GreaterThan) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis a b) (CC.NBE)))
+      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.NBE)))
 (rule (emit_fcmp (FloatCC.GreaterThanOrEqual) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis a b) (CC.NB)))
+      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.NB)))
 (rule (emit_fcmp (FloatCC.UnorderedOrLessThan) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis a b) (CC.B)))
+      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.B)))
 (rule (emit_fcmp (FloatCC.UnorderedOrLessThanOrEqual) a @ (value_type (ty_scalar_float ty)) b)
-      (FcmpCondResult.Condition (x64_ucomis a b) (CC.BE)))
+      (FcmpCondResult.Condition (x64_ucomis ty a b) (CC.BE)))
 
 ;; Other scalar lowerings are made possible by flipping the operands and
 ;; reversing the condition code.
 
 (rule (emit_fcmp (FloatCC.LessThan) a @ (value_type (ty_scalar_float ty)) b)
       ;; Same flags as `GreaterThan`.
-      (FcmpCondResult.Condition (x64_ucomis b a) (CC.NBE)))
+      (FcmpCondResult.Condition (x64_ucomis ty b a) (CC.NBE)))
 (rule (emit_fcmp (FloatCC.LessThanOrEqual) a @ (value_type (ty_scalar_float ty)) b)
       ;; Same flags as `GreaterThanOrEqual`.
-      (FcmpCondResult.Condition (x64_ucomis b a) (CC.NB)))
+      (FcmpCondResult.Condition (x64_ucomis ty b a) (CC.NB)))
 (rule (emit_fcmp (FloatCC.UnorderedOrGreaterThan) a @ (value_type (ty_scalar_float ty)) b)
       ;; Same flags as `UnorderedOrLessThan`.
-      (FcmpCondResult.Condition (x64_ucomis b a) (CC.B)))
+      (FcmpCondResult.Condition (x64_ucomis ty b a) (CC.B)))
 (rule (emit_fcmp (FloatCC.UnorderedOrGreaterThanOrEqual) a @ (value_type (ty_scalar_float ty)) b)
       ;; Same flags as `UnorderedOrLessThanOrEqual`.
-      (FcmpCondResult.Condition (x64_ucomis b a) (CC.BE)))
+      (FcmpCondResult.Condition (x64_ucomis ty b a) (CC.BE)))
 
 ;;;; Type Guards ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -367,6 +367,10 @@
                     (dst WritableGpr)
                     (dst_size OperandSize))
 
+       ;; Float comparisons/tests: cmp (b w l q) (reg addr imm) reg.
+       (XmmCmpRmRVex (op AvxOpcode)
+                     (src1 Xmm)
+                     (src2 XmmMem))
 
        ;; XMM (scalar or vector) binary op that relies on the EVEX
        ;; prefix. Takes two inputs.
@@ -1413,6 +1417,9 @@
             Vsqrtsd
             Vroundss
             Vroundsd
+            Vucomiss
+            Vucomisd
+            Vptest
           ))
 
 (type Avx512Opcode
@@ -2817,12 +2824,24 @@
       (ProducesFlags.ProducesFlagsSideEffect
        (MInst.XmmCmpRmR opcode src1 src2)))
 
+;; Helper for creating `MInst.XmmCmpRmRVex` instructions.
+(decl xmm_cmp_rm_r_vex (AvxOpcode Xmm XmmMem) ProducesFlags)
+(rule (xmm_cmp_rm_r_vex opcode src1 src2)
+      (ProducesFlags.ProducesFlagsSideEffect
+       (MInst.XmmCmpRmRVex opcode src1 src2)))
+
 ;; Helper for creating floating-point comparison instructions (`UCOMIS[S|D]`).
 (decl x64_ucomis (Type Xmm XmmMem) ProducesFlags)
 (rule (x64_ucomis $F32 src1 src2)
       (xmm_cmp_rm_r (SseOpcode.Ucomiss) src1 src2))
 (rule (x64_ucomis $F64 src1 src2)
       (xmm_cmp_rm_r (SseOpcode.Ucomisd) src1 src2))
+(rule 1 (x64_ucomis $F32 src1 src2)
+        (if-let $true (use_avx))
+        (xmm_cmp_rm_r_vex (AvxOpcode.Vucomiss) src1 src2))
+(rule 1 (x64_ucomis $F64 src1 src2)
+        (if-let $true (use_avx))
+        (xmm_cmp_rm_r_vex (AvxOpcode.Vucomisd) src1 src2))
 
 ;; Helper for creating `test` instructions.
 (decl x64_test (OperandSize GprMemImm Gpr) ProducesFlags)
@@ -2833,6 +2852,9 @@
 (decl x64_ptest (Xmm XmmMem) ProducesFlags)
 (rule (x64_ptest src1 src2)
       (xmm_cmp_rm_r (SseOpcode.Ptest) src1 src2))
+(rule 1 (x64_ptest src1 src2)
+        (if-let $true (use_avx))
+        (xmm_cmp_rm_r_vex (AvxOpcode.Vptest) src1 src2))
 
 ;; Helper for creating `cmove` instructions. Note that these instructions do not
 ;; always result in a single emitted x86 instruction; e.g., XmmCmove uses jumps

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -1814,7 +1814,10 @@ impl AvxOpcode {
             | AvxOpcode::Vsqrtsd
             | AvxOpcode::Vroundss
             | AvxOpcode::Vroundsd
-            | AvxOpcode::Vunpcklpd => {
+            | AvxOpcode::Vunpcklpd
+            | AvxOpcode::Vptest
+            | AvxOpcode::Vucomiss
+            | AvxOpcode::Vucomisd => {
                 smallvec![InstructionSet::AVX]
             }
 

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -191,7 +191,8 @@ impl Inst {
             | Inst::XmmToGprImmVex { op, .. }
             | Inst::XmmToGprVex { op, .. }
             | Inst::GprToXmmVex { op, .. }
-            | Inst::CvtIntToFloatVex { op, .. } => op.available_from(),
+            | Inst::CvtIntToFloatVex { op, .. }
+            | Inst::XmmCmpRmRVex { op, .. } => op.available_from(),
         }
     }
 }
@@ -1351,6 +1352,12 @@ impl PrettyPrint for Inst {
                 format!("{op} {src1}, {src2}, {dst}")
             }
 
+            Inst::XmmCmpRmRVex { op, src1, src2 } => {
+                let src1 = pretty_print_reg(src1.to_reg(), 8, allocs);
+                let src2 = src2.pretty_print(8, allocs);
+                format!("{} {src2}, {src1}", ljustify(op.to_string()))
+            }
+
             Inst::CvtUint64ToFloatSeq {
                 src,
                 dst,
@@ -2156,6 +2163,10 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &Inst, collector: &mut OperandCol
             dst.get_operands(collector);
         }
         Inst::XmmCmpRmR { src1, src2, .. } => {
+            collector.reg_use(src1.to_reg());
+            src2.get_operands(collector);
+        }
+        Inst::XmmCmpRmRVex { src1, src2, .. } => {
             collector.reg_use(src1.to_reg());
             src2.get_operands(collector);
         }

--- a/cranelift/codegen/src/isa/x64/pcc.rs
+++ b/cranelift/codegen/src/isa/x64/pcc.rs
@@ -813,6 +813,18 @@ pub(crate) fn check(
             ensure_no_fact(vcode, dst.to_reg())
         }
 
+        Inst::XmmCmpRmRVex {
+            ref src1, ref src2, ..
+        } => {
+            match <&RegMem>::from(src2) {
+                RegMem::Mem { ref addr } => {
+                    check_load(ctx, None, addr, vcode, F32, 32)?;
+                }
+                RegMem::Reg { .. } => {}
+            }
+            ensure_no_fact(vcode, src1.to_reg())
+        }
+
         Inst::CallKnown { .. }
         | Inst::ReturnCallKnown { .. }
         | Inst::JmpKnown { .. }

--- a/cranelift/filetests/filetests/isa/x64/branches.clif
+++ b/cranelift/filetests/filetests/isa/x64/branches.clif
@@ -630,15 +630,13 @@ block202:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   movl    $1112539136, %eax
-;   movd    %eax, %xmm4
-;   ucomiss %xmm4, %xmm0
+;   ucomiss const(1), %xmm0
 ;   jp      label2
 ;   jnz     label2; j label1
 ; block1:
 ;   jmp     label5
 ; block2:
-;   ucomiss %xmm4, %xmm0
+;   ucomiss const(0), %xmm0
 ;   jnp     label4; j label3
 ; block3:
 ;   jmp     label5
@@ -654,20 +652,36 @@ block202:
 ;   pushq %rbp
 ;   movq %rsp, %rbp
 ; block1: ; offset 0x4
-;   movl $0x42500000, %eax
-;   movd %eax, %xmm4
-;   ucomiss %xmm4, %xmm0
-;   jp 0x1c
-;   je 0x27
-; block2: ; offset 0x1c
-;   ucomiss %xmm4, %xmm0
-;   jp 0x27
-; block3: ; offset 0x25
+;   ucomiss 0x25(%rip), %xmm0
+;   jp 0x17
+;   je 0x26
+; block2: ; offset 0x17
+;   ucomiss 0x22(%rip), %xmm0
+;   jp 0x26
+; block3: ; offset 0x24
 ;   ud2 ; trap: heap_oob
-; block4: ; offset 0x27
+; block4: ; offset 0x26
 ;   movq %rbp, %rsp
 ;   popq %rbp
 ;   retq
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %dl, 0x42(%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   pushq %rax
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
+;   addb %al, (%rax)
 
 function %br_i8_icmp(i32, i32) -> i32 {
 block0(v0: i32, v1: i32):

--- a/cranelift/filetests/filetests/isa/x64/f64-branches-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/f64-branches-avx.clif
@@ -1,0 +1,105 @@
+test compile precise-output
+target x86_64 has_avx
+
+function %f3(f32, f32) -> i32 {
+block0(v0: f32, v1: f32):
+  v2 = fcmp eq v0, v1
+  brif v2, block1, block2
+
+block1:
+  v3 = iconst.i32 1
+  return v3
+
+block2:
+  v4 = iconst.i32 2
+  return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   vucomiss %xmm0, %xmm1
+;   jp      label1
+;   jnz     label1; j label2
+; block1:
+;   movl    $2, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; block2:
+;   movl    $1, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   vucomiss %xmm1, %xmm0
+;   jp 0x14
+;   je 0x1e
+; block2: ; offset 0x14
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3: ; offset 0x1e
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %f3(f64, f64) -> i32 {
+block0(v0: f64, v1: f64):
+  v2 = fcmp eq v0, v1
+  brif v2, block1, block2
+
+block1:
+  v3 = iconst.i32 1
+  return v3
+
+block2:
+  v4 = iconst.i32 2
+  return v4
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   vucomisd %xmm0, %xmm1
+;   jp      label1
+;   jnz     label1; j label2
+; block1:
+;   movl    $2, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+; block2:
+;   movl    $1, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   vucomisd %xmm1, %xmm0
+;   jp 0x14
+;   je 0x1e
+; block2: ; offset 0x14
+;   movl $2, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+; block3: ; offset 0x1e
+;   movl $1, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/f64-branches-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/f64-branches-avx.clif
@@ -19,7 +19,7 @@ block2:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vucomiss %xmm0, %xmm1
+;   vucomiss %xmm1, %xmm0
 ;   jp      label1
 ;   jnz     label1; j label2
 ; block1:
@@ -70,7 +70,7 @@ block2:
 ;   pushq   %rbp
 ;   movq    %rsp, %rbp
 ; block0:
-;   vucomisd %xmm0, %xmm1
+;   vucomisd %xmm1, %xmm0
 ;   jp      label1
 ;   jnz     label1; j label2
 ; block1:

--- a/cranelift/filetests/filetests/isa/x64/simd-logical-compile-avx.clif
+++ b/cranelift/filetests/filetests/isa/x64/simd-logical-compile-avx.clif
@@ -1,0 +1,62 @@
+test compile precise-output
+target x86_64 sse42 has_avx
+
+function %vany_true_i32x4(i32x4) -> i8 {
+block0(v0: i32x4):
+    v1 = vany_true v0
+    return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   vptest  %xmm0, %xmm0
+;   setnz   %al
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   vptest %xmm0, %xmm0
+;   setne %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %vall_true_i64x2(i64x2) -> i8 {
+block0(v0: i64x2):
+    v1 = vall_true v0
+    return v1
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   uninit  %xmm2
+;   vpxor   %xmm2, %xmm2, %xmm4
+;   vpcmpeqq %xmm0, %xmm4, %xmm6
+;   vptest  %xmm6, %xmm6
+;   setz    %al
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   vpxor %xmm2, %xmm2, %xmm4
+;   vpcmpeqq %xmm4, %xmm0, %xmm6
+;   vptest %xmm6, %xmm6
+;   sete %al
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+

--- a/cranelift/filetests/filetests/isa/x64/very-carefully-sink-loads-in-float-compares.clif
+++ b/cranelift/filetests/filetests/isa/x64/very-carefully-sink-loads-in-float-compares.clif
@@ -1,0 +1,499 @@
+test compile precise-output
+target x86_64
+
+;; This test ensures that Cranelift does not attempt to too eagerly sink loads
+;; into float comparison operations. When a single `fcmp` is used multiple times
+;; it'll regenerate `ucomiss` instructions, for example, but if this duplication
+;; happens then it shouldn't have a load sunk into it because that would load
+;; at two different points in the program, possibly seeing two different
+;; results.
+;;
+;; Exactly how this guarantee is provided has changed a bit over time with
+;; Cranelift. Originally in #3934 this was done explicitly in ISLE by avoiding
+;; the use of `put_in_xmm_mem`. Later in #4061 that ended up removing the need
+;; for the safeguards in #3934. Today there are no guards in ISLE for this any
+;; more and this test is intended to serve as a reference-test for notifying
+;; reviewers if anything changes.
+
+function %select_cond_rhs(f32, i64, i32, i32) -> i32 {
+block0(v0: f32, v1: i64, v2: i32, v3: i32):
+  v4 = load.f32 notrap aligned v1
+  v5 = fcmp eq v0, v4
+  v6 = select v5, v2, v3
+  return v6
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   ucomiss 0(%rdi), %xmm0
+;   cmovpl  %edx, %esi, %esi
+;   movq    %rsi, %rax
+;   cmovnzl %edx, %eax, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   ucomiss (%rdi), %xmm0
+;   cmovpl %edx, %esi
+;   movq %rsi, %rax
+;   cmovnel %edx, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+
+function %select_cond_lhs(f32, i64, i32, i32) -> i32 {
+block0(v0: f32, v1: i64, v2: i32, v3: i32):
+  v4 = load.f32 notrap aligned v1
+  v5 = fcmp eq v4, v0
+  v6 = select v5, v2, v3
+  return v6
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   0(%rdi), %xmm7
+;   ucomiss %xmm0, %xmm7
+;   cmovpl  %edx, %esi, %esi
+;   movq    %rsi, %rax
+;   cmovnzl %edx, %eax, %eax
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movss (%rdi), %xmm7
+;   ucomiss %xmm0, %xmm7
+;   cmovpl %edx, %esi
+;   movq %rsi, %rax
+;   cmovnel %edx, %eax
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %select_cond_used_twice_rhs(f32, i64, i32, i32) -> i32, i32 {
+block0(v0: f32, v1: i64, v2: i32, v3: i32):
+  ;; this load should NOT sink into either `select` below
+  v4 = load.f32 notrap aligned v1
+  v5 = fcmp eq v0, v4
+  v6 = select v5, v2, v3
+  v7 = select v5, v3, v2
+  return v6, v7
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   0(%rdi), %xmm1
+;   ucomiss %xmm1, %xmm0
+;   movq    %rsi, %rax
+;   cmovpl  %edx, %eax, %eax
+;   cmovnzl %edx, %eax, %eax
+;   ucomiss %xmm1, %xmm0
+;   cmovpl  %esi, %edx, %edx
+;   cmovnzl %esi, %edx, %edx
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movss (%rdi), %xmm1
+;   ucomiss %xmm1, %xmm0
+;   movq %rsi, %rax
+;   cmovpl %edx, %eax
+;   cmovnel %edx, %eax
+;   ucomiss %xmm1, %xmm0
+;   cmovpl %esi, %edx
+;   cmovnel %esi, %edx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+
+function %select_cond_used_twice_lhs(f32, i64, i32, i32) -> i32, i32 {
+block0(v0: f32, v1: i64, v2: i32, v3: i32):
+  ;; this load should NOT sink into either `select` below
+  v4 = load.f32 notrap aligned v1
+  v5 = fcmp eq v4, v0
+  v6 = select v5, v2, v3
+  v7 = select v5, v3, v2
+  return v6, v7
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   0(%rdi), %xmm1
+;   ucomiss %xmm0, %xmm1
+;   movq    %rsi, %rax
+;   cmovpl  %edx, %eax, %eax
+;   cmovnzl %edx, %eax, %eax
+;   ucomiss %xmm0, %xmm1
+;   cmovpl  %esi, %edx, %edx
+;   cmovnzl %esi, %edx, %edx
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movss (%rdi), %xmm1
+;   ucomiss %xmm0, %xmm1
+;   movq %rsi, %rax
+;   cmovpl %edx, %eax
+;   cmovnel %edx, %eax
+;   ucomiss %xmm0, %xmm1
+;   cmovpl %esi, %edx
+;   cmovnel %esi, %edx
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %brif_cond_rhs(f32, i64, i32, i32) -> i32 {
+block0(v0: f32, v1: i64, v2: i32, v3: i32):
+  v4 = load.f32 notrap aligned v1
+  v5 = fcmp eq v0, v4
+  brif v5, block1(v2), block1(v3)
+block1(v8: i32):
+  return v8
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   0(%rdi), %xmm1
+;   ucomiss %xmm1, %xmm0
+;   jp      label2
+;   jnz     label2; j label1
+; block1:
+;   movq    %rsi, %rax
+;   jmp     label3
+; block2:
+;   movq    %rdx, %rax
+;   jmp     label3
+; block3:
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movss (%rdi), %xmm1
+;   ucomiss %xmm1, %xmm0
+;   jp 0x1f
+;   jne 0x1f
+; block2: ; offset 0x17
+;   movq %rsi, %rax
+;   jmp 0x22
+; block3: ; offset 0x1f
+;   movq %rdx, %rax
+; block4: ; offset 0x22
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %brif_cond_lhs(f32, i64, i32, i32) -> i32 {
+block0(v0: f32, v1: i64, v2: i32, v3: i32):
+  v4 = load.f32 notrap aligned v1
+  v5 = fcmp eq v4, v0
+  brif v5, block1(v2), block1(v3)
+block1(v8: i32):
+  return v8
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   0(%rdi), %xmm1
+;   ucomiss %xmm0, %xmm1
+;   jp      label2
+;   jnz     label2; j label1
+; block1:
+;   movq    %rsi, %rax
+;   jmp     label3
+; block2:
+;   movq    %rdx, %rax
+;   jmp     label3
+; block3:
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movss (%rdi), %xmm1
+;   ucomiss %xmm0, %xmm1
+;   jp 0x1f
+;   jne 0x1f
+; block2: ; offset 0x17
+;   movq %rsi, %rax
+;   jmp 0x22
+; block3: ; offset 0x1f
+;   movq %rdx, %rax
+; block4: ; offset 0x22
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %brif_cond_used_twice_rhs(f32, i64, i32, i32) -> i32, i32 {
+block0(v0: f32, v1: i64, v2: i32, v3: i32):
+  v4 = load.f32 notrap aligned v1
+  v5 = fcmp eq v0, v4
+  brif v5, block1(v2), block1(v3)
+block1(v6: i32):
+  brif v5, block2(v3), block2(v2)
+block2(v7: i32):
+  return v6, v7
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   0(%rdi), %xmm3
+;   ucomiss %xmm3, %xmm0
+;   jp      label2
+;   jnz     label2; j label1
+; block1:
+;   movq    %rsi, %rax
+;   jmp     label3
+; block2:
+;   movq    %rdx, %rax
+;   jmp     label3
+; block3:
+;   ucomiss %xmm3, %xmm0
+;   jp      label5
+;   jnz     label5; j label4
+; block4:
+;   jmp     label6
+; block5:
+;   movq    %rsi, %rdx
+;   jmp     label6
+; block6:
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movss (%rdi), %xmm3
+;   ucomiss %xmm3, %xmm0
+;   jp 0x1f
+;   jne 0x1f
+; block2: ; offset 0x17
+;   movq %rsi, %rax
+;   jmp 0x22
+; block3: ; offset 0x1f
+;   movq %rdx, %rax
+; block4: ; offset 0x22
+;   ucomiss %xmm3, %xmm0
+;   jp 0x31
+;   je 0x34
+; block5: ; offset 0x31
+;   movq %rsi, %rdx
+; block6: ; offset 0x34
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %brif_cond_used_twice_lhs(f32, i64, i32, i32) -> i32, i32 {
+block0(v0: f32, v1: i64, v2: i32, v3: i32):
+  v4 = load.f32 notrap aligned v1
+  v5 = fcmp eq v4, v0
+  brif v5, block1(v2), block1(v3)
+block1(v6: i32):
+  brif v5, block2(v3), block2(v2)
+block2(v7: i32):
+  return v6, v7
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   0(%rdi), %xmm3
+;   ucomiss %xmm0, %xmm3
+;   jp      label2
+;   jnz     label2; j label1
+; block1:
+;   movq    %rsi, %rax
+;   jmp     label3
+; block2:
+;   movq    %rdx, %rax
+;   jmp     label3
+; block3:
+;   ucomiss %xmm0, %xmm3
+;   jp      label5
+;   jnz     label5; j label4
+; block4:
+;   jmp     label6
+; block5:
+;   movq    %rsi, %rdx
+;   jmp     label6
+; block6:
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movss (%rdi), %xmm3
+;   ucomiss %xmm0, %xmm3
+;   jp 0x1f
+;   jne 0x1f
+; block2: ; offset 0x17
+;   movq %rsi, %rax
+;   jmp 0x22
+; block3: ; offset 0x1f
+;   movq %rdx, %rax
+; block4: ; offset 0x22
+;   ucomiss %xmm0, %xmm3
+;   jp 0x31
+;   je 0x34
+; block5: ; offset 0x31
+;   movq %rsi, %rdx
+; block6: ; offset 0x34
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %mix_select_and_brif_rhs(f32, i64, i32, i32) -> i32, i32 {
+block0(v0: f32, v1: i64, v2: i32, v3: i32):
+  v4 = load.f32 notrap aligned v1
+  v5 = fcmp eq v0, v4
+  v6 = select v5, v2, v3
+  brif v5, block1(v3), block1(v2)
+block1(v7: i32):
+  return v6, v7
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   0(%rdi), %xmm2
+;   ucomiss %xmm2, %xmm0
+;   movq    %rsi, %rax
+;   cmovpl  %edx, %eax, %eax
+;   cmovnzl %edx, %eax, %eax
+;   ucomiss %xmm2, %xmm0
+;   jp      label2
+;   jnz     label2; j label1
+; block1:
+;   jmp     label3
+; block2:
+;   movq    %rsi, %rdx
+;   jmp     label3
+; block3:
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movss (%rdi), %xmm2
+;   ucomiss %xmm2, %xmm0
+;   movq %rsi, %rax
+;   cmovpl %edx, %eax
+;   cmovnel %edx, %eax
+;   ucomiss %xmm2, %xmm0
+;   jp 0x23
+;   je 0x26
+; block2: ; offset 0x23
+;   movq %rsi, %rdx
+; block3: ; offset 0x26
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+
+function %mix_select_and_brif_lhs(f32, i64, i32, i32) -> i32, i32 {
+block0(v0: f32, v1: i64, v2: i32, v3: i32):
+  v4 = load.f32 notrap aligned v1
+  v5 = fcmp eq v4, v0
+  v6 = select v5, v2, v3
+  brif v5, block1(v3), block1(v2)
+block1(v7: i32):
+  return v6, v7
+}
+
+; VCode:
+;   pushq   %rbp
+;   movq    %rsp, %rbp
+; block0:
+;   movss   0(%rdi), %xmm2
+;   ucomiss %xmm0, %xmm2
+;   movq    %rsi, %rax
+;   cmovpl  %edx, %eax, %eax
+;   cmovnzl %edx, %eax, %eax
+;   ucomiss %xmm0, %xmm2
+;   jp      label2
+;   jnz     label2; j label1
+; block1:
+;   jmp     label3
+; block2:
+;   movq    %rsi, %rdx
+;   jmp     label3
+; block3:
+;   movq    %rbp, %rsp
+;   popq    %rbp
+;   ret
+;
+; Disassembled:
+; block0: ; offset 0x0
+;   pushq %rbp
+;   movq %rsp, %rbp
+; block1: ; offset 0x4
+;   movss (%rdi), %xmm2
+;   ucomiss %xmm0, %xmm2
+;   movq %rsi, %rax
+;   cmovpl %edx, %eax
+;   cmovnel %edx, %eax
+;   ucomiss %xmm0, %xmm2
+;   jp 0x23
+;   je 0x26
+; block2: ; offset 0x23
+;   movq %rsi, %rdx
+; block3: ; offset 0x26
+;   movq %rbp, %rsp
+;   popq %rbp
+;   retq
+


### PR DESCRIPTION
This PR finishes the support of AVX instructions in Cranelift (to my knowledge at least). These last few instrucitons were omitted historically because I never got around to sorting the story with comparisons. That's now sorted out, leading to this PR.

Note that this PR is broken into separate commits which lead up to and enable the final change to "drop in" AVX support.