### PR TITLE
cranelift/x64: Use immediates for all 32-bit constants

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst.isle
+++ b/cranelift/codegen/src/isa/x64/inst.isle
@@ -1792,10 +1792,6 @@
 (decl simm32_from_value (GprMemImm) Value)
 (extern extractor simm32_from_value simm32_from_value)
 
-;; Extract a constant `RegMemImm.Imm` from an `Imm64` immediate.
-(decl simm32_from_imm64 (GprMemImm) Imm64)
-(extern extractor simm32_from_imm64 simm32_from_imm64)
-
 ;; A load that can be sunk into another operation.
 (type SinkableLoad extern (enum))
 


### PR DESCRIPTION
On x86-64, instructions which take 32-bit immediate operands in 64-bit mode sign-extend those immediates.

To accommodate that, we currently only generate an immediate if the 64-bit constant we want is equal to truncating to 32 bits and then sign-extending back to 64 bits. Otherwise we put the 64-bit constant in the constant pool.

However, if the constant's type is I32, we don't care about its upper 32 bits. In that case it's safe to generate an immediate whether the sign bit is set or not. We should never need to use the constant pool for types smaller than 64 bits on x64.