### PR TITLE
cargo-vet: Exclude fuzzing-only dependencies

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -9,6 +9,31 @@ oracles and pass libFuzzer-provided inputs to them. The test case generators and
 oracles themselves are independent from the fuzzing engine that is driving the
 fuzzing process and are defined in `wasmtime/crates/fuzzing`.
 
+## Safety warning
+
+Fuzzers exist to generate random garbage and then try running it. **You
+should not trust these fuzz targets**: they could in theory try to read
+or write files on your disk, send your private data to reporters, or do
+anything else. If they succeed at doing something malicious, they are
+doing a great job at identifying dangerous bugs and we're proud of them.
+
+In addition, some of these fuzz targets use other libraries, such as to
+test that our implementation matches other WebAssembly runtimes. **We
+have not reviewed those runtimes or libraries** for safety, security,
+correctness, supply-chain attacks, or any other properties. Software
+used only during fuzzing is not subject to [our usual `cargo vet`
+requirements][vet-docs].
+
+[vet-docs]: https://docs.wasmtime.dev/contributing-coding-guidelines.html#dependencies-of-wasmtime
+
+Paragraphs 7 and 8 of the license which this work is distributed to you
+under are especially important here: **We disclaim all warranties and
+liability** if running some fuzz target causes you any harm.
+
+Therefore, **if you are at all concerned about the safety of your
+computer**, then you should either not run these fuzz targets, or only
+run them in a sandbox with sufficient isolation for your threat model.
+
 ## Example
 
 To start fuzzing run the following command, where `$MY_FUZZ_TARGET` is one of

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -46,6 +46,9 @@ audit-as-crates-io = true
 [policy.cranelift-frontend]
 audit-as-crates-io = true
 
+[policy.cranelift-fuzzgen]
+criteria = []
+
 [policy.cranelift-interpreter]
 audit-as-crates-io = true
 
@@ -74,7 +77,7 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.isle-fuzz]
-criteria = "safe-to-run"
+criteria = []
 
 [policy.wasi-common]
 audit-as-crates-io = true
@@ -113,7 +116,7 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.wasmtime-environ-fuzz]
-criteria = "safe-to-run"
+criteria = []
 
 [policy.wasmtime-explorer]
 audit-as-crates-io = true
@@ -122,10 +125,10 @@ audit-as-crates-io = true
 audit-as-crates-io = true
 
 [policy.wasmtime-fuzz]
-criteria = "safe-to-run"
+criteria = []
 
 [policy.wasmtime-fuzzing]
-criteria = "safe-to-run"
+criteria = []
 
 [policy.wasmtime-jit-debug]
 audit-as-crates-io = true


### PR DESCRIPTION
We can't meaningfully audit the other WebAssembly implementations that we use for differential fuzzing, such as wasmi and especially v8. Let's acknowledge that the effort to do so is not practical for us, and focus our vetting efforts on crates that developers and users are more likely to build.

This reduces our estimated audit backlog by over three million lines, according to `cargo vet suggest`.

Note that our crates which depend on those engines, such as wasmtime-fuzzing, are not published to crates.io, so if we fall victim to a supply chain attack against dependencies of these crates, the folks who might be impacted are limited.

Although there is value in also auditing code that might be run by people who clone our git repository, in this case I propose that anyone who is concerned about the risks of supply chain attacks against their development systems should be running fuzzers inside a sandbox. After all, it's a fuzzer: it's specifically designed to try to do anything.

I'd like to especially seek comment from folks who've expressed interest in our use of cargo-vet, like @alexcrichton, @bholley, @cfallin, and @tschneidereit. I'm open to being persuaded that we shouldn't make this change, but I can't currently see that we get any value from auditing these particular dependencies.