### PR TITLE
cranelift: Don't resolve VReg aliases too early

### DIFF
--- a/cranelift/codegen/src/machinst/lower.rs
+++ b/cranelift/codegen/src/machinst/lower.rs
@@ -989,14 +989,10 @@ impl<'func, I: VCodeInst> Lower<'func, I> {
             for &arg in branch_args {
                 let arg = self.f.dfg.resolve_aliases(arg);
                 let regs = self.put_value_in_regs(arg);
-                for &vreg in regs.regs() {
-                    let vreg = self.vcode.vcode.resolve_vreg_alias(vreg.into());
-                    branch_arg_vregs.push(vreg.into());
-                }
+                branch_arg_vregs.extend_from_slice(regs.regs());
             }
             self.vcode.add_succ(succ, &branch_arg_vregs[..]);
         }
-        self.finish_ir_inst(Default::default());
     }
 
     fn collect_branches_and_targets(

--- a/cranelift/codegen/src/machinst/vcode.rs
+++ b/cranelift/codegen/src/machinst/vcode.rs
@@ -1231,7 +1231,7 @@ impl<I: VCodeInst> VCode<I> {
         self.block_order.lowered_order()[block.index()].orig_block()
     }
 
-    pub fn resolve_vreg_alias(&self, from: regalloc2::VReg) -> regalloc2::VReg {
+    fn resolve_vreg_alias(&self, from: regalloc2::VReg) -> regalloc2::VReg {
         Self::resolve_vreg_alias_impl(&self.vreg_aliases, from)
     }
 


### PR DESCRIPTION
When lower_branch_blockparam_args is called, the instructions which define the values used as blockparam args haven't been lowered yet, so we haven't set any aliases referring to them yet, so there's no point checking.

Note that block-param argument aliases are currently resolved after operand collection, so this work does happen eventually.

Also, this method doesn't add any instructions to self.ir_insts, so there's no need to call finish_ir_inst.

With this change, VReg alias resolution is purely local to vcode.rs.