### PR TITLE
Double the default allowed table elements

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -2590,7 +2590,7 @@ impl PoolingAllocationConfig {
     }
 
     /// The maximum table elements for any table defined in a module (default is
-    /// `10000`).
+    /// `20000`).
     ///
     /// If a table's minimum element limit is greater than this value, the
     /// module will fail to instantiate.

--- a/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
+++ b/crates/wasmtime/src/runtime/vm/instance/allocator/pooling.rs
@@ -156,7 +156,9 @@ impl Default for InstanceLimits {
             total_stacks: 1000,
             core_instance_size: 1 << 20, // 1 MiB
             max_tables_per_module: 1,
-            table_elements: 10_000,
+            // NB: in #8504 it was seen that a C# module in debug module can
+            // have 10k+ elements.
+            table_elements: 20_000,
             max_memories_per_module: 1,
             memory_pages: 160,
             #[cfg(feature = "gc")]


### PR DESCRIPTION
This commit doubles the default allowed table elements per table in the pooling allocator from 10k to 20k. This helps to, by default, run the module produced in #8504.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
