### PR TITLE
cranelift: Generalize OperandCollector into a trait

### DIFF
--- a/cranelift/codegen/src/isa/riscv64/inst/args.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/args.rs
@@ -127,10 +127,7 @@ impl AMode {
 
     /// Add the registers referenced by this AMode to `collector`.
     /// Keep this in sync with `with_allocs`.
-    pub(crate) fn get_operands<F: Fn(regalloc2::VReg) -> regalloc2::VReg>(
-        &mut self,
-        collector: &mut OperandCollector<'_, F>,
-    ) {
+    pub(crate) fn get_operands(&mut self, collector: &mut impl OperandVisitor) {
         match self {
             AMode::RegOffset(reg, ..) => collector.reg_use(reg),
             // Registers used in these modes aren't allocatable.

--- a/cranelift/codegen/src/isa/riscv64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/mod.rs
@@ -13,7 +13,7 @@ use crate::{settings, CodegenError, CodegenResult};
 pub use crate::ir::condcodes::FloatCC;
 
 use alloc::vec::Vec;
-use regalloc2::{PRegSet, RegClass, VReg};
+use regalloc2::{PRegSet, RegClass};
 use smallvec::{smallvec, SmallVec};
 use std::boxed::Box;
 use std::fmt::Write;
@@ -317,10 +317,7 @@ impl Inst {
 
 //=============================================================================
 
-fn vec_mask_operands<F: Fn(VReg) -> VReg>(
-    mask: &mut VecOpMasking,
-    collector: &mut OperandCollector<'_, F>,
-) {
+fn vec_mask_operands(mask: &mut VecOpMasking, collector: &mut impl OperandVisitor) {
     match mask {
         VecOpMasking::Enabled { reg } => {
             collector.reg_fixed_use(reg, pv_reg(0).into());
@@ -328,10 +325,7 @@ fn vec_mask_operands<F: Fn(VReg) -> VReg>(
         VecOpMasking::Disabled => {}
     }
 }
-fn vec_mask_late_operands<F: Fn(VReg) -> VReg>(
-    mask: &mut VecOpMasking,
-    collector: &mut OperandCollector<'_, F>,
-) {
+fn vec_mask_late_operands(mask: &mut VecOpMasking, collector: &mut impl OperandVisitor) {
     match mask {
         VecOpMasking::Enabled { reg } => {
             collector.reg_fixed_late_use(reg, pv_reg(0).into());
@@ -340,10 +334,7 @@ fn vec_mask_late_operands<F: Fn(VReg) -> VReg>(
     }
 }
 
-fn riscv64_get_operands<F: Fn(VReg) -> VReg>(
-    inst: &mut Inst,
-    collector: &mut OperandCollector<'_, F>,
-) {
+fn riscv64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
     match inst {
         Inst::Nop0 | Inst::Nop4 => {}
         Inst::BrTable {
@@ -789,7 +780,7 @@ impl MachInst for Inst {
         }
     }
 
-    fn get_operands<F: Fn(VReg) -> VReg>(&mut self, collector: &mut OperandCollector<'_, F>) {
+    fn get_operands(&mut self, collector: &mut impl OperandVisitor) {
         riscv64_get_operands(self, collector);
     }
 

--- a/cranelift/codegen/src/isa/riscv64/inst/vector.rs
+++ b/cranelift/codegen/src/isa/riscv64/inst/vector.rs
@@ -4,7 +4,7 @@ use crate::isa::riscv64::lower::isle::generated_code::{
     VecAMode, VecAluOpRImm5, VecAluOpRR, VecAluOpRRImm5, VecAluOpRRR, VecAluOpRRRImm5, VecAvl,
     VecElementWidth, VecLmul, VecMaskMode, VecOpCategory, VecOpMasking, VecTailMode,
 };
-use crate::machinst::{OperandCollector, RegClass};
+use crate::machinst::{OperandVisitor, RegClass};
 use crate::Reg;
 use core::fmt;
 
@@ -1070,10 +1070,7 @@ impl VecAMode {
         }
     }
 
-    pub fn get_operands<F: Fn(regalloc2::VReg) -> regalloc2::VReg>(
-        &mut self,
-        collector: &mut OperandCollector<'_, F>,
-    ) {
+    pub fn get_operands(&mut self, collector: &mut impl OperandVisitor) {
         match self {
             VecAMode::UnitStride { base, .. } => base.get_operands(collector),
         }

--- a/cranelift/codegen/src/isa/s390x/inst/mod.rs
+++ b/cranelift/codegen/src/isa/s390x/inst/mod.rs
@@ -8,7 +8,7 @@ use crate::machinst::*;
 use crate::{settings, CodegenError, CodegenResult};
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use regalloc2::{PRegSet, VReg};
+use regalloc2::PRegSet;
 use smallvec::SmallVec;
 use std::fmt::Write;
 use std::string::{String, ToString};
@@ -389,10 +389,7 @@ impl Inst {
 //=============================================================================
 // Instructions: get_regs
 
-fn memarg_operands<F: Fn(VReg) -> VReg>(
-    memarg: &mut MemArg,
-    collector: &mut OperandCollector<'_, F>,
-) {
+fn memarg_operands(memarg: &mut MemArg, collector: &mut impl OperandVisitor) {
     match memarg {
         MemArg::BXD12 { base, index, .. } | MemArg::BXD20 { base, index, .. } => {
             collector.reg_use(base);
@@ -409,10 +406,7 @@ fn memarg_operands<F: Fn(VReg) -> VReg>(
     collector.reg_fixed_nonallocatable(gpr_preg(1));
 }
 
-fn s390x_get_operands<F: Fn(VReg) -> VReg>(
-    inst: &mut Inst,
-    collector: &mut OperandCollector<'_, F>,
-) {
+fn s390x_get_operands(inst: &mut Inst, collector: &mut DenyReuseVisitor<impl OperandVisitor>) {
     match inst {
         Inst::AluRRR { rd, rn, rm, .. } => {
             collector.reg_def(rd);
@@ -952,15 +946,17 @@ fn s390x_get_operands<F: Fn(VReg) -> VReg>(
             memarg_operands(mem, collector);
         }
         Inst::Loop { body, .. } => {
-            for inst in body {
-                s390x_get_operands(inst, collector);
-            }
-
             // `reuse_def` constraints can't be permitted in a Loop instruction because the operand
             // index will always be relative to the Loop instruction, not the individual
             // instruction in the loop body. However, fixed-nonallocatable registers used with
             // instructions that would have emitted `reuse_def` constraints are fine.
-            debug_assert!(collector.no_reuse_def());
+            let mut collector = DenyReuseVisitor {
+                inner: collector.inner,
+                deny_reuse: true,
+            };
+            for inst in body {
+                s390x_get_operands(inst, &mut collector);
+            }
         }
         Inst::CondBreak { .. } => {}
         Inst::VirtualSPOffsetAdj { .. } => {}
@@ -968,6 +964,34 @@ fn s390x_get_operands<F: Fn(VReg) -> VReg>(
         Inst::DummyUse { reg } => {
             collector.reg_use(reg);
         }
+    }
+}
+
+struct DenyReuseVisitor<'a, T> {
+    inner: &'a mut T,
+    deny_reuse: bool,
+}
+
+impl<T: OperandVisitor> OperandVisitor for DenyReuseVisitor<'_, T> {
+    fn add_operand(
+        &mut self,
+        reg: &mut Reg,
+        constraint: regalloc2::OperandConstraint,
+        kind: regalloc2::OperandKind,
+        pos: regalloc2::OperandPos,
+    ) {
+        debug_assert!(
+            !self.deny_reuse || !matches!(constraint, regalloc2::OperandConstraint::Reuse(_))
+        );
+        self.inner.add_operand(reg, constraint, kind, pos);
+    }
+
+    fn debug_assert_is_allocatable_preg(&self, reg: regalloc2::PReg, expected: bool) {
+        self.inner.debug_assert_is_allocatable_preg(reg, expected);
+    }
+
+    fn reg_clobbers(&mut self, regs: PRegSet) {
+        self.inner.reg_clobbers(regs);
     }
 }
 
@@ -979,8 +1003,14 @@ impl MachInst for Inst {
     type LabelUse = LabelUse;
     const TRAP_OPCODE: &'static [u8] = &[0, 0];
 
-    fn get_operands<F: Fn(VReg) -> VReg>(&mut self, collector: &mut OperandCollector<'_, F>) {
-        s390x_get_operands(self, collector);
+    fn get_operands(&mut self, collector: &mut impl OperandVisitor) {
+        s390x_get_operands(
+            self,
+            &mut DenyReuseVisitor {
+                inner: collector,
+                deny_reuse: false,
+            },
+        );
     }
 
     fn is_move(&self) -> Option<(Writable<Reg>, Reg)> {

--- a/cranelift/codegen/src/isa/x64/inst/mod.rs
+++ b/cranelift/codegen/src/isa/x64/inst/mod.rs
@@ -11,7 +11,7 @@ use crate::isa::{CallConv, FunctionAlignment};
 use crate::{machinst::*, trace};
 use crate::{settings, CodegenError, CodegenResult};
 use alloc::boxed::Box;
-use regalloc2::{Allocation, PRegSet, VReg};
+use regalloc2::{Allocation, PRegSet};
 use smallvec::{smallvec, SmallVec};
 use std::fmt::{self, Write};
 use std::string::{String, ToString};
@@ -1895,7 +1895,7 @@ impl fmt::Debug for Inst {
     }
 }
 
-fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &mut Inst, collector: &mut OperandCollector<'_, F>) {
+fn x64_get_operands(inst: &mut Inst, collector: &mut impl OperandVisitor) {
     // Note: because we need to statically know the indices of each
     // reg in the operands list in order to fetch its allocation
     // later, we put the variable-operand-count bits (the RegMem,
@@ -2523,7 +2523,7 @@ fn x64_get_operands<F: Fn(VReg) -> VReg>(inst: &mut Inst, collector: &mut Operan
 impl MachInst for Inst {
     type ABIMachineSpec = X64ABIMachineSpec;
 
-    fn get_operands<F: Fn(VReg) -> VReg>(&mut self, collector: &mut OperandCollector<'_, F>) {
+    fn get_operands(&mut self, collector: &mut impl OperandVisitor) {
         x64_get_operands(self, collector)
     }
 

--- a/cranelift/codegen/src/machinst/mod.rs
+++ b/cranelift/codegen/src/machinst/mod.rs
@@ -96,7 +96,7 @@ pub trait MachInst: Clone + Debug {
 
     /// Return the registers referenced by this machine instruction along with
     /// the modes of reference (use, def, modify).
-    fn get_operands<F: Fn(VReg) -> VReg>(&mut self, collector: &mut OperandCollector<'_, F>);
+    fn get_operands(&mut self, collector: &mut impl OperandVisitor);
 
     /// If this is a simple move, return the (source, destination) tuple of registers.
     fn is_move(&self) -> Option<(Writable<Reg>, Reg)>;


### PR DESCRIPTION
This paves the way for more implementations of this OperandVisitor trait which can do different things with the operands.

Of particular note, this commit introduces a second implementation which is used only in the s390x backend and only to implement a debug assertion. Previously, s390x used an OperandCollector::no_reuse_def method to implement this assertion, but I didn't want to require that all implementors of the new trait have to provide that method, so this captures the same check but keeps it local to where it's needed.