### PR TITLE
Update nightly used in CI and fix warnings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -249,7 +249,7 @@ jobs:
         submodules: true
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2024-03-21
+        toolchain: nightly-2024-04-19
 
     # Build C API documentation
     - run: curl -L https://sourceforge.net/projects/doxygen/files/rel-1.9.3/doxygen-1.9.3.linux.bin.tar.gz/download | tar xzf -
@@ -452,7 +452,7 @@ jobs:
     # happen upstream. This is periodically updated through a PR.
     - uses: ./.github/actions/install-rust
       with:
-        toolchain: nightly-2024-03-21
+        toolchain: nightly-2024-04-19
 
     # Ensure that fuzzers still build.
     #

--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -61,7 +61,7 @@ for (let build of array) {
   // Next generate a "min" build and add it to the builds list. Min builds
   // require Nightly rust due to some nightly build options that are configured.
   build.build += '-min';
-  build.rust = 'nightly-2024-03-21';
+  build.rust = 'nightly-2024-04-19';
   builds.push(build);
 }
 

--- a/cranelift/codegen/src/ir/instructions.rs
+++ b/cranelift/codegen/src/ir/instructions.rs
@@ -6,6 +6,7 @@
 //! A large part of this module is auto-generated from the instruction descriptions in the meta
 //! directory.
 
+use crate::constant_hash::Table;
 use alloc::vec::Vec;
 use core::fmt::{self, Display, Formatter};
 use core::ops::{Deref, DerefMut};
@@ -211,17 +212,7 @@ impl FromStr for Opcode {
 
     /// Parse an Opcode name from a string.
     fn from_str(s: &str) -> Result<Self, &'static str> {
-        use crate::constant_hash::{probe, simple_hash, Table};
-
-        impl<'a> Table<&'a str> for [Option<Opcode>] {
-            fn len(&self) -> usize {
-                self.len()
-            }
-
-            fn key(&self, idx: usize) -> Option<&'a str> {
-                self[idx].map(opcode_name)
-            }
-        }
+        use crate::constant_hash::{probe, simple_hash};
 
         match probe::<&str, [Option<Self>]>(&OPCODE_HASH_TABLE, s, simple_hash(s)) {
             Err(_) => Err("Unknown opcode"),
@@ -229,6 +220,16 @@ impl FromStr for Opcode {
             // at this index is not None.
             Ok(i) => Ok(OPCODE_HASH_TABLE[i].unwrap()),
         }
+    }
+}
+
+impl<'a> Table<&'a str> for [Option<Opcode>] {
+    fn len(&self) -> usize {
+        self.len()
+    }
+
+    fn key(&self, idx: usize) -> Option<&'a str> {
+        self[idx].map(opcode_name)
     }
 }
 

--- a/cranelift/filetests/src/concurrent.rs
+++ b/cranelift/filetests/src/concurrent.rs
@@ -21,7 +21,6 @@ struct Request(usize, PathBuf);
 pub enum Reply {
     Starting {
         jobid: usize,
-        thread_num: usize,
     },
     Done {
         jobid: usize,
@@ -145,7 +144,7 @@ fn worker_thread(
 
                 // Tell them we're starting this job.
                 // The receiver should always be present for this as long as we have jobs.
-                replies.send(Reply::Starting { jobid, thread_num }).unwrap();
+                replies.send(Reply::Starting { jobid }).unwrap();
 
                 let result = catch_unwind(|| runone::run(path.as_path(), None, None))
                     .unwrap_or_else(|e| {

--- a/cranelift/filetests/src/subtest.rs
+++ b/cranelift/filetests/src/subtest.rs
@@ -29,6 +29,7 @@ pub struct Context<'a> {
     pub isa: Option<&'a dyn TargetIsa>,
 
     /// Full path to the file containing the test.
+    #[allow(dead_code)]
     pub file_path: &'a str,
 
     /// Context used to update the original `file_path` in-place with its test

--- a/crates/component-macro/tests/codegen.rs
+++ b/crates/component-macro/tests/codegen.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 macro_rules! gentest {
     ($id:ident $name:tt $path:tt) => {
         mod $id {

--- a/crates/cranelift/src/debug.rs
+++ b/crates/cranelift/src/debug.rs
@@ -8,7 +8,7 @@ pub enum ModuleMemoryOffset {
     /// Offset to the defined memory.
     Defined(u32),
     /// Offset to the imported memory.
-    Imported(u32),
+    Imported(#[allow(dead_code)] u32),
 }
 
 pub use write_debuginfo::{emit_dwarf, DwarfSectionRelocTarget};

--- a/crates/cranelift/src/debug/transform/expression.rs
+++ b/crates/cranelift/src/debug/transform/expression.rs
@@ -3,7 +3,7 @@
 use super::address_transform::AddressTransform;
 use crate::debug::ModuleMemoryOffset;
 use anyhow::{Context, Error, Result};
-use cranelift_codegen::ir::{StackSlots, ValueLabel};
+use cranelift_codegen::ir::ValueLabel;
 use cranelift_codegen::isa::TargetIsa;
 use cranelift_codegen::LabelValueLoc;
 use cranelift_codegen::ValueLabelsRanges;
@@ -19,7 +19,6 @@ use wasmtime_environ::{DefinedFuncIndex, EntityRef};
 pub struct FunctionFrameInfo<'a> {
     pub value_ranges: &'a ValueLabelsRanges,
     pub memory_offset: ModuleMemoryOffset,
-    pub sized_stack_slots: &'a StackSlots,
 }
 
 impl<'a> FunctionFrameInfo<'a> {
@@ -1206,15 +1205,12 @@ mod tests {
     fn test_debug_value_range_builder() {
         use super::ValueLabelRangesBuilder;
         use crate::debug::ModuleMemoryOffset;
-        use cranelift_codegen::ir::StackSlots;
         use wasmtime_environ::{DefinedFuncIndex, EntityRef};
 
         let addr_tr = create_mock_address_transform();
-        let sized_stack_slots = StackSlots::new();
         let (value_ranges, value_labels) = create_mock_value_ranges();
         let fi = FunctionFrameInfo {
             memory_offset: ModuleMemoryOffset::None,
-            sized_stack_slots: &sized_stack_slots,
             value_ranges: &value_ranges,
         };
 

--- a/crates/cranelift/src/debug/transform/utils.rs
+++ b/crates/cranelift/src/debug/transform/utils.rs
@@ -178,7 +178,6 @@ where
         let frame_info = FunctionFrameInfo {
             value_ranges: &func.value_labels_ranges,
             memory_offset: memory_offset.clone(),
-            sized_stack_slots: &func.sized_stack_slots,
         };
         Some(frame_info)
     } else {

--- a/crates/environ/src/fact/signature.rs
+++ b/crates/environ/src/fact/signature.rs
@@ -12,14 +12,6 @@ pub struct Signature {
     pub params: Vec<ValType>,
     /// Core wasm results.
     pub results: Vec<ValType>,
-    /// Indicator to whether parameters are indirect, meaning that the first
-    /// entry of `params` is a pointer type which all parameters are loaded
-    /// through.
-    pub params_indirect: bool,
-    /// Indicator whether results are passed indirectly. This may mean that
-    /// `results` is an `i32` or that `params` ends with an `i32` depending on
-    /// the `Context`.
-    pub results_indirect: bool,
 }
 
 impl ComponentTypesBuilder {
@@ -33,7 +25,6 @@ impl ComponentTypesBuilder {
         let ty = &self[options.ty];
         let ptr_ty = options.options.ptr();
 
-        let mut params_indirect = false;
         let mut params = match self.flatten_types(
             &options.options,
             MAX_FLAT_PARAMS,
@@ -41,12 +32,10 @@ impl ComponentTypesBuilder {
         ) {
             Some(list) => list,
             None => {
-                params_indirect = true;
                 vec![ptr_ty]
             }
         };
 
-        let mut results_indirect = false;
         let results = match self.flatten_types(
             &options.options,
             MAX_FLAT_RESULTS,
@@ -54,7 +43,6 @@ impl ComponentTypesBuilder {
         ) {
             Some(list) => list,
             None => {
-                results_indirect = true;
                 match context {
                     // For a lifted function too-many-results gets translated to a
                     // returned pointer where results are read from. The callee
@@ -70,12 +58,7 @@ impl ComponentTypesBuilder {
                 }
             }
         };
-        Signature {
-            params,
-            results,
-            params_indirect,
-            results_indirect,
-        }
+        Signature { params, results }
     }
 
     /// Pushes the flat version of a list of component types into a final result

--- a/crates/runtime/src/send_sync_ptr.rs
+++ b/crates/runtime/src/send_sync_ptr.rs
@@ -93,7 +93,7 @@ impl<T: ?Sized> Copy for SendSyncPtr<T> {}
 impl<T: ?Sized> PartialEq for SendSyncPtr<T> {
     #[inline]
     fn eq(&self, other: &SendSyncPtr<T>) -> bool {
-        self.0 == other.0
+        std::ptr::eq(self.0.as_ptr(), other.0.as_ptr())
     }
 }
 

--- a/crates/wasmtime/src/runtime/component/linker.rs
+++ b/crates/wasmtime/src/runtime/component/linker.rs
@@ -195,7 +195,6 @@ impl<T> Linker<T> {
 
     fn typecheck<'a>(&'a self, component: &'a Component) -> Result<TypeChecker<'a>> {
         let mut cx = TypeChecker {
-            component: component.env_component(),
             types: component.types(),
             strings: &self.strings,
             imported_resources: Default::default(),

--- a/crates/wasmtime/src/runtime/component/matching.rs
+++ b/crates/wasmtime/src/runtime/component/matching.rs
@@ -15,7 +15,6 @@ use wasmtime_runtime::component::ComponentInstance;
 
 pub struct TypeChecker<'a> {
     pub types: &'a Arc<ComponentTypes>,
-    pub component: &'a wasmtime_environ::component::Component,
     pub strings: &'a Strings,
     pub imported_resources: Arc<PrimaryMap<ResourceIndex, ResourceType>>,
 }

--- a/tests/all/component_model/bindgen.rs
+++ b/tests/all/component_model/bindgen.rs
@@ -1,4 +1,5 @@
 #![cfg(not(miri))]
+#![allow(dead_code)]
 
 use super::engine;
 use anyhow::Result;

--- a/tests/all/component_model/bindgen/ownership.rs
+++ b/tests/all/component_model/bindgen/ownership.rs
@@ -114,8 +114,9 @@ fn component() -> String {
     )
 }
 
-#[test]
-fn owning() -> Result<()> {
+mod owning {
+    use super::*;
+
     wasmtime::component::bindgen!({
         inline: "
         package inline:inline;
@@ -157,33 +158,36 @@ fn owning() -> Result<()> {
         }
     }
 
-    let engine = engine();
-    let component = Component::new(&engine, component())?;
+    #[test]
+    fn owning() -> Result<()> {
+        let engine = engine();
+        let component = Component::new(&engine, component())?;
 
-    let linker = Linker::new(&engine);
-    let mut store = Store::new(&engine, ());
-    let (test, _) = Test::instantiate(&mut store, &component, &linker)?;
+        let linker = Linker::new(&engine);
+        let mut store = Store::new(&engine, ());
+        let (test, _) = Test::instantiate(&mut store, &component, &linker)?;
 
-    let value = vec![vec!["a".to_owned(), "b".to_owned()]];
-    assert_eq!(value, test.lists().call_foo(&mut store, &value)?);
+        let value = vec![vec!["a".to_owned(), "b".to_owned()]];
+        assert_eq!(value, test.lists().call_foo(&mut store, &value)?);
 
-    let value = exports::thing_in::Thing {
-        name: "thing 1".to_owned(),
-        value: vec!["some value".to_owned(), "another value".to_owned()],
-    };
-    test.thing_in().call_bar(&mut store, &value)?;
+        let value = exports::thing_in::Thing {
+            name: "thing 1".to_owned(),
+            value: vec!["some value".to_owned(), "another value".to_owned()],
+        };
+        test.thing_in().call_bar(&mut store, &value)?;
 
-    let value = exports::thing_in_and_out::Thing {
-        name: "thing 1".to_owned(),
-        value: vec!["some value".to_owned(), "another value".to_owned()],
-    };
-    assert_eq!(value, test.thing_in_and_out().call_baz(&mut store, &value)?);
+        let value = exports::thing_in_and_out::Thing {
+            name: "thing 1".to_owned(),
+            value: vec!["some value".to_owned(), "another value".to_owned()],
+        };
+        assert_eq!(value, test.thing_in_and_out().call_baz(&mut store, &value)?);
 
-    Ok(())
+        Ok(())
+    }
 }
 
-#[test]
-fn borrowing_no_duplication() -> Result<()> {
+mod borrowing_no_duplication {
+    use super::*;
     wasmtime::component::bindgen!({
         inline: "
         package inline:inline;
@@ -227,33 +231,37 @@ fn borrowing_no_duplication() -> Result<()> {
         }
     }
 
-    let engine = engine();
-    let component = Component::new(&engine, component())?;
+    #[test]
+    fn borrowing_no_duplication() -> Result<()> {
+        let engine = engine();
+        let component = Component::new(&engine, component())?;
 
-    let linker = Linker::new(&engine);
-    let mut store = Store::new(&engine, ());
-    let (test, _) = Test::instantiate(&mut store, &component, &linker)?;
+        let linker = Linker::new(&engine);
+        let mut store = Store::new(&engine, ());
+        let (test, _) = Test::instantiate(&mut store, &component, &linker)?;
 
-    let value = &[&["a", "b"] as &[_]] as &[_];
-    assert_eq!(value, test.lists().call_foo(&mut store, value)?);
+        let value = &[&["a", "b"] as &[_]] as &[_];
+        assert_eq!(value, test.lists().call_foo(&mut store, value)?);
 
-    let value = exports::thing_in::Thing {
-        name: "thing 1",
-        value: &["some value", "another value"],
-    };
-    test.thing_in().call_bar(&mut store, value)?;
+        let value = exports::thing_in::Thing {
+            name: "thing 1",
+            value: &["some value", "another value"],
+        };
+        test.thing_in().call_bar(&mut store, value)?;
 
-    let value = exports::thing_in_and_out::Thing {
-        name: "thing 1".to_owned(),
-        value: vec!["some value".to_owned(), "another value".to_owned()],
-    };
-    assert_eq!(value, test.thing_in_and_out().call_baz(&mut store, &value)?);
+        let value = exports::thing_in_and_out::Thing {
+            name: "thing 1".to_owned(),
+            value: vec!["some value".to_owned(), "another value".to_owned()],
+        };
+        assert_eq!(value, test.thing_in_and_out().call_baz(&mut store, &value)?);
 
-    Ok(())
+        Ok(())
+    }
 }
 
-#[test]
-fn borrowing_with_duplication() -> Result<()> {
+mod borrowing_with_duplication {
+    use super::*;
+
     wasmtime::component::bindgen!({
         inline: "
         package inline:inline;
@@ -297,33 +305,36 @@ fn borrowing_with_duplication() -> Result<()> {
         }
     }
 
-    let engine = engine();
-    let component = Component::new(&engine, component())?;
+    #[test]
+    fn borrowing_with_duplication() -> Result<()> {
+        let engine = engine();
+        let component = Component::new(&engine, component())?;
 
-    let linker = Linker::new(&engine);
-    let mut store = Store::new(&engine, ());
-    let (test, _) = Test::instantiate(&mut store, &component, &linker)?;
+        let linker = Linker::new(&engine);
+        let mut store = Store::new(&engine, ());
+        let (test, _) = Test::instantiate(&mut store, &component, &linker)?;
 
-    let value = &[&["a", "b"] as &[_]] as &[_];
-    assert_eq!(value, test.lists().call_foo(&mut store, value)?);
+        let value = &[&["a", "b"] as &[_]] as &[_];
+        assert_eq!(value, test.lists().call_foo(&mut store, value)?);
 
-    let value = exports::thing_in::Thing {
-        name: "thing 1",
-        value: &["some value", "another value"],
-    };
-    test.thing_in().call_bar(&mut store, value)?;
+        let value = exports::thing_in::Thing {
+            name: "thing 1",
+            value: &["some value", "another value"],
+        };
+        test.thing_in().call_bar(&mut store, value)?;
 
-    let value = exports::thing_in_and_out::ThingParam {
-        name: "thing 1",
-        value: &["some value", "another value"],
-    };
-    assert_eq!(
-        exports::thing_in_and_out::ThingResult {
-            name: "thing 1".to_owned(),
-            value: vec!["some value".to_owned(), "another value".to_owned()],
-        },
-        test.thing_in_and_out().call_baz(&mut store, value)?
-    );
+        let value = exports::thing_in_and_out::ThingParam {
+            name: "thing 1",
+            value: &["some value", "another value"],
+        };
+        assert_eq!(
+            exports::thing_in_and_out::ThingResult {
+                name: "thing 1".to_owned(),
+                value: vec!["some value".to_owned(), "another value".to_owned()],
+            },
+            test.thing_in_and_out().call_baz(&mut store, value)?
+        );
 
-    Ok(())
+        Ok(())
+    }
 }


### PR DESCRIPTION
Fixes some warnings that nightly Rust has started emitting.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
