### PR TITLE
cranelift: add icmp-of-icmp rules for comparisons with 1

### DIFF
--- a/cranelift/codegen/src/opts/icmp.isle
+++ b/cranelift/codegen/src/opts/icmp.isle
@@ -14,15 +14,33 @@
 (rule (simplify (sle (ty_int ty) x x)) (subsume (iconst_u ty 1)))
 
 ;; Optimize icmp-of-icmp.
+;; ne(icmp(ty, cc, x, y), 0) == icmp(ty, cc, x, y)
+;; e.g. neq(ugt(x, y), 0) == ugt(x, y) 
 (rule (simplify (ne ty
                       (uextend_maybe _ inner @ (icmp ty _ _ _))
                       (iconst_u _ 0)))
       (subsume inner))
 
+;; eq(icmp(ty, cc, x, y), 0) == icmp(ty, cc_complement, x, y)
+;; e.g. eq(ugt(x, y), 0) == ule(x, y) 
 (rule (simplify (eq ty
                       (uextend_maybe _ (icmp ty cc x y))
                       (iconst_u _ 0)))
       (subsume (icmp ty (intcc_complement cc) x y)))
+
+;; ne(icmp(ty, cc, x, y), 1) == icmp(ty, cc_complement, x, y)
+;; e.g. ne(ugt(x, y), 1) == ule(x, y)
+(rule (simplify (ne ty
+                      (uextend_maybe _ (icmp ty cc x y))
+                      (iconst_u _ 1)))
+      (subsume (icmp ty (intcc_complement cc) x y)))
+
+;; eq(icmp(ty, cc, x, y), 1) == icmp(ty, cc, x, y)
+;; e.g. eq(ugt(x, y), 1) == ugt(x, y)
+(rule (simplify (eq ty
+                      (uextend_maybe _ inner @ (icmp _ _ _ _))
+                      (iconst_u _ 1)))
+      (subsume inner))
 
 ;; Optimize select-of-uextend-of-icmp to select-of-icmp, because
 ;; select can take an I8 condition too.

--- a/cranelift/filetests/filetests/egraph/icmp.clif
+++ b/cranelift/filetests/filetests/egraph/icmp.clif
@@ -125,3 +125,48 @@ block0(v0: i8):
 ;     return v4
 ; }
 
+function %eq_one_of_icmp(i8) -> i8 fast {
+block0(v0: i8):
+    v1 = iconst.i8 5
+    v2 = icmp eq v0, v1
+    v3 = iconst.i8 1
+    v4 = icmp eq v2, v3
+    return v4
+}
+
+; function %eq_one_of_icmp(i8) -> i8 fast {
+; block0(v0: i8):
+;     v1 = iconst.i8 5
+;     v2 = icmp eq v0, v1  ; v1 = 5
+;     return v2
+; }
+
+function %ne_one_of_icmp(i8) -> i8 fast {
+block0(v0: i8):
+    v1 = iconst.i8 5
+    v2 = icmp eq v0, v1
+    v3 = iconst.i8 1
+    v4 = icmp ne v2, v3
+    return v4
+}
+
+; function %ne_one_of_icmp(i8) -> i8 fast {
+; block0(v0: i8):
+;     v1 = iconst.i8 5
+;     v5 = icmp ne v0, v1  ; v1 = 5
+;     return v5
+; }
+
+function %negate_lt(i8, i8) -> i8 fast {
+block0(v0: i8, v1: i8):
+    v2 = icmp ult v0, v1
+    v3 = iconst.i8 1
+    v4 = icmp ne v2, v3
+    return v4
+}
+
+; function %negate_lt(i8, i8) -> i8 fast {
+; block0(v0: i8, v1: i8):
+;     v5 = icmp uge v0, v1
+;     return v5
+; }

--- a/cranelift/filetests/filetests/runtests/icmp-of-icmp.clif
+++ b/cranelift/filetests/filetests/runtests/icmp-of-icmp.clif
@@ -1,0 +1,56 @@
+test interpret
+test run
+set opt_level=speed
+target aarch64
+target x86_64
+target s390x
+target riscv64
+target riscv64 has_c has_zcb
+
+function %eq_eq_zero(i8) -> i8 {
+block0(v0: i8):
+    v1 = iconst.i8 5
+    v2 = icmp eq v0, v1
+    v3 = iconst.i8 0
+    v4 = icmp eq v2, v3
+    return v4
+}
+
+; run: %eq_eq_zero(5) == 0
+; run: %eq_eq_zero(3) == 1
+
+function %ne_eq_one(i8) -> i8 {
+block0(v0: i8):
+    v1 = iconst.i8 5
+    v2 = icmp eq v0, v1
+    v3 = iconst.i8 1
+    v4 = icmp ne v2, v3
+    return v4
+}
+
+; run: %ne_eq_one(5) == 0
+; run: %ne_eq_one(3) == 1
+
+function %ne_eq_zero(i8) -> i8 {
+block0(v0: i8):
+    v1 = iconst.i8 5
+    v2 = icmp eq v0, v1
+    v3 = iconst.i8 0
+    v4 = icmp ne v2, v3
+    return v4
+}
+
+; run: %ne_eq_zero(5) == 1
+; run: %ne_eq_zero(3) == 0
+
+function %eq_eq_one(i8) -> i8 {
+block0(v0: i8):
+    v1 = iconst.i8 5
+    v2 = icmp eq v0, v1
+    v3 = iconst.i8 1
+    v4 = icmp eq v2, v3
+    return v4
+}
+
+; run: %eq_eq_one(5) == 1
+; run: %eq_eq_one(3) == 0


### PR DESCRIPTION
<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->

Suggested by @cfallin in this zulip thread: https://bytecodealliance.zulipchat.com/#narrow/stream/217117-cranelift/topic/disassemly.20seems.20.28relatively.29.20unoptimized

The icmp-of-icmp rules only included comparisons with 0. So this
```
(x == y) != 0
```
gets simplified to
```
x == y
```

But the equivalent
```
(x == y) == 1
```
did not get simplified, even though the rules to apply are just the inverse of the rules for 0.

I've added the rules for `icmp(..) == 1` and `icmp(..) != 1` and tried to add some more comments to the existing rules.

I need some help to figure out how I could write a test for this, because I haven't found the tests in the codebase :)