### PR TITLE
cranelift: Update operand aliases in-place

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -128,11 +128,11 @@ impl AMode {
     /// Add the registers referenced by this AMode to `collector`.
     /// Keep this in sync with `with_allocs`.
     pub(crate) fn get_operands<F: Fn(regalloc2::VReg) -> regalloc2::VReg>(
-        &self,
+        &mut self,
         collector: &mut OperandCollector<'_, F>,
     ) {
         match self {
-            &AMode::RegOffset(reg, ..) => collector.reg_use(reg),
+            AMode::RegOffset(reg, ..) => collector.reg_use(reg),
             // Registers used in these modes aren't allocatable.
             AMode::SPOffset(..)
             | AMode::FPOffset(..)

--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -1071,7 +1071,7 @@ impl VecAMode {
     }
 
     pub fn get_operands<F: Fn(regalloc2::VReg) -> regalloc2::VReg>(
-        &self,
+        &mut self,
         collector: &mut OperandCollector<'_, F>,
     ) {
         match self {

--- a/cranelift/codegen/src/isa/x64/inst/args.rs
+++ b/cranelift/codegen/src/isa/x64/inst/args.rs
@@ -55,12 +55,6 @@ macro_rules! newtype_of_reg {
             }
         }
 
-        impl From<&$newtype_reg> for Reg {
-            fn from(r: &$newtype_reg) -> Self {
-                r.0
-            }
-        }
-
         impl $newtype_reg {
             /// Create this newtype from the given register, or return `None` if the register
             /// is not a valid instance of this newtype.
@@ -89,6 +83,15 @@ macro_rules! newtype_of_reg {
 
             fn deref(&self) -> &Reg {
                 &self.0
+            }
+        }
+
+        /// If you know what you're doing, you can explicitly mutably borrow the
+        /// underlying `Reg`. Don't make it point to the wrong type of register
+        /// please.
+        impl AsMut<Reg> for $newtype_reg {
+            fn as_mut(&mut self) -> &mut Reg {
+                &mut self.0
             }
         }
 
@@ -164,7 +167,7 @@ macro_rules! newtype_of_reg {
 
                 #[allow(dead_code)] // Used by some newtypes and not others.
                 pub(crate) fn get_operands<F: Fn(VReg) -> VReg>(
-                    &self,
+                    &mut self,
                     collector: &mut OperandCollector<'_, F>,
                 ) {
                     self.0.get_operands(collector);
@@ -232,7 +235,7 @@ macro_rules! newtype_of_reg {
 
                 #[allow(dead_code)] // Used by some newtypes and not others.
                 pub(crate) fn get_operands<F: Fn(VReg) -> VReg>(
-                    &self,
+                    &mut self,
                     collector: &mut OperandCollector<'_, F>,
                 ) {
                     self.0.get_operands(collector);
@@ -273,6 +276,12 @@ macro_rules! newtype_of_reg {
             #[allow(dead_code)] // Used by some newtypes and not others.
             pub fn as_imm8_reg(&self) -> &Imm8Reg {
                 &self.0
+            }
+
+            /// Borrow this newtype as its underlying `Imm8Reg`.
+            #[allow(dead_code)] // Used by some newtypes and not others.
+            pub fn as_imm8_reg_mut(&mut self) -> &mut Imm8Reg {
+                &mut self.0
             }
         }
     };
@@ -362,16 +371,16 @@ impl Amode {
 
     /// Add the registers mentioned by `self` to `collector`.
     pub(crate) fn get_operands<F: Fn(VReg) -> VReg>(
-        &self,
+        &mut self,
         collector: &mut OperandCollector<'_, F>,
     ) {
         match self {
             Amode::ImmReg { base, .. } => {
                 if *base != regs::rbp() && *base != regs::rsp() {
-                    collector.reg_use(*base);
+                    collector.reg_use(base);
                 }
             }
-            &Amode::ImmRegRegShift { base, index, .. } => {
+            Amode::ImmRegRegShift { base, index, .. } => {
                 debug_assert_ne!(base.to_reg(), regs::rbp());
                 debug_assert_ne!(base.to_reg(), regs::rsp());
                 collector.reg_use(base);
@@ -387,14 +396,14 @@ impl Amode {
 
     /// Same as `get_operands`, but add the registers in the "late" phase.
     pub(crate) fn get_operands_late<F: Fn(VReg) -> VReg>(
-        &self,
+        &mut self,
         collector: &mut OperandCollector<'_, F>,
     ) {
         match self {
             Amode::ImmReg { base, .. } => {
-                collector.reg_late_use(*base);
+                collector.reg_late_use(base);
             }
-            &Amode::ImmRegRegShift { base, index, .. } => {
+            Amode::ImmRegRegShift { base, index, .. } => {
                 collector.reg_late_use(base);
                 collector.reg_late_use(index);
             }
@@ -527,7 +536,7 @@ impl SyntheticAmode {
 
     /// Add the registers mentioned by `self` to `collector`.
     pub(crate) fn get_operands<F: Fn(VReg) -> VReg>(
-        &self,
+        &mut self,
         collector: &mut OperandCollector<'_, F>,
     ) {
         match self {
@@ -544,7 +553,7 @@ impl SyntheticAmode {
 
     /// Same as `get_operands`, but add the register in the "late" phase.
     pub(crate) fn get_operands_late<F: Fn(VReg) -> VReg>(
-        &self,
+        &mut self,
         collector: &mut OperandCollector<'_, F>,
     ) {
         match self {
@@ -678,11 +687,11 @@ impl RegMemImm {
 
     /// Add the regs mentioned by `self` to `collector`.
     pub(crate) fn get_operands<F: Fn(VReg) -> VReg>(
-        &self,
+        &mut self,
         collector: &mut OperandCollector<'_, F>,
     ) {
         match self {
-            Self::Reg { reg } => collector.reg_use(*reg),
+            Self::Reg { reg } => collector.reg_use(reg),
             Self::Mem { addr } => addr.get_operands(collector),
             Self::Imm { .. } => {}
         }
@@ -788,11 +797,11 @@ impl RegMem {
     }
     /// Add the regs mentioned by `self` to `collector`.
     pub(crate) fn get_operands<F: Fn(VReg) -> VReg>(
-        &self,
+        &mut self,
         collector: &mut OperandCollector<'_, F>,
     ) {
         match self {
-            RegMem::Reg { reg } => collector.reg_use(*reg),
+            RegMem::Reg { reg } => collector.reg_use(reg),
             RegMem::Mem { addr, .. } => addr.get_operands(collector),
         }
     }

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -96,7 +96,7 @@ pub trait MachInst: Clone + Debug {
 
     /// Return the registers referenced by this machine instruction along with
     /// the modes of reference (use, def, modify).
-    fn get_operands<F: Fn(VReg) -> VReg>(&self, collector: &mut OperandCollector<'_, F>);
+    fn get_operands<F: Fn(VReg) -> VReg>(&mut self, collector: &mut OperandCollector<'_, F>);
 
     /// If this is a simple move, return the (source, destination) tuple of registers.
     fn is_move(&self) -> Option<(Writable<Reg>, Reg)>;

--- a/cranelift/codegen/src/machinst/reg.rs
+++ b/cranelift/codegen/src/machinst/reg.rs
@@ -96,6 +96,12 @@ impl std::fmt::Debug for Reg {
     }
 }
 
+impl AsMut<Reg> for Reg {
+    fn as_mut(&mut self) -> &mut Reg {
+        self
+    }
+}
+
 /// A real (physical) register. This corresponds to one of the target
 /// ISA's named registers and can be used as an instruction operand.
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -321,14 +327,14 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
     /// Add an operand.
     fn add_operand(
         &mut self,
-        reg: Reg,
+        reg: &mut Reg,
         constraint: OperandConstraint,
         kind: OperandKind,
         pos: OperandPos,
     ) {
-        let vreg = (self.renamer)(reg.into());
+        reg.0 = (self.renamer)(reg.0);
         self.operands
-            .push(Operand::new(vreg, constraint, kind, pos));
+            .push(Operand::new(reg.0, constraint, kind, pos));
     }
 
     /// Finish the operand collection and return the tuple giving the
@@ -344,59 +350,58 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
     pub fn reg_fixed_nonallocatable(&mut self, preg: PReg) {
         debug_assert!(!self.is_allocatable_preg(preg));
         // Magic VReg which does not participate in register allocation.
-        let vreg = VReg::new(VReg::MAX, preg.class());
+        let mut reg = Reg(VReg::new(VReg::MAX, preg.class()));
         let constraint = OperandConstraint::FixedReg(preg);
         // This operand won't be allocated, so kind and pos don't matter.
-        self.add_operand(Reg(vreg), constraint, OperandKind::Use, OperandPos::Early);
+        self.add_operand(&mut reg, constraint, OperandKind::Use, OperandPos::Early);
     }
 
     /// Add a register use, at the start of the instruction (`Before`
     /// position).
-    pub fn reg_use(&mut self, reg: impl Into<Reg>) {
-        self.reg_maybe_fixed(reg.into(), OperandKind::Use, OperandPos::Early);
+    pub fn reg_use(&mut self, reg: &mut impl AsMut<Reg>) {
+        self.reg_maybe_fixed(reg.as_mut(), OperandKind::Use, OperandPos::Early);
     }
 
     /// Add a register use, at the end of the instruction (`After` position).
-    pub fn reg_late_use(&mut self, reg: impl Into<Reg>) {
-        self.reg_maybe_fixed(reg.into(), OperandKind::Use, OperandPos::Late);
+    pub fn reg_late_use(&mut self, reg: &mut impl AsMut<Reg>) {
+        self.reg_maybe_fixed(reg.as_mut(), OperandKind::Use, OperandPos::Late);
     }
 
     /// Add a register def, at the end of the instruction (`After`
     /// position). Use only when this def will be written after all
     /// uses are read.
-    pub fn reg_def(&mut self, reg: Writable<impl Into<Reg>>) {
-        self.reg_maybe_fixed(reg.to_reg().into(), OperandKind::Def, OperandPos::Late);
+    pub fn reg_def(&mut self, reg: &mut Writable<impl AsMut<Reg>>) {
+        self.reg_maybe_fixed(reg.reg.as_mut(), OperandKind::Def, OperandPos::Late);
     }
 
     /// Add a register "early def", which logically occurs at the
     /// beginning of the instruction, alongside all uses. Use this
     /// when the def may be written before all uses are read; the
     /// regalloc will ensure that it does not overwrite any uses.
-    pub fn reg_early_def(&mut self, reg: Writable<impl Into<Reg>>) {
-        self.reg_maybe_fixed(reg.to_reg().into(), OperandKind::Def, OperandPos::Early);
+    pub fn reg_early_def(&mut self, reg: &mut Writable<impl AsMut<Reg>>) {
+        self.reg_maybe_fixed(reg.reg.as_mut(), OperandKind::Def, OperandPos::Early);
     }
 
     /// Add a register "fixed use", which ties a vreg to a particular
     /// RealReg at the end of the instruction.
-    pub fn reg_fixed_late_use(&mut self, reg: impl Into<Reg>, rreg: Reg) {
-        self.reg_fixed(reg.into(), rreg, OperandKind::Use, OperandPos::Late);
+    pub fn reg_fixed_late_use(&mut self, reg: &mut impl AsMut<Reg>, rreg: Reg) {
+        self.reg_fixed(reg.as_mut(), rreg, OperandKind::Use, OperandPos::Late);
     }
 
     /// Add a register "fixed use", which ties a vreg to a particular
     /// RealReg at this point.
-    pub fn reg_fixed_use(&mut self, reg: impl Into<Reg>, rreg: Reg) {
-        self.reg_fixed(reg.into(), rreg, OperandKind::Use, OperandPos::Early);
+    pub fn reg_fixed_use(&mut self, reg: &mut impl AsMut<Reg>, rreg: Reg) {
+        self.reg_fixed(reg.as_mut(), rreg, OperandKind::Use, OperandPos::Early);
     }
 
     /// Add a register "fixed def", which ties a vreg to a particular
     /// RealReg at this point.
-    pub fn reg_fixed_def(&mut self, reg: Writable<impl Into<Reg>>, rreg: Reg) {
-        let reg = reg.to_reg().into();
-        self.reg_fixed(reg, rreg, OperandKind::Def, OperandPos::Late);
+    pub fn reg_fixed_def(&mut self, reg: &mut Writable<impl AsMut<Reg>>, rreg: Reg) {
+        self.reg_fixed(reg.reg.as_mut(), rreg, OperandKind::Def, OperandPos::Late);
     }
 
     /// Add an operand tying a virtual register to a physical register.
-    fn reg_fixed(&mut self, reg: Reg, rreg: Reg, kind: OperandKind, pos: OperandPos) {
+    fn reg_fixed(&mut self, reg: &mut Reg, rreg: Reg, kind: OperandKind, pos: OperandPos) {
         debug_assert!(reg.is_virtual());
         let rreg = rreg.to_real_reg().expect("fixed reg is not a RealReg");
         debug_assert!(
@@ -408,7 +413,7 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
     }
 
     /// Add an operand which might already be a physical register.
-    fn reg_maybe_fixed(&mut self, reg: Reg, kind: OperandKind, pos: OperandPos) {
+    fn reg_maybe_fixed(&mut self, reg: &mut Reg, kind: OperandKind, pos: OperandPos) {
         if let Some(rreg) = reg.to_real_reg() {
             self.reg_fixed_nonallocatable(rreg.into());
         } else {
@@ -420,8 +425,8 @@ impl<'a, F: Fn(VReg) -> VReg> OperandCollector<'a, F> {
     /// Add a register def that reuses an earlier use-operand's
     /// allocation. The index of that earlier operand (relative to the
     /// current instruction's start of operands) must be known.
-    pub fn reg_reuse_def(&mut self, reg: Writable<impl Into<Reg>>, idx: usize) {
-        let reg = reg.to_reg().into();
+    pub fn reg_reuse_def(&mut self, reg: &mut Writable<impl AsMut<Reg>>, idx: usize) {
+        let reg = reg.reg.as_mut();
         if let Some(rreg) = reg.to_real_reg() {
             // In some cases we see real register arguments to a reg_reuse_def
             // constraint. We assume the creator knows what they're doing

--- a/cranelift/codegen/src/machinst/valueregs.rs
+++ b/cranelift/codegen/src/machinst/valueregs.rs
@@ -82,9 +82,15 @@ impl<R: Clone + Copy + Debug + PartialEq + Eq + InvalidSentinel> ValueRegs<R> {
         }
     }
 
-    /// Return an iterator over the registers storing this value.
+    /// Return a slice of the registers storing this value.
     pub fn regs(&self) -> &[R] {
         &self.parts[0..self.len()]
+    }
+
+    /// Return a mutable slice of the registers storing this value.
+    pub fn regs_mut(&mut self) -> &mut [R] {
+        let len = self.len();
+        &mut self.parts[0..len]
     }
 }
 


### PR DESCRIPTION
Now all registers passed to the operand collector are mutably borrowed directly out of their original locations in the Inst, so it is possible to update them in place.

As an initial demonstration of the utility of this change, the results of the VReg renamer are applied directly to the instructions during operand collection, and then all VReg aliases are cleared after operand collection.

Most of this commit consists of deleting noise from the many `get_operands` implementations in all the backends: most ampersands and asterisks, and all uses of the `ref` keyword.