### PR TITLE
Start migrating some Wasmtime crates to no_std

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -360,6 +360,19 @@ jobs:
     - run: cargo check -p wasmtime-c-api --no-default-features --features wat
     - run: cargo check -p wasmtime-c-api --no-default-features --features wasi
 
+    # Checks for no_std support, ensure that crates can build on a no_std
+    # target
+    - run: rustup target add x86_64-unknown-none
+    - run: cargo check -p wasmtime-jit-icache-coherence
+      env:
+        CARGO_BUILD_TARGET: x86_64-unknown-none
+    - run: cargo check -p wasmtime-component-util
+      env:
+        CARGO_BUILD_TARGET: x86_64-unknown-none
+    - run: cargo check -p wasmtime-asm-macros
+      env:
+        CARGO_BUILD_TARGET: x86_64-unknown-none
+
     # Check that wasmtime-runtime compiles with panic=abort since there's some
     # #[cfg] for specifically panic=abort there.
     - run: cargo check -p wasmtime-runtime

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3803,6 +3803,7 @@ dependencies = [
 name = "wasmtime-jit-icache-coherence"
 version = "21.0.0"
 dependencies = [
+ "anyhow",
  "cfg-if",
  "libc",
  "windows-sys 0.52.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ object = { workspace = true }
 windows-sys = { workspace = true, features = ["Win32_System_Memory"] }
 
 [build-dependencies]
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ['std'] }
 
 [profile.release.build-override]
 opt-level = 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,14 +32,14 @@ wasmtime-cranelift = { workspace = true, optional = true }
 wasmtime-environ = { workspace = true }
 wasmtime-explorer = { workspace = true, optional = true }
 wasmtime-wast = { workspace = true, optional = true }
-wasi-common = { workspace = true, default-features = true, features = ["exit" ], optional = true }
+wasi-common = { workspace = true, default-features = true, features = ["exit"], optional = true }
 wasmtime-wasi = { workspace = true, default-features = true, optional = true }
 wasmtime-wasi-nn = { workspace = true, optional = true }
 wasmtime-wasi-threads = { workspace = true, optional = true }
 wasmtime-wasi-http = { workspace = true, optional = true }
 wasmtime-runtime = { workspace = true, optional = true }
 clap = { workspace = true }
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ['std'] }
 target-lexicon = { workspace = true }
 once_cell = { workspace = true }
 listenfd = { version = "1.0.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ wit-component = "0.206.0"
 # --------------------------
 object = { version = "0.33", default-features = false, features = ['read_core', 'elf', 'std'] }
 gimli = { version = "0.28.0", default-features = false, features = ['read', 'std'] }
-anyhow = "1.0.22"
+anyhow = { version = "1.0.22", default-features = false }
 windows-sys = "0.52.0"
 env_logger = "0.10"
 log = { version = "0.4.8", default-features = false }

--- a/cranelift/codegen/Cargo.toml
+++ b/cranelift/codegen/Cargo.toml
@@ -16,7 +16,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true, optional = true }
+anyhow = { workspace = true, optional = true, features = ['std'] }
 bumpalo = "3"
 capstone = { workspace = true, optional = true }
 cranelift-codegen-shared = { path = "./shared", version = "0.108.0" }

--- a/cranelift/module/Cargo.toml
+++ b/cranelift/module/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 cranelift-codegen = { workspace = true }
 cranelift-control = { workspace = true }
 hashbrown = { workspace = true, optional = true }
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ['std'] }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 

--- a/cranelift/reader/Cargo.toml
+++ b/cranelift/reader/Cargo.toml
@@ -13,7 +13,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true, features = ['std'] }
 cranelift-codegen = { workspace = true }
 smallvec = { workspace = true }
 target-lexicon = { workspace = true }

--- a/crates/asm-macros/src/lib.rs
+++ b/crates/asm-macros/src/lib.rs
@@ -6,6 +6,8 @@
 //! function) and additionally handles visibility across platforms. All symbols
 //! should be visible to Rust but not visible externally outside of a `*.so`.
 
+#![no_std]
+
 cfg_if::cfg_if! {
     if #[cfg(target_os = "macos")] {
         #[macro_export]

--- a/crates/cache/Cargo.toml
+++ b/crates/cache/Cargo.toml
@@ -12,7 +12,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ['std'] }
 base64 = "0.21.0"
 postcard = { workspace = true }
 directories-next = "2.0"

--- a/crates/component-util/src/lib.rs
+++ b/crates/component-util/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 /// Represents the possible sizes in bytes of the discriminant of a variant type in the component model
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub enum DiscriminantSize {

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -14,7 +14,7 @@ edition.workspace = true
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ['std'] }
 postcard = { workspace = true }
 cpp_demangle = { version = "0.4.3", optional = true }
 cranelift-entity = { workspace = true }

--- a/crates/jit-icache-coherence/Cargo.toml
+++ b/crates/jit-icache-coherence/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 
 [dependencies]
 cfg-if = { workspace = true }
+anyhow = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 workspace = true

--- a/crates/jit-icache-coherence/src/lib.rs
+++ b/crates/jit-icache-coherence/src/lib.rs
@@ -34,7 +34,7 @@
 //! #   len: usize,
 //! # }
 //! #
-//! # fn main() -> io::Result<()> {
+//! # fn main() -> anyhow::Result<()> {
 //! #
 //! # let run_code = || {};
 //! # let code = vec![0u8; 64];
@@ -67,8 +67,9 @@
 //!
 //! [ARM Community - Caches and Self-Modifying Code]: https://community.arm.com/arm-community-blogs/b/architectures-and-processors-blog/posts/caches-and-self-modifying-code
 
-use std::ffi::c_void;
-use std::io::Result;
+#![no_std]
+
+use core::ffi::c_void;
 
 cfg_if::cfg_if! {
     if #[cfg(target_os = "windows")] {
@@ -91,7 +92,7 @@ cfg_if::cfg_if! {
 /// after all calls to [clear_cache].
 ///
 /// If the architecture does not require a pipeline flush, this function does nothing.
-pub fn pipeline_flush_mt() -> Result<()> {
+pub fn pipeline_flush_mt() -> imp::Result<()> {
     imp::pipeline_flush_mt()
 }
 
@@ -103,6 +104,6 @@ pub fn pipeline_flush_mt() -> Result<()> {
 ///
 /// It is necessary to call [pipeline_flush_mt] after this function if you are running in a multi-threaded
 /// environment.
-pub unsafe fn clear_cache(ptr: *const c_void, len: usize) -> Result<()> {
+pub unsafe fn clear_cache(ptr: *const c_void, len: usize) -> imp::Result<()> {
     imp::clear_cache(ptr, len)
 }

--- a/crates/jit-icache-coherence/src/libc.rs
+++ b/crates/jit-icache-coherence/src/libc.rs
@@ -1,14 +1,16 @@
-use std::ffi::c_void;
-use std::io::Result;
+use core::ffi::c_void;
 
 #[cfg(all(
     target_arch = "aarch64",
     any(target_os = "linux", target_os = "android")
 ))]
 mod details {
+    extern crate std;
+
     use super::*;
     use libc::{syscall, EINVAL, EPERM};
     use std::io::Error;
+    pub use std::io::Result;
 
     const MEMBARRIER_CMD_GLOBAL: libc::c_int = 1;
     const MEMBARRIER_CMD_PRIVATE_EXPEDITED_SYNC_CORE: libc::c_int = 32;
@@ -87,7 +89,10 @@ mod details {
     any(target_os = "linux", target_os = "android")
 )))]
 mod details {
-    pub(crate) fn pipeline_flush_mt() -> std::io::Result<()> {
+    // NB: this uses `anyhow::Result` instead of `std::io::Result` to compile on
+    // `no_std`.
+    pub use anyhow::Result;
+    pub(crate) fn pipeline_flush_mt() -> Result<()> {
         Ok(())
     }
 }

--- a/crates/jit-icache-coherence/src/libc.rs
+++ b/crates/jit-icache-coherence/src/libc.rs
@@ -1,11 +1,11 @@
 use core::ffi::c_void;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 extern crate std;
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub use std::io::Result;
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
 pub use anyhow::Result;
 
 #[cfg(all(

--- a/crates/jit-icache-coherence/src/miri.rs
+++ b/crates/jit-icache-coherence/src/miri.rs
@@ -1,5 +1,5 @@
-use std::ffi::c_void;
-use std::io::Result;
+pub use anyhow::Result;
+use core::ffi::c_void;
 
 pub(crate) fn pipeline_flush_mt() -> Result<()> {
     Ok(())

--- a/crates/jit-icache-coherence/src/win.rs
+++ b/crates/jit-icache-coherence/src/win.rs
@@ -1,8 +1,12 @@
+extern crate std;
+
 use std::ffi::c_void;
-use std::io::{Error, Result};
+use std::io::Error;
 use windows_sys::Win32::System::Diagnostics::Debug::FlushInstructionCache;
 use windows_sys::Win32::System::Threading::FlushProcessWriteBuffers;
 use windows_sys::Win32::System::Threading::GetCurrentProcess;
+
+pub use std::io::Result;
 
 /// See docs on [crate::pipeline_flush_mt] for a description of what this function is trying to do.
 #[inline]

--- a/crates/test-programs/Cargo.toml
+++ b/crates/test-programs/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0 WITH LLVM-exception"
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ['std'] }
 wasi = "0.11.0"
 wasi-nn = "0.6.0"
 wit-bindgen = { workspace = true, features = ['default'] }

--- a/crates/wasi-preview1-component-adapter/verify/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/verify/Cargo.toml
@@ -11,4 +11,4 @@ workspace = true
 [dependencies]
 wasmparser = { workspace = true }
 wat = { workspace = true }
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ['std'] }

--- a/examples/min-platform/Cargo.toml
+++ b/examples/min-platform/Cargo.toml
@@ -9,6 +9,6 @@ rust-version.workspace = true
 workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow = { workspace = true, features = ['std'] }
 libloading = "0.8"
 object = { workspace = true }


### PR DESCRIPTION
This commit is the first in what will be multiple PRs to migrate Wasmtime to being compatible with `#![no_std]`. This work is outlined in #8341 and the rough plan I have in mind is to go on a crate-by-crate basis and use CI as a "ratchet" to ensure that `no_std` compat is preserved. In that sense this PR is a bit of a template for future PRs.

This PR migrates a few small crates to `no_std`, basically those that need no changes beyond simply adding the attribute. The nontrivial parts introduced in this PR are:

* CI is introduced to verify that a subset of crates can indeed be built on a `no_std` target. The target selected is `x86_64-unknown-none` which is known to not have `std` and will result in a build error if it's attempted to be used.

* The `anyhow` crate, which `wasmtime-jit-icache-coherence` now depends on, has its `std` feature disabled by default in Wasmtime's workspace. This means that some crates which require `std` now need to explicitly enable the feature, but it means that by-default its usage is appropriate for `no_std`.

The first point should provide CI checks that compatibility with `no_std` indeed works, at least from an "it compiles" perspective. Note that it's not sufficient to test with a target like `x86_64-unknown-linux-gnu` because `extern crate std` will work on that target, even when `#![no_std]` is active.

The second point however is likely to increase maintenance burden in Wasmtime unfortunately. Namely we'll inevitably, either here or in the future, forget to turn on some feature for some crate that's not covered in CI checks. While I've tried to do my best here in covering it there's no guarantee that everything will work and the combinatorial explosion of what could be checked in CI can't all be added to CI. Instead we'll have to rely on bug fixes, users, and perhaps point releases to add more use cases to CI over time as we see fit.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
