### PR TITLE
Update CI configuration for macOS builds/tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -495,7 +495,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v4

--- a/ci/build-build-matrix.js
+++ b/ci/build-build-matrix.js
@@ -36,7 +36,7 @@ const array = [
   },
   {
     "build": "aarch64-macos",
-    "os": "macos-14",
+    "os": "macos-latest",
     "target": "aarch64-apple-darwin",
   },
   {

--- a/ci/build-test-matrix.js
+++ b/ci/build-test-matrix.js
@@ -56,7 +56,7 @@ const array = [
     "isa": "x64"
   },
   {
-    "os": "macos-latest",
+    "os": "macos-13",
     "name": "Test macOS x86_64",
     "filter": "macos-x64",
     "extra_features": "--features wasmtime-wasi-nn/onnx"


### PR DESCRIPTION
Looks like GitHub is changing `macos-latest` to arm64 so change the test builder that test x64 macos to `macos-13` which is the last builder that wasn't arm64. Additionally drop `macos-14` from the C API tests since testing `macos-latest` should be sufficient enough.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
