### PR TITLE
Fix combining `cache_call_indirects` and memory64

### DIFF
--- a/crates/environ/src/compile/module_environ.rs
+++ b/crates/environ/src/compile/module_environ.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 use std::mem;
 use std::path::PathBuf;
 use std::sync::Arc;
-use wasmparser::OperatorsReader;
 use wasmparser::{
     types::Types, CustomSectionReader, DataKind, ElementItems, ElementKind, Encoding, ExternalKind,
     FuncToValidate, FunctionBody, NameSectionReader, Naming, Operator, Parser, Payload, TypeRef,
@@ -543,6 +542,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
 
             Payload::CodeSectionEntry(mut body) => {
                 let validator = self.validator.code_section_entry(&body)?;
+                body.allow_memarg64(self.validator.features().contains(WasmFeatures::MEMORY64));
                 let func_index =
                     self.result.code_index + self.result.module.num_imported_funcs as u32;
                 let func_index = FuncIndex::from_u32(func_index);
@@ -567,7 +567,7 @@ impl<'a, 'data> ModuleEnvironment<'a, 'data> {
                             params: sig.params().into(),
                         });
                 }
-                self.prescan_code_section(body.get_operators_reader()?)?;
+                self.prescan_code_section(&body)?;
                 body.allow_memarg64(self.validator.features().contains(WasmFeatures::MEMORY64));
                 self.result.function_body_inputs.push(FunctionBodyData {
                     validator,
@@ -721,9 +721,9 @@ and for re-adding support for interface types you can see this issue:
     ///   index in this count for each function, so we can generate
     ///   its code (with accesses to its own `call_indirect` callsite
     ///   caches) in parallel.
-    fn prescan_code_section(&mut self, reader: OperatorsReader<'data>) -> Result<()> {
+    fn prescan_code_section(&mut self, body: &FunctionBody<'_>) -> Result<()> {
         if self.tunables.cache_call_indirects {
-            for op in reader {
+            for op in body.get_operators_reader()? {
                 let op = op?;
                 match op {
                     // Check whether a table may be mutated by any

--- a/tests/all/module.rs
+++ b/tests/all/module.rs
@@ -250,3 +250,22 @@ fn compile_a_component() -> Result<()> {
     );
     Ok(())
 }
+
+#[test]
+fn call_indirect_caching_and_memory64() -> Result<()> {
+    let mut config = Config::new();
+    config.wasm_memory64(true);
+    config.cache_call_indirects(true);
+    let engine = Engine::new(&config)?;
+    Module::new(
+        &engine,
+        "(module
+            (memory i64 1)
+            (func (param i64) (result i32)
+                local.get 0
+                i32.load offset=0x100000000
+            )
+        )",
+    )?;
+    Ok(())
+}


### PR DESCRIPTION
This commit fixes a fuzz bug that popped up where the `cache_call_indirects` feature wasn't reading memory64-based offsets correctly. This is due to (not great) API design in `wasmparser` (introduced by me) where wasmparser by default won't read 64-bit offsets unless explicitly allowed to. This is to handle how spec tests assert that overlong 32-bit encodings are invalid as the memory64 proposal isn't merged into the spec yet.

The fix here is to call `allow_memarg64` with whether memory64 is enabled or not and then that'll enable reading these overlong and/or larger offsets correctly.

<!--
Please make sure you include the following information:

- If this work has been discussed elsewhere, please include a link to that
  conversation. If it was discussed in an issue, just mention "issue #...".

- Explain why this change is needed. If the details are in an issue already,
  this can be brief.

Our development process is documented in the Wasmtime book:
https://docs.wasmtime.dev/contributing-development-process.html

Please ensure all communication follows the code of conduct:
https://github.com/bytecodealliance/wasmtime/blob/main/CODE_OF_CONDUCT.md
-->
