### PR TITLE
c-api: Tidy up some `wasmtime_func_t` usage

### DIFF
--- a/crates/c-api/include/wasmtime/extern.h
+++ b/crates/c-api/include/wasmtime/extern.h
@@ -17,58 +17,62 @@ extern "C" {
 
 /// \brief Representation of a function in Wasmtime.
 ///
-/// Functions are represented with a 64-bit identifying integer in Wasmtime.
-/// They do not have any destructor associated with them. Functions cannot
-/// interoperate between #wasmtime_store_t instances and if the wrong function
-/// is passed to the wrong store then it may trigger an assertion to abort the
-/// process.
+/// Functions in Wasmtime are represented as an index into a store and don't
+/// have any data or destructor associated with the #wasmtime_func_t value.
+/// Functions cannot interoperate between #wasmtime_store_t instances and if the
+/// wrong function is passed to the wrong store then it may trigger an assertion
+/// to abort the process.
 typedef struct wasmtime_func {
-  /// Internal identifier of what store this belongs to, never zero.
+  /// Internal identifier of what store this belongs to.
+  ///
+  /// This field may be zero when used in conjunction with #wasmtime_val_t
+  /// to represent a null `funcref` value in WebAssembly. For a valid function
+  /// this field is otherwise never zero.
   uint64_t store_id;
-  /// Internal index within the store.
-  size_t index;
+  /// Private field for Wasmtime, undefined if `store_id` is zero.
+  size_t __private;
 } wasmtime_func_t;
 
 /// \brief Representation of a table in Wasmtime.
 ///
-/// Tables are represented with a 64-bit identifying integer in Wasmtime.
-/// They do not have any destructor associated with them. Tables cannot
-/// interoperate between #wasmtime_store_t instances and if the wrong table
-/// is passed to the wrong store then it may trigger an assertion to abort the
-/// process.
+/// Tables in Wasmtime are represented as an index into a store and don't
+/// have any data or destructor associated with the #wasmtime_table_t value.
+/// Tables cannot interoperate between #wasmtime_store_t instances and if the
+/// wrong table is passed to the wrong store then it may trigger an assertion
+/// to abort the process.
 typedef struct wasmtime_table {
   /// Internal identifier of what store this belongs to, never zero.
   uint64_t store_id;
-  /// Internal index within the store.
-  size_t index;
+  /// Private field for Wasmtime.
+  size_t __private;
 } wasmtime_table_t;
 
 /// \brief Representation of a memory in Wasmtime.
 ///
-/// Memories are represented with a 64-bit identifying integer in Wasmtime.
-/// They do not have any destructor associated with them. Memories cannot
-/// interoperate between #wasmtime_store_t instances and if the wrong memory
-/// is passed to the wrong store then it may trigger an assertion to abort the
-/// process.
+/// Memories in Wasmtime are represented as an index into a store and don't
+/// have any data or destructor associated with the #wasmtime_memory_t value.
+/// Memories cannot interoperate between #wasmtime_store_t instances and if the
+/// wrong memory is passed to the wrong store then it may trigger an assertion
+/// to abort the process.
 typedef struct wasmtime_memory {
   /// Internal identifier of what store this belongs to, never zero.
   uint64_t store_id;
-  /// Internal index within the store.
-  size_t index;
+  /// Private field for Wasmtime.
+  size_t __private;
 } wasmtime_memory_t;
 
 /// \brief Representation of a global in Wasmtime.
 ///
-/// Globals are represented with a 64-bit identifying integer in Wasmtime.
-/// They do not have any destructor associated with them. Globals cannot
-/// interoperate between #wasmtime_store_t instances and if the wrong global
-/// is passed to the wrong store then it may trigger an assertion to abort the
-/// process.
+/// Globals in Wasmtime are represented as an index into a store and don't
+/// have any data or destructor associated with the #wasmtime_global_t value.
+/// Globals cannot interoperate between #wasmtime_store_t instances and if the
+/// wrong global is passed to the wrong store then it may trigger an assertion
+/// to abort the process.
 typedef struct wasmtime_global {
   /// Internal identifier of what store this belongs to, never zero.
   uint64_t store_id;
-  /// Internal index within the store.
-  size_t index;
+  /// Private field for Wasmtime.
+  size_t __private;
 } wasmtime_global_t;
 
 /// \brief Discriminant of #wasmtime_extern_t

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -241,12 +241,30 @@ typedef union wasmtime_valunion {
   wasmtime_externref_t *externref;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_FUNCREF
   ///
-  /// If this value represents a `ref.null func` value then the `store_id` field
-  /// is set to zero.
+  /// Use #wasmtime_funcref_is_null to test whether this is a null function
+  /// reference.
   wasmtime_func_t funcref;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_V128
   wasmtime_v128 v128;
 } wasmtime_valunion_t;
+
+/// \brief Initialize a `wasmtime_func_t` value as a null function reference.
+///
+/// This function will initialize the `func` provided to be a null function
+/// reference. Used in conjunction with #wasmtime_val_t and
+/// #wasmtime_valunion_t.
+static inline void wasmtime_funcref_set_null(wasmtime_func_t *func) {
+  func->store_id = 0;
+}
+
+/// \brief Helper function to test whether the `func` provided is a null
+/// function reference.
+///
+/// This function is used with #wasmtime_val_t and #wasmtime_valunion_t and its
+/// `funcref` field. This will test whether the field represents a null funcref.
+static inline bool wasmtime_funcref_is_null(const wasmtime_func_t *func) {
+  return func->store_id == 0;
+}
 
 /**
  * \typedef wasmtime_val_raw_t

--- a/crates/c-api/include/wasmtime/val.h
+++ b/crates/c-api/include/wasmtime/val.h
@@ -241,7 +241,7 @@ typedef union wasmtime_valunion {
   wasmtime_externref_t *externref;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_FUNCREF
   ///
-  /// Use #wasmtime_funcref_is_null to test whether this is a null function
+  /// Use `wasmtime_funcref_is_null` to test whether this is a null function
   /// reference.
   wasmtime_func_t funcref;
   /// Field used if #wasmtime_val_t::kind is #WASMTIME_V128

--- a/crates/wasmtime/src/runtime/store/data.rs
+++ b/crates/wasmtime/src/runtime/store/data.rs
@@ -237,7 +237,7 @@ impl StoreId {
     }
 }
 
-#[repr(C)] // used by reference in the C API
+#[repr(C)] // used by reference in the C API, also in `wasmtime_func_t`.
 pub struct Stored<T> {
     store_id: StoreId,
     index: usize,


### PR DESCRIPTION
Try to avoid using a `transmute` in the implementation of the C API and instead use a `union` like is being done in #8451. Additionally add some helper functions to the header to work with null funcref values instead of only documenting the implementation.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
