### PR TITLE
cranelift/x64: Allow collecting Gpr/Xmm operands

### DIFF
--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -55,6 +55,12 @@ macro_rules! newtype_of_reg {
             }
         }
 
+        impl From<&$newtype_reg> for Reg {
+            fn from(r: &$newtype_reg) -> Self {
+                r.0
+            }
+        }
+
         impl $newtype_reg {
             /// Create this newtype from the given register, or return `None` if the register
             /// is not a valid instance of this newtype.
@@ -365,13 +371,13 @@ impl Amode {
                     collector.reg_use(*base);
                 }
             }
-            Amode::ImmRegRegShift { base, index, .. } => {
+            &Amode::ImmRegRegShift { base, index, .. } => {
                 debug_assert_ne!(base.to_reg(), regs::rbp());
                 debug_assert_ne!(base.to_reg(), regs::rsp());
-                collector.reg_use(base.to_reg());
+                collector.reg_use(base);
                 debug_assert_ne!(index.to_reg(), regs::rbp());
                 debug_assert_ne!(index.to_reg(), regs::rsp());
-                collector.reg_use(index.to_reg());
+                collector.reg_use(index);
             }
             Amode::RipRelative { .. } => {
                 // RIP isn't involved in regalloc.
@@ -388,9 +394,9 @@ impl Amode {
             Amode::ImmReg { base, .. } => {
                 collector.reg_late_use(*base);
             }
-            Amode::ImmRegRegShift { base, index, .. } => {
-                collector.reg_late_use(base.to_reg());
-                collector.reg_late_use(index.to_reg());
+            &Amode::ImmRegRegShift { base, index, .. } => {
+                collector.reg_late_use(base);
+                collector.reg_late_use(index);
             }
             Amode::RipRelative { .. } => {
                 // RIP isn't involved in regalloc.


### PR DESCRIPTION
Previously, the operand collector required its arguments to be of type Reg. But the x86-64 backend uses newtype wrappers around Reg to ensure that different register classes don't get mixed up, so it had to convert types everywhere to pass registers to the operand collector.

This commit allows the operand collector to accept any type which implements `Into<Reg>` instead. The newtype wrappers already implemented that, so we can mostly just delete the `to_reg` and `to_writable_reg` calls.

However, those calls were also automatically dereferencing borrows as needed, so to minimize the need for explicit dereferences I've also introduced implementations for converting from &Gpr/&Xmm to Reg. That doesn't help with the Writable-wrapped registers but it's good enough. I have a PR in progress which will clean it up the rest of the way.