### PR TITLE
cranelift: Add `znver4` arch preset

### DIFF
--- a/cranelift/codegen/meta/src/isa/x86.rs
+++ b/cranelift/codegen/meta/src/isa/x86.rs
@@ -373,10 +373,22 @@ pub(crate) fn define() -> TargetIsa {
         "Zen (second generation) microarchitecture.",
         preset!(znver1),
     );
-    settings.add_preset(
+    let znver3 = settings.add_preset(
         "znver3",
         "Zen (third generation) microarchitecture.",
         preset!(znver2),
+    );
+    settings.add_preset(
+        "znver4",
+        "Zen (fourth generation) microarchitecture.",
+        preset!(
+            znver3
+                && has_avx512bitalg
+                && has_avx512dq
+                && has_avx512f
+                && has_avx512vbmi
+                && has_avx512vl
+        ),
     );
 
     // Generic


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Added `znver4` architecture preset to `cranelift` settings. This should sync with LLVM at least on the AMD side. This was previously updated in #5575.