### PR TITLE
Ignore the lookup result in `preview2_ip_name_lookup`

### DIFF
--- a/crates/test-programs/src/bin/preview2_ip_name_lookup.rs
+++ b/crates/test-programs/src/bin/preview2_ip_name_lookup.rs
@@ -5,7 +5,10 @@ fn main() {
     // Valid domains
     resolve("localhost").unwrap();
     resolve("example.com").unwrap();
-    resolve("münchen.de").unwrap();
+
+    // NB: this is an actual real resolution, so it might time out, might cause
+    // issues, etc. This result is ignored to prevent flaky failures in CI.
+    let _ = resolve("münchen.de");
 
     // Valid IP addresses
     assert_eq!(resolve_one("0.0.0.0").unwrap(), IpAddress::IPV4_UNSPECIFIED);


### PR DESCRIPTION
This test feels like it's failed in a flaky fashion a fair amount recently. Ignore the result until the flakiness has a better fix.

Closes #8148

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
