### PR TITLE
c-api: Remove allocations from `wasmtime_val_t`

### DIFF
--- a/crates/c-api/include/wasmtime/global.h
+++ b/crates/c-api/include/wasmtime/global.h
@@ -54,7 +54,7 @@ wasmtime_global_type(const wasmtime_context_t *store,
  * \param out where to store the value in this global.
  *
  * This function returns ownership of the contents of `out`, so
- * #wasmtime_val_delete may need to be called on the value.
+ * #wasmtime_val_unroot may need to be called on the value.
  */
 WASM_API_EXTERN void wasmtime_global_get(wasmtime_context_t *store,
                                          const wasmtime_global_t *global,

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -33,7 +33,7 @@ extern "C" {
  * #wasmtime_anyref_unroot to enable them to be garbage-collected.
  *
  * Null anyref values are represented by this structure and can be tested and
- * created with the #wasmtime_anyref_is_null and #wasmtime_anyref_set_null
+ * created with the `wasmtime_anyref_is_null` and `wasmtime_anyref_set_null`
  * functions.
  */
 typedef struct wasmtime_anyref {
@@ -168,8 +168,8 @@ WASM_API_EXTERN bool wasmtime_anyref_i31_get_s(wasmtime_context_t *context,
  * enable garbage collection.
  *
  * Note that null is represented with this structure and created with
- * #wasmtime_externref_set_null. Null can be tested for with the
- * #wasmtime_externref_is_null function.
+ * `wasmtime_externref_set_null`. Null can be tested for with the
+ * `wasmtime_externref_is_null` function.
  */
 typedef struct wasmtime_externref {
   /// Internal metadata tracking within the store, embedders should not

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -44,7 +44,8 @@ typedef struct wasmtime_anyref {
 } wasmtime_anyref_t;
 
 /// Helper macro to create a `wasmtime_anyref_t` value that is null.
-#define WASMTIME_ANYREF_NULL {0}
+#define WASMTIME_ANYREF_NULL                                                   \
+  { 0 }
 
 /// Helper macro to test whether a `wasmtime_anyref_t` value references null.
 #define WASMTIME_ANYREF_IS_NULL(p) ((p).store_id == 0)
@@ -168,7 +169,8 @@ typedef struct wasmtime_externref {
 } wasmtime_externref_t;
 
 /// Helper macro to create a `wasmtime_externref_t` value that is null.
-#define WASMTIME_EXTERNREF_NULL {0}
+#define WASMTIME_EXTERNREF_NULL                                                \
+  { 0 }
 
 /// Helper macro to test whether a `wasmtime_externref_t` value references null.
 #define WASMTIME_EXTERNREF_IS_NULL(p) ((p).store_id == 0)

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -33,13 +33,16 @@ extern "C" {
  * #wasmtime_anyref_unroot to enable them to be garbage-collected.
  *
  * Null anyref values are represented by this structure and can be tested and
- * created with the #WASMTIME_ANYREF_IS_NULL and #WASMTIME_ANYREF_NULL macros.
+ * created with the #wasmtime_anyref_is_null and #wasmtime_anyref_set_null
+ * functions.
  */
 typedef struct wasmtime_anyref {
   /// Internal metadata tracking within the store, embedders should not
   /// configure or modify these fields.
   uint64_t store_id;
+  /// Internal to Wasmtime.
   uint32_t __private1;
+  /// Internal to Wasmtime.
   uint32_t __private2;
 } wasmtime_anyref_t;
 
@@ -165,14 +168,16 @@ WASM_API_EXTERN bool wasmtime_anyref_i31_get_s(wasmtime_context_t *context,
  * enable garbage collection.
  *
  * Note that null is represented with this structure and created with
- * #WASMTIME_EXTERNREF_NULL. Null can be tested for with the
- * #WASMTIME_EXTERNREF_IS_NULL macro.
+ * #wasmtime_externref_set_null. Null can be tested for with the
+ * #wasmtime_externref_is_null function.
  */
 typedef struct wasmtime_externref {
   /// Internal metadata tracking within the store, embedders should not
   /// configure or modify these fields.
   uint64_t store_id;
+  /// Internal to Wasmtime.
   uint32_t __private1;
+  /// Internal to Wasmtime.
   uint32_t __private2;
 } wasmtime_externref_t;
 
@@ -412,8 +417,8 @@ static inline void __wasmtime_val_assertions() {
  * Note that this structure may contain an owned value, namely rooted GC
  * references, depending on the context in which this is used. APIs which
  * consume a #wasmtime_val_t do not take ownership, but APIs that return
- * #wasmtime_val_t require that #wasmtime_val_delete is called to deallocate the
- * value.
+ * #wasmtime_val_t require that #wasmtime_val_unroot is called to clean up
+ * any possible GC roots in the value.
  */
 typedef struct wasmtime_val {
   /// Discriminant of which field of #of is valid.

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -43,12 +43,20 @@ typedef struct wasmtime_anyref {
   uint32_t __private2;
 } wasmtime_anyref_t;
 
-/// Helper macro to create a `wasmtime_anyref_t` value that is null.
-#define WASMTIME_ANYREF_NULL                                                   \
-  { 0 }
+/// \brief Helper function to initialize the `ref` provided to a null anyref
+/// value.
+static inline void wasmtime_anyref_set_null(wasmtime_anyref_t *ref) {
+  ref->store_id = 0;
+}
 
-/// Helper macro to test whether a `wasmtime_anyref_t` value references null.
-#define WASMTIME_ANYREF_IS_NULL(p) ((p).store_id == 0)
+/// \brief Helper function to return whether the provided `ref` points to a null
+/// `anyref` value.
+///
+/// Note that `ref` itself should not be null as null is represented internally
+/// within a #wasmtime_anyref_t value.
+static inline bool wasmtime_anyref_is_null(const wasmtime_anyref_t *ref) {
+  return ref->store_id == 0;
+}
 
 /**
  * \brief Creates a new reference pointing to the same data that `anyref`
@@ -168,12 +176,20 @@ typedef struct wasmtime_externref {
   uint32_t __private2;
 } wasmtime_externref_t;
 
-/// Helper macro to create a `wasmtime_externref_t` value that is null.
-#define WASMTIME_EXTERNREF_NULL                                                \
-  { 0 }
+/// \brief Helper function to initialize the `ref` provided to a null externref
+/// value.
+static inline void wasmtime_externref_set_null(wasmtime_externref_t *ref) {
+  ref->store_id = 0;
+}
 
-/// Helper macro to test whether a `wasmtime_externref_t` value references null.
-#define WASMTIME_EXTERNREF_IS_NULL(p) ((p).store_id == 0)
+/// \brief Helper function to return whether the provided `ref` points to a null
+/// `externref` value.
+///
+/// Note that `ref` itself should not be null as null is represented internally
+/// within a #wasmtime_externref_t value.
+static inline bool wasmtime_externref_is_null(const wasmtime_externref_t *ref) {
+  return ref->store_id == 0;
+}
 
 /**
  * \brief Create a new `externref` value.

--- a/crates/c-api/src/ref.rs
+++ b/crates/c-api/src/ref.rs
@@ -1,5 +1,9 @@
 use crate::{abort, WasmtimeStoreContextMut};
-use std::{mem::MaybeUninit, os::raw::c_void, ptr};
+use std::{
+    mem::{ManuallyDrop, MaybeUninit},
+    os::raw::c_void,
+    ptr,
+};
 use wasmtime::{AnyRef, ExternRef, ManuallyRooted, Ref, RootScope, Val, I31};
 
 /// `*mut wasm_ref_t` is a reference type (`externref` or `funcref`), as seen by
@@ -182,25 +186,100 @@ pub extern "C" fn wasm_foreign_new(_store: &crate::wasm_store_t) -> Box<wasm_for
     abort("wasm_foreign_new")
 }
 
-pub type wasmtime_anyref_t = ManuallyRooted<AnyRef>;
-pub type wasmtime_externref_t = ManuallyRooted<ExternRef>;
+/// C-API representation of `anyref`.
+///
+/// This represented differently in the C API from the header to handle how
+/// this is dispatched internally. Null anyref values are represented with a
+/// `store_id` of zero, and otherwise the `rooted` field is valid.
+///
+/// Note that this relies on the Wasmtime definition of `ManuallyRooted` to have
+/// a 64-bit store_id first.
+pub union wasmtime_anyref_t {
+    store_id: u64,
+    rooted: ManuallyDrop<ManuallyRooted<AnyRef>>,
+}
 
-#[no_mangle]
-pub extern "C" fn wasmtime_anyref_clone(
-    cx: WasmtimeStoreContextMut<'_>,
-    anyref: Option<&wasmtime_anyref_t>,
-) -> Option<Box<wasmtime_anyref_t>> {
-    let anyref = anyref?;
-    Some(Box::new((*anyref).clone(cx)))
+/// Same as `wasmtime_anyref_t`, but for extenref.
+pub union wasmtime_externref_t {
+    store_id: u64,
+    rooted: ManuallyDrop<ManuallyRooted<ExternRef>>,
+}
+
+impl wasmtime_anyref_t {
+    pub unsafe fn as_wasmtime(&self) -> Option<&ManuallyRooted<AnyRef>> {
+        if self.store_id == 0 {
+            None
+        } else {
+            Some(&self.rooted)
+        }
+    }
+
+    pub unsafe fn into_wasmtime(self) -> Option<ManuallyRooted<AnyRef>> {
+        if self.store_id == 0 {
+            None
+        } else {
+            Some(ManuallyDrop::into_inner(self.rooted))
+        }
+    }
+}
+
+impl From<Option<ManuallyRooted<AnyRef>>> for wasmtime_anyref_t {
+    fn from(rooted: Option<ManuallyRooted<AnyRef>>) -> wasmtime_anyref_t {
+        match rooted {
+            Some(val) => wasmtime_anyref_t {
+                rooted: ManuallyDrop::new(val),
+            },
+            None => wasmtime_anyref_t { store_id: 0 },
+        }
+    }
+}
+
+impl wasmtime_externref_t {
+    pub unsafe fn as_wasmtime(&self) -> Option<&ManuallyRooted<ExternRef>> {
+        if self.store_id == 0 {
+            None
+        } else {
+            Some(&self.rooted)
+        }
+    }
+
+    pub unsafe fn into_wasmtime(self) -> Option<ManuallyRooted<ExternRef>> {
+        if self.store_id == 0 {
+            None
+        } else {
+            Some(ManuallyDrop::into_inner(self.rooted))
+        }
+    }
+}
+
+impl From<Option<ManuallyRooted<ExternRef>>> for wasmtime_externref_t {
+    fn from(rooted: Option<ManuallyRooted<ExternRef>>) -> wasmtime_externref_t {
+        match rooted {
+            Some(val) => wasmtime_externref_t {
+                rooted: ManuallyDrop::new(val),
+            },
+            None => wasmtime_externref_t { store_id: 0 },
+        }
+    }
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_anyref_delete(
+pub unsafe extern "C" fn wasmtime_anyref_clone(
     cx: WasmtimeStoreContextMut<'_>,
-    val: Option<Box<wasmtime_anyref_t>>,
+    anyref: Option<&wasmtime_anyref_t>,
+    out: &mut MaybeUninit<wasmtime_anyref_t>,
 ) {
-    if let Some(e) = val {
-        e.unroot(cx);
+    let anyref = anyref.and_then(|a| a.as_wasmtime()).map(|a| a.clone(cx));
+    crate::initialize(out, anyref.into());
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wasmtime_anyref_unroot(
+    cx: WasmtimeStoreContextMut<'_>,
+    val: Option<&mut MaybeUninit<wasmtime_anyref_t>>,
+) {
+    if let Some(val) = val.and_then(|v| v.assume_init_read().into_wasmtime()) {
+        val.unroot(cx);
     }
 }
 
@@ -209,39 +288,42 @@ pub unsafe extern "C" fn wasmtime_anyref_to_raw(
     cx: WasmtimeStoreContextMut<'_>,
     val: Option<&wasmtime_anyref_t>,
 ) -> u32 {
-    val.and_then(|e| e.to_raw(cx).ok()).unwrap_or_default()
+    val.and_then(|v| v.as_wasmtime())
+        .and_then(|e| e.to_raw(cx).ok())
+        .unwrap_or_default()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_anyref_from_raw(
     cx: WasmtimeStoreContextMut<'_>,
     raw: u32,
-) -> Option<Box<wasmtime_anyref_t>> {
+    val: &mut MaybeUninit<wasmtime_anyref_t>,
+) {
     let mut scope = RootScope::new(cx);
-    let e = AnyRef::from_raw(&mut scope, raw)?;
-    Some(Box::new(
-        e.to_manually_rooted(&mut scope).expect("in scope"),
-    ))
+    let anyref = AnyRef::from_raw(&mut scope, raw)
+        .map(|a| a.to_manually_rooted(&mut scope).expect("in scope"));
+    crate::initialize(val, anyref.into());
 }
 
 #[no_mangle]
 pub extern "C" fn wasmtime_anyref_from_i31(
     cx: WasmtimeStoreContextMut<'_>,
     val: u32,
-) -> Box<wasmtime_anyref_t> {
+    out: &mut MaybeUninit<wasmtime_anyref_t>,
+) {
     let mut scope = RootScope::new(cx);
     let anyref = AnyRef::from_i31(&mut scope, I31::wrapping_u32(val));
     let anyref = anyref.to_manually_rooted(&mut scope).expect("in scope");
-    Box::new(anyref)
+    crate::initialize(out, Some(anyref).into())
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_anyref_i31_get_u(
+pub unsafe extern "C" fn wasmtime_anyref_i31_get_u(
     cx: WasmtimeStoreContextMut<'_>,
     anyref: Option<&wasmtime_anyref_t>,
     dst: &mut MaybeUninit<u32>,
 ) -> bool {
-    match anyref {
+    match anyref.and_then(|a| a.as_wasmtime()) {
         Some(anyref) if anyref.is_i31(&cx).expect("ManuallyRooted always in scope") => {
             let val = anyref
                 .unwrap_i31(&cx)
@@ -255,12 +337,12 @@ pub extern "C" fn wasmtime_anyref_i31_get_u(
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_anyref_i31_get_s(
+pub unsafe extern "C" fn wasmtime_anyref_i31_get_s(
     cx: WasmtimeStoreContextMut<'_>,
     anyref: Option<&wasmtime_anyref_t>,
     dst: &mut MaybeUninit<i32>,
 ) -> bool {
-    match anyref {
+    match anyref.and_then(|a| a.as_wasmtime()) {
         Some(anyref) if anyref.is_i31(&cx).expect("ManuallyRooted always in scope") => {
             let val = anyref
                 .unwrap_i31(&cx)
@@ -278,19 +360,25 @@ pub extern "C" fn wasmtime_externref_new(
     cx: WasmtimeStoreContextMut<'_>,
     data: *mut c_void,
     finalizer: Option<extern "C" fn(*mut c_void)>,
-) -> Option<Box<wasmtime_externref_t>> {
+    out: &mut MaybeUninit<wasmtime_externref_t>,
+) -> bool {
     let mut scope = RootScope::new(cx);
-    let e = ExternRef::new(&mut scope, crate::ForeignData { data, finalizer }).ok()?;
+    let e = match ExternRef::new(&mut scope, crate::ForeignData { data, finalizer }) {
+        Ok(e) => e,
+        Err(_) => return false,
+    };
     let e = e.to_manually_rooted(&mut scope).expect("in scope");
-    Some(Box::new(e))
+    crate::initialize(out, Some(e).into());
+    true
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_externref_data(
+pub unsafe extern "C" fn wasmtime_externref_data(
     cx: WasmtimeStoreContextMut<'_>,
     externref: Option<&wasmtime_externref_t>,
 ) -> *mut c_void {
     externref
+        .and_then(|e| e.as_wasmtime())
         .and_then(|e| {
             let data = e.data(cx).ok()?;
             Some(data.downcast_ref::<crate::ForeignData>().unwrap().data)
@@ -299,21 +387,22 @@ pub extern "C" fn wasmtime_externref_data(
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_externref_clone(
+pub unsafe extern "C" fn wasmtime_externref_clone(
     cx: WasmtimeStoreContextMut<'_>,
     externref: Option<&wasmtime_externref_t>,
-) -> Option<Box<wasmtime_externref_t>> {
-    let externref = externref?;
-    Some(Box::new((*externref).clone(cx)))
+    out: &mut MaybeUninit<wasmtime_externref_t>,
+) {
+    let externref = externref.and_then(|e| e.as_wasmtime()).map(|e| e.clone(cx));
+    crate::initialize(out, externref.into());
 }
 
 #[no_mangle]
-pub extern "C" fn wasmtime_externref_delete(
+pub unsafe extern "C" fn wasmtime_externref_unroot(
     cx: WasmtimeStoreContextMut<'_>,
-    val: Option<Box<wasmtime_externref_t>>,
+    val: Option<&mut MaybeUninit<wasmtime_externref_t>>,
 ) {
-    if let Some(e) = val {
-        e.unroot(cx);
+    if let Some(val) = val.and_then(|v| v.assume_init_read().into_wasmtime()) {
+        val.unroot(cx);
     }
 }
 
@@ -322,17 +411,19 @@ pub unsafe extern "C" fn wasmtime_externref_to_raw(
     cx: WasmtimeStoreContextMut<'_>,
     val: Option<&wasmtime_externref_t>,
 ) -> u32 {
-    val.and_then(|e| e.to_raw(cx).ok()).unwrap_or_default()
+    val.and_then(|e| e.as_wasmtime())
+        .and_then(|e| e.to_raw(cx).ok())
+        .unwrap_or_default()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn wasmtime_externref_from_raw(
     cx: WasmtimeStoreContextMut<'_>,
     raw: u32,
-) -> Option<Box<wasmtime_externref_t>> {
+    val: &mut MaybeUninit<wasmtime_externref_t>,
+) {
     let mut scope = RootScope::new(cx);
-    let e = ExternRef::from_raw(&mut scope, raw)?;
-    Some(Box::new(
-        e.to_manually_rooted(&mut scope).expect("in scope"),
-    ))
+    let rooted = ExternRef::from_raw(&mut scope, raw)
+        .map(|e| e.to_manually_rooted(&mut scope).expect("in scope"));
+    crate::initialize(val, rooted.into());
 }

--- a/crates/c-api/src/val.rs
+++ b/crates/c-api/src/val.rs
@@ -297,12 +297,12 @@ pub unsafe extern "C" fn wasmtime_val_unroot(
     let val = val.assume_init_read();
     match val.kind {
         crate::WASMTIME_ANYREF => {
-            if let Some(val) = ManuallyDrop::into_inner(val.of.anyref).into_wasmtime() {
+            if let Some(val) = ManuallyDrop::into_inner(val.of.anyref).as_wasmtime() {
                 val.unroot(cx);
             }
         }
         crate::WASMTIME_EXTERNREF => {
-            if let Some(val) = ManuallyDrop::into_inner(val.of.externref).into_wasmtime() {
+            if let Some(val) = ManuallyDrop::into_inner(val.of.externref).as_wasmtime() {
                 val.unroot(cx);
             }
         }

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -107,6 +107,7 @@ use crate::{
     AsContext, AsContextMut, GcRef, Result, RootedGcRef,
 };
 use anyhow::anyhow;
+use std::num::NonZeroU64;
 use std::{
     fmt::Debug,
     hash::Hash,
@@ -1531,6 +1532,27 @@ where
             .get_gc_ref(store.as_context().0)
             .expect("ManuallyRooted's get_gc_ref is infallible");
         gc_ref.hash(state);
+    }
+
+    #[doc(hidden)]
+    pub fn into_parts_for_c_api(self) -> (NonZeroU64, u32, u32) {
+        (
+            self.inner.store_id.as_raw(),
+            self.inner.generation,
+            self.inner.index.0,
+        )
+    }
+
+    #[doc(hidden)]
+    pub unsafe fn from_raw_parts_for_c_api(a: NonZeroU64, b: u32, c: u32) -> ManuallyRooted<T> {
+        ManuallyRooted {
+            inner: GcRootIndex {
+                store_id: StoreId::from_raw(a),
+                generation: b,
+                index: PackedIndex(c),
+            },
+            _phantom: std::marker::PhantomData,
+        }
     }
 }
 

--- a/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
+++ b/crates/wasmtime/src/runtime/gc/enabled/rooting.rs
@@ -1209,6 +1209,16 @@ where
     _phantom: std::marker::PhantomData<T>,
 }
 
+const _: () = {
+    use crate::{AnyRef, ExternRef};
+
+    // NB: these match the C API which should also be updated if this changes
+    assert!(std::mem::size_of::<ManuallyRooted<AnyRef>>() == 16);
+    assert!(std::mem::align_of::<ManuallyRooted<AnyRef>>() == 8);
+    assert!(std::mem::size_of::<ManuallyRooted<ExternRef>>() == 16);
+    assert!(std::mem::align_of::<ManuallyRooted<ExternRef>>() == 8);
+};
+
 impl<T: GcRef> Debug for ManuallyRooted<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = format!("ManuallyRooted<{}>", std::any::type_name::<T>());

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -202,6 +202,7 @@ where
 /// it came from. Comparisons with this value are how panics are generated for
 /// mismatching the item that a store belongs to.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[repr(transparent)] // NB: relied on in the C API
 pub struct StoreId(NonZeroU64);
 
 impl StoreId {

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -236,6 +236,16 @@ impl StoreId {
         }
         store_id_mismatch();
     }
+
+    /// Raw accessor for the C API.
+    pub fn as_raw(&self) -> NonZeroU64 {
+        self.0
+    }
+
+    /// Raw constructor for the C API.
+    pub fn from_raw(id: NonZeroU64) -> StoreId {
+        StoreId(id)
+    }
 }
 
 #[repr(C)] // used by reference in the C API

--- a/examples/anyref.c
+++ b/examples/anyref.c
@@ -94,12 +94,13 @@ int main() {
 
   // Create a new `anyref` value from an i31 (`i31ref` is a subtype of
   // `anyref`).
-  wasmtime_anyref_t *anyref = wasmtime_anyref_from_i31(context, 1234);
-  assert(anyref != NULL);
+  wasmtime_anyref_t anyref;
+  wasmtime_anyref_from_i31(context, 1234, &anyref);
+  assert(!WASMTIME_ANYREF_IS_NULL(anyref));
 
   // The `anyref`'s inner i31 value should be 1234.
   uint32_t i31val = 0;
-  bool is_i31 = wasmtime_anyref_i31_get_u(context, anyref, &i31val);
+  bool is_i31 = wasmtime_anyref_i31_get_u(context, &anyref, &i31val);
   assert(is_i31);
   assert(i31val == 1234);
 
@@ -128,10 +129,10 @@ int main() {
   assert(elem.kind == WASMTIME_ANYREF);
   is_i31 = false;
   i31val = 0;
-  is_i31 = wasmtime_anyref_i31_get_u(context, elem.of.anyref, &i31val);
+  is_i31 = wasmtime_anyref_i31_get_u(context, &elem.of.anyref, &i31val);
   assert(is_i31);
   assert(i31val == 1234);
-  wasmtime_val_delete(context, &elem);
+  wasmtime_val_unroot(context, &elem);
 
   printf("Touching `anyref` global...\n");
 
@@ -152,10 +153,10 @@ int main() {
   assert(global_val.kind == WASMTIME_ANYREF);
   is_i31 = false;
   i31val = 0;
-  is_i31 = wasmtime_anyref_i31_get_u(context, global_val.of.anyref, &i31val);
+  is_i31 = wasmtime_anyref_i31_get_u(context, &global_val.of.anyref, &i31val);
   assert(is_i31);
   assert(i31val == 1234);
-  wasmtime_val_delete(context, &global_val);
+  wasmtime_val_unroot(context, &global_val);
 
   printf("Passing `anyref` into func...\n");
 
@@ -190,11 +191,11 @@ int main() {
   assert(results[0].kind == WASMTIME_ANYREF);
   is_i31 = false;
   i31val = 0;
-  is_i31 = wasmtime_anyref_i31_get_u(context, results[0].of.anyref, &i31val);
+  is_i31 = wasmtime_anyref_i31_get_u(context, &results[0].of.anyref, &i31val);
   assert(is_i31);
   assert(i31val == 42);
-  wasmtime_val_delete(context, &results[0]);
-  wasmtime_val_delete(context, &anyref_val);
+  wasmtime_val_unroot(context, &results[0]);
+  wasmtime_val_unroot(context, &anyref_val);
 
   // We can GC any now-unused references to our anyref that the store is
   // holding.

--- a/examples/anyref.c
+++ b/examples/anyref.c
@@ -96,7 +96,7 @@ int main() {
   // `anyref`).
   wasmtime_anyref_t anyref;
   wasmtime_anyref_from_i31(context, 1234, &anyref);
-  assert(!WASMTIME_ANYREF_IS_NULL(anyref));
+  assert(!wasmtime_anyref_is_null(&anyref));
 
   // The `anyref`'s inner i31 value should be 1234.
   uint32_t i31val = 0;

--- a/examples/externref.c
+++ b/examples/externref.c
@@ -94,11 +94,12 @@ int main() {
   //
   // Note that the NULL here is a finalizer callback, but we don't need one for
   // this example.
-  wasmtime_externref_t *externref =
-      wasmtime_externref_new(context, "Hello, World!", NULL);
+  wasmtime_externref_t externref;
+  ok = wasmtime_externref_new(context, "Hello, World!", NULL, &externref);
+  assert(ok);
 
   // The `externref`'s wrapped data should be the string "Hello, World!".
-  void *data = wasmtime_externref_data(context, externref);
+  void *data = wasmtime_externref_data(context, &externref);
   assert(strcmp((char *)data, "Hello, World!") == 0);
 
   wasmtime_extern_t item;
@@ -124,9 +125,9 @@ int main() {
     ok = wasmtime_table_get(context, &item.of.table, 3, &elem);
     assert(ok);
     assert(elem.kind == WASMTIME_EXTERNREF);
-    assert(strcmp((char *)wasmtime_externref_data(context, elem.of.externref),
+    assert(strcmp((char *)wasmtime_externref_data(context, &elem.of.externref),
                   "Hello, World!") == 0);
-    wasmtime_val_delete(context, &elem);
+    wasmtime_val_unroot(context, &elem);
   }
 
   printf("Touching `externref` global...\n");
@@ -148,9 +149,9 @@ int main() {
     wasmtime_global_get(context, &item.of.global, &global_val);
     assert(global_val.kind == WASMTIME_EXTERNREF);
     assert(strcmp((char *)wasmtime_externref_data(context,
-                                                  global_val.of.externref),
+                                                  &global_val.of.externref),
                   "Hello, World!") == 0);
-    wasmtime_val_delete(context, &global_val);
+    wasmtime_val_unroot(context, &global_val);
   }
 
   printf("Calling `externref` func...\n");
@@ -173,11 +174,11 @@ int main() {
     // our `externref`.
     assert(results[0].kind == WASMTIME_EXTERNREF);
     assert(strcmp((char *)wasmtime_externref_data(context,
-                                                  results[0].of.externref),
+                                                  &results[0].of.externref),
                   "Hello, World!") == 0);
-    wasmtime_val_delete(context, &results[0]);
+    wasmtime_val_unroot(context, &results[0]);
   }
-  wasmtime_val_delete(context, &externref_val);
+  wasmtime_val_unroot(context, &externref_val);
 
   // We can GC any now-unused references to our externref that the store is
   // holding.


### PR DESCRIPTION
This commit redesigns how GC references work in the C API. previously `wasmtime_{any,extern}ref_t` were both opaque pointers in the C API represented as a `Box`. Wasmtime did not, however, provide the ability to deallocate just the `Box` part. This was intended to be handled with unrooting APIs but unrooting requires a `wasmtime_context_t` parameter, meaning that destructors of types in other languages don't have a suitable means of managing the memory around the
`wasmtime_{any,extern}ref_t` which might lead to leaks.

This PR takes an alternate approach for the representation of these types in the C API. Instead of being an opaque pointer they're now actual structures with definitions in the header file. These structures mirror the internals in Rust and Rust is tagged to ensure that changes are reflected in the C API as well. This is similar to how `wasmtime_func_t` matches `wasmtime::Func`. This enables embedders to not need to worry about memory management of these values outside of the manual rooting otherwise required.

The hope is that this will reduce the likelihood of memory leaks and otherwise not make it any harder to manage references in the C API.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
