### PR TITLE
cranelift/riscv64: Fix `mv` instruction pretty-printing

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -1552,8 +1552,8 @@ impl Inst {
                 format!("virtual_sp_offset_adj {:+}", amount)
             }
             &MInst::Mov { rd, rm, ty } => {
-                let rd = format_reg(rd.to_reg(), allocs);
                 let rm = format_reg(rm, allocs);
+                let rd = format_reg(rd.to_reg(), allocs);
 
                 let op = match ty {
                     F32 => "fmv.s",

--- a/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
+++ b/cranelift/filetests/filetests/isa/riscv64/reftypes.clif
@@ -97,7 +97,7 @@ block3(v7: r64, v8: r64):
 ;   mv a3,a0
 ;   mv s5,a2
 ;   sd a1,16(nominal_sp)
-;   mv a3,a0
+;   mv a0,a3
 ;   mv s9,a3
 ;   load_sym a5,%f+0
 ;   sd s9,8(nominal_sp)


### PR DESCRIPTION
The operand collector and the instruction emitter for Inst::Mov both placed the `rm` register before `rd`, so the emitted code was correct, but the pretty-printer used the opposite order and so printed the operands backwards. Note that the VCode disassembly disagreed with Capstone's disassembly of the emitted machine code.