### PR TITLE
cranelift: Don't recompute allocatable register set

### DIFF
--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -509,6 +509,7 @@ impl<I: VCodeInst> VCodeBuilder<I> {
     }
 
     fn collect_operands(&mut self) {
+        let allocatable = PRegSet::from(self.vcode.machine_env());
         for (i, insn) in self.vcode.insts.iter().enumerate() {
             // Push operands from the instruction onto the operand list.
             //
@@ -522,7 +523,6 @@ impl<I: VCodeInst> VCodeBuilder<I> {
             // its register fields (which is slow, branchy code) once.
 
             let vreg_aliases = &self.vcode.vreg_aliases;
-            let allocatable = PRegSet::from(self.vcode.machine_env());
             let mut op_collector =
                 OperandCollector::new(&mut self.vcode.operands, allocatable, |vreg| {
                     VCode::<I>::resolve_vreg_alias_impl(vreg_aliases, vreg)


### PR DESCRIPTION
The implementation of `PRegSet::from(self.vcode.machine_env())` does a surprising amount of work: it lazily initializes a `OnceLock` in the backend, then loops over six vectors of registers and adds them all to the `PRegSet`.

We could likely implement that better, but in the meantime at least we can avoid repeating that work for every single machine instruction. The `PRegSet` itself only takes a few words to store so it's cheap to just keep it around.

I discovered this because when the call to `self.vcode.machine_env()` is in the middle of the loop, that prevents holding a mutable borrow on parts of `self.vcode`, which I want to be able to do in another PR.