### PR TITLE
Indirect call caching: put options under `-O` namespace.

### DIFF
--- a/crates/cli-flags/src/lib.rs
+++ b/crates/cli-flags/src/lib.rs
@@ -101,6 +101,17 @@ wasmtime_option_group! {
         /// The maximum number of WebAssembly stacks which can be created with
         /// the pooling allocator.
         pub pooling_total_stacks: Option<u32>,
+
+        /// Whether to enable call-indirect caching.
+        pub cache_call_indirects: Option<bool>,
+
+        /// The maximum call-indirect cache slot count.
+        ///
+        /// One slot is allocated per indirect callsite; if the module
+        /// has more indirect callsites than this limit, then the
+        /// first callsites in linear order in the code section, up to
+        /// the limit, will receive a cache slot.
+        pub max_call_indirect_cache_slots: Option<usize>,
     }
 
     enum Optimize {
@@ -244,15 +255,6 @@ wasmtime_option_group! {
         pub function_references: Option<bool>,
         /// Configure support for the GC proposal.
         pub gc: Option<bool>,
-        /// Whether to enable call-indirect caching.
-        pub cache_call_indirects: Option<bool>,
-        /// The maximum call-indirect cache slot count.
-        ///
-        /// One slot is allocated per indirect callsite; if the module
-        /// has more indirect callsites than this limit, then the
-        /// first callsites in linear order in the code section, up to
-        /// the limit, will receive a cache slot.
-        pub max_call_indirect_cache_slots: Option<usize>,
     }
 
     enum Wasm {
@@ -553,10 +555,10 @@ impl CommonOptions {
         if let Some(enable) = self.opts.memory_init_cow {
             config.memory_init_cow(enable);
         }
-        if let Some(enable) = self.wasm.cache_call_indirects {
+        if let Some(enable) = self.opts.cache_call_indirects {
             config.cache_call_indirects(enable);
         }
-        if let Some(max) = self.wasm.max_call_indirect_cache_slots {
+        if let Some(max) = self.opts.max_call_indirect_cache_slots {
             config.max_call_indirect_cache_slots(max);
         }
 

--- a/tests/disas/indirect-call-caching-exclude-0-index.wat
+++ b/tests/disas/indirect-call-caching-exclude-0-index.wat
@@ -1,5 +1,5 @@
 ;;! target = "x86_64"
-;;! flags = [ "-Wcache-call-indirects=y" ]
+;;! flags = [ "-Ocache-call-indirects=y" ]
 
 ;; This test checks that we do *not* get the indirect-call caching optimization
 ;; when it must not be used: in this case, because there is a non-null element

--- a/tests/disas/indirect-call-caching-exclude-table-export.wat
+++ b/tests/disas/indirect-call-caching-exclude-table-export.wat
@@ -1,5 +1,5 @@
 ;;! target = "x86_64"
-;;! flags = [ "-Wcache-call-indirects=y" ]
+;;! flags = [ "-Ocache-call-indirects=y" ]
 
 ;; This test checks that we do *not* get the indirect-call caching optimization
 ;; when it must not be used: in this case, because the table is exported so

--- a/tests/disas/indirect-call-caching-exclude-table-writes.wat
+++ b/tests/disas/indirect-call-caching-exclude-table-writes.wat
@@ -1,5 +1,5 @@
 ;;! target = "x86_64"
-;;! flags = [ "-Wcache-call-indirects=y" ]
+;;! flags = [ "-Ocache-call-indirects=y" ]
 
 ;; This test checks that we do *not* get the indirect-call caching optimization
 ;; when it must not be used: in this case, because the table is updated with a

--- a/tests/disas/indirect-call-caching-slot-limit-1.wat
+++ b/tests/disas/indirect-call-caching-slot-limit-1.wat
@@ -1,5 +1,5 @@
 ;;! target = "x86_64"
-;;! flags = [ "-Wcache-call-indirects=y", "-Wmax-call-indirect-cache-slots=2" ]
+;;! flags = [ "-Ocache-call-indirects=y", "-Omax-call-indirect-cache-slots=2" ]
 
 ;; This test checks that we properly bound the number of call-indirect
 ;; cache slots. The first case (here) is when the limit falls in the

--- a/tests/disas/indirect-call-caching-slot-limit-2.wat
+++ b/tests/disas/indirect-call-caching-slot-limit-2.wat
@@ -1,5 +1,5 @@
 ;;! target = "x86_64"
-;;! flags = [ "-Wcache-call-indirects=y", "-Wmax-call-indirect-cache-slots=2" ]
+;;! flags = [ "-Ocache-call-indirects=y", "-Omax-call-indirect-cache-slots=2" ]
 
 ;; This test checks that we properly bound the number of call-indirect
 ;; cache slots. The second case (here) is when the limit falls

--- a/tests/disas/indirect-call-caching.wat
+++ b/tests/disas/indirect-call-caching.wat
@@ -1,5 +1,5 @@
 ;;! target = "x86_64"
-;;! flags = [ "-Wcache-call-indirects=y" ]
+;;! flags = [ "-Ocache-call-indirects=y" ]
 
 ;; This test checks that we get the indirect-call caching optimization
 ;; where it should be applicable (immutable table, null 0-index).


### PR DESCRIPTION
As per [this comment], the call-indirect caching options should really be in the `-O` option namespace (for optimizations), not `-W` (for semantically-visible Wasm standards options); the original PR simply put them in the wrong place, and this PR moves them.

[this comment]: https://github.com/bytecodealliance/wasmtime/pull/8509#discussion_r1589594152

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
