### PR TITLE
fix(c-api): give a cleaner error message if cargo isn't found

### DIFF
--- a/crates/c-api/CMakeLists.txt
+++ b/crates/c-api/CMakeLists.txt
@@ -78,6 +78,9 @@ if(ANDROID)
 endif()
 include(ExternalProject)
 find_program(WASMTIME_CARGO_BINARY cargo)
+if(NOT WASMTIME_CARGO_BINARY)
+    message(FATAL_ERROR [["cargo" was not found. Ensure "cargo" is in PATH. Aborting...]])
+endif()
 ExternalProject_Add(
 	wasmtime-crate
 	DOWNLOAD_COMMAND ""


### PR DESCRIPTION
Instead of

> Performing build step for
'wasmtime-crate''WASMTIME_CARGO_BINARY-NOTFOUND' is not recognized as an
internal or external command, operable program or batch file.

this will now instead output

> "cargo" was not found. Ensure "cargo" is in PATH. Aborting...