### PR TITLE
winch: Handle -W tail-call

### DIFF
--- a/crates/cranelift/src/lib.rs
+++ b/crates/cranelift/src/lib.rs
@@ -228,6 +228,12 @@ fn wasm_call_signature(
                 Architecture::S390x,
                 "https://github.com/bytecodealliance/wasmtime/issues/6530"
             );
+
+            assert!(
+                !tunables.winch_callable,
+                "Winch doesn't support the WebAssembly tail call proposal",
+            );
+
             CallConv::Tail
         }
 

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1755,11 +1755,16 @@ impl Config {
                 Strategy::Cranelift => false,
                 Strategy::Winch => true,
             };
+
+            if tunables.winch_callable && tunables.tail_callable {
+                bail!("Winch does not support the WebAssembly tail call proposal");
+            }
         }
 
         if tunables.static_memory_offset_guard_size < tunables.dynamic_memory_offset_guard_size {
             bail!("static memory guard size cannot be smaller than dynamic memory guard size");
         }
+
         Ok(tunables)
     }
 


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/wasmtime/issues/8446

The WebAssembly tail call proposal is currently not supported in Winch. This commit returns an error when trying to enable the tail call proposal while using Winch as the compiler. 

Even though the issue linked above doesn't make use of any of the tail instructions, the trampolines were generated using Cranelift's tail call calling convention.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
