### PR TITLE
wasi-nn: factor out common test-program code

### DIFF
--- a/crates/test-programs/src/bin/nn_image_classification.rs
+++ b/crates/test-programs/src/bin/nn_image_classification.rs
@@ -1,59 +1,19 @@
 use anyhow::Result;
 use std::fs;
-use wasi_nn::*;
+use test_programs::nn::{classify, sort_results};
+use wasi_nn::{ExecutionTarget, GraphBuilder, GraphEncoding};
 
 pub fn main() -> Result<()> {
-    let xml = fs::read_to_string("fixture/model.xml").unwrap();
-    println!("Read graph XML, first 50 characters: {}", &xml[..50]);
-
-    let weights = fs::read("fixture/model.bin").unwrap();
-    println!("Read graph weights, size in bytes: {}", weights.len());
-
+    let xml = fs::read("fixture/model.xml")
+        .expect("the model file to be mapped to the fixture directory");
+    let weights = fs::read("fixture/model.bin")
+        .expect("the weights file to be mapped to the fixture directory");
     let graph = GraphBuilder::new(GraphEncoding::Openvino, ExecutionTarget::CPU)
-        .build_from_bytes([&xml.into_bytes(), &weights])?;
-    println!("Loaded graph into wasi-nn with ID: {}", graph);
-
-    let mut context = graph.init_execution_context()?;
-    println!("Created wasi-nn execution context with ID: {}", context);
-
-    // Load a tensor that precisely matches the graph input tensor (see
-    // `fixture/frozen_inference_graph.xml`).
-    let data = fs::read("fixture/tensor.bgr").unwrap();
-    println!("Read input tensor, size in bytes: {}", data.len());
-    context.set_input(0, wasi_nn::TensorType::F32, &[1, 3, 224, 224], &data)?;
-
-    // Execute the inference.
-    context.compute()?;
-    println!("Executed graph inference");
-
-    // Retrieve the output.
-    let mut output_buffer = vec![0f32; 1001];
-    context.get_output(0, &mut output_buffer[..])?;
-    println!(
-        "Found results, sorted top 5: {:?}",
-        &sort_results(&output_buffer)[..5]
-    );
-
+        .build_from_bytes([&xml, &weights])?;
+    let tensor = fs::read("fixture/tensor.bgr")
+        .expect("the tensor file to be mapped to the fixture directory");
+    let results = classify(graph, tensor)?;
+    let top_five = &sort_results(&results)[..5];
+    println!("found results, sorted top 5: {:?}", top_five);
     Ok(())
 }
-
-// Sort the buffer of probabilities. The graph places the match probability for
-// each class at the index for that class (e.g. the probability of class 42 is
-// placed at buffer[42]). Here we convert to a wrapping InferenceResult and sort
-// the results. It is unclear why the MobileNet output indices are "off by one"
-// but the `.skip(1)` below seems necessary to get results that make sense (e.g.
-// 763 = "revolver" vs 762 = "restaurant").
-fn sort_results(buffer: &[f32]) -> Vec<InferenceResult> {
-    let mut results: Vec<InferenceResult> = buffer
-        .iter()
-        .skip(1)
-        .enumerate()
-        .map(|(c, p)| InferenceResult(c, *p))
-        .collect();
-    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-    results
-}
-
-// A wrapper for class ID and match probabilities.
-#[derive(Debug, PartialEq)]
-struct InferenceResult(usize, f32);

--- a/crates/test-programs/src/bin/nn_image_classification_named.rs
+++ b/crates/test-programs/src/bin/nn_image_classification_named.rs
@@ -1,54 +1,15 @@
 use anyhow::Result;
 use std::fs;
-use wasi_nn::*;
+use test_programs::nn::{classify, sort_results};
+use wasi_nn::{ExecutionTarget, GraphBuilder, GraphEncoding};
 
 pub fn main() -> Result<()> {
-    // Load model from preloaded directory named "fixtures" which contains a model.[bin|xml] mobilenet model.
     let graph = GraphBuilder::new(GraphEncoding::Openvino, ExecutionTarget::CPU)
         .build_from_cache("fixtures")?;
-    println!("Loaded a graph: {:?}", graph);
-
-    let mut context = graph.init_execution_context()?;
-    println!("Created an execution context: {:?}", context);
-
-    // Load a tensor that precisely matches the graph input tensor (see
-    // `fixture/frozen_inference_graph.xml`).
-    let tensor_data = fs::read("fixture/tensor.bgr")?;
-    println!("Read input tensor, size in bytes: {}", tensor_data.len());
-    context.set_input(0, TensorType::F32, &[1, 3, 224, 224], &tensor_data)?;
-
-    // Execute the inference.
-    context.compute()?;
-    println!("Executed graph inference");
-
-    // Retrieve the output.
-    let mut output_buffer = vec![0f32; 1001];
-    context.get_output(0, &mut output_buffer[..])?;
-
-    println!(
-        "Found results, sorted top 5: {:?}",
-        &sort_results(&output_buffer)[..5]
-    );
+    let tensor = fs::read("fixture/tensor.bgr")
+        .expect("the tensor file to be mapped to the fixture directory");
+    let results = classify(graph, tensor)?;
+    let top_five = &sort_results(&results)[..5];
+    println!("found results, sorted top 5: {:?}", top_five);
     Ok(())
 }
-
-// Sort the buffer of probabilities. The graph places the match probability for
-// each class at the index for that class (e.g. the probability of class 42 is
-// placed at buffer[42]). Here we convert to a wrapping InferenceResult and sort
-// the results. It is unclear why the MobileNet output indices are "off by one"
-// but the `.skip(1)` below seems necessary to get results that make sense (e.g.
-// 763 = "revolver" vs 762 = "restaurant").
-fn sort_results(buffer: &[f32]) -> Vec<InferenceResult> {
-    let mut results: Vec<InferenceResult> = buffer
-        .iter()
-        .skip(1)
-        .enumerate()
-        .map(|(c, p)| InferenceResult(c, *p))
-        .collect();
-    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-    results
-}
-
-// A wrapper for class ID and match probabilities.
-#[derive(Debug, PartialEq)]
-struct InferenceResult(usize, f32);

--- a/crates/test-programs/src/bin/nn_image_classification_onnx.rs
+++ b/crates/test-programs/src/bin/nn_image_classification_onnx.rs
@@ -1,55 +1,17 @@
 use anyhow::Result;
 use std::fs;
-use wasi_nn::*;
+use test_programs::nn::{classify, sort_results};
+use wasi_nn::{ExecutionTarget, GraphBuilder, GraphEncoding};
 
 pub fn main() -> Result<()> {
-    let model = fs::read("fixture/model.onnx").unwrap();
-    println!("[ONNX] Read model, size in bytes: {}", model.len());
-
+    let model = fs::read("fixture/model.onnx")
+        .expect("the model file to be mapped to the fixture directory");
     let graph =
         GraphBuilder::new(GraphEncoding::Onnx, ExecutionTarget::CPU).build_from_bytes([&model])?;
-
-    let mut context = graph.init_execution_context()?;
-    println!(
-        "[ONNX] Created wasi-nn execution context with ID: {}",
-        context
-    );
-
-    // Prepare WASI-NN tensor - Tensor data is always a bytes vector
-    // Load a tensor that precisely matches the graph input tensor
-    let data = fs::read("fixture/tensor.bgr").unwrap();
-    println!("[ONNX] Read input tensor, size in bytes: {}", data.len());
-    context.set_input(0, wasi_nn::TensorType::F32, &[1, 3, 224, 224], &data)?;
-
-    // Execute the inferencing
-    context.compute()?;
-    println!("[ONNX] Executed graph inference");
-
-    // Retrieve the output.
-    let mut output_buffer = vec![0f32; 1000];
-    context.get_output(0, &mut output_buffer[..])?;
-    println!(
-        "[ONNX] Found results, sorted top 5: {:?}",
-        &sort_results(&output_buffer)[..5]
-    );
-
+    let tensor = fs::read("fixture/tensor.bgr")
+        .expect("the tensor file to be mapped to the fixture directory");
+    let results = classify(graph, tensor)?;
+    let top_five = &sort_results(&results)[..5];
+    println!("found results, sorted top 5: {:?}", top_five);
     Ok(())
 }
-
-// Sort the buffer of probabilities. The graph places the match probability for
-// each class at the index for that class (e.g. the probability of class 42 is
-// placed at buffer[42]). Here we convert to a wrapping InferenceResult and sort
-// the results.
-fn sort_results(buffer: &[f32]) -> Vec<InferenceResult> {
-    let mut results: Vec<InferenceResult> = buffer
-        .iter()
-        .enumerate()
-        .map(|(c, p)| InferenceResult(c, *p))
-        .collect();
-    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-    results
-}
-
-// A wrapper for class ID and match probabilities.
-#[derive(Debug, PartialEq)]
-struct InferenceResult(usize, f32);

--- a/crates/test-programs/src/bin/nn_image_classification_winml.rs
+++ b/crates/test-programs/src/bin/nn_image_classification_winml.rs
@@ -1,58 +1,17 @@
 use anyhow::Result;
 use std::fs;
-use std::time::Instant;
-use wasi_nn::*;
+use test_programs::nn::{classify, sort_results};
+
+use wasi_nn::{ExecutionTarget, GraphBuilder, GraphEncoding};
 
 pub fn main() -> Result<()> {
-    // Graph is supposed to be preloaded by `nn-graph` argument. The path ends with "mobilenet".
-    let graph =
-        wasi_nn::GraphBuilder::new(wasi_nn::GraphEncoding::Onnx, wasi_nn::ExecutionTarget::CPU)
-            .build_from_cache("mobilenet")
-            .unwrap();
-
-    let mut context = graph.init_execution_context().unwrap();
-    println!("Created an execution context.");
-
-    // Convert image to tensor data.
-    let tensor_data = fs::read("fixture/kitten.rgb")?;
-    context
-        .set_input(0, TensorType::F32, &[1, 3, 224, 224], &tensor_data)
-        .unwrap();
-
-    // Execute the inference.
-    let before_compute = Instant::now();
-    context.compute().unwrap();
-    println!(
-        "Executed graph inference, took {} ms.",
-        before_compute.elapsed().as_millis()
-    );
-
-    // Retrieve the output.
-    let mut output_buffer = vec![0f32; 1000];
-    context.get_output(0, &mut output_buffer[..]).unwrap();
-
-    let result = sort_results(&output_buffer);
-    println!("Found results, sorted top 5: {:?}", &result[..5]);
-    assert_eq!(result[0].0, 284);
+    let graph = GraphBuilder::new(GraphEncoding::Onnx, ExecutionTarget::CPU)
+        .build_from_cache("mobilenet")?;
+    let tensor = fs::read("fixture/kitten.rgb")
+        .expect("the tensor file to be mapped to the fixture directory");
+    let results = classify(graph, tensor)?;
+    let top_five = &sort_results(&results)[..5];
+    println!("found results, sorted top 5: {:?}", top_five);
+    assert_eq!(top_five[0].class_id(), 284);
     Ok(())
 }
-
-// Sort the buffer of probabilities. The graph places the match probability for each class at the
-// index for that class (e.g. the probability of class 42 is placed at buffer[42]). Here we convert
-// to a wrapping InferenceResult and sort the results. It is unclear why the MobileNet output
-// indices are "off by one" but the `.skip(1)` below seems necessary to get results that make sense
-// (e.g. 763 = "revolver" vs 762 = "restaurant")
-fn sort_results(buffer: &[f32]) -> Vec<InferenceResult> {
-    let mut results: Vec<InferenceResult> = buffer
-        .iter()
-        .skip(1)
-        .enumerate()
-        .map(|(c, p)| InferenceResult(c, *p))
-        .collect();
-    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-    results
-}
-
-// A wrapper for class ID and match probabilities.
-#[derive(Debug, PartialEq)]
-struct InferenceResult(usize, f32);

--- a/crates/test-programs/src/lib.rs
+++ b/crates/test-programs/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod http;
+pub mod nn;
 pub mod preview1;
 pub mod sockets;
 

--- a/crates/test-programs/src/nn.rs
+++ b/crates/test-programs/src/nn.rs
@@ -1,0 +1,68 @@
+use anyhow::Result;
+use std::time::Instant;
+use wasi_nn::{Graph, TensorType};
+
+/// Run a wasi-nn inference using a simple classifier model (single input,
+/// single output).
+pub fn classify(graph: Graph, tensor: Vec<u8>) -> Result<Vec<f32>> {
+    let mut context = graph.init_execution_context()?;
+    println!(
+        "[nn] created wasi-nn execution context with ID: {}",
+        context
+    );
+
+    // Many classifiers have a single input; currently, this test suite also
+    // uses tensors of the same shape, though this is not usually the case.
+    context.set_input(0, TensorType::F32, &[1, 3, 224, 224], &tensor)?;
+    println!("[nn] set input tensor: {} bytes", tensor.len());
+
+    let before = Instant::now();
+    context.compute()?;
+    println!(
+        "[nn] executed graph inference in {} ms",
+        before.elapsed().as_millis()
+    );
+
+    // Many classifiers emit probabilities as floating point values; here we
+    // convert the raw bytes to `f32` knowing all models used here use that
+    // type.
+    let mut output_buffer = vec![0u8; 1001 * std::mem::size_of::<f32>()];
+    let num_bytes = context.get_output(0, &mut output_buffer)?;
+    println!("[nn] retrieved output tensor: {} bytes", num_bytes);
+    let output: Vec<f32> = output_buffer[..num_bytes]
+        .chunks(4)
+        .map(|b| f32::from_le_bytes([b[0], b[1], b[2], b[3]]))
+        .collect();
+    Ok(output)
+}
+
+/// Sort some classification probabilities.
+///
+/// Many classification models output a buffer of probabilities for each class,
+/// placing the match probability for each class at the index for that class
+/// (the probability of class `N` is stored at `probabilities[N]`).
+pub fn sort_results(probabilities: &[f32]) -> Vec<InferenceResult> {
+    // It is unclear why the MobileNet output indices are "off by one" but the
+    // `.skip(1)` below seems necessary to get results that make sense (e.g. 763
+    // = "revolver" vs 762 = "restaurant").
+    let mut results: Vec<InferenceResult> = probabilities
+        .iter()
+        .skip(1)
+        .enumerate()
+        .map(|(c, p)| InferenceResult(c, *p))
+        .collect();
+    results.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+    results
+}
+
+// A wrapper for class ID and match probabilities.
+#[derive(Debug, PartialEq)]
+pub struct InferenceResult(usize, f32);
+impl InferenceResult {
+    pub fn class_id(&self) -> usize {
+        self.0
+    }
+    pub fn probability(&self) -> f32 {
+        self.1
+    }
+}


### PR DESCRIPTION
`wasi-nn`'s test program suite is light at the moment but, in order to expand it, this change factors out some of the common bits that are being used in the `test-programs` crate. Since all of the tests perform some kind of image classification, the new `nn` module gains `classify` and `sort_results` functions to help with this exact case.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
