### PR TITLE
cranelift/s390x: Use PRegs consistently

### DIFF
--- a/cranelift/codegen/src/isa/s390x/inst/regs.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/regs.rs
@@ -2,7 +2,6 @@
 
 use alloc::string::String;
 use regalloc2::PReg;
-use regalloc2::VReg;
 
 use crate::isa::s390x::inst::{RegPair, WritableRegPair};
 use crate::machinst::*;
@@ -12,8 +11,7 @@ use crate::machinst::*;
 
 /// Get a reference to a GPR (integer register).
 pub fn gpr(num: u8) -> Reg {
-    let preg = gpr_preg(num);
-    Reg::from(VReg::new(preg.index(), RegClass::Int))
+    Reg::from(gpr_preg(num))
 }
 
 pub(crate) const fn gpr_preg(num: u8) -> PReg {
@@ -28,8 +26,7 @@ pub fn writable_gpr(num: u8) -> Writable<Reg> {
 
 /// Get a reference to a VR (vector register).
 pub fn vr(num: u8) -> Reg {
-    let preg = vr_preg(num);
-    Reg::from(VReg::new(preg.index(), RegClass::Float))
+    Reg::from(vr_preg(num))
 }
 
 pub(crate) const fn vr_preg(num: u8) -> PReg {


### PR DESCRIPTION
When OperandCollector's reg_use/reg_late_use/reg_def/reg_early_def methods are handed a Reg that refers to a physical ("real") register, they all delegate to reg_fixed_nonallocatable, ignoring the constraint kinds and positions. This behavior was introduced in #5132.

In several cases, the s390x backend was calling those methods with the result of the `gpr` or `writable_gpr` functions, which return physical registers. In these cases we can be more explicit that this is a non-allocatable register.

In addition, this PR reverts #4973 and #5121 because they became unecessary due, again, to #5132.

This doesn't change any behavior but is a nice change to split out of a larger PR I'm working on.

cc: @uweigand