### PR TITLE
cranelift/riscv64: Inline multi-reg operand collector helpers

### DIFF
--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -365,13 +365,6 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
         }
     }
 
-    /// Add multiple register uses.
-    pub fn reg_uses(&mut self, regs: &[Reg]) {
-        for &reg in regs {
-            self.reg_use(reg);
-        }
-    }
-
     /// Add a register def, at the end of the instruction (`After`
     /// position). Use only when this def will be written after all
     /// uses are read.
@@ -381,13 +374,6 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
         } else {
             debug_assert!(reg.to_reg().is_virtual());
             self.add_operand(Operand::reg_def(reg.to_reg().into()));
-        }
-    }
-
-    /// Add multiple register defs.
-    pub fn reg_defs(&mut self, regs: &[Writable<Reg>]) {
-        for &reg in regs {
-            self.reg_def(reg);
         }
     }
 


### PR DESCRIPTION
The `reg_uses` and `reg_defs` helpers are not widely useful and have become quite rarely used over time. The last few remaining callers are all in the riscv64 backend. This commit replaces those calls with simple loops or unrolled calls to `reg_use` or `reg_def`, then deletes the helpers.