### PR TITLE
wasmtime: Use ConstExpr for element segment offsets

### DIFF
--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -494,19 +494,8 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                             offset_expr,
                         } => {
                             let table_index = TableIndex::from_u32(table_index.unwrap_or(0));
-                            let mut offset_expr_reader = offset_expr.get_binary_reader();
-                            let (base, offset) = match offset_expr_reader.read_operator()? {
-                                Operator::I32Const { value } => (None, value.unsigned()),
-                                Operator::GlobalGet { global_index } => {
-                                    (Some(GlobalIndex::from_u32(global_index)), 0)
-                                }
-                                ref s => {
-                                    bail!(WasmError::Unsupported(format!(
-                                        "unsupported init expr in element section: {:?}",
-                                        s
-                                    )));
-                                }
-                            };
+                            let (offset, escaped) = ConstExpr::from_wasmparser(offset_expr)?;
+                            debug_assert!(escaped.is_empty());
 
                             self.result
                                 .module
@@ -514,7 +503,6 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                                 .segments
                                 .push(TableSegment {
                                     table_index,
-                                    base,
                                     offset,
                                     elements: elements.into(),
                                 });
@@ -1165,14 +1153,15 @@ impl ModuleTranslation<'_> {
             // If the base of this segment is dynamic, then we can't
             // include it in the statically-built array of initial
             // contents.
-            if segment.base.is_some() {
-                break;
-            }
+            let offset = match segment.offset.ops() {
+                &[ConstOp::I32Const(offset)] => offset as u32,
+                _ => break,
+            };
 
             // Get the end of this segment. If out-of-bounds, or too
             // large for our dense table representation, then skip the
             // segment.
-            let top = match segment.offset.checked_add(segment.elements.len()) {
+            let top = match offset.checked_add(segment.elements.len()) {
                 Some(top) => top,
                 None => break,
             };
@@ -1228,7 +1217,7 @@ impl ModuleTranslation<'_> {
             if precomputed.len() < top as usize {
                 precomputed.resize(top as usize, FuncIndex::reserved_value());
             }
-            let dst = &mut precomputed[(segment.offset as usize)..(top as usize)];
+            let dst = &mut precomputed[offset as usize..top as usize];
             dst.copy_from_slice(&function_elements);
 
             // advance the iterator to see the next segment

--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -1154,7 +1154,7 @@ impl ModuleTranslation<'_> {
             // include it in the statically-built array of initial
             // contents.
             let offset = match segment.offset.ops() {
-                &[ConstOp::I32Const(offset)] => offset as u32,
+                &[ConstOp::I32Const(offset)] => offset.unsigned(),
                 _ => break,
             };
 

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -427,10 +427,8 @@ pub enum TableInitialValue {
 pub struct TableSegment {
     /// The index of a table to initialize.
     pub table_index: TableIndex,
-    /// Optionally, a global variable giving a base index.
-    pub base: Option<GlobalIndex>,
-    /// The offset to add to the base.
-    pub offset: u32,
+    /// The base offset to start this segment at.
+    pub offset: ConstExpr,
     /// The values to write into the table elements.
     pub elements: TableSegmentElements,
 }


### PR DESCRIPTION
This shouldn't change any behavior currently, but prepares us for supporting extended constant expressions.

I have a separate commit for doing the same to data segments (#8515), but it needs more work.