### PR TITLE
Restrict the preview1 implementation of fd_read to one iovec

### DIFF
--- a/crates/wasi-common/tests/all/async_.rs
+++ b/crates/wasi-common/tests/all/async_.rs
@@ -133,6 +133,10 @@ async fn preview1_file_pread_pwrite() {
     run(PREVIEW1_FILE_PREAD_PWRITE, true).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn preview1_file_read_write() {
+    run(PREVIEW1_FILE_READ_WRITE, true).await.unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn preview1_file_seek_tell() {
     run(PREVIEW1_FILE_SEEK_TELL, true).await.unwrap()
 }

--- a/crates/wasi-common/tests/all/sync.rs
+++ b/crates/wasi-common/tests/all/sync.rs
@@ -125,6 +125,10 @@ fn preview1_file_pread_pwrite() {
     run(PREVIEW1_FILE_PREAD_PWRITE, true).unwrap()
 }
 #[test_log::test]
+fn preview1_file_read_write() {
+    run(PREVIEW1_FILE_READ_WRITE, true).unwrap()
+}
+#[test_log::test]
 fn preview1_file_seek_tell() {
     run(PREVIEW1_FILE_SEEK_TELL, true).unwrap()
 }

--- a/crates/wasi/tests/all/async_.rs
+++ b/crates/wasi/tests/all/async_.rs
@@ -99,6 +99,12 @@ async fn preview1_file_pread_pwrite() {
         .unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn preview1_file_read_write() {
+    run(PREVIEW1_FILE_READ_WRITE_COMPONENT, false)
+        .await
+        .unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn preview1_file_seek_tell() {
     run(PREVIEW1_FILE_SEEK_TELL_COMPONENT, false).await.unwrap()
 }

--- a/crates/wasi/tests/all/preview1.rs
+++ b/crates/wasi/tests/all/preview1.rs
@@ -86,6 +86,10 @@ async fn preview1_file_pread_pwrite() {
     run(PREVIEW1_FILE_PREAD_PWRITE, false).await.unwrap()
 }
 #[test_log::test(tokio::test(flavor = "multi_thread"))]
+async fn preview1_file_read_write() {
+    run(PREVIEW1_FILE_READ_WRITE, false).await.unwrap()
+}
+#[test_log::test(tokio::test(flavor = "multi_thread"))]
 async fn preview1_file_seek_tell() {
     run(PREVIEW1_FILE_SEEK_TELL, false).await.unwrap()
 }

--- a/crates/wasi/tests/all/sync.rs
+++ b/crates/wasi/tests/all/sync.rs
@@ -91,6 +91,10 @@ fn preview1_file_pread_pwrite() {
     run(PREVIEW1_FILE_PREAD_PWRITE_COMPONENT, false).unwrap()
 }
 #[test_log::test]
+fn preview1_file_read_write() {
+    run(PREVIEW1_FILE_READ_WRITE_COMPONENT, false).unwrap()
+}
+#[test_log::test]
 fn preview1_file_seek_tell() {
     run(PREVIEW1_FILE_SEEK_TELL_COMPONENT, false).unwrap()
 }


### PR DESCRIPTION
In the wasi-common implementation of `fd_read` for preview1, switch to only reading the first iovec given in a vectored read. This avoids issues with Wiggle's runtime borrow-checker implemented in #8277, which would cause the reads to unconditionally fail when two mutable borrows were taken out on the same memory.

While it's not as efficient to perform a single read at a time, it is also valid, as read never promises to read all of the vectors provided.

Co-authored-by: Nick Fitzgerald <fitzgen@gmail.com>

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
