### PR TITLE
Fix a panic calling host functions with refs in async mode

### DIFF
--- a/crates/wasmtime/src/runtime/func.rs
+++ b/crates/wasmtime/src/runtime/func.rs
@@ -1346,24 +1346,6 @@ impl Func {
         let (params, results) = val_vec.split_at_mut(nparams);
         func(caller.sub_caller(), params, results)?;
 
-        #[cfg(feature = "gc")]
-        {
-            // See the comment in `Func::call_impl_check_args`.
-            let num_gc_refs = ty.as_wasm_func_type().non_i31_gc_ref_returns_count();
-            if let Some(num_gc_refs) = NonZeroUsize::new(num_gc_refs) {
-                if caller
-                    .as_context()
-                    .0
-                    .gc_store()?
-                    .gc_heap
-                    .need_gc_before_entering_wasm(num_gc_refs)
-                {
-                    assert!(!caller.as_context().0.async_support());
-                    caller.as_context_mut().gc();
-                }
-            }
-        }
-
         // Unlike our arguments we need to dynamically check that the return
         // values produced are correct. There could be a bug in `func` that
         // produces the wrong number, wrong types, or wrong stores of


### PR DESCRIPTION
This commit fixes a panic when a host function defined with `Func::new` returned GC references and was called in async mode. The logic to auto-gc before the return values go to wasm asserted that a synchronous GC was possible but the context this function is called in could be either async or sync. The fix applied in this commit is to remove the auto-gc. This means that hosts will need to explicitly GC in these situations until auto-gc is re-added back to Wasmtime.

cc #8433 as this will make the behavior consistent, but we'll want to re-add the gc behavior.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
