### PR TITLE
Enable the tail calling convention by default

### DIFF
--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1729,8 +1729,9 @@ impl Config {
     }
 
     pub(crate) fn conditionally_enable_defaults(&mut self) {
-        // Enable tail calls by default when cranelift is going to be used as the compilation
-        // strategy, and we're not targeting s390x, which currently lacks tail-call support.
+        // If tail calls were not explicitly enabled/disabled (i.e. tail_callable is None), enable
+        // them if we are targeting a backend that supports them. Currently the Cranelift
+        // compilation strategy is the only one that supports tail calls, but not targeting s390x.
         if self.tunables.tail_callable.is_none() {
             #[cfg(feature = "cranelift")]
             let default_tail_calls = self.compiler_config.strategy == Strategy::Cranelift

--- a/crates/wasmtime/src/config.rs
+++ b/crates/wasmtime/src/config.rs
@@ -1728,7 +1728,30 @@ impl Config {
         self
     }
 
-    pub(crate) fn validate(&self) -> Result<Tunables> {
+    pub(crate) fn validate(mut self) -> Result<(Self, Tunables)> {
+        // Enable tail calls by default when cranelift is going to be used as the compilation
+        // strategy, and we're not targeting s390x, which currently lacks tail-call support.
+        match self.tunables.tail_callable {
+            None => {
+                #[cfg(feature = "cranelift")]
+                let default_tail_calls = self.compiler_config.strategy == Strategy::Cranelift
+                    && self.compiler_config.target.as_ref().map_or_else(
+                        || target_lexicon::Triple::host().architecture,
+                        |triple| triple.architecture,
+                    ) != Architecture::S390x;
+                #[cfg(not(feature = "cranelift"))]
+                let default_tail_calls = false;
+
+                self.features
+                    .set(WasmFeatures::TAIL_CALL, default_tail_calls);
+                self.tunables.tail_callable = Some(default_tail_calls);
+            }
+
+            Some(val) => {
+                self.features.set(WasmFeatures::TAIL_CALL, val);
+            }
+        }
+
         if self.features.contains(WasmFeatures::REFERENCE_TYPES)
             && !self.features.contains(WasmFeatures::BULK_MEMORY)
         {
@@ -1820,7 +1843,7 @@ impl Config {
             bail!("static memory guard size cannot be smaller than dynamic memory guard size");
         }
 
-        Ok(tunables)
+        Ok((self, tunables))
     }
 
     #[cfg(feature = "runtime")]

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -101,8 +101,7 @@ impl Engine {
             crate::runtime::vm::debug_builtins::ensure_exported();
         }
 
-        let config = config.clone();
-        let tunables = config.validate()?;
+        let (config, tunables) = config.clone().validate()?;
 
         #[cfg(any(feature = "cranelift", feature = "winch"))]
         let (config, compiler) = config.build_compiler(&tunables)?;

--- a/crates/wasmtime/src/engine.rs
+++ b/crates/wasmtime/src/engine.rs
@@ -101,7 +101,13 @@ impl Engine {
             crate::runtime::vm::debug_builtins::ensure_exported();
         }
 
-        let (config, tunables) = config.clone().validate()?;
+        let config = {
+            let mut config = config.clone();
+            config.conditionally_enable_defaults();
+            config
+        };
+
+        let tunables = config.validate()?;
 
         #[cfg(any(feature = "cranelift", feature = "winch"))]
         let (config, compiler) = config.build_compiler(&tunables)?;

--- a/tests/all/defaults.rs
+++ b/tests/all/defaults.rs
@@ -1,0 +1,62 @@
+use wasmtime::*;
+
+#[test]
+fn test_tail_call_default() -> Result<()> {
+    for (expected, cfg) in [
+        (
+            true,
+            Config::new()
+                .strategy(Strategy::Cranelift)
+                .target("x86_64")?,
+        ),
+        (
+            true,
+            Config::new()
+                .strategy(Strategy::Cranelift)
+                .target("aarch64")?,
+        ),
+        (
+            true,
+            Config::new()
+                .strategy(Strategy::Cranelift)
+                .target("riscv64")?,
+        ),
+        (
+            false,
+            Config::new()
+                .strategy(Strategy::Cranelift)
+                .target("s390x")?,
+        ),
+        (
+            false,
+            Config::new().strategy(Strategy::Winch).target("x86_64")?,
+        ),
+        (
+            false,
+            Config::new().strategy(Strategy::Winch).target("aarch64")?,
+        ),
+        (
+            false,
+            Config::new()
+                .strategy(Strategy::Cranelift)
+                .wasm_tail_call(false)
+                .target("x86_64")?,
+        ),
+    ] {
+        let engine = Engine::new(cfg)?;
+
+        let wat = r#"
+            (module $from_name_section
+                (func (export "run") (return_call 0))
+            )
+        "#;
+
+        let result = engine.precompile_module(wat.as_bytes()).map(|_| ());
+
+        eprintln!("for config {cfg:?}, got: {result:?}");
+
+        assert_eq!(expected, result.is_ok());
+    }
+
+    Ok(())
+}

--- a/tests/all/main.rs
+++ b/tests/all/main.rs
@@ -7,6 +7,7 @@ mod code_too_large;
 mod component_model;
 mod coredump;
 mod debug;
+mod defaults;
 mod epoch_interruption;
 mod externals;
 mod fuel;


### PR DESCRIPTION
Switch to enabling the wasm tail call feature by default when the target is one of `x86_64`, `aarch64`, or `riscv64`, and the compilation strategy is `cranelift`. We also added tests checking that the feature is not enabled for either winch or the `s390x` backend.


Co-authored-by: Nick Fitzgerald <fitzgen@gmail.com>

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
