### PR TITLE
wasmtime: Make table lazy-init configurable

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -63,6 +63,12 @@ wasmtime_option_group! {
         /// linear memories.
         pub guard_before_linear_memory: Option<bool>,
 
+        /// Whether to initialize tables lazily, so that instantiation is
+        /// fast but indirect calls are a little slower. If no, tables are
+        /// initialized eagerly from any active element segments that apply to
+        /// them during instantiation. (default: yes)
+        pub table_lazy_init: Option<bool>,
+
         /// Enable the pooling allocator, in place of the on-demand allocator.
         pub pooling_allocator: Option<bool>,
 
@@ -543,6 +549,9 @@ impl CommonOptions {
         }
         if let Some(enable) = self.opts.guard_before_linear_memory {
             config.guard_before_linear_memory(enable);
+        }
+        if let Some(enable) = self.opts.table_lazy_init {
+            config.table_lazy_init(enable);
         }
 
         // If fuel has been configured, set the `consume fuel` flag on the config.

--- a/crates/cranelift/src/func_environ.rs
+++ b/crates/cranelift/src/func_environ.rs
@@ -817,6 +817,7 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
         table_index: TableIndex,
         index: ir::Value,
         cold_blocks: bool,
+        lazy_init: bool,
     ) -> ir::Value {
         let pointer_type = self.pointer_type();
         self.ensure_table_exists(builder.func, table_index);
@@ -833,6 +834,11 @@ impl<'module_environment> FuncEnvironment<'module_environment> {
             self.isa.flags().enable_table_access_spectre_mitigation(),
         );
         let value = builder.ins().load(pointer_type, flags, table_entry_addr, 0);
+
+        if !lazy_init {
+            return value;
+        }
+
         // Mask off the "initialized bit". See documentation on
         // FUNCREF_INIT_BIT in crates/environ/src/ref_bits.rs for more
         // details. Note that `FUNCREF_MASK` has type `usize` which may not be
@@ -1354,11 +1360,14 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
         cold_blocks: bool,
     ) -> WasmResult<Option<(ir::Value, ir::Value)>> {
         // Get the funcref pointer from the table.
+        let table = &self.env.module.table_plans[table_index];
+        let TableStyle::CallerChecksSignature { lazy_init } = table.style;
         let funcref_ptr = self.env.get_or_init_func_ref_table_elem(
             self.builder,
             table_index,
             callee,
             cold_blocks,
+            lazy_init,
         );
 
         // If necessary, check the signature.
@@ -1407,7 +1416,7 @@ impl<'a, 'func, 'module_env> Call<'a, 'func, 'module_env> {
 
         // Generate a rustc compile error here if more styles are added in
         // the future as the following code is tailored to just this style.
-        let TableStyle::CallerChecksSignature = table.style;
+        let TableStyle::CallerChecksSignature { .. } = table.style;
 
         // Test if a type check is necessary for this table. If this table is a
         // table of typed functions and that type matches `ty_index`, then
@@ -1747,9 +1756,14 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
 
             // Function types.
             WasmHeapTopType::Func => match plan.style {
-                TableStyle::CallerChecksSignature => {
-                    Ok(self.get_or_init_func_ref_table_elem(builder, table_index, index, false))
-                }
+                TableStyle::CallerChecksSignature { lazy_init } => Ok(self
+                    .get_or_init_func_ref_table_elem(
+                        builder,
+                        table_index,
+                        index,
+                        false,
+                        lazy_init,
+                    )),
             },
         }
     }
@@ -1800,7 +1814,7 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
             // Function types.
             WasmHeapTopType::Func => {
                 match plan.style {
-                    TableStyle::CallerChecksSignature => {
+                    TableStyle::CallerChecksSignature { lazy_init } => {
                         let (elem_addr, flags) = table_data.prepare_table_addr(
                             builder,
                             index,
@@ -1810,9 +1824,13 @@ impl<'module_environment> cranelift_wasm::FuncEnvironment for FuncEnvironment<'m
                         // Set the "initialized bit". See doc-comment on
                         // `FUNCREF_INIT_BIT` in
                         // crates/environ/src/ref_bits.rs for details.
-                        let value_with_init_bit = builder
-                            .ins()
-                            .bor_imm(value, Imm64::from(FUNCREF_INIT_BIT as i64));
+                        let value_with_init_bit = if lazy_init {
+                            builder
+                                .ins()
+                                .bor_imm(value, Imm64::from(FUNCREF_INIT_BIT as i64))
+                        } else {
+                            value
+                        };
                         builder
                             .ins()
                             .store(flags, value_with_init_bit, elem_addr, 0);

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -311,7 +311,8 @@ pub trait InitMemory {
 pub enum TableStyle {
     /// Signatures are stored in the table and checked in the caller.
     CallerChecksSignature {
-        /// TODO
+        /// Whether this table is initialized lazily and requires an
+        /// initialization check on every access.
         lazy_init: bool,
     },
 }

--- a/crates/environ/src/module.rs
+++ b/crates/environ/src/module.rs
@@ -310,13 +310,18 @@ pub trait InitMemory {
 #[derive(Debug, Clone, Hash, Serialize, Deserialize)]
 pub enum TableStyle {
     /// Signatures are stored in the table and checked in the caller.
-    CallerChecksSignature,
+    CallerChecksSignature {
+        /// TODO
+        lazy_init: bool,
+    },
 }
 
 impl TableStyle {
     /// Decide on an implementation style for the given `Table`.
-    pub fn for_table(_table: Table, _tunables: &Tunables) -> Self {
-        Self::CallerChecksSignature
+    pub fn for_table(_table: Table, tunables: &Tunables) -> Self {
+        Self::CallerChecksSignature {
+            lazy_init: tunables.table_lazy_init,
+        }
     }
 }
 

--- a/crates/environ/src/tunables.rs
+++ b/crates/environ/src/tunables.rs
@@ -42,6 +42,12 @@ pub struct Tunables {
     /// beginning of the allocation in addition to the end.
     pub guard_before_linear_memory: bool,
 
+    /// Whether to initialize tables lazily, so that instantiation is fast but
+    /// indirect calls are a little slower. If false, tables are initialized
+    /// eagerly from any active element segments that apply to them during
+    /// instantiation.
+    pub table_lazy_init: bool,
+
     /// Indicates whether an address map from compiled native code back to wasm
     /// offsets in the original file is generated.
     pub generate_address_map: bool,
@@ -113,6 +119,7 @@ impl Tunables {
             epoch_interruption: false,
             static_memory_bound_is_maximum: false,
             guard_before_linear_memory: true,
+            table_lazy_init: true,
             generate_address_map: true,
             debug_adapter_modules: false,
             relaxed_simd_deterministic: false,

--- a/crates/fuzzing/src/generators/config.rs
+++ b/crates/fuzzing/src/generators/config.rs
@@ -227,6 +227,9 @@ impl Config {
             }
 
             cfg.cranelift_pcc(pcc);
+
+            // Eager init is currently only supported on Cranelift, not Winch.
+            cfg.table_lazy_init(self.wasmtime.table_lazy_init);
         }
 
         self.wasmtime.async_config.configure(&mut cfg);
@@ -483,6 +486,7 @@ pub struct WasmtimeConfig {
     cache_call_indirects: bool,
     /// The maximum number of call-indirect cache slots.
     max_call_indirect_cache_slots: usize,
+    table_lazy_init: bool,
 
     /// Whether or not fuzzing should enable PCC.
     pcc: bool,

--- a/crates/wasmtime/src/compile.rs
+++ b/crates/wasmtime/src/compile.rs
@@ -807,7 +807,9 @@ impl FunctionIndices {
                 // Attempt to convert table initializer segments to
                 // FuncTable representation where possible, to enable
                 // table lazy init.
-                translation.try_func_table_init();
+                if engine.tunables().table_lazy_init {
+                    translation.try_func_table_init();
+                }
 
                 let funcs: PrimaryMap<DefinedFuncIndex, CompiledFunctionInfo> =
                     wasm_functions_for_module(&mut wasm_functions, module)

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -149,6 +149,7 @@ struct ConfigTunables {
     epoch_interruption: Option<bool>,
     static_memory_bound_is_maximum: Option<bool>,
     guard_before_linear_memory: Option<bool>,
+    table_lazy_init: Option<bool>,
     generate_address_map: Option<bool>,
     debug_adapter_modules: Option<bool>,
     relaxed_simd_deterministic: Option<bool>,
@@ -1541,6 +1542,19 @@ impl Config {
         self
     }
 
+    /// Indicates whether to initialize tables lazily, so that instantiation
+    /// is fast but indirect calls are a little slower. If false, tables
+    /// are initialized eagerly during instantiation from any active element
+    /// segments that apply to them.
+    ///
+    /// ## Default
+    ///
+    /// This value defaults to `true`.
+    pub fn table_lazy_init(&mut self, table_lazy_init: bool) -> &mut Self {
+        self.tunables.table_lazy_init = Some(table_lazy_init);
+        self
+    }
+
     /// Configure the version information used in serialized and deserialzied [`crate::Module`]s.
     /// This effects the behavior of [`crate::Module::serialize()`], as well as
     /// [`crate::Module::deserialize()`] and related functions.
@@ -1810,6 +1824,7 @@ impl Config {
             epoch_interruption
             static_memory_bound_is_maximum
             guard_before_linear_memory
+            table_lazy_init
             generate_address_map
             debug_adapter_modules
             relaxed_simd_deterministic

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1845,6 +1845,10 @@ impl Config {
             if tunables.winch_callable && tunables.tail_callable {
                 bail!("Winch does not support the WebAssembly tail call proposal");
             }
+
+            if tunables.winch_callable && !tunables.table_lazy_init {
+                bail!("Winch requires the table-lazy-init configuration option");
+            }
         }
 
         if tunables.static_memory_offset_guard_size < tunables.dynamic_memory_offset_guard_size {

--- a/crates/wasmtime/src/engine/serialization.rs
+++ b/crates/wasmtime/src/engine/serialization.rs
@@ -355,6 +355,7 @@ impl Metadata<'_> {
             epoch_interruption,
             static_memory_bound_is_maximum,
             guard_before_linear_memory,
+            table_lazy_init,
             relaxed_simd_deterministic,
             tail_callable,
             winch_callable,
@@ -415,6 +416,7 @@ impl Metadata<'_> {
             other.guard_before_linear_memory,
             "guard before linear memory",
         )?;
+        Self::check_bool(table_lazy_init, other.table_lazy_init, "table lazy init")?;
         Self::check_bool(
             relaxed_simd_deterministic,
             other.relaxed_simd_deterministic,

--- a/tests/disas/typed-funcrefs-eager-init.wat
+++ b/tests/disas/typed-funcrefs-eager-init.wat
@@ -1,6 +1,6 @@
 ;;! target = "x86_64"
 ;;! test = "optimize"
-;;! flags = [ "-Wfunction-references=y", "-Otable-lazy-init=y" ]
+;;! flags = [ "-Wfunction-references=y", "-Otable-lazy-init=n" ]
 
 ;; This test is meant to simulate how typed funcrefs in a table may be
 ;; used for ICs (inline caches) in a Wasm module compiled from a dynamic
@@ -132,52 +132,28 @@
 ;;     gv2 = load.i64 notrap aligned gv1
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
-;;     sig0 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
-;;     sig1 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast
-;;     fn0 = colocated u1:9 sig0
+;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0048                               v12 = load.i64 notrap aligned readonly v0+88
-;;                                     v66 = iconst.i64 8
-;; @0048                               v14 = iadd v12, v66  ; v66 = 8
+;;                                     v48 = iconst.i64 8
+;; @0048                               v14 = iadd v12, v48  ; v48 = 8
 ;; @0048                               v17 = load.i64 table_oob aligned table v14
-;;                                     v54 = iconst.i64 -2
-;; @0048                               v18 = band v17, v54  ; v54 = -2
-;; @0048                               brif v17, block3(v18), block2
-;;
-;;                                 block2 cold:
-;; @003c                               v7 = iconst.i32 0
-;; @0046                               v8 = iconst.i32 1
-;; @0048                               v22 = call fn0(v0, v7, v8)  ; v7 = 0, v8 = 1
-;; @0048                               jump block3(v22)
-;;
-;;                                 block3(v19: i64):
-;; @004a                               v23 = load.i64 null_reference aligned readonly v19+16
-;; @004a                               v24 = load.i64 notrap aligned readonly v19+32
-;; @004a                               v25 = call_indirect sig1, v23(v24, v0, v2, v3, v4, v5)
-;;                                     v74 = iconst.i64 16
-;; @005b                               v38 = iadd.i64 v12, v74  ; v74 = 16
-;; @005b                               v41 = load.i64 table_oob aligned table v38
-;;                                     v75 = iconst.i64 -2
-;;                                     v76 = band v41, v75  ; v75 = -2
-;; @005b                               brif v41, block5(v76), block4
-;;
-;;                                 block4 cold:
-;;                                     v77 = iconst.i32 0
-;; @0059                               v32 = iconst.i32 2
-;; @005b                               v46 = call fn0(v0, v77, v32)  ; v77 = 0, v32 = 2
-;; @005b                               jump block5(v46)
-;;
-;;                                 block5(v43: i64):
-;; @005d                               v47 = load.i64 null_reference aligned readonly v43+16
-;; @005d                               v48 = load.i64 notrap aligned readonly v43+32
-;; @005d                               v49 = call_indirect sig1, v47(v48, v0, v2, v3, v4, v5)
+;; @004a                               v18 = load.i64 null_reference aligned readonly v17+16
+;; @004a                               v19 = load.i64 notrap aligned readonly v17+32
+;; @004a                               v20 = call_indirect sig0, v18(v19, v0, v2, v3, v4, v5)
+;;                                     v56 = iconst.i64 16
+;; @005b                               v28 = iadd v12, v56  ; v56 = 16
+;; @005b                               v31 = load.i64 table_oob aligned table v28
+;; @005d                               v32 = load.i64 null_reference aligned readonly v31+16
+;; @005d                               v33 = load.i64 notrap aligned readonly v31+32
+;; @005d                               v34 = call_indirect sig0, v32(v33, v0, v2, v3, v4, v5)
 ;; @0066                               jump block1
 ;;
 ;;                                 block1:
-;; @0061                               v51 = iadd.i32 v49, v25
-;; @0066                               return v51
+;; @0061                               v35 = iadd.i32 v34, v20
+;; @0066                               return v35
 ;; }
 ;;
 ;; function u0:2(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {
@@ -187,51 +163,27 @@
 ;;     gv3 = vmctx
 ;;     gv4 = load.i64 notrap aligned readonly gv3+88
 ;;     sig0 = (i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast
-;;     sig1 = (i64 vmctx, i32 uext, i32 uext) -> i64 system_v
-;;     fn0 = colocated u1:9 sig1
 ;;     stack_limit = gv2
 ;;
 ;;                                 block0(v0: i64, v1: i64, v2: i32, v3: i32, v4: i32, v5: i32):
 ;; @0075                               v12 = load.i64 notrap aligned readonly v0+88
-;;                                     v66 = iconst.i64 8
-;; @0075                               v14 = iadd v12, v66  ; v66 = 8
+;;                                     v48 = iconst.i64 8
+;; @0075                               v14 = iadd v12, v48  ; v48 = 8
 ;; @0075                               v17 = load.i64 table_oob aligned table v14
-;;                                     v54 = iconst.i64 -2
-;; @0075                               v18 = band v17, v54  ; v54 = -2
-;; @0075                               brif v17, block3(v18), block2
-;;
-;;                                 block2 cold:
-;; @0069                               v7 = iconst.i32 0
-;; @0073                               v8 = iconst.i32 1
-;; @0075                               v22 = call fn0(v0, v7, v8)  ; v7 = 0, v8 = 1
-;; @0075                               jump block3(v22)
-;;
-;;                                 block3(v19: i64):
-;; @0075                               v23 = load.i64 icall_null aligned readonly v19+16
-;; @0075                               v24 = load.i64 notrap aligned readonly v19+32
-;; @0075                               v25 = call_indirect sig0, v23(v24, v0, v2, v3, v4, v5)
-;;                                     v74 = iconst.i64 16
-;; @0087                               v38 = iadd.i64 v12, v74  ; v74 = 16
-;; @0087                               v41 = load.i64 table_oob aligned table v38
-;;                                     v75 = iconst.i64 -2
-;;                                     v76 = band v41, v75  ; v75 = -2
-;; @0087                               brif v41, block5(v76), block4
-;;
-;;                                 block4 cold:
-;;                                     v77 = iconst.i32 0
-;; @0085                               v32 = iconst.i32 2
-;; @0087                               v46 = call fn0(v0, v77, v32)  ; v77 = 0, v32 = 2
-;; @0087                               jump block5(v46)
-;;
-;;                                 block5(v43: i64):
-;; @0087                               v47 = load.i64 icall_null aligned readonly v43+16
-;; @0087                               v48 = load.i64 notrap aligned readonly v43+32
-;; @0087                               v49 = call_indirect sig0, v47(v48, v0, v2, v3, v4, v5)
+;; @0075                               v18 = load.i64 icall_null aligned readonly v17+16
+;; @0075                               v19 = load.i64 notrap aligned readonly v17+32
+;; @0075                               v20 = call_indirect sig0, v18(v19, v0, v2, v3, v4, v5)
+;;                                     v56 = iconst.i64 16
+;; @0087                               v28 = iadd v12, v56  ; v56 = 16
+;; @0087                               v31 = load.i64 table_oob aligned table v28
+;; @0087                               v32 = load.i64 icall_null aligned readonly v31+16
+;; @0087                               v33 = load.i64 notrap aligned readonly v31+32
+;; @0087                               v34 = call_indirect sig0, v32(v33, v0, v2, v3, v4, v5)
 ;; @0091                               jump block1
 ;;
 ;;                                 block1:
-;; @008c                               v51 = iadd.i32 v49, v25
-;; @0091                               return v51
+;; @008c                               v35 = iadd.i32 v34, v20
+;; @0091                               return v35
 ;; }
 ;;
 ;; function u0:3(i64 vmctx, i64, i32, i32, i32, i32) -> i32 fast {


### PR DESCRIPTION
Lazy initialization of tables has trade-offs that we haven't explored in a while. Making it configurable makes it easier to test the effects of these trade-offs on a variety of WebAssembly programs, and allows embedders to decide whether the trade-offs are worth-while for their use cases.

TODO:
- [x] Finish documentation comments
- [x] Add CLI flag in the `-O` group
- [x] Either implement support in Winch, or check in `Config::validate` that when Winch is enabled so is lazy-init
- [x] Add `disas` tests with lazy init disabled
- [x] Hook up this flag in fuzzing

I've tested this by temporarily setting the flag to disable lazy-init by default (in `crates/environ/src/tunables.rs`) and verifying that the test suite still passes, except for a bunch of Winch tests (as expected), as well as the amusing case of `code_too_large::code_too_large_without_panic`, which fails because disabling lazy-init deletes enough code that the code is no longer too large.

With lazy-init disabled, the `disas` tests show that this shaves off six or seven CLIF instructions and a cold block per `call_indirect` or `table_get`. The `typed-funcrefs.wat` test becomes branch-free, with two loads and an indirect call per `call_indirect`, making it equivalent to the version that uses globals instead of tables.

cc: @cfallin