### PR TITLE
winch(aarch64): Use single precision fmov

### DIFF
--- a/tests/disas/winch/aarch64/f32_add/const.wat
+++ b/tests/disas/winch/aarch64/f32_add/const.wat
@@ -24,7 +24,7 @@
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s1, w16
 ;;       fadd    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_add/locals.wat
+++ b/tests/disas/winch/aarch64/f32_add/locals.wat
@@ -39,7 +39,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fadd    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_add/params.wat
+++ b/tests/disas/winch/aarch64/f32_add/params.wat
@@ -22,7 +22,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fadd    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_div/const.wat
+++ b/tests/disas/winch/aarch64/f32_div/const.wat
@@ -24,7 +24,7 @@
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s1, w16
 ;;       fdiv    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_div/locals.wat
+++ b/tests/disas/winch/aarch64/f32_div/locals.wat
@@ -39,7 +39,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fdiv    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_div/params.wat
+++ b/tests/disas/winch/aarch64/f32_div/params.wat
@@ -22,7 +22,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fdiv    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_max/const.wat
+++ b/tests/disas/winch/aarch64/f32_max/const.wat
@@ -24,7 +24,7 @@
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s1, w16
 ;;       fmax    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_max/locals.wat
+++ b/tests/disas/winch/aarch64/f32_max/locals.wat
@@ -39,7 +39,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fmax    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_max/params.wat
+++ b/tests/disas/winch/aarch64/f32_max/params.wat
@@ -22,7 +22,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fmax    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_min/const.wat
+++ b/tests/disas/winch/aarch64/f32_min/const.wat
@@ -24,7 +24,7 @@
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s1, w16
 ;;       fmin    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_min/locals.wat
+++ b/tests/disas/winch/aarch64/f32_min/locals.wat
@@ -39,7 +39,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fmin    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_min/params.wat
+++ b/tests/disas/winch/aarch64/f32_min/params.wat
@@ -22,7 +22,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fmin    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_mul/const.wat
+++ b/tests/disas/winch/aarch64/f32_mul/const.wat
@@ -24,7 +24,7 @@
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s1, w16
 ;;       fmul    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_mul/locals.wat
+++ b/tests/disas/winch/aarch64/f32_mul/locals.wat
@@ -39,7 +39,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fmul    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_mul/params.wat
+++ b/tests/disas/winch/aarch64/f32_mul/params.wat
@@ -22,7 +22,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fmul    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_sub/const.wat
+++ b/tests/disas/winch/aarch64/f32_sub/const.wat
@@ -24,7 +24,7 @@
 ;;       movk    w16, #0x3f8c, lsl #16
 ;;       fmov    s1, w16
 ;;       fsub    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x10
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_sub/locals.wat
+++ b/tests/disas/winch/aarch64/f32_sub/locals.wat
@@ -39,7 +39,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fsub    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/tests/disas/winch/aarch64/f32_sub/params.wat
+++ b/tests/disas/winch/aarch64/f32_sub/params.wat
@@ -22,7 +22,7 @@
 ;;       ldur    w0, [x28]
 ;;       ldur    w1, [x28, #4]
 ;;       fsub    s1, s1, s0
-;;       fmov    d0, d1
+;;       fmov    s0, s1
 ;;       add     sp, sp, #0x18
 ;;       mov     x28, sp
 ;;       ldp     x29, x30, [sp], #0x10

--- a/winch/codegen/src/isa/aarch64/asm.rs
+++ b/winch/codegen/src/isa/aarch64/asm.rs
@@ -161,12 +161,22 @@ impl Assembler {
         });
     }
 
-    pub fn fmov64_rr(&mut self, rm: Reg, rd: Reg) {
-        let writable_rd = Writable::from_reg(rd.into());
-        self.emit(Inst::FpuMove64 {
-            rd: writable_rd,
-            rn: rm.into(),
-        })
+    /// Floating point register to register move.
+    pub fn fmov_rr(&mut self, rn: Reg, rd: Reg, size: OperandSize) {
+        let writable = Writable::from_reg(rd.into());
+        let inst = match size {
+            OperandSize::S32 => Inst::FpuMove32 {
+                rd: writable,
+                rn: rn.into(),
+            },
+            OperandSize::S64 => Inst::FpuMove64 {
+                rd: writable,
+                rn: rn.into(),
+            },
+            _ => unreachable!(),
+        };
+
+        self.emit(inst);
     }
 
     pub fn mov_to_fpu(&mut self, rn: Reg, rd: Reg, size: OperandSize) {

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -213,7 +213,7 @@ impl Masm for MacroAssembler {
             (RegImm::Reg(rs), rd) => match (rs.class(), rd.class()) {
                 (RegClass::Int, RegClass::Int) => self.asm.mov_rr(rs, rd, size),
                 // TODO: verify whether we should use `fmov sd, sn` for F32.
-                (RegClass::Float, RegClass::Float) => self.asm.fmov64_rr(rs, rd),
+                (RegClass::Float, RegClass::Float) => self.asm.fmov_rr(rs, rd, size),
                 (RegClass::Int, RegClass::Float) => self.asm.mov_to_fpu(rs, rd, size),
                 _ => todo!(),
             },

--- a/winch/codegen/src/isa/aarch64/masm.rs
+++ b/winch/codegen/src/isa/aarch64/masm.rs
@@ -212,7 +212,6 @@ impl Masm for MacroAssembler {
             }
             (RegImm::Reg(rs), rd) => match (rs.class(), rd.class()) {
                 (RegClass::Int, RegClass::Int) => self.asm.mov_rr(rs, rd, size),
-                // TODO: verify whether we should use `fmov sd, sn` for F32.
                 (RegClass::Float, RegClass::Float) => self.asm.fmov_rr(rs, rd, size),
                 (RegClass::Int, RegClass::Float) => self.asm.mov_to_fpu(rs, rd, size),
                 _ => todo!(),


### PR DESCRIPTION
This commit is a follow-up to https://github.com/bytecodealliance/wasmtime/pull/8365/. In https://github.com/bytecodealliance/wasmtime/pull/8453 single precision fmov was introduced in Cranelift, so now we can make use of that instruction in Winch.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
