### PR TITLE
Migrate the wasmtime-types crate to no_std

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -375,6 +375,9 @@ jobs:
     - run: cargo check -p wasmtime-slab
       env:
         CARGO_BUILD_TARGET: x86_64-unknown-none
+    - run: cargo check -p wasmtime-types
+      env:
+        CARGO_BUILD_TARGET: x86_64-unknown-none
 
     # Check that wasmtime-runtime compiles with panic=abort since there's some
     # #[cfg] for specifically panic=abort there.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3854,7 +3854,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "smallvec",
- "thiserror",
  "wasmparser 0.206.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -234,7 +234,7 @@ rustix = "0.38.31"
 wit-bindgen = { version = "0.22.0", default-features = false }
 
 # wasm-tools family:
-wasmparser = "0.206.0"
+wasmparser = { version = "0.206.0", default-features = false }
 wat = "1.206.0"
 wast = "206.0.0"
 wasmprinter = "0.206.0"
@@ -265,7 +265,7 @@ heck = "0.4"
 similar = "2.1.0"
 toml = "0.8.10"
 # serde and serde_derive must have the same version
-serde = "1.0.188"
+serde = { version = "1.0.188", default-features = false, features = ['alloc'] }
 serde_derive = "1.0.188"
 serde_json = "1.0.80"
 glob = "0.3.0"

--- a/crates/environ/Cargo.toml
+++ b/crates/environ/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = { workspace = true, features = ['std'] }
 postcard = { workspace = true }
 cpp_demangle = { version = "0.4.3", optional = true }
 cranelift-entity = { workspace = true }
-wasmtime-types = { workspace = true }
+wasmtime-types = { workspace = true, features = ['std'] }
 wasmparser = { workspace = true }
 indexmap = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -13,8 +13,10 @@ cranelift-entity = { workspace = true, features = ['enable-serde'] }
 serde = { workspace = true }
 serde_derive = { workspace = true }
 smallvec = { workspace = true, features = ["serde"] }
-thiserror = { workspace = true }
 wasmparser = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+std = ['wasmparser/std']

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,12 +1,22 @@
 //! Internal dependency of Wasmtime and Cranelift that defines types for
 //! WebAssembly.
 
-use smallvec::SmallVec;
+#![no_std]
+
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
 pub use wasmparser;
 
+#[doc(hidden)]
+pub use alloc::format as __format;
+
+use alloc::boxed::Box;
+use core::{fmt, ops::Range};
 use cranelift_entity::entity_impl;
 use serde_derive::{Deserialize, Serialize};
-use std::{fmt, ops::Range};
+use smallvec::SmallVec;
 
 mod error;
 pub use error::*;

--- a/crates/wasi-preview1-component-adapter/verify/Cargo.toml
+++ b/crates/wasi-preview1-component-adapter/verify/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 workspace = true
 
 [dependencies]
-wasmparser = { workspace = true }
+wasmparser = { workspace = true, features = ['std'] }
 wat = { workspace = true }
 anyhow = { workspace = true, features = ['std'] }


### PR DESCRIPTION
This commit is where no_std for Wasmtime starts to get a bit interesting. Specifically the `wasmtime-types` crate is the first crate that depends on some nontrivial crates that also need to be migrated to `no_std`. This PR disables the default feature of `wasmparser` by default and additionally does the same for `serde`. This enables them to compile in `no_std` contexts by default and default features will be enabled elsewhere in this repository as necessary.

This also opts to drop the `thiserror` dependency entirely in favor of a manual `Display` implementation with a cfg'd implementation of `Error`.

As before CI checks are added for `wasmtime-types` with a `no_std` target itself to ensure the crate and all dependencies all avoid `std`.

cc #8341